### PR TITLE
Update to enable pod tests in post submit tests.

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -28,9 +28,9 @@ jobs:
         run: ./scripts/code_coverage_report/get_updated_files.sh
 
   pod-lib-lint-database:
+    needs: check
     # Don't run on private repo unless it is a PR.
     if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job || github.event.pull_request.merged)
-    needs: check
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -47,9 +47,9 @@ jobs:
         path: /Users/runner/*.xcresult
 
   pod-lib-lint-functions:
+    needs: check
     # Don't run on private repo unless it is a PR.
     if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.functions_run_job || github.event.pull_request.merged)
-    needs: check
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -30,7 +30,7 @@ jobs:
   pod-lib-lint-database:
     needs: check
     # Don't run on private repo unless it is a PR.
-    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job || github.event.pull_request.merged)
+    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job == 'true' || github.event.pull_request.merged)
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
   pod-lib-lint-functions:
     needs: check
     # Don't run on private repo unless it is a PR.
-    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.functions_run_job || github.event.pull_request.merged)
+    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.functions_run_job == 'true'|| github.event.pull_request.merged)
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event.action == 'synchronize'
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event.action != 'closed'
     name: Check changed files
     outputs:
       database_run_job: ${{ steps.check_files.outputs.database_run_job }}
@@ -29,7 +29,7 @@ jobs:
 
   pod-lib-lint-database:
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job == 'true' || github.event.pull_request.merged == true)
+    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job || github.event.pull_request.merged)
     needs: check
     runs-on: macOS-latest
     strategy:
@@ -48,7 +48,7 @@ jobs:
 
   pod-lib-lint-functions:
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.functions_run_job == 'true' || github.event.pull_request.merged == true)
+    if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.functions_run_job || github.event.pull_request.merged)
     needs: check
     runs-on: macOS-latest
     strategy:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -5,11 +5,11 @@ on:
     # open will be triggered when a pull request is created.
     # synchronize will be triggered when a pull request has new commits.
     # closed will be triggered when a pull request is closed.
-    types: [open, synchronize, closed]
+    types: [opened, synchronize, closed]
 
 jobs:
   check:
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event.action != 'closed'
+    if: github.repository == 'Firebase/firebase-ios-sdk' && (github.event.action == 'opened' || github.event.action == 'synchronize')
     name: Check changed files
     outputs:
       database_run_job: ${{ steps.check_files.outputs.database_run_job }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -30,6 +30,7 @@ jobs:
   pod-lib-lint-database:
     needs: check
     # Don't run on private repo unless it is a PR.
+    # always() will trigger this job when `needs` are skipped in a `merge` pull_request event.
     if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.database_run_job == 'true' || github.event.pull_request.merged)
     runs-on: macOS-latest
     strategy:


### PR DESCRIPTION
Previously in post submit, pod test jobs will not run since their dependency job, `check`, does not run and their `if` conditions are overridden by `needs`.  This was discussed [here](https://github.com/actions/runner/issues/491). To make `if` with a higher priority than `needs`, [Job status check functions](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions) are added here. `always()` here will omit the result of `needs` jobs but will wait until dependency jobs finish.