### PR TITLE
Restore master manifest version

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "7.6.0",
+  version: "7.5.0",
   pods: [
     Pod("FirebaseCoreDiagnostics"),
     Pod("FirebaseCore"),


### PR DESCRIPTION
Restore manifest version until 7.6.0 release publishes.

The version update needs to be in the release branch only until we make the release process fully public to keep the nightly zip.yml running.