### PR TITLE
RTDB FSRWebSocket: suppress diagnostic error

### DIFF
--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v7.7.0
+- [fixed] Fix variable length array diagnistics warning (#7460).
 # v7.5.1
 - [changed] Optimize `FIRDatabaseQuery#getDataWithCompletionBlock` when in-memory active listener cache exists (#7312).
 

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v7.7.0
-- [fixed] Fix variable length array diagnistics warning (#7460).
+- [fixed] Fix variable length array diagnostics warning (#7460).
 # v7.5.1
 - [changed] Optimize `FIRDatabaseQuery#getDataWithCompletionBlock` when in-memory active listener cache exists (#7312).
 

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
@@ -1559,8 +1559,12 @@ static const size_t SRFrameHeaderOverhead = 32;
 
         case NSStreamEventHasBytesAvailable: {
             SRFastLog(@"NSStreamEventHasBytesAvailable %@", aStream);
+
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wvla"
             const NSUInteger bufferSize = 2048;
             uint8_t buffer[bufferSize];
+            #pragma clang diagnostic pop
 
             while (_inputStream.hasBytesAvailable) {
                 NSInteger bytes_read = [_inputStream read:buffer maxLength:bufferSize];

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
@@ -1560,14 +1560,12 @@ static const size_t SRFrameHeaderOverhead = 32;
         case NSStreamEventHasBytesAvailable: {
             SRFastLog(@"NSStreamEventHasBytesAvailable %@", aStream);
 
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wvla"
-            const NSUInteger bufferSize = 2048;
-            uint8_t buffer[bufferSize];
-            #pragma clang diagnostic pop
+            #define FSRWEB_SOCKET_BUFFER_SIZE 2048
+            uint8_t buffer[FSRWEB_SOCKET_BUFFER_SIZE];
+
 
             while (_inputStream.hasBytesAvailable) {
-                NSInteger bytes_read = [_inputStream read:buffer maxLength:bufferSize];
+                NSInteger bytes_read = [_inputStream read:buffer maxLength:FSRWEB_SOCKET_BUFFER_SIZE];
 
                 if (bytes_read > 0) {
                     [_readBuffer appendBytes:buffer length:bytes_read];
@@ -1575,7 +1573,7 @@ static const size_t SRFrameHeaderOverhead = 32;
                     [self _failWithError:_inputStream.streamError];
                 }
 
-                if (bytes_read != bufferSize) {
+                if (bytes_read != FSRWEB_SOCKET_BUFFER_SIZE) {
                     break;
                 }
             };


### PR DESCRIPTION
Fix for cl/355486726 - g3 build error:
```
error: variable length array used [-Werror,-Wvla]
            uint8_t buffer[bufferSize];
                           ^~~~~~~~~~
```