### PR TITLE
Enable watchOS for Remote Config and ABTesting

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -49,7 +49,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler

--- a/Example/watchOSSample/Podfile
+++ b/Example/watchOSSample/Podfile
@@ -12,6 +12,9 @@ target 'SampleWatchAppWatchKitExtension' do
   pod 'FirebaseCoreDiagnostics', :path => '../../'
   pod 'FirebaseInstallations', :path => '../../'
   pod 'FirebaseStorage', :path => '../../'
+  pod 'FirebaseRemoteConfig', :path => '../../'
+  pod 'FirebaseABTesting', :path => '../../'
+
 
 end
 

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -20,43 +20,43 @@ import FirebaseRemoteConfig
 
 /// Entry point of the watch app.
 class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
-  /// Initialize Firebase service here.
-  func applicationDidFinishLaunching() {
-    FirebaseApp.configure()
-    let center = UNUserNotificationCenter.current()
-    center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-      if granted {
-        WKExtension.shared().registerForRemoteNotifications()
-      }
+    /// Initialize Firebase service here.
+    func applicationDidFinishLaunching() {
+        FirebaseApp.configure()
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            if granted {
+                WKExtension.shared().registerForRemoteNotifications()
+            }
+        }
+        Messaging.messaging().delegate = self
+        let remoteConfig = RemoteConfig.remoteConfig()
+        remoteConfig.fetchAndActivate { _, error in
+            guard error == nil else {
+                print("error:" + error.debugDescription)
+                return
+            }
+            let configValue: String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
+            print("value:\n" + configValue)
+        }
     }
-    Messaging.messaging().delegate = self
-    let remoteConfig = RemoteConfig.remoteConfig()
-    remoteConfig.fetchAndActivate { status, error in
-      guard error == nil else {
-        print("error:" + error.debugDescription)
-        return
-      }
-      let configValue :String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
-      print("value:\n" + configValue)
-    }
-  }
 
-  /// MessagingDelegate
-  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-    print("token:\n" + fcmToken!)
-    Messaging.messaging().subscribe(toTopic: "watch") { error in
-      guard error == nil else {
-        print("error:" + error.debugDescription)
-        return
-      }
-      print("Successfully subscribed to topic")
+    /// MessagingDelegate
+    func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        print("token:\n" + fcmToken!)
+        Messaging.messaging().subscribe(toTopic: "watch") { error in
+            guard error == nil else {
+                print("error:" + error.debugDescription)
+                return
+            }
+            print("Successfully subscribed to topic")
+        }
     }
-  }
 
-  /// WKExtensionDelegate
-  func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
-    /// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
-    print("Set APNS Token\n")
-    Messaging.messaging().apnsToken = deviceToken
-  }
+    /// WKExtensionDelegate
+    func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+        /// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
+        print("Set APNS Token\n")
+        Messaging.messaging().apnsToken = deviceToken
+    }
 }

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -32,19 +32,23 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
     Messaging.messaging().delegate = self
     let remoteConfig = RemoteConfig.remoteConfig()
     remoteConfig.fetchAndActivate { status, error in
-        print("value:\n" + remoteConfig["test"].stringValue!)
+      guard error == nil else {
+        print("error:" + error.debugDescription)
+        return
+      }
+      print("value:\n" + remoteConfig["test"].stringValue!)
     }
   }
 
   /// MessagingDelegate
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print("token:\n" + fcmToken!)
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    print("token:\n" + fcmToken!)
     Messaging.messaging().subscribe(toTopic: "watch") { error in
-      if error != nil {
+      guard error == nil else {
         print("error:" + error.debugDescription)
-      } else {
-        print("Successfully subscribed to topic")
+        return
       }
+      print("Successfully subscribed to topic")
     }
   }
 

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -36,7 +36,8 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
         print("error:" + error.debugDescription)
         return
       }
-      print("value:\n" + remoteConfig["test"].stringValue!)
+      let configValue :String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
+      print("value:\n" + configValue)
     }
   }
 

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -32,33 +32,33 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
     Messaging.messaging().delegate = self
     let remoteConfig = RemoteConfig.remoteConfig()
     remoteConfig.fetchAndActivate { _, error in
-    guard error == nil else {
-      print("error:" + error.debugDescription)
-      return
-    }
-    let defaultOutput = "You have not set up a 'test' key in Remote Config console."
-    let configValue: String =
-      remoteConfig["test"].stringValue ?? defaultOutput
+      guard error == nil else {
+        print("error:" + error.debugDescription)
+        return
+      }
+      let defaultOutput = "You have not set up a 'test' key in Remote Config console."
+      let configValue: String =
+        remoteConfig["test"].stringValue ?? defaultOutput
       print("value:\n" + configValue)
-  }
-}
-
-/// MessagingDelegate
-func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-  print("token:\n" + fcmToken!)
-  Messaging.messaging().subscribe(toTopic: "watch") { error in
-    guard error == nil else {
-     print("error:" + error.debugDescription)
-	return
     }
-    print("Successfully subscribed to topic")
   }
-}
 
-/// WKExtensionDelegate
-func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
-/// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
-  print("Set APNS Token\n")
-  Messaging.messaging().apnsToken = deviceToken
+  /// MessagingDelegate
+  func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    print("token:\n" + fcmToken!)
+    Messaging.messaging().subscribe(toTopic: "watch") { error in
+      guard error == nil else {
+        print("error:" + error.debugDescription)
+        return
+      }
+      print("Successfully subscribed to topic")
+    }
+  }
+
+  /// WKExtensionDelegate
+  func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+    /// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
+    print("Set APNS Token\n")
+    Messaging.messaging().apnsToken = deviceToken
   }
 }

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -36,7 +36,9 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
       print("error:" + error.debugDescription)
       return
     }
-    let configValue: String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
+    let defaultOutput = "You have not set up a 'test' key in Remote Config console."
+    let configValue: String =
+      remoteConfig["test"].stringValue ?? defaultOutput
       print("value:\n" + configValue)
   }
 }

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -20,43 +20,43 @@ import FirebaseRemoteConfig
 
 /// Entry point of the watch app.
 class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
-    /// Initialize Firebase service here.
-    func applicationDidFinishLaunching() {
-        FirebaseApp.configure()
-        let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
-            if granted {
-                WKExtension.shared().registerForRemoteNotifications()
-            }
-        }
-        Messaging.messaging().delegate = self
-        let remoteConfig = RemoteConfig.remoteConfig()
-        remoteConfig.fetchAndActivate { _, error in
-            guard error == nil else {
-                print("error:" + error.debugDescription)
-                return
-            }
-            let configValue: String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
-            print("value:\n" + configValue)
-        }
+  /// Initialize Firebase service here.
+  func applicationDidFinishLaunching() {
+    FirebaseApp.configure()
+    let center = UNUserNotificationCenter.current()
+    center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+      if granted {
+        WKExtension.shared().registerForRemoteNotifications()
+      }
     }
+    Messaging.messaging().delegate = self
+    let remoteConfig = RemoteConfig.remoteConfig()
+    remoteConfig.fetchAndActivate { _, error in
+    guard error == nil else {
+      print("error:" + error.debugDescription)
+      return
+    }
+    let configValue: String = remoteConfig["test"].stringValue ?? "You have not set up a 'test' key in Remote Config console."
+      print("value:\n" + configValue)
+  }
+}
 
-    /// MessagingDelegate
-    func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        print("token:\n" + fcmToken!)
-        Messaging.messaging().subscribe(toTopic: "watch") { error in
-            guard error == nil else {
-                print("error:" + error.debugDescription)
-                return
-            }
-            print("Successfully subscribed to topic")
-        }
+/// MessagingDelegate
+func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+  print("token:\n" + fcmToken!)
+  Messaging.messaging().subscribe(toTopic: "watch") { error in
+    guard error == nil else {
+     print("error:" + error.debugDescription)
+	return
     }
+    print("Successfully subscribed to topic")
+  }
+}
 
-    /// WKExtensionDelegate
-    func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
-        /// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
-        print("Set APNS Token\n")
-        Messaging.messaging().apnsToken = deviceToken
-    }
+/// WKExtensionDelegate
+func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+/// Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
+  print("Set APNS Token\n")
+  Messaging.messaging().apnsToken = deviceToken
+  }
 }

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -16,6 +16,7 @@ import WatchKit
 
 import FirebaseCore
 import FirebaseMessaging
+import FirebaseRemoteConfig
 
 /// Entry point of the watch app.
 class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
@@ -29,11 +30,15 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
       }
     }
     Messaging.messaging().delegate = self
+    let remoteConfig = RemoteConfig.remoteConfig()
+    remoteConfig.fetchAndActivate { status, error in
+        print("value:\n" + remoteConfig["test"].stringValue!)
+    }
   }
 
   /// MessagingDelegate
-  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
-    print("token:\n" + fcmToken)
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        print("token:\n" + fcmToken!)
     Messaging.messaging().subscribe(toTopic: "watch") { error in
       if error != nil {
         print("error:" + error.debugDescription)

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -24,6 +24,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '6.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -45,6 +45,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
+    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = 'FirebaseABTesting/Tests/Unit/**/*.[mh]'
     unit_tests.resources = 'FirebaseABTesting/Tests/Unit/Resources/*.txt'
     unit_tests.requires_app_host = true

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -21,10 +21,15 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   }
 
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false

--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [added] Added community support for watchOS. (#7481)
+
 # v7.0.0
 - [removed] Removed `FIRExperimentController.updateExperiments(serviceOrigin:events:policy:lastStartTime:payloads:)`, which was deprecated. (#6543)
 

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -21,6 +21,7 @@ app update.
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '6.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -18,10 +18,15 @@ app update.
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [added] Added community support for watchOS. (#7481)
+
 # v7.6.0
 - [fixed] Fixed build warnings introduced with Xcode 12.5. (#7432)
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ pod 'Firebase/Firestore'     # No watchOS support yet
 pod 'Firebase/Functions'     # No watchOS support yet
 pod 'Firebase/Messaging'
 pod 'Firebase/Performance'   # No macOS, tvOS, watchOS, and Catalyst support yet
-pod 'Firebase/RemoteConfig'  # No watchOS support yet
+pod 'Firebase/RemoteConfig'
 pod 'Firebase/Storage'
 ```
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ macOS/tvOS/watchOS/Catalyst.
 To install, add a subset of the following to the Podfile:
 
 ```
-pod 'Firebase/ABTesting'     # No watchOS support yet
+pod 'Firebase/ABTesting'
 pod 'Firebase/Auth'          # Limited watchOS support
 pod 'Firebase/Crashlytics'
 pod 'Firebase/Database'      # No watchOS support yet


### PR DESCRIPTION
ABTesting is a hard dependency so enable it as well.
Testing: I'm able to get config value without any changes using the watchOS sample app.