### PR TITLE
Improve internal header documentation

### DIFF
--- a/HeadersImports.md
+++ b/HeadersImports.md
@@ -34,6 +34,10 @@ In Swift Package Manager, it's a library target.
   should be located among the source files. [Xcode](https://stackoverflow.com/a/8016333) refers to
   these as "Project Headers".
 
+* *Library C++ Internal Headers* - In CocoaPods, C++ internal headers should not be included
+  in the `source_files` attribute. Instead, they should be defined with the `preserve_paths`
+  attribute to avoid namespace collisions in the generated Xcode workspace.
+
 ## Imports - For Header File Consumers
 
 * *Headers within the Library* - Use a repo-relative path for all of the header types above.
@@ -42,9 +46,12 @@ In Swift Package Manager, it's a library target.
 
 * *Private Headers from other Libraries* - Import a private umbrella header like
   `FirebaseCore/Sources/Private/FirebaseCoreInternal.h`. For CocoaPods, these files should be
-  added to the podspec in the `preserved_path` attribute like:
+  added to the podspec in the `source_files` attribute like:
 ```
-  s.preserve_paths = 'Interop/Auth/Public/*.h', 'FirebaseCore/Sources/Private/*.h'
+  s.source_files = [ 'FirebaseFoo/Sources/**/*.[mh]'
+                     'Interop/Auth/Public/*.h',
+                     'FirebaseCore/Sources/Private/*.h',
+                   ]
 ```
 
 * *Headers from an external dependency* - Do a module import for Swift Package Manager and an

--- a/HeadersImports.md
+++ b/HeadersImports.md
@@ -36,7 +36,9 @@ In Swift Package Manager, it's a library target.
 
 * *Library C++ Internal Headers* - In CocoaPods, C++ internal headers should not be included
   in the `source_files` attribute. Instead, they should be defined with the `preserve_paths`
-  attribute to avoid namespace collisions in the generated Xcode workspace.
+  attribute to avoid filename collisions in the generated Xcode workspace. C++ does not assume
+  a global header map, so if filenames are qualified at all, it's generally by directory, not a
+  filename prefix like in Objective-C.
 
 ## Imports - For Header File Consumers
 

--- a/Interop/FirebaseComponentSystem.md
+++ b/Interop/FirebaseComponentSystem.md
@@ -348,7 +348,7 @@ Adding dependencies is easy once components are registered with Core. Let's take
 Functions above and add a dependency to `FIRAuthInterop` defined above.
 
 **Important**: You will also need to add `FirebaseAuthInterop` headers to your
-               product's podspec `preserved_paths` attribute for CocoaPods and something
+               product's podspec `source_files` attribute for CocoaPods and something
                comparable for any other package manager supported. Note, for Swift Package Manager,
                nothing special is needed as long as all the pods and headers are in the same repo.
 


### PR DESCRIPTION
As we made header searching more consistent between CocoaPods and SPM, private headers imported from other Firebase libraries are now specified with the CocoaPods `source_files` attribute.

Clarify that C++ internal headers should still be specified with `preserve_paths` to avoid namespace collisions in the generated client Xcode workspace.

Note that this has the downside of losing navigation to the header by filename in Xcode for which the workaround is using the file type.