### PR TITLE
Fix Downloader nightly

### DIFF
--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         access-token: '${{ secrets.GITHUB_TOKEN }}'
         # This is to exclude workflows that will be searched in the nightly report.
-        exclude-workflow-files: 'performance-integration-tests.ymls'
+        exclude-workflow-files: 'performance-integration-tests.yml'

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -16,4 +16,4 @@ jobs:
       with:
         access-token: '${{ secrets.GITHUB_TOKEN }}'
         # This is to exclude workflows that will be searched in the nightly report.
-        exclude-workflow-files: 'performance-integration-tests.yml,mlmodeldownloader.yml'
+        exclude-workflow-files: 'performance-integration-tests.ymls'

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -33,6 +33,29 @@ jobs:
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --platforms=${{ matrix.target }}
 
+  mlmodeldownloader-cron-only:
+    # Don't run on private repo.
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+
+    runs-on: macos-latest
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+    needs: pod-lib-lint
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install GoogleService-Info.plist
+      run: |
+        mkdir FirebaseMLModelDownloader/Tests/Integration/Resources
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/MLModelDownloader/GoogleService-Info.plist.gpg \
+          FirebaseMLModelDownloader/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
+    - name: PodLibLint MLModelDownloader Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --platforms=${{ matrix.target }} --use-static-frameworks
+
   spm:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'
@@ -72,22 +95,6 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Setup project and Build Catalyst
       run: scripts/test_catalyst.sh FirebaseMLModelDownloader test FirebaseMLModelDownloader-Unit-unit
-
-  mlmodeldownloader-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-    needs: pod-lib-lint
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint MLModelDownloader Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --platforms=${{ matrix.target }} --use-modular-headers
 
   mlmodeldownloader-sample-build-test:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -35,7 +35,7 @@ jobs:
 
   mlmodeldownloader-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     env:


### PR DESCRIPTION
- Use secret
- Static frameworks instead of modular headers
- Move next to similar regular pod lib lint tests
- Enable issue reporting for failures
