### PR TITLE
Update Firebase version in zip manifest

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "7.5.0",
+  version: "7.6.0",
   pods: [
     Pod("FirebaseCoreDiagnostics"),
     Pod("FirebaseCore"),


### PR DESCRIPTION
Fix #7500 

The version update did not end up correct after 7.6.0 published. Restoring here to fix the nightly tests.