### PR TITLE
Combine Support: Link user from a third-party provider

### DIFF
--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -19,8 +19,7 @@
 
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-extension User {
-    
+  extension User {
     /// Associates a user account from a third-party identity provider with this user and
     /// returns additional identity provider data.
     ///
@@ -39,15 +38,15 @@ extension User {
     ///
     ///   See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
     public func link(with credential: AuthCredential) -> Future<AuthDataResult, Error> {
-        Future<AuthDataResult, Error> { promise in
-            self.link(with: credential) { authDataResult, error in
-                if let error = error {
-                    promise(.failure(error))
-                } else if let authDataResult = authDataResult {
-                    promise(.success(authDataResult))
-                }
-            }
+      Future<AuthDataResult, Error> { promise in
+        self.link(with: credential) { authDataResult, error in
+          if let error = error {
+            promise(.failure(error))
+          } else if let authDataResult = authDataResult {
+            promise(.success(authDataResult))
+          }
         }
+      }
     }
-}
+  }
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+  import Combine
+  import FirebaseAuth
+
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension User {
+    
+    /// Associates a user account from a third-party identity provider with this user and
+    /// returns additional identity provider data.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameter credential: The credential for the identity provider.
+    /// - Returns: A publisher that emits an `AuthDataResult` when the association flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    /// - Remark: Possible error codes:
+    ///   - `FIRAuthErrorCodeProviderAlreadyLinked` - Indicates an attempt to link a provider of a type
+    ///     already linked to this account.
+    ///   - `FIRAuthErrorCodeCredentialAlreadyInUse` - Indicates an attempt to link with a credential
+    ///     that has already been linked with a different Firebase account.
+    ///   - `FIRAuthErrorCodeOperationNotAllowed` - Indicates that accounts with the identity provider
+    ///     represented by the credential are not enabled. Enable them in the Auth section of the Firebase console.
+    ///
+    ///   See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
+    public func link(with credential: AuthCredential) -> Future<AuthDataResult, Error> {
+        Future<AuthDataResult, Error> { promise in
+            self.link(with: credential) { authDataResult, error in
+                if let error = error {
+                    promise(.failure(error))
+                } else if let authDataResult = authDataResult {
+                    promise(.success(authDataResult))
+                }
+            }
+        }
+    }
+}
+#endif

--- a/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
@@ -220,6 +220,7 @@ class UserTests: XCTestCase {
         }
       } receiveValue: { linkAuthResult in
         let user = linkAuthResult.user
+        // Verify that the current user and reauthenticated user are same pointers.
         XCTAssertEqual(Auth.auth().currentUser, user)
         XCTAssertEqual(linkAuthResult.additionalUserInfo?.profile,
                        UserTests.googleProfile as [String: NSString])
@@ -236,7 +237,7 @@ class UserTests: XCTestCase {
     wait(for: [userSignInExpectation], timeout: expectationTimeout)
   }
 
-  func testlinkAndRetrieveDataError() {
+  func testLinkAndRetrieveDataError() {
     let facebookCredentials = ProviderCredentials(
       providerID: FacebookAuthProviderID,
       federatedID: "FACEBOOK_ID",
@@ -310,7 +311,7 @@ class UserTests: XCTestCase {
     wait(for: [userSignInExpectation], timeout: expectationTimeout)
   }
 
-  func testlinkAndRetrieveDataProviderAlreadyLinked() {
+  func testLinkAndRetrieveDataProviderAlreadyLinked() {
     let facebookCredentials = ProviderCredentials(
       providerID: FacebookAuthProviderID,
       federatedID: "FACEBOOK_ID",
@@ -370,7 +371,7 @@ class UserTests: XCTestCase {
     wait(for: [userSignInExpectation], timeout: expectationTimeout)
   }
 
-  func testlinkAndRetrieveDataErrorAutoSignOut() {
+  func testLinkAndRetrieveDataErrorAutoSignOut() {
     let facebookCredentials = ProviderCredentials(
       providerID: FacebookAuthProviderID,
       federatedID: "FACEBOOK_ID",

--- a/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
@@ -1,0 +1,421 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Combine
+import XCTest
+import FirebaseAuth
+
+class UserTests: XCTestCase {
+  override class func setUp() {
+    FirebaseApp.configureForTests()
+  }
+
+  override class func tearDown() {
+    FirebaseApp.app()?.delete { success in
+      if success {
+        print("Shut down app successfully.")
+      } else {
+        print("💥 There was a problem when shutting down the app..")
+      }
+    }
+  }
+    
+    override func setUp() {
+      do {
+        try Auth.auth().signOut()
+      } catch {}
+    }
+    
+    fileprivate struct ProviderCredentials {
+        var providerID: String
+        var federatedID: String
+        var displayName: String
+        var providerIDToken: String?
+        var providerAccessToken: String
+        var email: String
+    }
+    fileprivate static let passwordHash = "UkVEQUNURUQ="
+    fileprivate static let accessTokenTimeToLive: TimeInterval = 60 * 60
+    fileprivate static let refreshToken = "REFRESH_TOKEN"
+    fileprivate static let accessToken = "ACCESS_TOKEN"
+    fileprivate static let email = "user@company.com"
+    fileprivate static let password = "!@#$%^"
+    fileprivate static let userName = "User Doe"
+    fileprivate static let localID = "localId"
+    fileprivate static let googleEmail = "user@gmail.com"
+    fileprivate static let googleProfile: [String: String] = {
+      [
+        "iss": "https://accounts.google.com\\",
+        "email": googleEmail,
+        "given_name": "User",
+        "family_name": "Doe",
+      ]
+    }()
+    
+    class MockGetAccountInfoResponse: FIRGetAccountInfoResponse {
+        fileprivate var providerCredentials: ProviderCredentials!
+        
+      override var users: [FIRGetAccountInfoResponseUser] {
+        let response = MockGetAccountInfoResponseUser(dictionary: [:])
+        response.providerCredentials = providerCredentials
+        return [response]
+      }
+    }
+    
+    class MockGetAccountInfoResponseUser: FIRGetAccountInfoResponseUser {
+        fileprivate var providerCredentials: ProviderCredentials!
+        
+        override var localID: String { UserTests.localID }
+        override var email: String { providerCredentials.email }
+        override var displayName: String { providerCredentials.displayName }
+        override var passwordHash: String? { UserTests.passwordHash }
+        override var providerUserInfo: [FIRGetAccountInfoResponseProviderUserInfo]? {
+            let response = MockGetAccountInfoResponseProviderUserInfo(dictionary: [:])
+            response.providerCredentials = providerCredentials
+            return [response]
+        }
+    }
+    
+    class MockVerifyAssertionResponse: FIRVerifyAssertionResponse {
+        fileprivate var providerCredentials: ProviderCredentials!
+        
+        override var localID: String? { UserTests.localID }
+        override var federatedID: String? { providerCredentials.federatedID }
+        override var providerID: String? { providerCredentials.providerID }
+        override var displayName: String? { providerCredentials.displayName }
+        override var profile: [String : NSObject]? { googleProfile as [String: NSString] }
+        override var username: String? { userName }
+        override var idToken: String? { accessToken }
+        override var refreshToken: String? { UserTests.refreshToken }
+        override var approximateExpirationDate: Date? {
+            Date(timeIntervalSinceNow: accessTokenTimeToLive)
+        }
+    }
+    
+    class MockVerifyPasswordResponse: FIRVerifyPasswordResponse {
+      override var refreshToken: String { UserTests.refreshToken }
+      override var email: String { UserTests.email }
+      override var idToken: String { UserTests.accessToken }
+      override var approximateExpirationDate: Date {
+        Date(timeIntervalSinceNow: UserTests.accessTokenTimeToLive)
+      }
+    }
+    
+    class MockGetAccountInfoResponseProviderUserInfo: FIRGetAccountInfoResponseProviderUserInfo {
+        fileprivate var providerCredentials: ProviderCredentials!
+        
+        override var providerID: String? { providerCredentials.providerID }
+        override var displayName: String? { providerCredentials.displayName }
+        override var federatedID: String? { providerCredentials.federatedID }
+        override var email: String? { googleEmail }
+    }
+    
+    class MockAuthBackend: AuthBackendImplementationMock {
+        fileprivate var providerCredentials: ProviderCredentials!
+        
+        var verifyAssertionCallback: Result<MockVerifyAssertionResponse, Error> =
+          .success(MockVerifyAssertionResponse())
+        override func verifyAssertion(_ request: FIRVerifyAssertionRequest, callback: @escaping FIRVerifyAssertionResponseCallback) {
+            XCTAssertEqual(request.apiKey, Credentials.apiKey)
+            XCTAssertEqual(request.providerID, providerCredentials.providerID)
+            XCTAssertEqual(request.providerIDToken, providerCredentials.providerIDToken)
+            XCTAssertEqual(request.providerAccessToken, providerCredentials.providerAccessToken)
+            XCTAssertTrue(request.returnSecureToken)
+
+            switch verifyAssertionCallback {
+            case let .success(response):
+                response.providerCredentials = providerCredentials
+              callback(response, nil)
+            case let .failure(error):
+              callback(nil, error)
+            }
+        }
+        
+        override func verifyPassword(_ request: FIRVerifyPasswordRequest, callback: @escaping FIRVerifyPasswordResponseCallback) {
+            let response = MockVerifyPasswordResponse()
+            callback(response, nil)
+        }
+        
+        override func getAccountInfo(_ request: FIRGetAccountInfoRequest,
+                                     callback: @escaping FIRGetAccountInfoResponseCallback) {
+          XCTAssertEqual(request.apiKey, Credentials.apiKey)
+          XCTAssertEqual(request.accessToken, accessToken)
+            
+          let response = MockGetAccountInfoResponse()
+            response.providerCredentials = providerCredentials
+          callback(response, nil)
+        }
+    }
+
+    func testlinkAndRetrieveDataSuccess() {
+        let facebookCredentials = ProviderCredentials(
+            providerID: FacebookAuthProviderID,
+            federatedID: "FACEBOOK_ID",
+            displayName: "Facebook Doe",
+            providerIDToken: nil,
+            providerAccessToken: "FACEBOOK_ACCESS_TOKEN",
+            email: UserTests.email
+        )
+        
+        let authBackend = MockAuthBackend()
+        authBackend.providerCredentials = facebookCredentials
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User associated from a third-party")
+
+        let facebookCredential = FacebookAuthProvider.credential(withAccessToken: facebookCredentials.providerAccessToken)
+
+        // when
+        Auth.auth()
+            .signIn(with: facebookCredential)
+            .flatMap({ [weak authBackend] (authResult) -> Future<AuthDataResult, Error> in
+                XCTAssertEqual(authResult.additionalUserInfo?.profile,
+                               UserTests.googleProfile as [String: NSString])
+                XCTAssertEqual(authResult.additionalUserInfo?.username,
+                               UserTests.userName)
+                XCTAssertEqual(authResult.additionalUserInfo?.providerID,
+                               FacebookAuthProviderID)
+                
+                let googleCredentials = ProviderCredentials(
+                    providerID: GoogleAuthProviderID,
+                    federatedID: "GOOGLE_ID",
+                    displayName: "Google Doe",
+                    providerIDToken: "GOOGLE_ID_TOKEN",
+                    providerAccessToken: "GOOGLE_ACCESS_TOKEN",
+                    email: UserTests.googleEmail
+                )
+                
+                authBackend?.providerCredentials = googleCredentials
+                
+                let linkGoogleCredential = GoogleAuthProvider.credential(
+                    withIDToken: googleCredentials.providerIDToken!,
+                    accessToken: googleCredentials.providerAccessToken
+                )
+                return authResult.user
+                    .link(with: linkGoogleCredential)
+            })
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { linkAuthResult in
+                let user = linkAuthResult.user
+                XCTAssertEqual(Auth.auth().currentUser, user)
+                XCTAssertEqual(linkAuthResult.additionalUserInfo?.profile,
+                               UserTests.googleProfile as [String: NSString])
+                XCTAssertEqual(linkAuthResult.additionalUserInfo?.username,
+                               UserTests.userName)
+                XCTAssertEqual(linkAuthResult.additionalUserInfo?.providerID,
+                               GoogleAuthProviderID)
+
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+
+
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testlinkAndRetrieveDataError() {
+        let facebookCredentials = ProviderCredentials(
+            providerID: FacebookAuthProviderID,
+            federatedID: "FACEBOOK_ID",
+            displayName: "Facebook Doe",
+            providerIDToken: nil,
+            providerAccessToken: "FACEBOOK_ACCESS_TOKEN",
+            email: UserTests.email
+        )
+        
+        let authBackend = MockAuthBackend()
+        authBackend.providerCredentials = facebookCredentials
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User associated from a third-party")
+
+        let facebookCredential = FacebookAuthProvider.credential(withAccessToken: facebookCredentials.providerAccessToken)
+
+        // when
+        Auth.auth()
+            .signIn(with: facebookCredential)
+            .flatMap({ [weak authBackend] (authResult) -> Future<AuthDataResult, Error> in
+                XCTAssertEqual(authResult.additionalUserInfo?.profile,
+                               UserTests.googleProfile as [String: NSString])
+                XCTAssertEqual(authResult.additionalUserInfo?.username,
+                               UserTests.userName)
+                XCTAssertEqual(authResult.additionalUserInfo?.providerID,
+                               FacebookAuthProviderID)
+                XCTAssertEqual(Auth.auth().currentUser, authResult.user)
+                
+                let googleCredentials = ProviderCredentials(
+                    providerID: GoogleAuthProviderID,
+                    federatedID: "GOOGLE_ID",
+                    displayName: "Google Doe",
+                    providerIDToken: "GOOGLE_ID_TOKEN",
+                    providerAccessToken: "GOOGLE_ACCESS_TOKEN",
+                    email: UserTests.googleEmail
+                )
+                
+                authBackend?.providerCredentials = googleCredentials
+                authBackend?.verifyAssertionCallback = .failure(FIRAuthErrorUtils.accountExistsWithDifferentCredentialError(withEmail: UserTests.userName, updatedCredential: nil))
+                
+                let linkGoogleCredential = GoogleAuthProvider.credential(
+                    withIDToken: googleCredentials.providerIDToken!,
+                    accessToken: googleCredentials.providerAccessToken
+                )
+                return authResult.user
+                    .link(with: linkGoogleCredential)
+            })
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                  XCTAssertEqual(error.code, AuthErrorCode.accountExistsWithDifferentCredential.rawValue)
+                    
+                  userSignInExpectation.fulfill()
+                }
+            } receiveValue: { linkAuthResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+
+
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testlinkAndRetrieveDataProviderAlreadyLinked() {
+        let facebookCredentials = ProviderCredentials(
+            providerID: FacebookAuthProviderID,
+            federatedID: "FACEBOOK_ID",
+            displayName: "Facebook Doe",
+            providerIDToken: nil,
+            providerAccessToken: "FACEBOOK_ACCESS_TOKEN",
+            email: UserTests.email
+        )
+        
+        let authBackend = MockAuthBackend()
+        authBackend.providerCredentials = facebookCredentials
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User associated from a third-party")
+
+        let facebookCredential = FacebookAuthProvider.credential(withAccessToken: facebookCredentials.providerAccessToken)
+
+        // when
+        Auth.auth()
+            .signIn(with: facebookCredential)
+            .flatMap({ [weak authBackend] (authResult) -> Future<AuthDataResult, Error> in
+                XCTAssertEqual(authResult.additionalUserInfo?.profile,
+                               UserTests.googleProfile as [String: NSString])
+                XCTAssertEqual(authResult.additionalUserInfo?.username,
+                               UserTests.userName)
+                XCTAssertEqual(authResult.additionalUserInfo?.providerID,
+                               FacebookAuthProviderID)
+                XCTAssertEqual(Auth.auth().currentUser, authResult.user)
+                
+                authBackend?.providerCredentials = facebookCredentials
+                authBackend?.verifyAssertionCallback = .failure(FIRAuthErrorUtils.accountExistsWithDifferentCredentialError(withEmail: UserTests.userName, updatedCredential: nil))
+                
+                let linkFacebookCredential = FacebookAuthProvider.credential(withAccessToken: facebookCredentials.providerAccessToken)
+                return authResult.user
+                    .link(with: linkFacebookCredential)
+            })
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                  XCTAssertEqual(error.code, AuthErrorCode.providerAlreadyLinked.rawValue)
+                    
+                  userSignInExpectation.fulfill()
+                }
+            } receiveValue: { linkAuthResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testlinkAndRetrieveDataErrorAutoSignOut() {
+        let facebookCredentials = ProviderCredentials(
+            providerID: FacebookAuthProviderID,
+            federatedID: "FACEBOOK_ID",
+            displayName: "Facebook Doe",
+            providerIDToken: nil,
+            providerAccessToken: "FACEBOOK_ACCESS_TOKEN",
+            email: UserTests.email
+        )
+        
+        let authBackend = MockAuthBackend()
+        authBackend.providerCredentials = facebookCredentials
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User associated from a third-party")
+
+        let facebookCredential = FacebookAuthProvider.credential(withAccessToken: facebookCredentials.providerAccessToken)
+
+        // when
+        Auth.auth()
+            .signIn(with: facebookCredential)
+            .flatMap({ [weak authBackend] (authResult) -> Future<AuthDataResult, Error> in
+                XCTAssertEqual(authResult.additionalUserInfo?.profile,
+                               UserTests.googleProfile as [String: NSString])
+                XCTAssertEqual(authResult.additionalUserInfo?.username,
+                               UserTests.userName)
+                XCTAssertEqual(authResult.additionalUserInfo?.providerID,
+                               FacebookAuthProviderID)
+                XCTAssertEqual(Auth.auth().currentUser, authResult.user)
+                
+                let googleCredentials = ProviderCredentials(
+                    providerID: GoogleAuthProviderID,
+                    federatedID: "GOOGLE_ID",
+                    displayName: "Google Doe",
+                    providerIDToken: "GOOGLE_ID_TOKEN",
+                    providerAccessToken: "GOOGLE_ACCESS_TOKEN",
+                    email: UserTests.googleEmail
+                )
+                
+                authBackend?.providerCredentials = googleCredentials
+                authBackend?.verifyAssertionCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
+                
+                let linkGoogleCredential = GoogleAuthProvider.credential(
+                    withIDToken: googleCredentials.providerIDToken!,
+                    accessToken: googleCredentials.providerAccessToken
+                )
+                return authResult.user
+                    .link(with: linkGoogleCredential)
+            })
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                  XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
+                    
+                  userSignInExpectation.fulfill()
+                }
+            } receiveValue: { linkAuthResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+}

--- a/FirebaseCombineSwift/Tests/Unit/Credentials.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Credentials.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-class Credentials {
+enum Credentials {
   static let googleAppID = "1:1085102361755:ios:f790a919483d5bdf"
   static let gcmSenderID = "217397612173"
   static let apiKey = "FAKE_API_KEY"


### PR DESCRIPTION
Associates a user account from a third-party identity provider with this user.

```swift
Auth().currentUser
  .link(withCredential: credential)
  .sink { completion in
        // Handle completion
      } receiveValue: { authResult in
       // Handle AuthDataResult 
      }
  .store(in: &cancellables)
```