### PR TITLE
Adding "utmParametersDictionary" api to FIRDynamicLink

### DIFF
--- a/FIRDynamicLinkTest.m
+++ b/FIRDynamicLinkTest.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FIRDynamicLinkTest.m
+++ b/FIRDynamicLinkTest.m
@@ -1,0 +1,69 @@
+//
+//  FIRDynamicLinkTest.m
+//  FirebaseDynamicLinks-Unit-unit
+//
+//  Created by Eldhose Mathokkil Babu on 2/9/21.
+//
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h"
+
+@interface FIRDynamicLinkTest : XCTestCase {
+}
+@end
+
+@implementation FIRDynamicLinkTest
+
+NSMutableDictionary<NSString *, NSString *> *fdlParameters = nil;
+NSDictionary<NSString *, NSString *> *linkParameters = nil;
+NSDictionary<NSString *, NSString *> *utmParameters = nil;
+
+- (void)setUp {
+  [super setUp];
+
+  linkParameters = @{
+    @"deep_link_id" : @"https://mmaksym.com/test-app1",
+    @"match_message" : @"Link is uniquely matched for this device.",
+    @"match_type" : @"unique",
+    @"a_parameter" : @"a_value"
+  };
+  utmParameters = @{
+    @"utm_campaign" : @"eldhosembabu Test",
+    @"utm_medium" : @"test_medium",
+    @"utm_source" : @"test_source",
+  };
+
+  fdlParameters = [[NSMutableDictionary alloc] initWithDictionary:linkParameters];
+  [fdlParameters addEntriesFromDictionary:utmParameters];
+}
+
+- (void)testDynamicLinkParameters_InitWithParameters {
+  FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:fdlParameters];
+  XCTAssertEqual([fdlParameters count], [[dynamicLink parametersDictionary] count]);
+  for (id key in fdlParameters) {
+    NSString *expectedValue = [fdlParameters valueForKey:key];
+    NSString *derivedValue = [[dynamicLink parametersDictionary] valueForKey:key];
+    XCTAssertNotNil(derivedValue, @"Cannot be null!");
+    XCTAssertEqualObjects(derivedValue, expectedValue);
+  }
+}
+
+- (void)testDynamicLinkUtmParameters_InitWithParameters {
+  FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:fdlParameters];
+  XCTAssertEqual([[dynamicLink utmParametersDictionary] count], [utmParameters count]);
+  for (id key in utmParameters) {
+    NSString *expectedValue = [utmParameters valueForKey:key];
+    NSString *derivedValue = [[dynamicLink utmParametersDictionary] valueForKey:key];
+    XCTAssertNotNil(derivedValue, @"Cannot be null!");
+    XCTAssertEqualObjects(derivedValue, expectedValue);
+  }
+}
+
+- (void)testDynamicLinkParameters_InitWithNoUtmParameters {
+  FIRDynamicLink *dynamicLink =
+      [[FIRDynamicLink alloc] initWithParametersDictionary:linkParameters];
+  XCTAssertEqual([[dynamicLink parametersDictionary] count], [linkParameters count]);
+  XCTAssertEqual([[dynamicLink utmParametersDictionary] count], 0);
+}
+
+@end

--- a/FIRDynamicLinkTest.m
+++ b/FIRDynamicLinkTest.m
@@ -1,9 +1,19 @@
-//
-//  FIRDynamicLinkTest.m
-//  FirebaseDynamicLinks-Unit-unit
-//
-//  Created by Eldhose Mathokkil Babu on 2/9/21.
-//
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 #import "FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h"

--- a/FIRDynamicLinkTest.m
+++ b/FIRDynamicLinkTest.m
@@ -50,7 +50,7 @@ NSDictionary<NSString *, NSString *> *utmParameters = nil;
 - (void)testDynamicLinkParameters_InitWithParameters {
   FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:fdlParameters];
   XCTAssertEqual([fdlParameters count], [[dynamicLink parametersDictionary] count]);
-  for (id key in fdlParameters) {
+  for (NSString *key in fdlParameters) {
     NSString *expectedValue = [fdlParameters valueForKey:key];
     NSString *derivedValue = [[dynamicLink parametersDictionary] valueForKey:key];
     XCTAssertNotNil(derivedValue, @"Cannot be null!");
@@ -61,7 +61,7 @@ NSDictionary<NSString *, NSString *> *utmParameters = nil;
 - (void)testDynamicLinkUtmParameters_InitWithParameters {
   FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:fdlParameters];
   XCTAssertEqual([[dynamicLink utmParametersDictionary] count], [utmParameters count]);
-  for (id key in utmParameters) {
+  for (NSString *key in utmParameters) {
     NSString *expectedValue = [utmParameters valueForKey:key];
     NSString *derivedValue = [[dynamicLink utmParametersDictionary] valueForKey:key];
     XCTAssertNotNil(derivedValue, @"Cannot be null!");

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v7.7.0
-- [added] Adding "utmParametersDictionary" api to FIRDynamicLink. (#6730)
+- [added] Added `utmParametersDictionary` property to `DynamicLink`. (#6730)
 
 # v7.6.0
 - [fixed] Fixed build warnings introduced with Xcode 12.5. (#7434)

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
-# v7.6.1
-- [added] Adding "utmParametersDictionary" api to FIRDynamicLink. (#7505)
+# v7.7.0
+- [added] Adding "utmParametersDictionary" api to FIRDynamicLink. (#6730)
 
 # v7.6.0
 - [fixed] Fixed build warnings introduced with Xcode 12.5. (#7434)

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v7.6.1
+- [added] Adding "utmParametersDictionary" api to FIRDynamicLink. (#7505)
+
 # v7.6.0
 - [fixed] Fixed build warnings introduced with Xcode 12.5. (#7434)
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLink.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLink.m
@@ -23,6 +23,8 @@
 
 @implementation FIRDynamicLink
 
+NSString *const UTM_PARAM_PREFIX = @"utm_";
+
 - (NSString *)description {
   return [NSString stringWithFormat:@"<%@: %p, url [%@], match type: %@, minimumAppVersion: %@, "
                                      "match message: %@>",
@@ -36,7 +38,7 @@
 
   if (self = [super init]) {
     _parametersDictionary = [parameters copy];
-
+    _utmParametersDictionary = [[self class] extractUtmParams:parameters];
     NSString *urlString = parameters[kFIRDLParameterDeepLinkIdentifier];
     _url = [NSURL URLWithString:urlString];
     _inviteId = parameters[kFIRDLParameterInviteId];
@@ -132,6 +134,20 @@
     };
   });
   return [matchMap[string] integerValue] ?: FIRDLMatchTypeNone;
+}
+
++ (NSDictionary<NSString *, id> *)extractUtmParams:(NSDictionary<NSString *, id> *)parameters {
+  NSMutableDictionary<NSString *, id> *utmParamsDictionary = [[NSMutableDictionary alloc] init];
+
+  if (parameters) {
+    for (id key in parameters) {
+      if ([key hasPrefix:UTM_PARAM_PREFIX]) {
+        [utmParamsDictionary setObject:[parameters valueForKey:key] forKey:key];
+      }
+    }
+  }
+
+  return utmParamsDictionary;
 }
 
 @end

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLink.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLink.m
@@ -23,7 +23,7 @@
 
 @implementation FIRDynamicLink
 
-NSString *const UTM_PARAM_PREFIX = @"utm_";
+NSString *const FDLUTMParamPrefix = @"utm_";
 
 - (NSString *)description {
   return [NSString stringWithFormat:@"<%@: %p, url [%@], match type: %@, minimumAppVersion: %@, "
@@ -38,7 +38,7 @@ NSString *const UTM_PARAM_PREFIX = @"utm_";
 
   if (self = [super init]) {
     _parametersDictionary = [parameters copy];
-    _utmParametersDictionary = [[self class] extractUtmParams:parameters];
+    _utmParametersDictionary = [[self class] extractUTMParams:parameters];
     NSString *urlString = parameters[kFIRDLParameterDeepLinkIdentifier];
     _url = [NSURL URLWithString:urlString];
     _inviteId = parameters[kFIRDLParameterInviteId];
@@ -136,18 +136,16 @@ NSString *const UTM_PARAM_PREFIX = @"utm_";
   return [matchMap[string] integerValue] ?: FIRDLMatchTypeNone;
 }
 
-+ (NSDictionary<NSString *, id> *)extractUtmParams:(NSDictionary<NSString *, id> *)parameters {
++ (NSDictionary<NSString *, id> *)extractUTMParams:(NSDictionary<NSString *, id> *)parameters {
   NSMutableDictionary<NSString *, id> *utmParamsDictionary = [[NSMutableDictionary alloc] init];
 
-  if (parameters) {
-    for (id key in parameters) {
-      if ([key hasPrefix:UTM_PARAM_PREFIX]) {
-        [utmParamsDictionary setObject:[parameters valueForKey:key] forKey:key];
-      }
+  for (NSString *key in parameters) {
+    if ([key hasPrefix:FDLUTMParamPrefix]) {
+      [utmParamsDictionary setObject:[parameters valueForKey:key] forKey:key];
     }
   }
 
-  return utmParamsDictionary;
+  return [[NSDictionary alloc] initWithDictionary:utmParamsDictionary];
 }
 
 @end

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -68,8 +68,8 @@ NS_SWIFT_NAME(DynamicLink)
 @property(nonatomic, assign, readonly) FIRDLMatchType matchType;
 
 /**
- * @property matchType
- * @abstract The match type of the received Dynamic Link.
+ * @property utmParametersDictionary
+ * @abstract UTM parameters associated with a firebase dynamic link.
  */
 @property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *utmParametersDictionary;
 

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(DynamicLink)
 
 /**
  * @property utmParametersDictionary
- * @abstract UTM parameters associated with a firebase dynamic link.
+ * @abstract UTM parameters associated with a Firebase Dynamic Link.
  */
 @property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *utmParametersDictionary;
 

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -68,6 +68,12 @@ NS_SWIFT_NAME(DynamicLink)
 @property(nonatomic, assign, readonly) FIRDLMatchType matchType;
 
 /**
+ * @property matchType
+ * @abstract The match type of the received Dynamic Link.
+ */
+@property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *utmParametersDictionary;
+
+/**
  * @property minimumAppVersion
  * @abstract The minimum iOS application version that supports the Dynamic Link. This is retrieved
  *     from the imv= parameter of the Dynamic Link URL. Note: This is not the minimum iOS system

--- a/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/AppDelegate.m
+++ b/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/AppDelegate.m
@@ -84,10 +84,12 @@
 
   UIAlertController *alertVC = [UIAlertController
       alertControllerWithTitle:@"Got Dynamic Link!"
-                       message:[NSString stringWithFormat:
-                                             @"URL [%@], matchType [%ld], minimumAppVersion [%@]",
-                                             dynamicLink.url, (unsigned long)dynamicLink.matchType,
-                                             dynamicLink.minimumAppVersion]
+                       message:[NSString stringWithFormat:@"URL [%@], matchType [%ld], "
+                                                          @"minimumAppVersion [%@], utmParams [%@]",
+                                                          dynamicLink.url,
+                                                          (unsigned long)dynamicLink.matchType,
+                                                          dynamicLink.minimumAppVersion,
+                                                          dynamicLink.utmParametersDictionary]
                 preferredStyle:UIAlertControllerStyleAlert];
   [alertVC addAction:[UIAlertAction actionWithTitle:@"Dismiss"
                                               style:UIAlertActionStyleCancel

--- a/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
+++ b/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
@@ -92,10 +92,12 @@
 
   UIAlertController *alertVC = [UIAlertController
       alertControllerWithTitle:@"Got Dynamic Link!"
-                       message:[NSString stringWithFormat:
-                                             @"URL [%@], matchType [%ld], minimumAppVersion [%@]",
-                                             dynamicLink.url, (unsigned long)dynamicLink.matchType,
-                                             dynamicLink.minimumAppVersion]
+                       message:[NSString stringWithFormat:@"URL [%@], matchType [%ld], "
+                                                          @"minimumAppVersion [%@], utmParams [%@]",
+                                                          dynamicLink.url,
+                                                          (unsigned long)dynamicLink.matchType,
+                                                          dynamicLink.minimumAppVersion,
+                                                          dynamicLink.utmParametersDictionary]
                 preferredStyle:UIAlertControllerStyleAlert];
   [alertVC addAction:[UIAlertAction actionWithTitle:@"Dismiss"
                                               style:UIAlertActionStyleCancel


### PR DESCRIPTION
Adding "utmParametersDictionary" api to FIRDynamicLink.

This new property will enable 3p developers to fetch the Utm parameters associated with a Firebase Dynamic Link.

Related Issue: https://github.com/firebase/firebase-ios-sdk/issues/6730

API Review Doc : https://docs.google.com/document/d/1NDBjiuCQEs3vnaPGfYKK2cdvJMIsJqukRtrZf8wsWCk (Approved)