### PR TITLE
Output log error when RCNConfigFetch is already deallocated

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -134,6 +134,7 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
   dispatch_async(_lockQueue, ^{
     RCNConfigFetch *strongSelf = weakSelf;
     if (strongSelf == nil) {
+      FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076", @"RCNConfigFetch is already deallocated");
       return;
     }
 
@@ -224,6 +225,7 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
       FIRInstallationsAuthTokenResult *tokenResult, NSError *error) {
     RCNConfigFetch *strongSelf = weakSelf;
     if (strongSelf == nil) {
+      FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076", @"RCNConfigFetch is already deallocated");
       return;
     }
 
@@ -248,6 +250,8 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
                                                   NSError *_Nullable error) {
       RCNConfigFetch *strongSelf = weakSelf;
       if (strongSelf == nil) {
+        FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076",
+                    @"RCNConfigFetch is already deallocated");
         return;
       }
 
@@ -255,6 +259,8 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
       dispatch_async(strongSelf->_lockQueue, ^{
         RCNConfigFetch *strongSelfQueue = weakSelf;
         if (strongSelfQueue == nil) {
+          FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076",
+                      @"RCNConfigFetch is already deallocated");
           return;
         }
 
@@ -353,6 +359,7 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
 
     RCNConfigFetch *fetcherCompletionSelf = weakSelf;
     if (fetcherCompletionSelf == nil) {
+      FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076", @"RCNConfigFetch is already deallocated");
       return;
     }
 
@@ -362,6 +369,8 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
     dispatch_async(fetcherCompletionSelf->_lockQueue, ^{
       RCNConfigFetch *strongSelf = weakSelf;
       if (strongSelf == nil) {
+        FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000076",
+                    @"RCNConfigFetch is already deallocated");
         return;
       }
 


### PR DESCRIPTION
### Discussion
- If access `remoteConfig` while running` remoteConfig.fetch(withExpirationDuration:)` `completionHandler` might not be called because `RCNConfigFetch.dealloc` is called.
- It happens about once every five times when the app is launched for the first time.
- Changed to output LogError to judge whether it was deallocated

### Referrence
fetch(withExpirationDuration:): https://github.com/firebase/firebase-ios-sdk/blob/95cf1d3508ab2bfd412917722068ac10fe3979ae/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m#L229-L237
RCNConfigFetch.dealloc: https://github.com/firebase/firebase-ios-sdk/blob/95cf1d3508ab2bfd412917722068ac10fe3979ae/FirebaseRemoteConfig/Sources/RCNConfigFetch.m#L121-L123
