### PR TITLE
Remove Carthage Protobuf special casing

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -31,10 +31,6 @@ more details and additional installation methods.
 Firebase components that you want to include in your app. Note that
 **FirebaseAnalyticsBinary** must always be included.
 
-- Starting with the 6.23.0 release, if you're using FirebaseMessaging,
-FirebasePerformance, FirebaserRemoteConfig,
-FirebaseABTesting, FirebaseInAppMessaging, or FirebaseML,
-**FirebaseProtobufBinary** must also be included.
 ```
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json"
@@ -50,7 +46,6 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinar
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json"
 ```
@@ -91,8 +86,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
 
 ## Versioning
 
-Unlike the CocoaPods distribution, the Carthage distribution is like the
-Firebase zip release in that all the Firebase components share the same version.
+All Firebase components share the same version.
 Mixing and matching components with different versions may cause linker errors.
 
 ## Static Frameworks

--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -92,7 +92,6 @@ extension CarthageUtils {
                                               artifacts: ZipBuilder.ReleaseArtifacts,
                                               outputDir: URL,
                                               versionCheckEnabled: Bool) {
-    factorProtobuf(inPackagedDir: packagedDir)
     let directories: [String]
     do {
       directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
@@ -209,44 +208,6 @@ extension CarthageUtils {
         print("Successfully written Carthage JSON manifest for \(product).")
       } catch {
         fatalError("Could not write new Carthage JSON manifest to disk for \(product). \(error)")
-      }
-    }
-  }
-
-  /// Factor Protobuf into a separate Carthage distribution to avoid Carthage install issues
-  /// trying to install the same framework from multiple bundles(#5276).
-  ///
-  /// - Parameters:
-  ///   - packagedDir: The packaged directory assembled for Carthage and Zip distribution.
-
-  private static func factorProtobuf(inPackagedDir packagedDir: URL) {
-    let directories: [String]
-    let protobufDir = packagedDir.appendingPathComponent("FirebaseProtobuf")
-    do {
-      directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
-    } catch {
-      fatalError("Could not get contents of Firebase directory to package Carthage build. \(error)")
-    }
-    let fileManager = FileManager.default
-    var didMove = false
-    // Loop through each directory to see if it includes Protobuf.framework.
-    for package in directories {
-      let fullPath = packagedDir.appendingPathComponent(package)
-        .appendingPathComponent("Protobuf.framework")
-      if fileManager.fileExists(atPath: fullPath.path) {
-        if didMove == false {
-          didMove = true
-          do {
-            try fileManager.createDirectory(at: protobufDir, withIntermediateDirectories: true)
-            try fileManager
-              .moveItem(at: fullPath, to: protobufDir.appendingPathComponent("Protobuf.framework"))
-          } catch {
-            fatalError("Failed to create Carthage protobuf directory at \(protobufDir) \(error)")
-          }
-
-        } else {
-          fileManager.removeIfExists(at: fullPath)
-        }
       }
     }
   }


### PR DESCRIPTION
Carthage Protobuf special casing is no longer needed now that only one Firebase library depends upon it (Performance).

Also update the version info in the Carthage docs.