### PR TITLE
ML model downloader fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ FirebaseSegmentation/Tests/Sample/GoogleService-Info.plist
 
 # FirebaseMLModelDownloader integration tests GoogleService-Info.plist
 FirebaseMLModelDownloader/Tests/Integration/Resources/GoogleService-Info.plist
-FirebaseMLModelDownloader/Apps/Sample/Resources/GoogleService-Info.plist
+FirebaseMLModelDownloader/Apps/Sample/**/GoogleService-Info.plist
 
 # FirebasePerformance dev test App and integration tests GoogleService-Info.plist
 FirebasePerformance/**/GoogleService-Info.plist

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -242,7 +242,7 @@ public class ModelDownloader {
           appName: appName,
           modelName: modelName
         ),
-          url == modelURL, ModelFileManager.isFileReachable(at: modelURL) else {
+          ModelFileManager.isFileReachable(at: modelURL) else {
           DeviceLogger.logEvent(level: .debug,
                                 message: ModelDownloader.ErrorDescription.outdatedModelPath,
                                 messageCode: .outdatedModelPathError)

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -132,6 +132,11 @@ public class ModelDownloader {
                        conditions: ModelDownloadConditions,
                        progressHandler: ((Float) -> Void)? = nil,
                        completion: @escaping (Result<CustomModel, DownloadError>) -> Void) {
+    guard !modelName.isEmpty else {
+      asyncOnMainQueue(completion(.failure(.emptyModelName)))
+      return
+    }
+
     switch downloadType {
     case .localModel:
       if let localModel = getLocalModel(modelName: modelName) {
@@ -530,6 +535,8 @@ public enum DownloadError: Error, Equatable {
   case notEnoughSpace
   /// Malformed model name or Firebase app options.
   case invalidArgument
+  /// Model name is empty.
+  case emptyModelName
   /// Other errors with description.
   case internalError(description: String)
 }

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -56,10 +56,10 @@ public class ModelDownloader {
   /// DispatchQueue to manage download task dictionary.
   let taskSerialQueue = DispatchQueue(label: "downloadtask.serial.queue")
 
-  /// Handler that always runs on the main thread
-  let mainQueueHandler = { handler in
+  /// Re-dispatch a function on the main queue.
+  func asyncOnMainQueue(_ work: @autoclosure @escaping () -> Void ) {
     DispatchQueue.main.async {
-      handler
+      work()
     }
   }
 
@@ -138,7 +138,7 @@ public class ModelDownloader {
         DeviceLogger.logEvent(level: .debug,
                               message: ModelDownloader.DebugDescription.localModelFound,
                               messageCode: .localModelFound)
-        mainQueueHandler(completion(.success(localModel)))
+        asyncOnMainQueue(completion(.success(localModel)))
       } else {
         getRemoteModel(
           modelName: modelName,
@@ -153,7 +153,7 @@ public class ModelDownloader {
         DeviceLogger.logEvent(level: .debug,
                               message: ModelDownloader.DebugDescription.localModelFound,
                               messageCode: .localModelFound)
-        mainQueueHandler(completion(.success(localModel)))
+        asyncOnMainQueue(completion(.success(localModel)))
         telemetryLogger?.logModelDownloadEvent(
           eventName: .modelDownload,
           status: .scheduled,
@@ -225,7 +225,7 @@ public class ModelDownloader {
           DeviceLogger.logEvent(level: .debug,
                                 message: description,
                                 messageCode: .modelNameParseError)
-          mainQueueHandler(completion(.failure(.internalError(description: description))))
+          asyncOnMainQueue(completion(.failure(.internalError(description: description))))
           return
         }
         // Check if model information corresponding to model is stored in UserDefaults.
@@ -234,7 +234,7 @@ public class ModelDownloader {
           DeviceLogger.logEvent(level: .debug,
                                 message: description,
                                 messageCode: .noLocalModelInfo)
-          mainQueueHandler(completion(.failure(.internalError(description: description))))
+          asyncOnMainQueue(completion(.failure(.internalError(description: description))))
           return
         }
         // Ensure that local model path is as expected, and reachable.
@@ -246,7 +246,7 @@ public class ModelDownloader {
           DeviceLogger.logEvent(level: .debug,
                                 message: ModelDownloader.ErrorDescription.outdatedModelPath,
                                 messageCode: .outdatedModelPathError)
-          mainQueueHandler(completion(.failure(.internalError(description: ModelDownloader
+          asyncOnMainQueue(completion(.failure(.internalError(description: ModelDownloader
               .ErrorDescription.outdatedModelPath))))
           return
         }
@@ -262,12 +262,12 @@ public class ModelDownloader {
       DeviceLogger.logEvent(level: .debug,
                             message: ModelDownloader.ErrorDescription.listModelsFailed(error),
                             messageCode: .listModelsError)
-      mainQueueHandler(completion(.failure(error)))
+      asyncOnMainQueue(completion(.failure(error)))
     } catch {
       DeviceLogger.logEvent(level: .debug,
                             message: ModelDownloader.ErrorDescription.listModelsFailed(error),
                             messageCode: .listModelsError)
-      mainQueueHandler(completion(.failure(.internalError(description: error
+      asyncOnMainQueue(completion(.failure(.internalError(description: error
           .localizedDescription))))
     }
   }
@@ -290,7 +290,7 @@ public class ModelDownloader {
       DeviceLogger.logEvent(level: .debug,
                             message: ModelDownloader.ErrorDescription.modelNotFound(modelName),
                             messageCode: .modelNotFound)
-      mainQueueHandler(completion(.failure(.notFound)))
+      asyncOnMainQueue(completion(.failure(.notFound)))
       return
     }
     do {
@@ -305,7 +305,7 @@ public class ModelDownloader {
         eventName: .remoteModelDeleteOnDevice,
         isSuccessful: true
       )
-      mainQueueHandler(completion(.success(())))
+      asyncOnMainQueue(completion(.success(())))
     } catch let error as DownloadedModelError {
       DeviceLogger.logEvent(level: .debug,
                             message: ModelDownloader.ErrorDescription.modelDeletionFailed(error),
@@ -314,7 +314,7 @@ public class ModelDownloader {
         eventName: .remoteModelDeleteOnDevice,
         isSuccessful: false
       )
-      mainQueueHandler(completion(.failure(error)))
+      asyncOnMainQueue(completion(.failure(error)))
     } catch {
       DeviceLogger.logEvent(level: .debug,
                             message: ModelDownloader.ErrorDescription.modelDeletionFailed(error),
@@ -323,7 +323,7 @@ public class ModelDownloader {
         eventName: .remoteModelDeleteOnDevice,
         isSuccessful: false
       )
-      mainQueueHandler(completion(.failure(.internalError(description: error
+      asyncOnMainQueue(completion(.failure(.internalError(description: error
           .localizedDescription))))
     }
   }
@@ -417,28 +417,28 @@ extension ModelDownloader {
           // Progress handler for model file download.
           let taskProgressHandler: ModelDownloadTask.ProgressHandler = { progress in
             if let progressHandler = progressHandler {
-              self.mainQueueHandler(progressHandler(progress))
+              self.asyncOnMainQueue(progressHandler(progress))
             }
           }
           // Completion handler for model file download.
           let taskCompletion: ModelDownloadTask.Completion = { result in
             switch result {
             case let .success(model):
-              self.mainQueueHandler(completion(.success(model)))
+              self.asyncOnMainQueue(completion(.success(model)))
             case let .failure(error):
               switch error {
               case .notFound:
-                self.mainQueueHandler(completion(.failure(.notFound)))
+                self.asyncOnMainQueue(completion(.failure(.notFound)))
               case .invalidArgument:
-                self.mainQueueHandler(completion(.failure(.invalidArgument)))
+                self.asyncOnMainQueue(completion(.failure(.invalidArgument)))
               case .permissionDenied:
-                self.mainQueueHandler(completion(.failure(.permissionDenied)))
+                self.asyncOnMainQueue(completion(.failure(.permissionDenied)))
               // This is the error returned when model download URL has expired.
               case .expiredDownloadURL:
                 // Retry model info and model file download, if allowed.
                 guard self.numberOfRetries > 0 else {
                   self
-                    .mainQueueHandler(
+                    .asyncOnMainQueue(
                       completion(.failure(.internalError(description: ModelDownloader
                           .ErrorDescription
                           .expiredModelInfo)))
@@ -458,7 +458,7 @@ extension ModelDownloader {
                   completion: completion
                 )
               default:
-                self.mainQueueHandler(completion(.failure(error)))
+                self.asyncOnMainQueue(completion(.failure(error)))
               }
             }
             self.taskSerialQueue.async {
@@ -502,15 +502,15 @@ extension ModelDownloader {
           guard let localModel = self.getLocalModel(modelName: modelName) else {
             // This can only happen if either local model info or the model file was wiped out after model info request but before server response.
             self
-              .mainQueueHandler(completion(.failure(.internalError(description: ModelDownloader
+              .asyncOnMainQueue(completion(.failure(.internalError(description: ModelDownloader
                   .ErrorDescription.deletedLocalModelInfoOrFile))))
             return
           }
-          self.mainQueueHandler(completion(.success(localModel)))
+          self.asyncOnMainQueue(completion(.success(localModel)))
         }
       // Error retrieving model info.
       case let .failure(error):
-        self.mainQueueHandler(completion(.failure(error)))
+        self.asyncOnMainQueue(completion(.failure(error)))
       }
     }
   }

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -57,7 +57,7 @@ public class ModelDownloader {
   let taskSerialQueue = DispatchQueue(label: "downloadtask.serial.queue")
 
   /// Re-dispatch a function on the main queue.
-  func asyncOnMainQueue(_ work: @autoclosure @escaping () -> Void ) {
+  func asyncOnMainQueue(_ work: @autoclosure @escaping () -> Void) {
     DispatchQueue.main.async {
       work()
     }

--- a/FirebaseMLModelDownloader/Sources/ModelFileManager.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelFileManager.swift
@@ -27,11 +27,29 @@ enum ModelFileManager {
 
   /// Root directory of model file storage on device.
   static var modelsDirectory: URL? {
-    #if os(tvOS)
+    let rootDirOptional: URL? = {
+      #if os(tvOS)
       return fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
     #else
       return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? nil
     #endif
+    }()
+
+    guard let rootDirURL = rootDirOptional else {
+      return nil
+    }
+
+    let modelDirURL = rootDirURL.appendingPathComponent("com.firebase.FirebaseMLModelDownloader", isDirectory: true)
+
+    do {
+      if !fileManager.fileExists(atPath: modelDirURL.absoluteString) {
+        try fileManager.createDirectory(at: modelDirURL, withIntermediateDirectories: true)
+      }
+    } catch {
+      return nil
+    }
+
+    return modelDirURL
   }
 
   /// Name for model file stored on device.

--- a/FirebaseMLModelDownloader/Sources/ModelFileManager.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelFileManager.swift
@@ -29,17 +29,20 @@ enum ModelFileManager {
   static var modelsDirectory: URL? {
     let rootDirOptional: URL? = {
       #if os(tvOS)
-      return fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
-    #else
-      return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? nil
-    #endif
+        return fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+      #else
+        return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? nil
+      #endif
     }()
 
     guard let rootDirURL = rootDirOptional else {
       return nil
     }
 
-    let modelDirURL = rootDirURL.appendingPathComponent("com.firebase.FirebaseMLModelDownloader", isDirectory: true)
+    let modelDirURL = rootDirURL.appendingPathComponent(
+      "com.firebase.FirebaseMLModelDownloader",
+      isDirectory: true
+    )
 
     do {
       if !fileManager.fileExists(atPath: modelDirURL.absoluteString) {

--- a/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
@@ -303,6 +303,48 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
     wait(for: [localModelExpectation], timeout: 5)
   }
 
+  func testGetModelWhenNameIsEmpty() {
+    guard let testApp = FirebaseApp.app() else {
+      XCTFail("Default app was not configured.")
+      return
+    }
+    let testName = String(#function.dropLast(2))
+    let emptyModelName = ""
+
+    let conditions = ModelDownloadConditions()
+    let modelDownloader = ModelDownloader.modelDownloaderWithDefaults(
+      .createTestInstance(testName: testName),
+      app: testApp
+    )
+
+    let completionExpectation = expectation(description: "getModel")
+    let progressExpectation = expectation(description: "progressHandler")
+    progressExpectation.isInverted = true
+
+    modelDownloader.getModel(
+      name: emptyModelName,
+      downloadType: .latestModel,
+      conditions: conditions,
+      progressHandler: { progress in
+        progressExpectation.fulfill()
+      }
+    ) { result in
+      XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+
+      switch result {
+      case .failure(.emptyModelName):
+        // The expected error.
+        break
+
+      default:
+        XCTFail("Unexpected result: \(result)")
+      }
+      completionExpectation.fulfill()
+    }
+
+    wait(for: [completionExpectation, progressExpectation], timeout: 5)
+  }
+
   /// Delete previously downloaded model.
   func testDeleteModel() {
     guard let testApp = FirebaseApp.app() else {

--- a/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
@@ -233,7 +233,7 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
       }
     ) { result in
       XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
-      
+
       switch result {
       case let .success(model):
         XCTAssertNotNil(model.path)

--- a/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
@@ -226,10 +226,14 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
       downloadType: downloadType,
       conditions: conditions,
       progressHandler: { progress in
+        XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+
         XCTAssertLessThanOrEqual(progress, 1)
         XCTAssertGreaterThanOrEqual(progress, 0)
       }
     ) { result in
+      XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+      
       switch result {
       case let .success(model):
         XCTAssertNotNil(model.path)
@@ -323,10 +327,13 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
       downloadType: downloadType,
       conditions: conditions,
       progressHandler: { progress in
+        XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
         XCTAssertLessThanOrEqual(progress, 1)
         XCTAssertGreaterThanOrEqual(progress, 0)
       }
     ) { result in
+      XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+
       switch result {
       case let .success(model):
         XCTAssertNotNil(model.path)
@@ -343,6 +350,8 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
     let deleteExpectation = expectation(description: "Wait for model deletion.")
     modelDownloader.deleteDownloadedModel(name: testModelName) { result in
       deleteExpectation.fulfill()
+      XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+
       switch result {
       case .success: break
       case let .failure(error):

--- a/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
@@ -494,10 +494,13 @@ final class ModelDownloaderIntegrationTests: XCTestCase {
       downloadType: .latestModel,
       conditions: conditions,
       progressHandler: { progress in
+        XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
         XCTAssertLessThanOrEqual(progress, 1)
         XCTAssertGreaterThanOrEqual(progress, 0)
       }
     ) { result in
+      XCTAssertTrue(Thread.isMainThread, "Completion must be called on the main thread.")
+
       switch result {
       case let .success(model):
         XCTAssertNotNil(model.path)


### PR DESCRIPTION
- fix call handlers on the main queue
- fix `listDownloadedModels` method for real devices
- use a subfolder named "com.firebase.FirebaseMLModelDownloader" to store models
- `getModel()`: fail fast with a specific error when model name is empty 