### PR TITLE
Update Firebase SPM version to 7.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "7.5.0"
+let firebaseVersion = "7.6.0"
 
 let package = Package(
   name: "Firebase",


### PR DESCRIPTION
Firebase was updated to version 7.6.0 but the SPM version was still on 7.5.0, so I opened this PR to fix it.
