### PR TITLE
Update Firebase SPM version to 7.6.0 (#7531)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "7.5.0"
+let firebaseVersion = "7.6.0"
 
 let package = Package(
   name: "Firebase",


### PR DESCRIPTION
Cherry-pick #7531 to fix the version logged with Swift Package Manager in 7.6.0

After merging, we'll need to move the 7.6.0 tag to finish the fix.