### PR TITLE
Fix FIRFunctions.useEmulatorWithHost scheme

### DIFF
--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed missing "http://" prefix when using Functions with the emulator. (#7537, #7538)
+
 # v7.2.0
 - [added] Made emulator connection API consistent between Auth, Database, Firestore, and Functions (#5916).
 

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -60,7 +60,7 @@
   [_functionsCustomDomain useEmulatorWithHost:@"localhost" port:5005];
   NSLog(@"%@", _functionsCustomDomain.emulatorOrigin);
   NSString *url = [_functionsCustomDomain URLWithName:@"my-endpoint"];
-  XCTAssertEqualObjects(@"localhost:5005/my-project/my-region/my-endpoint", url);
+  XCTAssertEqualObjects(@"http://localhost:5005/my-project/my-region/my-endpoint", url);
 }
 
 - (void)testCustomDomain {
@@ -71,12 +71,12 @@
 - (void)testCustomDomainWithEmulator {
   [_functionsCustomDomain useEmulatorWithHost:@"localhost" port:5005];
   NSString *url = [_functionsCustomDomain URLWithName:@"my-endpoint"];
-  XCTAssertEqualObjects(@"localhost:5005/my-project/my-region/my-endpoint", url);
+  XCTAssertEqualObjects(@"http://localhost:5005/my-project/my-region/my-endpoint", url);
 }
 
 - (void)testSetEmulatorSettings {
   [_functions useEmulatorWithHost:@"localhost" port:1000];
-  XCTAssertEqualObjects(@"localhost:1000", _functions.emulatorOrigin);
+  XCTAssertEqualObjects(@"http://localhost:1000", _functions.emulatorOrigin);
 }
 
 @end

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -63,6 +63,13 @@
   XCTAssertEqualObjects(@"http://localhost:5005/my-project/my-region/my-endpoint", url);
 }
 
+- (void)testRegionWithEmulatorWithScheme {
+  [_functionsCustomDomain useEmulatorWithHost:@"http://localhost" port:5005];
+  NSLog(@"%@", _functionsCustomDomain.emulatorOrigin);
+  NSString *url = [_functionsCustomDomain URLWithName:@"my-endpoint"];
+  XCTAssertEqualObjects(@"http://localhost:5005/my-project/my-region/my-endpoint", url);
+}
+
 - (void)testCustomDomain {
   NSString *url = [_functionsCustomDomain URLWithName:@"my-endpoint"];
   XCTAssertEqualObjects(@"https://mydomain.com/my-endpoint", url);

--- a/Functions/FirebaseFunctions/FIRFunctions.m
+++ b/Functions/FirebaseFunctions/FIRFunctions.m
@@ -154,7 +154,7 @@ NSString *const kFUNDefaultRegion = @"us-central1";
 
 - (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port {
   NSAssert(host.length > 0, @"Cannot connect to nil or empty host");
-  NSString *origin = [NSString stringWithFormat:@"%@:%li", host, (long)port];
+  NSString *origin = [NSString stringWithFormat:@"http://%@:%li", host, (long)port];
   _emulatorOrigin = origin;
 }
 

--- a/Functions/FirebaseFunctions/FIRFunctions.m
+++ b/Functions/FirebaseFunctions/FIRFunctions.m
@@ -154,7 +154,7 @@ NSString *const kFUNDefaultRegion = @"us-central1";
 
 - (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port {
   NSAssert(host.length > 0, @"Cannot connect to nil or empty host");
-  NSString *prefix = [host hasPrefix:@"http"] ? @"" :  @"http://";
+  NSString *prefix = [host hasPrefix:@"http"] ? @"" : @"http://";
   NSString *origin = [NSString stringWithFormat:@"%@%@:%li", prefix, host, (long)port];
   _emulatorOrigin = origin;
 }

--- a/Functions/FirebaseFunctions/FIRFunctions.m
+++ b/Functions/FirebaseFunctions/FIRFunctions.m
@@ -149,7 +149,7 @@ NSString *const kFUNDefaultRegion = @"us-central1";
 }
 
 - (void)useLocalhost {
-  [self useEmulatorWithHost:@"http://localhost" port:5005];
+  [self useEmulatorWithHost:@"localhost" port:5005];
 }
 
 - (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port {

--- a/Functions/FirebaseFunctions/FIRFunctions.m
+++ b/Functions/FirebaseFunctions/FIRFunctions.m
@@ -154,7 +154,8 @@ NSString *const kFUNDefaultRegion = @"us-central1";
 
 - (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port {
   NSAssert(host.length > 0, @"Cannot connect to nil or empty host");
-  NSString *origin = [NSString stringWithFormat:@"http://%@:%li", host, (long)port];
+  NSString *prefix = [host hasPrefix:@"http"] ? @"" :  @"http://";
+  NSString *origin = [NSString stringWithFormat:@"%@%@:%li", prefix, host, (long)port];
   _emulatorOrigin = origin;
 }
 


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Fixes #7537
  * Fixes #7538

### Testing

  * Updated unit tests

### API Changes

  * This technically could be considered a breaking change however the original implementation was a bug. The API is meant to be `useEmulator("locahost", 1234)` but right now it requires `useEmulator("http://localhost", 1234)`