### PR TITLE
update abtesting changelog

### DIFF
--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v7.7.0
-- [added] Added community support for watchOS. (#7481)
+- [added] Added community support for watchOS. Currently ABTtesting will build on watchOS, but some functions might not work yet. (#7481)
 
 # v7.0.0
 - [removed] Removed `FIRExperimentController.updateExperiments(serviceOrigin:events:policy:lastStartTime:payloads:)`, which was deprecated. (#6543)

--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v7.7.0
-- [added] Added community support for watchOS. Currently ABTtesting will build on watchOS, but some functions might not work yet. (#7481)
+- [added] Added community support for watchOS. ABTesting can now build on watchOS, but some functions might not work yet. (#7481)
 
 # v7.0.0
 - [removed] Removed `FIRExperimentController.updateExperiments(serviceOrigin:events:policy:lastStartTime:payloads:)`, which was deprecated. (#6543)


### PR DESCRIPTION
ABTesting needs analytics to function, and analytics currently doesn't work on watchOS. So clarify that in the chagnelog.