### PR TITLE
FirebaseAnalytics SwiftUI API for `screen_view`

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'FirebaseAnalytics.podspec.json'
+    - 'FirebaseAnalyticsSwift**'
     - 'GoogleAppMeasurement.podspec.json'
     - 'Gemfile'
   schedule:
@@ -22,6 +23,8 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: GoogleAppMeasurement
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurement.podspec.json
+    - name: FirebaseAnalyticsSwift
+      run: scripts/third_party/travis/retry.sh pod spec lint FirebaseAnalyticsSwift.podspec
 
 # TODO: Consider pushing GoogleAppMeasurement.podspec.json to SpecsStaging to enable similar test
 # for FirebaseAnalytics.podspec.json

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -24,7 +24,7 @@ jobs:
     - name: GoogleAppMeasurement
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurement.podspec.json
     - name: FirebaseAnalyticsSwift
-      run: scripts/third_party/travis/retry.sh pod spec lint FirebaseAnalyticsSwift.podspec
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAnalyticsSwift.podspec --platforms=ios
 
 # TODO: Consider pushing GoogleAppMeasurement.podspec.json to SpecsStaging to enable similar test
 # for FirebaseAnalytics.podspec.json

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -29,7 +29,8 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    # REVERT ME:
+    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
     runs-on: macOS-latest
     strategy:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
@@ -734,6 +734,48 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAnalyticsSwift"
+               BuildableName = "FirebaseAnalyticsSwift"
+               BlueprintName = "FirebaseAnalyticsSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAnalyticsSwiftTarget"
+               BuildableName = "FirebaseAnalyticsSwiftTarget"
+               BlueprintName = "FirebaseAnalyticsSwiftTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAnalyticsSwift-Beta"
+               BuildableName = "FirebaseAnalyticsSwift-Beta"
+               BlueprintName = "FirebaseAnalyticsSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -26,5 +26,5 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     'FirebaseAnalyticsSwift/Sources/*.swift',
   ]
 
-  s.dependency 'FirebaseAnalytics', '~> 7.8'
+  s.dependency 'FirebaseAnalytics', '~> 7.7'
 end

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -16,6 +16,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
+  s.static_framework        = true
   s.swift_version           = '5.0'
   s.ios.deployment_target   = '13.0'
 

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseAnalyticsSwift'
-  s.version                 = '7.6.0-beta'
+  s.version                 = '7.9.0-beta'
   s.summary                 = 'Swift Extensions for Firebase Analytics'
 
   s.description      = <<-DESC
@@ -26,5 +26,5 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     'FirebaseAnalyticsSwift/Sources/*.swift',
   ]
 
-  s.dependency 'Analytics', '~> 7.6'
+  s.dependency 'FirebaseAnalytics', '~> 7.8'
 end

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name                    = 'FirebaseAnalyticsSwift'
+  s.version                 = '7.6.0-beta'
+  s.summary                 = 'Swift Extensions for Firebase Analytics'
+
+  s.description      = <<-DESC
+Firebase Analytics is a free, out-of-the-box analytics solution that inspires actionable insights based on app usage and user engagement.
+                       DESC
+
+  s.homepage                = 'https://firebase.google.com/features/analytics/'
+  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.authors                 = 'Google, Inc.'
+
+  s.source                  = {
+    :git => 'https://github.com/Firebase/firebase-ios-sdk.git',
+    :tag => 'CocoaPods-' + s.version.to_s
+  }
+
+  s.swift_version           = '5.0'
+  s.ios.deployment_target   = '13.0'
+
+  s.cocoapods_version       = '>= 1.10.0'
+  s.prefix_header_file      = false
+
+  s.source_files = [
+    'FirebaseAnalyticsSwift/Sources/*.swift',
+  ]
+
+  s.dependency 'Analytics', '~> 7.6'
+end

--- a/FirebaseAnalyticsSwift/CHANGELOG.md
+++ b/FirebaseAnalyticsSwift/CHANGELOG.md
@@ -1,6 +1,4 @@
 # Unreleased
-
-# 7.6.0-Beta
 - Initial public beta release. Introduces new SwiftUI friendly APIs for
   screen tracking. To use, add `pod 'FirebaseAnalyticsSwift'` to the Podfile or
   add the `FirebaseAnalyticsSwift-Beta` framework in Swift Package Manager, then 

--- a/FirebaseAnalyticsSwift/CHANGELOG.md
+++ b/FirebaseAnalyticsSwift/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - Initial public beta release. Introduces new SwiftUI friendly APIs for
   screen tracking. To use, add `pod 'FirebaseAnalyticsSwift'` to the Podfile or
-  add the `FirebaseAnalyticsSwift-Beta` framework in Swift Package Manager, then 
+  add the `FirebaseAnalyticsSwift-Beta` framework in Swift Package Manager, then
   and `import FirebaseAnalyticsSwift` to the source. Please provide feedback about
   these new APIs and suggestions about other potential Swift extensions to
   https://github.com/firebase/firebase-ios-sdk/issues.

--- a/FirebaseAnalyticsSwift/CHANGELOG.md
+++ b/FirebaseAnalyticsSwift/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - Initial public beta release. Introduces new SwiftUI friendly APIs for
-  screen tracking. To use, add `pod 'FirebaseAnalyticsSwift'` to the Podfile or
+  screen tracking. To use, add `pod 'FirebaseAnalyticsSwift', '~> 7.9-beta'` to the Podfile or
   add the `FirebaseAnalyticsSwift-Beta` framework in Swift Package Manager, then
   and `import FirebaseAnalyticsSwift` to the source. Please provide feedback about
   these new APIs and suggestions about other potential Swift extensions to

--- a/FirebaseAnalyticsSwift/CHANGELOG.md
+++ b/FirebaseAnalyticsSwift/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Unreleased
+
+# 7.6.0-Beta
+- Initial public beta release. Introduces new SwiftUI friendly APIs for
+  screen tracking. To use, add `pod 'FirebaseAnalyticsSwift'` to the Podfile or
+  add the `FirebaseAnalyticsSwift-Beta` framework in Swift Package Manager, then 
+  and `import FirebaseAnalyticsSwift` to the source. Please provide feedback about
+  these new APIs and suggestions about other potential Swift extensions to
+  https://github.com/firebase/firebase-ios-sdk/issues.

--- a/FirebaseAnalyticsSwift/Sources/Analytics+SwiftUI.swift
+++ b/FirebaseAnalyticsSwift/Sources/Analytics+SwiftUI.swift
@@ -60,7 +60,7 @@
     /// - Returns: A view with a custom `ViewModifier` used to log `screen_view` events when this
     ///    view appears on screen.
     func analyticsScreen(name: String,
-                         class: String = "",
+                         class: String = "View",
                          extraParameters: [String: Any] = [:]) -> some View {
       // `self` is the view, we're just adding an `LoggedAnalyticsModifier` modifier on it.
       modifier(LoggedAnalyticsModifier(screenName: name,

--- a/FirebaseAnalyticsSwift/Sources/Analytics+SwiftUI.swift
+++ b/FirebaseAnalyticsSwift/Sources/Analytics+SwiftUI.swift
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(SwiftUI)
+  import FirebaseAnalytics
+  import SwiftUI
+
+  /// Custom view modifier to allow for easily logging screen view events.
+  @available(iOS 13, *)
+  @available(tvOS, unavailable)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
+  @available(watchOS, unavailable)
+  internal struct LoggedAnalyticsModifier: ViewModifier {
+    /// The name of the view to log in the `AnalyticsParameterScreenName` parameter.
+    let screenName: String
+
+    /// The name of the view to log in the `AnalyticsParameterScreenClass` parameter.
+    let screenClass: String
+
+    /// Extra parameters to log with the screen view event.
+    let extraParameters: [String: Any]
+
+    func body(content: Content) -> some View {
+      // Take the content and add an onAppear action to know when the view has appeared on screen.
+      content.onAppear {
+        // Log the event appearing, adding the appropriate keys and values needed for screen
+        // view events.
+        var parameters = extraParameters
+        parameters[AnalyticsParameterScreenName] = screenName
+        parameters[AnalyticsParameterScreenClass] = screenClass
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: parameters)
+      }
+    }
+  }
+
+  @available(iOS 13, *)
+  @available(tvOS, unavailable)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
+  @available(watchOS, unavailable)
+  public extension View {
+    /// Logs `screen_view` events in Google Analytics for Firebase when this view appears on screen.
+    /// - Parameters:
+    ///   - name: Current screen name logged with the `screen_view` event.
+    ///   - class: Current screen class or struct logged with the `screen_view` event.
+    ///   - extraParameters: Any additional parameters to be logged. These extra parameters must
+    ///       follow the same rules as described in the `Analytics.logEvent(_:parameters:)` docs.
+    /// - Returns: A view with a custom `ViewModifier` used to log `screen_view` events when this
+    ///    view appears on screen.
+    func analyticsScreen(name: String,
+                         class: String = "",
+                         extraParameters: [String: Any] = [:]) -> some View {
+      // `self` is the view, we're just adding an `LoggedAnalyticsModifier` modifier on it.
+      modifier(LoggedAnalyticsModifier(screenName: name,
+                                       screenClass: `class`,
+                                       extraParameters: extraParameters))
+    }
+  }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
       targets: ["FirebaseAnalyticsTarget"]
     ),
     .library(
+      name: "FirebaseAnalyticsSwift-Beta",
+      targets: ["FirebaseAnalyticsSwiftTarget"]
+    ),
+    .library(
       name: "FirebaseAuth",
       targets: ["FirebaseAuth"]
     ),
@@ -247,6 +251,17 @@ let package = Package(
       name: "FirebaseAnalytics",
       url: "https://dl.google.com/firebase/ios/swiftpm/7.5.0/FirebaseAnalytics.zip",
       checksum: "2a622329e1f233d9bd38333c62c900854cb2eb9c63a00b65df14dadf4ef7988e"
+    ),
+    .target(
+      name: "FirebaseAnalyticsSwiftTarget",
+      dependencies: [.target(name: "FirebaseAnalyticsSwift",
+                             condition: .when(platforms: [.iOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap"
+    ),
+    .target(
+      name: "FirebaseAnalyticsSwift",
+      dependencies: ["FirebaseAnalyticsWrapper"],
+      path: "FirebaseAnalyticsSwift/Sources"
     ),
 
     .target(
@@ -772,6 +787,7 @@ let package = Package(
     .testTarget(
       name: "analytics-import-test",
       dependencies: [
+        "FirebaseAnalyticsSwiftTarget",
         "FirebaseAnalyticsWrapper",
         "Firebase",
       ],

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/dummy.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/dummy.m
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <TargetConditionals.h>
+#if !TARGET_OS_IOS
+#warning "Firebase Analytics only supports the iOS platform"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/include/dummy.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPMTests/analytics-import-test/analytics-import.swift
+++ b/SwiftPMTests/analytics-import-test/analytics-import.swift
@@ -15,8 +15,8 @@
 import XCTest
 import FirebaseAnalytics
 #if canImport(SwiftUI)
-import SwiftUI
-import FirebaseAnalyticsSwift
+  import SwiftUI
+  import FirebaseAnalyticsSwift
 #endif
 
 class importTest: XCTestCase {
@@ -31,7 +31,7 @@ class importTest: XCTestCase {
   @available(macCatalyst, unavailable)
   @available(watchOS, unavailable)
   func testAnalyticsSwiftImported() {
-    let _ = Text("Hello, Analytics")
+    _ = Text("Hello, Analytics")
       .analyticsScreen(name: "analytics_text",
                        class: "Greeting",
                        extraParameters: ["greeted": true])

--- a/SwiftPMTests/analytics-import-test/analytics-import.swift
+++ b/SwiftPMTests/analytics-import-test/analytics-import.swift
@@ -14,10 +14,26 @@
 
 import XCTest
 import FirebaseAnalytics
+#if canImport(SwiftUI)
+import SwiftUI
+import FirebaseAnalyticsSwift
+#endif
 
 class importTest: XCTestCase {
   func testAnalyticsImported() {
     Analytics.logEvent(AnalyticsEventEcommercePurchase,
                        parameters: [AnalyticsParameterShipping: 10.0])
+  }
+
+  @available(iOS 13, *)
+  @available(tvOS, unavailable)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
+  @available(watchOS, unavailable)
+  func testAnalyticsSwiftImported() {
+    let _ = Text("Hello, Analytics")
+      .analyticsScreen(name: "analytics_text",
+                       class: "Greeting",
+                       extraParameters: ["greeted": true])
   }
 }


### PR DESCRIPTION
This is a new FirebaseAnalyticsSwift SDK that adds native Swift
extensions for FirebaseAnalytics, starting with a SwiftUI screen view
function.

#no-changelog

**TODO**:
- [x] Add GHA tests for the Podspec