### PR TITLE
Future Apple toolchain fixes

### DIFF
--- a/Firestore/core/src/remote/grpc_root_certificates_generated.h
+++ b/Firestore/core/src/remote/grpc_root_certificates_generated.h
@@ -3,7 +3,7 @@
 #ifndef FIRESTORE_CORE_SRC_REMOTE_GRPC_ROOT_CERTIFICATES_GENERATED_H_
 #define FIRESTORE_CORE_SRC_REMOTE_GRPC_ROOT_CERTIFICATES_GENERATED_H_
 
-#include <cstdlib>
+#include <stddef.h>
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/util/secure_random_arc4random.cc
+++ b/Firestore/core/src/util/secure_random_arc4random.cc
@@ -20,7 +20,7 @@
 
 #if HAVE_ARC4RANDOM
 
-#include <cstdlib>
+#include <stdlib.h>
 
 namespace firebase {
 namespace firestore {

--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
     .package(
       name: "gRPC",
       url: "https://github.com/firebase/grpc-SwiftPM.git",
-      "1.28.2" ..< "1.29.0"
+      .revision("7a35043b663302bb3ff4be62ed85c8a265fb6338")
     ),
     .package(
       name: "OCMock",

--- a/Package.swift
+++ b/Package.swift
@@ -121,13 +121,15 @@ let package = Package(
       // This revision adds SPM enablement to the 0.3.9.6 release tag.
       "2.30907.0" ..< "2.30908.0"
     ),
-    .package(name: "abseil",
-             url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-             from: "0.20200225.0"),
+    .package(
+      name: "abseil",
+      url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      .revision("320052bd5dfbec803043ab838ec87b32d601aca0")
+    ),
     .package(
       name: "gRPC",
       url: "https://github.com/firebase/grpc-SwiftPM.git",
-      .revision("7a35043b663302bb3ff4be62ed85c8a265fb6338")
+      .revision("3393c6955ee1097c87bbc5f8cf01b7dac736f418")
     ),
     .package(
       name: "OCMock",

--- a/Package.swift
+++ b/Package.swift
@@ -124,12 +124,12 @@ let package = Package(
     .package(
       name: "abseil",
       url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      .revision("320052bd5dfbec803043ab838ec87b32d601aca0")
+      .revision("973d27376eedfb8f0f0a324be4b4121d44808dc9")
     ),
     .package(
       name: "gRPC",
       url: "https://github.com/firebase/grpc-SwiftPM.git",
-      .revision("3393c6955ee1097c87bbc5f8cf01b7dac736f418")
+      .revision("b54af2c0d3b77209ccc8dc25af902c31a2095943")
     ),
     .package(
       name: "OCMock",
@@ -139,7 +139,7 @@ let package = Package(
     .package(
       name: "leveldb",
       url: "https://github.com/firebase/leveldb.git",
-      "1.22.1" ..< "1.23.0"
+      .revision("e4e8ab44a2781a3656b4b5852e71c07fd18fecfa")
     ),
     // Branches need a force update with a run with the revision set like below.
     //   .package(url: "https://github.com/paulb777/nanopb.git", .revision("564392bd87bd093c308a3aaed3997466efb95f74"))

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -511,10 +511,10 @@ _CPP_HEADERS = frozenset([
     'cstdalign',
     'cstdarg',
     'cstdbool',
-    'cstddef',
+    # 'cstddef', https://github.com/firebase/firebase-ios-sdk/pull/7563
     'cstdint',
     'cstdio',
-    'cstdlib',
+    # 'cstdlib', https://github.com/firebase/firebase-ios-sdk/pull/7563
     'cstring',
     'ctgmath',
     'ctime',


### PR DESCRIPTION
Fix #7552 

The future Apple toolchain is more strict about a few things that impact Firestore and its dependencies:

- Requires usage of stdlib.h instead of cstdlib for some declarations like https://github.com/google/boringssl/commit/061a7f5596c4125fc4bead14ebb37cf51d2ae627
- Requires all headers specified by SPM to build (wasn't the case previously and the packages included some test headers)
- More strict about C++ headers being in extern C - see https://github.com/firebase/leveldb/commit/e4e8ab44a2781a3656b4b5852e71c07fd18fecfa
- Associated PRs
  - https://github.com/firebase/leveldb/pull/2
  - https://github.com/firebase/boringSSL-SwiftPM/pull/1
  - https://github.com/firebase/abseil-cpp-SwiftPM/pull/2
  - https://github.com/firebase/grpc-SwiftPM/pull/1

#no-changelog - will be invisible to clients if this lands before the future toolchain releases