### PR TITLE
Completely stop forcing static frameworks

### DIFF
--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
-  s.static_framework = true
   s.prefix_header_file = false
 
   s.source_files = [

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -24,7 +24,6 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.tvos.deployment_target = tvos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
-  s.static_framework = true
   s.prefix_header_file = false
 
   base_dir = "FirebasePerformance/"

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -54,9 +54,9 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
 
-  s.ios.framework = 'CoreTelephony'
-  s.ios.framework = 'QuartzCore'
-  s.ios.framework = 'SystemConfiguration'
+  s.framework = 'CoreTelephony'
+  s.framework = 'QuartzCore'
+  s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseCore', '~> 7.0'
   s.dependency 'FirebaseInstallations', '~> 7.0'
   s.dependency 'FirebaseRemoteConfig', '~> 7.0'

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -54,7 +54,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
 
-  s.framework = 'CoreTelephony'
+  s.ios.framework = 'CoreTelephony'
   s.framework = 'QuartzCore'
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseCore', '~> 7.0'

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * Deprecate Clearcut event transport mechanism.
+* Enable dynamic framework support. (#7569)
 
 # Version 7.7.0
 * Add community supported tvOS.

--- a/FirebasePerformance/Sources/FPRClient.m
+++ b/FirebasePerformance/Sources/FPRClient.m
@@ -119,7 +119,7 @@
     // Create the Logger for the Perf SDK events to be sent to Google Data Transport.
     self.gdtLogger = [[FPRGDTLogger alloc] initWithLogSource:logSource];
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
     // Create telephony network information object ahead of time to avoid runtime delays.
     FPRNetworkInfo();
 #endif

--- a/FirebasePerformance/Sources/FPRProtoUtils.h
+++ b/FirebasePerformance/Sources/FPRProtoUtils.h
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#import <TargetConditionals.h>
+#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
+#define TARGET_HAS_MOBILE_CONNECTIVITY
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 
@@ -55,7 +57,7 @@ extern FPRMSGGaugeMetric* _Nullable FPRGetGaugeMetric(NSArray* _Nonnull gaugeDat
  */
 extern FPRMSGApplicationProcessState FPRApplicationProcessState(FPRTraceState state);
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 /** Obtain a CTTelephonyNetworkInfo object to determine device network attributes.
  *  @return CTTelephonyNetworkInfo object.
  */

--- a/FirebasePerformance/Sources/FPRProtoUtils.m
+++ b/FirebasePerformance/Sources/FPRProtoUtils.m
@@ -14,7 +14,7 @@
 
 #import "FirebasePerformance/Sources/FPRProtoUtils.h"
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -36,7 +36,7 @@ static GPBStringInt64Dictionary *FPRGetProtoCounterForDictionary(
     NSDictionary<NSString *, NSNumber *> *dictionary);
 static FPRMSGNetworkRequestMetric_HttpMethod FPRHTTPMethodForString(NSString *methodString);
 static FPRMSGNetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType(void);
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 static FPRMSGNetworkConnectionInfo_MobileSubtype FPRCellularNetworkType(void);
 #endif
 NSArray<FPRSessionDetails *> *FPRMakeFirstSessionVerbose(NSArray<FPRSessionDetails *> *sessions);
@@ -58,7 +58,7 @@ FPRMSGApplicationInfo *FPRGetApplicationInfoMessage() {
   iosAppInfo.bundleShortVersion = [mainBundle infoDictionary][@"CFBundleShortVersionString"];
   iosAppInfo.sdkVersion = [NSString stringWithUTF8String:kFPRSDKVersion];
   iosAppInfo.networkConnectionInfo.networkType = FPRNetworkConnectionInfoNetworkType();
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
   CTTelephonyNetworkInfo *networkInfo = FPRNetworkInfo();
   CTCarrier *provider = networkInfo.subscriberCellularProvider;
   NSString *mccMnc = FPRValidatedMccMnc(provider.mobileCountryCode, provider.mobileNetworkCode);
@@ -256,7 +256,7 @@ FPRMSGApplicationProcessState FPRApplicationProcessState(FPRTraceState state) {
   return processState;
 }
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 CTTelephonyNetworkInfo *FPRNetworkInfo() {
   static CTTelephonyNetworkInfo *networkInfo;
   static dispatch_once_t onceToken;
@@ -340,7 +340,7 @@ static FPRMSGNetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkTy
   return networkType;
 }
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 /** Get the current cellular network connection type in NetworkConnectionInfo_MobileSubtype format.
  *  @return Current cellular network connection type.
  */

--- a/FirebasePerformance/Sources/FPRProtoUtils.m
+++ b/FirebasePerformance/Sources/FPRProtoUtils.m
@@ -36,7 +36,7 @@ static GPBStringInt64Dictionary *FPRGetProtoCounterForDictionary(
     NSDictionary<NSString *, NSNumber *> *dictionary);
 static FPRMSGNetworkRequestMetric_HttpMethod FPRHTTPMethodForString(NSString *methodString);
 static FPRMSGNetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType(void);
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
 static FPRMSGNetworkConnectionInfo_MobileSubtype FPRCellularNetworkType(void);
 #endif
 NSArray<FPRSessionDetails *> *FPRMakeFirstSessionVerbose(NSArray<FPRSessionDetails *> *sessions);
@@ -340,7 +340,7 @@ static FPRMSGNetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkTy
   return networkType;
 }
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
 /** Get the current cellular network connection type in NetworkConnectionInfo_MobileSubtype format.
  *  @return Current cellular network connection type.
  */

--- a/FirebasePerformance/Tests/Unit/FPRProtoUtilsTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRProtoUtilsTest.m
@@ -256,7 +256,7 @@
                  FPRApplicationProcessState(100));
 }
 
-#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h")
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 /** Validates if network object creation works. */
 - (void)testNetworkInfoObjectCreation {
   XCTAssertNotNil(FPRNetworkInfo());

--- a/FirebaseSegmentation.podspec
+++ b/FirebaseSegmentation.podspec
@@ -19,7 +19,6 @@ Firebase Segmentation enables you to associate your custom application instance 
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'
-  s.static_framework = true
   s.prefix_header_file = false
 
   s.source_files = [


### PR DESCRIPTION
Follow up fix for #6557 for Performance, MLModelDownloader, and Segmentation, that were not yet on master when the original 7.0.0 update was made.

Also fix exposed Catalyst build problem with mobile connectivity header. 

Fix #7569