### PR TITLE
Log number of custom keys truncated

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -198,7 +198,8 @@ void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
     // but it's very uncommon to go down this path.
     NSArray *keys = [finalKVs allKeys];
 
-    FIRCLSSDKLogInfo("Truncating KV set, which is above max %d\n", maxCount);
+    FIRCLSSDKLogInfo("Truncating %lu keys from KV set, which is above max %d\n",
+                     [finalKVs count] - maxCount, maxCount);
 
     finalKVs =
         [finalKVs dictionaryWithValuesForKeys:[keys subarrayWithRange:NSMakeRange(0, maxCount)]];

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -198,7 +198,7 @@ void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
     // but it's very uncommon to go down this path.
     NSArray *keys = [finalKVs allKeys];
 
-    FIRCLSSDKLogInfo("Truncating %d keys from KV set, which is above max %d\n",
+    FIRCLSSDKLogInfo("Truncating %lu keys from KV set, which is above max %d\n",
                      ([finalKVs count] - maxCount), maxCount);
 
     finalKVs =

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -198,8 +198,8 @@ void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
     // but it's very uncommon to go down this path.
     NSArray *keys = [finalKVs allKeys];
 
-    FIRCLSSDKLogInfo("Truncating %lu keys from KV set, which is above max %d\n",
-                     ([finalKVs count] - maxCount), maxCount);
+    FIRCLSSDKLogInfo("Truncating %d keys from KV set, which is above max %d\n",
+                     (uint32_t)(finalKVs.count - maxCount), maxCount);
 
     finalKVs =
         [finalKVs dictionaryWithValuesForKeys:[keys subarrayWithRange:NSMakeRange(0, maxCount)]];

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -198,8 +198,8 @@ void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
     // but it's very uncommon to go down this path.
     NSArray *keys = [finalKVs allKeys];
 
-    FIRCLSSDKLogInfo("Truncating %lu keys from KV set, which is above max %d\n",
-                     [finalKVs count] - maxCount, maxCount);
+    FIRCLSSDKLogInfo("Truncating %d keys from KV set, which is above max %d\n",
+                     ([finalKVs count] - maxCount), maxCount);
 
     finalKVs =
         [finalKVs dictionaryWithValuesForKeys:[keys subarrayWithRange:NSMakeRange(0, maxCount)]];


### PR DESCRIPTION
Adds the number of keys truncated to the log messages when more than 64 custom keys are logged.

#no-changelog