### PR TITLE
Treat bridging headers as test-related

### DIFF
--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -87,6 +87,7 @@ private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL)
   // Treat all files with names finishing on "Test" or "Tests" as files with tests.
   let isTestFile = file.contains("Test.m") || file.contains("Tests.m") ||
     file.contains("Test.swift") || file.contains("Tests.swift")
+  let isBridgingHeader = file.contains("Bridging-Header.h")
   var inSwiftPackage = false
   var inSwiftPackageElse = false
   let lines = fileContents.components(separatedBy: .newlines)
@@ -141,7 +142,7 @@ private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL)
             logger.importLog("Import \(importFileRaw) does not exist.", file, lineNum)
           }
         }
-      } else if importFile.first == "<", !isPrivate, !isTestFile {
+      } else if importFile.first == "<", !isPrivate, !isTestFile, !isBridgingHeader {
         // Verify that double quotes are always used for intra-module imports.
         if importFileRaw.starts(with: "Firebase") {
           logger


### PR DESCRIPTION
As discussed in https://github.com/firebase/firebase-ios-sdk/pull/7547#discussion_r580442313, this patch makes sure that bridging headers may use angle-bracket imports.

 #no-changelog