### PR TITLE
Publish command updates

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
@@ -47,9 +47,10 @@ public struct Pod {
     return isClosedSource ? "\(name).podspec.json" : "\(name).podspec"
   }
 
-  /// Closed source pods do not validate on Xcode 12 until they support the ARM simulator slice.
+  /// The Firebase pod does not support import validation with Xcode 12 because of the deprecated
+  /// ML pods not supporting the ARM Mac slice.
   public func skipImportValidation() -> String {
-    if isClosedSource || name == "Firebase" {
+    if name == "Firebase" {
       return "--skip-import-validation"
     } else {
       return ""

--- a/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
@@ -53,7 +53,7 @@ enum Push {
         case .trunk:
           return "pod trunk push --skip-tests --synchronous \(warningsOK) " +
             pod
-            .skipImportValidation() + " ~/.cocoapods/repos/\(stagingLocation)/Specs/\(pod.name)/" +
+            .skipImportValidation() + " ~/.cocoapods/repos/\(stagingLocation)/\(pod.name)/" +
             "\(manifest.versionString(pod))/\(pod.name).podspec.json"
         }
       }()


### PR DESCRIPTION
- Now that they contain xcframeworks, Analytics pods no longer need to `--skip-import-validation`
- Fix the staging location path

#no-changelog