### PR TITLE
FirePerf: potential fix for a race condition in FPRGaugeManager

### DIFF
--- a/FirebasePerformance/Sources/Gauges/FPRGaugeManager.m
+++ b/FirebasePerformance/Sources/Gauges/FPRGaugeManager.m
@@ -178,7 +178,7 @@ NSInteger const kGaugeDataBatchSize = 25;
 
 /// The method MUST be called on `gaugeDataProtectionQueue`.
 - (void)prepareAndDispatchGaugeData {
-  NSArray *currentBatch = self.gaugeData;
+  NSArray *currentBatch = [self.gaugeData copy];
   NSString *currentSessionId = self.currentSessionId;
   self.gaugeData = [[NSMutableArray alloc] init];
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/FirebasePerformance/Sources/Gauges/FPRGaugeManager.m
+++ b/FirebasePerformance/Sources/Gauges/FPRGaugeManager.m
@@ -37,7 +37,7 @@ NSInteger const kGaugeDataBatchSize = 25;
 @property(nonatomic) NSMutableArray *gaugeData;
 
 /** @brief Currently active sessionID. */
-@property(nonatomic, readwrite) NSString *currentSessionId;
+@property(nonatomic, readwrite, copy) NSString *currentSessionId;
 
 @end
 

--- a/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
+++ b/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
@@ -106,7 +106,7 @@
 
   // Wait for operation to complete.
   dispatch_sync(manager.gaugeDataProtectionQueue, ^{
-  });
+                });
 
   XCTAssertTrue((manager.activeGauges & FPRGaugeCPU) == 1);
   XCTAssertTrue((manager.activeGauges & FPRGaugeMemory) == 0);
@@ -122,7 +122,7 @@
 
   // Wait for operation to complete.
   dispatch_sync(manager.gaugeDataProtectionQueue, ^{
-  });
+                });
 
   XCTAssertTrue((manager.activeGauges & FPRGaugeCPU) == FPRGaugeCPU);
   XCTAssertTrue((manager.activeGauges & FPRGaugeMemory) == FPRGaugeMemory);
@@ -133,7 +133,7 @@
 
   // Wait for operation to complete.
   dispatch_sync(manager.gaugeDataProtectionQueue, ^{
-  });
+                });
 
   XCTAssertTrue((manager.activeGauges & FPRGaugeCPU) == FPRGaugeNone);
   XCTAssertTrue((manager.activeGauges & FPRGaugeMemory) == FPRGaugeMemory);
@@ -156,7 +156,7 @@
 
   // Wait for operation to complete.
   dispatch_sync(manager.gaugeDataProtectionQueue, ^{
-  });
+                });
 
   id cpuMock = [OCMockObject partialMockForObject:manager.cpuGaugeCollector];
   id memoryMock = [OCMockObject partialMockForObject:manager.memoryGaugeCollector];
@@ -194,7 +194,7 @@
   [manager.cpuGaugeCollector stopCollecting];
   // Wait for start/stop to complete.
   dispatch_sync(manager.gaugeDataProtectionQueue, ^{
-  });
+                });
 
   OCMReject([mock prepareAndDispatchGaugeData]);
   for (int i = 0; i < kGaugeDataBatchSize - 1; i++) {


### PR DESCRIPTION
Possibly fixes #7535.

- do gauge data and session manipulations on `gaugeDataProtectionQueue`
- adjust tests for now async start/stop collection methods