### PR TITLE
Remove the warning when Analytics is not included

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -99,12 +99,6 @@ FirebaseAnalytics dependency to your project to ensure Messaging works as intend
 
   #if __has_include(<FirebasePerformance/FirebasePerformance.h>)
     #import <FirebasePerformance/FirebasePerformance.h>
-    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-      #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
-FirebaseAnalytics dependency to your project to ensure Firebase Performance works as intended."
-      #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-    #endif
   #endif
 
   #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 * Deprecate Clearcut event transport mechanism.
 * Enable dynamic framework support. (#7569)
+* Remove the warning to include Firebase Analytics as Perf does not depend on Analytics (#7487)
 
 # Version 7.7.0
 * Add community supported tvOS.


### PR DESCRIPTION
Firebase Performance does not require inclusion of Analytics. Fixes #7487 