### PR TITLE
Combine support to send verification email

### DIFF
--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -110,9 +110,9 @@
     ///   - `FIRAuthErrorCodeRequiresRecentLogin` - Updating email is a security sensitive
     ///      operation that requires a recent login from the user. This error indicates the user
     ///      has not signed in recently enough. To resolve, reauthenticate the user by invoking
-    ///      reauthenticateWithCredential:completion: on FIRUser.
+    ///      reauthenticateWithCredential:completion: on `FIRUser`.
     ///
-    ///   See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
+    ///   See `FIRAuthErrors` for a list of error codes that are common to all `FIRUser` methods.
     public func unlink(fromProvider provider: String) -> Future<User, Error> {
       Future<User, Error> { promise in
         self.unlink(fromProvider: provider) { user, error in
@@ -123,6 +123,74 @@
           }
         }
       }
+    }
+    
+    /// Initiates email verification for the user.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Returns: A publisher that emits no type when the verification flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///
+    ///   Possible error codes:
+    ///
+    ///   - `FIRAuthErrorCodeInvalidRecipientEmail` - Indicates an invalid recipient email was
+    ///      sent in the request.
+    ///   - `FIRAuthErrorCodeInvalidSender` - Indicates an invalid sender email is set in
+    ///      the console for this action.
+    ///   - `FIRAuthErrorCodeInvalidMessagePayload` - Indicates an invalid email template for
+    ///      sending update email.
+    ///   - `FIRAuthErrorCodeUserNotFound` - Indicates the user account was not found.
+    ///
+    ///   See `FIRAuthErrors` for a list of error codes that are common to all `FIRUser` methods.
+    public func sendEmailVerification() -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+            self.sendEmailVerification { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Initiates email verification for the user.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameter actionCodeSettings: An `FIRActionCodeSettings` object containing settings related to
+    ///   handling action codes.
+    /// - Returns: A publisher that emits no type when the verification flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///
+    ///   Possible error codes:
+    ///
+    ///   -  `FIRAuthErrorCodeInvalidRecipientEmail` - Indicates an invalid recipient email was
+    ///    sent in the request.
+    ///   - `FIRAuthErrorCodeInvalidSender` - Indicates an invalid sender email is set in
+    ///    the console for this action.
+    ///   - `FIRAuthErrorCodeInvalidMessagePayload` - Indicates an invalid email template for
+    ///    sending update email.
+    ///   - `FIRAuthErrorCodeUserNotFound` - Indicates the user account was not found.
+    ///   - `FIRAuthErrorCodeMissingIosBundleID` - Indicates that the iOS bundle ID is missing when
+    ///    a iOS App Store ID is provided.
+    ///   - `FIRAuthErrorCodeMissingAndroidPackageName` - Indicates that the android package name
+    ///    is missing when the `androidInstallApp` flag is set to true.
+    ///   - `FIRAuthErrorCodeUnauthorizedDomain` - Indicates that the domain specified in the
+    ///    continue URL is not allowlisted in the Firebase console.
+    ///   - `FIRAuthErrorCodeInvalidContinueURI` - Indicates that the domain specified in the
+    ///    continue URI is not valid.
+    public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+            self.sendEmailVerification(with: actionCodeSettings) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
     }
   }
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -124,7 +124,7 @@
         }
       }
     }
-    
+
     /// Initiates email verification for the user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -144,17 +144,17 @@
     ///
     ///   See `FIRAuthErrors` for a list of error codes that are common to all `FIRUser` methods.
     public func sendEmailVerification() -> Future<Void, Error> {
-        Future<Void, Error> { promise in
-            self.sendEmailVerification { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+      Future<Void, Error> { promise in
+        self.sendEmailVerification { error in
+          if let error = error {
+            promise(.failure(error))
+          } else {
+            promise(.success(()))
+          }
         }
+      }
     }
-    
+
     /// Initiates email verification for the user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -181,16 +181,17 @@
     ///    continue URL is not allowlisted in the Firebase console.
     ///   - `FIRAuthErrorCodeInvalidContinueURI` - Indicates that the domain specified in the
     ///    continue URI is not valid.
-    public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings) -> Future<Void, Error> {
-        Future<Void, Error> { promise in
-            self.sendEmailVerification(with: actionCodeSettings) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+    public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings)
+      -> Future<Void, Error> {
+      Future<Void, Error> { promise in
+        self.sendEmailVerification(with: actionCodeSettings) { error in
+          if let error = error {
+            promise(.failure(error))
+          } else {
+            promise(.success(()))
+          }
         }
+      }
     }
   }
 #endif

--- a/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/UserTests.swift
@@ -213,26 +213,26 @@ class UserTests: XCTestCase {
       response.providerCredentials = providerCredentials
       callback(response, nil)
     }
-    
+
     var actionCodeSettings: ActionCodeSettings?
     var getOOBConfirmationCodeError: Error?
     override func getOOBConfirmationCode(_ request: FIRGetOOBConfirmationCodeRequest,
                                          callback: @escaping FIRGetOOBConfirmationCodeResponseCallback) {
       XCTAssertEqual(request.accessToken, UserTests.accessToken)
-        XCTAssertEqual(request.continueURL, actionCodeSettings?.url?.absoluteString)
-        XCTAssertEqual(request.dynamicLinkDomain, actionCodeSettings?.dynamicLinkDomain)
-        
-        if let error = getOOBConfirmationCodeError {
-            callback(nil, error)
-        } else {
-            callback(MockGetOOBConfirmationCodeResponse(), nil)
-        }
+      XCTAssertEqual(request.continueURL, actionCodeSettings?.url?.absoluteString)
+      XCTAssertEqual(request.dynamicLinkDomain, actionCodeSettings?.dynamicLinkDomain)
+
+      if let error = getOOBConfirmationCodeError {
+        callback(nil, error)
+      } else {
+        callback(MockGetOOBConfirmationCodeResponse(), nil)
+      }
     }
   }
-    
-    class MockGetOOBConfirmationCodeResponse: FIRGetOOBConfirmationCodeResponse {
-      override var oobCode: String { return UserTests.fakeOOBCode }
-    }
+
+  class MockGetOOBConfirmationCodeResponse: FIRGetOOBConfirmationCodeResponse {
+    override var oobCode: String { return UserTests.fakeOOBCode }
+  }
 
   func testlinkAndRetrieveDataSuccess() {
     let facebookCredentials = ProviderCredentials(
@@ -818,145 +818,145 @@ class UserTests: XCTestCase {
     // then
     wait(for: [userUnlinkedExpectation], timeout: expectationTimeout)
   }
-    
-    func testSendVerificationEmailSuccess() {
-        // given
-        let emailCredentials = ProviderCredentials(
-          providerID: PhoneAuthProviderID,
-          federatedID: "EMAIL_ID",
-          displayName: "Google Doe",
-          idToken: nil,
-          accessToken: UserTests.accessToken,
-          email: UserTests.email,
-          localID: UserTests.localID
-        )
 
-        let authBackend = MockAuthBackend()
-        authBackend.providerCredentials = emailCredentials
-        FIRAuthBackend.setBackendImplementation(authBackend)
+  func testSendVerificationEmailSuccess() {
+    // given
+    let emailCredentials = ProviderCredentials(
+      providerID: PhoneAuthProviderID,
+      federatedID: "EMAIL_ID",
+      displayName: "Google Doe",
+      idToken: nil,
+      accessToken: UserTests.accessToken,
+      email: UserTests.email,
+      localID: UserTests.localID
+    )
 
-        var cancellables = Set<AnyCancellable>()
-        let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
+    let authBackend = MockAuthBackend()
+    authBackend.providerCredentials = emailCredentials
+    FIRAuthBackend.setBackendImplementation(authBackend)
 
-        // when
-        Auth.auth()
-          .signIn(withEmail: UserTests.email, password: UserTests.password)
-          .flatMap { authResult -> Future<Void, Error> in
-            XCTAssertNotNil(authResult.user)
-            
-            return authResult.user
-                .sendEmailVerification()
-          }
-          .sink { completion in
-            switch completion {
-            case .finished:
-              print("Finished")
-            case let .failure(error):
-              XCTFail("💥 Something went wrong: \(error)")
-            }
-          } receiveValue: { _ in
+    var cancellables = Set<AnyCancellable>()
+    let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
 
-            sentVerificationEmailExpectation.fulfill()
-          }
-          .store(in: &cancellables)
+    // when
+    Auth.auth()
+      .signIn(withEmail: UserTests.email, password: UserTests.password)
+      .flatMap { authResult -> Future<Void, Error> in
+        XCTAssertNotNil(authResult.user)
 
-        // then
-        wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSendVerificationEmailWithActionCodeSettingsSuccess() {
-        // given
-        let emailCredentials = ProviderCredentials(
-          providerID: PhoneAuthProviderID,
-          federatedID: "EMAIL_ID",
-          displayName: "Google Doe",
-          idToken: nil,
-          accessToken: UserTests.accessToken,
-          email: UserTests.email,
-          localID: UserTests.localID
-        )
+        return authResult.user
+          .sendEmailVerification()
+      }
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { _ in
 
-        let authBackend = MockAuthBackend()
-        authBackend.providerCredentials = emailCredentials
-        FIRAuthBackend.setBackendImplementation(authBackend)
+        sentVerificationEmailExpectation.fulfill()
+      }
+      .store(in: &cancellables)
 
-        var cancellables = Set<AnyCancellable>()
-        let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
+    // then
+    wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
+  }
 
-        // when
-        Auth.auth()
-          .signIn(withEmail: UserTests.email, password: UserTests.password)
-          .flatMap { authResult -> Future<Void, Error> in
-            XCTAssertNotNil(authResult.user)
-            
-            let actionCodeSettings =  ActionCodeSettings()
-            actionCodeSettings.url = URL(string: UserTests.continueURL)
-            actionCodeSettings.dynamicLinkDomain = "example.page.link"
-            authBackend.actionCodeSettings = actionCodeSettings
-            
-            return authResult.user
-                .sendEmailVerification(with: actionCodeSettings)
-          }
-          .sink { completion in
-            switch completion {
-            case .finished:
-              print("Finished")
-            case let .failure(error):
-              XCTFail("💥 Something went wrong: \(error)")
-            }
-          } receiveValue: { _ in
+  func testSendVerificationEmailWithActionCodeSettingsSuccess() {
+    // given
+    let emailCredentials = ProviderCredentials(
+      providerID: PhoneAuthProviderID,
+      federatedID: "EMAIL_ID",
+      displayName: "Google Doe",
+      idToken: nil,
+      accessToken: UserTests.accessToken,
+      email: UserTests.email,
+      localID: UserTests.localID
+    )
 
-            sentVerificationEmailExpectation.fulfill()
-          }
-          .store(in: &cancellables)
+    let authBackend = MockAuthBackend()
+    authBackend.providerCredentials = emailCredentials
+    FIRAuthBackend.setBackendImplementation(authBackend)
 
-        // then
-        wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSendVerificationEmailInvalidRecipientEmail() {
-        // given
-        let emailCredentials = ProviderCredentials(
-          providerID: PhoneAuthProviderID,
-          federatedID: "EMAIL_ID",
-          displayName: "Google Doe",
-          idToken: nil,
-          accessToken: UserTests.accessToken,
-          email: UserTests.email,
-          localID: UserTests.localID
-        )
+    var cancellables = Set<AnyCancellable>()
+    let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
 
-        let authBackend = MockAuthBackend()
-        authBackend.providerCredentials = emailCredentials
-        authBackend.getOOBConfirmationCodeError = FIRAuthErrorUtils.invalidRecipientEmailError(withMessage: nil)
-        FIRAuthBackend.setBackendImplementation(authBackend)
+    // when
+    Auth.auth()
+      .signIn(withEmail: UserTests.email, password: UserTests.password)
+      .flatMap { authResult -> Future<Void, Error> in
+        XCTAssertNotNil(authResult.user)
 
-        var cancellables = Set<AnyCancellable>()
-        let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
+        let actionCodeSettings = ActionCodeSettings()
+        actionCodeSettings.url = URL(string: UserTests.continueURL)
+        actionCodeSettings.dynamicLinkDomain = "example.page.link"
+        authBackend.actionCodeSettings = actionCodeSettings
 
-        // when
-        Auth.auth()
-          .signIn(withEmail: UserTests.email, password: UserTests.password)
-          .flatMap { authResult -> Future<Void, Error> in
-            XCTAssertNotNil(authResult.user)
-            
-            return authResult.user
-                .sendEmailVerification()
-          }
-            .sink { completion in
-              if case let .failure(error as NSError) = completion {
-                // Verify user mismatch error.
-                XCTAssertEqual(error.code, AuthErrorCode.invalidRecipientEmail.rawValue)
+        return authResult.user
+          .sendEmailVerification(with: actionCodeSettings)
+      }
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { _ in
 
-                sentVerificationEmailExpectation.fulfill()
-              }
-            } receiveValue: { authResult in
-              XCTFail("💥 result unexpected")
-            }
-          .store(in: &cancellables)
+        sentVerificationEmailExpectation.fulfill()
+      }
+      .store(in: &cancellables)
 
-        // then
-        wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
-    }
-    
+    // then
+    wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
+  }
+
+  func testSendVerificationEmailInvalidRecipientEmail() {
+    // given
+    let emailCredentials = ProviderCredentials(
+      providerID: PhoneAuthProviderID,
+      federatedID: "EMAIL_ID",
+      displayName: "Google Doe",
+      idToken: nil,
+      accessToken: UserTests.accessToken,
+      email: UserTests.email,
+      localID: UserTests.localID
+    )
+
+    let authBackend = MockAuthBackend()
+    authBackend.providerCredentials = emailCredentials
+    authBackend.getOOBConfirmationCodeError = FIRAuthErrorUtils
+      .invalidRecipientEmailError(withMessage: nil)
+    FIRAuthBackend.setBackendImplementation(authBackend)
+
+    var cancellables = Set<AnyCancellable>()
+    let sentVerificationEmailExpectation = expectation(description: "Sent verification email")
+
+    // when
+    Auth.auth()
+      .signIn(withEmail: UserTests.email, password: UserTests.password)
+      .flatMap { authResult -> Future<Void, Error> in
+        XCTAssertNotNil(authResult.user)
+
+        return authResult.user
+          .sendEmailVerification()
+      }
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          // Verify user mismatch error.
+          XCTAssertEqual(error.code, AuthErrorCode.invalidRecipientEmail.rawValue)
+
+          sentVerificationEmailExpectation.fulfill()
+        }
+      } receiveValue: { authResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [sentVerificationEmailExpectation], timeout: expectationTimeout)
+  }
 }


### PR DESCRIPTION
```swift
user.sendEmailVerification(with: actionCodeSettings)
  .sink { completion in
    /* Handle completion */
  } receiveValue: { _ in
    /* No type */
  }
  .store(in: &cancellables)
```

```swift
user.sendEmailVerification()
  .sink { completion in
    /* Handle completion */
  } receiveValue: { _ in
    /* No type */
  }
  .store(in: &cancellables)
```