### PR TITLE
Only update experiments for firebase namespace

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Store fetch metadata per namespace to address activation issues. (#7179)
-- [fixed] Only update experiment data for `firebase` namespace fetch requests to ensure correct experiment exposures. (#7604) 
+- [fixed] Only update experiment data for `firebase` namespace fetch requests to ensure correct experiment exposures. (#7604)
 
 # v7.7.0
 - [added] Added community support for watchOS. (#7481)

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [fixed] Store fetch metadata per namespace to address activation issues. (#7179)
+- [fixed] Only update experiment data for `firebase` namespace fetch requests to ensure correct experiment exposures. (#7604) 
 
 # v7.7.0
 - [added] Added community support for watchOS. (#7481)

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -480,9 +480,13 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
         // Update config content to cache and DB.
         [strongSelf->_content updateConfigContentWithResponse:fetchedConfig
                                                  forNamespace:strongSelf->_FIRNamespace];
-        // Update experiments.
-        [strongSelf->_experiment
-            updateExperimentsWithResponse:fetchedConfig[RCNFetchResponseKeyExperimentDescriptions]];
+        // Update experiments only for 3p namespace
+        NSString *namespace = [strongSelf->_FIRNamespace
+            substringToIndex:[strongSelf->_FIRNamespace rangeOfString:@":"].location];
+        if ([namespace isEqualToString:FIRNamespaceGoogleMobilePlatform]) {
+          [strongSelf->_experiment updateExperimentsWithResponse:
+                                       fetchedConfig[RCNFetchResponseKeyExperimentDescriptions]];
+        }
       } else {
         FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000063",
                     @"Empty response with no fetched config.");

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -82,8 +82,8 @@
 typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   RCNTestRCInstanceDefault,
   RCNTestRCInstanceSecondNamespace,
-  RCNTestRCInstanceSecondApp,
-  RCNTestRCNumTotalInstances
+  RCNTestRCNumTotalInstances,
+  RCNTestRCInstanceSecondApp
 };
 
 @interface RCNRemoteConfigTest : XCTestCase {
@@ -1371,10 +1371,12 @@ static NSString *UTCToLocal(NSString *utcTime) {
 }
 
 - (FIROptions *)secondAppOptions {
-  FIROptions *options =
-      [[FIROptions alloc] initWithContentsOfFile:[[NSBundle bundleForClass:[self class]]
-                                                     pathForResource:@"SecondApp-GoogleService-Info"
-                                                              ofType:@"plist"]];
+  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSString *plistPath = [bundle pathForResource:@"SecondApp-GoogleService-Info" ofType:@"plist"];
+#if SWIFT_PACKAGE
+  bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
+#endif
+  FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:plistPath];
   XCTAssertNotNil(options);
   return options;
 }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -82,8 +82,8 @@
 typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   RCNTestRCInstanceDefault,
   RCNTestRCInstanceSecondNamespace,
-  RCNTestRCNumTotalInstances,
-  RCNTestRCInstanceSecondApp
+  RCNTestRCInstanceSecondApp,
+  RCNTestRCNumTotalInstances
 };
 
 @interface RCNRemoteConfigTest : XCTestCase {
@@ -1372,10 +1372,10 @@ static NSString *UTCToLocal(NSString *utcTime) {
 
 - (FIROptions *)secondAppOptions {
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-  NSString *plistPath = [bundle pathForResource:@"SecondApp-GoogleService-Info" ofType:@"plist"];
 #if SWIFT_PACKAGE
   bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
 #endif
+  NSString *plistPath = [bundle pathForResource:@"SecondApp-GoogleService-Info" ofType:@"plist"];
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:plistPath];
   XCTAssertNotNil(options);
   return options;

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -465,13 +465,14 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
 
 - (void)testFetch3pNamespaceUpdatesExperiments {
   [[_experimentMock expect] updateExperimentsWithResponse:[OCMArg any]];
+
   XCTestExpectation *expectation = [self
       expectationWithDescription:
           [NSString
               stringWithFormat:@"Fetch call for 'firebase' namespace updates experiment data"]];
   XCTAssertEqual(_configInstances[RCNTestRCInstanceDefault].lastFetchStatus,
                  FIRRemoteConfigFetchStatusNoFetchYet);
-  FIRRemoteConfigFetchCompletion fetchCompletionDefault =
+  FIRRemoteConfigFetchCompletion fetchCompletion =
       ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
         XCTAssertEqual(self->_configInstances[RCNTestRCInstanceDefault].lastFetchStatus,
                        FIRRemoteConfigFetchStatusSuccess);
@@ -479,7 +480,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [expectation fulfill];
       };
   [_configInstances[RCNTestRCInstanceDefault] fetchWithExpirationDuration:43200
-                                                        completionHandler:fetchCompletionDefault];
+                                                        completionHandler:fetchCompletion];
   [self waitForExpectationsWithTimeout:_expectationTimeout
                                handler:^(NSError *error) {
                                  XCTAssertNil(error);
@@ -495,16 +496,15 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                            @"doesn't update experiment data"]];
   XCTAssertEqual(_configInstances[RCNTestRCInstanceSecondNamespace].lastFetchStatus,
                  FIRRemoteConfigFetchStatusNoFetchYet);
-  FIRRemoteConfigFetchCompletion fetchCompletionSecondNamespace =
+  FIRRemoteConfigFetchCompletion fetchCompletion =
       ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
         XCTAssertEqual(self->_configInstances[RCNTestRCInstanceSecondNamespace].lastFetchStatus,
                        FIRRemoteConfigFetchStatusSuccess);
         XCTAssertNil(error);
         [expectation fulfill];
       };
-  [_configInstances[RCNTestRCInstanceSecondNamespace]
-      fetchWithExpirationDuration:43200
-                completionHandler:fetchCompletionSecondNamespace];
+  [_configInstances[RCNTestRCInstanceSecondNamespace] fetchWithExpirationDuration:43200
+                                                                completionHandler:fetchCompletion];
   [self waitForExpectationsWithTimeout:_expectationTimeout
                                handler:^(NSError *error) {
                                  XCTAssertNil(error);


### PR DESCRIPTION
Currently `updateExperimentsWithResponse` is being called on fetches for all namespaces, causing issues with experiment exposures as `fireperf` fetch requests are incorrectly updating experiment data

Tracked internally in b/179461119