### PR TITLE
Limit the number of unsent reports on disk to prevent disk filling

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [added] Added a new API checkAndUpdateUnsentReportsWithCompletion for updating the crash report from the previous run of the app if, for example, the developer wants to implement a feedback dialog to ask end-users for more information. Unsent Crashlytics Reports have familiar methods like setting custom keys and logs.
+- [changed] Added a limit to the number of unsent reports on disk to prevent disk filling up when automatic data collection is off. Developers can ensure this limit is never reached by calling send/deleteUnsentReports every run.
 
 # v7.6.0
 - [fixed] Fixed an issue where some developers experienced a race condition involving binary image operations (#7459).

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [added] Added a new API checkAndUpdateUnsentReportsWithCompletion for updating the crash report from the previous run of the app if, for example, the developer wants to implement a feedback dialog to ask end-users for more information. Unsent Crashlytics Reports have familiar methods like setting custom keys and logs.
-- [changed] Added a limit to the number of unsent reports on disk to prevent disk filling up when automatic data collection is off. Developers can ensure this limit is never reached by calling send/deleteUnsentReports every run.
+- [added] Added a new API checkAndUpdateUnsentReportsWithCompletion for updating the crash report from the previous run of the app if, for example, the developer wants to implement a feedback dialog to ask end-users for more information. Unsent Crashlytics Reports have familiar methods like setting custom keys and logs (#7503).
+- [changed] Added a limit to the number of unsent reports on disk to prevent disk filling up when automatic data collection is off. Developers can ensure this limit is never reached by calling send/deleteUnsentReports every run (#7619).
 
 # v7.6.0
 - [fixed] Fixed an issue where some developers experienced a race condition involving binary image operations (#7459).

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
@@ -43,11 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * This value needs to stay in sync with numUnsentReports, so if there is > 0 numUnsentReports,
- * collectNewestReport needs to return a value. Otherwise it needs to return null.
+ * newestUnsentReport needs to return a value. Otherwise it needs to return null.
  *
  * FIRCLSContext needs to be initialized before the FIRCrashlyticsReport is instantiated.
  */
-@property(nonatomic, strong) FIRCrashlyticsReport *_Nullable newestUnsentReport;
+@property(nonatomic, readonly) FIRCrashlyticsReport *_Nullable newestUnsentReport;
 
 - (instancetype)initWithManagerData:(FIRCLSManagerData *)managerData
                      reportUploader:(FIRCLSReportUploader *)reportUploader;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class FIRCLSDataCollectionToken;
 @class FIRCrashlyticsReport;
 
+FOUNDATION_EXPORT NSUInteger const FIRCLSMaxUnsentReports;
+
 @interface FIRCLSExistingReportManager : NSObject
 
 /**

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) NSUInteger unsentReportsCount;
 
+/**
+ * This value needs to stay in sync with numUnsentReports, so if there is > 0 numUnsentReports,
+ * collectNewestReport needs to return a value. Otherwise it needs to return null.
+ *
+ * FIRCLSContext needs to be initialized before the FIRCrashlyticsReport is instantiated.
+ */
+@property(nonatomic, strong) FIRCrashlyticsReport *_Nullable newestUnsentReport;
+
 - (instancetype)initWithManagerData:(FIRCLSManagerData *)managerData
                      reportUploader:(FIRCLSReportUploader *)reportUploader;
 
@@ -52,20 +60,12 @@ NS_ASSUME_NONNULL_BEGIN
  * new report for this run of the app has been created. Any
  * reports in ExistingReportManager will be uploaded or deleted
  * and we don't want to do that for the current run of the app.
+ *
+ * If there are over MAX_UNSENT_REPORTS valid reports, this will delete them.
+ *
+ * This methods is slow and should be called only once.
  */
 - (void)collectExistingReports;
-
-/**
- * This value needs to stay in sync with numUnsentReports, so if there is > 0 numUnsentReports,
- * collectNewestReport needs to return a value. Otherwise it needs to return null.
- *
- * FIRCLSContext needs to be initialized before the FIRCrashlyticsReport is instantiated.
- *
- * This has the side effect of deleting any reports over the max, starting with oldest reports.
- *
- * This method is slow.
- */
-- (FIRCrashlyticsReport *_Nullable)findNewestUnsentReport;
 
 /**
  * This is the side-effect of calling deleteUnsentReports, or collect_reports setting

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h
@@ -41,14 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) NSUInteger unsentReportsCount;
 
-/**
- * This value needs to stay in sync with numUnsentReports, so if there is > 0 numUnsentReports,
- * newestUnsentReport needs to return a value. Otherwise it needs to return null.
- *
- * FIRCLSContext needs to be initialized before the FIRCrashlyticsReport is instantiated.
- */
-@property(nonatomic, readonly) FIRCrashlyticsReport *_Nullable newestUnsentReport;
-
 - (instancetype)initWithManagerData:(FIRCLSManagerData *)managerData
                      reportUploader:(FIRCLSReportUploader *)reportUploader;
 
@@ -62,6 +54,18 @@ NS_ASSUME_NONNULL_BEGIN
  * and we don't want to do that for the current run of the app.
  */
 - (void)collectExistingReports;
+
+/**
+ * This value needs to stay in sync with numUnsentReports, so if there is > 0 numUnsentReports,
+ * collectNewestReport needs to return a value. Otherwise it needs to return null.
+ *
+ * FIRCLSContext needs to be initialized before the FIRCrashlyticsReport is instantiated.
+ *
+ * This has the side effect of deleting any reports over the max, starting with oldest reports.
+ *
+ * This method is slow.
+ */
+- (FIRCrashlyticsReport *_Nullable)findNewestUnsentReport;
 
 /**
  * This is the side-effect of calling deleteUnsentReports, or collect_reports setting

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
@@ -29,14 +29,16 @@ const NSUInteger MAX_UNSENT_REPORTS = 4;
 @interface FIRCLSExistingReportManager ()
 
 @property(nonatomic, strong) FIRCLSFileManager *fileManager;
-@property(nonatomic, strong) NSOperationQueue *operationQueue;
 @property(nonatomic, strong) FIRCLSReportUploader *reportUploader;
+@property(nonatomic, strong) NSOperationQueue *operationQueue;
 
 // This list of active reports excludes the brand new active report that will be created this run of
 // the app.
 @property(nonatomic, strong) NSArray *existingUnemptyActiveReportPaths;
 @property(nonatomic, strong) NSArray *processingReportPaths;
 @property(nonatomic, strong) NSArray *preparedReportPaths;
+
+@property(nonatomic, strong) FIRCLSInternalReport *newestInternalReport;
 
 @end
 
@@ -56,54 +58,25 @@ const NSUInteger MAX_UNSENT_REPORTS = 4;
   return self;
 }
 
-NSInteger compareOlder(FIRCLSInternalReport *reportA,
+NSInteger compareNewer(FIRCLSInternalReport *reportA,
                        FIRCLSInternalReport *reportB,
                        void *context) {
-  return [reportA.dateCreated compare:reportB.dateCreated];
+  return -1 * [reportA.dateCreated compare:reportB.dateCreated];
 }
 
 - (void)collectExistingReports {
   self.existingUnemptyActiveReportPaths =
-      [self getUnemptyExistingActiveReportsAndDeleteEmpty:self.fileManager.activePathContents];
+      [self getUnsentActiveReportsAndDeleteEmptyOrOld:self.fileManager.activePathContents];
   self.processingReportPaths = self.fileManager.processingPathContents;
   self.preparedReportPaths = self.fileManager.preparedPathContents;
 }
 
-- (FIRCrashlyticsReport *)findNewestUnsentReport {
+- (FIRCrashlyticsReport *)newestUnsentReport {
   if (self.unsentReportsCount <= 0) {
     return nil;
   }
 
-  NSMutableArray<NSString *> *allReportPaths =
-      [NSMutableArray arrayWithArray:self.existingUnemptyActiveReportPaths];
-
-  NSMutableArray<FIRCLSInternalReport *> *validReports = [NSMutableArray array];
-  for (NSString *path in allReportPaths) {
-    FIRCLSInternalReport *_Nullable report = [FIRCLSInternalReport reportWithPath:path];
-    if (!report) {
-      continue;
-    }
-    [validReports addObject:report];
-  }
-
-  // Sort with the newest at the end
-  [validReports sortUsingFunction:compareOlder context:nil];
-
-  // Delete any reports above the limit, starting with the oldest
-  // which should be at the start of the array.
-  if (validReports.count > MAX_UNSENT_REPORTS) {
-    NSUInteger deletingCount = validReports.count - MAX_UNSENT_REPORTS;
-    FIRCLSInfoLog(@"Deleting %lu unsent reports over the limit of %lu to prevent disk space from filling up. To prevent this make sure to call send/deleteUnsentReports.", deletingCount, MAX_UNSENT_REPORTS);
-    for (int i = 0; i < deletingCount; i++) {
-      [self.operationQueue addOperationWithBlock:^{
-        NSString *path = [[validReports objectAtIndex:i] path];
-        [self.fileManager removeItemAtPath:path];
-      }];
-    }
-  }
-
-  FIRCLSInternalReport *_Nullable internalReport = [validReports lastObject];
-  return [[FIRCrashlyticsReport alloc] initWithInternalReport:internalReport];
+  return [[FIRCrashlyticsReport alloc] initWithInternalReport:self.newestInternalReport];
 }
 
 - (NSUInteger)unsentReportsCount {
@@ -112,19 +85,62 @@ NSInteger compareOlder(FIRCLSInternalReport *reportA,
   return self.existingUnemptyActiveReportPaths.count;
 }
 
-- (NSArray *)getUnemptyExistingActiveReportsAndDeleteEmpty:(NSArray *)reportPaths {
-  NSMutableArray *unemptyReports = [NSMutableArray array];
+/*
+ * This has the side effect of deleting any reports over the max, starting with oldest reports.
+ */
+- (NSArray<NSString *> *)getUnsentActiveReportsAndDeleteEmptyOrOld:(NSArray *)reportPaths {
+  NSMutableArray<FIRCLSInternalReport *> *validReports = [NSMutableArray array];
   for (NSString *path in reportPaths) {
-    FIRCLSInternalReport *report = [FIRCLSInternalReport reportWithPath:path];
-    if ([report hasAnyEvents]) {
-      [unemptyReports addObject:path];
-    } else {
+    FIRCLSInternalReport *_Nullable report = [FIRCLSInternalReport reportWithPath:path];
+    if (!report) {
+      continue;
+    }
+
+    // Delete reports without any crashes or non-fatals
+    if (![report hasAnyEvents]) {
       [self.operationQueue addOperationWithBlock:^{
         [self.fileManager removeItemAtPath:path];
       }];
+      continue;
+    }
+
+    [validReports addObject:report];
+  }
+
+  if (validReports.count == 0) {
+    return @[];
+  }
+
+  // Sort with the newest at the end
+  [validReports sortUsingFunction:compareNewer context:nil];
+
+  // Set our report for updating in checkAndUpdateUnsentReports
+  self.newestInternalReport = [validReports firstObject];
+
+  // Delete any reports above the limit, starting with the oldest
+  // which should be at the start of the array.
+  if (validReports.count > MAX_UNSENT_REPORTS) {
+    NSUInteger deletingCount = validReports.count - MAX_UNSENT_REPORTS;
+    FIRCLSInfoLog(@"Deleting %lu unsent reports over the limit of %lu to prevent disk space from "
+                  @"filling up. To prevent this make sure to call send/deleteUnsentReports.",
+                  deletingCount, MAX_UNSENT_REPORTS);
+  }
+
+  // Not that validReports is sorted, delete any reports at indices > MAX_UNSENT_REPORTS, and
+  // collect the rest of the reports to return.
+  NSMutableArray<NSString *> *validReportPaths = [NSMutableArray array];
+  for (int i = 0; i < validReports.count; i++) {
+    if (i >= MAX_UNSENT_REPORTS) {
+      [self.operationQueue addOperationWithBlock:^{
+        NSString *path = [[validReports objectAtIndex:i] path];
+        [self.fileManager removeItemAtPath:path];
+      }];
+    } else {
+      [validReportPaths addObject:[[validReports objectAtIndex:i] path]];
     }
   }
-  return unemptyReports;
+
+  return validReportPaths;
 }
 
 - (void)sendUnsentReportsWithToken:(FIRCLSDataCollectionToken *)dataCollectionToken

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
@@ -24,7 +24,7 @@
 #import "Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h"
 
 // This value should stay in sync with the Android SDK
-const NSUInteger MAX_UNSENT_REPORTS = 4;
+NSUInteger const FIRCLSMaxUnsentReports = 4;
 
 @interface FIRCLSExistingReportManager ()
 
@@ -61,7 +61,8 @@ const NSUInteger MAX_UNSENT_REPORTS = 4;
 NSInteger compareNewer(FIRCLSInternalReport *reportA,
                        FIRCLSInternalReport *reportB,
                        void *context) {
-  return -1 * [reportA.dateCreated compare:reportB.dateCreated];
+  // Compare naturally sorts with oldest first, so swap A and B
+  return [reportB.dateCreated compare:reportA.dateCreated];
 }
 
 - (void)collectExistingReports {
@@ -119,18 +120,18 @@ NSInteger compareNewer(FIRCLSInternalReport *reportA,
 
   // Delete any reports above the limit, starting with the oldest
   // which should be at the start of the array.
-  if (validReports.count > MAX_UNSENT_REPORTS) {
-    NSUInteger deletingCount = validReports.count - MAX_UNSENT_REPORTS;
+  if (validReports.count > FIRCLSMaxUnsentReports) {
+    NSUInteger deletingCount = validReports.count - FIRCLSMaxUnsentReports;
     FIRCLSInfoLog(@"Deleting %lu unsent reports over the limit of %lu to prevent disk space from "
                   @"filling up. To prevent this make sure to call send/deleteUnsentReports.",
-                  deletingCount, MAX_UNSENT_REPORTS);
+                  deletingCount, FIRCLSMaxUnsentReports);
   }
 
   // Not that validReports is sorted, delete any reports at indices > MAX_UNSENT_REPORTS, and
   // collect the rest of the reports to return.
   NSMutableArray<NSString *> *validReportPaths = [NSMutableArray array];
   for (int i = 0; i < validReports.count; i++) {
-    if (i >= MAX_UNSENT_REPORTS) {
+    if (i >= FIRCLSMaxUnsentReports) {
       [self.operationQueue addOperationWithBlock:^{
         NSString *path = [[validReports objectAtIndex:i] path];
         [self.fileManager removeItemAtPath:path];

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -192,7 +192,7 @@ typedef NSNumber FIRCLSWrappedReportAction;
 //    2. The developer uses the processCrashReports API to indicate whether the report
 //       should be sent or deleted, at which point the promise will be resolved with the action.
 - (FBLPromise<FIRCLSWrappedReportAction *> *)waitForReportAction {
-  FIRCrashlyticsReport *unsentReport = [self.existingReportManager findNewestUnsentReport];
+  FIRCrashlyticsReport *unsentReport = [self.existingReportManager newestUnsentReport];
   [_unsentReportsAvailable fulfill:unsentReport];
 
   // If data collection gets enabled while we are waiting for an action, go ahead and send the

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -192,7 +192,7 @@ typedef NSNumber FIRCLSWrappedReportAction;
 //    2. The developer uses the processCrashReports API to indicate whether the report
 //       should be sent or deleted, at which point the promise will be resolved with the action.
 - (FBLPromise<FIRCLSWrappedReportAction *> *)waitForReportAction {
-  FIRCrashlyticsReport *unsentReport = self.existingReportManager.newestUnsentReport;
+  FIRCrashlyticsReport *unsentReport = [self.existingReportManager findNewestUnsentReport];
   [_unsentReportsAvailable fulfill:unsentReport];
 
   // If data collection gets enabled while we are waiting for an action, go ahead and send the

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -192,7 +192,7 @@ typedef NSNumber FIRCLSWrappedReportAction;
 //    2. The developer uses the processCrashReports API to indicate whether the report
 //       should be sent or deleted, at which point the promise will be resolved with the action.
 - (FBLPromise<FIRCLSWrappedReportAction *> *)waitForReportAction {
-  FIRCrashlyticsReport *unsentReport = [self.existingReportManager newestUnsentReport];
+  FIRCrashlyticsReport *unsentReport = self.existingReportManager.newestUnsentReport;
   [_unsentReportsAvailable fulfill:unsentReport];
 
   // If data collection gets enabled while we are waiting for an action, go ahead and send the

--- a/Crashlytics/Crashlytics/Private/FIRCLSExistingReportManager_Private.h
+++ b/Crashlytics/Crashlytics/Private/FIRCLSExistingReportManager_Private.h
@@ -1,9 +1,16 @@
+// Copyright 2021 Google LLC
 //
-//  FIRCLSExistingReportManager_Private.h
-//  Pods
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Sam Edson on 2/26/21.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef FIRCLSExistingReportManager_Private_h
 #define FIRCLSExistingReportManager_Private_h

--- a/Crashlytics/Crashlytics/Private/FIRCLSExistingReportManager_Private.h
+++ b/Crashlytics/Crashlytics/Private/FIRCLSExistingReportManager_Private.h
@@ -1,0 +1,26 @@
+//
+//  FIRCLSExistingReportManager_Private.h
+//  Pods
+//
+//  Created by Sam Edson on 2/26/21.
+//
+
+#ifndef FIRCLSExistingReportManager_Private_h
+#define FIRCLSExistingReportManager_Private_h
+
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h"
+
+/**
+ * Visible for testing
+ */
+@interface FIRCLSExistingReportManager (Private)
+
+@property(nonatomic, strong) NSOperationQueue *operationQueue;
+
+@property(nonatomic, strong) NSArray *existingUnemptyActiveReportPaths;
+@property(nonatomic, strong) NSArray *processingReportPaths;
+@property(nonatomic, strong) NSArray *preparedReportPaths;
+
+@end
+
+#endif /* FIRCLSExistingReportManager_Private_h */

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -175,15 +175,17 @@
   // Reports with events should be kept if there's less than MAX_UNSENT_REPORTS reports
   XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, FIRCLSMaxUnsentReports);
-  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, FIRCLSMaxUnsentReports);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count,
+                 FIRCLSMaxUnsentReports);
 
   // Newest report based on started_at timestamp
   XCTAssertEqualObjects(self.existingReportManager.newestUnsentReport.reportID, @"report_D");
 }
 
 /**
- * When we go over the limit of FIRCLSMaxUnsentReports, we delete any reports over the limit to ensure performant
- * startup and prevent disk space from filling up. Delete starting with the oldest first.
+ * When we go over the limit of FIRCLSMaxUnsentReports, we delete any reports over the limit to
+ * ensure performant startup and prevent disk space from filling up. Delete starting with the oldest
+ * first.
  */
 - (void)testUnsentReportsOverLimit {
   // Create a bunch of reports starting at different times
@@ -204,7 +206,8 @@
   // Remove any reports over the limit, starting with the oldest
   XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, FIRCLSMaxUnsentReports);
-  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, FIRCLSMaxUnsentReports);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count,
+                 FIRCLSMaxUnsentReports);
 
   // Newest report based on started_at timestamp
   XCTAssertEqualObjects(self.existingReportManager.newestUnsentReport.reportID, @"report_G");

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -129,7 +129,8 @@
 }
 
 - (BOOL)reportPathAtIndex:(NSUInteger)index isReportID:(NSString *)reportID {
-  return [[self.existingReportManager.existingUnemptyActiveReportPaths objectAtIndex:index] containsString:reportID];
+  return [[self.existingReportManager.existingUnemptyActiveReportPaths objectAtIndex:index]
+      containsString:reportID];
 }
 
 #pragma mark - Tests

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -1,9 +1,16 @@
+// Copyright 2021 Google LLC
 //
-//  FIRCLSExistingReportManagerTests.m
-//  Pods
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Sam Edson on 2/26/21.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import <XCTest/XCTest.h>
 
@@ -121,6 +128,10 @@
                                atPath:[report pathForContentFile:FIRCLSReportExceptionFile]];
 }
 
+- (BOOL)reportPathAtIndex:(NSUInteger)index isReportID:(NSString *)reportID {
+  return [[self.existingReportManager.existingUnemptyActiveReportPaths objectAtIndex:index] containsString:reportID];
+}
+
 #pragma mark - Tests
 
 - (void)testNoReports {
@@ -191,6 +202,12 @@
 
   // Newest report based on started_at timestamp
   XCTAssertEqualObjects(self.existingReportManager.newestUnsentReport.reportID, @"report_G");
+
+  // Make sure we're sorting correctly
+  XCTAssertEqual([self reportPathAtIndex:0 isReportID:@"report_G"], true);
+  XCTAssertEqual([self reportPathAtIndex:1 isReportID:@"report_D"], true);
+  XCTAssertEqual([self reportPathAtIndex:2 isReportID:@"report_I"], true);
+  XCTAssertEqual([self reportPathAtIndex:3 isReportID:@"report_F"], true);
 }
 
 @end

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -106,7 +106,6 @@
 }
 
 - (BOOL)createFileWithContents:(NSString *)contents atPath:(NSString *)path {
-  NSLog(@"path: %@", path);
   return [self.fileManager.underlyingFileManager
       createFileAtPath:path
               contents:[contents dataUsingEncoding:NSUTF8StringEncoding]

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -1,0 +1,197 @@
+//
+//  FIRCLSExistingReportManagerTests.m
+//  Pods
+//
+//  Created by Sam Edson on 2/26/21.
+//
+
+#import <XCTest/XCTest.h>
+
+#include "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
+#import "Crashlytics/Crashlytics/Private/FIRCLSExistingReportManager_Private.h"
+#import "Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h"
+#import "Crashlytics/UnitTests/Mocks/FIRCLSMockReportUploader.h"
+#import "Crashlytics/UnitTests/Mocks/FIRCLSTempMockFileManager.h"
+
+#define METADATA_FORMAT                                                                        \
+  (@"{\"identity\":{\"generator\":\"Crashlytics iOS "                                          \
+   @"SDK/"                                                                                     \
+   @"7.7.0\",\"display_version\":\"7.7.0\",\"build_version\":\"7.7.0\",\"started_at\":%ld,"    \
+   @"\"session_id\":\"%@\",\"install_id\":\"CA3EE845-594A-4AAD-8343-B0379559E5C5\",\"beta_"    \
+   @"token\":\"\",\"absolute_log_timestamps\":true}}\n{\"host\":{\"model\":\"iOS Simulator "   \
+   @"(iPhone)\",\"machine\":\"x86_64\",\"cpu\":\"Intel(R) Core(TM) i9-9880H CPU @ "            \
+   @"2.30GHz\",\"os_build_version\":\"20D74\",\"os_display_version\":\"14.3.0\",\"platform\":" \
+   @"\"ios\",\"locale\":\"en_US\"}}\n{\"application\":{\"bundle_id\":\"com.google.firebase."   \
+   @"quickstart.TestingNoAWS\",\"custom_bundle_id\":null,\"build_version\":\"131\",\"display_" \
+   @"version\":\"10.10.33\",\"extension_id\":null}}\n{\"executable\":{\"architecture\":\"x86_" \
+   @"64\",\"uuid\":\"6a082b52b92a36bdb766fda9049deb21\",\"base\":4471803904,\"size\":49152,"   \
+   @"\"encrypted\":false,\"minimum_sdk_version\":\"8.0.0\",\"built_sdk_version\":\"14.3.0\"}}")
+
+@interface FIRCLSExistingReportManagerTests : XCTestCase
+
+@property(nonatomic, strong) FIRCLSMockReportUploader *mockReportUploader;
+@property(nonatomic, strong) FIRCLSTempMockFileManager *fileManager;
+@property(nonatomic, strong) FIRCLSExistingReportManager *existingReportManager;
+@property(nonatomic, strong) FIRCLSManagerData *managerData;
+
+@end
+
+@implementation FIRCLSExistingReportManagerTests
+
+- (void)setUp {
+  [super setUp];
+
+  FIRCLSContextBaseInit();
+
+  self.fileManager = [[FIRCLSTempMockFileManager alloc] init];
+
+  // Allow nil values only in tests
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  self.managerData = [[FIRCLSManagerData alloc] initWithGoogleAppID:@"TEST_GOOGLE_APP_ID"
+                                                    googleTransport:nil
+                                                      installations:nil
+                                                          analytics:nil
+                                                        fileManager:self.fileManager
+                                                        dataArbiter:nil
+                                                           settings:nil];
+#pragma clang diagnostic pop
+
+  self.mockReportUploader = [[FIRCLSMockReportUploader alloc] initWithManagerData:self.managerData];
+  self.existingReportManager =
+      [[FIRCLSExistingReportManager alloc] initWithManagerData:self.managerData
+                                                reportUploader:self.mockReportUploader];
+}
+
+- (void)tearDown {
+  if ([[NSFileManager defaultManager] fileExistsAtPath:[self.fileManager rootPath]]) {
+    assert([self.fileManager removeItemAtPath:[self.fileManager rootPath]]);
+  }
+
+  FIRCLSContextBaseDeinit();
+
+  [super tearDown];
+}
+
+- (NSArray *)contentsOfActivePath {
+  return [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.fileManager.activePath
+                                                             error:nil];
+}
+
+#pragma mark - Helpers
+
+- (FIRCLSInternalReport *)createActiveReportWithID:(NSString *)reportID
+                                              time:(time_t)time
+                                        withEvents:(BOOL)withEvents {
+  NSString *reportPath = [self.fileManager.activePath stringByAppendingPathComponent:reportID];
+  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:reportPath
+                                                        executionIdentifier:reportID];
+
+  if (![self.fileManager createDirectoryAtPath:report.path]) {
+    return nil;
+  }
+
+  NSString *metadata = [NSString stringWithFormat:METADATA_FORMAT, time, reportID];
+  if (![self createMetadata:metadata forReport:report]) {
+    return nil;
+  }
+
+  if (withEvents) {
+    [self createCrashExceptionFile:@"Content doesn't matter" forReport:report];
+  }
+
+  return report;
+}
+
+- (BOOL)createFileWithContents:(NSString *)contents atPath:(NSString *)path {
+  NSLog(@"path: %@", path);
+  return [self.fileManager.underlyingFileManager
+      createFileAtPath:path
+              contents:[contents dataUsingEncoding:NSUTF8StringEncoding]
+            attributes:nil];
+}
+
+- (BOOL)createMetadata:(NSString *)value forReport:(FIRCLSInternalReport *)report {
+  return [self createFileWithContents:value atPath:[report metadataPath]];
+}
+
+- (BOOL)createCrashExceptionFile:(NSString *)value forReport:(FIRCLSInternalReport *)report {
+  return [self createFileWithContents:value
+                               atPath:[report pathForContentFile:FIRCLSReportExceptionFile]];
+}
+
+#pragma mark - Tests
+
+- (void)testNoReports {
+  [self.existingReportManager collectExistingReports];
+
+  [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
+
+  // Reports without events should be deleted
+  XCTAssertEqual([[self contentsOfActivePath] count], 0);
+  XCTAssertEqual(self.existingReportManager.unsentReportsCount, 0);
+  XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
+}
+
+- (void)testReportNoEvents {
+  [self createActiveReportWithID:@"report_A" time:12312 withEvents:NO];
+  [self createActiveReportWithID:@"report_B" time:12315 withEvents:NO];
+
+  [self.existingReportManager collectExistingReports];
+
+  [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
+
+  // Reports without events should be deleted
+  XCTAssertEqual([[self contentsOfActivePath] count], 0);
+  XCTAssertEqual(self.existingReportManager.unsentReportsCount, 0);
+  XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
+}
+
+- (void)testUnsentReportsUnderLimit {
+  [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];
+  [self createActiveReportWithID:@"report_B" time:12315 withEvents:YES];
+  [self createActiveReportWithID:@"report_C" time:31533 withEvents:YES];
+  [self createActiveReportWithID:@"report_D" time:63263 withEvents:YES];
+
+  [self.existingReportManager collectExistingReports];
+
+  [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
+
+  // Reports with events should be kept if there's less than MAX_UNSENT_REPORTS reports
+  XCTAssertEqual([[self contentsOfActivePath] count], 4);
+  XCTAssertEqual(self.existingReportManager.unsentReportsCount, 4);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 4);
+
+  // Newest report based on started_at timestamp
+  XCTAssertEqualObjects(self.existingReportManager.newestUnsentReport.reportID, @"report_D");
+}
+
+- (void)testUnsentReportsOverLimit {
+  [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];
+  [self createActiveReportWithID:@"report_B" time:12315 withEvents:YES];
+  [self createActiveReportWithID:@"report_C" time:31533 withEvents:YES];
+  [self createActiveReportWithID:@"report_D" time:63263 withEvents:YES];
+  [self createActiveReportWithID:@"report_E" time:33263 withEvents:YES];
+  [self createActiveReportWithID:@"report_F" time:43263 withEvents:YES];
+  [self createActiveReportWithID:@"report_G" time:77777 withEvents:YES];
+  [self createActiveReportWithID:@"report_H" time:13263 withEvents:YES];
+  [self createActiveReportWithID:@"report_I" time:61263 withEvents:YES];
+
+  [self.existingReportManager collectExistingReports];
+
+  [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
+
+  // Remove any reports over the limit, starting with the oldest
+  XCTAssertEqual([[self contentsOfActivePath] count], 4);
+  XCTAssertEqual(self.existingReportManager.unsentReportsCount, 4);
+  XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 4);
+
+  // Newest report based on started_at timestamp
+  XCTAssertEqualObjects(self.existingReportManager.newestUnsentReport.reportID, @"report_G");
+}
+
+@end

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -161,7 +161,6 @@
 }
 
 - (BOOL)createFileWithContents:(NSString *)contents atPath:(NSString *)path {
-  NSLog(@"path: %@", path);
   return [self.fileManager.underlyingFileManager
       createFileAtPath:path
               contents:[contents dataUsingEncoding:NSUTF8StringEncoding]


### PR DESCRIPTION
If the developer turns automatic collection off, they run the risk of filling up disk space with unsent reports if they never call send/deleteUnsentReports. In addition, having too many unsent reports can cause performance problems when trying to find the newest unsent report.

This change limits the number of unsent reports to 4 to match Android: https://github.com/firebase/firebase-android-sdk/blob/e65f4876ff61b5791986c249b21cb094c37bd29e/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsJsonConstants.java#L61