### PR TITLE
WIP: making Firestore / Combine testable

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
@@ -734,6 +734,118 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAuthCombineSwift-Beta"
+               BuildableName = "FirebaseAuthCombineSwift-Beta"
+               BlueprintName = "FirebaseAuthCombineSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseCombineSwift-Beta"
+               BuildableName = "FirebaseCombineSwift-Beta"
+               BlueprintName = "FirebaseCombineSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFunctionsCombineSwift-Beta"
+               BuildableName = "FirebaseFunctionsCombineSwift-Beta"
+               BlueprintName = "FirebaseFunctionsCombineSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAuthCombineSwift"
+               BuildableName = "FirebaseAuthCombineSwift"
+               BlueprintName = "FirebaseAuthCombineSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseCombineSwift"
+               BuildableName = "FirebaseCombineSwift"
+               BlueprintName = "FirebaseCombineSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFunctionsCombineSwift"
+               BuildableName = "FirebaseFunctionsCombineSwift"
+               BlueprintName = "FirebaseFunctionsCombineSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFirestoreCombineSwift-Beta"
+               BuildableName = "FirebaseFirestoreCombineSwift-Beta"
+               BlueprintName = "FirebaseFirestoreCombineSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFirestoreCombineSwift"
+               BuildableName = "FirebaseFirestoreCombineSwift"
+               BlueprintName = "FirebaseFirestoreCombineSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -63,10 +63,15 @@ Combine Publishers for Firebase.
       'FirebaseCombineSwift/Tests/Unit/**/*.swift',
       'FirebaseCombineSwift/Tests/Unit/**/*.h',
       'SharedTestUtilities/FIROptionsMock.[mh]',
+      # 'Firestore/Example/Tests/API/FSTAPIHelpers.h',
+      # 'Firestore/Example/Tests/API/FSTAPIHelpers.mm'
     ]
     unit_tests.exclude_files = 'FirebaseCombineSwift/Tests/Unit/**/*Template.swift'
     unit_tests.requires_app_host = true
+    unit_tests.library = 'c++'
     unit_tests.pod_target_xcconfig = {
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++0x',
+      'GCC_C_LANGUAGE_STANDARD' => 'c99',  
       'SWIFT_OBJC_BRIDGING_HEADER' => '$(PODS_TARGET_SRCROOT)/FirebaseCombineSwift/Tests/Unit/FirebaseCombine-unit-Bridging-Header.h'
     }
     unit_tests.dependency 'OCMock'

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -46,6 +46,8 @@ Combine Publishers for Firebase.
   s.dependency 'FirebaseCore', '~> 7.0'
   s.dependency 'FirebaseAuth', '~> 7.0'
   s.dependency 'FirebaseFunctions', '~> 7.0'
+  s.dependency 'FirebaseFirestore', '~> 7.0'
+  s.dependency 'FirebaseFirestoreSwift', '~> 7.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseCombineSwift/Sources/Firestore/CollectionReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/CollectionReference+Combine.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseFirestore)
+
+import Combine
+import FirebaseFirestore
+
+#if canImport(FirebaseFirestoreSwift)
+
+import FirebaseFirestoreSwift
+
+#endif
+
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension CollectionReference {
+    
+    // MARK: - Add Document
+    
+    /// Adds a new document to this collection with the specified data, assigning it a document ID
+    /// automatically.
+    /// - Parameter data: A `Dictionary` containing the data for the new document.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emits  while the client is offline, though
+    /// local changes will be visible immediately.
+    public func addDocument(data: [String: Any])
+    -> AnyPublisher<DocumentReference, Error> {
+        var reference: DocumentReference!
+        return Future { promise in
+            reference = self.addDocument(data: data) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+        .map { reference }
+        .eraseToAnyPublisher()
+    }
+    
+    #if canImport(FirebaseFirestoreSwift)
+    
+    /// Adds a new document to this collection with the specified data, assigning it a document ID
+    /// automatically.
+    /// - Parameters:
+    ///   - value: An instance of Encodable to be encoded to a document.
+    ///   - encoder: An encoder instance to use to run the encoding.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emits  while the client is offline, though
+    /// local changes will be visible immediately.
+    public func addDocument<T: Encodable>(from value: T, encoder: Firestore.Encoder = Firestore.Encoder()) -> AnyPublisher<DocumentReference, Error> {
+        var reference: DocumentReference!
+        return Future { promise in
+            do {
+                try reference = self.addDocument(from: value, encoder: encoder) { error in
+                    if let error = error {
+                        promise(.failure(error))
+                    } else {
+                        promise(.success(()))
+                    }
+                }
+            } catch {
+                promise(.failure(error))
+            }
+        }
+        .map { reference }
+        .eraseToAnyPublisher()
+    }
+    
+    #endif
+    
+}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Firestore/CollectionReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/CollectionReference+Combine.swift
@@ -25,6 +25,39 @@ import FirebaseFirestoreSwift
 
 #endif
 
+public protocol CollectionReferenceExtension {
+  func addDocument(data: [String : Any], completion: ((Error?) -> Void)?) -> DocumentReference
+}
+
+public extension CollectionReferenceExtension {
+  // MARK: - Add Document
+  
+  /// Adds a new document to this collection with the specified data, assigning it a document ID
+  /// automatically.
+  /// - Parameter data: A `Dictionary` containing the data for the new document.
+  /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+  /// written to the server. This publisher will not emits  while the client is offline, though
+  /// local changes will be visible immediately.
+  func addDocument(data: [String: Any])
+  -> AnyPublisher<DocumentReference, Error> {
+    var reference: DocumentReference!
+    return Future { promise in
+      reference = self.addDocument(data: data) { error in
+        if let error = error {
+          promise(.failure(error))
+        } else {
+          promise(.success(()))
+        }
+      }
+    }
+    .map { reference }
+    .eraseToAnyPublisher()
+  }
+}
+
+// conform the original class to the protocol, and tack on the protocol extension
+extension CollectionReference: CollectionReferenceExtension {}
+
 @available(swift 5.0)
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CollectionReference {

--- a/FirebaseCombineSwift/Sources/Firestore/DocumentReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/DocumentReference+Combine.swift
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2021 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseFirestore)
+
+import Combine
+import FirebaseFirestore
+
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension DocumentReference {
+    
+    // MARK: - Set Data
+    
+    /// Overwrites the document referred to by this `DocumentReference`. If no document exists, it
+    /// is created. If a document already exists, it is overwritten.
+    /// - Parameter documentData: A `Dictionary` containing the fields that make up the document to
+    ///  be written.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    /// local changes will be visible immediately.
+    public func setData(_ documentData: [String: Any]) -> Future<Void, Error> {
+        Future { promise in
+            self.setData(documentData) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Writes to the document referred to by this `DocumentReference`. If the document does not yet
+    /// exist, it will be created. If you pass `merge: true`, the provided data will be merged into
+    /// any existing document.
+    /// - Parameters:
+    ///   - documentData: A `Dictionary` containing the fields that make up the document to be
+    ///   written.
+    ///   - merge: Whether to merge the provided data into any existing document.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    /// local changes will be visible immediately.
+    public func setData(_ documentData: [String: Any], merge: Bool) -> Future<Void, Error> {
+        Future { promise in
+            self.setData(documentData, merge: merge) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Writes to the document referred to by this `DocumentReference` and only replace the fields
+    /// specified under `mergeFields`. Any field that is not specified in `mergeFields` is ignored
+    /// and remains untouched. If the document doesn't yet exist, this method creates it and then
+    /// sets the data.
+    /// - Parameters:
+    ///   - documentData: A `Dictionary` containing the fields that make up the document to be
+    ///   written.
+    ///   - mergeFields: An `Array` that contains a list of `String` or `FieldPath` elements
+    ///   specifying which fields to merge. Fields can contain dots to reference nested fields
+    ///   within the document.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    /// local changes will be visible immediately.
+    public func setData(_ documentData: [String: Any], mergeFields: [Any]) -> Future<Void, Error> {
+        Future { promise in
+            self.setData(documentData, mergeFields: mergeFields) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Encodes an instance of `Encodable` and overwrites the encoded data to the document referred
+    ///  by this `DocumentReference`. If no document exists, it is created. If a document already
+    ///  exists, it is overwritten.
+    /// - Parameters:
+    ///   - value: An instance of `Encodable` to be encoded to a document.
+    ///   - encoder: An encoder instance to use to run the encoding.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    /// local changes will be visible immediately.
+    public func setData<T: Encodable>(from value: T, encoder: Firestore.Encoder = Firestore.Encoder()) -> Future<Void, Error> {
+        Future { promise in
+            do {
+                try self.setData(from: value) { error in
+                    if let error = error {
+                        promise(.failure(error))
+                    } else {
+                        promise(.success(()))
+                    }
+                }
+            } catch {
+                promise(.failure(error))
+            }
+        }
+    }
+    
+    /// Encodes an instance of `Encodable` and overwrites the encoded data to the document referred
+    ///  by this `DocumentReference`. If no document exists, it is created. If a document already
+    ///  exists, it is overwritten. If you pass `merge: true`, the provided Encodable will be merged
+    ///   into any existing document.
+    /// - Parameters:
+    ///   - value: An instance of `Encodable` to be encoded to a document.
+    ///   - merge: Whether to merge the provided data into any existing document.
+    ///   - encoder: An encoder instance to use to run the encoding.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    /// local changes will be visible immediately.
+    public func setData<T: Encodable>(from value: T, merge: Bool, encoder: Firestore.Encoder = Firestore.Encoder()) -> Future<Void, Error> {
+        Future { promise in
+            do {
+                try self.setData(from: value, merge: merge) { error in
+                    if let error = error {
+                        promise(.failure(error))
+                    } else {
+                        promise(.success(()))
+                    }
+                }
+            } catch {
+                promise(.failure(error))
+            }
+        }
+    }
+    
+    /// Encodes an instance of `Encodable` and writes the encoded data to the document referred by
+    /// this DocumentReference by only replacing the fields specified under mergeFields. Any field
+    /// that is not specified in mergeFields is ignored and remains untouched. If the document
+    /// doesn’t yet exist, this method creates it and then sets the data.
+    /// - Parameters:
+    ///   - value: An instance of `Encodable` to be encoded to a document.
+    ///   - mergeFields: An `Array` that contains a list of `String` or `FieldPath` elements
+    ///   specifying which fields to merge. Fields can contain dots to reference nested fields
+    ///   within the document.
+    ///   - encoder: An encoder instance to use to run the encoding.
+    /// - Returns: A publisher emitting a `Void` value once the document has been successfully
+    /// written to the server. This publisher will not emit while the client is offline, though
+    ///  local changes will be visible immediately.
+    public func setData<T: Encodable>(from value: T, mergeFields: [Any], encoder: Firestore.Encoder = Firestore.Encoder()) -> Future<Void, Error> {
+        Future { promise in
+            do {
+                try self.setData(from: value, mergeFields: mergeFields) { error in
+                    if let error = error {
+                        promise(.failure(error))
+                    } else {
+                        promise(.success(()))
+                    }
+                }
+            } catch {
+                promise(.failure(error))
+            }
+        }
+    }
+    
+    // MARK: - Update Data
+    
+    /// Updates fields in the document referred to by this `DocumentReference`. If the document does
+    ///  not exist, the update fails and the specified completion block receives an error.
+    /// - Parameter documentData: A `Dictionary` containing the fields (expressed as a `String` or
+    /// `FieldPath`) and values with which to update the document.
+    /// - Returns: A publisher emitting a `Void` when the update is complete. This block will only
+    /// execute when the client is online and the commit has completed against the server. This
+    /// publisher will not emit while the device is offline, though local changes will be visible
+    /// immediately.
+    public func updateData(_ documentData: [String: Any]) -> Future<Void, Error> {
+        Future { promise in
+            self.updateData(documentData) { error in
+            if let error = error {
+                promise(.failure(error))
+            } else {
+                promise(.success(()))
+            }
+        }
+        }
+    }
+    
+    // MARK: - Delete
+    
+    /// Deletes the document referred to by this `DocumentReference`.
+    /// - Returns: A publisher emitting a `Void` when the document has been deleted from the server.
+    ///  This publisher will not emit while the device is offline, though local changes will be
+    ///  visible immediately.
+    public func delete() -> Future<Void, Error> {
+        Future { promise in
+            self.delete { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    // MARK: - Get Document
+    
+    /// Reads the document referenced by this `DocumentReference`.
+    /// - Parameter source: Indicates whether the results should be fetched from the cache only
+    ///  (`Source.cache`), the server only (`Source.server`), or to attempt the server and fall back
+    ///   to the cache (`Source.default`).
+    /// - Returns: A publisher emitting a `DocumentSnapshot` instance.
+    public func getDocument(source: FirestoreSource = .default)
+    -> Future<DocumentSnapshot, Error> {
+        Future { promise in
+            self.getDocument(source: source) { snapshot, error in
+                if let error = error {
+                    promise(.failure(error))
+                } else if let snapshot = snapshot {
+                    promise(.success(snapshot))
+                }
+            }
+        }
+    }
+    
+    // MARK: - Snapshot Publisher
+    
+    /// Registers a publisher that publishes document snapshot changes.
+    /// - Parameter includeMetadataChanges: Whether metadata-only changes (i.e. only
+    /// `DocumentSnapshot.metadata` changed) should trigger snapshot events.
+    /// - Returns: A publisher emitting `DocumentSnapshot` instances.
+    public func snapshotPublisher(includeMetadataChanges: Bool = false)
+    -> AnyPublisher<DocumentSnapshot, Error> {
+        let subject = PassthroughSubject<DocumentSnapshot, Error>()
+        let listenerHandle = addSnapshotListener(includeMetadataChanges: includeMetadataChanges) { snapshot, error in
+            if let error = error {
+                subject.send(completion: .failure(error))
+            } else if let snapshot = snapshot {
+                subject.send(snapshot)
+            }
+        }
+        return subject
+            .handleEvents(receiveCancel: listenerHandle.remove)
+            .eraseToAnyPublisher()
+    }
+}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Firestore/DocumentReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/DocumentReference+Combine.swift
@@ -19,6 +19,27 @@
 import Combine
 import FirebaseFirestore
 
+public protocol DocumentReferenceExtension {
+  func setData(_ documentData: [String : Any], completion: ((Error?) -> Void)?)
+  func setData(_ documentData: [String: Any]) -> Future<Void, Error>
+}
+
+public extension DocumentReferenceExtension {
+  func setData(_ documentData: [String: Any]) -> Future<Void, Error> {
+    Future { promise in
+      self.setData(documentData) { error in
+        if let error = error {
+          promise(.failure(error))
+        } else {
+          promise(.success(()))
+        }
+      }
+    }
+  }
+}
+
+extension DocumentReference: DocumentReferenceExtension { }
+
 @available(swift 5.0)
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension DocumentReference {

--- a/FirebaseCombineSwift/Sources/Firestore/Query+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/Query+Combine.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseFirestore)
+
+import Combine
+import FirebaseFirestore
+
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension Query {
+    
+    // MARK: - Get Documents
+    
+    /// Reads the documents matching this query.
+    /// - Parameter source: Indicates whether the results should be fetched from the cache only
+    ///  (`Source.cache`), the server only (`Source.server`), or to attempt the server and fall back
+    ///  to the cache (`Source.default`).
+    /// - Returns: A publisher emitting a `QuerySnapshot` instance.
+    public func getDocuments(source: FirestoreSource = .default) -> Future<QuerySnapshot, Error> {
+        Future { promise in
+            self.getDocuments(source: source) { snapshot, error in
+                if let error = error {
+                    promise(.failure(error))
+                } else if let snapshot = snapshot {
+                    promise(.success(snapshot))
+                }
+            }
+        }
+    }
+    
+    // MARK: - Snapshot Publisher
+    
+    /// Registers a publisher that publishes query snapshot changes.
+    /// - Parameter includeMetadataChanges: Whether metadata-only changes (i.e. only
+    /// `QuerySnapshot.metadata` changed) should trigger snapshot events.
+    /// - Returns: A publisher emitting `QuerySnapshot` instances.
+    public func snapshotPublisher(includeMetadataChanges: Bool = false)
+    -> AnyPublisher<QuerySnapshot, Error> {
+        let subject = PassthroughSubject<QuerySnapshot, Error>()
+        let listenerHandle = addSnapshotListener(includeMetadataChanges: includeMetadataChanges) { snapshot, error in
+            if let error = error {
+                subject.send(completion: .failure(error))
+            } else if let snapshot = snapshot {
+                subject.send(snapshot)
+            }
+        }
+        return subject
+            .handleEvents(receiveCancel: listenerHandle.remove)
+            .eraseToAnyPublisher()
+    }
+}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Firestore/Transaction+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/Transaction+Combine.swift
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseFirestore)
+
+import Combine
+import FirebaseFirestore
+
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension Firestore {
+    
+    /// Executes the given updateBlock and then attempts to commit the changes applied within an
+    /// atomic transaction.
+    ///
+    /// The maximum number of writes allowed in a single transaction is 500, but note that each
+    /// usage of `FieldValue.serverTimestamp()`, `FieldValue.arrayUnion()`,
+    /// `FieldValue.arrayRemove()`, or `FieldValue.increment()` inside a transaction counts as an
+    ///  additional write.
+    ///
+    /// In the updateBlock, a set of reads and writes can be performed atomically using the
+    ///  `Transaction` object passed to the block. After the updateBlock is run, Firestore will
+    ///  attempt to apply the changes to the server. If any of the data read has been modified
+    ///  outside of this transaction since being read, then the transaction will be retried by
+    ///  executing the updateBlock again. If the transaction still fails after 5 retries, then the
+    ///   transaction will fail.
+    ///
+    /// Since the updateBlock may be executed multiple times, it should avoiding doing anything that
+    /// would cause side effects.
+    ///
+    /// Any value maybe be returned from the updateBlock. If the transaction is successfully
+    /// committed, then the completion block will be passed that value. The updateBlock also has an
+    ///  `Error` out parameter. If this is set, then the transaction will not attempt to commit, and
+    ///  the given error will be passed to the completion block.
+    ///
+    /// The `Transaction` object passed to the updateBlock contains methods for accessing documents
+    ///  and collections. Unlike other firestore access, data accessed with the transaction will not
+    ///  reflect local changes that have not been committed. For this reason, it is required that
+    ///  all reads are performed before any writes. Transactions must be performed while online.
+    ///  Otherwise, reads will fail, the final commit will fail, and the completion block will
+    ///  return an error.
+    ///
+    /// - Parameter updateBlock: The block to execute within the transaction context.
+    /// - Returns: A publisher emitting a value instance passed from the updateBlock. This block
+    ///  will run even if the client is offline, unless the process is killed.
+    public func runTransaction<T>(_ updateBlock: @escaping (Transaction) throws -> T)
+    -> Future<T, Error> {
+        Future { promise in
+            self.runTransaction({ transaction, errorPointer in
+                do {
+                    return try updateBlock(transaction)
+                } catch {
+                    errorPointer?.pointee = error as NSError
+                    return nil
+                }
+            }) { value, error in
+                if let error = error {
+                    promise(.failure(error))
+                } else if let value = value as? T {
+                    promise(.success(value))
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Firestore/WriteBatch+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/WriteBatch+Combine.swift
@@ -1,0 +1,47 @@
+/*
+  * Copyright 2021 Google
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+ #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseFirestore)
+
+   import Combine
+   import FirebaseFirestore
+
+   @available(swift 5.0)
+   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+ 
+ 
+   extension WriteBatch {
+    
+     /// Commits all of the writes in this write batch as a single atomic unit.
+     ///
+     /// - Returns: A publisher emitting a `Void` value once all of the writes in the batch
+     ///   have been successfully written to the backend as an atomic unit. This publisher will only
+     ///   emits when the client is online and the commit has completed against the server.
+     ///   The changes will be visible immediately.
+    public func commit() -> Future<Void, Error> {
+       Future { promise in
+        self.commit { error in
+            if let error = error {
+                promise(.failure(error))
+            } else {
+                promise(.success(()))
+            }
+        }
+       }
+     }
+   }
+
+ #endif

--- a/FirebaseCombineSwift/Tests/Unit/FirebaseCombine-unit-Bridging-Header.h
+++ b/FirebaseCombineSwift/Tests/Unit/FirebaseCombine-unit-Bridging-Header.h
@@ -69,3 +69,5 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebUtils.h"
+
+#import "Firestore/Example/Tests/API/FSTAPIHelpers.h"

--- a/FirebaseCombineSwift/Tests/Unit/Firestore/AddDocumentTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Firestore/AddDocumentTests.swift
@@ -1,0 +1,213 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import FirebaseCombineSwift
+import FirebaseFirestore
+import Combine
+import XCTest
+
+class AddDocumentTests: XCTestCase {
+    
+    class MockCollectionReference: CollectionReference {
+        
+        var mockAddDocument: () throws -> Void = {
+            fatalError("You need to implement \(#function) in your mock.")
+        }
+        
+        var verifyData: ((_ data: [String : Any]) throws -> Void)?
+        
+        override func addDocument(data: [String : Any], completion: ((Error?) -> Void)? = nil) -> DocumentReference {
+            do {
+                try verifyData?(data)
+                try mockAddDocument()
+                completion?(nil)
+            } catch {
+                completion?(error)
+            }
+            return document()
+        }
+        
+        override init() {
+        }
+    }
+    
+    override class func setUp() {
+        FirebaseApp.configureForTests()
+    }
+    
+    override class func tearDown() {
+        FirebaseApp.app()?.delete { success in
+            if success {
+                print("Shut down app successfully.")
+            } else {
+                print("💥 There was a problem when shutting down the app..")
+            }
+        }
+    }
+    
+    override func setUp() {
+        do {
+            try Auth.auth().signOut()
+        } catch {}
+    }
+    
+    func testAddDocumentWithDataSuccess() {
+        // given
+        var cancellables = Set<AnyCancellable>()
+        
+        let addDocumentWasCalledExpectation = expectation(description: "addDocument was called")
+        let addDocumentSuccessExpectation = expectation(description: "addDocument succeeded")
+        
+        let reference = MockCollectionReference()
+        
+        reference.mockAddDocument = {
+            addDocumentWasCalledExpectation.fulfill()
+        }
+        
+        let dummyData = ["name": "Johnny Appleseed"]
+        
+        // when
+        reference.addDocument(data: dummyData)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    print("Finished")
+                case let .failure(error):
+                    XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { _ in
+                addDocumentSuccessExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(
+            for: [addDocumentWasCalledExpectation, addDocumentSuccessExpectation],
+            timeout: expectationTimeout
+        )
+    }
+    
+    func testAddDocumentWithEncodableSuccess() {
+        // given
+        var cancellables = Set<AnyCancellable>()
+        
+        let addDocumentWasCalledExpectation = expectation(description: "addDocument was called")
+        let addDocumentSuccessExpectation = expectation(description: "addDocument succeeded")
+        
+        let reference = MockCollectionReference()
+        
+        reference.mockAddDocument = {
+            addDocumentWasCalledExpectation.fulfill()
+        }
+        
+        let dummyData = ["name": "Johnny Appleseed"]
+        
+        // when
+        reference.addDocument(from: dummyData)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    print("Finished")
+                case let .failure(error):
+                    XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { _ in
+                addDocumentSuccessExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(
+            for: [addDocumentWasCalledExpectation, addDocumentSuccessExpectation],
+            timeout: expectationTimeout
+        )
+    }
+    func testAddDocumentWithDataFailure() {
+        // given
+        var cancellables = Set<AnyCancellable>()
+        
+        let addDocumentWasCalledExpectation = expectation(description: "addDocument was called")
+        let addDocumentFailureExpectation = expectation(description: "addDocument failed")
+        
+        let reference = MockCollectionReference()
+        
+        reference.mockAddDocument = {
+            addDocumentWasCalledExpectation.fulfill()
+        }
+        
+        let dummyData = ["name": "Johnny Appleseed"]
+        
+        // when
+        reference.addDocument(data: dummyData)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    print("Finished")
+                case let .failure(error as NSError):
+                    XCTAssertEqual(error.code, FirestoreErrorCode.unknown.rawValue)
+                    addDocumentFailureExpectation.fulfill()
+                }
+            } receiveValue: { _ in
+                XCTFail("💥 Something went wrong")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(
+            for: [addDocumentWasCalledExpectation, addDocumentFailureExpectation],
+            timeout: expectationTimeout
+        )
+    }
+    
+    func testAddDocumentWithEncodableFailure() {
+        // given
+        var cancellables = Set<AnyCancellable>()
+        
+        let addDocumentWasCalledExpectation = expectation(description: "addDocument was called")
+        let addDocumentFailureExpectation = expectation(description: "addDocument failed")
+        
+        let reference = MockCollectionReference()
+        
+        reference.mockAddDocument = {
+            addDocumentWasCalledExpectation.fulfill()
+            throw NSError(domain: FirestoreErrorDomain,
+                          code: FirestoreErrorCode.unknown.rawValue,
+                          userInfo: [NSLocalizedDescriptionKey: "Dummy Error"])
+        }
+        
+        let dummyData = ["name": "Johnny Appleseed"]
+        
+        // when
+        reference.addDocument(from: dummyData)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    print("Finished")
+                case let .failure(error as NSError):
+                    XCTAssertEqual(error.code, FirestoreErrorCode.unknown.rawValue)
+                    addDocumentFailureExpectation.fulfill()
+                }
+            } receiveValue: { _ in
+                XCTFail("💥 Something went wrong")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(
+            for: [addDocumentWasCalledExpectation, addDocumentFailureExpectation],
+            timeout: expectationTimeout
+        )
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,10 @@ let package = Package(
       targets: ["FirebaseAuthCombineSwift"]
     ),
     .library(
+      name: "FirebaseFirestoreCombineSwift-Beta",
+      targets: ["FirebaseFirestoreCombineSwift"]
+    ),
+    .library(
       name: "FirebaseFunctionsCombineSwift-Beta",
       targets: ["FirebaseFunctionsCombineSwift"]
     ),
@@ -325,13 +329,18 @@ let package = Package(
     ),
     .target(
       name: "FirebaseCombineSwift",
-      dependencies: ["FirebaseAuthCombineSwift", "FirebaseFunctionsCombineSwift"],
+      dependencies: ["FirebaseAuthCombineSwift", "FirebaseFirestoreCombineSwift", "FirebaseFunctionsCombineSwift"],
       path: "FirebaseCombineSwift/Sources/Core"
     ),
     .target(
       name: "FirebaseAuthCombineSwift",
       dependencies: ["FirebaseAuth"],
       path: "FirebaseCombineSwift/Sources/Auth"
+    ),
+    .target(
+      name: "FirebaseFirestoreCombineSwift",
+      dependencies: ["FirebaseFirestore", "FirebaseFirestoreSwift"],
+      path: "FirebaseCombineSwift/Sources/Firestore"
     ),
     .target(
       name: "FirebaseFunctionsCombineSwift",


### PR DESCRIPTION
Hi all,

This is an attempt at making the Firebase / Combine code testable. It is baes on @lorenzofiamingo's PR #7623 - see his original comment about not being able to mock Firestore classes: https://github.com/firebase/firebase-ios-sdk/pull/7623#discussion_r584122727

The main issue (yet again) that the initialisers for many classes are hidden, and only accessible internally. I've tried to add the internal headers to the bridging header, but failed. If someone else would like to have a go at it, please go ahead - I'm no expert in cross-language integrations, so might have missed something when setting up the Podfile.

The current attempt is to use protocols and protocol extensions to make it easier to replace the implementation with a mock. I've implemented this according to @maksymmalyhin's PR #7557. This approach seems to work quite well - except that we need to create dummy results for some of the methods, and (you guessed it) that's not possible because the initialisers are hidden. There is a utility file that should help (`Firestore/Example/Tests/API/FSTAPIHelpers.mm`), but when trying to import it via the bridging header, I get a bunch of error messages as well.

If we cannot mock the Firestore base classes, we'll have to resort to using a similar approach to the original Firestore tests:
1. write integration tests that make use of the Emulator suite
2. use "compile"-tests that verify that the API signatures look like we expect them

Any help/suggestions appreciated.