### PR TITLE
Fix a signed/unsigned comparison

### DIFF
--- a/Firestore/core/src/local/leveldb_persistence.cc
+++ b/Firestore/core/src/local/leveldb_persistence.cc
@@ -196,7 +196,9 @@ StatusOr<int64_t> LevelDbPersistence::CalculateByteSize() {
     int64_t file_size = maybe_size.ValueOrDie();
     count += file_size;
 
-    if (count < old_count || count > std::numeric_limits<int64_t>::max()) {
+    auto max_signed_value =
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    if (count < old_count || count > max_signed_value) {
       return Status(Error::kErrorOutOfRange,
                     "Failed to size LevelDB: count overflowed");
     }


### PR DESCRIPTION
This triggers a warning in newer versions of GCC and causes compilation to fail with `-Werror`.

#no-changelog