### PR TITLE
comparing uint to uint.

### DIFF
--- a/Firestore/core/src/local/leveldb_persistence.cc
+++ b/Firestore/core/src/local/leveldb_persistence.cc
@@ -196,7 +196,7 @@ StatusOr<int64_t> LevelDbPersistence::CalculateByteSize() {
     int64_t file_size = maybe_size.ValueOrDie();
     count += file_size;
 
-    if (count < old_count || count > std::numeric_limits<int64_t>::max()) {
+    if (count < old_count || count > std::numeric_limits<uint64_t>::max()) {
       return Status(Error::kErrorOutOfRange,
                     "Failed to size LevelDB: count overflowed");
     }


### PR DESCRIPTION
Fixes compiler errors after github ubuntu runners were upgraded to 20 from 18 and gcc from 10.1.0 to 10.2.0.

```
build/external/src/firestore/Firestore/core/src/local/leveldb_persistence.cc:199:36: error: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
2021-03-01T23:04:48.9071111Z   199 |     if (count < old_count || count > std::numeric_limits<int64_t>::max()) {
2021-03-01T23:04:48.9071795Z       |                              ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-03-01T23:04:48.9072445Z cc1plus: all warnings being treated as errors
```

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
