### PR TITLE
ML downloader: enable verbose logging to investigate flaky tests

### DIFF
--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -29,7 +29,8 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/MLModelDownloader/GoogleService-Info.plist.gpg \
           FirebaseMLModelDownloader/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: Build and test
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --platforms=${{ matrix.target }})
+      # TODO: Disable verbose logging after flaky test investigation.
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --verbose --platforms=${{ matrix.target }})
 
   mlmodeldownloader-cron-only:
     if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'


### PR DESCRIPTION
- needed to investigate nightly failures like [this](https://github.com/firebase/firebase-ios-sdk/actions/runs/613185286)