### PR TITLE
Add notes to make sure issue_generations can catch nightly results.

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 7pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 3 * * *'
 
 jobs:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 7pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 3 * * *'
 
 jobs:

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 7pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 3 * * *'
 
 jobs:

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # Run every day at 2am (PST) - cron uses UTC times
     # This is set to 3 hours after zip workflow finishes so zip testing can run after.
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 10 * * *'
 
 jobs:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 7pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 3 * * *'
 
 jobs:

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 7pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 3 * * *'
 
 jobs:

--- a/.github/workflows/core-diagnostics.yml
+++ b/.github/workflows/core-diagnostics.yml
@@ -10,6 +10,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 8pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 4 * * *'
 
 jobs:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 8pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 4 * * *'
 
 jobs:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -10,6 +10,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 8pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 4 * * *'
 
 jobs:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -12,6 +12,7 @@ on:
     - 'scripts/run_database_emulator.sh'
   schedule:
     # Run every day at 8pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 4 * * *'
 
 jobs:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 9pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 5 * * *'
 
 jobs:

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -11,6 +11,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 9pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 5 * * *'
 
 jobs:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -57,6 +57,7 @@ on:
 
   schedule:
     # Run every day at 9pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 5 * * *'
 
 jobs:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -10,6 +10,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -7,6 +7,7 @@ on:
     - '.github/actions/testing_report_generation**'
   schedule:
     # Run every day at 5am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 13 * * *'
 jobs:
   generate_an_issue:

--- a/.github/workflows/google-utilities-components.yml
+++ b/.github/workflows/google-utilities-components.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -9,6 +9,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/instanceid.yml
+++ b/.github/workflows/instanceid.yml
@@ -10,6 +10,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -15,6 +15,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 10pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 6 * * *'
 
 jobs:

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,6 +16,7 @@ on:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     # Specified in format 'minutes hours day month dayofweek'
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -10,6 +10,7 @@ on:
     - 'scripts/generate_access_token.sh'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
 jobs:

--- a/.github/workflows/segmentation.yml
+++ b/.github/workflows/segmentation.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
 jobs:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -8,6 +8,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
 # This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -11,6 +11,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
 jobs:

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -10,6 +10,7 @@ on:
     - 'Gemfile'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
 jobs:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -11,6 +11,7 @@ on:
     - '!ReleaseTooling/*.md'
   schedule:
     # Run every day at midnight(PST) - cron uses UTC times
+    # Make sure this job is finished before generate_issues.yml is triggered
     - cron:  '0 8 * * *'
 
   workflow_dispatch:


### PR DESCRIPTION
Once the scheduled time of cron jobs are updated , be sure that the jobs are finished before issue_generations so the issue_generations workflow can catch results of jobs and generate the updated latest report.