### PR TITLE
Update release/prerelease workflows.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,7 +17,10 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
+      # Podspecs from this repo will be validated and pushed to the testing repo.
       local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
+      # Podspecs from the master branch will be tested.
+      podspec_repo_branch: master
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +33,7 @@ jobs:
     - name: Update SpecsReleasing repo setup
       run: |
          ossbotaccess=`cat oss-bot-access.txt`
-         BOT_TOKEN="${ossbotaccess}" test_version="${nightly_version}" sdk_version_config="${GITHUB_WORKSPACE}/scripts/create_spec_repo/RC_firebase_sdk.textproto" scripts/release_testing_setup.sh RC_testing
+         BOT_TOKEN="${ossbotaccess}" test_version="${nightly_version}" sdk_version_config="${GITHUB_WORKSPACE}/scripts/create_spec_repo/RC_firebase_sdk.textproto" local_sdk_repo_dir="${local_sdk_repo_dir}" podspec_repo_branch="${podspec_repo_branch}" scripts/release_testing_setup.sh RC_testing
     - name: Update SpecsReleasing repo
       run: |
         botaccess=`cat bot-access.txt`

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,9 +17,10 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
-      # Podspecs from this repo will be validated and pushed to the testing repo.
+      # The SDK repo will be cloned to this dir and podspecs from
+      # 'podspec_repo_branch' of this repo will be validated and pushed to the
+      # testing repo.
       local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
-      # Podspecs from the master branch will be tested.
       podspec_repo_branch: master
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
+      # The SDK repo will be cloned to this dir and podspecs from
+      # the latest release branch of this repo will be validated and pushed to
+      # the testing repo.
       local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,7 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
-      nightly_version: "7.5.0"
       local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
-      podspec_repo_branch: master
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +31,7 @@ jobs:
     - name: Update SpecsTesting repo setup
       run: |
          ossbotaccess=`cat oss-bot-access.txt`
-         BOT_TOKEN="${ossbotaccess}" test_version="${nightly_version}" scripts/release_testing_setup.sh nightly_testing
+         BOT_TOKEN="${ossbotaccess}" test_scripts/release_testing_setup.sh nightly_testing
     - name: Update SpecsTesting repo
       run: |
         botaccess=`cat bot-access.txt`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Update SpecsTesting repo setup
       run: |
          ossbotaccess=`cat oss-bot-access.txt`
-         BOT_TOKEN="${ossbotaccess}" test_scripts/release_testing_setup.sh nightly_testing
+         BOT_TOKEN="${ossbotaccess}" scripts/release_testing_setup.sh nightly_testing
     - name: Update SpecsTesting repo
       run: |
         botaccess=`cat bot-access.txt`

--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -24,7 +24,6 @@ extension Constants {
   static let dependencyLineSeparators = CharacterSet(charactersIn: " ,/")
   static let podSources = [
     "https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting",
-    "https://github.com/firebase/SpecsDev.git",
     "https://github.com/firebase/SpecsStaging.git",
     "https://cdn.cocoapods.org/",
   ]

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script will `git clone` the SDK repo to local and look for the latest
+# release branch
 set -xe
 
 TESTINGMODE=${1-}
@@ -28,7 +30,8 @@ git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${
 set -x
 
 cd  "${local_sdk_repo_dir}"
-# This is to search Cocoapods-X.Y.Z tags from all branches of the sdk repo and test_version is X.Y.Z
+# The chunk below is to determine the latest version by searching
+# Cocoapods-X.Y.Z tags from all branches of the sdk repo and test_version is X.Y.Z
 test_version=$(git tag -l --sort=-version:refname CocoaPods-*[0-9] | head -n 1 | sed -n 's/CocoaPods-//p')
 # Check if release-X.Y.Z branch exists in the remote repo.
 release_branch=$(git branch -r -l "origin/release-${test_version}")

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -23,6 +23,7 @@ fi
 mkdir -p "${local_sdk_repo_dir}"
 echo "git clone ${podspec_repo_branch} from github.com/firebase/firebase-ios-sdk.git to ${local_sdk_repo_dir}"
 set +x
+# Using token here to update tags later.
 git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
 set -x
 
@@ -43,8 +44,10 @@ if [ -z $release_branch ];then
   fi
 fi
 
-# Get release branch, release-X.Y.Z.
-podspec_repo_branch=$(echo $release_branch | sed -n 's/\s*origin\///p')
+if [ -z $podspec_repo_branch ];then
+  # Get release branch, release-X.Y.Z.
+  podspec_repo_branch=$(echo $release_branch | sed -n 's/\s*origin\///p')
+fi
 
 git config --global user.email "google-oss-bot@example.com"
 git config --global user.name "google-oss-bot"


### PR DESCRIPTION
The release workflow will run from the latest release branch of the SDK repo.
The prerelease workflow will run from the head of the master branch.

Pods tested in release workflow will  source from 
[SpecsTesting repo](https://github.com/FirebasePrivate/SpecsTesting)
[SpecsStaging repo](https://github.com/firebase/SpecsStaging)
cdn

Pods tested in prerelease workflow will source from
[SpecsReleasing repo](github.com/FirebasePrivate/SpecsReleasing)
[SpecsDev](github.com/firebase/SpecsDev.git)
[SpecsStaging repo](https://github.com/firebase/SpecsStaging)
cdn