### PR TITLE
Undo accidental commenting out of cron job.

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -29,8 +29,7 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-    # REVERT ME:
-    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
     runs-on: macOS-latest
     strategy:


### PR DESCRIPTION
This should have been reverted in a previous PR.