### PR TITLE
Firebase Analytics M91.1 update

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '7.8.0'
+  s.version          = '7.8.1'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -34,7 +34,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.ios.dependency 'FirebaseAnalytics', '7.8.0'
+    ss.ios.dependency 'FirebaseAnalytics', '7.8.1'
     ss.dependency 'Firebase/CoreOnly'
   end
 

--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "FirebaseCore": "~> 7.0",
         "FirebaseInstallations": "~> 7.0",
-        "GoogleAppMeasurement": "7.8.0",
+        "GoogleAppMeasurement": "7.8.1",
         "GoogleUtilities/AppDelegateSwizzler": "~> 7.0",
         "GoogleUtilities/MethodSwizzler": "~> 7.0",
         "GoogleUtilities/NSData+zlib": "~> 7.0",
@@ -30,11 +30,11 @@
         "ios": "9.0"
     },
     "source": {
-        "http": "https://dl.google.com/firebase/ios/analytics/4caadc0768d3a69a/FirebaseAnalytics-7.8.0.tar.gz"
+        "http": "https://dl.google.com/firebase/ios/analytics/c1a9581cce87aa7d/FirebaseAnalytics-7.8.1.tar.gz"
     },
     "summary": "Firebase Analytics for iOS",
     "vendored_frameworks": [
         "Frameworks/FirebaseAnalytics.xcframework"
     ],
-    "version": "7.8.0"
+    "version": "7.8.1"
 }

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -27,11 +27,11 @@
         "ios": "9.0"
     },
     "source": {
-        "http": "https://dl.google.com/firebase/ios/analytics/43f476f690196e4b/GoogleAppMeasurement-7.8.0.tar.gz"
+        "http": "https://dl.google.com/firebase/ios/analytics/42ed5cda50d981f3/GoogleAppMeasurement-7.8.1.tar.gz"
     },
     "summary": "Shared measurement methods for Google libraries. Not intended for direct use.",
     "vendored_frameworks": [
         "Frameworks/GoogleAppMeasurement.xcframework"
     ],
-    "version": "7.8.0"
+    "version": "7.8.1"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "7.8.0"
+let firebaseVersion = "7.8.1"
 
 let package = Package(
   name: "Firebase",
@@ -102,7 +102,7 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
-      .exact("7.8.0")
+      .exact("7.8.1")
     ),
     .package(
       name: "GoogleDataTransport",
@@ -251,8 +251,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "FirebaseAnalytics",
-      url: "https://dl.google.com/firebase/ios/swiftpm/7.8.0/FirebaseAnalytics.zip",
-      checksum: "1a833b113a8d877e978c4b4b55ad5ae7c7f10b148dc37f1321be7bb7e7053f3a"
+      url: "https://dl.google.com/firebase/ios/swiftpm/7.8.1/FirebaseAnalytics.zip",
+      checksum: "d3838e4d498a4846254feebf8d1995f63904a845fb57036b0520a413fb39b8a4"
     ),
     .target(
       name: "FirebaseAnalyticsSwiftTarget",


### PR DESCRIPTION
Hopefully addresses #7695.
Next steps:
1. Cherry-pick this into the `release-7.8` branch
2. Add CocoaPods tags for the release
3. Publish the CocoaPod
4. Add the `7.8.1` tag