### PR TITLE
Don't generate missing Analytics warning on Catalyst

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -103,7 +103,7 @@ FirebaseAnalytics dependency to your project to ensure Messaging works as intend
 
   #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
     #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !TARGET_OS_CATALYST && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
         #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
 FirebaseAnalytics dependency to your project to ensure Firebase Remote Config works as intended."

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v7.9.0
 - [added] Enabled community supported watchOS build in Swift Package Manager. (#7696)
+- [fixed] Don't generate missing Analytics warning on Catalyst. (#7693)
 
 # v7.8.0
 - [fixed] Store fetch metadata per namespace to address activation issues. (#7179)


### PR DESCRIPTION
Fix #7693

Don't generate a warning for missing Analytics when including Performance for Catalyst.

Relatedly and separately  the Perf and RC teams should work out the strategy for these warnings on iOS. See #7487 