### PR TITLE
Throw exception when projectID is missing from FIROptions

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,7 +1,9 @@
+# Unreleased
+- [changed] Throw exception if projectID is missing from FirebaseOptions. (#7725)
+
 # v7.9.0
 - [added] Enabled community supported watchOS build in Swift Package Manager. (#7696)
 - [fixed] Don't generate missing Analytics warning on Catalyst. (#7693)
-- [changed] Throw exception if projectID is missing from FirebaseOptions. (#7725)
 
 # v7.8.0
 - [fixed] Store fetch metadata per namespace to address activation issues. (#7179)

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v7.9.0
 - [added] Enabled community supported watchOS build in Swift Package Manager. (#7696)
 - [fixed] Don't generate missing Analytics warning on Catalyst. (#7693)
+- [changed] Throw exception if projectID is missing from FirebaseOptions. (#7725)
 
 # v7.8.0
 - [fixed] Store fetch metadata per namespace to address activation issues. (#7179)

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.m
@@ -38,6 +38,8 @@
     errorPropertyName = @"googleAppID";
   } else if (options.GCMSenderID.length == 0) {
     errorPropertyName = @"GCMSenderID";
+  } else if (options.projectID.length == 0) {
+    errorPropertyName = @"projectID";
   }
 
   if (errorPropertyName) {

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -218,6 +218,19 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
                                                     NSLocalizedDescriptionKey : errorDescription
                                                   }]];
   }
+  // Check for projectID
+  if (!_options.projectID) {
+    NSString *errorDescription = @"Failed to get `projectID`";
+    FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000070", @"%@",
+                [NSString stringWithFormat:@"%@", errorDescription]);
+    NSError *error = [NSError errorWithDomain:FIRRemoteConfigErrorDomain
+                                         code:FIRRemoteConfigErrorInternalError
+                                     userInfo:@{NSLocalizedDescriptionKey : errorDescription}];
+    self->_settings.isFetchInProgress = NO;
+    return [self reportCompletionOnHandler:completionHandler
+                                withStatus:FIRRemoteConfigFetchStatusFailure
+                                 withError:error];
+  }
 
   __weak RCNConfigFetch *weakSelf = self;
   FIRInstallationsTokenHandler installationsTokenHandler = ^(
@@ -516,16 +529,8 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
 - (NSString *)constructServerURL {
   NSString *serverURLStr = [[NSString alloc] initWithString:kServerURLDomain];
   serverURLStr = [serverURLStr stringByAppendingString:kServerURLVersion];
-
-  if (_options.projectID) {
-    serverURLStr = [serverURLStr stringByAppendingString:kServerURLProjects];
-    serverURLStr = [serverURLStr stringByAppendingString:_options.projectID];
-  } else {
-    FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000070",
-                @"Missing `projectID` from `FirebaseOptions`, please ensure the configured "
-                @"`FirebaseApp` is configured with `FirebaseOptions` that contains a `projectID`.");
-  }
-
+  serverURLStr = [serverURLStr stringByAppendingString:kServerURLProjects];
+  serverURLStr = [serverURLStr stringByAppendingString:_options.projectID];
   serverURLStr = [serverURLStr stringByAppendingString:kServerURLNamespaces];
 
   // Get the namespace from the fully qualified namespace string of "namespace:FIRAppName".

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -218,19 +218,6 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
                                                     NSLocalizedDescriptionKey : errorDescription
                                                   }]];
   }
-  // Check for projectID
-  if (!_options.projectID) {
-    NSString *errorDescription = @"Failed to get `projectID`";
-    FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000070", @"%@",
-                [NSString stringWithFormat:@"%@", errorDescription]);
-    NSError *error = [NSError errorWithDomain:FIRRemoteConfigErrorDomain
-                                         code:FIRRemoteConfigErrorInternalError
-                                     userInfo:@{NSLocalizedDescriptionKey : errorDescription}];
-    self->_settings.isFetchInProgress = NO;
-    return [self reportCompletionOnHandler:completionHandler
-                                withStatus:FIRRemoteConfigFetchStatusFailure
-                                 withError:error];
-  }
 
   __weak RCNConfigFetch *weakSelf = self;
   FIRInstallationsTokenHandler installationsTokenHandler = ^(

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -184,7 +184,7 @@
   FIROptions *options = [self fakeOptions];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  options.GCMSenderID = nil;
+  options.projectID = nil;
 #pragma clang diagnostic pop
 
   // Create the provider to vend Remote Config instances.

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -176,7 +176,7 @@
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:appName options:options];
   FIRRemoteConfigComponent *component = [[FIRRemoteConfigComponent alloc] initWithApp:app];
 
-  // Creating a Remote Config instance should fail since the GCMSenderID is empty.
+  // Creating a Remote Config instance should fail since the projectID is empty.
   XCTAssertThrows([component remoteConfigForNamespace:@"some_namespace"]);
 }
 
@@ -192,7 +192,7 @@
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:appName options:options];
   FIRRemoteConfigComponent *component = [[FIRRemoteConfigComponent alloc] initWithApp:app];
 
-  // Creating a Remote Config instance should fail since the GCMSenderID is empty.
+  // Creating a Remote Config instance should fail since the projectID is empty.
   XCTAssertThrows([component remoteConfigForNamespace:@"some_namespace"]);
 }
 

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -167,6 +167,35 @@
   XCTAssertThrows([component remoteConfigForNamespace:@"some_namespace"]);
 }
 
+- (void)testThrowsWithEmptyProjectID {
+  FIROptions *options = [self fakeOptions];
+  options.projectID = @"";
+
+  // Create the provider to vend Remote Config instances.
+  NSString *appName = [self generatedTestAppName];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:appName options:options];
+  FIRRemoteConfigComponent *component = [[FIRRemoteConfigComponent alloc] initWithApp:app];
+
+  // Creating a Remote Config instance should fail since the GCMSenderID is empty.
+  XCTAssertThrows([component remoteConfigForNamespace:@"some_namespace"]);
+}
+
+- (void)testThrowsWithNilProjectID {
+  FIROptions *options = [self fakeOptions];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  options.GCMSenderID = nil;
+#pragma clang diagnostic pop
+
+  // Create the provider to vend Remote Config instances.
+  NSString *appName = [self generatedTestAppName];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:appName options:options];
+  FIRRemoteConfigComponent *component = [[FIRRemoteConfigComponent alloc] initWithApp:app];
+
+  // Creating a Remote Config instance should fail since the GCMSenderID is empty.
+  XCTAssertThrows([component remoteConfigForNamespace:@"some_namespace"]);
+}
+
 #pragma mark - Helpers
 
 - (FIROptions *)fakeOptions {


### PR DESCRIPTION
If `projectID` is missing the fetch request can't succeed, so we can fail the request before sending it to the server. This is causing some downstream issues (tracked in b/167621250)