### PR TITLE
Combine: PhoneAuthProvider + MultiFactor Publishers

### DIFF
--- a/FirebaseAuthTestingSupport.podspec
+++ b/FirebaseAuthTestingSupport.podspec
@@ -1,0 +1,57 @@
+Pod::Spec.new do |s|
+  s.name                    = 'FirebaseAuthTestingSupport'
+  s.version                 = '1.0.0'
+  s.summary                 = 'Firebase SDKs testing support types and utilities.'
+
+  s.description      = <<-DESC
+  Type declarations and utilities needed for unit testing of the code dependent on Firebase SDKs
+                       DESC
+
+  s.homepage                = 'https://developers.google.com/'
+  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.authors                 = 'Google, Inc.'
+
+  s.source                  = {
+    :git => 'https://github.com/Firebase/firebase-ios-sdk.git',
+    :tag => 'CocoaPods-' + s.version.to_s
+  }
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
+
+  s.cocoapods_version       = '>= 1.4.0'
+  s.prefix_header_file      = false
+  s.requires_arc            = true
+
+  base_dir = 'FirebaseTestingSupport/Auth/'
+
+  s.source_files = [
+    base_dir + 'Sources/**/*.{m,mm,h}',
+  ]
+
+  s.public_header_files = base_dir + '**/*.h'
+
+  s.dependency 'FirebaseAuth', '~> 7.7'
+
+  s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
+    'OTHER_CFLAGS' => '-fno-autolink',
+    'HEADER_SEARCH_PATHS' =>
+      '"${PODS_TARGET_SRCROOT}" '
+  }
+
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.scheme = { :code_coverage => true }
+    unit_tests.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
+    unit_tests.source_files = [
+      base_dir + 'Tests/**/*.swift'
+    ]
+  end
+end

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -61,7 +61,6 @@ Combine Publishers for Firebase.
       'FirebaseCombineSwift/Tests/Unit/**/*.swift',
       'FirebaseCombineSwift/Tests/Unit/**/*.h',
       'SharedTestUtilities/FIROptionsMock.[mh]',
-      'Fakes/*.[mh]',
     ]
     unit_tests.exclude_files = 'FirebaseCombineSwift/Tests/Unit/**/*Template.swift'
     unit_tests.requires_app_host = true

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -61,6 +61,7 @@ Combine Publishers for Firebase.
       'FirebaseCombineSwift/Tests/Unit/**/*.swift',
       'FirebaseCombineSwift/Tests/Unit/**/*.h',
       'SharedTestUtilities/FIROptionsMock.[mh]',
+      'Fakes/*.[mh]',
     ]
     unit_tests.exclude_files = 'FirebaseCombineSwift/Tests/Unit/**/*Template.swift'
     unit_tests.requires_app_host = true
@@ -68,5 +69,6 @@ Combine Publishers for Firebase.
       'SWIFT_OBJC_BRIDGING_HEADER' => '$(PODS_TARGET_SRCROOT)/FirebaseCombineSwift/Tests/Unit/FirebaseCombine-unit-Bridging-Header.h'
     }
     unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'FirebaseAuthTestingSupport'
   end
 end

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -19,8 +19,7 @@
 
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-extension MultiFactor {
-    
+  extension MultiFactor {
     /// Get a session for a second factor enrollment operation.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -30,17 +29,17 @@ extension MultiFactor {
     ///   The publisher will emit on the *main* thread.
     @discardableResult
     public func getSession() -> Future<MultiFactorSession, Error> {
-        Future<MultiFactorSession, Error> { promise in
-            self.getSessionWithCompletion { session, error in
-                if let session = session {
-                    promise(.success(session))
-                } else if let error = error {
-                    promise(.failure(error))
-                }
-            }
+      Future<MultiFactorSession, Error> { promise in
+        self.getSessionWithCompletion { session, error in
+          if let session = session {
+            promise(.success(session))
+          } else if let error = error {
+            promise(.failure(error))
+          }
         }
+      }
     }
-    
+
     /// Enrolls a second factor as identified by the `MultiFactorAssertion` parameter for the
     /// current user.
     ///
@@ -52,18 +51,19 @@ extension MultiFactor {
     ///
     /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     @discardableResult
-    public func enroll(with assertion: MultiFactorAssertion, displayName: String?) -> Future<Void, Error> {
-        Future<Void, Error> { promise in
-            self.enroll(with: assertion, displayName: displayName) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+    public func enroll(with assertion: MultiFactorAssertion,
+                       displayName: String?) -> Future<Void, Error> {
+      Future<Void, Error> { promise in
+        self.enroll(with: assertion, displayName: displayName) { error in
+          if let error = error {
+            promise(.failure(error))
+          } else {
+            promise(.success(()))
+          }
         }
+      }
     }
-    
+
     /// Unenroll the given multi factor.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -72,17 +72,17 @@ extension MultiFactor {
     /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
     @discardableResult
     public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
-        Future<Void, Error> { promise in
-            self.unenroll(with: factorInfo) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+      Future<Void, Error> { promise in
+        self.unenroll(with: factorInfo) { error in
+          if let error = error {
+            promise(.failure(error))
+          } else {
+            promise(.success(()))
+          }
         }
+      }
     }
-    
+
     /// Unenroll the given multi factor.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -90,15 +90,15 @@ extension MultiFactor {
     /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
     @discardableResult
     public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
-        Future<Void, Error> { promise in
-            self.unenroll(withFactorUID: factorUID) { error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(()))
-                }
-            }
+      Future<Void, Error> { promise in
+        self.unenroll(withFactorUID: factorUID) { error in
+          if let error = error {
+            promise(.failure(error))
+          } else {
+            promise(.success(()))
+          }
         }
+      }
     }
-}
+  }
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -1,0 +1,104 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+  import Combine
+  import FirebaseAuth
+
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension MultiFactor {
+    
+    /// Get a session for a second factor enrollment operation.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Returns: A publisher that emits an `MultiFactorSession` for a second factor
+    ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
+    ///   The publisher will emit on the *main* thread.
+    @discardableResult
+    public func getSession() -> Future<MultiFactorSession, Error> {
+        Future<MultiFactorSession, Error> { promise in
+            self.getSessionWithCompletion { session, error in
+                if let session = session {
+                    promise(.success(session))
+                } else if let error = error {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+    
+    /// Enrolls a second factor as identified by the `MultiFactorAssertion` parameter for the
+    /// current user.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameters:
+    ///     - assertion: The base class for asserting ownership of a second factor.
+    ///     - displayName: An optional display name associated with the multi factor to enroll.
+    ///
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
+    @discardableResult
+    public func enroll(with assertion: MultiFactorAssertion, displayName: String?) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+            self.enroll(with: assertion, displayName: displayName) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Unenroll the given multi factor.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameter factorInfo: The structure used to represent a second factor entity from a client perspective.
+    /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
+    @discardableResult
+    public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+            self.unenroll(with: factorInfo) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+    
+    /// Unenroll the given multi factor.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
+    @discardableResult
+    public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+            self.unenroll(withFactorUID: factorUID) { error in
+                if let error = error {
+                    promise(.failure(error))
+                } else {
+                    promise(.success(()))
+                }
+            }
+        }
+    }
+}
+#endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -24,7 +24,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher that emits an `MultiFactorSession` for a second factor
+    /// - Returns: A publisher that emits a `MultiFactorSession` for a second factor
     ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
     ///   The publisher will emit on the *main* thread.
     @discardableResult

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -21,7 +21,6 @@
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   extension PhoneAuthProvider {
-    
     /// Starts the phone number authentication flow by sending a verification code to the
     /// specified phone number.
     ///
@@ -49,17 +48,17 @@
     public func verifyPhoneNumber(with phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil)
       -> Future<String, Error> {
-        Future<String, Error> { promise in
-            self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate) { verificationID, error in
-                if let error = error {
-                  promise(.failure(error))
-                } else if let verificationID = verificationID {
-                  promise(.success(verificationID))
-                }
-            }
+      Future<String, Error> { promise in
+        self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate) { verificationID, error in
+          if let error = error {
+            promise(.failure(error))
+          } else if let verificationID = verificationID {
+            promise(.success(verificationID))
+          }
         }
+      }
     }
-    
+
     /// Verify ownership of the second factor phone number by the current user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -90,17 +89,21 @@
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession?)
       -> Future<String, Error> {
-        Future<String, Error> { promise in
-            self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate, multiFactorSession: multiFactorSession) { verificationID, error in
-                if let error = error {
-                  promise(.failure(error))
-                } else if let verificationID = verificationID {
-                  promise(.success(verificationID))
-                }
-            }
+      Future<String, Error> { promise in
+        self.verifyPhoneNumber(
+          phoneNumber,
+          uiDelegate: uiDelegate,
+          multiFactorSession: multiFactorSession
+        ) { verificationID, error in
+          if let error = error {
+            promise(.failure(error))
+          } else if let verificationID = verificationID {
+            promise(.success(verificationID))
+          }
         }
+      }
     }
-    
+
     /// Verify ownership of the second factor phone number by the current user.
     ///
     /// The publisher will emit events on the **main** thread.

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -21,6 +21,86 @@
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   extension PhoneAuthProvider {
+    
+    /// Starts the phone number authentication flow by sending a verification code to the
+    /// specified phone number.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameters:
+    ///     - phoneNumber: The phone number to be verified.
+    ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
+    ///       by this method until the completion block is executed.
+    ///
+    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///
+    /// - Remark:
+    ///   Possible error codes:
+    ///
+    ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
+    ///      the Firebase Auth is invalid or has expired.
+    ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
+    ///      project has been exceeded.
+    ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
+    ///      invalid.
+    ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
+    @discardableResult
+    public func verifyPhoneNumber(with phoneNumber: String,
+                                  uiDelegate: AuthUIDelegate? = nil)
+      -> Future<String, Error> {
+        Future<String, Error> { promise in
+            self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate) { verificationID, error in
+                if let error = error {
+                  promise(.failure(error))
+                } else if let verificationID = verificationID {
+                  promise(.success(verificationID))
+                }
+            }
+        }
+    }
+    
+    /// Verify ownership of the second factor phone number by the current user.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameters:
+    ///     - phoneNumber: The phone number to be verified.
+    ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
+    ///       by this method until the completion block is executed.
+    ///     - session: A session to identify the MFA flow. For enrollment, this identifies the user
+    ///       trying to enroll. For sign-in, this identifies that the user already passed the first
+    ///       factor challenge.
+    ///
+    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///
+    /// - Remark:
+    ///   Possible error codes:
+    ///
+    ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
+    ///      the Firebase Auth is invalid or has expired.
+    ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
+    ///      project has been exceeded.
+    ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
+    ///      invalid.
+    ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
+    @discardableResult
+    public func verifyPhoneNumber(with phoneNumber: String,
+                                  uiDelegate: AuthUIDelegate? = nil,
+                                  multiFactorSession: MultiFactorSession?)
+      -> Future<String, Error> {
+        Future<String, Error> { promise in
+            self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate, multiFactorSession: multiFactorSession) { verificationID, error in
+                if let error = error {
+                  promise(.failure(error))
+                } else if let verificationID = verificationID {
+                  promise(.success(verificationID))
+                }
+            }
+        }
+    }
+    
     /// Verify ownership of the second factor phone number by the current user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -31,7 +111,7 @@
     ///   by this method until the completion block is executed.
     ///   - multiFactorSession: session A session to identify the MFA flow. For enrollment, this identifies the user
     ///   trying to enroll. For sign-in, this identifies that the user already passed the first factor challenge.
-    /// - Returns: A publisher that emits an `CerificationID` when the sign-in flow completed
+    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
     ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     @discardableResult
     public func verifyPhoneNumber(with phoneMultiFactorInfo: PhoneMultiFactorInfo,

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -45,7 +45,7 @@
     ///      invalid.
     ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
     @discardableResult
-    public func verifyPhoneNumber(with phoneNumber: String,
+    public func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil)
       -> Future<String, Error> {
       Future<String, Error> { promise in
@@ -85,7 +85,7 @@
     ///      invalid.
     ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
     @discardableResult
-    public func verifyPhoneNumber(with phoneNumber: String,
+    public func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession?)
       -> Future<String, Error> {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
@@ -19,121 +19,120 @@ import FirebaseAuth
 import FirebaseAuthTestingSupport
 
 class PhoneAuthProviderTests: XCTestCase {
-    
-    fileprivate static let phoneNumber = "55555555"
-    fileprivate static let invalidPhoneNumber = "555+!*55555"
-    fileprivate static let verificationID = "verificationID"
-    
-    func testVerifyEmptyPhoneNumber() {
-        // given
-        let provider = PhoneAuthProviderFake()
-        var cancellables = Set<AnyCancellable>()
-        provider.verifyPhoneNumberHandler = { completion in
-            completion(nil, FIRAuthErrorUtils.missingPhoneNumberError(withMessage: ""))
-        }
-        
-        // Empty phone number is checked on the client side so no backend RPC is mocked.
-        let expectation = self.expectation(description: #function)
-        
-        // When
-        provider.verifyPhoneNumber(with: "", uiDelegate: nil)
-            .sink { completion in
-              if case let .failure(error as NSError) = completion {
-                XCTAssertEqual(error.code, AuthErrorCode.missingPhoneNumber.rawValue)
+  fileprivate static let phoneNumber = "55555555"
+  fileprivate static let invalidPhoneNumber = "555+!*55555"
+  fileprivate static let verificationID = "verificationID"
 
-                expectation.fulfill()
-              }
-            } receiveValue: { verificationID in
-              XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-
-          // then
-          wait(for: [expectation], timeout: expectationTimeout)
-    }
-    
-    func testVerifyInvalidPhoneNumber() {
-        // given
-        let provider = PhoneAuthProviderFake()
-        var cancellables = Set<AnyCancellable>()
-        provider.verifyPhoneNumberHandler = { completion in
-            completion(nil, FIRAuthErrorUtils.invalidPhoneNumberError(withMessage: ""))
-        }
-
-        let expectation = self.expectation(description: #function)
-        
-        // When
-        provider.verifyPhoneNumber(with: Self.invalidPhoneNumber, uiDelegate: nil)
-            .sink { completion in
-              if case let .failure(error as NSError) = completion {
-                XCTAssertEqual(error.code, AuthErrorCode.invalidPhoneNumber.rawValue)
-
-                expectation.fulfill()
-              }
-            } receiveValue: { verificationID in
-              XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-
-          // then
-          wait(for: [expectation], timeout: expectationTimeout)
+  func testVerifyEmptyPhoneNumber() {
+    // given
+    let provider = PhoneAuthProviderFake()
+    var cancellables = Set<AnyCancellable>()
+    provider.verifyPhoneNumberHandler = { completion in
+      completion(nil, FIRAuthErrorUtils.missingPhoneNumberError(withMessage: ""))
     }
 
-    func testVerifyPhoneNumber() {
-        // given
-        let provider = PhoneAuthProviderFake()
-        var cancellables = Set<AnyCancellable>()
-        provider.verifyPhoneNumberHandler = { completion in
-            completion(Self.verificationID, nil)
+    // Empty phone number is checked on the client side so no backend RPC is mocked.
+    let expectation = self.expectation(description: #function)
+
+    // When
+    provider.verifyPhoneNumber(with: "", uiDelegate: nil)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.missingPhoneNumber.rawValue)
+
+          expectation.fulfill()
         }
+      } receiveValue: { verificationID in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
 
-        let expectation = self.expectation(description: #function)
-        
-        // When
-        provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-              } receiveValue: { verificationID in
-                XCTAssertEqual(verificationID, Self.verificationID)
+    // then
+    wait(for: [expectation], timeout: expectationTimeout)
+  }
 
-                expectation.fulfill()
-              }
-              .store(in: &cancellables)
-
-        // then
-        wait(for: [expectation], timeout: expectationTimeout)
+  func testVerifyInvalidPhoneNumber() {
+    // given
+    let provider = PhoneAuthProviderFake()
+    var cancellables = Set<AnyCancellable>()
+    provider.verifyPhoneNumberHandler = { completion in
+      completion(nil, FIRAuthErrorUtils.invalidPhoneNumberError(withMessage: ""))
     }
 
-    func testVerifyPhoneNumberInTestModeFailure() {
-        // given
-        let provider = PhoneAuthProviderFake()
-        var cancellables = Set<AnyCancellable>()
-        provider.verifyPhoneNumberHandler = { completion in
-            let underlyingError = NSError(domain: "Test Error", code: 1, userInfo: nil)
-            completion(nil, FIRAuthErrorUtils.networkError(withUnderlyingError: underlyingError))
+    let expectation = self.expectation(description: #function)
+
+    // When
+    provider.verifyPhoneNumber(with: Self.invalidPhoneNumber, uiDelegate: nil)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.invalidPhoneNumber.rawValue)
+
+          expectation.fulfill()
         }
+      } receiveValue: { verificationID in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
 
-        let expectation = self.expectation(description: #function)
+    // then
+    wait(for: [expectation], timeout: expectationTimeout)
+  }
 
-        // When
-        provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
-            .sink { completion in
-              if case let .failure(error as NSError) = completion {
-                XCTAssertEqual(error.code, AuthErrorCode.networkError.rawValue)
-
-                expectation.fulfill()
-              }
-            } receiveValue: { verificationID in
-              XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-
-        // then
-        wait(for: [expectation], timeout: expectationTimeout)
+  func testVerifyPhoneNumber() {
+    // given
+    let provider = PhoneAuthProviderFake()
+    var cancellables = Set<AnyCancellable>()
+    provider.verifyPhoneNumberHandler = { completion in
+      completion(Self.verificationID, nil)
     }
+
+    let expectation = self.expectation(description: #function)
+
+    // When
+    provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { verificationID in
+        XCTAssertEqual(verificationID, Self.verificationID)
+
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [expectation], timeout: expectationTimeout)
+  }
+
+  func testVerifyPhoneNumberInTestModeFailure() {
+    // given
+    let provider = PhoneAuthProviderFake()
+    var cancellables = Set<AnyCancellable>()
+    provider.verifyPhoneNumberHandler = { completion in
+      let underlyingError = NSError(domain: "Test Error", code: 1, userInfo: nil)
+      completion(nil, FIRAuthErrorUtils.networkError(withUnderlyingError: underlyingError))
+    }
+
+    let expectation = self.expectation(description: #function)
+
+    // When
+    provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.networkError.rawValue)
+
+          expectation.fulfill()
+        }
+      } receiveValue: { verificationID in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [expectation], timeout: expectationTimeout)
+  }
 }

--- a/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
@@ -1,0 +1,139 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Combine
+import XCTest
+import FirebaseAuth
+import FirebaseAuthTestingSupport
+
+class PhoneAuthProviderTests: XCTestCase {
+    
+    fileprivate static let phoneNumber = "55555555"
+    fileprivate static let invalidPhoneNumber = "555+!*55555"
+    fileprivate static let verificationID = "verificationID"
+    
+    func testVerifyEmptyPhoneNumber() {
+        // given
+        let provider = PhoneAuthProviderFake()
+        var cancellables = Set<AnyCancellable>()
+        provider.verifyPhoneNumberHandler = { completion in
+            completion(nil, FIRAuthErrorUtils.missingPhoneNumberError(withMessage: ""))
+        }
+        
+        // Empty phone number is checked on the client side so no backend RPC is mocked.
+        let expectation = self.expectation(description: #function)
+        
+        // When
+        provider.verifyPhoneNumber(with: "", uiDelegate: nil)
+            .sink { completion in
+              if case let .failure(error as NSError) = completion {
+                XCTAssertEqual(error.code, AuthErrorCode.missingPhoneNumber.rawValue)
+
+                expectation.fulfill()
+              }
+            } receiveValue: { verificationID in
+              XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+          // then
+          wait(for: [expectation], timeout: expectationTimeout)
+    }
+    
+    func testVerifyInvalidPhoneNumber() {
+        // given
+        let provider = PhoneAuthProviderFake()
+        var cancellables = Set<AnyCancellable>()
+        provider.verifyPhoneNumberHandler = { completion in
+            completion(nil, FIRAuthErrorUtils.invalidPhoneNumberError(withMessage: ""))
+        }
+
+        let expectation = self.expectation(description: #function)
+        
+        // When
+        provider.verifyPhoneNumber(with: Self.invalidPhoneNumber, uiDelegate: nil)
+            .sink { completion in
+              if case let .failure(error as NSError) = completion {
+                XCTAssertEqual(error.code, AuthErrorCode.invalidPhoneNumber.rawValue)
+
+                expectation.fulfill()
+              }
+            } receiveValue: { verificationID in
+              XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+          // then
+          wait(for: [expectation], timeout: expectationTimeout)
+    }
+
+    func testVerifyPhoneNumber() {
+        // given
+        let provider = PhoneAuthProviderFake()
+        var cancellables = Set<AnyCancellable>()
+        provider.verifyPhoneNumberHandler = { completion in
+            completion(Self.verificationID, nil)
+        }
+
+        let expectation = self.expectation(description: #function)
+        
+        // When
+        provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+              } receiveValue: { verificationID in
+                XCTAssertEqual(verificationID, Self.verificationID)
+
+                expectation.fulfill()
+              }
+              .store(in: &cancellables)
+
+        // then
+        wait(for: [expectation], timeout: expectationTimeout)
+    }
+
+    func testVerifyPhoneNumberInTestModeFailure() {
+        // given
+        let provider = PhoneAuthProviderFake()
+        var cancellables = Set<AnyCancellable>()
+        provider.verifyPhoneNumberHandler = { completion in
+            let underlyingError = NSError(domain: "Test Error", code: 1, userInfo: nil)
+            completion(nil, FIRAuthErrorUtils.networkError(withUnderlyingError: underlyingError))
+        }
+
+        let expectation = self.expectation(description: #function)
+
+        // When
+        provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+            .sink { completion in
+              if case let .failure(error as NSError) = completion {
+                XCTAssertEqual(error.code, AuthErrorCode.networkError.rawValue)
+
+                expectation.fulfill()
+              }
+            } receiveValue: { verificationID in
+              XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+
+        // then
+        wait(for: [expectation], timeout: expectationTimeout)
+    }
+}

--- a/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/PhoneAuthProviderTests.swift
@@ -35,7 +35,7 @@ class PhoneAuthProviderTests: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     // When
-    provider.verifyPhoneNumber(with: "", uiDelegate: nil)
+    provider.verifyPhoneNumber("", uiDelegate: nil)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.missingPhoneNumber.rawValue)
@@ -62,7 +62,7 @@ class PhoneAuthProviderTests: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     // When
-    provider.verifyPhoneNumber(with: Self.invalidPhoneNumber, uiDelegate: nil)
+    provider.verifyPhoneNumber(Self.invalidPhoneNumber, uiDelegate: nil)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.invalidPhoneNumber.rawValue)
@@ -89,7 +89,7 @@ class PhoneAuthProviderTests: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     // When
-    provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+    provider.verifyPhoneNumber(Self.phoneNumber, uiDelegate: nil)
       .sink { completion in
         switch completion {
         case .finished:
@@ -120,7 +120,7 @@ class PhoneAuthProviderTests: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     // When
-    provider.verifyPhoneNumber(with: Self.phoneNumber, uiDelegate: nil)
+    provider.verifyPhoneNumber(Self.phoneNumber, uiDelegate: nil)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.networkError.rawValue)

--- a/FirebaseTestingSupport/Auth/Sources/FIRPhoneAuthProviderFake.m
+++ b/FirebaseTestingSupport/Auth/Sources/FIRPhoneAuthProviderFake.m
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebaseTestingSupport/Auth/Sources/Public/FirebaseAuthTestingSupport/FIRPhoneAuthProviderFake.h"
+
+@implementation FIRPhoneAuthProviderFake
+
+- (instancetype)init {
+  // The object is partially initialized. Make sure the methods used during testing are overridden.
+  return self;
+}
+
+- (void)verifyPhoneNumber:(NSString *)phoneNumber UIDelegate:(id<FIRAuthUIDelegate>)UIDelegate completion:(FIRVerificationResultCallback)completion {
+    if (self.verifyPhoneNumberHandler) {
+      self.verifyPhoneNumberHandler(completion);
+    }
+}
+
+@end

--- a/FirebaseTestingSupport/Auth/Sources/FIRPhoneAuthProviderFake.m
+++ b/FirebaseTestingSupport/Auth/Sources/FIRPhoneAuthProviderFake.m
@@ -21,10 +21,12 @@
   return self;
 }
 
-- (void)verifyPhoneNumber:(NSString *)phoneNumber UIDelegate:(id<FIRAuthUIDelegate>)UIDelegate completion:(FIRVerificationResultCallback)completion {
-    if (self.verifyPhoneNumberHandler) {
-      self.verifyPhoneNumberHandler(completion);
-    }
+- (void)verifyPhoneNumber:(NSString *)phoneNumber
+               UIDelegate:(id<FIRAuthUIDelegate>)UIDelegate
+               completion:(FIRVerificationResultCallback)completion {
+  if (self.verifyPhoneNumberHandler) {
+    self.verifyPhoneNumberHandler(completion);
+  }
 }
 
 @end

--- a/FirebaseTestingSupport/Auth/Sources/Public/FirebaseAuthTestingSupport/FIRPhoneAuthProviderFake.h
+++ b/FirebaseTestingSupport/Auth/Sources/Public/FirebaseAuthTestingSupport/FIRPhoneAuthProviderFake.h
@@ -24,7 +24,8 @@ NS_SWIFT_NAME(PhoneAuthProviderFake)
 
 - (instancetype)init;
 
-/// The block to be called each time when `verifyPhoneNumber(_:uiDelegate:completion:)` method is called.
+/// The block to be called each time when `verifyPhoneNumber(_:uiDelegate:completion:)` method is
+/// called.
 @property(nonatomic, nullable, copy) FIRVerifyPhoneNumberHandler verifyPhoneNumberHandler;
 
 // TODO: Implement other handlers as needed.

--- a/FirebaseTestingSupport/Auth/Sources/Public/FirebaseAuthTestingSupport/FIRPhoneAuthProviderFake.h
+++ b/FirebaseTestingSupport/Auth/Sources/Public/FirebaseAuthTestingSupport/FIRPhoneAuthProviderFake.h
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <FirebaseAuth/FirebaseAuth.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^FIRVerifyPhoneNumberHandler)(FIRVerificationResultCallback completion);
+
+/// A fake object to replace a real `AuthAPNSTokenManager` in tests.
+NS_SWIFT_NAME(PhoneAuthProviderFake)
+@interface FIRPhoneAuthProviderFake : FIRPhoneAuthProvider
+
+- (instancetype)init;
+
+/// The block to be called each time when `verifyPhoneNumber(_:uiDelegate:completion:)` method is called.
+@property(nonatomic, nullable, copy) FIRVerifyPhoneNumberHandler verifyPhoneNumberHandler;
+
+// TODO: Implement other handlers as needed.
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseTestingSupport/Auth/Tests/PhoneAuthProviderFakeTests.swift
+++ b/FirebaseTestingSupport/Auth/Tests/PhoneAuthProviderFakeTests.swift
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import XCTest
+@testable import FirebaseAuthTestingSupport
+
+class PhoneAuthProviderFakeTests: XCTestCase {
+    func testPhoneAuthProviderFakeConstructor() throws {
+      let fakePhoneAuthProvider = PhoneAuthProviderFake()
+      XCTAssertNotNil(fakePhoneAuthProvider)
+      XCTAssertTrue(fakePhoneAuthProvider.isKind(of: PhoneAuthProvider.self))
+    }
+    
+    func testVerifyPhoneNumberHandler() {
+      let fakePhoneAuthProvider = PhoneAuthProviderFake()
+
+      let handlerExpectation = expectation(description: "Handler called")
+        fakePhoneAuthProvider.verifyPhoneNumberHandler = { completion in
+            handlerExpectation.fulfill()
+
+            completion(nil, nil)
+        }
+
+      let completionExpectation = expectation(description: "Completion called")
+        fakePhoneAuthProvider.verifyPhoneNumber("", uiDelegate: nil) { verficationID, error in
+            completionExpectation.fulfill()
+            XCTAssertNil(verficationID)
+            XCTAssertNil(error)
+        }
+
+      wait(for: [handlerExpectation, completionExpectation], timeout: 0.5)
+    }
+}

--- a/FirebaseTestingSupport/Auth/Tests/PhoneAuthProviderFakeTests.swift
+++ b/FirebaseTestingSupport/Auth/Tests/PhoneAuthProviderFakeTests.swift
@@ -17,29 +17,29 @@ import XCTest
 @testable import FirebaseAuthTestingSupport
 
 class PhoneAuthProviderFakeTests: XCTestCase {
-    func testPhoneAuthProviderFakeConstructor() throws {
-      let fakePhoneAuthProvider = PhoneAuthProviderFake()
-      XCTAssertNotNil(fakePhoneAuthProvider)
-      XCTAssertTrue(fakePhoneAuthProvider.isKind(of: PhoneAuthProvider.self))
+  func testPhoneAuthProviderFakeConstructor() throws {
+    let fakePhoneAuthProvider = PhoneAuthProviderFake()
+    XCTAssertNotNil(fakePhoneAuthProvider)
+    XCTAssertTrue(fakePhoneAuthProvider.isKind(of: PhoneAuthProvider.self))
+  }
+
+  func testVerifyPhoneNumberHandler() {
+    let fakePhoneAuthProvider = PhoneAuthProviderFake()
+
+    let handlerExpectation = expectation(description: "Handler called")
+    fakePhoneAuthProvider.verifyPhoneNumberHandler = { completion in
+      handlerExpectation.fulfill()
+
+      completion(nil, nil)
     }
-    
-    func testVerifyPhoneNumberHandler() {
-      let fakePhoneAuthProvider = PhoneAuthProviderFake()
 
-      let handlerExpectation = expectation(description: "Handler called")
-        fakePhoneAuthProvider.verifyPhoneNumberHandler = { completion in
-            handlerExpectation.fulfill()
-
-            completion(nil, nil)
-        }
-
-      let completionExpectation = expectation(description: "Completion called")
-        fakePhoneAuthProvider.verifyPhoneNumber("", uiDelegate: nil) { verficationID, error in
-            completionExpectation.fulfill()
-            XCTAssertNil(verficationID)
-            XCTAssertNil(error)
-        }
-
-      wait(for: [handlerExpectation, completionExpectation], timeout: 0.5)
+    let completionExpectation = expectation(description: "Completion called")
+    fakePhoneAuthProvider.verifyPhoneNumber("", uiDelegate: nil) { verficationID, error in
+      completionExpectation.fulfill()
+      XCTAssertNil(verficationID)
+      XCTAssertNil(error)
     }
+
+    wait(for: [handlerExpectation, completionExpectation], timeout: 0.5)
+  }
 }


### PR DESCRIPTION
I've changed the way `Publishers` are tested to avoid bloating the codebase with tests already implemented on `FirebaseAuth`.  Now, `Publishers` are tested to full fill the expectation that relative methods are called properly. Please leave me your feedback on this strategy to apply to the next PRs.

```swift
let provider = PhoneAuthProviderFake()
provider.verifyPhoneNumberHandler = { completion in
  completion(nil, FIRAuthErrorUtils.missingPhoneNumberError(withMessage: ""))
}

provider.verifyPhoneNumber(with: "", uiDelegate: nil)
  .sink { completion in
    if case let .failure(error as NSError) = completion {
      XCTAssertEqual(error.code, AuthErrorCode.missingPhoneNumber.rawValue)

      expectation.fulfill()
    }
  } receiveValue: { verificationID in
     XCTFail("💥 result unexpected")
  }
  .store(in: &cancellables)
```