### PR TITLE
Add missing new header to Firestore podspec

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,6 +5,8 @@ on:
     paths:
     - '.github/workflows/prerelease.yml'
     - 'Gemfile'
+    # Revert me. Test that Firestore podspec is fixed.
+    - 'FirebaseFirestore.podspec'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,8 +5,6 @@ on:
     paths:
     - '.github/workflows/prerelease.yml'
     - 'Gemfile'
-    # Revert me. Test that Firestore podspec is fixed.
-    - 'FirebaseFirestore.podspec'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -66,6 +66,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/Protos/nanopb/**/*.h',
     'Firestore/core/include/**/*.h',
     'Firestore/core/src/**/*.h',
+    'Firestore/third_party/nlohmann_json/json.hpp',
   ]
   s.requires_arc = [
     'Firestore/Source/**/*',


### PR DESCRIPTION
Fix `pod spec lint` failure introduced in #7717 and caught in nightly #7726.

`- NOTE | xcodebuild: FirebaseFirestore/Firestore/core/src/bundle/bundle_serializer.h:33:10: fatal error: 'Firestore/third_party/nlohmann_json/json.hpp' file not found`