### PR TITLE
Fix FIAM Swift podspec

### DIFF
--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -33,5 +33,5 @@ See more product details at https://firebase.google.com/products/in-app-messagin
       unit_tests.requires_app_host = true
    end
 
-  s.dependency 'FirebaseInAppMessaging'
+  s.dependency 'FirebaseInAppMessaging', '~> 7.8-beta'
 end


### PR DESCRIPTION
Without the beta specifier, Firebase 6.x is specified and fails because it is static.

Our `pod lib lint` and `pod gen` tests don't catch this because they override the version specifier to use the local podspecs.

Verified this fixes with a `pod gen` without `-local-sources=./`