### PR TITLE
Consistent podspec minimum version management

### DIFF
--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -21,6 +21,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   }
 
   s.social_media_url = 'https://twitter.com/Firebase'
+
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
@@ -50,7 +51,11 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'FirebaseABTesting/Tests/Unit/**/*.[mh]'
     unit_tests.resources = 'FirebaseABTesting/Tests/Unit/Resources/*.txt'
     unit_tests.requires_app_host = true

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -18,10 +18,16 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
 
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -51,7 +57,11 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
     # Unit tests can't run on watchOS.
-    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'FirebaseAuth/Tests/Unit/*.[mh]'
     unit_tests.osx.exclude_files = [
       'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -57,7 +57,11 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   }
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = [
       'FirebaseCore/Tests/Unit/**/*.[mh]',
       'SharedTestUtilities/FIROptionsMock.[mh]',
@@ -68,7 +72,11 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   end
 
   s.test_spec 'swift-unit' do |swift_unit_tests|
-    swift_unit_tests.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
+    swift_unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     swift_unit_tests.source_files = [
       'FirebaseCore/Tests/SwiftUnit/**/*.swift',
       'FirebaseCore/Tests/SwiftUnit/**/*.h',

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -11,10 +11,15 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  ios_deployment_target = '9.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -98,7 +103,11 @@ Pod::Spec.new do |s|
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
     # Unit tests can't run on watchOS.
-    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'Crashlytics/UnitTests/*.[mh]',
                               'Crashlytics/UnitTests/*/*.[mh]'
     unit_tests.resources = 'Crashlytics/UnitTests/Data/*',

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -52,7 +52,11 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   }
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.scheme = { :code_coverage => true }
     unit_tests.source_files = [
       'FirebaseDatabase/Tests/Unit/*.[mh]',

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -16,10 +16,16 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '9.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -52,7 +58,11 @@ Pod::Spec.new do |s|
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => '9.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = base_dir + 'Tests/Unit/*.[mh]',
                               base_dir + 'Tests/Utils/*.[mh]'
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -18,10 +18,16 @@ services.
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -46,7 +52,11 @@ services.
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'Example/InstanceID/Tests/*.[mh]'
     unit_tests.requires_app_host = true
     unit_tests.dependency 'OCMock'
@@ -62,7 +72,11 @@ services.
 
    s.test_spec 'integration' do |int_tests|
     int_tests.scheme = { :code_coverage => true }
-    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    int_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     int_tests.source_files = 'Example/InstanceID/IntegrationTests/*.[mh]'
     int_tests.resources = 'Example/InstanceID/Resources/**/*'
     int_tests.requires_app_host = true

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -19,10 +19,16 @@ device, and it is completely free.
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -57,7 +63,11 @@ device, and it is completely free.
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'FirebaseMessaging/Tests/UnitTests*/*.{m,h,swift}'
     unit_tests.requires_app_host = true
     unit_tests.pod_target_xcconfig = {
@@ -68,7 +78,11 @@ device, and it is completely free.
 
   s.test_spec 'integration' do |int_tests|
     int_tests.scheme = { :code_coverage => true }
-    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    int_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     int_tests.source_files = 'FirebaseMessaging/Tests/IntegrationTests/*.swift'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -82,7 +82,11 @@ app update.
   # Run Swift API tests on a real backend.
   s.test_spec 'swift-api-tests' do |swift_api|
     swift_api.scheme = { :code_coverage => true }
-    swift_api.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    swift_api.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     swift_api.source_files = 'FirebaseRemoteConfig/Tests/SwiftAPI/*.swift',
                              'FirebaseRemoteConfig/Tests/FakeUtils/*.[hm]',
                              'FirebaseRemoteConfig/Tests/FakeUtils/*.swift'
@@ -98,7 +102,11 @@ app update.
   # Run Swift API tests and tests requiring console changes on a Fake Console.
   s.test_spec 'fake-console-tests' do |fake_console|
     fake_console.scheme = { :code_coverage => true }
-    fake_console.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    fake_console.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     fake_console.source_files = 'FirebaseRemoteConfig/Tests/SwiftAPI/*.swift',
                                       'FirebaseRemoteConfig/Tests/FakeUtils/*.[hm]',
                                       'FirebaseRemoteConfig/Tests/FakeUtils/*.swift',

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -16,10 +16,16 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
@@ -42,7 +48,11 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
-    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     unit_tests.source_files = 'FirebaseStorage/Tests/Unit/*.[mh]',
                               'SharedTestUtilities/FIRComponentTestUtilities.*',
                               'SharedTestUtilities/FIRAuthInteropFake.*'
@@ -51,7 +61,11 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
 
   s.test_spec 'integration' do |int_tests|
     int_tests.scheme = { :code_coverage => true }
-    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    int_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     int_tests.source_files = 'FirebaseStorage/Tests/Integration/*.[mh]'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',

--- a/FirebaseStorageSwift.podspec
+++ b/FirebaseStorageSwift.podspec
@@ -18,10 +18,16 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   }
 
   s.swift_version           = '5.0'
-  s.ios.deployment_target   = '10.0'
-  s.osx.deployment_target   = '10.12'
-  s.tvos.deployment_target  = '10.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.12'
+  tvos_deployment_target = '10.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.cocoapods_version       = '>= 1.4.0'
   s.prefix_header_file      = false
@@ -34,7 +40,11 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
 
   s.test_spec 'integration' do |int_tests|
     int_tests.scheme = { :code_coverage => true }
-    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
+    int_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     int_tests.source_files = 'FirebaseStorageSwift/Tests/Integration/*.swift'
     int_tests.requires_app_host = true
     # Resources are shared with FirebaseStorage's integration tests.


### PR DESCRIPTION
Background is that we need a different set of platforms for libraries and tests when the library supports watchOS since tests aren't supported with watchOS and CocoaPods even with Xcode 12.5.

Current plan is for watchOS CI to be SPM only