### PR TITLE
Validate FirebaseAnalytics.podspec.json explicitly separately

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -7,6 +7,7 @@ on:
     - 'FirebaseAnalyticsSwift**'
     - 'GoogleAppMeasurement.podspec.json'
     - 'Gemfile'
+    - '.github/workflows/analytics.yml'
   schedule:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron: '0 9 * * *'

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -23,6 +23,8 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: GoogleAppMeasurement
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurement.podspec.json
+    - name: FirebaseAnalytics
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAnalytics.podspec.json
     - name: FirebaseAnalyticsSwift
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAnalyticsSwift.podspec --platforms=ios
 

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -140,14 +140,18 @@ def find_local_deps(podspec_file, seen = Set[])
   specs = load_specs(podspec_file)
   deps = all_deps(specs)
 
+  spec_suffixes = [".podspec", ".podspec.json"]
+
   deps.each do |dep_name|
-    dep_file = File.join(spec_dir, "#{dep_name}.podspec")
-    if File.exist?(dep_file) then
-      dep_podspec = File.basename(dep_file)
-      if seen.add?(dep_podspec)
-        # Depend on the podspec we found and any podspecs it depends upon.
-        results.push(dep_podspec)
-        results.push(*find_local_deps(dep_file, seen))
+    spec_suffixes.each do |spec_suffix|
+      dep_file = File.join(spec_dir, "#{dep_name}#{spec_suffix}")
+      if File.exist?(dep_file) then
+        dep_podspec = File.basename(dep_file)
+        if seen.add?(dep_podspec)
+          # Depend on the podspec we found and any podspecs it depends upon.
+          results.push(dep_podspec)
+          results.push(*find_local_deps(dep_file, seen))
+        end
       end
     end
   end


### PR DESCRIPTION
In the [run](https://github.com/firebase/firebase-ios-sdk/pull/7749/checks?check_run_id=2142547898) `FirebaseAnalytics.podspec.json` was invalid but the error was obscure. Let's have an explicit validation for the spec.

#no-changelog