### PR TITLE
Fix SPM resource inclusion for FIAM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -600,7 +600,7 @@ let package = Package(
         "DefaultUI/CHANGELOG.md",
         "DefaultUI/README.md",
       ],
-      resources: [.process("Resources")],
+      resources: [.process("../Resources")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),


### PR DESCRIPTION
Having trouble including the FIAM package as a local dependency. Shall we check this in for now?

Fixes #7715.