### PR TITLE
Enable TSAN diagnostics for xcodebuild tests  

### DIFF
--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -932,23 +932,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   OCMVerifyAllWithDelay(self.mockCoreDiagnosticsConnector, 0.5);
 }
 
-// TODO: Remove after testing the TSAN flag.
-- (void)testTSAN {
-  __block BOOL variable = YES;
-  NSInteger count = 10;
-  XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-  expectation.expectedFulfillmentCount = count;
-  for (NSInteger i = 0; i <= count; i++) {
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-      // Should fail on the thread sanitizer diagnostics.
-      variable = !variable;
-      [expectation fulfill];
-    });
-  }
-
-  [self waitForExpectations:@[ expectation ] timeout:1];
-}
-
 #pragma mark - private
 
 - (XCTestExpectation *)expectNotificationNamed:(NSNotificationName)name

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -932,6 +932,23 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   OCMVerifyAllWithDelay(self.mockCoreDiagnosticsConnector, 0.5);
 }
 
+// TODO: Remove after testing the TSAN flag.
+- (void)testTSAN {
+  __block BOOL variable = YES;
+  NSInteger count = 10;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+  expectation.expectedFulfillmentCount = count;
+  for (NSInteger i = 0; i <= count; i++) {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+      // Should fail on the thread sanitizer diagnostics.
+      variable = !variable;
+      [expectation fulfill];
+    });
+  }
+
+  [self waitForExpectations:@[ expectation ] timeout:1];
+}
+
 #pragma mark - private
 
 - (XCTestExpectation *)expectNotificationNamed:(NSNotificationName)name

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,20 +104,13 @@ esac
 # Source function to check if CI secrets are available.
 source scripts/check_secrets.sh
 
-# Runs xcodebuild with the given flags, piping output to xcpretty
+# Runs xcodebuild with the given flags.
 # If xcodebuild fails with known error codes, retries once.
 function RunXcodebuild() {
   echo xcodebuild "$@"
 
-  xcpretty_cmd=(xcpretty)
-  if [[ -n "${TRAVIS:-}" ]]; then
-    # The formatter argument takes a file location of a formatter.
-    # The xcpretty-travis-formatter binary prints its location on stdout.
-    xcpretty_cmd+=(-f $(xcpretty-travis-formatter))
-  fi
-
   result=0
-  xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+  xcodebuild "$@" || result=$?
 
   if [[ $result == 65 ]]; then
     ExportLogs "$@"
@@ -126,7 +119,7 @@ function RunXcodebuild() {
     sleep 5
 
     result=0
-    xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+    xcodebuild "$@" || result=$?
   fi
 
   if [[ $result != 0 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -224,6 +224,7 @@ xcb_flags+=(
   CODE_SIGNING_REQUIRED=NO
   CODE_SIGNING_ALLOWED=YES
   COMPILER_INDEX_STORE_ENABLE=NO
+  -enableThreadSanitizer YES
 )
 
 # TODO(varconst): Add --warn-unused-vars and --warn-uninitialized.


### PR DESCRIPTION
- enable TSAN diagnostics for xcodebuild to detect issues like #7771 earlier
- disable `xcpretty` because it filters out the diagnostics logs

#no-changelog