### PR TITLE
[#7791] Removed Duplicate Code in IAM

### DIFF
--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
@@ -116,7 +116,7 @@
       return;
     }
 
-    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper UIWindowForModalView];
+    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper windowForBlockingView];
     displayUIWindow.rootViewController = cardVC;
     [displayUIWindow setHidden:NO];
   });
@@ -153,7 +153,7 @@
       return;
     }
 
-    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper UIWindowForModalView];
+    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper windowForBlockingView];
     displayUIWindow.rootViewController = modalVC;
     [displayUIWindow setHidden:NO];
   });
@@ -190,7 +190,7 @@
       return;
     }
 
-    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper UIWindowForBannerView];
+    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper windowForNonBlockingView];
     displayUIWindow.rootViewController = bannerVC;
     [displayUIWindow setHidden:NO];
   });
@@ -228,7 +228,7 @@
       return;
     }
 
-    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper UIWindowForImageOnlyView];
+    UIWindow *displayUIWindow = [FIRIAMRenderingWindowHelper windowForBlockingView];
     displayUIWindow.rootViewController = imageOnlyVC;
     [displayUIWindow setHidden:NO];
   });

--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.h
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.h
@@ -19,19 +19,19 @@
 NS_ASSUME_NONNULL_BEGIN
 /**
  * To avoid the risk of hijacking the app's existing view transition flow, we render in-app message
- * views in a top level UI Window instead of presenting from app's existing UIWindow. The caller is
- * supposed to set the rootViewController to be the appropriate view controller for the in-app
- * message and call setHidden:NO to make it really visible.
+ * views in a new top-level UIWindow instead of presenting them from app's existing UIWindow.
+ * The caller is supposed to set the rootViewController to be the appropriate view controller
+ * for the in-app message and call setHidden:NO to make it really visible.
  */
 @interface FIRIAMRenderingWindowHelper : NSObject
 
-// Return the singleton UIWindow that can be used for rendering modal IAM views
-+ (UIWindow *)UIWindowForModalView;
+/// Returns the singleton `UIWindow` object used for rendering IAM views that block
+/// user interactions with underlying content.
++ (UIWindow *)windowForBlockingView;
 
-// Return the singleton UIWindow that can be used for rendering banner IAM views
-+ (UIWindow *)UIWindowForBannerView;
+/// Returns the singleton `UIWindow` object used for rendering IAM views that don't block
+/// user interactions with underlying content.
++ (UIWindow *)windowForNonBlockingView;
 
-// Return the singleton UIWindow that can be used for rendering banner IAM views
-+ (UIWindow *)UIWindowForImageOnlyView;
 @end
 NS_ASSUME_NONNULL_END

--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
@@ -22,7 +22,7 @@
 
 @implementation FIRIAMRenderingWindowHelper
 
-+ (UIWindow *)UIWindowForModalView {
++ (UIWindow *)windowForBlockingView {
   static UIWindow *UIWindowForModal;
   static dispatch_once_t onceToken;
 
@@ -41,7 +41,7 @@
   return UIWindowForModal;
 }
 
-+ (UIWindow *)UIWindowForBannerView {
++ (UIWindow *)windowForNonBlockingView {
   static UIWindow *UIWindowForBanner;
   static dispatch_once_t onceToken;
 
@@ -60,26 +60,6 @@
   });
 
   return UIWindowForBanner;
-}
-
-+ (UIWindow *)UIWindowForImageOnlyView {
-  static UIWindow *UIWindowForImageOnly;
-  static dispatch_once_t onceToken;
-
-  dispatch_once(&onceToken, ^{
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    if (@available(iOS 13.0, tvOS 13.0, *)) {
-      UIWindowForImageOnly = [[self class] iOS13PlusWindow];
-    } else {
-#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-      UIWindowForImageOnly = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    }
-#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-    UIWindowForImageOnly.windowLevel = UIWindowLevelNormal;
-  });
-
-  return UIWindowForImageOnly;
 }
 
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000


### PR DESCRIPTION
[Closes #7791]

* Removed `FIRIAMRenderingWindowHelper`’s `UIWindowForImageOnlyView` method whose body was identical to `UIWindowForModalView`’s
* Renamed `UIWindowForModalView` to `windowForBlockingView` and `UIWindowForBannerView` to `windowForNonBlockingView`, respectively, to clarify their purpose