### PR TITLE
Use correct preprocessor macro for Mac Catalyst

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -103,7 +103,7 @@ FirebaseAnalytics dependency to your project to ensure Messaging works as intend
 
   #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
     #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-    #if TARGET_OS_IOS && !TARGET_OS_CATALYST && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
         #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
 FirebaseAnalytics dependency to your project to ensure Firebase Remote Config works as intended."


### PR DESCRIPTION
This was introduced in #7719 to fix a warning that was generated when using Remote Config on Catalyst, however, the PR was not using the correct preprocessor macro for Mac Catalyst, as defined in TargetConditionals.h