### PR TITLE
Revert "Nightly zip should use SpecsDev (#7807)"

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -48,7 +48,7 @@ jobs:
     - name: ZipBuildingTest
       run: |
          mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git' }}"
+         sh -x scripts/build_zip.sh zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
     - uses: actions/upload-artifact@v1
       with:
         name: Firebase-actions-dir


### PR DESCRIPTION
This reverts commit a7ada99447d7763b498c0f0887455c7890bc269e.

#7807 was the wrong way to add the SpecsDev repo to the zip CI build.   See #7797

@granluo Would you take a look?