### PR TITLE
Directly initialize `g_log_level` to fix compilation error.

### DIFF
--- a/Firestore/core/src/util/log_stdio.cc
+++ b/Firestore/core/src/util/log_stdio.cc
@@ -27,7 +27,7 @@ namespace firestore {
 namespace util {
 namespace {
 
-std::atomic<LogLevel> g_log_level = kLogLevelNotice;
+std::atomic<LogLevel> g_log_level(kLogLevelNotice);
 
 }  // namespace
 


### PR DESCRIPTION
In #7754, the `g_log_level` variable was changed from `LogLevel` to `std::atomic<LogLevel>` and it was left being initialized with the `=` operator; however, this caused some compilation errors, such as:

```
../Firestore/core/src/util/log_stdio.cc:30:37: error: use of deleted function ‘std::atomic<_Tp>::atomic(const std::atomic<_Tp>&) [with _Tp = firebase::firestore::util::LogLevel]’
30 | std::atomic<LogLevel> g_log_level = kLogLevelNotice;
   |                                     ^~~~~~~~~~~~~~~
```

The fix in this PR is to initialize `g_log_level` directly.