### PR TITLE
Rotate Crashlytics Install UUID during upload instead of startup

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -86,7 +86,6 @@ typedef struct {
   const char* rootPath;
   const char* previouslyCrashedFileRootPath;
   const char* sessionId;
-  const char* installId;
   const char* betaToken;
 #if CLS_MACH_EXCEPTION_SUPPORTED
   exception_mask_t machExceptionMask;
@@ -102,13 +101,11 @@ typedef struct {
 #ifdef __OBJC__
 bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
                              FIRCLSSettings* settings,
-                             FIRCLSInstallIdentifierModel* installIDModel,
                              FIRCLSFileManager* fileManager);
 
 // Re-writes the metadata file on the current thread
 void FIRCLSContextUpdateMetadata(FIRCLSInternalReport* report,
                                  FIRCLSSettings* settings,
-                                 FIRCLSInstallIdentifierModel* installIDModel,
                                  FIRCLSFileManager* fileManager);
 #endif
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -53,7 +53,6 @@ static void FIRCLSContextAllocate(FIRCLSContext* context);
 
 FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
                                                  FIRCLSSettings* settings,
-                                                 FIRCLSInstallIdentifierModel* installIDModel,
                                                  FIRCLSFileManager* fileManager) {
   // Because we need to start the crash reporter right away,
   // it starts up either with default settings, or cached settings
@@ -64,7 +63,6 @@ FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
   memset(&initData, 0, sizeof(FIRCLSContextInitData));
 
   initData.customBundleId = nil;
-  initData.installId = [installIDModel.installID UTF8String];
   initData.sessionId = [[report identifier] UTF8String];
   initData.rootPath = [[report path] UTF8String];
   initData.previouslyCrashedFileRootPath = [[fileManager rootPath] UTF8String];
@@ -101,10 +99,8 @@ FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
 
 bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
                              FIRCLSSettings* settings,
-                             FIRCLSInstallIdentifierModel* installIDModel,
                              FIRCLSFileManager* fileManager) {
-  FIRCLSContextInitData initDataObj =
-      FIRCLSContextBuildInitData(report, settings, installIDModel, fileManager);
+  FIRCLSContextInitData initDataObj = FIRCLSContextBuildInitData(report, settings, fileManager);
   FIRCLSContextInitData* initData = &initDataObj;
 
   if (!initData) {
@@ -263,24 +259,6 @@ bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
   return true;
 }
 
-void FIRCLSContextUpdateMetadata(FIRCLSInternalReport* report,
-                                 FIRCLSSettings* settings,
-                                 FIRCLSInstallIdentifierModel* installIDModel,
-                                 FIRCLSFileManager* fileManager) {
-  FIRCLSContextInitData initDataObj =
-      FIRCLSContextBuildInitData(report, settings, installIDModel, fileManager);
-  FIRCLSContextInitData* initData = &initDataObj;
-
-  NSString* rootPath = [NSString stringWithUTF8String:initData->rootPath];
-
-  const char* metaDataPath =
-      [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile] fileSystemRepresentation];
-
-  if (!FIRCLSContextRecordMetadata(metaDataPath, initData)) {
-    FIRCLSErrorLog(@"Unable to update context metadata");
-  }
-}
-
 void FIRCLSContextBaseInit(void) {
   NSString* sdkBundleID = FIRCLSApplicationGetSDKBundleID();
 
@@ -411,7 +389,9 @@ static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const FIRCLSContextIni
   FIRCLSFileWriteHashEntryUint64(file, "started_at", time(NULL));
 
   FIRCLSFileWriteHashEntryString(file, "session_id", initData->sessionId);
-  FIRCLSFileWriteHashEntryString(file, "install_id", initData->installId);
+  // install_id is written into the proto directly. This is only left here to
+  // support Apple Report Converter.
+  FIRCLSFileWriteHashEntryString(file, "install_id", "");
   FIRCLSFileWriteHashEntryString(file, "beta_token", initData->betaToken);
   FIRCLSFileWriteHashEntryBoolean(file, "absolute_log_timestamps", true);
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -40,6 +40,7 @@
 }
 
 @property(nonatomic, strong) GDTCORTransport *googleTransport;
+@property(nonatomic, strong) FIRCLSInstallIdentifierModel *installIDModel;
 
 @property(nonatomic, readonly) NSString *googleAppID;
 
@@ -56,6 +57,7 @@
   _operationQueue = managerData.operationQueue;
   _googleAppID = managerData.googleAppID;
   _googleTransport = managerData.googleTransport;
+  _installIDModel = managerData.installIDModel;
   _fileManager = managerData.fileManager;
   _analytics = managerData.analytics;
 
@@ -84,6 +86,10 @@
   // symbolication operation may be computationally intensive.
   FIRCLSApplicationActivity(
       FIRCLSApplicationActivityDefault, @"Crashlytics Crash Report Processing", ^{
+        // Check to see if the FID has rotated before we construct the payload
+        // so that the payload has an updated value.
+        [self.installIDModel regenerateInstallIDIfNeeded];
+
         // Run on-device symbolication before packaging if we should process
         if (shouldProcess) {
           if (![self.fileManager moveItemAtPath:report.path
@@ -163,7 +169,8 @@
   }
 
   FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:path
-                                                               googleAppId:self.googleAppID];
+                                                               googleAppId:self.googleAppID
+                                                            installIDModel:self.installIDModel];
 
   GDTCOREvent *event = [self.googleTransport eventForTransport];
   event.dataObject = adapter;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -86,9 +86,15 @@
   // symbolication operation may be computationally intensive.
   FIRCLSApplicationActivity(
       FIRCLSApplicationActivityDefault, @"Crashlytics Crash Report Processing", ^{
-        // Check to see if the FID has rotated before we construct the payload
-        // so that the payload has an updated value.
-        [self.installIDModel regenerateInstallIDIfNeeded];
+        // Run this only once because it can be run multiple times in succession,
+        // and if it's slow it could delay crash upload too much without providing
+        // user benefit.
+        static dispatch_once_t regenerateOnceToken;
+        dispatch_once(&regenerateOnceToken, ^{
+          // Check to see if the FID has rotated before we construct the payload
+          // so that the payload has an updated value.
+          [self.installIDModel regenerateInstallIDIfNeeded];
+        });
 
         // Run on-device symbolication before packaging if we should process
         if (shouldProcess) {

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.h
@@ -34,12 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * To support end-users rotating Install IDs, this will check and rotate the Install ID,
- * which is a costly operation performance-wise. To keep the startup time impact down, call this in
- * a background thread.
- *
- * The block will be called on a background thread.
+ * which can be a slow operation. This should be run in an Activity or
+ * background thread.
  */
-- (void)regenerateInstallIDIfNeededWithBlock:(void (^)(BOOL didRotate))callback;
+- (BOOL)regenerateInstallIDIfNeeded;
 
 @end
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
@@ -27,11 +27,15 @@ static NSString *const FIRCLSInstallationIIDHashKey = @"com.crashlytics.install.
 // Legacy key that is automatically removed
 static NSString *const FIRCLSInstallationADIDKey = @"com.crashlytics.install.adid";
 
+static unsigned long long FIRCLSInstallationsWaitTime = 10 * NSEC_PER_SEC;
+
 @interface FIRCLSInstallIdentifierModel ()
 
 @property(nonatomic, copy) NSString *installID;
 
 @property(nonatomic, readonly) FIRInstallations *installations;
+
+@property(nonatomic, assign) dispatch_once_t regenerateOnceToken;
 
 @end
 
@@ -96,20 +100,33 @@ static NSString *const FIRCLSInstallationADIDKey = @"com.crashlytics.install.adi
 
 #pragma mark Privacy Shield
 
-/**
- * To support privacy shield we need to regenerate the install id when the IID changes.
- *
- * This is a blocking, slow call that must be called on a background thread.
- */
-- (void)regenerateInstallIDIfNeededWithBlock:(void (^)(BOOL didRotate))callback {
-  // This callback is on the main thread
-  [self.installations
-      installationIDWithCompletion:^(NSString *_Nullable currentIID, NSError *_Nullable error) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-          BOOL didRotate = [self rotateCrashlyticsInstallUUIDWithIID:currentIID error:error];
-          callback(didRotate);
-        });
-      }];
+- (BOOL)regenerateInstallIDIfNeeded {
+  BOOL __block didRotate = false;
+
+  // Run this only once because it can be run multiple times in succession,
+  // and if it's slow it could delay crash upload too much without providing
+  // user benefit.
+  dispatch_once(&_regenerateOnceToken, ^{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    // This runs Completion async, so wait a reasonable amount of time for it to finish.
+    [self.installations
+        installationIDWithCompletion:^(NSString *_Nullable currentIID, NSError *_Nullable error) {
+          didRotate = [self rotateCrashlyticsInstallUUIDWithIID:currentIID error:error];
+
+          if (didRotate) {
+            FIRCLSInfoLog(@"Rotated Crashlytics Install UUID because Firebase Install ID changed.");
+          }
+          dispatch_semaphore_signal(semaphore);
+        }];
+
+    intptr_t result = dispatch_semaphore_wait(
+        semaphore, dispatch_time(DISPATCH_TIME_NOW, FIRCLSInstallationsWaitTime));
+    if (result != 0) {
+      FIRCLSErrorLog(@"Crashlytics timed out while checking for Firebase Installation ID");
+    }
+  });
+  return didRotate;
 }
 
 - (BOOL)rotateCrashlyticsInstallUUIDWithIID:(NSString *_Nullable)currentIID

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
@@ -109,7 +109,7 @@ static unsigned long long FIRCLSInstallationsWaitTime = 10 * NSEC_PER_SEC;
         didRotate = [self rotateCrashlyticsInstallUUIDWithIID:currentIID error:error];
 
         if (didRotate) {
-          FIRCLSInfoLog(@"Rotated Crashlytics Install UUID because Firebase Install ID changed.");
+          FIRCLSInfoLog(@"Rotated Crashlytics Install UUID because Firebase Install ID changed");
         }
         dispatch_semaphore_signal(semaphore);
       }];

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
@@ -101,7 +101,6 @@ static unsigned long long FIRCLSInstallationsWaitTime = 10 * NSEC_PER_SEC;
 - (BOOL)regenerateInstallIDIfNeeded {
   BOOL __block didRotate = false;
 
-
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
   // This runs Completion async, so wait a reasonable amount of time for it to finish.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
@@ -19,6 +19,5 @@
 @interface FIRCLSRecordIdentity : FIRCLSRecordBase
 
 @property(nonatomic, copy) NSString *build_version;
-@property(nonatomic, copy) NSString *install_id;
 
 @end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
@@ -22,7 +22,6 @@
   self = [super initWithDict:dict];
   if (self) {
     _build_version = dict[@"build_version"];
-    _install_id = dict[@"install_id"];
   }
   return self;
 }

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.h
@@ -18,6 +18,8 @@
 
 #include "Crashlytics/Protogen/nanopb/crashlytics.nanopb.h"
 
+#import "Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.h"
+
 #import <GoogleDataTransport/GoogleDataTransport.h>
 
 /// This class is responsible for reading the persisted crash reports from disk and converting them
@@ -28,6 +30,9 @@
 
 /// Initializer
 /// @param folderPath Path where the persisted crash files reside
-- (instancetype)initWithPath:(NSString *)folderPath googleAppId:(NSString *)googleAppID;
-
+/// @param googleAppID ID for the app passed in from Firebase Core
+/// @param installIDModel for pulling the Crashlytics Installation UUID
+- (instancetype)initWithPath:(NSString *)folderPath
+                 googleAppId:(NSString *)googleAppID
+              installIDModel:(FIRCLSInstallIdentifierModel *)installIDModel;
 @end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -26,13 +26,22 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
+@interface FIRCLSReportAdapter ()
+
+@property(nonatomic, strong) FIRCLSInstallIdentifierModel *installIDModel;
+
+@end
+
 @implementation FIRCLSReportAdapter
 
-- (instancetype)initWithPath:(NSString *)folderPath googleAppId:(NSString *)googleAppID {
+- (instancetype)initWithPath:(NSString *)folderPath
+                 googleAppId:(NSString *)googleAppID
+              installIDModel:(FIRCLSInstallIdentifierModel *)installIDModel {
   self = [super init];
   if (self) {
     _folderPath = folderPath;
     _googleAppID = googleAppID;
+    _installIDModel = installIDModel;
 
     [self loadMetaDataFile];
 
@@ -141,7 +150,7 @@
   report.sdk_version = FIRCLSEncodeString(self.identity.build_version);
   report.gmp_app_id = FIRCLSEncodeString(self.googleAppID);
   report.platform = [self protoPlatformFromString:self.host.platform];
-  report.installation_uuid = FIRCLSEncodeString(self.identity.install_id);
+  report.installation_uuid = FIRCLSEncodeString(self.installIDModel.installID);
   report.build_version = FIRCLSEncodeString(self.application.build_version);
   report.display_version = FIRCLSEncodeString(self.application.display_version);
   report.apple_payload = [self protoFilesPayload];

--- a/Crashlytics/UnitTests/FIRCLSInstallIdentifierModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSInstallIdentifierModelTests.m
@@ -48,23 +48,6 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   [_defaults removeObjectForKey:FIRCLSInstallationIIDHashKey];
 }
 
-- (BOOL)blockOnRegeneration:(FIRCLSInstallIdentifierModel *)model {
-  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"promise"];
-  BOOL __block retDidRotate = NO;
-
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-    [model regenerateInstallIDIfNeededWithBlock:^(BOOL didRotate) {
-      retDidRotate = didRotate;
-
-      [expectation fulfill];
-    }];
-  });
-
-  [self waitForExpectations:@[ expectation ] timeout:1.0];
-
-  return retDidRotate;
-}
-
 - (void)testCreateUUID {
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_instance_id"];
 
@@ -83,7 +66,8 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
+  sleep(1);
 
   XCTAssertFalse(didRotate);
   XCTAssertEqualObjects([_defaults objectForKey:FABInstallationUUIDKey], model.installID);
@@ -100,7 +84,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
 
   XCTAssertFalse(didRotate);
   XCTAssertEqualObjects([_defaults objectForKey:FABInstallationUUIDKey], model.installID);
@@ -149,7 +133,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertTrue(didRotate);
 
   // Test that the UUID changed.
@@ -171,7 +155,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID changed.
@@ -192,7 +176,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID did not change. The FIID can be nil if
@@ -213,7 +197,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID did not change. The FIID can be nil if
@@ -236,7 +220,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID didn't change.
@@ -257,7 +241,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID didn't change.
@@ -280,7 +264,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertFalse(didRotate);
 
   // Test that the UUID didn't change.
@@ -304,7 +288,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
       [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
   XCTAssertNotNil(model.installID);
 
-  BOOL didRotate = [self blockOnRegeneration:model];
+  BOOL didRotate = [model regenerateInstallIDIfNeeded];
   XCTAssertTrue(didRotate);
 
   // Test that the UUID change.

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -44,8 +44,6 @@
   self.mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
                                                            appIDModel:appIDModel];
 
-  FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_instance_id"];
-
   NSString *name = @"exception_model_report";
   self.reportPath = [self.fileManager.rootPath stringByAppendingPathComponent:name];
   [self.fileManager createDirectoryAtPath:self.reportPath];

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -57,7 +57,7 @@
       [[FIRCLSInternalReport alloc] initWithPath:self.reportPath
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
-  FIRCLSContextInitialize(report, self.mockSettings, installIDModel, self.fileManager);
+  FIRCLSContextInitialize(report, self.mockSettings, self.fileManager);
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -46,9 +46,6 @@
 
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_instance_id"];
 
-  FIRCLSInstallIdentifierModel *installIDModel =
-      [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
-
   NSString *name = @"exception_model_report";
   self.reportPath = [self.fileManager.rootPath stringByAppendingPathComponent:name];
   [self.fileManager createDirectoryAtPath:self.reportPath];


### PR DESCRIPTION
This ensures we always call the `installationIDWithCompletion` during upload when we are already collecting crash data. Before we did this process at startup.

This moves the install_uuid out of the `.clsrecord` files and into the proto.

#no-changelog
