### PR TITLE
fix breakage in FM tests

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -18,7 +18,7 @@
 
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULUserDefaults.h>
-#import "FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h"
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingLogger.h"
 
 static const uint64_t kBytesToMegabytesDivisor = 1024 * 1024LL;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
@@ -120,7 +120,6 @@ static NSString *kRegistrationToken = @"token-12345";
   _checkinService = nil;
   _mockTokenStore = nil;
   [_mockInstallations stopMocking];
-
 }
 
 - (void)testThatTokenOperationsAuthHeaderStringMatchesCheckin {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
@@ -114,13 +114,13 @@ static NSString *kRegistrationToken = @"token-12345";
 }
 
 - (void)tearDown {
-  [_mockInstallations stopMocking];
-  _mockInstallations = nil;
   _authService = nil;
   [_mockCheckinService stopMocking];
   _mockCheckinService = nil;
   _checkinService = nil;
   _mockTokenStore = nil;
+  [_mockInstallations stopMocking];
+
 }
 
 - (void)testThatTokenOperationsAuthHeaderStringMatchesCheckin {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenStoreTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenStoreTest.m
@@ -52,6 +52,12 @@ static NSString *const kFakeCheckinPlistName = @"com.google.test.TestTokenStore"
 
 @end
 
+@interface FIRMessagingBackupExcludedPlist (ExposedForTest)
+
+- (BOOL)deleteFile:(NSError **)error;
+
+@end
+
 @interface FIRMessagingTokenStoreTest : XCTestCase
 
 @property(strong, nonatomic) FIRMessagingBackupExcludedPlist *checkinPlist;
@@ -86,11 +92,7 @@ static NSString *const kFakeCheckinPlistName = @"com.google.test.TestTokenStore"
 }
 
 - (void)tearDown {
-  NSString *path = [self pathForCheckinPlist];
-  if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
-    NSError *error;
-    [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
-  }
+  [self.checkinPlist deleteFile:nil];
   [_tokenStore removeAllTokensWithHandler:nil];
   [_mockCheckinStore stopMocking];
   [_mockTokenStore stopMocking];


### PR DESCRIPTION
The unit test is using a different path of plist file than the production code causing the test failed as it is checking the path of production code instead of unit test path. This fixes [#7797](https://github.com/firebase/firebase-ios-sdk/issues/7797)
