### PR TITLE
Replace NSCoding with NSSecureCoding

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2021-04 -- v7.11.0
 - [changed] Refactor Messaging to internally not depending on InstanceID, but can co-exist. Will remove InstanceID dependency in the next Firebase breaking change. (#7814)
+- [changed] Replaced NSCoding with NSSecureCoding. (#7831)
 
 # 2021-02 -- v7.7.0
 - [fixed] Fixed an issue in which, when checking storage size before writing to disk, the client was checking document folders that were no longer used. (#7480)

--- a/FirebaseMessaging/Sources/FIRMessagingCode.h
+++ b/FirebaseMessaging/Sources/FIRMessagingCode.h
@@ -220,11 +220,11 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTokenManagerAPNSChangedTokenInvalidated = 34011,
   kFIRMessagingMessageCodeTokenManagerInvalidateStaleToken = 34012,
   // FIRMessagingTokenStore.m
-  // DO NOT USE 15002 - 15013
+  // DO NOT USE 35002 - 35013
   kFIRMessagingMessageCodeTokenStore000 = 35000,
   kFIRMessagingMessageCodeTokenStore001 = 35001,
-  kFIRMessagingMessageCodeTokenStoreExceptionUnarchivingTokenInfo = 35015,
-
+  kFIRMessagingMessageCodeTokenStoreUnarchivingTokenInfo = 35015,
+  kFIRMessagingMessageCodeTokenStoreArchiveError = 35016,
   // DO NOT USE 16000, 18004
 
   // FIRMessagingUtilities.m

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Represents an APNS device token and whether its environment is for sandbox.
  *  It can read from and write to an NSDictionary for simple serialization.
  */
-@interface FIRMessagingAPNSInfo : NSObject <NSCoding, NSCopying>
+@interface FIRMessagingAPNSInfo : NSObject <NSSecureCoding, NSCopying>
 
 /// The APNs device token, provided by the OS to the application delegate
 @property(nonatomic, readonly, copy) NSData *deviceToken;

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.m
@@ -68,7 +68,11 @@ static NSString *const kFIRInstanceIDAPNSInfoSandboxKey = @"sandbox";
   return clone;
 }
 
-#pragma mark - NSCoding
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   id deviceToken = [aDecoder decodeObjectForKey:kFIRInstanceIDAPNSInfoTokenKey];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  associated with it. It can read from and write to an NSDictionary object, for
  *  simple serialization.
  */
-@interface FIRMessagingTokenInfo : NSObject <NSCoding>
+@interface FIRMessagingTokenInfo : NSObject <NSSecureCoding>
 
 /// The authorized entity (also known as Sender ID), associated with the token.
 @property(nonatomic, readonly, copy) NSString *authorizedEntity;

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -16,6 +16,7 @@
 
 #import "FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h"
 
+#import <GoogleUtilities/GULSecureCoding.h>
 #import "FirebaseMessaging/Sources/FIRMessagingConstants.h"
 #import "FirebaseMessaging/Sources/FIRMessagingLogger.h"
 #import "FirebaseMessaging/Sources/FIRMessagingUtilities.h"
@@ -119,7 +120,11 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   return [self.scope isEqualToString:kFIRMessagingDefaultTokenScope];
 }
 
-#pragma mark - NSCoding
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   // These value cannot be nil
@@ -140,7 +145,6 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   }
 
   // These values are nullable, so only fail the decode if the type does not match
-
   id appVersion = [aDecoder decodeObjectForKey:kFIRInstanceIDAppVersionKey];
   if (appVersion && ![appVersion isKindOfClass:[NSString class]]) {
     return nil;
@@ -158,19 +162,15 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
 
   FIRMessagingAPNSInfo *APNSInfo = nil;
   if (rawAPNSInfo) {
-    // TODO(chliangGoogle: Use the new API and secureCoding protocol.
-    @try {
-      [NSKeyedUnarchiver setClass:[FIRMessagingAPNSInfo class]
-                     forClassName:@"FIRInstanceIDAPNSInfo"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      APNSInfo = [NSKeyedUnarchiver unarchiveObjectWithData:rawAPNSInfo];
-#pragma clang diagnostic pop
-    } @catch (NSException *exception) {
-      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
-                             @"Could not parse raw APNS Info while parsing archived token info.");
-      APNSInfo = nil;
-    } @finally {
+    NSError *error;
+    APNSInfo = [GULSecureCoding
+        unarchivedObjectOfClasses:[NSSet setWithObjects:FIRMessagingAPNSInfo.class, nil]
+                         fromData:rawAPNSInfo
+                            error:&error];
+    if (error) {
+      FIRMessagingLoggerDebug(
+          kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
+          @"Could not parse raw APNS Info while parsing unarchived token info: %@", error);
     }
   }
 
@@ -200,15 +200,15 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   [aCoder encodeObject:self.firebaseAppID forKey:kFIRInstanceIDFirebaseAppIDKey];
   NSData *rawAPNSInfo;
   if (self.APNSInfo) {
-    // TODO(chliangGoogle: Use the new API and secureCoding protocol.
-    [NSKeyedArchiver setClassName:@"FIRInstanceIDAPNSInfo" forClass:[FIRMessagingAPNSInfo class]];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    rawAPNSInfo = [NSKeyedArchiver archivedDataWithRootObject:self.APNSInfo];
-#pragma clang diagnostic pop
-
-    [aCoder encodeObject:rawAPNSInfo forKey:kFIRInstanceIDAPNSInfoKey];
+    NSError *error;
+    rawAPNSInfo = [GULSecureCoding archivedDataWithRootObject:self.APNSInfo error:&error];
+    if (error) {
+      FIRMessagingLoggerDebug(
+          kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
+          @"Could not parse raw APNS Info while parsing archived token info: %@", error);
+    }
   }
+  [aCoder encodeObject:[rawAPNSInfo copy] forKey:kFIRInstanceIDAPNSInfoKey];
   [aCoder encodeObject:self.cacheTime forKey:kFIRInstanceIDCacheTimeKey];
 }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <GoogleUtilities/GULSecureCoding.h>
 #import "FirebaseMessaging/Sources/FIRMessagingConstants.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h"
 
@@ -76,11 +77,13 @@
   };
   FIRMessagingAPNSInfo *info =
       [[FIRMessagingAPNSInfo alloc] initWithTokenOptionsDictionary:validDictionary];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info];
-  FIRMessagingAPNSInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
-#pragma clang diagnostic pop
+  NSError *error;
+  NSData *archive = [GULSecureCoding archivedDataWithRootObject:info error:&error];
+  NSError *unarchiveError;
+  FIRMessagingAPNSInfo *restoredInfo = [GULSecureCoding
+      unarchivedObjectOfClasses:[NSSet setWithObjects:FIRMessagingAPNSInfo.class, nil]
+                       fromData:archive
+                          error:&unarchiveError];
   XCTAssertEqualObjects(info.deviceToken, restoredInfo.deviceToken);
   XCTAssertEqual(info.sandbox, restoredInfo.sandbox);
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -18,12 +18,12 @@
 #if !TARGET_OS_MACCATALYST && !SWIFT_PACKAGE
 // Skip keychain tests on Catalyst and swift package
 
+#import <GoogleUtilities/GULSecureCoding.h>
 #import <XCTest/XCTest.h>
-#import "OCMock.h"
-
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingCheckinPreferences.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h"
+#import "OCMock.h"
 
 static NSString *const kFIRMessagingTestKeychainId = @"com.google.iid-tests";
 
@@ -406,10 +406,8 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                         token:token
                                                    appVersion:@"1.0"
                                                 firebaseAppID:kFirebaseAppID];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return [NSKeyedArchiver archivedDataWithRootObject:tokenInfo];
-#pragma clang diagnostic pop
+  NSError *error;
+  return [GULSecureCoding archivedDataWithRootObject:tokenInfo error:&error];
 }
 @end
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
@@ -16,8 +16,8 @@
 
 #import "FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h"
 
+#import <GoogleUtilities/GULSecureCoding.h>
 #import <XCTest/XCTest.h>
-
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingUtilities.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h"
@@ -76,11 +76,14 @@ static BOOL const kAPNSSandbox = NO;
 // yields the same values for all the fields.
 - (void)testTokenInfoEncodingAndDecoding {
   FIRMessagingTokenInfo *info = self.validTokenInfo;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info];
-  FIRMessagingTokenInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
-#pragma clang diagnostic pop
+  NSError *archiverError;
+  NSData *archive = [GULSecureCoding archivedDataWithRootObject:info error:&archiverError];
+  NSError *unarchiverError;
+  FIRMessagingTokenInfo *restoredInfo =
+      [GULSecureCoding unarchivedObjectOfClasses:[NSSet setWithObjects:FIRMessagingTokenInfo.class,
+                                                                       NSDate.class, nil]
+                                        fromData:archive
+                                           error:&unarchiverError];
   XCTAssertEqualObjects(restoredInfo.authorizedEntity, info.authorizedEntity);
   XCTAssertEqualObjects(restoredInfo.scope, info.scope);
   XCTAssertEqualObjects(restoredInfo.token, info.token);


### PR DESCRIPTION
Also use GULSecureCoding to encode/decode. This partially fixes #3686.

Tested with previously installed app and fcm token is persisted correctly.