### PR TITLE
Fix pod spec lint and remove extraneous IID refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,12 @@ jobs:
 
     - stage: test
       env:
+        - PROJECT=Messaging METHOD=pod-lib-lint
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=ios
+
+    - stage: test
+      env:
         - PROJECT=RemoteConfig METHOD=pod-lib-lint
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=ios --skip-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,6 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Messaging METHOD=pod-lib-lint
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=ios
-
-    - stage: test
-      env:
         - PROJECT=RemoteConfig METHOD=pod-lib-lint
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=ios --skip-tests

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -51,6 +51,7 @@ device, and it is completely free.
   s.tvos.framework = 'SystemConfiguration'
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
+  s.dependency 'FirebaseInstanceID', '~> 7.0'
   s.dependency 'FirebaseInstallations', '~> 7.0'
   s.dependency 'FirebaseCore', '~> 7.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -39,8 +39,6 @@ device, and it is completely free.
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
-    'Firebase/InstanceID/Private/*.h',
-    'Firebase/InstanceID/Public/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseMessaging/*.h'
   s.library = 'sqlite3'
@@ -53,7 +51,6 @@ device, and it is completely free.
   s.tvos.framework = 'SystemConfiguration'
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
-  s.dependency 'FirebaseInstanceID', '~> 7.0'
   s.dependency 'FirebaseInstallations', '~> 7.0'
   s.dependency 'FirebaseCore', '~> 7.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -24,9 +24,8 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
-#import "Firebase/InstanceID/Private/FIRInstanceID_Private.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FirebaseInstallations.h"
+#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingAnalytics.h"
 #import "FirebaseMessaging/Sources/FIRMessagingCode.h"
 #import "FirebaseMessaging/Sources/FIRMessagingConstants.h"

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -113,12 +113,14 @@
   XCTestExpectation *batchSizeReductionExpectation =
       [self expectationWithDescription:@"Batch size was reduced after topic suscription"];
 
+  __weak id weakSelf = self;
   self.alwaysReadyDelegate.subscriptionHandler =
       ^(NSString *topic, FIRMessagingTopicAction action,
         FIRMessagingTopicOperationCompletion completion) {
         // Simulate that the handler is generally called asynchronously
         dispatch_async(dispatch_get_main_queue(), ^{
           if (action == FIRMessagingTopicActionUnsubscribe) {
+            id self = weakSelf; // XCTAssertEqual references self.
             XCTAssertEqual(pendingTopics.numberOfBatches, 1);
             [batchSizeReductionExpectation fulfill];
           }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -120,7 +120,7 @@
         // Simulate that the handler is generally called asynchronously
         dispatch_async(dispatch_get_main_queue(), ^{
           if (action == FIRMessagingTopicActionUnsubscribe) {
-            __unused id self = weakSelf; // In Xcode 11, XCTAssertEqual references self.
+            __unused id self = weakSelf;  // In Xcode 11, XCTAssertEqual references self.
             XCTAssertEqual(pendingTopics.numberOfBatches, 1);
             [batchSizeReductionExpectation fulfill];
           }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -120,7 +120,7 @@
         // Simulate that the handler is generally called asynchronously
         dispatch_async(dispatch_get_main_queue(), ^{
           if (action == FIRMessagingTopicActionUnsubscribe) {
-            id self = weakSelf; // XCTAssertEqual references self.
+            __unused id self = weakSelf; // In Xcode 11, XCTAssertEqual references self.
             XCTAssertEqual(pendingTopics.numberOfBatches, 1);
             [batchSizeReductionExpectation fulfill];
           }


### PR DESCRIPTION
Fix #7834 
 
Fix the nightly test failure caused by missing unspecified header:
    - NOTE  | [watchOS] xcodebuild:  FirebaseMessaging/FirebaseMessaging/Sources/FIRMessaging.m:29:9: note: did not find header 'Source/Library/Public/FirebaseInstallations/FirebaseInstallations.h' in framework 'FirebaseInstallations' (loaded from '/Users/runner/Library/Developer/Xcode/DerivedData/App-egulcarutpujhtfyjnzoycquvdim/Build/Products/Release-watchsimulator/FirebaseInstallations')

Remove IID from the podspec

#no-changelog