### PR TITLE
Firmer SPM dependency versions and iOS device build check

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -20,12 +20,22 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
+
+  # Test iOS Device build since some Firestore dependencies build different files.
+  iOS-Device:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize xcodebuild
+      run: xcodebuild -list
+    - name: iOS Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
 
   platforms:
     # Don't run on private repo unless it is a PR.
@@ -39,8 +49,6 @@ jobs:
         test: [objc-import-test, swift-test, version-test]
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Unit Tests

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+      # TODO (#7785) Change to Firebase-Package when #7785 is resolved.
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift-Beta iOS-device spmbuildonly
 
   platforms:
     # Don't run on private repo unless it is a PR.

--- a/Package.swift
+++ b/Package.swift
@@ -102,11 +102,14 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Promises", url: "https://github.com/google/promises.git", "1.2.8" ..< "1.3.0"),
+    .package(name: "Promises",
+      url: "https://github.com/google/promises.git",
+      "1.2.8" ..< "1.3.0"
+    ),
     .package(
       name: "SwiftProtobuf",
       url: "https://github.com/apple/swift-protobuf.git",
-      from: "1.14.0"
+      "1.15.0" ..< "2.0.0"
     ),
     .package(
       name: "GoogleAppMeasurement",
@@ -131,18 +134,17 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/firebase/nanopb.git",
-      // This revision adds SPM enablement to the 0.3.9.6 release tag.
       "2.30908.0" ..< "2.30909.0"
     ),
     .package(
       name: "abseil",
       url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      from: "0.20200225.1"
+      "0.20200225.3" ..< "0.20200226.0"
     ),
     .package(
       name: "gRPC",
       url: "https://github.com/firebase/grpc-SwiftPM.git",
-      "1.28.3" ..< "1.29.0"
+      "1.28.4" ..< "1.29.0"
     ),
     .package(
       name: "OCMock",

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Promises",
+    .package(
+      name: "Promises",
       url: "https://github.com/google/promises.git",
       "1.2.8" ..< "1.3.0"
     ),

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,6 +46,7 @@ product can be one of:
 
 platform can be one of:
   iOS (default)
+  iOS-device
   macOS
   tvOS
   watchOS
@@ -154,6 +155,10 @@ else
   )
 fi
 
+ios_device_flags=(
+  -sdk 'iphoneos'
+)
+
 ipad_flags=(
   -sdk 'iphonesimulator'
   -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)'
@@ -180,6 +185,11 @@ catalyst_flags=(
 case "$platform" in
   iOS)
     xcb_flags=("${ios_flags[@]}")
+    gen_platform=ios
+    ;;
+
+  iOS-device)
+    xcb_flags=("${ios_device_flags[@]}")
     gen_platform=ios
     ;;
 


### PR DESCRIPTION
Fix #7784 

While its sufficient to update Swift Package Manager versions to update the dependencies to fix #7784, this PR enforces the minimum dependency versions for the fixes for the future async/await toolchain.

The PR also makes dependency version management more robust by limiting the Firestore dependency updates to patch versions and SwiftProtobuf to minor versions.

Also adds an iOS device build test to catch device specific build problems like what showed up in #7777 earlier.