### PR TITLE
FIRSampleAppUtilities: Replace deprecated method.

### DIFF
--- a/SharedTestUtilities/FIRSampleAppUtilities.m
+++ b/SharedTestUtilities/FIRSampleAppUtilities.m
@@ -110,7 +110,7 @@ NSString *const kInvalidPlistAlertMessage = @"This sample app needs to be update
     [viewController showDetailViewController:safariController sender:nil];
   } else {
 #endif
-    [[UIApplication sharedApplication] openURL:url];
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 #if __has_include(<SafariServices/SafariServices.h>)
   }
 #endif


### PR DESCRIPTION
[`openURL:`](https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl?language=objc) has been deprecated since the introduction iOS 10. Replaced its use with [`openURL:options:completionHandler:`](https://developer.apple.com/documentation/uikit/uiapplication/1648685-openurl?language=objc), passing in empty options and a `nil` completion handler.

Noticed this in the GHA logs while working on #7788.

This should eliminate the deprecation warning when testing. 

#no-changelog 