### PR TITLE
Ensure to archive/unarchive to original FIRInstanceID TokenInfo and APNSInfo

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2021-04 -- v7.11.0
-- [changed] Refactor Messaging to internally not depending on InstanceID, but can co-exist. Will remove InstanceID dependency in the next Firebase breaking change. (#7814)
+- [changed] Refactor Messaging to internally not depend on InstanceID, but can co-exist. This makes Messaging's APIs of handling FCM registration token no longer depend on InstanceID to function. Recommend use Messaging to handle FCm registration tokens. (#7814)
 - [changed] Replaced NSCoding with NSSecureCoding. (#7831)
 
 # 2021-02 -- v7.7.0

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2021-04 -- v7.11.0
-- [changed] Refactor Messaging to internally not depend on InstanceID, but can co-exist. This makes Messaging's APIs of handling FCM registration token no longer depend on InstanceID to function. Recommend use Messaging to handle FCm registration tokens. (#7814)
+- [changed] Remove Messaging's dependency on InstanceID while continuing to optionally interoperate with it. This makes Messaging's APIs of handling FCM registration tokens no longer depend on InstanceID. We recommend migrating the handling of FCM registration tokens from InstanceID APIs to FCM APIs. https://firebase.google.com/docs/cloud-messaging/ios/client#access_the_registration_token (#7814)
 - [changed] Replaced NSCoding with NSSecureCoding. (#7831)
 
 # 2021-02 -- v7.7.0

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -168,9 +168,12 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
                          fromData:rawAPNSInfo
                             error:&error];
     if (error) {
-      FIRMessagingLoggerDebug(
+      FIRMessagingLoggerInfo(
           kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
-          @"Could not parse raw APNS Info while parsing unarchived token info: %@", error);
+          @"Could not parse raw APNS Info while parsing unarchived token info: %@. If you are "
+          @"still using the deprecated InstanceID SDK to handle FCM registration token. Please "
+          @"replace them with the Firebase Messaging token APIs.",
+          error);
     }
   }
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenStore.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenStore.m
@@ -94,11 +94,14 @@ static NSString *const kFIRMessagingTokenKeychainId = @"com.google.iid-tokens";
                                       setWithObjects:FIRMessagingTokenInfo.class, NSDate.class, nil]
                          fromData:item
                             error:&unarchiverError];
+
     if (unarchiverError) {
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTokenStoreUnarchivingTokenInfo,
-                              @"Unable to parse token info from Keychain item; item was in an "
-                              @"invalid format %@",
-                              unarchiverError);
+      FIRMessagingLoggerInfo(
+          kFIRMessagingMessageCodeTokenStoreUnarchivingTokenInfo,
+          @"Unable to parse token info from Keychain item; item was in an "
+          @"invalid format %@. If you are still using the deprecated InstanceID SDK to handle FCM "
+          @"registration token. Please replace them with the Firebase Messaging token APIs.",
+          unarchiverError);
       tokenInfo = nil;
     }
   }


### PR DESCRIPTION
Looks like we can archive and unarchive with an arbitrary class (Thanks Maksym!) so enforce messaging to always use FIRInstanceIDTokenInfo and FIRInstanceIDAPNSInfo to ensure backward compatibility.