### PR TITLE
Use Result type APIs for Storage Combine

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -34,29 +34,10 @@ on:
     - cron:  '0 7 * * *'
 
 jobs:
-  check:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-
-    - name: Setup check
-      run:  scripts/setup_check.sh
-
-    - name: Run check
-      run:  scripts/check.sh --test-only
-
-
   xcodebuild:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-latest
-    needs: check
 
     strategy:
       matrix:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
@@ -832,6 +832,34 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseStorageCombineSwift-Beta"
+               BuildableName = "FirebaseStorageCombineSwift-Beta"
+               BlueprintName = "FirebaseStorageCombineSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseStorageCombineSwift"
+               BuildableName = "FirebaseStorageCombineSwift"
+               BlueprintName = "FirebaseStorageCombineSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -43,16 +43,14 @@ Combine Publishers for Firebase.
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '~> 7.0'
-  s.dependency 'FirebaseAuth', '~> 7.0'
-  s.dependency 'FirebaseFunctions', '~> 7.0'
-  s.dependency 'FirebaseStorage', '~> 7.0'
+  s.dependency 'FirebaseCore', '~> 7.6'
+  s.dependency 'FirebaseAuth', '~> 7.6'
+  s.dependency 'FirebaseFunctions', '~> 7.6'
+  s.dependency 'FirebaseStorage', '~> 7.6'
+  s.dependency 'FirebaseStorageSwift', '~> 7.6-beta'
 
   s.pod_target_xcconfig = {
-    'GCC_C_LANGUAGE_STANDARD' => 'c99',
-    'GCC_PREPROCESSOR_DEFINITIONS' => 'Firebase_VERSION=' + s.version.to_s,
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
-    'OTHER_CFLAGS' => '-fno-autolink'
   }
 
   s.test_spec 'unit' do |unit_tests|

--- a/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
@@ -16,6 +16,7 @@
 
   import Combine
   import FirebaseStorage
+  import FirebaseStorageSwift
 
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -37,10 +38,11 @@
                         metadata: StorageMetadata?) -> Future<StorageMetadata, Error> {
       var task: StorageUploadTask?
       return Future<StorageMetadata, Error> { [weak self] promise in
-        task = self?.putData(data, metadata: metadata) { metadata, error in
-          if let metadata = metadata {
+        task = self?.putData(data, metadata: metadata) { result in
+          switch result {
+          case let .success(metadata):
             promise(.success(metadata))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -66,10 +68,11 @@
       -> Future<StorageMetadata, Error> {
       var task: StorageUploadTask?
       return Future<StorageMetadata, Error> { [weak self] promise in
-        task = self?.putFile(from: fileURL, metadata: metadata) { metadata, error in
-          if let metadata = metadata {
+        task = self?.putFile(from: fileURL, metadata: metadata) { result in
+          switch result {
+          case let .success(metadata):
             promise(.success(metadata))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -97,10 +100,11 @@
     public func getData(maxSize size: Int64) -> Future<Data, Error> {
       var task: StorageDownloadTask?
       return Future<Data, Error> { [weak self] promise in
-        task = self?.getData(maxSize: size) { data, error in
-          if let data = data {
+        task = self?.getData(maxSize: size) { result in
+          switch result {
+          case let .success(data):
             promise(.success(data))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -124,10 +128,11 @@
     public func write(toFile fileURL: URL) -> Future<URL, Error> {
       var task: StorageDownloadTask?
       return Future<URL, Error> { [weak self] promise in
-        task = self?.write(toFile: fileURL) { url, error in
-          if let url = url {
+        task = self?.write(toFile: fileURL) { result in
+          switch result {
+          case let .success(url):
             promise(.success(url))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -148,10 +153,11 @@
     @discardableResult
     public func downloadURL() -> Future<URL, Error> {
       Future<URL, Error> { promise in
-        self.downloadURL { url, error in
-          if let url = url {
+        self.downloadURL { result in
+          switch result {
+          case let .success(url):
             promise(.success(url))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -175,11 +181,12 @@
     @discardableResult
     public func listAll() -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
-        self.listAll { result, error in
-          if let error = error {
+        self.listAll { result in
+          switch result {
+          case let .success(list):
+            promise(.success(list))
+          case let .failure(error):
             promise(.failure(error))
-          } else {
-            promise(.success(result))
           }
         }
       }
@@ -204,11 +211,12 @@
     @discardableResult
     public func list(maxResults: Int64) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
-        self.list(maxResults: maxResults) { result, error in
-          if let error = error {
+        self.list(maxResults: maxResults) { result in
+          switch result {
+          case let .success(list):
+            promise(.success(list))
+          case let .failure(error):
             promise(.failure(error))
-          } else {
-            promise(.success(result))
           }
         }
       }
@@ -235,11 +243,12 @@
     @discardableResult
     public func list(maxResults: Int64, pageToken: String) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
-        self.list(maxResults: maxResults, pageToken: pageToken) { result, error in
-          if let error = error {
+        self.list(maxResults: maxResults, pageToken: pageToken) { result in
+          switch result {
+          case let .success(list):
+            promise(.success(list))
+          case let .failure(error):
             promise(.failure(error))
-          } else {
-            promise(.success(result))
           }
         }
       }
@@ -255,10 +264,11 @@
     @discardableResult
     public func getMetadata() -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
-        self.getMetadata { metadata, error in
-          if let metadata = metadata {
+        self.getMetadata { result in
+          switch result {
+          case let .success(metadata):
             promise(.success(metadata))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }
@@ -276,10 +286,11 @@
     @discardableResult
     public func updateMetadata(_ metadata: StorageMetadata) -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
-        self.updateMetadata(metadata) { metadata, error in
-          if let metadata = metadata {
+        self.updateMetadata(metadata) { result in
+          switch result {
+          case let .success(metadata):
             promise(.success(metadata))
-          } else if let error = error {
+          case let .failure(error):
             promise(.failure(error))
           }
         }

--- a/FirebaseCombineSwift/Tests/Unit/Storage/StorageReferenceTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Storage/StorageReferenceTests.swift
@@ -61,7 +61,8 @@ class StorageReferenceTests: XCTestCase {
           XCTAssertEqual(error.code, StorageErrorCode.unknown.rawValue)
 
           let expectedDescription =
-            "File at URL: \(dummyFileURL.absoluteString) is not reachable. Ensure file URL is not a directory, symbolic link, or invalid url."
+            "File at URL: \(dummyFileURL.absoluteString) is not reachable. Ensure file URL is not" +
+            " a directory, symbolic link, or invalid url."
           XCTAssertEqual(error.localizedDescription, expectedDescription)
         }
       } receiveValue: { metadata in

--- a/Package.swift
+++ b/Package.swift
@@ -348,7 +348,10 @@ let package = Package(
     ),
     .target(
       name: "FirebaseStorageCombineSwift",
-      dependencies: ["FirebaseStorage"],
+      dependencies: [
+        "FirebaseStorage",
+        "FirebaseStorageSwift",
+      ],
       path: "FirebaseCombineSwift/Sources/Storage"
     ),
     .target(

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -142,7 +142,7 @@ private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL)
             logger.importLog("Import \(importFileRaw) does not exist.", file, lineNum)
           }
         }
-      } else if importFile.first == "<", !isPrivate, !isTestFile, !isBridgingHeader {
+      } else if importFile.first == "<", !isPrivate, !isTestFile, !isBridgingHeader, !isPublic {
         // Verify that double quotes are always used for intra-module imports.
         if importFileRaw.starts(with: "Firebase") {
           logger


### PR DESCRIPTION
Use Result type FirebaseStorageSwift APIs for Storage Combine Implementation.

And some podspec cleanups and CI infrastructure fixes.

FYI, I'm just starting to kick the tires on Combine, so let me know if I'm missing anything here.