### PR TITLE
Run unit tests from pod lib lint

### DIFF
--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -118,7 +118,7 @@ jobs:
         # specified for the other three platforms.
         target: [ios, tvos, macos]
         spec: [
-          'FirebaseStorage.podspec --test-specs=unit' # The integration tests need more set up.
+          'FirebaseStorage.podspec --test-specs=unit', # The integration tests need more set up.
           'FirebaseStorageSwift.podspec --skip-tests' # No current unit tests.
         ]
     steps:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -117,18 +117,21 @@ jobs:
         # watchos is disabled since pod lib lint cannot handle test Auth dep even if the dep is only
         # specified for the other three platforms.
         target: [ios, tvos, macos]
+        spec: [
+          'FirebaseStorage.podspec --test-specs=unit' # The integration tests need more set up.
+          'FirebaseStorageSwift.podspec --skip-tests' # No current unit tests.
+        ]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: |
-       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=${{ matrix.target }}
-       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorageSwift.podspec --skip-tests --platforms=${{ matrix.target }}
+       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.spec }} --platforms=${{ matrix.target }}
 
   storage-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -145,4 +148,4 @@ jobs:
     - name: PodLibLint Storage Cron
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorageSwift.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -131,7 +131,7 @@ jobs:
 
   storage-cron-only:
     # Don't run on private repo.
-    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
@@ -151,7 +151,7 @@ jobs:
 
   storageswift-cron-only:
     # Don't run on private repo.
-    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -137,8 +137,8 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         flags: [
-          '--skip-tests --use-static-frameworks',
-          '--skip-tests --use-libraries'
+          '--use-static-frameworks --skip-tests ',
+          '--use-libraries --skip-tests '
         ]
     needs: pod-lib-lint
     steps:
@@ -148,4 +148,22 @@ jobs:
     - name: PodLibLint Storage Cron
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+
+  storageswift-cron-only:
+    # Don't run on private repo.
+    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--use-static-frameworks --skip-tests', # Swift pods do not support --use-libraries
+        ]
+    needs: pod-lib-lint
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint Storage Cron
+      run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorageSwift.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -496,14 +496,6 @@ case "$product-$platform-$method" in
 
   Storage-*-xcodebuild)
     pod_gen FirebaseStorage.podspec --platforms=ios
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-Unit-unit" \
-      "${ios_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-
     if check_secrets; then
       # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \
@@ -522,24 +514,6 @@ case "$product-$platform-$method" in
         build \
         test
       fi
-
-    pod_gen FirebaseStorage.podspec --platforms=macos --clean
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-Unit-unit" \
-      "${macos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-
-    pod_gen FirebaseStorage.podspec --platforms=tvos --clean
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-Unit-unit" \
-      "${tvos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
     ;;
 
   StorageSwift-*-xcodebuild)


### PR DESCRIPTION
Miscellaneous Storage CI cleanups

- Run unit tests from `pod lib lint`
- Remove a duplicate test
- Test FirebaseStorageSwift with `--no-modular-headers` option on cron

#no-changelog