### PR TITLE
Fix Storage Integration Test CI

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -496,6 +496,12 @@ case "$product-$platform-$method" in
 
   Storage-*-xcodebuild)
     pod_gen FirebaseStorage.podspec --platforms=ios
+
+    # Add GoogleService-Info.plist to generated Test Wrapper App.
+    ruby ./scripts/update_xcode_target.rb gen/FirebaseStorage/Pods/Pods.xcodeproj \
+      AppHost-FirebaseStorage-Unit-Tests \
+      ../../../FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist
+
     if check_secrets; then
       # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \
@@ -518,6 +524,12 @@ case "$product-$platform-$method" in
 
   StorageSwift-*-xcodebuild)
     pod_gen FirebaseStorageSwift.podspec --platforms=ios
+
+    # Add GoogleService-Info.plist to generated Test Wrapper App.
+    ruby ./scripts/update_xcode_target.rb gen/FirebaseStorageSwift/Pods/Pods.xcodeproj \
+      AppHost-FirebaseStorageSwift-Unit-Tests \
+      ../../../FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist
+
     if check_secrets; then
       # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \

--- a/scripts/code_coverage_report/code_coverage_file_list.json
+++ b/scripts/code_coverage_report/code_coverage_file_list.json
@@ -46,16 +46,6 @@
       "FirebaseFirestore\\.podspec",
       "CMakeLists\\.txt",
       "cmake/.*",
-      "scripts/binary_to_array\\.py",
-      "scripts/build\\.sh",
-      "scripts/install_prereqs\\.sh",
-      "scripts/localize_podfile\\.swift",
-      "scripts/pod_lib_lint\\.rb",
-      "scripts/run_firestore_emulator\\.sh",
-      "scripts/setup_[^/]+",
-      "scripts/sync_project\\.rb",
-      "scripts/test_quickstart\\.sh",
-      "scripts/xcresult_logs\\.py",
       "\\.github/workflows/firestore\\.yml",
       "Gemfile"
     ]

--- a/scripts/update_xcode_target.rb
+++ b/scripts/update_xcode_target.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to add a file to an Xcode target.
+# Adapted from https://github.com/firebase/quickstart-ios/blob/master/scripts/info_script.rb
+
+require 'xcodeproj'
+project_path = ARGV[0]
+target = ARGV[1]
+file_name = ARGV[2]
+
+project = Xcodeproj::Project.open(project_path)
+
+# Add a file to the project in the main group
+file = project.new_file(file_name)
+
+# Add the file to the all targets
+project.targets.each do |t|
+  if t.to_s == target
+    t.add_file_references([file])
+  end
+end
+
+#save project
+project.save()

--- a/scripts/update_xcode_target.rb
+++ b/scripts/update_xcode_target.rb
@@ -34,5 +34,5 @@ project.targets.each do |t|
   end
 end
 
-#save project
+# Save project
 project.save()


### PR DESCRIPTION
The Storage integration tests have been silently failing ever since 7.0.0 after the GoogleServiceInfo.plist does not get found because FirebaseCore is linked dynamically as a separate bundle instead of statically into the app. https://github.com/firebase/firebase-ios-sdk/runs/2294766037?check_suite_focus=true#step:7:475

This fix uses a ruby script to update the Test Container app with the GoogleService-Info.plist so that it gets found at initialization.

Also, stop running Firestore test_coverage CI on script changes.

See successful Storage integration test logs at https://github.com/firebase/firebase-ios-sdk/runs/2308057031?check_suite_focus=true