### PR TITLE
Remove duplicate Foundation import

### DIFF
--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -19,8 +19,6 @@
 
 #import "FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FIRInAppMessaging.h"
 
-#import <Foundation/Foundation.h>
-
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"


### PR DESCRIPTION
See Foundation import in header file [here](https://github.com/firebase/firebase-ios-sdk/blob/724caede52c05cdc00ecc48b3df91b278db43e25/FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FIRInAppMessaging.h#L20)

#no-changelog