### PR TITLE
Force the template argument of std::min to prevent Windows build error.

### DIFF
--- a/Firestore/core/src/bundle/bundle_reader.cc
+++ b/Firestore/core/src/bundle/bundle_reader.cc
@@ -121,7 +121,7 @@ void BundleReader::ReadJsonToBuffer(size_t required_size) {
   while (buffer_.size() < required_size) {
     // Read at most 1024 bytes every time, to avoid allocating a huge buffer
     // when corruption leads to large `required_size`.
-    auto size = std::min<unsigned long>(1024ul, required_size - buffer_.size());
+    auto size = std::min<size_t>(1024ul, required_size - buffer_.size());
     StreamReadResult result = input_->Read(size);
     if (!result.ok()) {
       reader_status_.Update(result.status());

--- a/Firestore/core/src/bundle/bundle_reader.cc
+++ b/Firestore/core/src/bundle/bundle_reader.cc
@@ -121,7 +121,7 @@ void BundleReader::ReadJsonToBuffer(size_t required_size) {
   while (buffer_.size() < required_size) {
     // Read at most 1024 bytes every time, to avoid allocating a huge buffer
     // when corruption leads to large `required_size`.
-    auto size = std::min(1024ul, required_size - buffer_.size());
+    auto size = std::min<unsigned long>(1024ul, required_size - buffer_.size());
     StreamReadResult result = input_->Read(size);
     if (!result.ok()) {
       reader_status_.Update(result.status());


### PR DESCRIPTION
Fixes an issue when building for Windows where this std::min line fails to infer the template type.

#no-changelog