### PR TITLE
Use private header import for FIRVersion.h

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNDevice.m
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.m
@@ -19,9 +19,9 @@
 #import <sys/utsname.h>
 
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
-#import "FIRVersion.h"
 
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x

--- a/FirebaseRemoteConfig/Sources/RCNDevice.m
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.m
@@ -19,9 +19,9 @@
 #import <sys/utsname.h>
 
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
-#import "FirebaseCore/Sources/Public/FirebaseCore/FIRVersion.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
+#import "FIRVersion.h"
 
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x


### PR DESCRIPTION
This was causing a failure in publishing the RemoteConfig pod.

#no-changelog