### PR TITLE
Continue FIRLoggerService client migration

### DIFF
--- a/FirebaseCore/Sources/FIRLogger.m
+++ b/FirebaseCore/Sources/FIRLogger.m
@@ -25,8 +25,6 @@ FIRLoggerService kFIRLoggerCore = @"[Firebase/Core]";
 // All the FIRLoggerService definitions should be migrated to clients. Do not add new ones!
 FIRLoggerService kFIRLoggerAnalytics = @"[Firebase/Analytics]";
 FIRLoggerService kFIRLoggerCrash = @"[Firebase/Crash]";
-FIRLoggerService kFIRLoggerMLKit = @"[Firebase/MLKit]";
-FIRLoggerService kFIRLoggerPerf = @"[Firebase/Performance]";
 FIRLoggerService kFIRLoggerRemoteConfig = @"[Firebase/RemoteConfig]";
 
 /// Arguments passed on launch.

--- a/FirebaseCore/Sources/Private/FIRLogger.h
+++ b/FirebaseCore/Sources/Private/FIRLogger.h
@@ -28,8 +28,6 @@ typedef NSString *const FIRLoggerService;
 extern FIRLoggerService kFIRLoggerAnalytics;
 extern FIRLoggerService kFIRLoggerCrash;
 extern FIRLoggerService kFIRLoggerCore;
-extern FIRLoggerService kFIRLoggerMLKit;
-extern FIRLoggerService kFIRLoggerPerf;
 extern FIRLoggerService kFIRLoggerRemoteConfig;
 
 /**

--- a/FirebaseCore/Tests/Unit/FIRLoggerTest.m
+++ b/FirebaseCore/Tests/Unit/FIRLoggerTest.m
@@ -75,7 +75,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   // Strings of type FIRLoggerServices.
   XCTAssertEqualObjects(kFIRLoggerAnalytics, @"[Firebase/Analytics]");
   XCTAssertEqualObjects(kFIRLoggerCore, @"[Firebase/Core]");
-  XCTAssertEqualObjects(kFIRLoggerMLKit, @"[Firebase/MLKit]");
 }
 
 - (void)testInitializeASLForNonDebugMode {

--- a/FirebasePerformance/Sources/FPRConsoleLogger.h
+++ b/FirebasePerformance/Sources/FPRConsoleLogger.h
@@ -16,6 +16,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXTERN NSString* const kFIRLoggerPerf;
+
 #define FPRLogDebug(messageCode, ...) FIRLogDebug(kFIRLoggerPerf, messageCode, __VA_ARGS__)
 #define FPRLogError(messageCode, ...) FIRLogError(kFIRLoggerPerf, messageCode, __VA_ARGS__)
 #define FPRLogInfo(messageCode, ...) FIRLogInfo(kFIRLoggerPerf, messageCode, __VA_ARGS__)

--- a/FirebasePerformance/Sources/FPRConsoleLogger.m
+++ b/FirebasePerformance/Sources/FPRConsoleLogger.m
@@ -14,6 +14,9 @@
 
 #import "FirebasePerformance/Sources/FPRConsoleLogger.h"
 
+// The Firebase service used in the Firebase logger.
+FIRLoggerService kFIRLoggerPerf = @"[Firebase/Performance]";
+
 // FPR Client message codes.
 NSString* const kFPRClientInitialize = @"I-PRF100001";
 NSString* const kFPRClientTempDirectory = @"I-PRF100002";


### PR DESCRIPTION
Firebase 8.0.0 progress on #2505.

kFIRLoggerMLKit and kFIRLoggerPerf no longer have google3 references and are updated.

The MLKit one is removed (b/146429345) and the Perf declaration is migrated.