### PR TITLE
Update to clang-format 12

### DIFF
--- a/Firebase/InstanceID/Public/FIRInstanceID.h
+++ b/Firebase/InstanceID/Public/FIRInstanceID.h
@@ -24,8 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The scope to be used when fetching/deleting a token for Firebase Messaging.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging
     NS_SWIFT_NAME(InstanceIDScopeFirebaseMessaging) DEPRECATED_ATTRIBUTE;
+// clang-format on
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /**
@@ -36,8 +39,11 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotification
     NS_SWIFT_NAME(InstanceIDTokenRefresh) DEPRECATED_ATTRIBUTE;
+// clang-format on
 #else
 /**
  *  Called when the system determines that tokens need to be refreshed.
@@ -47,8 +53,11 @@ FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotificatio
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDTokenRefreshNotification
     NS_SWIFT_NAME(InstanceIDTokenRefreshNotification) DEPRECATED_ATTRIBUTE;
+// clang-format on
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /**

--- a/Firebase/InstanceID/Public/FIRInstanceID.h
+++ b/Firebase/InstanceID/Public/FIRInstanceID.h
@@ -24,7 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The scope to be used when fetching/deleting a token for Firebase Messaging.
  */
-FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging NS_SWIFT_NAME(InstanceIDScopeFirebaseMessaging) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging
+    NS_SWIFT_NAME(InstanceIDScopeFirebaseMessaging) DEPRECATED_ATTRIBUTE;
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /**
@@ -35,7 +36,8 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging NS_SWIFT_
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
-FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotification NS_SWIFT_NAME(InstanceIDTokenRefresh) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotification
+    NS_SWIFT_NAME(InstanceIDTokenRefresh) DEPRECATED_ATTRIBUTE;
 #else
 /**
  *  Called when the system determines that tokens need to be refreshed.
@@ -45,7 +47,8 @@ FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotificatio
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
-FOUNDATION_EXPORT NSString *const kFIRInstanceIDTokenRefreshNotification NS_SWIFT_NAME(InstanceIDTokenRefreshNotification) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDTokenRefreshNotification
+    NS_SWIFT_NAME(InstanceIDTokenRefreshNotification) DEPRECATED_ATTRIBUTE;
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /**

--- a/Firebase/InstanceID/Public/FIRInstanceID.h
+++ b/Firebase/InstanceID/Public/FIRInstanceID.h
@@ -24,8 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The scope to be used when fetching/deleting a token for Firebase Messaging.
  */
-FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging
-    NS_SWIFT_NAME(InstanceIDScopeFirebaseMessaging) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging NS_SWIFT_NAME(InstanceIDScopeFirebaseMessaging) DEPRECATED_ATTRIBUTE;
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /**
@@ -36,8 +35,7 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceIDScopeFirebaseMessaging
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
-FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotification
-    NS_SWIFT_NAME(InstanceIDTokenRefresh) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotification NS_SWIFT_NAME(InstanceIDTokenRefresh) DEPRECATED_ATTRIBUTE;
 #else
 /**
  *  Called when the system determines that tokens need to be refreshed.
@@ -47,8 +45,7 @@ FOUNDATION_EXPORT const NSNotificationName kFIRInstanceIDTokenRefreshNotificatio
  *  Instance ID service will throttle the refresh event across all devices
  *  to control the rate of token updates on application servers.
  */
-FOUNDATION_EXPORT NSString *const kFIRInstanceIDTokenRefreshNotification
-    NS_SWIFT_NAME(InstanceIDTokenRefreshNotification) DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDTokenRefreshNotification NS_SWIFT_NAME(InstanceIDTokenRefreshNotification) DEPRECATED_ATTRIBUTE;
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /**

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
@@ -19,13 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Default event name for when an experiment is set.
 extern NSString *const FIRSetExperimentEventName NS_SWIFT_NAME(DefaultSetExperimentEventName);
 /// Default event name for when an experiment is activated.
-extern NSString *const FIRActivateExperimentEventName
-    NS_SWIFT_NAME(DefaultActivateExperimentEventName);
+extern NSString *const FIRActivateExperimentEventName NS_SWIFT_NAME(DefaultActivateExperimentEventName);
 /// Default event name for when an experiment is cleared.
 extern NSString *const FIRClearExperimentEventName NS_SWIFT_NAME(DefaultClearExperimentEventName);
 /// Default event name for when an experiment times out for being activated.
-extern NSString *const FIRTimeoutExperimentEventName
-    NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
+extern NSString *const FIRTimeoutExperimentEventName NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
 /// Default event name for when an experiment is expired as it reaches the end of TTL.
 extern NSString *const FIRExpireExperimentEventName NS_SWIFT_NAME(DefaultExpireExperimentEventName);
 

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
@@ -20,15 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const FIRSetExperimentEventName NS_SWIFT_NAME(DefaultSetExperimentEventName);
 /// Default event name for when an experiment is activated.
 // clang-format off
-// clang-format12 merges the next two lines.
+// clang-format12 will merge lines and exceed 100 character limit.
 extern NSString *const FIRActivateExperimentEventName
     NS_SWIFT_NAME(DefaultActivateExperimentEventName);
-// clang-format on
 /// Default event name for when an experiment is cleared.
 extern NSString *const FIRClearExperimentEventName NS_SWIFT_NAME(DefaultClearExperimentEventName);
 /// Default event name for when an experiment times out for being activated.
-// clang-format off
-// clang-format12 merges the next two lines.
 extern NSString *const FIRTimeoutExperimentEventName
     NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
 // clang-format on

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
@@ -19,11 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Default event name for when an experiment is set.
 extern NSString *const FIRSetExperimentEventName NS_SWIFT_NAME(DefaultSetExperimentEventName);
 /// Default event name for when an experiment is activated.
-extern NSString *const FIRActivateExperimentEventName NS_SWIFT_NAME(DefaultActivateExperimentEventName);
+extern NSString *const FIRActivateExperimentEventName
+    NS_SWIFT_NAME(DefaultActivateExperimentEventName);
 /// Default event name for when an experiment is cleared.
 extern NSString *const FIRClearExperimentEventName NS_SWIFT_NAME(DefaultClearExperimentEventName);
 /// Default event name for when an experiment times out for being activated.
-extern NSString *const FIRTimeoutExperimentEventName NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
+extern NSString *const FIRTimeoutExperimentEventName
+    NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
 /// Default event name for when an experiment is expired as it reaches the end of TTL.
 extern NSString *const FIRExpireExperimentEventName NS_SWIFT_NAME(DefaultExpireExperimentEventName);
 

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRLifecycleEvents.h
@@ -19,13 +19,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// Default event name for when an experiment is set.
 extern NSString *const FIRSetExperimentEventName NS_SWIFT_NAME(DefaultSetExperimentEventName);
 /// Default event name for when an experiment is activated.
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIRActivateExperimentEventName
     NS_SWIFT_NAME(DefaultActivateExperimentEventName);
+// clang-format on
 /// Default event name for when an experiment is cleared.
 extern NSString *const FIRClearExperimentEventName NS_SWIFT_NAME(DefaultClearExperimentEventName);
 /// Default event name for when an experiment times out for being activated.
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIRTimeoutExperimentEventName
     NS_SWIFT_NAME(DefaultTimeoutExperimentEventName);
+// clang-format on
 /// Default event name for when an experiment is expired as it reaches the end of TTL.
 extern NSString *const FIRExpireExperimentEventName NS_SWIFT_NAME(DefaultExpireExperimentEventName);
 

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -63,10 +63,12 @@ NS_SWIFT_NAME(AppDistribution)
 @end
 
 /// The error domain for codes in the `FIRAppDistributionError` enum.
-FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain NS_SWIFT_NAME(AppDistributionErrorDomain);
+FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain
+    NS_SWIFT_NAME(AppDistributionErrorDomain);
 
 /// The key for finding error details in the `NSError`'s `userInfo`.
-FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
+    NS_SWIFT_NAME(FunctionsErrorDetailsKey);
 
 /**
  * Error codes representing sign in or version check failure reasons.

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -63,12 +63,10 @@ NS_SWIFT_NAME(AppDistribution)
 @end
 
 /// The error domain for codes in the `FIRAppDistributionError` enum.
-FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain
-    NS_SWIFT_NAME(AppDistributionErrorDomain);
+FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain NS_SWIFT_NAME(AppDistributionErrorDomain);
 
 /// The key for finding error details in the `NSError`'s `userInfo`.
-FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
-    NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey NS_SWIFT_NAME(FunctionsErrorDetailsKey);
 
 /**
  * Error codes representing sign in or version check failure reasons.

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -63,12 +63,18 @@ NS_SWIFT_NAME(AppDistribution)
 @end
 
 /// The error domain for codes in the `FIRAppDistributionError` enum.
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain
     NS_SWIFT_NAME(AppDistributionErrorDomain);
+// clang-format on
 
 /// The key for finding error details in the `NSError`'s `userInfo`.
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
     NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+// clang-format on
 
 /**
  * Error codes representing sign in or version check failure reasons.

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -64,14 +64,11 @@ NS_SWIFT_NAME(AppDistribution)
 
 /// The error domain for codes in the `FIRAppDistributionError` enum.
 // clang-format off
-// clang-format12 merges the next two lines.
+// clang-format12 will merge lines and exceed 100 character limit.
 FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain
     NS_SWIFT_NAME(AppDistributionErrorDomain);
-// clang-format on
 
 /// The key for finding error details in the `NSError`'s `userInfo`.
-// clang-format off
-// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
     NS_SWIFT_NAME(FunctionsErrorDetailsKey);
 // clang-format on

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -44,8 +44,11 @@ typedef void (^FIRUserUpdateCallback)(NSError *_Nullable error) NS_SWIFT_NAME(Us
 /** @typedef FIRAuthStateDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addAuthStateDidChangeListener:`.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 typedef id<NSObject> FIRAuthStateDidChangeListenerHandle
     NS_SWIFT_NAME(AuthStateDidChangeListenerHandle);
+// clang-format on
 
 /** @typedef FIRAuthStateDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for auth state did change events.
@@ -59,8 +62,11 @@ typedef void (^FIRAuthStateDidChangeListenerBlock)(FIRAuth *auth, FIRUser *_Null
 /** @typedef FIRIDTokenDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addIDTokenDidChangeListener:`.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 typedef id<NSObject> FIRIDTokenDidChangeListenerHandle
     NS_SWIFT_NAME(IDTokenDidChangeListenerHandle);
+// clang-format on
 
 /** @typedef FIRIDTokenDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for ID token did change events.
@@ -95,8 +101,11 @@ extern const NSNotificationName FIRAuthStateDidChangeNotification NS_SWIFT_NAME(
         changes (for example, a new token has been produced, a user signs in or signs out). The
         object parameter of the notification is the sender `FIRAuth` instance.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIRAuthStateDidChangeNotification
     NS_SWIFT_NAME(AuthStateDidChangeNotification);
+// clang-format off
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /** @typedef FIRAuthResultCallback

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -44,8 +44,7 @@ typedef void (^FIRUserUpdateCallback)(NSError *_Nullable error) NS_SWIFT_NAME(Us
 /** @typedef FIRAuthStateDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addAuthStateDidChangeListener:`.
  */
-typedef id<NSObject> FIRAuthStateDidChangeListenerHandle
-    NS_SWIFT_NAME(AuthStateDidChangeListenerHandle);
+typedef id<NSObject> FIRAuthStateDidChangeListenerHandle NS_SWIFT_NAME(AuthStateDidChangeListenerHandle);
 
 /** @typedef FIRAuthStateDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for auth state did change events.
@@ -59,8 +58,7 @@ typedef void (^FIRAuthStateDidChangeListenerBlock)(FIRAuth *auth, FIRUser *_Null
 /** @typedef FIRIDTokenDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addIDTokenDidChangeListener:`.
  */
-typedef id<NSObject> FIRIDTokenDidChangeListenerHandle
-    NS_SWIFT_NAME(IDTokenDidChangeListenerHandle);
+typedef id<NSObject> FIRIDTokenDidChangeListenerHandle NS_SWIFT_NAME(IDTokenDidChangeListenerHandle);
 
 /** @typedef FIRIDTokenDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for ID token did change events.
@@ -95,8 +93,7 @@ extern const NSNotificationName FIRAuthStateDidChangeNotification NS_SWIFT_NAME(
         changes (for example, a new token has been produced, a user signs in or signs out). The
         object parameter of the notification is the sender `FIRAuth` instance.
  */
-extern NSString *const FIRAuthStateDidChangeNotification
-    NS_SWIFT_NAME(AuthStateDidChangeNotification);
+extern NSString *const FIRAuthStateDidChangeNotification NS_SWIFT_NAME(AuthStateDidChangeNotification);
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /** @typedef FIRAuthResultCallback

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -44,7 +44,8 @@ typedef void (^FIRUserUpdateCallback)(NSError *_Nullable error) NS_SWIFT_NAME(Us
 /** @typedef FIRAuthStateDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addAuthStateDidChangeListener:`.
  */
-typedef id<NSObject> FIRAuthStateDidChangeListenerHandle NS_SWIFT_NAME(AuthStateDidChangeListenerHandle);
+typedef id<NSObject> FIRAuthStateDidChangeListenerHandle
+    NS_SWIFT_NAME(AuthStateDidChangeListenerHandle);
 
 /** @typedef FIRAuthStateDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for auth state did change events.
@@ -58,7 +59,8 @@ typedef void (^FIRAuthStateDidChangeListenerBlock)(FIRAuth *auth, FIRUser *_Null
 /** @typedef FIRIDTokenDidChangeListenerHandle
     @brief The type of handle returned by `FIRAuth.addIDTokenDidChangeListener:`.
  */
-typedef id<NSObject> FIRIDTokenDidChangeListenerHandle NS_SWIFT_NAME(IDTokenDidChangeListenerHandle);
+typedef id<NSObject> FIRIDTokenDidChangeListenerHandle
+    NS_SWIFT_NAME(IDTokenDidChangeListenerHandle);
 
 /** @typedef FIRIDTokenDidChangeListenerBlock
     @brief The type of block which can be registered as a listener for ID token did change events.
@@ -93,7 +95,8 @@ extern const NSNotificationName FIRAuthStateDidChangeNotification NS_SWIFT_NAME(
         changes (for example, a new token has been produced, a user signs in or signs out). The
         object parameter of the notification is the sender `FIRAuth` instance.
  */
-extern NSString *const FIRAuthStateDidChangeNotification NS_SWIFT_NAME(AuthStateDidChangeNotification);
+extern NSString *const FIRAuthStateDidChangeNotification
+    NS_SWIFT_NAME(AuthStateDidChangeNotification);
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /** @typedef FIRAuthResultCallback

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -65,15 +65,13 @@ extern NSString *const FIRAuthErrorUserInfoEmailKey NS_SWIFT_NAME(AuthErrorUserI
         NSError object returned. This is the updated auth credential the developer should use for
         recovery if applicable.
  */
-extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey
-    NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
+extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
 
 /**
     @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
         returned when 2FA is required for sign-incompletion.
  */
-extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey
-    NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
+extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
 
 /**
     @brief Error codes used by Firebase Auth.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -65,13 +65,15 @@ extern NSString *const FIRAuthErrorUserInfoEmailKey NS_SWIFT_NAME(AuthErrorUserI
         NSError object returned. This is the updated auth credential the developer should use for
         recovery if applicable.
  */
-extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
+extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey
+    NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
 
 /**
     @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
         returned when 2FA is required for sign-incompletion.
  */
-extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
+extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey
+    NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
 
 /**
     @brief Error codes used by Firebase Auth.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -66,17 +66,14 @@ extern NSString *const FIRAuthErrorUserInfoEmailKey NS_SWIFT_NAME(AuthErrorUserI
         recovery if applicable.
  */
 // clang-format off
-// clang-format12 merges the next two lines.
+// clang-format12 will merge lines and exceed 100 character limit.
 extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey
     NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
-// clang-format on
 
 /**
     @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
         returned when 2FA is required for sign-incompletion.
  */
-// clang-format off
-// clang-format12 merges the next two lines.
 extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey
     NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
 // clang-format on

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -65,15 +65,21 @@ extern NSString *const FIRAuthErrorUserInfoEmailKey NS_SWIFT_NAME(AuthErrorUserI
         NSError object returned. This is the updated auth credential the developer should use for
         recovery if applicable.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIRAuthErrorUserInfoUpdatedCredentialKey
     NS_SWIFT_NAME(AuthErrorUserInfoUpdatedCredentialKey);
+// clang-format on
 
 /**
     @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
         returned when 2FA is required for sign-incompletion.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey
     NS_SWIFT_NAME(AuthErrorUserInfoMultiFactorResolverKey);
+// clang-format on
 
 /**
     @brief Error codes used by Firebase Auth.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
@@ -33,8 +33,11 @@ extern NSString *const FIREmailLinkAuthSignInMethod NS_SWIFT_NAME(EmailLinkAuthS
 /**
     @brief A string constant identifying the email & password sign-in method.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 extern NSString *const FIREmailPasswordAuthSignInMethod
     NS_SWIFT_NAME(EmailPasswordAuthSignInMethod);
+// clang-format on
 
 /** @class FIREmailAuthProvider
     @brief A concrete implementation of `FIRAuthProvider` for Email & Password Sign In.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
@@ -33,7 +33,8 @@ extern NSString *const FIREmailLinkAuthSignInMethod NS_SWIFT_NAME(EmailLinkAuthS
 /**
     @brief A string constant identifying the email & password sign-in method.
  */
-extern NSString *const FIREmailPasswordAuthSignInMethod NS_SWIFT_NAME(EmailPasswordAuthSignInMethod);
+extern NSString *const FIREmailPasswordAuthSignInMethod
+    NS_SWIFT_NAME(EmailPasswordAuthSignInMethod);
 
 /** @class FIREmailAuthProvider
     @brief A concrete implementation of `FIRAuthProvider` for Email & Password Sign In.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIREmailAuthProvider.h
@@ -33,8 +33,7 @@ extern NSString *const FIREmailLinkAuthSignInMethod NS_SWIFT_NAME(EmailLinkAuthS
 /**
     @brief A string constant identifying the email & password sign-in method.
  */
-extern NSString *const FIREmailPasswordAuthSignInMethod
-    NS_SWIFT_NAME(EmailPasswordAuthSignInMethod);
+extern NSString *const FIREmailPasswordAuthSignInMethod NS_SWIFT_NAME(EmailPasswordAuthSignInMethod);
 
 /** @class FIREmailAuthProvider
     @brief A concrete implementation of `FIRAuthProvider` for Email & Password Sign In.

--- a/FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m
@@ -24,7 +24,7 @@
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredential.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h"
 
-#define ANY_ERROR_POINTER ((NSError * __autoreleasing * _Nullable)[OCMArg anyPointer])
+#define ANY_ERROR_POINTER ((NSError * __autoreleasing *_Nullable)[OCMArg anyPointer])
 #define SAVE_TO(var)                     \
   [OCMArg checkWithBlock:^BOOL(id arg) { \
     var = arg;                           \

--- a/FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m
@@ -24,7 +24,7 @@
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredential.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h"
 
-#define ANY_ERROR_POINTER ((NSError * __autoreleasing *_Nullable)[OCMArg anyPointer])
+#define ANY_ERROR_POINTER ((NSError * __autoreleasing * _Nullable)[OCMArg anyPointer])
 #define SAVE_TO(var)                     \
   [OCMArg checkWithBlock:^BOOL(id arg) { \
     var = arg;                           \

--- a/FirebaseDatabase/Sources/Api/Private/FTypedefs_Private.h
+++ b/FirebaseDatabase/Sources/Api/Private/FTypedefs_Private.h
@@ -38,8 +38,8 @@ typedef NS_ENUM(NSInteger, FTransactionStatus) {
 typedef void (^fbt_void_nserror_bool_datasnapshot)(NSError *error,
                                                    BOOL committed,
                                                    FIRDataSnapshot *snapshot);
-typedef FIRTransactionResult * (^fbt_transactionresult_mutabledata)(
-    FIRMutableData *currentData);
+typedef FIRTransactionResult * (
+    ^fbt_transactionresult_mutabledata)(FIRMutableData *currentData);
 typedef void (^fbt_void_path_node)(FPath *, id<FNode>);
 typedef void (^fbt_void_nsstring)(NSString *);
 typedef BOOL (^fbt_bool_nsstring_node)(NSString *, id<FNode>);

--- a/FirebaseDatabase/Sources/Api/Private/FTypedefs_Private.h
+++ b/FirebaseDatabase/Sources/Api/Private/FTypedefs_Private.h
@@ -38,8 +38,8 @@ typedef NS_ENUM(NSInteger, FTransactionStatus) {
 typedef void (^fbt_void_nserror_bool_datasnapshot)(NSError *error,
                                                    BOOL committed,
                                                    FIRDataSnapshot *snapshot);
-typedef FIRTransactionResult * (
-    ^fbt_transactionresult_mutabledata)(FIRMutableData *currentData);
+typedef FIRTransactionResult * (^fbt_transactionresult_mutabledata)(
+    FIRMutableData *currentData);
 typedef void (^fbt_void_path_node)(FPath *, id<FNode>);
 typedef void (^fbt_void_nsstring)(NSString *);
 typedef BOOL (^fbt_bool_nsstring_node)(NSString *, id<FNode>);

--- a/FirebaseDatabase/Sources/Core/FWriteTree.m
+++ b/FirebaseDatabase/Sources/Core/FWriteTree.m
@@ -256,14 +256,14 @@
                 return nil;
             } else {
                 BOOL (^filter)(FWriteRecord *) = ^(FWriteRecord *record) {
-                  return (BOOL)(
-                      (record.visible || includeHiddenWrites) &&
-                      (writeIdsToExclude == nil ||
-                       ![writeIdsToExclude
-                           containsObject:
-                               [NSNumber numberWithInteger:record.writeId]]) &&
-                      ([record.path contains:treePath] ||
-                       [treePath contains:record.path]));
+                  return (BOOL)((record.visible || includeHiddenWrites) &&
+                                (writeIdsToExclude == nil ||
+                                 ![writeIdsToExclude
+                                     containsObject:[NSNumber
+                                                        numberWithInteger:
+                                                            record.writeId]]) &&
+                                ([record.path contains:treePath] ||
+                                 [treePath contains:record.path]));
                 };
                 FCompoundWrite *mergeAtPath =
                     [FWriteTree layerTreeFromWrites:self.allWrites

--- a/FirebaseDatabase/Sources/Core/FWriteTree.m
+++ b/FirebaseDatabase/Sources/Core/FWriteTree.m
@@ -256,14 +256,14 @@
                 return nil;
             } else {
                 BOOL (^filter)(FWriteRecord *) = ^(FWriteRecord *record) {
-                  return (BOOL)((record.visible || includeHiddenWrites) &&
-                                (writeIdsToExclude == nil ||
-                                 ![writeIdsToExclude
-                                     containsObject:[NSNumber
-                                                        numberWithInteger:
-                                                            record.writeId]]) &&
-                                ([record.path contains:treePath] ||
-                                 [treePath contains:record.path]));
+                  return (BOOL)(
+                      (record.visible || includeHiddenWrites) &&
+                      (writeIdsToExclude == nil ||
+                       ![writeIdsToExclude
+                           containsObject:
+                               [NSNumber numberWithInteger:record.writeId]]) &&
+                      ([record.path contains:treePath] ||
+                       [treePath contains:record.path]));
                 };
                 FCompoundWrite *mergeAtPath =
                     [FWriteTree layerTreeFromWrites:self.allWrites

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
@@ -37,7 +37,7 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
 @implementation FIRDatabaseTests
 
 - (void)testFIRDatabaseForNilApp {
-  XCTAssertThrowsSpecificNamed([FIRDatabase databaseForApp:(FIRApp *_Nonnull)nil], NSException,
+  XCTAssertThrowsSpecificNamed([FIRDatabase databaseForApp:(FIRApp * _Nonnull) nil], NSException,
                                @"InvalidFIRApp");
 }
 
@@ -92,7 +92,7 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
 - (void)testDatabaseForAppWithInvalidCustomURLs {
   id app = [[FIRFakeApp alloc] initWithName:@"testDatabaseForAppWithInvalidCustomURLs"
                                         URL:kFirebaseTestAltNamespace];
-  XCTAssertThrows([FIRDatabase databaseForApp:app URL:(NSString *_Nonnull)nil]);
+  XCTAssertThrows([FIRDatabase databaseForApp:app URL:(NSString * _Nonnull) nil]);
   XCTAssertThrows([FIRDatabase databaseForApp:app URL:@"not-a-url"]);
   XCTAssertThrows([FIRDatabase databaseForApp:app URL:@"http://x.fblocal.com:9000/paths/are/bad"]);
 }

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
@@ -37,7 +37,7 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
 @implementation FIRDatabaseTests
 
 - (void)testFIRDatabaseForNilApp {
-  XCTAssertThrowsSpecificNamed([FIRDatabase databaseForApp:(FIRApp * _Nonnull) nil], NSException,
+  XCTAssertThrowsSpecificNamed([FIRDatabase databaseForApp:(FIRApp *_Nonnull)nil], NSException,
                                @"InvalidFIRApp");
 }
 
@@ -92,7 +92,7 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
 - (void)testDatabaseForAppWithInvalidCustomURLs {
   id app = [[FIRFakeApp alloc] initWithName:@"testDatabaseForAppWithInvalidCustomURLs"
                                         URL:kFirebaseTestAltNamespace];
-  XCTAssertThrows([FIRDatabase databaseForApp:app URL:(NSString * _Nonnull) nil]);
+  XCTAssertThrows([FIRDatabase databaseForApp:app URL:(NSString *_Nonnull)nil]);
   XCTAssertThrows([FIRDatabase databaseForApp:app URL:@"not-a-url"]);
   XCTAssertThrows([FIRDatabase databaseForApp:app URL:@"http://x.fblocal.com:9000/paths/are/bad"]);
 }

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
@@ -22,11 +22,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** A notification with this name is sent each time an installation is created or deleted. */
-FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotification
-    NS_SWIFT_NAME(InstallationIDDidChange);
+FOUNDATION_EXPORT const NSNotificationName
+    FIRInstallationIDDidChangeNotification NS_SWIFT_NAME(InstallationIDDidChange);
 /** `userInfo` key for the `FirebaseApp.name` in `FIRInstallationIDDidChangeNotification`. */
-FOUNDATION_EXPORT NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey
-    NS_SWIFT_NAME(InstallationIDDidChangeAppNameKey);
+FOUNDATION_EXPORT NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey NS_SWIFT_NAME(InstallationIDDidChangeAppNameKey);
 
 /**
  * An installation ID handler block.
@@ -73,7 +72,8 @@ NS_SWIFT_NAME(Installations)
  * @returns An instance of `Installations` corresponding to the passed application.
  * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
-+ (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
++ (FIRInstallations *)installationsWithApp:(FIRApp *)application
+    NS_SWIFT_NAME(installations(app:));
 
 /**
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
@@ -76,7 +76,8 @@ NS_SWIFT_NAME(Installations)
  * @returns An instance of `Installations` corresponding to the passed application.
  * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
-+ (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
++ (FIRInstallations *)installationsWithApp:(FIRApp *)application
+    NS_SWIFT_NAME(installations(app:));
 
 /**
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
@@ -22,10 +22,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** A notification with this name is sent each time an installation is created or deleted. */
-FOUNDATION_EXPORT const NSNotificationName
-    FIRInstallationIDDidChangeNotification NS_SWIFT_NAME(InstallationIDDidChange);
+FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotification
+    NS_SWIFT_NAME(InstallationIDDidChange);
 /** `userInfo` key for the `FirebaseApp.name` in `FIRInstallationIDDidChangeNotification`. */
-FOUNDATION_EXPORT NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey NS_SWIFT_NAME(InstallationIDDidChangeAppNameKey);
+FOUNDATION_EXPORT NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey
+    NS_SWIFT_NAME(InstallationIDDidChangeAppNameKey);
 
 /**
  * An installation ID handler block.
@@ -72,8 +73,7 @@ NS_SWIFT_NAME(Installations)
  * @returns An instance of `Installations` corresponding to the passed application.
  * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
-+ (FIRInstallations *)installationsWithApp:(FIRApp *)application
-    NS_SWIFT_NAME(installations(app:));
++ (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 
 /**
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallations.h
@@ -22,11 +22,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** A notification with this name is sent each time an installation is created or deleted. */
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotification
     NS_SWIFT_NAME(InstallationIDDidChange);
 /** `userInfo` key for the `FirebaseApp.name` in `FIRInstallationIDDidChangeNotification`. */
 FOUNDATION_EXPORT NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey
     NS_SWIFT_NAME(InstallationIDDidChangeAppNameKey);
+// clang-format on
 
 /**
  * An installation ID handler block.

--- a/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
+++ b/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
@@ -61,8 +61,11 @@ typedef void (^FIRMessagingTopicOperationCompletion)(NSError *_Nullable error);
  *  FIRMessaging delegate method `messaging:didReceiveRegistrationToken:` to receive current and
  *  updated tokens.
  */
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification
     NS_SWIFT_NAME(MessagingRegistrationTokenRefreshed);
+// clang-format on
 
 /**
  *  @enum FIRMessagingError

--- a/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
+++ b/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
@@ -61,8 +61,8 @@ typedef void (^FIRMessagingTopicOperationCompletion)(NSError *_Nullable error);
  *  FIRMessaging delegate method `messaging:didReceiveRegistrationToken:` to receive current and
  *  updated tokens.
  */
-FOUNDATION_EXPORT const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification
-    NS_SWIFT_NAME(MessagingRegistrationTokenRefreshed);
+FOUNDATION_EXPORT const NSNotificationName
+    FIRMessagingRegistrationTokenRefreshedNotification NS_SWIFT_NAME(MessagingRegistrationTokenRefreshed);
 
 /**
  *  @enum FIRMessagingError

--- a/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
+++ b/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
@@ -61,8 +61,8 @@ typedef void (^FIRMessagingTopicOperationCompletion)(NSError *_Nullable error);
  *  FIRMessaging delegate method `messaging:didReceiveRegistrationToken:` to receive current and
  *  updated tokens.
  */
-FOUNDATION_EXPORT const NSNotificationName
-    FIRMessagingRegistrationTokenRefreshedNotification NS_SWIFT_NAME(MessagingRegistrationTokenRefreshed);
+FOUNDATION_EXPORT const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification
+    NS_SWIFT_NAME(MessagingRegistrationTokenRefreshed);
 
 /**
  *  @enum FIRMessagingError

--- a/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
+++ b/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
@@ -20,23 +20,23 @@
 typedef NS_ENUM(NSInteger, FIRHTTPMethod) {
   /** HTTP Method GET */
   FIRHTTPMethodGET NS_SWIFT_NAME(get),
-      /** HTTP Method PUT */
-      FIRHTTPMethodPUT NS_SWIFT_NAME(put),
-          /** HTTP Method POST */
-          FIRHTTPMethodPOST NS_SWIFT_NAME(post),
-              /** HTTP Method DELETE */
-              FIRHTTPMethodDELETE NS_SWIFT_NAME(delete),
-                  /** HTTP Method HEAD */
-                  FIRHTTPMethodHEAD NS_SWIFT_NAME(head),
-                      /** HTTP Method PATCH */
-                      FIRHTTPMethodPATCH NS_SWIFT_NAME(patch),
-                          /** HTTP Method OPTIONS */
-                          FIRHTTPMethodOPTIONS NS_SWIFT_NAME(options),
-                              /** HTTP Method TRACE */
-                              FIRHTTPMethodTRACE NS_SWIFT_NAME(trace),
-                                  /** HTTP Method CONNECT */
-                                  FIRHTTPMethodCONNECT NS_SWIFT_NAME(connect)
-                              } NS_SWIFT_NAME(HTTPMethod);
+  /** HTTP Method PUT */
+  FIRHTTPMethodPUT NS_SWIFT_NAME(put),
+  /** HTTP Method POST */
+  FIRHTTPMethodPOST NS_SWIFT_NAME(post),
+  /** HTTP Method DELETE */
+  FIRHTTPMethodDELETE NS_SWIFT_NAME(delete),
+  /** HTTP Method HEAD */
+  FIRHTTPMethodHEAD NS_SWIFT_NAME(head),
+  /** HTTP Method PATCH */
+  FIRHTTPMethodPATCH NS_SWIFT_NAME(patch),
+  /** HTTP Method OPTIONS */
+  FIRHTTPMethodOPTIONS NS_SWIFT_NAME(options),
+  /** HTTP Method TRACE */
+  FIRHTTPMethodTRACE NS_SWIFT_NAME(trace),
+  /** HTTP Method CONNECT */
+  FIRHTTPMethodCONNECT NS_SWIFT_NAME(connect)
+} NS_SWIFT_NAME(HTTPMethod);
 
 /**
  * FIRHTTPMetric object can be used to make the SDK record information about a HTTP network request.
@@ -50,8 +50,7 @@ NS_SWIFT_NAME(HTTPMetric)
  * @param httpMethod HTTP method used by the request.
  */
 - (nullable instancetype)initWithURL:(nonnull NSURL *)URL
-                          HTTPMethod:(FIRHTTPMethod)httpMethod
-    NS_SWIFT_NAME(init(url:httpMethod:));
+                          HTTPMethod:(FIRHTTPMethod)httpMethod NS_SWIFT_NAME(init(url:httpMethod:));
 
 /**
  * Use `initWithURL:HTTPMethod:` for Objective-C and `init(url:httpMethod:)` for Swift.

--- a/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
+++ b/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
@@ -20,23 +20,23 @@
 typedef NS_ENUM(NSInteger, FIRHTTPMethod) {
   /** HTTP Method GET */
   FIRHTTPMethodGET NS_SWIFT_NAME(get),
-  /** HTTP Method PUT */
-  FIRHTTPMethodPUT NS_SWIFT_NAME(put),
-  /** HTTP Method POST */
-  FIRHTTPMethodPOST NS_SWIFT_NAME(post),
-  /** HTTP Method DELETE */
-  FIRHTTPMethodDELETE NS_SWIFT_NAME(delete),
-  /** HTTP Method HEAD */
-  FIRHTTPMethodHEAD NS_SWIFT_NAME(head),
-  /** HTTP Method PATCH */
-  FIRHTTPMethodPATCH NS_SWIFT_NAME(patch),
-  /** HTTP Method OPTIONS */
-  FIRHTTPMethodOPTIONS NS_SWIFT_NAME(options),
-  /** HTTP Method TRACE */
-  FIRHTTPMethodTRACE NS_SWIFT_NAME(trace),
-  /** HTTP Method CONNECT */
-  FIRHTTPMethodCONNECT NS_SWIFT_NAME(connect)
-} NS_SWIFT_NAME(HTTPMethod);
+      /** HTTP Method PUT */
+      FIRHTTPMethodPUT NS_SWIFT_NAME(put),
+          /** HTTP Method POST */
+          FIRHTTPMethodPOST NS_SWIFT_NAME(post),
+              /** HTTP Method DELETE */
+              FIRHTTPMethodDELETE NS_SWIFT_NAME(delete),
+                  /** HTTP Method HEAD */
+                  FIRHTTPMethodHEAD NS_SWIFT_NAME(head),
+                      /** HTTP Method PATCH */
+                      FIRHTTPMethodPATCH NS_SWIFT_NAME(patch),
+                          /** HTTP Method OPTIONS */
+                          FIRHTTPMethodOPTIONS NS_SWIFT_NAME(options),
+                              /** HTTP Method TRACE */
+                              FIRHTTPMethodTRACE NS_SWIFT_NAME(trace),
+                                  /** HTTP Method CONNECT */
+                                  FIRHTTPMethodCONNECT NS_SWIFT_NAME(connect)
+                              } NS_SWIFT_NAME(HTTPMethod);
 
 /**
  * FIRHTTPMetric object can be used to make the SDK record information about a HTTP network request.
@@ -50,7 +50,8 @@ NS_SWIFT_NAME(HTTPMetric)
  * @param httpMethod HTTP method used by the request.
  */
 - (nullable instancetype)initWithURL:(nonnull NSURL *)URL
-                          HTTPMethod:(FIRHTTPMethod)httpMethod NS_SWIFT_NAME(init(url:httpMethod:));
+                          HTTPMethod:(FIRHTTPMethod)httpMethod
+    NS_SWIFT_NAME(init(url:httpMethod:));
 
 /**
  * Use `initWithURL:HTTPMethod:` for Objective-C and `init(url:httpMethod:)` for Swift.

--- a/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
+++ b/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
@@ -16,6 +16,8 @@
 
 #import "FIRPerformanceAttributable.h"
 
+// clang-format off
+// clang-format12 does a weird cascading indent of this enum.
 /* Different HTTP methods. */
 typedef NS_ENUM(NSInteger, FIRHTTPMethod) {
   /** HTTP Method GET */
@@ -37,6 +39,7 @@ typedef NS_ENUM(NSInteger, FIRHTTPMethod) {
   /** HTTP Method CONNECT */
   FIRHTTPMethodCONNECT NS_SWIFT_NAME(connect)
 } NS_SWIFT_NAME(HTTPMethod);
+// clang-format on
 
 /**
  * FIRHTTPMetric object can be used to make the SDK record information about a HTTP network request.

--- a/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
+++ b/FirebasePerformance/Sources/Public/FIRHTTPMetric.h
@@ -53,7 +53,8 @@ NS_SWIFT_NAME(HTTPMetric)
  * @param httpMethod HTTP method used by the request.
  */
 - (nullable instancetype)initWithURL:(nonnull NSURL *)URL
-                          HTTPMethod:(FIRHTTPMethod)httpMethod NS_SWIFT_NAME(init(url:httpMethod:));
+                          HTTPMethod:(FIRHTTPMethod)httpMethod
+    NS_SWIFT_NAME(init(url:httpMethod:));
 
 /**
  * Use `initWithURL:HTTPMethod:` for Objective-C and `init(url:httpMethod:)` for Swift.

--- a/FirebasePerformance/Sources/Public/FIRPerformance.h
+++ b/FirebasePerformance/Sources/Public/FIRPerformance.h
@@ -62,8 +62,7 @@ NS_SWIFT_NAME(Performance)
  * @param name The name of the Trace.
  * @return The FIRTrace object.
  */
-+ (nullable FIRTrace *)startTraceWithName:(nonnull NSString *)name
-    NS_SWIFT_NAME(startTrace(name:));
++ (nullable FIRTrace *)startTraceWithName:(nonnull NSString *)name NS_SWIFT_NAME(startTrace(name:));
 
 /**
  * Creates an instance of FIRTrace. This API does not start the trace. To start the trace, use the

--- a/FirebasePerformance/Sources/Public/FIRPerformance.h
+++ b/FirebasePerformance/Sources/Public/FIRPerformance.h
@@ -62,7 +62,8 @@ NS_SWIFT_NAME(Performance)
  * @param name The name of the Trace.
  * @return The FIRTrace object.
  */
-+ (nullable FIRTrace *)startTraceWithName:(nonnull NSString *)name NS_SWIFT_NAME(startTrace(name:));
++ (nullable FIRTrace *)startTraceWithName:(nonnull NSString *)name
+    NS_SWIFT_NAME(startTrace(name:));
 
 /**
  * Creates an instance of FIRTrace. This API does not start the trace. To start the trace, use the

--- a/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
@@ -227,13 +227,13 @@
 - (void)testProxyWrappedSessionWithConfiguration {
   Method method = class_getClassMethod([NSURLSession class], @selector(sessionWithConfiguration:));
   IMP originalImp = method_getImplementation(method);
-  IMP swizzledImp =
-      imp_implementationWithBlock(^(id session, NSURLSessionConfiguration *configuration) {
-        typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *);
-        NSURLSession *originalSession = ((OriginalImp)originalImp)(
-            session, @selector(sessionWithConfiguration:), configuration);
-        return [[FPRNSURLSessionProxy alloc] initWithSession:originalSession];
-      });
+  IMP swizzledImp = imp_implementationWithBlock(^(id session,
+                                                  NSURLSessionConfiguration *configuration) {
+    typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *);
+    NSURLSession *originalSession =
+        ((OriginalImp)originalImp)(session, @selector(sessionWithConfiguration:), configuration);
+    return [[FPRNSURLSessionProxy alloc] initWithSession:originalSession];
+  });
   method_setImplementation(method, swizzledImp);
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
   XCTAssertEqual([[NSURLSession sessionWithConfiguration:config] class],

--- a/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
@@ -227,13 +227,13 @@
 - (void)testProxyWrappedSessionWithConfiguration {
   Method method = class_getClassMethod([NSURLSession class], @selector(sessionWithConfiguration:));
   IMP originalImp = method_getImplementation(method);
-  IMP swizzledImp = imp_implementationWithBlock(^(id session,
-                                                  NSURLSessionConfiguration *configuration) {
-    typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *);
-    NSURLSession *originalSession =
-        ((OriginalImp)originalImp)(session, @selector(sessionWithConfiguration:), configuration);
-    return [[FPRNSURLSessionProxy alloc] initWithSession:originalSession];
-  });
+  IMP swizzledImp =
+      imp_implementationWithBlock(^(id session, NSURLSessionConfiguration *configuration) {
+        typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *);
+        NSURLSession *originalSession = ((OriginalImp)originalImp)(
+            session, @selector(sessionWithConfiguration:), configuration);
+        return [[FPRNSURLSessionProxy alloc] initWithSession:originalSession];
+      });
   method_setImplementation(method, swizzledImp);
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
   XCTAssertEqual([[NSURLSession sessionWithConfiguration:config] class],

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestore.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestore.h
@@ -292,8 +292,7 @@ NS_SWIFT_NAME(Firestore)
  * @return A `FIRLoadBundleTask` (`LoadBundleTask` in Swift) which allows registered observers
  * to receive progress updates and completion or error events.
  */
-- (FIRLoadBundleTask *)loadBundleStream:(NSInputStream *)bundleStream
-    NS_SWIFT_NAME(loadBundle(_:));
+- (FIRLoadBundleTask *)loadBundleStream:(NSInputStream *)bundleStream NS_SWIFT_NAME(loadBundle(_:));
 
 /**
  * Loads a Firestore bundle into the local cache.

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestore.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestore.h
@@ -292,7 +292,8 @@ NS_SWIFT_NAME(Firestore)
  * @return A `FIRLoadBundleTask` (`LoadBundleTask` in Swift) which allows registered observers
  * to receive progress updates and completion or error events.
  */
-- (FIRLoadBundleTask *)loadBundleStream:(NSInputStream *)bundleStream NS_SWIFT_NAME(loadBundle(_:));
+- (FIRLoadBundleTask *)loadBundleStream:(NSInputStream *)bundleStream
+    NS_SWIFT_NAME(loadBundle(_:));
 
 /**
  * Loads a Firestore bundle into the local cache.

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
@@ -19,8 +19,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Used to set on-disk cache size to unlimited. Garbage collection will not run. */
-FOUNDATION_EXTERN const int64_t kFIRFirestoreCacheSizeUnlimited
-    NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
+FOUNDATION_EXTERN const int64_t
+    kFIRFirestoreCacheSizeUnlimited NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
 
 /** Settings used to configure a `FIRFirestore` instance. */
 NS_SWIFT_NAME(FirestoreSettings)

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
@@ -19,8 +19,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Used to set on-disk cache size to unlimited. Garbage collection will not run. */
-FOUNDATION_EXTERN const int64_t
-    kFIRFirestoreCacheSizeUnlimited NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
+FOUNDATION_EXTERN const int64_t kFIRFirestoreCacheSizeUnlimited
+    NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
 
 /** Settings used to configure a `FIRFirestore` instance. */
 NS_SWIFT_NAME(FirestoreSettings)

--- a/Firestore/Source/Public/FirebaseFirestore/FIRQuery.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRQuery.h
@@ -283,7 +283,8 @@ NS_SWIFT_NAME(Query)
  * @return The created `FIRQuery`.
  */
 - (FIRQuery *)queryWhereField:(NSString *)field
-             arrayContainsAny:(NSArray<id> *)values NS_SWIFT_NAME(whereField(_:arrayContainsAny:));
+             arrayContainsAny:(NSArray<id> *)values
+    NS_SWIFT_NAME(whereField(_:arrayContainsAny:));
 
 /**
  * Creates and returns a new `FIRQuery` with the additional filter that documents must contain
@@ -525,7 +526,8 @@ NS_SWIFT_NAME(Query)
  *
  * @return The created `FIRQuery`.
  */
-- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document NS_SWIFT_NAME(end(atDocument:));
+- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document
+    NS_SWIFT_NAME(end(atDocument:));
 
 /**
  * Creates and returns a new `FIRQuery` that ends at the provided fields relative to the order of

--- a/Firestore/Source/Public/FirebaseFirestore/FIRQuery.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRQuery.h
@@ -283,8 +283,7 @@ NS_SWIFT_NAME(Query)
  * @return The created `FIRQuery`.
  */
 - (FIRQuery *)queryWhereField:(NSString *)field
-             arrayContainsAny:(NSArray<id> *)values
-    NS_SWIFT_NAME(whereField(_:arrayContainsAny:));
+             arrayContainsAny:(NSArray<id> *)values NS_SWIFT_NAME(whereField(_:arrayContainsAny:));
 
 /**
  * Creates and returns a new `FIRQuery` with the additional filter that documents must contain
@@ -526,8 +525,7 @@ NS_SWIFT_NAME(Query)
  *
  * @return The created `FIRQuery`.
  */
-- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document
-    NS_SWIFT_NAME(end(atDocument:));
+- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document NS_SWIFT_NAME(end(atDocument:));
 
 /**
  * Creates and returns a new `FIRQuery` that ends at the provided fields relative to the order of

--- a/Firestore/core/src/util/error_apple.h
+++ b/Firestore/core/src/util/error_apple.h
@@ -34,8 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 // The Cloud Firestore error domain. Keep in sync with FIRFirestoreErrors.h.
 // Exposed here to make it possible to build in CMake without bringing in the
 // sources under Firestore/Source.
-FOUNDATION_EXPORT NSString* const FIRFirestoreErrorDomain
-    NS_SWIFT_NAME(FirestoreErrorDomain);
+FOUNDATION_EXPORT NSString* const FIRFirestoreErrorDomain NS_SWIFT_NAME(FirestoreErrorDomain);
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/util/error_apple.h
+++ b/Firestore/core/src/util/error_apple.h
@@ -34,7 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 // The Cloud Firestore error domain. Keep in sync with FIRFirestoreErrors.h.
 // Exposed here to make it possible to build in CMake without bringing in the
 // sources under Firestore/Source.
-FOUNDATION_EXPORT NSString* const FIRFirestoreErrorDomain NS_SWIFT_NAME(FirestoreErrorDomain);
+// clang-format off
+// clang-format12 merges the next two lines.
+FOUNDATION_EXPORT NSString* const FIRFirestoreErrorDomain
+    NS_SWIFT_NAME(FirestoreErrorDomain);
+// clang-format on
 
 namespace firebase {
 namespace firestore {

--- a/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
+++ b/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
@@ -20,8 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDomain NS_SWIFT_NAME(FunctionsErrorDomain);
 
 // The key for finding error details in the NSError userInfo.
+// clang-format off
+// clang-format12 merges the next two lines.
 FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDetailsKey
     NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+// clang-format on
 
 /**
  * The set of error status codes that can be returned from a Callable HTTPS tigger. These are the

--- a/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
+++ b/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
@@ -20,7 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDomain NS_SWIFT_NAME(FunctionsErrorDomain);
 
 // The key for finding error details in the NSError userInfo.
-FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDetailsKey NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDetailsKey
+    NS_SWIFT_NAME(FunctionsErrorDetailsKey);
 
 /**
  * The set of error status codes that can be returned from a Callable HTTPS tigger. These are the

--- a/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
+++ b/Functions/FirebaseFunctions/Public/FirebaseFunctions/FIRError.h
@@ -20,8 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDomain NS_SWIFT_NAME(FunctionsErrorDomain);
 
 // The key for finding error details in the NSError userInfo.
-FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDetailsKey
-    NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+FOUNDATION_EXPORT NSString *const FIRFunctionsErrorDetailsKey NS_SWIFT_NAME(FunctionsErrorDetailsKey);
 
 /**
  * The set of error status codes that can be returned from a Callable HTTPS tigger. These are the

--- a/Interop/Analytics/Public/FIRInteropParameterNames.h
+++ b/Interop/Analytics/Public/FIRInteropParameterNames.h
@@ -52,7 +52,7 @@ static NSString *const kFIRIParameterMedium NS_SWIFT_NAME(AnalyticsParameterMedi
 ///     };
 /// </pre>
 static NSString *const kFIRIParameterCampaign NS_SWIFT_NAME(AnalyticsParameterCampaign) =
-    @"campaign";
+                                                                @"campaign";
 
 /// Message identifier.
 static NSString *const kFIRIParameterMessageIdentifier = @"_nmid";

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ GitHub Actions will verify that any code changes are done in a style compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@11
+brew install clang-format@12
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@11
+brew install clang-format@12
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -42,7 +42,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  11)
+  12)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -51,7 +51,7 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 11."
+    echo "Please upgrade to clang-format version 12."
     echo "If it's installed via homebrew you can run:"
     echo "brew upgrade clang-format"
     exit 1


### PR DESCRIPTION
clang-format 11 has disappeared from brew causing the style check in the check CI workflow to fail.

This PR upgrades to clang-format 12.0.0 which does some weird things with lines including `NS_SWIFT_NAME` including disregarding the 100 character line length.

clang-format bugs reported at https://bugs.llvm.org/show_bug.cgi?id=49995 and https://bugs.llvm.org/show_bug.cgi?id=49996

Any suggestions here would be appreciated.