### PR TITLE
Firebase.h updates for 8.0.0

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -40,12 +40,6 @@
 
   #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
     #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
-    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-      #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
-FirebaseAnalytics dependency to your project to ensure Firebase Dynamic Links works as intended."
-      #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-    #endif
   #endif
 
   #if __has_include(<FirebaseFirestore/FirebaseFirestore.h>)
@@ -58,43 +52,14 @@ FirebaseAnalytics dependency to your project to ensure Firebase Dynamic Links wo
 
   #if __has_include(<FirebaseInAppMessaging/FirebaseInAppMessaging.h>)
     #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
-    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-      #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
-FirebaseAnalytics dependency to your project to ensure Firebase In App Messaging works as intended."
-      #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-    #endif
   #endif
 
   #if __has_include(<FirebaseInstallations/FirebaseInstallations.h>)
     #import <FirebaseInstallations/FirebaseInstallations.h>
   #endif
 
-  #if __has_include(<FirebaseInstanceID/FirebaseInstanceID.h>)
-    #import <FirebaseInstanceID/FirebaseInstanceID.h>
-  #endif
-
   #if __has_include(<FirebaseMessaging/FirebaseMessaging.h>)
     #import <FirebaseMessaging/FirebaseMessaging.h>
-      #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-      #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
-FirebaseAnalytics dependency to your project to ensure Messaging works as intended."
-
-      #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-    #endif
-  #endif
-
-  #if __has_include(<FirebaseMLCommon/FirebaseMLCommon.h>)
-    #import <FirebaseMLCommon/FirebaseMLCommon.h>
-  #endif
-
-  #if __has_include(<FirebaseMLModelInterpreter/FirebaseMLModelInterpreter.h>)
-    #import <FirebaseMLModelInterpreter/FirebaseMLModelInterpreter.h>
-  #endif
-
-  #if __has_include(<FirebaseMLVision/FirebaseMLVision.h>)
-    #import <FirebaseMLVision/FirebaseMLVision.h>
   #endif
 
   #if __has_include(<FirebasePerformance/FirebasePerformance.h>)
@@ -103,24 +68,10 @@ FirebaseAnalytics dependency to your project to ensure Messaging works as intend
 
   #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
     #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-    #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-      #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
-FirebaseAnalytics dependency to your project to ensure Firebase Remote Config works as intended."
-      #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-    #endif
   #endif
 
   #if __has_include(<FirebaseStorage/FirebaseStorage.h>)
     #import <FirebaseStorage/FirebaseStorage.h>
-  #endif
-
-  #if __has_include(<GoogleMobileAds/GoogleMobileAds.h>)
-    #import <GoogleMobileAds/GoogleMobileAds.h>
-  #endif
-
-  #if __has_include(<Fabric/Fabric.h>)
-    #import <Fabric/Fabric.h>
   #endif
 
   #if __has_include(<Crashlytics/Crashlytics.h>)

--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -74,8 +74,4 @@
     #import <FirebaseStorage/FirebaseStorage.h>
   #endif
 
-  #if __has_include(<Crashlytics/Crashlytics.h>)
-    #import <Crashlytics/Crashlytics.h>
-  #endif
-
 #endif  // defined(__has_include)

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -183,21 +183,4 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.watchos.deployment_target = '6.0'
   end
 
-  # The deprecated ML subspecs should be deleted in Firebase 8.0.0.
-
-  s.subspec 'MLCommon' do |ss|
-    ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseMLCommon', '~> 7.6.0-beta'
-  end
-
-  s.subspec 'MLModelInterpreter' do |ss|
-    ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseMLModelInterpreter', '~> 7.6.0-beta'
-  end
-
-  s.subspec 'MLVision' do |ss|
-    ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseMLVision', '~> 7.6.0-beta'
-  end
-
 end

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
 - [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
- `Firebase/MLMLModelDownloaderDownloader` subspec instead.
+ `Firebase/MLModelDownloaderDownloader` subspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
 - [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
- `Firebase/FirebaseMLDownloader` subsspec instead.
+ `Firebase/MLDownloader` subsspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
 - [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
- `FirebaseFirebaseMLDownloader` subsspec instead.
+ `Firebase/FirebaseMLDownloader` subsspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [removed] The `Firebase/MLModelInterpreter` CocoaPods subspec has been removed. Use the
  `Firebase/MLModelDownloader` subspec instead.
   CocoaPod instead.
-- [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
+- [removed] The `Firebase/MLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.
 
 # Firebase 7.10.0

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -3,6 +3,8 @@
   CocoaPod instead. (#7833)
 - [removed] Build warnings will no longer be generated to warn about missing capabilities resulting
   from not including FirebaseAnalytics in the app. See the Firebase docs instead. (#7487)
+- [removed] Removed FirebaseMLModelInterpreter. Use FirebaseMLDownloader instead.
+- [removed] Removed FirebaseMLVision. Use GoogleMLKit instead.
 
 # Firebase 7.10.0
 - [changed] Update Nanopb to version 0.3.9.8. It fixes a possible security issue. (#7787)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Firebase 8.0.0
-- [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
-  CocoaPod instead. (#7833)
 - [removed] Build warnings will no longer be generated to warn about missing capabilities resulting
   from not including FirebaseAnalytics in the app. See the Firebase docs instead. (#7487)
-- [removed] Removed FirebaseMLModelInterpreter. Use FirebaseMLDownloader instead.
-- [removed] Removed FirebaseMLVision. Use GoogleMLKit instead.
+- [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
+  CocoaPod instead. (#7833)
+- [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
+ `FirebaseFirebaseMLDownloader` subsspec instead.
+  CocoaPod instead.
+- [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
+  `GoogleMLKit` CocoaPod instead.
 
 # Firebase 7.10.0
 - [changed] Update Nanopb to version 0.3.9.8. It fixes a possible security issue. (#7787)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Firebase 8.0.0
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
+- [removed] Build warnings will no longer be generated to warn about missing capabilities resulting
+  from not including FirebaseAnalytics in the app. See the Firebase docs instead. (#7487)
 
 # Firebase 7.10.0
 - [changed] Update Nanopb to version 0.3.9.8. It fixes a possible security issue. (#7787)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
 - [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
- `Firebase/MLModelDownloaderDownloader` subspec instead.
+ `Firebase/MLModelDownloader` subspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
 - [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
- `Firebase/MLDownloader` subsspec instead.
+ `Firebase/MLMLModelDownloaderDownloader` subspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -3,7 +3,7 @@
   from not including FirebaseAnalytics in the app. See the Firebase docs instead. (#7487)
 - [removed] The `Firebase/AdMob` CocoaPods subspec has been removed. Use the `Google-Mobile-Ads-SDK`
   CocoaPod instead. (#7833)
-- [removed] The `Firebase/FirebaseMLModelInterpreter` CocoaPods subspec has been removed. Use the
+- [removed] The `Firebase/MLModelInterpreter` CocoaPods subspec has been removed. Use the
  `Firebase/MLModelDownloader` subspec instead.
   CocoaPod instead.
 - [removed] The `Firebase/FirebaseMLVision` CocoaPods subspec has been removed. Use the


### PR DESCRIPTION
Fix #7487 and fix #7832

- Stop generating warnings for not including Analytics
- Remove deleted FirebaseML umbrella headers and remove them from Firebase podspec
- Remove InstanceID umbrella header
- Remove GoogleMobileAds umbrella header
- Remove Fabric umbrella header

podspec version updates will be done separately using the standard script after 7.11.0 is published