### PR TITLE
Remove unbalanced clang format pop

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingServiceTest.m
@@ -308,6 +308,5 @@ static NSString *const kFIRMessagingTestsServiceSuiteName = @"com.messaging.test
       retrieveFCMTokenForSenderID:[OCMArg any]
                        completion:([OCMArg invokeBlockWithArgs:kFakeToken, [NSNull null], nil])]);
 }
-#pragma clang diagnostic pop
 
 @end

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
@@ -189,7 +189,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
                        }];
   [self waitForExpectationsWithTimeout:0.1 handler:nil];
 }
-#pragma clang diagnostic pop
+
 - (void)testReturnsErrorWhenFetchingTokenWithoutSenderID {
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Returned an error fetching token without Sender ID"];


### PR DESCRIPTION
This *pop*ped up during copybara imports.

#no-changelog