### PR TITLE
Crashlytics send Firebase Apple Platform for filtering

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -103,10 +103,6 @@ bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
                              FIRCLSSettings* settings,
                              FIRCLSFileManager* fileManager);
 
-// Re-writes the metadata file on the current thread
-void FIRCLSContextUpdateMetadata(FIRCLSInternalReport* report,
-                                 FIRCLSSettings* settings,
-                                 FIRCLSFileManager* fileManager);
 #endif
 
 void FIRCLSContextBaseInit(void);

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -25,6 +25,8 @@
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h"
 #import "Crashlytics/Shared/FIRCLSFABHost.h"
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #else
@@ -158,6 +160,7 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file) {
   FIRCLSFileWriteHashEntryString(file, "os_display_version",
                                  [FIRCLSHostOSDisplayVersion() UTF8String]);
   FIRCLSFileWriteHashEntryString(file, "platform", [FIRCLSApplicationGetPlatform() UTF8String]);
+  FIRCLSFileWriteHashEntryString(file, "firebase_platform", [[GULAppEnvironmentUtil applePlatform] UTF8String]);
 }
 
 bool FIRCLSHostRecord(FIRCLSFile* file) {

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -160,7 +160,8 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file) {
   FIRCLSFileWriteHashEntryString(file, "os_display_version",
                                  [FIRCLSHostOSDisplayVersion() UTF8String]);
   FIRCLSFileWriteHashEntryString(file, "platform", [FIRCLSApplicationGetPlatform() UTF8String]);
-  FIRCLSFileWriteHashEntryString(file, "firebase_platform", [[GULAppEnvironmentUtil applePlatform] UTF8String]);
+  FIRCLSFileWriteHashEntryString(file, "firebase_platform",
+                                 [[GULAppEnvironmentUtil applePlatform] UTF8String]);
 }
 
 bool FIRCLSHostRecord(FIRCLSFile* file) {


### PR DESCRIPTION
Using this method to filter: https://github.com/google/GoogleUtilities/blob/main/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m#L267

We're going to convert this on the backend instead of in the SDK. The advantage is we may want details like catalyst vs normal macOS at a later date.