### PR TITLE
Disable GoogleMLKit until it updates to GDT 9

### DIFF
--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -32,6 +32,9 @@ target 'SymbolCollisionTest' do
 
 #    pod 'FirebaseUI'. - requires use_frameworks!
 
+    # Google Pods depedending on a Firebase or GDT major version
+#    pod 'GoogleMLKit'
+
   # Other Google Pods
 #    pod 'ARCore' Conflicts with FirebasePerformance via Clearcut and google-cast-sdk
 #    pod 'Blockly' This is a Swift Pod and requires usage of use_frameworks!
@@ -51,7 +54,6 @@ target 'SymbolCollisionTest' do
     pod 'GoogleInterchangeUtilities'
     pod 'GoogleMaps'
 
-    pod 'GoogleMLKit'
 #    pod 'GoogleMobileVision' # After Firebase 6.8.0, conflicts with FirebaseML
     pod 'GoogleNetworkingUtilities'
     pod 'GoogleParsingUtilities'

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -32,7 +32,7 @@ target 'SymbolCollisionTest' do
 
 #    pod 'FirebaseUI'. - requires use_frameworks!
 
-    # Google Pods depedending on a Firebase or GDT major version
+    # Google Pods depending on a Firebase or GDT major version
 #    pod 'GoogleMLKit'
 
   # Other Google Pods


### PR DESCRIPTION
Fix recent nightly symbol collision failure. See #7921

Restoration is tracked in #7953 

#no-changelog