### PR TITLE
Bump zip build minimum version options

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -12,6 +12,9 @@
 - [changed] The Swift Package Manager distribution now requires at least watchOS 7.0 for products
   that support watchOS. The CocoaPods distribution continues to support watchOS 6.0 with the
   exception of FirebaseDatabase.
+- [changed] The zip and Carthage distributions now require a minimum iOS version of 11.0,
+  macOS 10.13 and tvOS 11.0. The CocoaPods distribution remains unchanged - the minimum supported
+  iOS version is 10.0 (Analytics and Crashlytics 9.0).
 
 # Firebase 7.10.0
 - [changed] Update Nanopb to version 0.3.9.8. It fixes a possible security issue. (#7787)

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -106,15 +106,15 @@ struct ZipBuilderTool: ParsableCommand {
   // MARK: - Platform Arguments
 
   /// The minimum iOS Version to build for.
-  @Option(default: "10.0", help: ArgumentHelp("The minimum supported iOS version."))
+  @Option(default: "11.0", help: ArgumentHelp("The minimum supported iOS version."))
   var minimumIOSVersion: String
 
   /// The minimum macOS Version to build for.
-  @Option(default: "10.12", help: ArgumentHelp("The minimum supported macOS version."))
+  @Option(default: "10.13", help: ArgumentHelp("The minimum supported macOS version."))
   var minimumMacOSVersion: String
 
   /// The minimum tvOS Version to build for.
-  @Option(default: "10.0", help: ArgumentHelp("The minimum supported tvOS version."))
+  @Option(default: "11.0", help: ArgumentHelp("The minimum supported tvOS version."))
   var minimumTVOSVersion: String
 
   /// The list of platforms to build for.


### PR DESCRIPTION
The zip builder does not support mixed minimum platform versions. Since AppCheck requires iOS 11.0, bumping the zip and Carthage distribution minimum iOS versions.