### PR TITLE
Disable CocoaPods minimum version install testing for Firebase zip build

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/Platform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/Platform.swift
@@ -58,6 +58,7 @@ class PlatformMinimum {
     minimumMacOSVersion = macos
     minimumTVOSVersion = tvos
   }
+
   /// Useful to disable minimum version checking on pod installation. Pods still get built with
   /// for the minimum version specified in the podspec.
   static func useRecentVersions() {

--- a/ReleaseTooling/Sources/ZipBuilder/Platform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/Platform.swift
@@ -58,6 +58,13 @@ class PlatformMinimum {
     minimumMacOSVersion = macos
     minimumTVOSVersion = tvos
   }
+  /// Useful to disable minimum version checking on pod installation. Pods still get built with
+  /// for the minimum version specified in the podspec.
+  static func useRecentVersions() {
+    minimumIOSVersion = "14.0"
+    minimumMacOSVersion = "11.0"
+    minimumTVOSVersion = "14.0"
+  }
 }
 
 class SkipCatalyst {

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -230,11 +230,6 @@ struct ZipBuilderTool: ParsableCommand {
       fatalError("Missing template inside of the repo. \(templateDir) does not exist.")
     }
 
-    // Set the platform minimum versions.
-    PlatformMinimum.initialize(ios: minimumIOSVersion,
-                               macos: minimumMacOSVersion,
-                               tvos: minimumTVOSVersion)
-
     // Update iOS target platforms if `--include-catalyst` was specified.
     if !includeCatalyst {
       SkipCatalyst.set()
@@ -272,6 +267,12 @@ struct ZipBuilderTool: ParsableCommand {
     }
 
     if let podsToBuild = podsToBuild {
+
+      // Set the platform minimum versions.
+      PlatformMinimum.initialize(ios: minimumIOSVersion,
+                                 macos: minimumMacOSVersion,
+                                 tvos: minimumTVOSVersion)
+
       let (installedPods, frameworks, _) =
         builder.buildAndAssembleZip(podsToInstall: podsToBuild,
                                     includeDependencies: buildDependencies)
@@ -300,6 +301,14 @@ struct ZipBuilderTool: ParsableCommand {
       }
     } else {
       // Do a Firebase Zip Release package build.
+
+      // For the Firebase zip distribution, we disable version checking at install time by
+      // setting a high version to install. The minimum versions are controlled by each individual
+      // pod's podspec options.
+      PlatformMinimum.initialize(ios: "14.0",
+                                 macos: "11.0",
+                                 tvos: "14.0")
+
       var carthageOptions: CarthageBuildOptions?
       if carthageBuild {
         let jsonDir = paths.repoDir.appendingPathComponents(["ReleaseTooling", "CarthageJSON"])

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -304,9 +304,7 @@ struct ZipBuilderTool: ParsableCommand {
       // For the Firebase zip distribution, we disable version checking at install time by
       // setting a high version to install. The minimum versions are controlled by each individual
       // pod's podspec options.
-      PlatformMinimum.initialize(ios: "14.0",
-                                 macos: "11.0",
-                                 tvos: "14.0")
+      PlatformMinimum.useRecentVersions()
 
       var carthageOptions: CarthageBuildOptions?
       if carthageBuild {

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -267,7 +267,6 @@ struct ZipBuilderTool: ParsableCommand {
     }
 
     if let podsToBuild = podsToBuild {
-
       // Set the platform minimum versions.
       PlatformMinimum.initialize(ios: minimumIOSVersion,
                                  macos: minimumMacOSVersion,


### PR DESCRIPTION
This is a more flexible approach to allowing different Firebase pods with different platform version support than #7956.

It's safe because the actual build minimum version is controlled by the podspec. The minimum version that is being disregarded here was only for insuring a full installation had a consistent minimum version.