### PR TITLE
FirebaseAnalytics 7.11.1 release.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "7.11.0"
+let firebaseVersion = "7.11.1"
 
 let package = Package(
   name: "Firebase",
@@ -119,7 +119,7 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
-      .exact("7.11.0")
+      .exact("7.11.1")
     ),
     .package(
       name: "GoogleDataTransport",
@@ -267,8 +267,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "FirebaseAnalytics",
-      url: "https://dl.google.com/firebase/ios/swiftpm/7.11.0/FirebaseAnalytics.zip",
-      checksum: "96fdd7d7e7812748b11ec2e8ca9c0cec186e1caa6037996b74410d89a4ddf6af"
+      url: "https://dl.google.com/firebase/ios/swiftpm/7.11.1/FirebaseAnalytics.zip",
+      checksum: "ed5aa9898d9cf10c354cff0047dca688e66790604626b482e3cc8e34cd50a506"
     ),
     .target(
       name: "FirebaseAnalyticsSwiftTarget",


### PR DESCRIPTION
This includes the same artifact as 7.11.0 but put into the proper .zip format (with zip on the command line instead of Finder's compress menu option).

#no-changelog