### PR TITLE
Bump floating minor dependency versions to latest minimum

### DIFF
--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -5,10 +5,10 @@
     "dependencies": {
         "FirebaseCore": "~> 8.0",
         "FirebaseInstallations": "~> 8.0",
-        "GoogleUtilities/AppDelegateSwizzler": "~> 7.0",
-        "GoogleUtilities/MethodSwizzler": "~> 7.0",
-        "GoogleUtilities/NSData+zlib": "~> 7.0",
-        "GoogleUtilities/Network": "~> 7.0",
+        "GoogleUtilities/AppDelegateSwizzler": "~> 7.4",
+        "GoogleUtilities/MethodSwizzler": "~> 7.4",
+        "GoogleUtilities/NSData+zlib": "~> 7.4",
+        "GoogleUtilities/Network": "~> 7.4",
         "nanopb": "~> 2.30908.0"
     },
     "description": "Firebase Analytics is a free, out-of-the-box analytics solution that inspires actionable insights based on app usage and user engagement.",

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'FirebaseCore', '~> 8.0'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.2'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -29,8 +29,8 @@ iOS SDK for App Distribution for Firebase.
   s.public_header_files = base_dir + 'Public/FirebaseAppDistribution/*.h'
 
   s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.0'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.4'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.4'
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'GoogleDataTransport', '~> 9.0'
 

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -50,9 +50,9 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.4'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.4'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -45,8 +45,8 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/Logger', '~> 7.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/Logger', '~> 7.4'
   s.dependency 'FirebaseCoreDiagnostics', '~> 8.0'
 
   s.pod_target_xcconfig = {

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -57,8 +57,8 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.framework = 'Foundation'
 
   s.dependency 'GoogleDataTransport', '~> 9.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/Logger', '~> 7.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/Logger', '~> 7.4'
   s.dependency 'nanopb', '~> 2.30908.0'
 
   s.test_spec 'unit' do |unit_tests|
@@ -68,7 +68,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
       :osx => osx_deployment_target,
       :tvos => tvos_deployment_target
     }
-    unit_tests.dependency 'GoogleUtilities/UserDefaults', '~> 7.0'
+    unit_tests.dependency 'GoogleUtilities/UserDefaults', '~> 7.4'
     unit_tests.dependency 'OCMock'
     unit_tests.source_files = [
       'Example/CoreDiagnostics/Tests/**/*.[mh]',

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -47,7 +47,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
                            # Supply plist for custom domain testing.
                            'FirebaseDynamicLinks/Tests/Unit/DL-Info.plist'
     unit_tests.dependency 'OCMock'
-    unit_tests.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.0'
-    unit_tests.dependency 'GoogleUtilities/SwizzlerTestHelpers', '~> 7.0'
+    unit_tests.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.4'
+    unit_tests.dependency 'GoogleUtilities/SwizzlerTestHelpers', '~> 7.4'
   end
 end

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -32,7 +32,7 @@ Cloud Functions for Firebase.
   s.public_header_files = 'Functions/FirebaseFunctions/Public/FirebaseFunctions/*.h'
 
   s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.4'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -77,7 +77,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'FirebaseCore', '~> 8.0'
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'FirebaseABTesting', '~> 8.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
   s.dependency 'nanopb', '~> 2.30908.0'
 
   s.test_spec 'unit' do |unit_tests|

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -42,8 +42,8 @@ Pod::Spec.new do |s|
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 8.0'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.4'
 
   preprocessor_definitions = ''
   if ENV['FIS_ALLOWS_INCOMPATIBLE_IID_VERSION'] && ENV['FIS_ALLOWS_INCOMPATIBLE_IID_VERSION'] == '1' then

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'GoogleDataTransport', '~> 9.0'
   # TODO: Revisit this dependency
-  s.dependency 'GoogleUtilities/Logger', '~> 7.2'
+  s.dependency 'GoogleUtilities/Logger', '~> 7.4'
   s.dependency 'SwiftProtobuf', '~> 1.0'
 
   s.pod_target_xcconfig = {

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -53,10 +53,10 @@ device, and it is completely free.
   s.weak_framework = 'UserNotifications'
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'
-  s.dependency 'GoogleUtilities/Reachability', '~> 7.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.0'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.4'
+  s.dependency 'GoogleUtilities/Reachability', '~> 7.4'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 7.4'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -61,10 +61,10 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'FirebaseRemoteConfig', '~> 8.0'
   s.dependency 'GoogleDataTransport', '~> 9.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/ISASwizzler', '~> 7.0'
-  s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.0'
-  s.dependency 'Protobuf', '~> 3.12'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/ISASwizzler', '~> 7.4'
+  s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.4'
+  s.dependency 'Protobuf', '~> 3.15'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => ios_deployment_target, :tvos => tvos_deployment_target}

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -47,8 +47,8 @@ app update.
   s.dependency 'FirebaseABTesting', '~> 8.0'
   s.dependency 'FirebaseCore', '~> 8.0'
   s.dependency 'FirebaseInstallations', '~> 8.0'
-  s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 7.4'
+  s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.4'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -41,7 +41,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.4'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -3,10 +3,10 @@
     "cocoapods_version": ">= 1.10.0",
     "default_subspecs": "AdIdSupport",
     "dependencies": {
-        "GoogleUtilities/AppDelegateSwizzler": "~> 7.0",
-        "GoogleUtilities/MethodSwizzler": "~> 7.0",
-        "GoogleUtilities/NSData+zlib": "~> 7.0",
-        "GoogleUtilities/Network": "~> 7.0",
+        "GoogleUtilities/AppDelegateSwizzler": "~> 7.4",
+        "GoogleUtilities/MethodSwizzler": "~> 7.4",
+        "GoogleUtilities/NSData+zlib": "~> 7.4",
+        "GoogleUtilities/Network": "~> 7.4",
         "nanopb": "~> 2.30908.0"
     },
     "description": "Measurement methods that are shared between Google libraries. This pod does not expose any headers and isn't intended for direct use, but rather as a dependency of some Google libraries.",

--- a/Package.swift
+++ b/Package.swift
@@ -150,12 +150,12 @@ let package = Package(
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.2.1" ..< "8.0.0"
+      "7.3.0" ..< "8.0.0"
     ),
     .package(
       name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "1.4.0" ..< "2.0.0"
+      "1.5.0" ..< "2.0.0"
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
To minimize testing matrix in Firebase 8.x +

GoogleUtilities 7.4+
Protobuf 3.15+
GTMSessionFetcher 1.5+

GoogleUtilities SPM 7.4 update is deferred until its tagged

#no-changelog