### PR TITLE
Block calls to get config until DB load completes

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [fixed] Fixed throttling issue when fetch fails due to no network. (#6628)
+- [fixed] Fixed issue where sometimes the local config returned is empty. (#7424)
 
 # v7.10.0
 - [changed] Throw exception if projectID is missing from FirebaseOptions. (#7725)

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -122,6 +122,7 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
                    dispatch_semaphore_signal(self->_configLoadFromDBSemaphore);
                  }];
 
+  // TODO(karenzeng): Refactor personalization to be returned in loadMainWithBundleIdentifier above
   [_DBManager loadPersonalizationWithCompletionHandler:^(
                   BOOL success, NSDictionary *fetchedPersonalization,
                   NSDictionary *activePersonalization, NSDictionary *defaultConfig) {

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -86,8 +86,7 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
       _bundleIdentifier = @"";
     }
     _DBManager = DBManager;
-    // Waits for both config and Personalization data to load.
-    _configLoadFromDBSemaphore = dispatch_semaphore_create(1);
+    _configLoadFromDBSemaphore = dispatch_semaphore_create(0);
     [self loadConfigFromMainTable];
   }
   return self;
@@ -128,7 +127,6 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
                   NSDictionary *activePersonalization, NSDictionary *defaultConfig) {
     self->_fetchedPersonalization = [fetchedPersonalization copy];
     self->_activePersonalization = [activePersonalization copy];
-    dispatch_semaphore_signal(self->_configLoadFromDBSemaphore);
   }];
 }
 


### PR DESCRIPTION
`_configLoadFromDBSemaphore = dispatch_semaphore_create(1)` causes the later `dispatch_semaphore_wait` call in `checkAndWaitForInitialDatabaseLoad()` to never be blocked, so it's possible to return a config before we finish loading from the DB.

Removing `dispatch_semaphore_signal` from `loadPersonalization` as its success/failure should not impact RC returning a config

fixes #7424