### PR TITLE
DynamicLinks: Skip retrieving web locale when running targeting below iOS14 (only on simulator & Apple Silicon)

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.0.0
+- [fixed] Fixed crashes on simulators targeting below iOS14 on Apple Silicon. (#7989)
+
 # v7.7.0
 - [added] Added `utmParametersDictionary` property to `DynamicLink`. (#6730)
 

--- a/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
@@ -75,18 +75,18 @@ NSString *GINFingerprintJSMethodString(void) {
 
 #pragma mark - Internal methods
 - (void)start {
-  // Initializing a `WKWebView` causes a memory allocation error when the process
-  // is running under Rosetta translation on Apple Silicon.
-  // The issue only occurs on the simulator in apps targeting below iOS 14. (Issue #7618)
-  #if TARGET_OS_SIMULATOR
-  BOOL systemVersionAtLeastiOS14 =
-    [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){14,0,0}];
+// Initializing a `WKWebView` causes a memory allocation error when the process
+// is running under Rosetta translation on Apple Silicon.
+// The issue only occurs on the simulator in apps targeting below iOS 14. (Issue #7618)
+#if TARGET_OS_SIMULATOR
+  BOOL systemVersionAtLeastiOS14 = [NSProcessInfo.processInfo
+      isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){14, 0, 0}];
   // Perform an early exit if the process is running under Rosetta translation and targeting
   // under iOS 14.
   if (processIsTranslated() && !systemVersionAtLeastiOS14) {
     return;
   }
-  #endif
+#endif
   NSString *htmlContent =
       [NSString stringWithFormat:@"<html><head><script>%@</script></head></html>", _script];
 
@@ -152,16 +152,16 @@ NSString *GINFingerprintJSMethodString(void) {
 // Determine whether a process is running under Rosetta translation.
 // Returns 0 for a native process, 1 for a translated process,
 // and -1 when an error occurs.
-// From: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+// From:
+// https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
 int processIsTranslated() {
-   int ret = 0;
-   size_t size = sizeof(ret);
-   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
-      if (errno == ENOENT)
-         return 0;
-      return -1;
-   }
-   return ret;
+  int ret = 0;
+  size_t size = sizeof(ret);
+  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+    if (errno == ENOENT) return 0;
+    return -1;
+  }
+  return ret;
 }
 
 @end

--- a/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
@@ -84,6 +84,7 @@ NSString *GINFingerprintJSMethodString(void) {
   // Perform an early exit if the process is running under Rosetta translation and targeting
   // under iOS 14.
   if (processIsTranslated() && !systemVersionAtLeastiOS14) {
+    [self handleExecutionError:nil];
     return;
   }
 #endif

--- a/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
@@ -155,7 +155,7 @@ NSString *GINFingerprintJSMethodString(void) {
 // and -1 when an error occurs.
 // From:
 // https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
-int processIsTranslated() {
+static int processIsTranslated() {
   int ret = 0;
   size_t size = sizeof(ret);
   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {


### PR DESCRIPTION
Manually tested fix on M1 machine and it successfully ran without crashing. 

Fixes #7618 