### PR TITLE
FirebaseMessaging: Mock FIRHeartbeatInfo in test

### DIFF
--- a/FirebaseCore/Sources/Private/FIRHeartbeatInfo.h
+++ b/FirebaseCore/Sources/Private/FIRHeartbeatInfo.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, FIRHeartbeatInfoCode) {
 };
 
 /**
- * Get heartbeat code requred for the sdk.
+ * Get heartbeat code required for the sdk.
  * @param heartbeatTag String representing the sdk heartbeat tag.
  * @return Heartbeat code indicating whether or not an sdk/global heartbeat
  * needs to be sent

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
@@ -108,8 +108,6 @@ static NSString *kRegistrationToken = @"token-12345";
   // `FIRMessagingTokenOperation` uses `FIRInstallations` under the hood to get FIS auth token.
   // Stub `FIRInstallations` to avoid using a real object.
   [self stubInstallations];
-
-  [self setupHeartbeatStorageForTesting];
 }
 
 - (void)tearDown {
@@ -119,6 +117,8 @@ static NSString *kRegistrationToken = @"token-12345";
   _checkinService = nil;
   _mockTokenStore = nil;
   [_mockInstallations stopMocking];
+
+  [self tearDownHeartbeatStorage];
 }
 
 - (void)testThatTokenOperationsAuthHeaderStringMatchesCheckin {
@@ -440,7 +440,7 @@ static NSString *kRegistrationToken = @"token-12345";
   OCMStub([_mockInstallations authTokenWithCompletion:authTokenWithCompletionArg]);
 }
 
-- (void)setupHeartbeatStorageForTesting {
+- (void)tearDownHeartbeatStorage {
   NSString *const kHeartbeatStorageName = @"HEARTBEAT_INFO_STORAGE";
   id<GULHeartbeatDateStorable> dataStorage;
 #if TARGET_OS_TV

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
@@ -391,9 +391,8 @@ static NSString *kRegistrationToken = @"token-12345";
                     XCTAssertEqualObjects(userAgentValue, [FIRApp firebaseUserAgent]);
                     NSString *heartBeatCode =
                         sentRequest.allHTTPHeaderFields[kFIRMessagingFirebaseHeartbeatKey];
-                    // See FirebaseCore/Sources/Private/FIRHeartbeatInfo.h for heartbeat codes.
-                    NSInteger sdkAndGlobalHeartbeatRequestedCode = 3;
-                    XCTAssertEqual(heartBeatCode.integerValue, sdkAndGlobalHeartbeatRequestedCode,
+                    // It is expected that both the SDK and global heartbeat are requested.
+                    XCTAssertEqual(heartBeatCode.integerValue, FIRHeartbeatInfoCodeCombined,
                                    @"Heartbeat storage info needed to be updated but was not.");
                     [completionExpectation fulfill];
 
@@ -444,9 +443,8 @@ static NSString *kRegistrationToken = @"token-12345";
 
 - (void)stubHeartbeatInfo {
   _mockHeartbeatInfo = OCMClassMock([FIRHeartbeatInfo class]);
-  NSInteger sdkAndGlobalHeartbeatRequestedCode = 3;
-  OCMStub([_mockHeartbeatInfo heartbeatCodeForTag:[OCMArg any]])
-      .andReturn(sdkAndGlobalHeartbeatRequestedCode);
+  OCMStub([_mockHeartbeatInfo heartbeatCodeForTag:@"fire-iid"])
+      .andReturn(FIRHeartbeatInfoCodeCombined);
 }
 
 @end

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenOperationsTest.m
@@ -18,9 +18,6 @@
 
 #import "OCMock.h"
 
-#import <GoogleUtilities/GULHeartbeatDateStorable.h>
-#import <GoogleUtilities/GULHeartbeatDateStorage.h>
-#import <GoogleUtilities/GULHeartbeatDateStorageUserDefaults.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingConstants.h"
@@ -107,9 +104,11 @@ static NSString *kRegistrationToken = @"token-12345";
   _instanceID = @"instanceID";
 
   // `FIRMessagingTokenOperation` uses `FIRInstallations` under the hood to get FIS auth token.
-  // `FIRMessagingTokenFetchOperation` uses `FIRHeartbeatInfo` to retrieve a heartbeat code.
-  // Stub `FIRInstallations` and `FIRHeartbeatInfo` to avoid using real objects.
+  // Stub `FIRInstallations` to avoid using a real object.
   [self stubInstallations];
+
+  // `FIRMessagingTokenFetchOperation` uses `FIRHeartbeatInfo` to retrieve a heartbeat code.
+  // Stub `FIRHeartbeatInfo` to avoid using a real object.
   [self stubHeartbeatInfo];
 }
 


### PR DESCRIPTION
~~Add to test setup to use platform specific heartbeat storage APIs.~~
Revised approach: Mock `FIRHeartbeatInfo` to avoid side effects of using GULHeartbeatDateStorable objects. 

Breakage due to:
GoogleUtilites [#23](https://github.com/google/GoogleUtilities/pull/23) and firebase-ios-sdk #7893 for context.

Fixes FirebaseMessaging Failure in #7993.

cc @chliangGoogle 

#no-changelog