### PR TITLE
Test Refactor for Protobuf-backed FieldValue

### DIFF
--- a/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
@@ -50,7 +50,6 @@ using firebase::firestore::model::Document;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
-using firebase::firestore::model::DocumentState;
 
 using testutil::Doc;
 using testutil::DocSet;
@@ -89,8 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testIncludeMetadataChanges {
-  Document doc1Old = Doc("foo/bar", 1, Map("a", "b"), DocumentState::kLocalMutations);
-  Document doc1New = Doc("foo/bar", 1, Map("a", "b"), DocumentState::kSynced);
+  Document doc1Old = Doc("foo/bar", 1, Map("a", "b")).SetHasLocalMutations();
+  Document doc1New = Doc("foo/bar", 1, Map("a", "b"));
 
   Document doc2Old = Doc("foo/baz", 1, Map("a", "b"));
   Document doc2New = Doc("foo/baz", 1, Map("a", "c"));

--- a/Firestore/core/test/unit/bundle/bundle_loader_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_loader_test.cc
@@ -43,7 +43,7 @@ using api::LoadBundleTaskProgress;
 using api::LoadBundleTaskState;
 using core::LimitType;
 using model::DocumentKeySet;
-using model::MaybeDocumentMap;
+using model::DocumentMap;
 using util::StatusOr;
 
 class BundleLoaderTest : public ::testing::Test {
@@ -53,14 +53,14 @@ class BundleLoaderTest : public ::testing::Test {
     explicit TestBundleCallback(BundleLoaderTest& parant) : parent_(parant) {
     }
 
-    model::MaybeDocumentMap ApplyBundledDocuments(
-        const model::MaybeDocumentMap& documents,
+    model::DocumentMap ApplyBundledDocuments(
+        const model::MutableDocumentMap& documents,
         const std::string& bundle_id) override {
       (void)bundle_id;
       for (const auto& entry : documents) {
         parent_.last_documents_ = parent_.last_documents_.insert(entry.first);
       }
-      return MaybeDocumentMap{};
+      return DocumentMap{};
     }
 
     void SaveNamedQuery(const NamedQuery& query,

--- a/Firestore/core/test/unit/core/query_listener_test.cc
+++ b/Firestore/core/test/unit/core/query_listener_test.cc
@@ -43,10 +43,9 @@ namespace firebase {
 namespace firestore {
 namespace core {
 
-using model::Document;
 using model::DocumentKeySet;
 using model::DocumentSet;
-using model::DocumentState;
+using model::MutableDocument;
 using model::OnlineState;
 using remote::TargetChange;
 using util::DelayedConstructor;
@@ -103,9 +102,9 @@ TEST_F(QueryListenerTest, RaisesCollectionEvents) {
   std::vector<ViewSnapshot> other_accum;
 
   Query query = testutil::Query("rooms");
-  Document doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
-  Document doc2prime =
+  MutableDocument doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc2prime =
       Doc("rooms/Hades", 3, Map("name", "Hades", "owner", "Jonny"));
 
   auto listener = QueryListener::Create(query, include_metadata_changes_,
@@ -180,8 +179,8 @@ TEST_F(QueryListenerTest, MutingAsyncListenerPreventsAllSubsequentEvents) {
   std::vector<ViewSnapshot> accum;
 
   Query query = testutil::Query("rooms/Eros");
-  Document doc1 = Doc("rooms/Eros", 3, Map("name", "Eros"));
-  Document doc2 = Doc("rooms/Eros", 4, Map("name", "Eros2"));
+  MutableDocument doc1 = Doc("rooms/Eros", 3, Map("name", "Eros"));
+  MutableDocument doc2 = Doc("rooms/Eros", 4, Map("name", "Eros2"));
 
   std::shared_ptr<AsyncEventListener<ViewSnapshot>> listener =
       AsyncEventListener<ViewSnapshot>::Create(
@@ -215,8 +214,8 @@ TEST_F(QueryListenerTest, DoesNotRaiseEventsForMetadataChangesUnlessSpecified) {
   std::vector<ViewSnapshot> full_accum;
 
   Query query = testutil::Query("rooms");
-  Document doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
 
   auto filtered_listener =
       QueryListener::Create(query, Accumulating(&filtered_accum));
@@ -248,11 +247,11 @@ TEST_F(QueryListenerTest, RaisesDocumentMetadataEventsOnlyWhenSpecified) {
   std::vector<ViewSnapshot> full_accum;
 
   Query query = testutil::Query("rooms");
-  Document doc1 =
-      Doc("rooms/Eros", 1, Map("name", "Eros"), DocumentState::kLocalMutations);
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
-  Document doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
+  MutableDocument doc1 =
+      Doc("rooms/Eros", 1, Map("name", "Eros")).SetHasLocalMutations();
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,
@@ -298,13 +297,13 @@ TEST_F(QueryListenerTest,
   std::vector<ViewSnapshot> full_accum;
 
   Query query = testutil::Query("rooms");
-  Document doc1 =
-      Doc("rooms/Eros", 1, Map("name", "Eros"), DocumentState::kLocalMutations);
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"),
-                      DocumentState::kLocalMutations);
-  Document doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc2_prime = Doc("rooms/Hades", 2, Map("name", "Hades"));
-  Document doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
+  MutableDocument doc1 =
+      Doc("rooms/Eros", 1, Map("name", "Eros")).SetHasLocalMutations();
+  MutableDocument doc2 =
+      Doc("rooms/Hades", 2, Map("name", "Hades")).SetHasLocalMutations();
+  MutableDocument doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc2_prime = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
 
   ListenOptions options(
       /*include_query_metadata_changes=*/true,
@@ -346,11 +345,11 @@ TEST_F(QueryListenerTest,
   std::vector<ViewSnapshot> filtered_accum;
 
   Query query = testutil::Query("rooms");
-  Document doc1 =
-      Doc("rooms/Eros", 1, Map("name", "Eros"), DocumentState::kLocalMutations);
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
-  Document doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
+  MutableDocument doc1 =
+      Doc("rooms/Eros", 1, Map("name", "Eros")).SetHasLocalMutations();
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc1_prime = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc3 = Doc("rooms/Other", 3, Map("name", "Other"));
 
   auto filtered_listener =
       QueryListener::Create(query, Accumulating(&filtered_accum));
@@ -381,8 +380,8 @@ TEST_F(QueryListenerTest, WillWaitForSyncIfOnline) {
   std::vector<ViewSnapshot> events;
 
   Query query = testutil::Query("rooms");
-  Document doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,
@@ -420,8 +419,8 @@ TEST_F(QueryListenerTest, WillRaiseInitialEventWhenGoingOffline) {
   std::vector<ViewSnapshot> events;
 
   Query query = testutil::Query("rooms");
-  Document doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
-  Document doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
+  MutableDocument doc1 = Doc("rooms/Eros", 1, Map("name", "Eros"));
+  MutableDocument doc2 = Doc("rooms/Hades", 2, Map("name", "Hades"));
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,

--- a/Firestore/core/test/unit/core/view_snapshot_test.cc
+++ b/Firestore/core/test/unit/core/view_snapshot_test.cc
@@ -26,11 +26,10 @@ namespace firebase {
 namespace firestore {
 namespace core {
 
-using model::Document;
 using model::DocumentComparator;
 using model::DocumentKeySet;
 using model::DocumentSet;
-using model::DocumentState;
+using model::MutableDocument;
 
 using testutil::Doc;
 using testutil::Map;
@@ -38,7 +37,7 @@ using testutil::Map;
 using Type = DocumentViewChange::Type;
 
 TEST(ViewSnapshotTest, DocumentChangeConstructor) {
-  Document doc = Doc("a/b", 0, Map());
+  MutableDocument doc = Doc("a/b", 0, Map());
   Type type = Type::Modified;
   DocumentViewChange change{doc, type};
   ASSERT_EQ(change.document(), doc);
@@ -48,15 +47,15 @@ TEST(ViewSnapshotTest, DocumentChangeConstructor) {
 TEST(ViewSnapshotTest, Track) {
   DocumentViewChangeSet set;
 
-  Document doc_added = Doc("a/1", 0, Map());
-  Document doc_removed = Doc("a/2", 0, Map());
-  Document doc_modified = Doc("a/3", 0, Map());
+  MutableDocument doc_added = Doc("a/1", 0, Map());
+  MutableDocument doc_removed = Doc("a/2", 0, Map());
+  MutableDocument doc_modified = Doc("a/3", 0, Map());
 
-  Document doc_added_then_modified = Doc("b/1", 0, Map());
-  Document doc_added_then_removed = Doc("b/2", 0, Map());
-  Document doc_removed_then_added = Doc("b/3", 0, Map());
-  Document doc_modified_then_removed = Doc("b/4", 0, Map());
-  Document doc_modified_then_modified = Doc("b/5", 0, Map());
+  MutableDocument doc_added_then_modified = Doc("b/1", 0, Map());
+  MutableDocument doc_added_then_removed = Doc("b/2", 0, Map());
+  MutableDocument doc_removed_then_added = Doc("b/3", 0, Map());
+  MutableDocument doc_modified_then_removed = Doc("b/4", 0, Map());
+  MutableDocument doc_modified_then_modified = Doc("b/5", 0, Map());
 
   set.AddChange(DocumentViewChange{doc_added, Type::Added});
   set.AddChange(DocumentViewChange{doc_removed, Type::Removed});

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -16,7 +16,6 @@
 
 #include "Firestore/core/src/local/leveldb_key.h"
 
-#include "Firestore/core/src/model/maybe_document.h"
 #include "Firestore/core/src/util/string_util.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
 #include "absl/strings/match.h"

--- a/Firestore/core/test/unit/local/lru_garbage_collector_test.h
+++ b/Firestore/core/test/unit/local/lru_garbage_collector_test.h
@@ -23,7 +23,7 @@
 #include "Firestore/core/src/auth/user.h"
 #include "Firestore/core/src/local/reference_set.h"
 #include "Firestore/core/src/local/target_data.h"
-#include "Firestore/core/src/model/field_value.h"
+#include "Firestore/core/src/model/object_value.h"
 #include "Firestore/core/src/model/types.h"
 #include "gtest/gtest.h"
 
@@ -182,7 +182,7 @@ class LruGarbageCollectorTest : public ::testing::TestWithParam<FactoryFunc> {
    *   - added to a target
    *   - now has or previously had a pending mutation
    */
-  model::Document CacheADocumentInTransaction();
+  model::MutableDocument CacheADocumentInTransaction();
 
   /**
    * Returns a new arbitrary, unsaved mutation for the document named by
@@ -194,10 +194,10 @@ class LruGarbageCollectorTest : public ::testing::TestWithParam<FactoryFunc> {
   model::DocumentKey NextTestDocKey();
 
   /** Returns a new, unsaved document with arbitrary contents. */
-  model::Document NextTestDocument();
+  model::MutableDocument NextTestDocument();
 
   /** Returns a new, unsaved document with the given contents. */
-  model::Document NextTestDocumentWithValue(model::ObjectValue value);
+  model::MutableDocument NextTestDocumentWithValue(model::ObjectValue value);
 
   std::unique_ptr<LruGarbageCollectorTestHelper> test_helper_;
 

--- a/Firestore/core/test/unit/model/document_set_test.cc
+++ b/Firestore/core/test/unit/model/document_set_test.cc
@@ -52,17 +52,17 @@ TEST_F(DocumentSetTest, Count) {
 TEST_F(DocumentSetTest, HasKey) {
   DocumentSet set = DocSet(comp_, {doc1_, doc2_});
 
-  EXPECT_TRUE(set.ContainsKey(doc1_.key()));
-  EXPECT_TRUE(set.ContainsKey(doc2_.key()));
-  EXPECT_FALSE(set.ContainsKey(doc3_.key()));
+  EXPECT_TRUE(set.ContainsKey(doc1_->key()));
+  EXPECT_TRUE(set.ContainsKey(doc2_->key()));
+  EXPECT_FALSE(set.ContainsKey(doc3_->key()));
 }
 
 TEST_F(DocumentSetTest, DocumentForKey) {
   DocumentSet set = DocSet(comp_, {doc1_, doc2_});
 
-  EXPECT_EQ(set.GetDocument(doc1_.key()), doc1_);
-  EXPECT_EQ(set.GetDocument(doc2_.key()), doc2_);
-  EXPECT_EQ(set.GetDocument(doc3_.key()), absl::nullopt);
+  EXPECT_EQ(set.GetDocument(doc1_->key()), doc1_);
+  EXPECT_EQ(set.GetDocument(doc2_->key()), doc2_);
+  EXPECT_EQ(set.GetDocument(doc3_->key()), absl::nullopt);
 }
 
 TEST_F(DocumentSetTest, FirstAndLastDocument) {
@@ -83,14 +83,14 @@ TEST_F(DocumentSetTest, KeepsDocumentsInTheRightOrder) {
 TEST_F(DocumentSetTest, Deletes) {
   DocumentSet set = DocSet(comp_, {doc1_, doc2_, doc3_});
 
-  DocumentSet set_without_doc1 = set.erase(doc1_.key());
+  DocumentSet set_without_doc1 = set.erase(doc1_->key());
   ASSERT_THAT(set_without_doc1, ElementsAre(doc3_, doc2_));
   EXPECT_EQ(set_without_doc1.size(), 2);
 
   // Original remains unchanged
   ASSERT_THAT(set, ElementsAre(doc3_, doc1_, doc2_));
 
-  DocumentSet set_without_doc3 = set_without_doc1.erase(doc3_.key());
+  DocumentSet set_without_doc3 = set_without_doc1.erase(doc3_->key());
   ASSERT_THAT(set_without_doc3, ElementsAre(doc2_));
   EXPECT_EQ(set_without_doc3.size(), 1);
 }
@@ -102,7 +102,7 @@ TEST_F(DocumentSetTest, Updates) {
 
   set = set.insert(doc2_prime);
   ASSERT_EQ(set.size(), 3);
-  EXPECT_EQ(set.GetDocument(doc2_prime.key()), doc2_prime);
+  EXPECT_EQ(set.GetDocument(doc2_prime->key()), doc2_prime);
   ASSERT_THAT(set, ElementsAre(doc3_, doc1_, doc2_prime));
 }
 

--- a/Firestore/core/test/unit/model/transform_operation_test.cc
+++ b/Firestore/core/test/unit/model/transform_operation_test.cc
@@ -16,7 +16,6 @@
 
 #include "Firestore/core/src/model/transform_operation.h"
 
-#include "Firestore/core/src/model/field_value.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
 #include "gtest/gtest.h"
 

--- a/Firestore/core/test/unit/remote/watch_change_test.cc
+++ b/Firestore/core/test/unit/remote/watch_change_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/remote/watch_change.h"
 
-#include "Firestore/core/src/model/document.h"
+#include "Firestore/core/src/model/mutable_document.h"
 #include "Firestore/core/src/remote/existence_filter.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
 #include "gtest/gtest.h"
@@ -25,14 +25,13 @@ namespace firebase {
 namespace firestore {
 namespace remote {
 
-using model::DocumentState;
-using model::MaybeDocument;
+using model::MutableDocument;
 
 using testutil::Doc;
 using testutil::Map;
 
 TEST(WatchChangeTest, CanCreateDocumentWatchChange) {
-  MaybeDocument doc = Doc("a/b", 1, Map());
+  MutableDocument doc = Doc("a/b", 1, Map());
   DocumentWatchChange change{{1, 2, 3}, {4, 5}, doc.key(), doc};
 
   EXPECT_EQ(change.updated_target_ids().size(), 3);

--- a/Firestore/core/test/unit/testutil/view_testing.cc
+++ b/Firestore/core/test/unit/testutil/view_testing.cc
@@ -33,21 +33,20 @@ using core::ViewSnapshot;
 using model::Document;
 using model::DocumentKeySet;
 using model::DocumentMap;
-using model::MutableDocument;
 using nanopb::ByteString;
 using remote::TargetChange;
 
-model::DocumentMap DocUpdates(const std::vector<model::MutableDocument>& docs) {
+model::DocumentMap DocUpdates(const std::vector<model::Document>& docs) {
   DocumentMap updates;
-  for (const MutableDocument& doc : docs) {
-    updates = updates.insert(doc.key(), doc);
+  for (const Document& doc : docs) {
+    updates = updates.insert(doc->key(), doc);
   }
   return updates;
 }
 
 absl::optional<ViewSnapshot> ApplyChanges(
     View* view,
-    const std::vector<MutableDocument>& docs,
+    const std::vector<Document>& docs,
     const absl::optional<TargetChange>& target_change) {
   ViewChange change = view->ApplyChanges(
       view->ComputeDocumentChanges(DocUpdates(docs)), target_change);
@@ -62,10 +61,10 @@ TargetChange AckTarget(DocumentKeySet docs) {
           /*removed_documents*/ DocumentKeySet{}};
 }
 
-TargetChange AckTarget(std::initializer_list<MutableDocument> docs) {
+TargetChange AckTarget(std::initializer_list<Document> docs) {
   DocumentKeySet keys;
   for (const auto& doc : docs) {
-    keys = keys.insert(doc.key());
+    keys = keys.insert(doc->key());
   }
   return AckTarget(keys);
 }

--- a/Firestore/core/test/unit/testutil/view_testing.cc
+++ b/Firestore/core/test/unit/testutil/view_testing.cc
@@ -20,6 +20,7 @@
 
 #include "Firestore/core/src/core/view.h"
 #include "Firestore/core/src/core/view_snapshot.h"
+#include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/remote/remote_event.h"
 
 namespace firebase {
@@ -31,15 +32,14 @@ using core::ViewChange;
 using core::ViewSnapshot;
 using model::Document;
 using model::DocumentKeySet;
-using model::MaybeDocument;
-using model::MaybeDocumentMap;
+using model::DocumentMap;
+using model::MutableDocument;
 using nanopb::ByteString;
 using remote::TargetChange;
 
-model::MaybeDocumentMap DocUpdates(
-    const std::vector<model::MaybeDocument>& docs) {
-  MaybeDocumentMap updates;
-  for (const MaybeDocument& doc : docs) {
+model::DocumentMap DocUpdates(const std::vector<model::MutableDocument>& docs) {
+  DocumentMap updates;
+  for (const MutableDocument& doc : docs) {
     updates = updates.insert(doc.key(), doc);
   }
   return updates;
@@ -47,7 +47,7 @@ model::MaybeDocumentMap DocUpdates(
 
 absl::optional<ViewSnapshot> ApplyChanges(
     View* view,
-    const std::vector<MaybeDocument>& docs,
+    const std::vector<MutableDocument>& docs,
     const absl::optional<TargetChange>& target_change) {
   ViewChange change = view->ApplyChanges(
       view->ComputeDocumentChanges(DocUpdates(docs)), target_change);
@@ -62,7 +62,7 @@ TargetChange AckTarget(DocumentKeySet docs) {
           /*removed_documents*/ DocumentKeySet{}};
 }
 
-TargetChange AckTarget(std::initializer_list<Document> docs) {
+TargetChange AckTarget(std::initializer_list<MutableDocument> docs) {
   DocumentKeySet keys;
   for (const auto& doc : docs) {
     keys = keys.insert(doc.key());

--- a/Firestore/core/test/unit/testutil/view_testing.h
+++ b/Firestore/core/test/unit/testutil/view_testing.h
@@ -34,8 +34,7 @@ class TargetChange;
 namespace testutil {
 
 /** Converts a list of documents to a sorted map. */
-model::MaybeDocumentMap DocUpdates(
-    const std::vector<model::MaybeDocument>& docs);
+model::DocumentMap DocUpdates(const std::vector<model::MutableDocument>& docs);
 
 /**
  * Computes changes to the view with the docs and then applies them and returns
@@ -43,7 +42,7 @@ model::MaybeDocumentMap DocUpdates(
  */
 absl::optional<core::ViewSnapshot> ApplyChanges(
     core::View* view,
-    const std::vector<model::MaybeDocument>& docs,
+    const std::vector<model::MutableDocument>& docs,
     const absl::optional<remote::TargetChange>& target_change);
 
 /**
@@ -52,7 +51,8 @@ absl::optional<core::ViewSnapshot> ApplyChanges(
  */
 remote::TargetChange AckTarget(model::DocumentKeySet docs);
 
-remote::TargetChange AckTarget(std::initializer_list<model::Document> docs);
+remote::TargetChange AckTarget(
+    std::initializer_list<model::MutableDocument> docs);
 
 /** Creates a test target change that marks the target as CURRENT  */
 remote::TargetChange MarkCurrent();

--- a/Firestore/core/test/unit/testutil/view_testing.h
+++ b/Firestore/core/test/unit/testutil/view_testing.h
@@ -34,7 +34,7 @@ class TargetChange;
 namespace testutil {
 
 /** Converts a list of documents to a sorted map. */
-model::DocumentMap DocUpdates(const std::vector<model::MutableDocument>& docs);
+model::DocumentMap DocUpdates(const std::vector<model::Document>& docs);
 
 /**
  * Computes changes to the view with the docs and then applies them and returns
@@ -42,7 +42,7 @@ model::DocumentMap DocUpdates(const std::vector<model::MutableDocument>& docs);
  */
 absl::optional<core::ViewSnapshot> ApplyChanges(
     core::View* view,
-    const std::vector<model::MutableDocument>& docs,
+    const std::vector<model::Document>& docs,
     const absl::optional<remote::TargetChange>& target_change);
 
 /**
@@ -51,8 +51,7 @@ absl::optional<core::ViewSnapshot> ApplyChanges(
  */
 remote::TargetChange AckTarget(model::DocumentKeySet docs);
 
-remote::TargetChange AckTarget(
-    std::initializer_list<model::MutableDocument> docs);
+remote::TargetChange AckTarget(std::initializer_list<model::Document> docs);
 
 /** Creates a test target change that marks the target as CURRENT  */
 remote::TargetChange MarkCurrent();


### PR DESCRIPTION
This is part of #7904. It will break the feature branch, but I am planning to send out small reviewable chunks with an end goal of a feature branch that passes CI.

This PR contains the test files that only have "mechanical refactor" changes.

- No more DocumentState. Instead we use `SetHasLocalMutations`/`SetHasCommittedMutations`. `
- No more MaybeDocument. Instead we now have MutableDocument.
- No more MaybeDocumentMap. Instead just DocumentMap. 
- A Document is now a const wrapper on top of MutableDocument. Hence, some callsites change to `->`