### PR TITLE
Add iPadOS as split out in Crashlytics Platform

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
@@ -48,7 +48,7 @@ NSString* FIRCLSApplicationGetSDKBundleID(void);
 NSString* FIRCLSApplicationGetPlatform(void);
 
 /**
- * Returns the Operating System for filtering. Should be kept consisten with Analytics.
+ * Returns the Operating System for filtering. Should be kept consistent with Analytics.
  */
 NSString* FIRCLSApplicationGetFirebasePlatform(void);
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
@@ -48,6 +48,11 @@ NSString* FIRCLSApplicationGetSDKBundleID(void);
 NSString* FIRCLSApplicationGetPlatform(void);
 
 /**
+ * Returns the Operating System for filtering. Should be kept consisten with Analytics.
+ */
+NSString* FIRCLSApplicationGetFirebasePlatform(void);
+
+/**
  * Returns the user-facing app name
  */
 NSString* FIRCLSApplicationGetName(void);

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -17,6 +17,8 @@
 #import "Crashlytics/Crashlytics/Components/FIRCLSHost.h"
 #import "Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h"
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+
 #if CLS_TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
@@ -47,6 +49,14 @@ NSString* FIRCLSApplicationGetPlatform(void) {
 #elif TARGET_OS_WATCH
   return @"ios";  // TODO: temporarily use iOS until Firebase can add watchos to the backend
 #endif
+}
+
+NSString* FIRCLSApplicationGetFirebasePlatform(void) {
+  NSString *firebasePlatform = [GULAppEnvironmentUtil applePlatform];
+  if ([firebasePlatform isEqualToString:@"ios"] && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+    return @"ipados";
+  }
+  return firebasePlatform;
 }
 
 // these defaults match the FIRCLSInfoPlist helper in FIRCLSIDEFoundation

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -53,10 +53,14 @@ NSString* FIRCLSApplicationGetPlatform(void) {
 
 NSString* FIRCLSApplicationGetFirebasePlatform(void) {
   NSString* firebasePlatform = [GULAppEnvironmentUtil applePlatform];
+
+#if TARGET_OS_IOS
   if ([firebasePlatform isEqualToString:@"ios"] &&
       UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
     return @"ipados";
   }
+#endif
+
   return firebasePlatform;
 }
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -52,8 +52,9 @@ NSString* FIRCLSApplicationGetPlatform(void) {
 }
 
 NSString* FIRCLSApplicationGetFirebasePlatform(void) {
-  NSString *firebasePlatform = [GULAppEnvironmentUtil applePlatform];
-  if ([firebasePlatform isEqualToString:@"ios"] && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  NSString* firebasePlatform = [GULAppEnvironmentUtil applePlatform];
+  if ([firebasePlatform isEqualToString:@"ios"] &&
+      UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
     return @"ipados";
   }
   return firebasePlatform;

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -158,7 +158,8 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file) {
   FIRCLSFileWriteHashEntryString(file, "os_display_version",
                                  [FIRCLSHostOSDisplayVersion() UTF8String]);
   FIRCLSFileWriteHashEntryString(file, "platform", [FIRCLSApplicationGetPlatform() UTF8String]);
-  FIRCLSFileWriteHashEntryString(file, "firebase_platform", [FIRCLSApplicationGetFirebasePlatform() UTF8String]);
+  FIRCLSFileWriteHashEntryString(file, "firebase_platform",
+                                 [FIRCLSApplicationGetFirebasePlatform() UTF8String]);
 }
 
 bool FIRCLSHostRecord(FIRCLSFile* file) {

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -25,8 +25,6 @@
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h"
 #import "Crashlytics/Shared/FIRCLSFABHost.h"
 
-#import <GoogleUtilities/GULAppEnvironmentUtil.h>
-
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #else
@@ -160,8 +158,7 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file) {
   FIRCLSFileWriteHashEntryString(file, "os_display_version",
                                  [FIRCLSHostOSDisplayVersion() UTF8String]);
   FIRCLSFileWriteHashEntryString(file, "platform", [FIRCLSApplicationGetPlatform() UTF8String]);
-  FIRCLSFileWriteHashEntryString(file, "firebase_platform",
-                                 [[GULAppEnvironmentUtil applePlatform] UTF8String]);
+  FIRCLSFileWriteHashEntryString(file, "firebase_platform", [FIRCLSApplicationGetFirebasePlatform() UTF8String]);
 }
 
 bool FIRCLSHostRecord(FIRCLSFile* file) {


### PR DESCRIPTION
We need to split off iPad

#no-changelog
