### PR TITLE
Adjust the Messaging changelog after we remove iid from github

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2021-04 -- v8.0.0
-- [changed] Remove Instance ID dependency from Messaging. This is a breaking change for Firebase Messaging users who use Instance ID to manage registration tokens without explicitly specifying Instance ID in their podfile or Swift Package Manager. For a short-term resolution, those Messaging users can update their dependencies to explicitly specify Instance ID. Longer term, all users should migrate to Messaging's token APIs following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)
+- [changed] Remove Instance ID dependency from Messaging. This is a breaking change for Firebase Messaging users who use Instance ID to manage registration tokens. Please migrate to Messaging's token APIs following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)
 
 # 2021-04 -- v7.11.0
 - [changed] Refactor Messaging to internally not depending on InstanceID, but can co-exist. Will remove InstanceID dependency in the next Firebase breaking change. (#7814)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2021-04 -- v8.0.0
-- [changed] Remove Instance ID dependency from Messaging. This is a breaking change for Firebase Messaging users who use Instance ID to manage registration tokens. Please migrate to Messaging's token APIs following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)
+- [changed] Remove the Instance ID dependency from Firebase Cloud Messaging. This is a breaking change for FCM users who use the deprecated Instance ID API to manage registration tokens. Users should migrate to FCM's token APIs by following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)
 
 # 2021-04 -- v7.11.0
 - [changed] Refactor Messaging to internally not depending on InstanceID, but can co-exist. Will remove InstanceID dependency in the next Firebase breaking change. (#7814)


### PR DESCRIPTION
Since the Firebase 8 will not have IID as part of its repo, developers will not be able to include InstanceID in the podfile to keep using InstanceID. They will have to migrate to new token APIs. Adjust the changelog to reflect this change.