### PR TITLE
FieldValue changes for transform_operation

### DIFF
--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -243,7 +243,7 @@ google_firestore_v1_ArrayValue ArrayTransform::Rep::CoercedFieldValueArray(
   if (IsArray(value)) {
     return value->array_value;
   } else {
-    // coerce to empty array.;
+    // coerce to empty array.
     return {};
   }
 }

--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -16,13 +16,17 @@
 
 #include "Firestore/core/src/model/transform_operation.h"
 
+#include <functional>
 #include <memory>
 #include <ostream>
+#include <set>
 #include <utility>
-#include <vector>
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
-#include "Firestore/core/src/model/field_value.h"
+#include "Firestore/core/src/model/server_timestamp_util.h"
+#include "Firestore/core/src/model/value_util.h"
+#include "Firestore/core/src/nanopb/nanopb_util.h"
+#include "Firestore/core/src/util/comparison.h"
 #include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/to_string.h"
 #include "absl/algorithm/container.h"
@@ -33,6 +37,13 @@ namespace firestore {
 namespace model {
 
 using Type = TransformOperation::Type;
+
+struct ValueCompare {
+  bool operator()(const google_firestore_v1_Value& lhs,
+                  const google_firestore_v1_Value& rhs) const {
+    return Compare(lhs, rhs) == util::ComparisonResult::Ascending;
+  }
+};
 
 // MARK: - TransformOperation
 
@@ -62,20 +73,20 @@ class ServerTimestampTransform::Rep : public TransformOperation::Rep {
     return Type::ServerTimestamp;
   }
 
-  model::FieldValue ApplyToLocalView(
-      const absl::optional<model::FieldValue>& previous_value,
+  google_firestore_v1_Value ApplyToLocalView(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp& local_write_time) const override {
-    return FieldValue::FromServerTimestamp(local_write_time, previous_value);
+    return EncodeServerTimestamp(local_write_time, previous_value);
   }
 
-  model::FieldValue ApplyToRemoteDocument(
-      const absl::optional<model::FieldValue>&,
-      const model::FieldValue& transform_result) const override {
+  google_firestore_v1_Value ApplyToRemoteDocument(
+      const absl::optional<google_firestore_v1_Value>&,
+      const google_firestore_v1_Value& transform_result) const override {
     return transform_result;
   }
 
-  absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>&) const override {
+  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+      const absl::optional<google_firestore_v1_Value>&) const override {
     // Server timestamps are idempotent and don't require a base value.
     return absl::nullopt;
   }
@@ -110,37 +121,37 @@ static_assert(sizeof(TransformOperation) == sizeof(ArrayTransform),
  */
 class ArrayTransform::Rep : public TransformOperation::Rep {
  public:
-  Rep(Type type, std::vector<model::FieldValue> elements)
-      : type_(type), elements_(std::move(elements)) {
+  Rep(Type type, google_firestore_v1_ArrayValue elements)
+      : type_(type), elements_{elements} {
   }
 
   Type type() const override {
     return type_;
   }
 
-  model::FieldValue ApplyToLocalView(
-      const absl::optional<model::FieldValue>& previous_value,
+  google_firestore_v1_Value ApplyToLocalView(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp&) const override {
     return Apply(previous_value);
   }
 
-  model::FieldValue ApplyToRemoteDocument(
-      const absl::optional<model::FieldValue>& previous_value,
-      const model::FieldValue&) const override {
+  google_firestore_v1_Value ApplyToRemoteDocument(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
+      const google_firestore_v1_Value&) const override {
     // The server just sends null as the transform result for array operations,
     // so we have to calculate a result the same as we do for local
     // applications.
     return Apply(previous_value);
   }
 
-  absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>&) const override {
+  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+      const absl::optional<google_firestore_v1_Value>&) const override {
     // Array transforms are idempotent and don't require a base value.
     return absl::nullopt;
   }
 
-  const std::vector<model::FieldValue>& elements() const {
-    return elements_;
+  google_firestore_v1_ArrayValue elements() const {
+    return *elements_;
   }
 
   bool Equals(const TransformOperation::Rep& other) const override;
@@ -149,25 +160,22 @@ class ArrayTransform::Rep : public TransformOperation::Rep {
 
   std::string ToString() const override;
 
-  static const std::vector<model::FieldValue>& Elements(
-      const TransformOperation& op);
-
  private:
   friend class ArrayTransform;
 
   /**
-   * Inspects the provided value, returning a mutable copy of the internal array
-   * if it's of type Array and an empty mutable array if it's nil or any other
-   * type of FieldValue.
+   * Inspects the provided value, returning a copy of the internal array if it's
+   * of type Array and an empty array if it's nil or any other type of
+   * google_firestore_v1_Value.
    */
-  static std::vector<model::FieldValue> CoercedFieldValuesArray(
-      const absl::optional<model::FieldValue>& value);
+  google_firestore_v1_ArrayValue CoercedFieldValueArray(
+      const absl::optional<google_firestore_v1_Value>& value) const;
 
-  model::FieldValue Apply(
-      const absl::optional<model::FieldValue>& previous_value) const;
+  google_firestore_v1_Value Apply(
+      const absl::optional<google_firestore_v1_Value>& previous_value) const;
 
   Type type_;
-  std::vector<model::FieldValue> elements_;
+  nanopb::Message<google_firestore_v1_ArrayValue> elements_;
 };
 
 namespace {
@@ -179,9 +187,8 @@ constexpr bool IsArrayTransform(Type type) {
 }  // namespace
 
 ArrayTransform::ArrayTransform(Type type,
-                               std::vector<model::FieldValue> elements)
-    : TransformOperation(
-          std::make_shared<const Rep>(type, std::move(elements))) {
+                               google_firestore_v1_ArrayValue elements)
+    : TransformOperation(std::make_shared<const Rep>(type, elements)) {
   HARD_ASSERT(IsArrayTransform(type), "Expected array transform type; got %s",
               type);
 }
@@ -192,8 +199,8 @@ ArrayTransform::ArrayTransform(const TransformOperation& op)
               "Expected array transform type; got %s", op.type());
 }
 
-const std::vector<FieldValue>& ArrayTransform::elements() const {
-  return array_rep().elements_;
+google_firestore_v1_ArrayValue ArrayTransform::elements() const {
+  return *(array_rep().elements_);
 }
 
 const ArrayTransform::Rep& ArrayTransform::array_rep() const {
@@ -204,12 +211,12 @@ bool ArrayTransform::Rep::Equals(const TransformOperation::Rep& other) const {
   if (other.type() != type()) {
     return false;
   }
-  auto other_rep = static_cast<const ArrayTransform::Rep&>(other);
-  if (other_rep.elements_.size() != elements_.size()) {
+  auto& other_rep = static_cast<const ArrayTransform::Rep&>(other);
+  if (other_rep.elements_->values_count != elements_->values_count) {
     return false;
   }
-  for (size_t i = 0; i < elements_.size(); i++) {
-    if (other_rep.elements_[i] != elements_[i]) {
+  for (pb_size_t i = 0; i < elements_->values_count; i++) {
+    if (other_rep.elements_->values[i] != elements_->values[i]) {
       return false;
     }
   }
@@ -219,48 +226,68 @@ bool ArrayTransform::Rep::Equals(const TransformOperation::Rep& other) const {
 size_t ArrayTransform::Rep::Hash() const {
   size_t result = 37;
   result = 31 * result + (type() == Type::ArrayUnion ? 1231 : 1237);
-  for (const FieldValue& element : elements_) {
-    result = 31 * result + element.Hash();
+  for (size_t i = 0; i < elements_->values_count; i++) {
+    result = 31 * result +
+             std::hash<std::string>()(CanonicalId(elements_->values[i]));
   }
   return result;
 }
 
 std::string ArrayTransform::Rep::ToString() const {
   const char* name = type_ == Type::ArrayUnion ? "ArrayUnion" : "ArrayRemove";
-  return absl::StrCat(name, "(", util::ToString(elements_), ")");
+  return absl::StrCat(name, "(", CanonicalId(*elements_), ")");
 }
 
-FieldValue::Array ArrayTransform::Rep::CoercedFieldValuesArray(
-    const absl::optional<model::FieldValue>& value) {
-  if (value && value->type() == FieldValue::Type::Array) {
-    return value->array_value();
+google_firestore_v1_ArrayValue ArrayTransform::Rep::CoercedFieldValueArray(
+    const absl::optional<google_firestore_v1_Value>& value) const {
+  if (IsArray(value)) {
+    return value->array_value;
   } else {
-    // coerce to empty array.
+    // coerce to empty array.;
     return {};
   }
 }
 
-FieldValue ArrayTransform::Rep::Apply(
-    const absl::optional<FieldValue>& previous_value) const {
-  FieldValue::Array result = CoercedFieldValuesArray(previous_value);
-  for (const FieldValue& element : elements_) {
-    auto pos = absl::c_find(result, element);
-    if (type_ == Type::ArrayUnion) {
-      if (pos == result.end()) {
-        result.push_back(element);
-      }
-    } else {
-      HARD_ASSERT(type_ == Type::ArrayRemove);
-      for (size_t i = 0; i < result.size();) {
-        if (element == result.at(i)) {
-          result.erase(result.cbegin() + i);
-        } else {
-          ++i;
-        }
+google_firestore_v1_Value ArrayTransform::Rep::Apply(
+    const absl::optional<google_firestore_v1_Value>& previous_value) const {
+  google_firestore_v1_ArrayValue array_value =
+      CoercedFieldValueArray(previous_value);
+  if (type_ == Type::ArrayUnion) {
+    // Gather the list of elements that have to be added.
+    std::set<google_firestore_v1_Value, ValueCompare> new_elements;
+    for (pb_size_t i = 0; i < elements_->values_count; ++i) {
+      if (!Contains(array_value, elements_->values[i])) {
+        new_elements.insert(elements_->values[i]);
       }
     }
+
+    // Append the elements to the end of the list
+    pb_size_t new_size = array_value.values_count + new_elements.size();
+    array_value.values = nanopb::ResizeArray<google_firestore_v1_Value>(
+        array_value.values, new_size);
+    for (const auto& element : new_elements) {
+      array_value.values[array_value.values_count] = DeepClone(element);
+      ++array_value.values_count;
+    }
+  } else {
+    HARD_ASSERT(type_ == Type::ArrayRemove);
+    pb_size_t new_index = 0;
+    for (pb_size_t old_index = 0; old_index < array_value.values_count;
+         ++old_index) {
+      if (Contains(*elements_, array_value.values[old_index])) {
+        nanopb::FreeFieldsArray(&array_value.values[old_index]);
+      } else {
+        array_value.values[new_index] = array_value.values[old_index];
+        ++new_index;
+      }
+    }
+    array_value.values_count = new_index;
   }
-  return FieldValue::FromArray(std::move(result));
+
+  google_firestore_v1_Value result{};
+  result.which_value_type = google_firestore_v1_Value_array_value_tag;
+  result.array_value = array_value;
+  return result;
 }
 
 // MARK: - NumericIncrementTransform
@@ -270,34 +297,34 @@ static_assert(sizeof(TransformOperation) == sizeof(NumericIncrementTransform),
 
 class NumericIncrementTransform::Rep : public TransformOperation::Rep {
  public:
-  explicit Rep(model::FieldValue operand) : operand_(std::move(operand)) {
+  explicit Rep(google_firestore_v1_Value operand)
+      : operand_(std::move(operand)) {
   }
 
   Type type() const override {
     return Type::Increment;
   }
 
-  model::FieldValue ApplyToLocalView(
-      const absl::optional<model::FieldValue>& previous_value,
+  google_firestore_v1_Value ApplyToLocalView(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp& local_write_time) const override;
 
-  model::FieldValue ApplyToRemoteDocument(
-      const absl::optional<model::FieldValue>&,
-      const model::FieldValue& transform_result) const override {
+  google_firestore_v1_Value ApplyToRemoteDocument(
+      const absl::optional<google_firestore_v1_Value>&,
+      const google_firestore_v1_Value& transform_result) const override {
     return transform_result;
   }
 
-  absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>& previous_value) const override;
+  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+      const absl::optional<google_firestore_v1_Value>& previous_value)
+      const override;
 
-  model::FieldValue operand() const {
-    return operand_;
-  }
+  double OperandAsDouble() const;
 
   bool Equals(const TransformOperation::Rep& other) const override;
 
   size_t Hash() const override {
-    return operand_.Hash();
+    return std::hash<std::string>()(CanonicalId(operand_));
   }
 
   std::string ToString() const override {
@@ -307,12 +334,13 @@ class NumericIncrementTransform::Rep : public TransformOperation::Rep {
  private:
   friend class NumericIncrementTransform;
 
-  model::FieldValue operand_;
+  google_firestore_v1_Value operand_{};
 };
 
-NumericIncrementTransform::NumericIncrementTransform(FieldValue operand)
+NumericIncrementTransform::NumericIncrementTransform(
+    google_firestore_v1_Value operand)
     : TransformOperation(std::make_shared<Rep>(operand)) {
-  HARD_ASSERT(operand.is_number());
+  HARD_ASSERT(IsNumber(operand));
 }
 
 NumericIncrementTransform::NumericIncrementTransform(
@@ -322,7 +350,7 @@ NumericIncrementTransform::NumericIncrementTransform(
               op.type());
 }
 
-const FieldValue& NumericIncrementTransform::operand() const {
+const google_firestore_v1_Value& NumericIncrementTransform::operand() const {
   return static_cast<const Rep&>(rep()).operand_;
 }
 
@@ -344,44 +372,52 @@ int64_t SafeIncrement(int64_t x, int64_t y) {
   return x + y;
 }
 
-double AsDouble(const FieldValue& value) {
-  if (value.type() == FieldValue::Type::Double) {
-    return value.double_value();
-  } else if (value.type() == FieldValue::Type::Integer) {
-    return static_cast<double>(value.integer_value());
+}  // namespace
+
+double NumericIncrementTransform::Rep::OperandAsDouble() const {
+  if (IsDouble(operand_)) {
+    return operand_.double_value;
+  } else if (IsInteger(operand_)) {
+    return static_cast<double>(operand_.integer_value);
   } else {
     HARD_FAIL("Expected 'operand' to be of numeric type, but was %s (type %s)",
-              value.ToString(), value.type());
+              CanonicalId(operand_), GetTypeOrder(operand_));
   }
 }
 
-}  // namespace
-
-FieldValue NumericIncrementTransform::Rep::ApplyToLocalView(
-    const absl::optional<FieldValue>& previous_value,
+google_firestore_v1_Value NumericIncrementTransform::Rep::ApplyToLocalView(
+    const absl::optional<google_firestore_v1_Value>& previous_value,
     const Timestamp& /* local_write_time */) const {
-  absl::optional<FieldValue> base_value = ComputeBaseValue(previous_value);
+  absl::optional<google_firestore_v1_Value> base_value =
+      ComputeBaseValue(previous_value);
+  google_firestore_v1_Value result{};
 
   // Return an integer value only if the previous value and the operand is an
   // integer.
-  if (base_value && base_value->type() == FieldValue::Type::Integer &&
-      operand_.type() == FieldValue::Type::Integer) {
-    int64_t sum =
-        SafeIncrement(base_value->integer_value(), operand_.integer_value());
-    return FieldValue::FromInteger(sum);
+  if (IsInteger(base_value) && IsInteger(operand_)) {
+    result.which_value_type = google_firestore_v1_Value_integer_value_tag;
+    result.integer_value =
+        SafeIncrement(base_value->integer_value, operand_.integer_value);
+  } else if (IsInteger(base_value)) {
+    result.which_value_type = google_firestore_v1_Value_double_value_tag;
+    result.double_value = base_value->integer_value + OperandAsDouble();
   } else {
-    HARD_ASSERT(base_value && base_value->is_number(),
-                "'base_value' is not of numeric type");
-    double sum = AsDouble(*base_value) + AsDouble(operand_);
-    return FieldValue::FromDouble(sum);
+    HARD_ASSERT(IsDouble(base_value), "'base_value' is not of numeric type");
+    result.which_value_type = google_firestore_v1_Value_double_value_tag;
+    result.double_value = base_value->double_value + OperandAsDouble();
   }
+
+  return result;
 }
 
-absl::optional<FieldValue> NumericIncrementTransform::Rep::ComputeBaseValue(
-    const absl::optional<FieldValue>& previous_value) const {
-  return previous_value && previous_value->is_number()
-             ? previous_value
-             : absl::optional<FieldValue>{FieldValue::FromInteger(0)};
+absl::optional<google_firestore_v1_Value>
+NumericIncrementTransform::Rep::ComputeBaseValue(
+    const absl::optional<google_firestore_v1_Value>& previous_value) const {
+  if (IsNumber(previous_value)) return previous_value;
+
+  google_firestore_v1_Value zero_value{};
+  zero_value.which_value_type = google_firestore_v1_Value_integer_value_tag;
+  return zero_value;
 }
 
 bool NumericIncrementTransform::Rep::Equals(

--- a/Firestore/core/src/model/transform_operation.h
+++ b/Firestore/core/src/model/transform_operation.h
@@ -23,7 +23,9 @@
 #include <utility>
 #include <vector>
 
-#include "Firestore/core/src/model/field_value.h"
+#include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
+#include "Firestore/core/src/nanopb/message.h"
+#include "Firestore/core/src/util/hard_assert.h"
 #include "absl/types/optional.h"
 
 namespace firebase {
@@ -75,8 +77,9 @@ class TransformOperation {
    * Computes the local transform result against the provided `previous_value`,
    * optionally using the provided local_write_time.
    */
-  FieldValue ApplyToLocalView(const absl::optional<FieldValue>& previous_value,
-                              const Timestamp& local_write_time) const {
+  google_firestore_v1_Value ApplyToLocalView(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
+      const Timestamp& local_write_time) const {
     return rep().ApplyToLocalView(previous_value, local_write_time);
   }
 
@@ -84,9 +87,9 @@ class TransformOperation {
    * Computes a final transform result after the transform has been acknowledged
    * by the server, potentially using the server-provided transform_result.
    */
-  FieldValue ApplyToRemoteDocument(
-      const absl::optional<FieldValue>& previous_value,
-      const FieldValue& transform_result) const {
+  google_firestore_v1_Value ApplyToRemoteDocument(
+      const absl::optional<google_firestore_v1_Value>& previous_value,
+      const google_firestore_v1_Value& transform_result) const {
     return rep().ApplyToRemoteDocument(previous_value, transform_result);
   }
 
@@ -105,8 +108,8 @@ class TransformOperation {
    * @return a base value to store along with the mutation, or empty for
    *     idempotent transforms.
    */
-  absl::optional<FieldValue> ComputeBaseValue(
-      const absl::optional<FieldValue>& previous_value) const {
+  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+      const absl::optional<google_firestore_v1_Value>& previous_value) const {
     return rep().ComputeBaseValue(previous_value);
   }
 
@@ -133,16 +136,17 @@ class TransformOperation {
 
     virtual Type type() const = 0;
 
-    virtual FieldValue ApplyToLocalView(
-        const absl::optional<FieldValue>& previous_value,
+    virtual google_firestore_v1_Value ApplyToLocalView(
+        const absl::optional<google_firestore_v1_Value>& previous_value,
         const Timestamp& local_write_time) const = 0;
 
-    virtual FieldValue ApplyToRemoteDocument(
-        const absl::optional<FieldValue>& previous_value,
-        const FieldValue& transform_result) const = 0;
+    virtual google_firestore_v1_Value ApplyToRemoteDocument(
+        const absl::optional<google_firestore_v1_Value>& previous_value,
+        const google_firestore_v1_Value& transform_result) const = 0;
 
-    virtual absl::optional<FieldValue> ComputeBaseValue(
-        const absl::optional<FieldValue>& previous_value) const = 0;
+    virtual absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+        const absl::optional<google_firestore_v1_Value>& previous_value)
+        const = 0;
 
     virtual bool Equals(const TransformOperation::Rep& other) const = 0;
 
@@ -176,7 +180,7 @@ class ServerTimestampTransform : public TransformOperation {
  */
 class ArrayTransform : public TransformOperation {
  public:
-  ArrayTransform(Type type, std::vector<FieldValue> elements);
+  ArrayTransform(Type type, google_firestore_v1_ArrayValue array_value);
 
   /**
    * Casts a TransformOperation to an ArrayTransform. This is a checked
@@ -185,9 +189,7 @@ class ArrayTransform : public TransformOperation {
    */
   explicit ArrayTransform(const TransformOperation& op);
 
-  ArrayTransform() = default;
-
-  const std::vector<model::FieldValue>& elements() const;
+  google_firestore_v1_ArrayValue elements() const;
 
  private:
   class Rep;
@@ -202,7 +204,7 @@ class ArrayTransform : public TransformOperation {
  */
 class NumericIncrementTransform : public TransformOperation {
  public:
-  explicit NumericIncrementTransform(FieldValue operand);
+  explicit NumericIncrementTransform(google_firestore_v1_Value operand);
 
   /**
    * Casts a TransformOperation to a NumericIncrementTransform. This is a
@@ -211,7 +213,7 @@ class NumericIncrementTransform : public TransformOperation {
    */
   explicit NumericIncrementTransform(const TransformOperation& op);
 
-  const FieldValue& operand() const;
+  const google_firestore_v1_Value& operand() const;
 
  private:
   class Rep;


### PR DESCRIPTION
These are two files from https://github.com/firebase/firebase-ios-sdk/pull/7904 that should be able to be reviewed relatively independently. Most of the missing functions are in review here: https://github.com/firebase/firebase-ios-sdk/pull/7991 (such as `IsArray`.

This PR changes all FieldTransforms to use Protobuf directly. It follows the code on Android: https://github.com/firebase/firebase-android-sdk/tree/master/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation
