### PR TITLE
LocalStore changes for Protobuf migration

### DIFF
--- a/Firestore/core/src/local/local_store.cc
+++ b/Firestore/core/src/local/local_store.cc
@@ -29,6 +29,7 @@
 #include "Firestore/core/src/local/query_result.h"
 #include "Firestore/core/src/local/reference_delegate.h"
 #include "Firestore/core/src/local/target_cache.h"
+#include "Firestore/core/src/model/mutable_document.h"
 #include "Firestore/core/src/model/mutation_batch.h"
 #include "Firestore/core/src/model/mutation_batch_result.h"
 #include "Firestore/core/src/model/patch_mutation.h"
@@ -46,19 +47,19 @@ using core::Query;
 using core::Target;
 using core::TargetIdGenerator;
 using model::BatchId;
+using model::Document;
 using model::DocumentKey;
 using model::DocumentKeySet;
 using model::DocumentMap;
 using model::DocumentUpdateMap;
 using model::DocumentVersionMap;
 using model::ListenSequenceNumber;
-using model::MaybeDocument;
-using model::MaybeDocumentMap;
+using model::MutableDocument;
+using model::MutableDocumentMap;
 using model::Mutation;
 using model::MutationBatch;
 using model::MutationBatchResult;
 using model::ObjectValue;
-using model::OptionalMaybeDocumentMap;
 using model::PatchMutation;
 using model::Precondition;
 using model::ResourcePath;
@@ -108,7 +109,7 @@ void LocalStore::StartMutationQueue() {
   persistence_->Run("Start MutationQueue", [&] { mutation_queue_->Start(); });
 }
 
-MaybeDocumentMap LocalStore::HandleUserChange(const User& user) {
+DocumentMap LocalStore::HandleUserChange(const User& user) {
   // Swap out the mutation queue, grabbing the pending mutation batches before
   // and after.
   std::vector<MutationBatch> old_batches = persistence_->Run(
@@ -157,7 +158,7 @@ LocalWriteResult LocalStore::WriteLocally(std::vector<Mutation>&& mutations) {
     // Load and apply all existing mutations. This lets us compute the current
     // base state for all non-idempotent transforms before applying any
     // additional user-provided writes.
-    MaybeDocumentMap existing_documents = local_documents_->GetDocuments(keys);
+    DocumentMap existing_documents = local_documents_->GetDocuments(keys);
 
     // For non-idempotent mutations (such as `FieldValue.increment()`), we
     // record the base state in a separate patch mutation. This is later used to
@@ -165,11 +166,10 @@ LocalWriteResult LocalStore::WriteLocally(std::vector<Mutation>&& mutations) {
     // sends us an update that already includes our transform.
     std::vector<Mutation> base_mutations;
     for (const Mutation& mutation : mutations) {
-      absl::optional<MaybeDocument> base_document =
-          existing_documents.get(mutation.key());
+      absl::optional<Document> base_document = existing_documents.get(mutation.key());
 
       absl::optional<ObjectValue> base_value =
-          mutation.ExtractTransformBaseValue(base_document);
+          mutation.ExtractTransformBaseValue(*base_document);
       if (base_value) {
         // NOTE: The base state should only be applied if there's some existing
         // document to override, so use a Precondition of exists=true
@@ -181,13 +181,12 @@ LocalWriteResult LocalStore::WriteLocally(std::vector<Mutation>&& mutations) {
 
     MutationBatch batch = mutation_queue_->AddMutationBatch(
         local_write_time, std::move(base_mutations), std::move(mutations));
-    MaybeDocumentMap changed_documents =
-        batch.ApplyToLocalDocumentSet(existing_documents);
-    return LocalWriteResult{batch.batch_id(), std::move(changed_documents)};
+    batch.ApplyToLocalDocumentSet(existing_documents);
+    return LocalWriteResult{batch.batch_id(), std::move(existing_documents)};
   });
 }
 
-MaybeDocumentMap LocalStore::AcknowledgeBatch(
+DocumentMap LocalStore::AcknowledgeBatch(
     const MutationBatchResult& batch_result) {
   return persistence_->Run("Acknowledge batch", [&] {
     const MutationBatch& batch = batch_result.batch();
@@ -205,24 +204,17 @@ void LocalStore::ApplyBatchResult(const MutationBatchResult& batch_result) {
   const DocumentVersionMap& versions = batch_result.doc_versions();
 
   for (const DocumentKey& doc_key : doc_keys) {
-    absl::optional<MaybeDocument> remote_doc =
-        remote_document_cache_->Get(doc_key);
-    absl::optional<MaybeDocument> doc = remote_doc;
+    MutableDocument doc = remote_document_cache_->Get(doc_key);
 
     auto ack_version_iter = versions.find(doc_key);
     HARD_ASSERT(ack_version_iter != versions.end(),
                 "doc_versions should contain every doc in the write.");
     const SnapshotVersion& ack_version = ack_version_iter->second;
 
-    if (!doc || doc->version() < ack_version) {
-      doc = batch.ApplyToRemoteDocument(doc, doc_key, batch_result);
-      if (!doc) {
-        HARD_ASSERT(
-            !remote_doc,
-            "Mutation batch %s applied to document %s resulted in nullopt.",
-            batch.ToString(), util::ToString(remote_doc));
-      } else {
-        remote_document_cache_->Add(*doc, batch_result.commit_version());
+    if (doc.version() < ack_version) {
+      batch.ApplyToRemoteDocument(doc, doc_key, batch_result);
+      if (doc.is_valid_document()) {
+        remote_document_cache_->Add(doc, batch_result.commit_version());
       }
     }
   }
@@ -230,7 +222,7 @@ void LocalStore::ApplyBatchResult(const MutationBatchResult& batch_result) {
   mutation_queue_->RemoveMutationBatch(batch);
 }
 
-MaybeDocumentMap LocalStore::RejectBatch(BatchId batch_id) {
+DocumentMap LocalStore::RejectBatch(BatchId batch_id) {
   return persistence_->Run("Reject batch", [&] {
     absl::optional<MutationBatch> to_reject =
         mutation_queue_->LookupMutationBatch(batch_id);
@@ -256,7 +248,7 @@ const SnapshotVersion& LocalStore::GetLastRemoteSnapshotVersion() const {
   return target_cache_->GetLastRemoteSnapshotVersion();
 }
 
-model::MaybeDocumentMap LocalStore::ApplyRemoteEvent(
+model::DocumentMap LocalStore::ApplyRemoteEvent(
     const remote::RemoteEvent& remote_event) {
   const SnapshotVersion& last_remote_version =
       target_cache_->GetLastRemoteSnapshotVersion();
@@ -285,8 +277,8 @@ model::MaybeDocumentMap LocalStore::ApplyRemoteEvent(
 
       // Update the resume token if the change includes one. Don't clear any
       // preexisting value. Bump the sequence number as well, so that documents
-      // being removed now are ordered later than documents that were reviously
-      // _removed from this target.
+      // being removed now are ordered later than documents that were previously
+      // removed from this target.
       const ByteString& resume_token = change.resume_token();
       // Update the resume token if the change includes one.
       if (!resume_token.empty()) {
@@ -414,7 +406,7 @@ absl::optional<MutationBatch> LocalStore::GetNextMutationBatch(
   });
 }
 
-absl::optional<MaybeDocument> LocalStore::ReadDocument(const DocumentKey& key) {
+const Document LocalStore::ReadDocument(const DocumentKey& key) {
   return persistence_->Run("ReadDocument",
                            [&] { return local_documents_->GetDocument(key); });
 }
@@ -522,8 +514,8 @@ void LocalStore::SaveBundle(const bundle::BundleMetadata& metadata) {
       "Save bundle", [&] { bundle_cache_->SaveBundleMetadata(metadata); });
 }
 
-MaybeDocumentMap LocalStore::ApplyBundledDocuments(
-    const MaybeDocumentMap& bundled_documents, const std::string& bundle_id) {
+DocumentMap LocalStore::ApplyBundledDocuments(
+    const MutableDocumentMap& bundled_documents, const std::string& bundle_id) {
   // Allocates a target to hold all document keys from the bundle, such that
   // they will not get garbage collected right away.
   TargetData umbrella_target = AllocateTarget(NewUmbrellaTarget(bundle_id));
@@ -535,7 +527,7 @@ MaybeDocumentMap LocalStore::ApplyBundledDocuments(
     for (const auto& kv : bundled_documents) {
       const DocumentKey& key = kv.first;
       const auto& doc = kv.second;
-      if (doc.type() == MaybeDocument::Type::Document) {
+      if (doc.is_found_document()) {
         keys = keys.insert(key);
       }
       document_updates.emplace(key, doc);
@@ -591,11 +583,11 @@ Target LocalStore::NewUmbrellaTarget(const std::string& bundle_id) {
       .ToTarget();
 }
 
-OptionalMaybeDocumentMap LocalStore::PopulateDocumentChanges(
+MutableDocumentMap LocalStore::PopulateDocumentChanges(
     const DocumentUpdateMap& documents,
     const DocumentVersionMap& document_versions,
     const SnapshotVersion& global_version) {
-  OptionalMaybeDocumentMap changed_docs;
+  MutableDocumentMap changed_docs;
 
   DocumentKeySet updated_keys;
   for (const auto& kv : documents) {
@@ -603,17 +595,13 @@ OptionalMaybeDocumentMap LocalStore::PopulateDocumentChanges(
   }
   // Each loop iteration only affects its "own" doc, so it's safe to get all
   // the remote documents in advance in a single call.
-  OptionalMaybeDocumentMap existing_docs =
+  MutableDocumentMap existing_docs =
       remote_document_cache_->GetAll(updated_keys);
 
   for (const auto& kv : documents) {
     const DocumentKey& key = kv.first;
-    const MaybeDocument& doc = kv.second;
-    absl::optional<MaybeDocument> existing_doc;
-    auto found_existing = existing_docs.get(key);
-    if (found_existing) {
-      existing_doc = *found_existing;
-    }
+    const MutableDocument& doc = kv.second;
+    const MutableDocument& existing_doc = *existing_docs.get(key);
     auto search_version = document_versions.find(key);
     const SnapshotVersion& read_time = search_version != document_versions.end()
                                            ? search_version->second
@@ -622,15 +610,15 @@ OptionalMaybeDocumentMap LocalStore::PopulateDocumentChanges(
     // Note: The order of the steps below is important, since we want to
     // ensure that rejected limbo resolutions (which fabricate NoDocuments
     // with SnapshotVersion::None) never add documents to cache.
-    if (doc.type() == MaybeDocument::Type::NoDocument &&
-        doc.version() == SnapshotVersion::None()) {
+    if (doc.is_no_document() && doc.version() == SnapshotVersion::None()) {
       // NoDocuments with SnapshotVersion::None are used in manufactured
       // events. We remove these documents from cache since we lost access.
       remote_document_cache_->Remove(key);
       changed_docs = changed_docs.insert(key, doc);
-    } else if (!existing_doc || doc.version() > existing_doc->version() ||
-               (doc.version() == existing_doc->version() &&
-                existing_doc->has_pending_writes())) {
+    } else if (!existing_doc.is_valid_document() ||
+               doc.version() > existing_doc.version() ||
+               (doc.version() == existing_doc.version() &&
+                existing_doc.has_pending_writes())) {
       HARD_ASSERT(read_time != SnapshotVersion::None(),
                   "Cannot add a document when the remote version is zero");
       remote_document_cache_->Add(doc, read_time);
@@ -639,7 +627,7 @@ OptionalMaybeDocumentMap LocalStore::PopulateDocumentChanges(
       LOG_DEBUG(
           "LocalStore Ignoring outdated update for %s. "
           "Current version: %s  Remote version: %s",
-          key.ToString(), existing_doc->version().ToString(),
+          key.ToString(), existing_doc.version().ToString(),
           doc.version().ToString());
     }
   }

--- a/Firestore/core/src/local/local_store.cc
+++ b/Firestore/core/src/local/local_store.cc
@@ -212,7 +212,7 @@ void LocalStore::ApplyBatchResult(const MutationBatchResult& batch_result) {
     const SnapshotVersion& ack_version = ack_version_iter->second;
 
     if (doc.version() < ack_version) {
-      batch.ApplyToRemoteDocument(doc, doc_key, batch_result);
+      batch.ApplyToRemoteDocument(doc, batch_result);
       if (doc.is_valid_document()) {
         remote_document_cache_->Add(doc, batch_result.commit_version());
       }

--- a/Firestore/core/src/local/local_store.h
+++ b/Firestore/core/src/local/local_store.h
@@ -28,6 +28,7 @@
 #include "Firestore/core/src/core/target_id_generator.h"
 #include "Firestore/core/src/local/reference_set.h"
 #include "Firestore/core/src/local/target_data.h"
+#include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/model/model_fwd.h"
 #include "absl/types/optional.h"
 
@@ -120,17 +121,16 @@ class LocalStore : public bundle::BundleCallback {
    * In response the local store switches the mutation queue to the new user and
    * returns any resulting document changes.
    */
-  model::MaybeDocumentMap HandleUserChange(const auth::User& user);
+  model::DocumentMap HandleUserChange(const auth::User& user);
 
   /** Accepts locally generated Mutations and commits them to storage. */
   LocalWriteResult WriteLocally(std::vector<model::Mutation>&& mutations);
 
   /**
-   * Returns the current value of a document with a given key, or `nullopt` if
-   * not found.
+   * Returns the current value of a document with a given key, or an invalid
+   * document if not found.
    */
-  absl::optional<model::MaybeDocument> ReadDocument(
-      const model::DocumentKey& key);
+  const model::Document ReadDocument(const model::DocumentKey& key);
 
   /**
    * Acknowledges the given batch.
@@ -146,7 +146,7 @@ class LocalStore : public bundle::BundleCallback {
    *
    * @return The resulting (modified) documents.
    */
-  model::MaybeDocumentMap AcknowledgeBatch(
+  model::DocumentMap AcknowledgeBatch(
       const model::MutationBatchResult& batch_result);
 
   /**
@@ -155,7 +155,7 @@ class LocalStore : public bundle::BundleCallback {
    *
    * @return The resulting (modified) documents.
    */
-  model::MaybeDocumentMap RejectBatch(model::BatchId batch_id);
+  model::DocumentMap RejectBatch(model::BatchId batch_id);
 
   /** Returns the last recorded stream token for the current user. */
   nanopb::ByteString GetLastStreamToken();
@@ -181,8 +181,7 @@ class LocalStore : public bundle::BundleCallback {
    * LocalDocuments are re-calculated if there are remaining mutations in the
    * queue.
    */
-  model::MaybeDocumentMap ApplyRemoteEvent(
-      const remote::RemoteEvent& remote_event);
+  model::DocumentMap ApplyRemoteEvent(const remote::RemoteEvent& remote_event);
 
   /**
    * Returns the keys of the documents that are associated with the given
@@ -259,8 +258,8 @@ class LocalStore : public bundle::BundleCallback {
    * Local documents are re-calculated if there are remaining mutations in the
    * queue.
    */
-  model::MaybeDocumentMap ApplyBundledDocuments(
-      const model::MaybeDocumentMap& documents,
+  model::DocumentMap ApplyBundledDocuments(
+      const model::MutableDocumentMap& documents,
       const std::string& bundle_id) override;
 
   /** Saves the given `NamedQuery` to local persistence. */
@@ -322,7 +321,7 @@ class LocalStore : public bundle::BundleCallback {
    * @param global_version A SnapshotVersion representing the read time if all
    * documents have the same read time.
    */
-  model::OptionalMaybeDocumentMap PopulateDocumentChanges(
+  model::MutableDocumentMap PopulateDocumentChanges(
       const model::DocumentUpdateMap& documents,
       const model::DocumentVersionMap& document_versions,
       const model::SnapshotVersion& global_version);

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -30,13 +30,12 @@
 #include "Firestore/core/src/local/query_result.h"
 #include "Firestore/core/src/local/target_data.h"
 #include "Firestore/core/src/model/delete_mutation.h"
-#include "Firestore/core/src/model/document_map.h"
+#include "Firestore/core/src/model/document.h"
+#include "Firestore/core/src/model/mutable_document.h"
 #include "Firestore/core/src/model/mutation_batch_result.h"
-#include "Firestore/core/src/model/no_document.h"
 #include "Firestore/core/src/model/patch_mutation.h"
 #include "Firestore/core/src/model/set_mutation.h"
 #include "Firestore/core/src/model/transform_operation.h"
-#include "Firestore/core/src/model/unknown_document.h"
 #include "Firestore/core/src/remote/remote_event.h"
 #include "Firestore/core/src/remote/watch_change.h"
 #include "Firestore/core/test/unit/remote/fake_target_metadata_provider.h"
@@ -57,11 +56,9 @@ using model::Document;
 using model::DocumentKey;
 using model::DocumentKeySet;
 using model::DocumentMap;
-using model::DocumentState;
-using model::FieldValue;
 using model::ListenSequenceNumber;
-using model::MaybeDocument;
-using model::MaybeDocumentMap;
+using model::MutableDocument;
+using model::MutableDocumentMap;
 using model::Mutation;
 using model::MutationBatch;
 using model::MutationBatchResult;
@@ -89,24 +86,16 @@ using testutil::UnknownDoc;
 using testutil::Value;
 using testutil::Vector;
 
-std::vector<MaybeDocument> DocMapToVector(const MaybeDocumentMap& docs) {
-  std::vector<MaybeDocument> result;
+std::vector<Document> DocMapToVector(const DocumentMap& docs) {
+  std::vector<Document> result;
   for (const auto& kv : docs) {
     result.push_back(kv.second);
   }
   return result;
 }
 
-std::vector<Document> DocMapToVector(const DocumentMap& docs) {
-  std::vector<Document> result;
-  for (const auto& kv : docs.underlying_map()) {
-    result.push_back(Document(kv.second));
-  }
-  return result;
-}
-
-MaybeDocumentMap DocVectorToMap(const std::vector<MaybeDocument>& docs) {
-  MaybeDocumentMap result;
+MutableDocumentMap DocVectorToMap(const std::vector<MutableDocument>& docs) {
+  MutableDocumentMap result;
   for (const auto& d : docs) {
     result = result.insert(d.key(), d);
   }
@@ -114,11 +103,11 @@ MaybeDocumentMap DocVectorToMap(const std::vector<MaybeDocument>& docs) {
 }
 
 RemoteEvent UpdateRemoteEventWithLimboTargets(
-    const MaybeDocument& doc,
+    const MutableDocument& doc,
     const std::vector<TargetId>& updated_in_targets,
     const std::vector<TargetId>& removed_from_targets,
     const std::vector<TargetId>& limbo_targets) {
-  HARD_ASSERT(!doc.is_document() || !Document(doc).has_local_mutations(),
+  HARD_ASSERT(!doc.is_found_document() || !doc.has_local_mutations(),
               "Docs from remote updates shouldn't have local changes.");
   DocumentWatchChange change{updated_in_targets, removed_from_targets,
                              doc.key(), doc};
@@ -158,7 +147,7 @@ RemoteEvent NoChangeEvent(int target_id, int version) {
 }
 
 /** Creates a remote event that inserts a list of documents. */
-RemoteEvent AddedRemoteEvent(const std::vector<MaybeDocument>& docs,
+RemoteEvent AddedRemoteEvent(const std::vector<MutableDocument>& docs,
                              const std::vector<TargetId>& added_to_targets) {
   HARD_ASSERT(!docs.empty(), "Cannot pass empty docs array");
 
@@ -169,8 +158,8 @@ RemoteEvent AddedRemoteEvent(const std::vector<MaybeDocument>& docs,
   WatchChangeAggregator aggregator{&metadata_provider};
 
   SnapshotVersion version;
-  for (const MaybeDocument& doc : docs) {
-    HARD_ASSERT(!doc.is_document() || !Document(doc).has_local_mutations(),
+  for (const MutableDocument& doc : docs) {
+    HARD_ASSERT(!doc.has_local_mutations(),
                 "Docs from remote updates shouldn't have local changes.");
     DocumentWatchChange change{added_to_targets, {}, doc.key(), doc};
     aggregator.HandleDocumentChange(change);
@@ -181,15 +170,15 @@ RemoteEvent AddedRemoteEvent(const std::vector<MaybeDocument>& docs,
 }
 
 /** Creates a remote event that inserts a new document. */
-RemoteEvent AddedRemoteEvent(const MaybeDocument& doc,
+RemoteEvent AddedRemoteEvent(const MutableDocument& doc,
                              const std::vector<TargetId>& added_to_targets) {
-  std::vector<MaybeDocument> docs{doc};
+  std::vector<MutableDocument> docs{doc};
   return AddedRemoteEvent(docs, added_to_targets);
 }
 
 /** Creates a remote event with changes to a document. */
 RemoteEvent UpdateRemoteEvent(
-    const MaybeDocument& doc,
+    const MutableDocument& doc,
     const std::vector<TargetId>& updated_in_targets,
     const std::vector<TargetId>& removed_from_targets) {
   return UpdateRemoteEventWithLimboTargets(doc, updated_in_targets,
@@ -249,7 +238,8 @@ void LocalStoreTest::UpdateViews(int target_id, bool from_cache) {
 }
 
 void LocalStoreTest::AcknowledgeMutationWithVersion(
-    int64_t document_version, absl::optional<FieldValue> transform_result) {
+    int64_t document_version,
+    absl::optional<google_firestore_v1_Value> transform_result) {
   ASSERT_GT(batches_.size(), 0) << "Missing batch to acknowledge.";
   MutationBatch batch = batches_.front();
   batches_.erase(batches_.begin());
@@ -258,13 +248,15 @@ void LocalStoreTest::AcknowledgeMutationWithVersion(
       << "Acknowledging more than one mutation not supported.";
   SnapshotVersion version = testutil::Version(document_version);
 
-  absl::optional<std::vector<FieldValue>> mutation_transform_result;
+  google_firestore_v1_ArrayValue mutation_transform_result{};
   if (transform_result) {
-    mutation_transform_result = std::vector<FieldValue>{*transform_result};
+    mutation_transform_result = Array(*transform_result);
   }
 
   MutationResult mutation_result(version, mutation_transform_result);
-  MutationBatchResult result(batch, version, {mutation_result}, {});
+  std::vector<MutationResult> mutation_results;
+  mutation_results.emplace_back(std::move(mutation_result));
+  MutationBatchResult result(batch, version, std::move(mutation_results), {});
   last_changes_ = local_store_.AcknowledgeBatch(result);
 }
 
@@ -294,7 +286,7 @@ QueryResult LocalStoreTest::ExecuteQuery(const core::Query& query) {
 }
 
 void LocalStoreTest::ApplyBundledDocuments(
-    const std::vector<MaybeDocument>& documents) {
+    const std::vector<MutableDocument>& documents) {
   last_changes_ =
       local_store_.ApplyBundledDocuments(DocVectorToMap(documents), "");
 }
@@ -312,29 +304,29 @@ void LocalStoreTest::ResetPersistenceStats() {
 /** Asserts that a the last_changes contain the docs in the given array. */
 #define FSTAssertChanged(...)                               \
   do {                                                      \
-    std::vector<MaybeDocument> expected = {__VA_ARGS__};    \
+    std::vector<Document> expected = {__VA_ARGS__};         \
     ASSERT_EQ(last_changes_.size(), expected.size());       \
     auto last_changes_list = DocMapToVector(last_changes_); \
     ASSERT_EQ(last_changes_list, expected);                 \
-    last_changes_ = MaybeDocumentMap{};                     \
+    last_changes_ = DocumentMap{};                          \
   } while (0)
 
 /**
  * Asserts that the last ExecuteQuery results contain the docs in the given
  * array.
  */
-#define FSTAssertQueryReturned(...)                                          \
-  do {                                                                       \
-    std::vector<std::string> expected_keys = {__VA_ARGS__};                  \
-    ASSERT_EQ(last_query_result_.documents().size(), expected_keys.size());  \
-    auto expected_keys_iterator = expected_keys.begin();                     \
-    for (const auto& kv : last_query_result_.documents().underlying_map()) { \
-      const DocumentKey& actual_key = kv.first;                              \
-      DocumentKey expected_key = Key(*expected_keys_iterator);               \
-      ASSERT_EQ(actual_key, expected_key);                                   \
-      ++expected_keys_iterator;                                              \
-    }                                                                        \
-    last_query_result_ = QueryResult{};                                      \
+#define FSTAssertQueryReturned(...)                                         \
+  do {                                                                      \
+    std::vector<std::string> expected_keys = {__VA_ARGS__};                 \
+    ASSERT_EQ(last_query_result_.documents().size(), expected_keys.size()); \
+    auto expected_keys_iterator = expected_keys.begin();                    \
+    for (const auto& kv : last_query_result_.documents()) {                 \
+      const DocumentKey& actual_key = kv.first;                             \
+      DocumentKey expected_key = Key(*expected_keys_iterator);              \
+      ASSERT_EQ(actual_key, expected_key);                                  \
+      ++expected_keys_iterator;                                             \
+    }                                                                       \
+    last_query_result_ = QueryResult{};                                     \
   } while (0)
 
 /** Asserts that the given keys were removed. */
@@ -345,30 +337,29 @@ void LocalStoreTest::ResetPersistenceStats() {
     auto key_path_iterator = key_paths.begin();           \
     for (const auto& kv : last_changes_) {                \
       const DocumentKey& actual_key = kv.first;           \
-      const MaybeDocument& value = kv.second;             \
+      const Document& value = kv.second;                  \
       DocumentKey expected_key = Key(*key_path_iterator); \
       ASSERT_EQ(actual_key, expected_key);                \
-      ASSERT_TRUE(value.is_no_document());                \
+      ASSERT_FALSE(value->is_found_document());           \
       ++key_path_iterator;                                \
     }                                                     \
-    last_changes_ = MaybeDocumentMap{};                   \
+    last_changes_ = DocumentMap{};                        \
   } while (0)
 
 /** Asserts that the given local store contains the given document. */
-#define FSTAssertContains(document)                \
-  do {                                             \
-    MaybeDocument expected = (document);           \
-    absl::optional<MaybeDocument> actual =         \
-        local_store_.ReadDocument(expected.key()); \
-    ASSERT_EQ(actual, expected);                   \
+#define FSTAssertContains(document)                              \
+  do {                                                           \
+    MutableDocument expected = (document);                       \
+    Document actual = local_store_.ReadDocument(expected.key()); \
+    ASSERT_EQ(actual, expected);                                 \
   } while (0)
 
 /** Asserts that the given local store does not contain the given document. */
-#define FSTAssertNotContains(key_path_string)                              \
-  do {                                                                     \
-    DocumentKey key = Key(key_path_string);                                \
-    absl::optional<MaybeDocument> actual = local_store_.ReadDocument(key); \
-    ASSERT_EQ(actual, absl::nullopt);                                      \
+#define FSTAssertNotContains(key_path_string)         \
+  do {                                                \
+    DocumentKey key = Key(key_path_string);           \
+    Document actual = local_store_.ReadDocument(key); \
+    ASSERT_FALSE(actual->is_valid_document());        \
   } while (0)
 
 /**
@@ -416,39 +407,36 @@ TEST_P(LocalStoreTest, MutationBatchKeys) {
 
 TEST_P(LocalStoreTest, HandlesSetMutation) {
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
-  AcknowledgeMutationWithVersion(0);
+  AcknowledgeMutationWithVersion(1);
   FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 1, Map("foo", "bar")).SetHasCommittedMutations());
   if (IsGcEager()) {
     // Nothing is pinning this anymore, as it has been acknowledged and there
     // are no targets active.
     FSTAssertNotContains("foo/bar");
   } else {
-    FSTAssertContains(Doc("foo/bar", 0, Map("foo", "bar"),
-                          DocumentState::kCommittedMutations));
+    FSTAssertContains(
+        Doc("foo/bar", 1, Map("foo", "bar")).SetHasCommittedMutations());
   }
 }
 
 TEST_P(LocalStoreTest, HandlesSetMutationThenDocument) {
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
   TargetId target_id = AllocateQuery(Query("foo"));
 
   ApplyRemoteEvent(UpdateRemoteEvent(Doc("foo/bar", 2, Map("it", "changed")),
                                      {target_id}, {}));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesAckThenRejectThenRemoteEvent) {
@@ -457,30 +445,28 @@ TEST_P(LocalStoreTest, HandlesAckThenRejectThenRemoteEvent) {
   TargetId target_id = AllocateQuery(query);
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
   // The last seen version is zero, so this ack must be held.
   AcknowledgeMutationWithVersion(1);
   FSTAssertChanged(
-      Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 1, Map("foo", "bar")).SetHasCommittedMutations());
 
   // Under eager GC, there is no longer a reference for the document, and it
   // should be deleted.
   if (IsGcEager()) {
     FSTAssertNotContains("foo/bar");
   } else {
-    FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar"),
-                          DocumentState::kCommittedMutations));
+    FSTAssertContains(
+        Doc("foo/bar", 1, Map("foo", "bar")).SetHasCommittedMutations());
   }
 
   WriteMutation(testutil::SetMutation("bar/baz", Map("bar", "baz")));
-  FSTAssertChanged(
-      Doc("bar/baz", 0, Map("bar", "baz"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("bar/baz", 0, Map("bar", "baz")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("bar/baz", 0, Map("bar", "baz"), DocumentState::kLocalMutations));
+      Doc("bar/baz", 0, Map("bar", "baz")).SetHasLocalMutations());
 
   RejectMutation();
   FSTAssertRemoved("bar/baz");
@@ -503,25 +489,24 @@ TEST_P(LocalStoreTest, HandlesDeletedDocumentThenSetMutationThenAck) {
   // Under eager GC, there is no longer a reference for the document, and it
   // should be deleted.
   if (!IsGcEager()) {
-    FSTAssertContains(DeletedDoc("foo/bar", 2, false));
+    FSTAssertContains(DeletedDoc("foo/bar", 2));
   } else {
     FSTAssertNotContains("foo/bar");
   }
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   // Can now remove the target, since we have a mutation pinning the document
   local_store_.ReleaseTarget(target_id);
   // Verify we didn't lose anything
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(3);
   FSTAssertChanged(
-      Doc("foo/bar", 3, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 3, Map("foo", "bar")).SetHasCommittedMutations());
   // It has been acknowledged, and should no longer be retained as there is no
   // target and mutation
   if (IsGcEager()) {
@@ -534,15 +519,13 @@ TEST_P(LocalStoreTest, HandlesSetMutationThenDeletedDocument) {
   TargetId target_id = AllocateQuery(query);
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
   ApplyRemoteEvent(
       UpdateRemoteEvent(DeletedDoc("foo/bar", 2), {target_id}, {}));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesDocumentThenSetMutationThenAckThenDocument) {
@@ -556,17 +539,16 @@ TEST_P(LocalStoreTest, HandlesDocumentThenSetMutationThenAckThenDocument) {
   FSTAssertContains(Doc("foo/bar", 2, Map("it", "base")));
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "bar")));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(3);
   // we haven't seen the remote event yet, so the write is still held.
   FSTAssertChanged(
-      Doc("foo/bar", 3, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 3, Map("foo", "bar")).SetHasCommittedMutations());
   FSTAssertContains(
-      Doc("foo/bar", 3, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 3, Map("foo", "bar")).SetHasCommittedMutations());
 
   ApplyRemoteEvent(UpdateRemoteEvent(Doc("foo/bar", 3, Map("it", "changed")),
                                      {target_id}, {}));
@@ -598,18 +580,18 @@ TEST_P(LocalStoreTest, HandlesPatchMutationThenDocumentThenAck) {
 
   ApplyRemoteEvent(
       AddedRemoteEvent(Doc("foo/bar", 1, Map("it", "base")), {target_id}));
-  FSTAssertChanged(Doc("foo/bar", 1, Map("foo", "bar", "it", "base"),
-                       DocumentState::kLocalMutations));
-  FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar", "it", "base"),
-                        DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("foo", "bar", "it", "base"))
+                       .SetHasLocalMutations());
+  FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar", "it", "base"))
+                        .SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(2);
   // We still haven't seen the remote events for the patch, so the local changes
   // remain, and there are no changes
-  FSTAssertChanged(Doc("foo/bar", 2, Map("foo", "bar", "it", "base"),
-                       DocumentState::kCommittedMutations));
-  FSTAssertContains(Doc("foo/bar", 2, Map("foo", "bar", "it", "base"),
-                        DocumentState::kCommittedMutations));
+  FSTAssertChanged(Doc("foo/bar", 2, Map("foo", "bar", "it", "base"))
+                       .SetHasCommittedMutations());
+  FSTAssertContains(Doc("foo/bar", 2, Map("foo", "bar", "it", "base"))
+                        .SetHasCommittedMutations());
 
   ApplyRemoteEvent(UpdateRemoteEvent(
       Doc("foo/bar", 2, Map("foo", "bar", "it", "base")), {target_id}, {}));
@@ -731,43 +713,39 @@ TEST_P(LocalStoreTest, HandlesDocumentThenDeletedDocumentThenDocument) {
 TEST_P(LocalStoreTest,
        HandlesSetMutationThenPatchMutationThenDocumentThenAckThenAck) {
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "old")));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "old"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "old")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "old"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "old")).SetHasLocalMutations());
 
   WriteMutation(testutil::PatchMutation("foo/bar", Map("foo", "bar"), {}));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 
   core::Query query = Query("foo");
   TargetId target_id = AllocateQuery(query);
 
   ApplyRemoteEvent(
       UpdateRemoteEvent(Doc("foo/bar", 1, Map("it", "base")), {target_id}, {}));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 1, Map("foo", "bar")).SetHasLocalMutations());
 
   local_store_.ReleaseTarget(target_id);
   AcknowledgeMutationWithVersion(2);  // delete mutation
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 2, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 2, Map("foo", "bar")).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(3);  // patch mutation
   FSTAssertChanged(
-      Doc("foo/bar", 3, Map("foo", "bar"), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 3, Map("foo", "bar")).SetHasCommittedMutations());
   if (IsGcEager()) {
     // we've ack'd all of the mutations, nothing is keeping this pinned anymore
     FSTAssertNotContains("foo/bar");
   } else {
-    FSTAssertContains(Doc("foo/bar", 3, Map("foo", "bar"),
-                          DocumentState::kCommittedMutations));
+    FSTAssertContains(
+        Doc("foo/bar", 3, Map("foo", "bar")).SetHasCommittedMutations());
   }
 }
 
@@ -775,10 +753,9 @@ TEST_P(LocalStoreTest, HandlesSetMutationAndPatchMutationTogether) {
   WriteMutations({testutil::SetMutation("foo/bar", Map("foo", "old")),
                   testutil::PatchMutation("foo/bar", Map("foo", "bar"), {})});
 
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesSetMutationThenPatchMutationThenReject) {
@@ -786,7 +763,7 @@ TEST_P(LocalStoreTest, HandlesSetMutationThenPatchMutationThenReject) {
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("foo", "old")));
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "old"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "old")).SetHasLocalMutations());
   AcknowledgeMutationWithVersion(1);
   FSTAssertNotContains("foo/bar");
 
@@ -803,13 +780,12 @@ TEST_P(LocalStoreTest, HandlesSetMutationsAndPatchMutationOfJustOneTogether) {
                   testutil::SetMutation("bar/baz", Map("bar", "baz")),
                   testutil::PatchMutation("foo/bar", Map("foo", "bar"), {})});
 
-  FSTAssertChanged(
-      Doc("bar/baz", 0, Map("bar", "baz"), DocumentState::kLocalMutations),
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("bar/baz", 0, Map("bar", "baz")).SetHasLocalMutations(),
+                   Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("bar/baz", 0, Map("bar", "baz"), DocumentState::kLocalMutations));
+      Doc("bar/baz", 0, Map("bar", "baz")).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesDeleteMutationThenPatchMutationThenAckThenAck) {
@@ -823,8 +799,7 @@ TEST_P(LocalStoreTest, HandlesDeleteMutationThenPatchMutationThenAckThenAck) {
 
   AcknowledgeMutationWithVersion(2);  // delete mutation
   FSTAssertRemoved("foo/bar");
-  FSTAssertContains(
-      DeletedDoc("foo/bar", 2, /* has_committed_mutations= */ true));
+  FSTAssertContains(DeletedDoc("foo/bar", 2).SetHasCommittedMutations());
 
   AcknowledgeMutationWithVersion(3);  // patch mutation
   FSTAssertChanged(UnknownDoc("foo/bar", 3));
@@ -880,15 +855,15 @@ TEST_P(LocalStoreTest, CollectsGarbageAfterAcknowledgedMutation) {
   WriteMutation(testutil::SetMutation("foo/bah", Map("foo", "bah")));
   WriteMutation(testutil::DeleteMutation("foo/baz"));
   FSTAssertContains(
-      Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 1, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
+      Doc("foo/bah", 0, Map("foo", "bah")).SetHasLocalMutations());
   FSTAssertContains(DeletedDoc("foo/baz"));
 
   AcknowledgeMutationWithVersion(3);
   FSTAssertNotContains("foo/bar");
   FSTAssertContains(
-      Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
+      Doc("foo/bah", 0, Map("foo", "bah")).SetHasLocalMutations());
   FSTAssertContains(DeletedDoc("foo/baz"));
 
   AcknowledgeMutationWithVersion(4);
@@ -918,15 +893,15 @@ TEST_P(LocalStoreTest, CollectsGarbageAfterRejectedMutation) {
   WriteMutation(testutil::SetMutation("foo/bah", Map("foo", "bah")));
   WriteMutation(testutil::DeleteMutation("foo/baz"));
   FSTAssertContains(
-      Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
+      Doc("foo/bar", 1, Map("foo", "bar")).SetHasLocalMutations());
   FSTAssertContains(
-      Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
+      Doc("foo/bah", 0, Map("foo", "bah")).SetHasLocalMutations());
   FSTAssertContains(DeletedDoc("foo/baz"));
 
   RejectMutation();  // patch mutation
   FSTAssertNotContains("foo/bar");
   FSTAssertContains(
-      Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
+      Doc("foo/bah", 0, Map("foo", "bah")).SetHasLocalMutations());
   FSTAssertContains(DeletedDoc("foo/baz"));
 
   RejectMutation();  // set mutation
@@ -951,7 +926,7 @@ TEST_P(LocalStoreTest, PinsDocumentsInTheLocalView) {
   WriteMutation(testutil::SetMutation("foo/baz", Map("foo", "baz")));
   FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar")));
   FSTAssertContains(
-      Doc("foo/baz", 0, Map("foo", "baz"), DocumentState::kLocalMutations));
+      Doc("foo/baz", 0, Map("foo", "baz")).SetHasLocalMutations());
 
   NotifyLocalViewChanges(TestViewChanges(target_id, /* from_cache= */ false,
                                          {"foo/bar", "foo/baz"}, {}));
@@ -961,7 +936,7 @@ TEST_P(LocalStoreTest, PinsDocumentsInTheLocalView) {
   ApplyRemoteEvent(
       UpdateRemoteEvent(Doc("foo/baz", 2, Map("foo", "baz")), {target_id}, {}));
   FSTAssertContains(
-      Doc("foo/baz", 2, Map("foo", "baz"), DocumentState::kLocalMutations));
+      Doc("foo/baz", 2, Map("foo", "baz")).SetHasLocalMutations());
   AcknowledgeMutationWithVersion(2);
   FSTAssertContains(Doc("foo/baz", 2, Map("foo", "baz")));
   FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar")));
@@ -993,8 +968,8 @@ TEST_P(LocalStoreTest, CanExecuteDocumentQueries) {
   core::Query query = Query("foo/bar");
   QueryResult query_result = ExecuteQuery(query);
   ASSERT_EQ(DocMapToVector(query_result.documents()),
-            Vector(Doc("foo/bar", 0, Map("foo", "bar"),
-                       DocumentState::kLocalMutations)));
+            Vector(Document{
+                Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations()}));
 }
 
 TEST_P(LocalStoreTest, CanExecuteCollectionQueries) {
@@ -1006,11 +981,12 @@ TEST_P(LocalStoreTest, CanExecuteCollectionQueries) {
        testutil::SetMutation("fooo/blah", Map("fooo", "blah"))});
   core::Query query = Query("foo");
   QueryResult query_result = ExecuteQuery(query);
-  ASSERT_EQ(DocMapToVector(query_result.documents()),
-            Vector(Doc("foo/bar", 0, Map("foo", "bar"),
-                       DocumentState::kLocalMutations),
-                   Doc("foo/baz", 0, Map("foo", "baz"),
-                       DocumentState::kLocalMutations)));
+  ASSERT_EQ(
+      DocMapToVector(query_result.documents()),
+      Vector(
+          Document{Doc("foo/bar", 0, Map("foo", "bar")).SetHasLocalMutations()},
+          Document{
+              Doc("foo/baz", 0, Map("foo", "baz")).SetHasLocalMutations()}));
 }
 
 TEST_P(LocalStoreTest, CanExecuteMixedCollectionQueries) {
@@ -1029,8 +1005,9 @@ TEST_P(LocalStoreTest, CanExecuteMixedCollectionQueries) {
   ASSERT_EQ(
       DocMapToVector(query_result.documents()),
       Vector(
-          Doc("foo/bar", 20, Map("a", "b")), Doc("foo/baz", 10, Map("a", "b")),
-          Doc("foo/bonk", 0, Map("a", "b"), DocumentState::kLocalMutations)));
+          Document{Doc("foo/bar", 20, Map("a", "b"))},
+          Document{Doc("foo/baz", 10, Map("a", "b"))},
+          Document{Doc("foo/bonk", 0, Map("a", "b")).SetHasLocalMutations()}));
 }
 
 TEST_P(LocalStoreTest, ReadsAllDocumentsForInitialCollectionQueries) {
@@ -1108,24 +1085,18 @@ TEST_P(LocalStoreTest, RemoteDocumentKeysForTarget) {
 
 TEST_P(LocalStoreTest, HandlesSetMutationThenTransformThenTransform) {
   WriteMutation(testutil::SetMutation("foo/bar", Map("sum", 0)));
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
 
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(1))}));
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
 
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(2))}));
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 3), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 3), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 3)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 3)).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest,
@@ -1136,36 +1107,28 @@ TEST_P(LocalStoreTest,
   if (IsGcEager()) return;
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("sum", 0)));
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(1);
   FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 0), DocumentState::kCommittedMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 0), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 1, Map("sum", 0)).SetHasCommittedMutations());
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 0)).SetHasCommittedMutations());
 
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(1))}));
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(2, Value(1));
   FSTAssertContains(
-      Doc("foo/bar", 2, Map("sum", 1), DocumentState::kCommittedMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("sum", 1), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 2, Map("sum", 1)).SetHasCommittedMutations());
+  FSTAssertChanged(Doc("foo/bar", 2, Map("sum", 1)).SetHasCommittedMutations());
 
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(2))}));
-  FSTAssertContains(
-      Doc("foo/bar", 2, Map("sum", 3), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("sum", 3), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 2, Map("sum", 3)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 2, Map("sum", 3)).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, UsesTargetMappingToExecuteQueries) {
@@ -1345,10 +1308,8 @@ TEST_P(LocalStoreTest,
   FSTAssertTargetID(2);
 
   WriteMutation(testutil::SetMutation("foo/bar", Map("sum", 0)));
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 0), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 0)).SetHasLocalMutations());
 
   ApplyRemoteEvent(AddedRemoteEvent(Doc("foo/bar", 1, Map("sum", 0)), {2}));
 
@@ -1358,40 +1319,32 @@ TEST_P(LocalStoreTest,
 
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(1))}));
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 
   // The value in this remote event gets ignored since we still have a pending
   // transform mutation.
   ApplyRemoteEvent(
       UpdateRemoteEvent(Doc("foo/bar", 2, Map("sum", 0)), {2}, {}));
-  FSTAssertContains(
-      Doc("foo/bar", 2, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 2, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 2, Map("sum", 1)).SetHasLocalMutations());
 
   // Add another increment. Note that we still compute the increment based on
   // the local value.
   WriteMutation(testutil::PatchMutation(
       "foo/bar", Map(), {testutil::Increment("sum", Value(2))}));
-  FSTAssertContains(
-      Doc("foo/bar", 2, Map("sum", 3), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 2, Map("sum", 3), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 2, Map("sum", 3)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 2, Map("sum", 3)).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(3, Value(1));
-  FSTAssertContains(
-      Doc("foo/bar", 3, Map("sum", 3), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 3, Map("sum", 3), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 3, Map("sum", 3)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 3, Map("sum", 3)).SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(4, Value(1339));
   FSTAssertContains(
-      Doc("foo/bar", 4, Map("sum", 1339), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 4, Map("sum", 1339)).SetHasCommittedMutations());
   FSTAssertChanged(
-      Doc("foo/bar", 4, Map("sum", 1339), DocumentState::kCommittedMutations));
+      Doc("foo/bar", 4, Map("sum", 1339)).SetHasCommittedMutations());
 }
 
 TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
@@ -1401,12 +1354,12 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
 
   WriteMutation(
       testutil::SetMutation("foo/bar", Map("sum", 0, "array_union", Array())));
-  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 0, "array_union", Array()),
-                       DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 0, "array_union", Array()))
+                       .SetHasLocalMutations());
 
   AcknowledgeMutationWithVersion(1);
-  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 0, "array_union", Array()),
-                       DocumentState::kCommittedMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 0, "array_union", Array()))
+                       .SetHasCommittedMutations());
 
   ApplyRemoteEvent(AddedRemoteEvent(
       Doc("foo/bar", 1, Map("sum", 0, "array_union", Array())), {2}));
@@ -1420,8 +1373,8 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
           {testutil::ArrayUnion("array_union", {Value("foo")})}),
   });
 
-  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1, "array_union", Array("foo")),
-                       DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1, "array_union", Array("foo")))
+                       .SetHasLocalMutations());
 
   // The sum transform is not idempotent and the backend's updated value is
   // ignored. The ArrayUnion transform is recomputed and includes the backend
@@ -1429,9 +1382,9 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
   ApplyRemoteEvent(UpdateRemoteEvent(
       Doc("foo/bar", 2, Map("sum", 1337, "array_union", Array("bar"))), {2},
       {}));
-  FSTAssertChanged(Doc("foo/bar", 2,
-                       Map("sum", 1, "array_union", Array("bar", "foo")),
-                       DocumentState::kLocalMutations));
+  FSTAssertChanged(
+      Doc("foo/bar", 2, Map("sum", 1, "array_union", Array("bar", "foo")))
+          .SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesMergeMutationWithTransformThenRemoteEvent) {
@@ -1443,17 +1396,13 @@ TEST_P(LocalStoreTest, HandlesMergeMutationWithTransformThenRemoteEvent) {
       testutil::MergeMutation("foo/bar", Map(), std::vector<model::FieldPath>(),
                               {testutil::Increment("sum", Value(1))}));
 
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
 
   ApplyRemoteEvent(AddedRemoteEvent(Doc("foo/bar", 1, Map("sum", 1337)), {2}));
 
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesPatchMutationWithTransformThenRemoteEvent) {
@@ -1471,10 +1420,8 @@ TEST_P(LocalStoreTest, HandlesPatchMutationWithTransformThenRemoteEvent) {
   // replay the mutation once we receive the first value from the remote event.
   ApplyRemoteEvent(AddedRemoteEvent(Doc("foo/bar", 1, Map("sum", 1337)), {2}));
 
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 }
 
 TEST_P(LocalStoreTest, HandlesSavingBundledDocuments) {
@@ -1553,16 +1500,12 @@ TEST_P(LocalStoreTest,
       testutil::MergeMutation("foo/bar", Map(), std::vector<model::FieldPath>(),
                               {testutil::Increment("sum", Value(1))}));
 
-  FSTAssertContains(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertChanged(
-      Doc("foo/bar", 0, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertChanged(Doc("foo/bar", 0, Map("sum", 1)).SetHasLocalMutations());
 
   ApplyBundledDocuments({Doc("foo/bar", 1, Map("sum", 1337))});
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 
   DocumentKeySet expected_keys({Key("foo/bar")});
   FSTAssertQueryDocumentMapping(4, expected_keys);
@@ -1582,10 +1525,8 @@ TEST_P(LocalStoreTest,
   FSTAssertChanged(DeletedDoc("foo/bar"));
 
   ApplyBundledDocuments({Doc("foo/bar", 1, Map("sum", 1337))});
-  FSTAssertChanged(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
-  FSTAssertContains(
-      Doc("foo/bar", 1, Map("sum", 1), DocumentState::kLocalMutations));
+  FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
+  FSTAssertContains(Doc("foo/bar", 1, Map("sum", 1)).SetHasLocalMutations());
 
   DocumentKeySet expected_keys({Key("foo/bar")});
   FSTAssertQueryDocumentMapping(4, expected_keys);


### PR DESCRIPTION
This is also part of https://github.com/firebase/firebase-ios-sdk/pull/7904. It is also best compared to Android. 

Android's `ImmutableSortedMap<DocumentKey, Document>` is a DocumentMap in this PR. `ImmutableSortedMap<DocumentKey, MutableDocument>` is a MutableDocumentMap.