### PR TITLE
Bump the minimum SwiftPM iOS version to 11.

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -15,6 +15,8 @@
   CocoaPod instead.
 - [removed] The `Firebase/MLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.
+- [changed] The Swift Package Manager distribution now requires at least iOS 11.0. The CocoaPods
+  distribution continues to support iOS 10.0.
 - [changed] The Swift Package Manager distribution now requires at least watchOS 7.0 for products
   that support watchOS. The CocoaPods distribution continues to support watchOS 6.0 with the
   exception of FirebaseDatabase.

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let firebaseVersion = "8.0.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v7)],
+  platforms: [.iOS(.v11), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -6,11 +6,14 @@ Starting with the 6.31.0 release, Firebase supports installation via [Swift
 Package Manager](https://swift.org/package-manager/) in Beta status. Exiting Beta is targeted for
 the 8.0.0 release.
 
-
-## Limitations
+## Requirements
 
 - Requires Xcode 12.5
 - Analytics requires clients to add `-ObjC` linker option.
+- See [Package.swift](Package.swift) for supported platform versions.
+
+## Limitations
+
 - Analytics is only supported for iOS and cannot be used in apps that support other platforms.
 - Performance is not yet available.
 - watchOS support is available for Auth, Crashlytics, Messaging, Realtime Database, RemoteConfig,


### PR DESCRIPTION
This is to avoid an issue with newer APIs being unable to compile when
building for device while this manifest targets iOS 10.

See https://github.com/firebase/firebase-ios-sdk/issues/7785#issuecomment-831959399
for more details on the issue and a reproduction. This should be
re-evaluated if Xcode ever fixes the issue.

This will need to be cherry-picked onto the `release-8.0` branch.