### PR TITLE
Restore Crashlytics to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,10 +64,10 @@ let package = Package(
     //   name: "FirebaseStorageCombineSwift-Beta",
     //   targets: ["FirebaseStorageCombineSwift"]
     // ),
-    // .library(
-    //   name: "FirebaseCrashlytics",
-    //   targets: ["FirebaseCrashlytics"]
-    // ),
+    .library(
+      name: "FirebaseCrashlytics",
+      targets: ["FirebaseCrashlytics"]
+    ),
     .library(
       name: "FirebaseDatabase",
       targets: ["FirebaseDatabase"]


### PR DESCRIPTION
Crashlytics was inadvertently deleted from SPM product list.

Restoring here.

And another +1 for more SPM tests ...

#no-changelog