### PR TITLE
LocalDocumentsView FieldValue migration

### DIFF
--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -50,8 +50,8 @@
 #include "Firestore/core/src/model/resource_path.h"
 #include "Firestore/core/src/model/server_timestamp_util.h"
 #include "Firestore/core/src/model/value_util.h"
-#include "Firestore/core/src/nanopb/nanopb_util.h"
 #include "Firestore/core/src/nanopb/message.h"
+#include "Firestore/core/src/nanopb/nanopb_util.h"
 #include "Firestore/core/src/util/error_apple.h"
 #include "Firestore/core/src/util/exception.h"
 #include "Firestore/core/src/util/hard_assert.h"
@@ -632,7 +632,6 @@ int32_t SaturatedLimitValue(NSInteger limit) {
       fieldValue.release();
       components.values[idx] = *fieldValue;
     }
-
   }
 
   return Bound(components, isBefore);

--- a/Firestore/core/src/local/local_documents_view.cc
+++ b/Firestore/core/src/local/local_documents_view.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/local/local_documents_view.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -25,9 +26,8 @@
 #include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/model/document_key.h"
 #include "Firestore/core/src/model/document_key_set.h"
-#include "Firestore/core/src/model/document_map.h"
+#include "Firestore/core/src/model/mutable_document.h"
 #include "Firestore/core/src/model/mutation_batch.h"
-#include "Firestore/core/src/model/no_document.h"
 #include "Firestore/core/src/model/resource_path.h"
 #include "Firestore/core/src/model/snapshot_version.h"
 #include "Firestore/core/src/util/hard_assert.h"
@@ -41,79 +41,55 @@ using model::Document;
 using model::DocumentKey;
 using model::DocumentKeySet;
 using model::DocumentMap;
-using model::MaybeDocument;
-using model::MaybeDocumentMap;
+using model::MutableDocument;
+using model::MutableDocumentMap;
 using model::Mutation;
 using model::MutationBatch;
-using model::NoDocument;
-using model::OptionalMaybeDocumentMap;
 using model::ResourcePath;
 using model::SnapshotVersion;
 
-absl::optional<MaybeDocument> LocalDocumentsView::GetDocument(
-    const DocumentKey& key) {
+const Document LocalDocumentsView::GetDocument(const DocumentKey& key) {
   std::vector<MutationBatch> batches =
       mutation_queue_->AllMutationBatchesAffectingDocumentKey(key);
   return GetDocument(key, batches);
 }
 
-absl::optional<MaybeDocument> LocalDocumentsView::GetDocument(
+Document LocalDocumentsView::GetDocument(
     const DocumentKey& key, const std::vector<MutationBatch>& batches) {
-  absl::optional<MaybeDocument> document = remote_document_cache_->Get(key);
+  MutableDocument document = remote_document_cache_->Get(key);
   for (const MutationBatch& batch : batches) {
-    document = batch.ApplyToLocalDocument(document, key);
+    batch.ApplyToLocalDocument(document);
   }
-
-  return document;
+  return Document{std::move(document)};
 }
 
-OptionalMaybeDocumentMap LocalDocumentsView::ApplyLocalMutationsToDocuments(
-    const OptionalMaybeDocumentMap& docs,
-    const std::vector<MutationBatch>& batches) {
-  OptionalMaybeDocumentMap results;
-
+DocumentMap LocalDocumentsView::ApplyLocalMutationsToDocuments(
+    MutableDocumentMap& docs, const std::vector<MutationBatch>& batches) {
+  DocumentMap results;
   for (const auto& kv : docs) {
-    const DocumentKey& key = kv.first;
-    absl::optional<MaybeDocument> local_view = kv.second;
+    MutableDocument local_view = kv.second;
     for (const MutationBatch& batch : batches) {
-      local_view = batch.ApplyToLocalDocument(local_view, key);
+      batch.ApplyToLocalDocument(local_view);
     }
-    results = results.insert(key, local_view);
+    results = results.insert(kv.first, std::move(local_view));
   }
   return results;
 }
 
-MaybeDocumentMap LocalDocumentsView::GetDocuments(const DocumentKeySet& keys) {
-  OptionalMaybeDocumentMap docs = remote_document_cache_->GetAll(keys);
-  return GetLocalViewOfDocuments(docs);
+DocumentMap LocalDocumentsView::GetDocuments(const DocumentKeySet& keys) {
+  MutableDocumentMap docs = remote_document_cache_->GetAll(keys);
+  return GetLocalViewOfDocuments(std::move(docs));
 }
 
-MaybeDocumentMap LocalDocumentsView::GetLocalViewOfDocuments(
-    const OptionalMaybeDocumentMap& base_docs) {
+DocumentMap LocalDocumentsView::GetLocalViewOfDocuments(
+    MutableDocumentMap docs) {
   DocumentKeySet all_keys;
-  for (const auto& kv : base_docs) {
+  for (const auto& kv : docs) {
     all_keys = all_keys.insert(kv.first);
   }
   std::vector<MutationBatch> batches =
       mutation_queue_->AllMutationBatchesAffectingDocumentKeys(all_keys);
-
-  OptionalMaybeDocumentMap docs =
-      ApplyLocalMutationsToDocuments(base_docs, batches);
-
-  MaybeDocumentMap results;
-  for (const auto& kv : docs) {
-    const DocumentKey& key = kv.first;
-    absl::optional<MaybeDocument> maybe_doc = kv.second;
-
-    // TODO(http://b/32275378): Don't conflate missing / deleted.
-    if (!maybe_doc) {
-      maybe_doc = NoDocument(key, SnapshotVersion::None(),
-                             /* has_committed_mutations= */ false);
-    }
-    results = results.insert(key, *maybe_doc);
-  }
-
-  return results;
+  return ApplyLocalMutationsToDocuments(docs, batches);
 }
 
 DocumentMap LocalDocumentsView::GetDocumentsMatchingQuery(
@@ -131,9 +107,9 @@ DocumentMap LocalDocumentsView::GetDocumentsMatchingDocumentQuery(
     const ResourcePath& doc_path) {
   DocumentMap result;
   // Just do a simple document lookup.
-  absl::optional<MaybeDocument> doc = GetDocument(DocumentKey{doc_path});
-  if (doc && doc->is_document()) {
-    result = result.insert(doc->key(), Document(*doc));
+  Document doc = GetDocument(DocumentKey{doc_path});
+  if (doc->is_found_document()) {
+    result = result.insert(doc->key(), doc);
   }
   return result;
 }
@@ -156,7 +132,7 @@ model::DocumentMap LocalDocumentsView::GetDocumentsMatchingCollectionGroupQuery(
         query.AsCollectionQueryAtPath(parent.Append(collection_id));
     DocumentMap collection_results =
         GetDocumentsMatchingCollectionQuery(collection_query, since_read_time);
-    for (const auto& kv : collection_results.underlying_map()) {
+    for (const auto& kv : collection_results) {
       const DocumentKey& key = kv.first;
       results = results.insert(key, Document(kv.second));
     }
@@ -166,13 +142,14 @@ model::DocumentMap LocalDocumentsView::GetDocumentsMatchingCollectionGroupQuery(
 
 DocumentMap LocalDocumentsView::GetDocumentsMatchingCollectionQuery(
     const Query& query, const SnapshotVersion& since_read_time) {
-  DocumentMap results =
+  MutableDocumentMap remote_documents =
       remote_document_cache_->GetMatching(query, since_read_time);
   // Get locally persisted mutation batches.
   std::vector<MutationBatch> matching_batches =
       mutation_queue_->AllMutationBatchesAffectingQuery(query);
 
-  results = AddMissingBaseDocuments(matching_batches, std::move(results));
+  remote_documents =
+      AddMissingBaseDocuments(matching_batches, std::move(remote_documents));
 
   for (const MutationBatch& batch : matching_batches) {
     for (const Mutation& mutation : batch.mutations()) {
@@ -184,16 +161,16 @@ DocumentMap LocalDocumentsView::GetDocumentsMatchingCollectionQuery(
       const DocumentKey& key = mutation.key();
       // base_doc may be unset for the documents that weren't yet written to
       // the backend.
-      absl::optional<MaybeDocument> base_doc =
-          results.underlying_map().get(key);
+      absl::optional<MutableDocument> document = remote_documents.get(key);
+      if (!document) {
+        // Create invalid document to apply mutations on top of
+        document = MutableDocument::InvalidDocument(key);
+        remote_documents = remote_documents.insert(key, *document);
+      }
 
-      absl::optional<MaybeDocument> mutated_doc =
-          mutation.ApplyToLocalView(base_doc, batch.local_write_time());
-
-      if (mutated_doc && mutated_doc->is_document()) {
-        results = results.insert(key, Document(*mutated_doc));
-      } else {
-        results = results.erase(key);
+      mutation.ApplyToLocalView(*document, batch.local_write_time());
+      if (!document->is_found_document()) {
+        remote_documents = remote_documents.erase(key);
       }
     }
   }
@@ -202,38 +179,39 @@ DocumentMap LocalDocumentsView::GetDocumentsMatchingCollectionQuery(
   // that the extra reference here prevents DocumentMap's destructor from
   // deallocating the initial unfiltered results while we're iterating over
   // them.
-  DocumentMap unfiltered = results;
-  for (const auto& kv : unfiltered.underlying_map()) {
+  DocumentMap results;
+  for (const auto& kv : remote_documents) {
     const DocumentKey& key = kv.first;
-    Document doc(kv.second);
-    if (!query.Matches(doc)) {
-      results = results.erase(key);
+    Document doc{std::move(kv.second)};
+    if (query.Matches(doc)) {
+      results = results.insert(key, std::move(doc));
     }
   }
 
   return results;
 }
 
-DocumentMap LocalDocumentsView::AddMissingBaseDocuments(
+MutableDocumentMap LocalDocumentsView::AddMissingBaseDocuments(
     const std::vector<MutationBatch>& matching_batches,
-    DocumentMap existing_docs) {
+    MutableDocumentMap existing_docs) {
   DocumentKeySet missing_doc_keys;
   for (const MutationBatch& batch : matching_batches) {
     for (const Mutation& mutation : batch.mutations()) {
       const DocumentKey& key = mutation.key();
       if (mutation.type() == Mutation::Type::Patch &&
-          !existing_docs.underlying_map().contains(key)) {
+          !existing_docs.contains(key)) {
         missing_doc_keys = missing_doc_keys.insert(key);
       }
     }
   }
 
-  OptionalMaybeDocumentMap missing_docs =
+  MutableDocumentMap merged_docs = existing_docs;
+  MutableDocumentMap missing_docs =
       remote_document_cache_->GetAll(missing_doc_keys);
   for (const auto& kv : missing_docs) {
-    const absl::optional<MaybeDocument>& maybe_doc = kv.second;
-    if (maybe_doc && maybe_doc->is_document()) {
-      existing_docs = existing_docs.insert(kv.first, Document(*maybe_doc));
+    const MutableDocument document = kv.second;
+    if (document.is_found_document()) {
+      existing_docs = existing_docs.insert(kv.first, document);
     }
   }
 

--- a/Firestore/core/src/local/local_documents_view.h
+++ b/Firestore/core/src/local/local_documents_view.h
@@ -31,6 +31,10 @@ namespace core {
 class Query;
 }  // namespace core
 
+namespace model {
+class Document;
+}  // namespace model
+
 namespace local {
 
 /**
@@ -57,8 +61,7 @@ class LocalDocumentsView {
    * @return Local view of the document or nil if we don't have any cached state
    * for it.
    */
-  absl::optional<model::MaybeDocument> GetDocument(
-      const model::DocumentKey& key);
+  const model::Document GetDocument(const model::DocumentKey& key);
 
   /**
    * Gets the local view of the documents identified by `keys`.
@@ -66,14 +69,14 @@ class LocalDocumentsView {
    * If we don't have cached state for a document in `keys`, a DeletedDocument
    * will be stored for that key in the resulting set.
    */
-  model::MaybeDocumentMap GetDocuments(const model::DocumentKeySet& keys);
+  model::DocumentMap GetDocuments(const model::DocumentKeySet& keys);
 
   /**
    * Similar to `GetDocuments`, but creates the local view from the given
    * `base_docs` without retrieving documents from the local store.
    */
-  model::MaybeDocumentMap GetLocalViewOfDocuments(
-      const model::OptionalMaybeDocumentMap& base_docs);
+  model::DocumentMap GetLocalViewOfDocuments(
+      model::MutableDocumentMap base_docs);
 
   /**
    * Performs a query against the local view of all documents.
@@ -90,16 +93,15 @@ class LocalDocumentsView {
   friend class CountingQueryEngine;  // For testing
 
   /** Internal version of GetDocument that allows re-using batches. */
-  absl::optional<model::MaybeDocument> GetDocument(
-      const model::DocumentKey& key,
-      const std::vector<model::MutationBatch>& batches);
+  model::Document GetDocument(const model::DocumentKey& key,
+                              const std::vector<model::MutationBatch>& batches);
 
   /**
    * Returns the view of the given `docs` as they would appear after applying
    * all mutations in the given `batches`.
    */
-  model::OptionalMaybeDocumentMap ApplyLocalMutationsToDocuments(
-      const model::OptionalMaybeDocumentMap& docs,
+  static model::DocumentMap ApplyLocalMutationsToDocuments(
+      model::MutableDocumentMap& docs,
       const std::vector<model::MutationBatch>& batches);
 
   /** Performs a simple document lookup for the given path. */
@@ -122,9 +124,9 @@ class LocalDocumentsView {
    * `PatchMutation`s will be ignored because no base document can be found, and
    * lead to missing results for the query.
    */
-  model::DocumentMap AddMissingBaseDocuments(
+  model::MutableDocumentMap AddMissingBaseDocuments(
       const std::vector<model::MutationBatch>& matching_batches,
-      model::DocumentMap existing_docs);
+      model::MutableDocumentMap existing_docs);
 
   RemoteDocumentCache* remote_document_cache() {
     return remote_document_cache_;

--- a/Firestore/core/src/local/local_documents_view.h
+++ b/Firestore/core/src/local/local_documents_view.h
@@ -31,10 +31,6 @@ namespace core {
 class Query;
 }  // namespace core
 
-namespace model {
-class Document;
-}  // namespace model
-
 namespace local {
 
 /**


### PR DESCRIPTION
LocalDocumentsView is now responsible for applying all mutations to MutableDocuments and returning them as `Document`s which can no longer be mutated.

Android link: https://github.com/firebase/firebase-android-sdk/blob/7be699f74d6effca46e765d22bd7635d78d17253/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java