### PR TITLE
Fix a directory not able to be moved

### DIFF
--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -28,15 +28,15 @@ if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
   REPO="${REPO}" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
 fi
 if [ ! -f "Firebase/Firebase.h" ]; then
-  mv "${HOME}"/ios_frameworks/Firebase/Firebase.h Firebase/
+  cp "${HOME}"/ios_frameworks/Firebase/Firebase.h Firebase/
 fi
 if [ ! -f "Firebase/module.modulemap" ]; then
-  mv "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
+  cp "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 fi
 for file in "$@"
 do
   if [ ! -f "Firebase/${file}" ]; then
-    mv -n ${file} Firebase/
+    cp -nR ${file} Firebase/
   fi
 done
 


### PR DESCRIPTION
A framework/file could be moved twice for both '${SDK}Example` and `${SDK}ExampleSwift` quickstart. Update from `mv` to `cp` to make it able to copy more than once.  #8049 