### PR TITLE
Mark SwiftPM support as Official.

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -15,7 +15,8 @@
   CocoaPod instead.
 - [removed] The `Firebase/MLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.
-- [added] The Swift Package Manager distribution is now officially supported.
+- [added] The Swift Package Manager distribution has exited beta and is now generally available for
+  use.
 - [changed] The Swift Package Manager distribution now requires at least iOS 11.0. The CocoaPods
   distribution continues to support iOS 10.0.
 - [changed] The Swift Package Manager distribution now requires at least watchOS 7.0 for products

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -15,6 +15,7 @@
   CocoaPod instead.
 - [removed] The `Firebase/MLVision` CocoaPods subspec has been removed. Use the
   `GoogleMLKit` CocoaPod instead.
+- [added] The Swift Package Manager distribution is now officially supported.
 - [changed] The Swift Package Manager distribution now requires at least iOS 11.0. The CocoaPods
   distribution continues to support iOS 10.0.
 - [changed] The Swift Package Manager distribution now requires at least watchOS 7.0 for products

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ which are utilities used by Firebase and other Google products.
 
 See the subsections below for details about the different installation methods.
 1. [Standard pod install](README.md#standard-pod-install)
-1. [Swift Package Manager (Beta)](SwiftPackageManager.md)
+1. [Swift Package Manager](SwiftPackageManager.md)
 1. [Installing from the GitHub repo](README.md#installing-from-github)
 1. [Experimental Carthage](README.md#carthage-ios-only)
 
@@ -57,10 +57,10 @@ Go to
 [https://firebase.google.com/docs/ios/setup](https://firebase.google.com/docs/ios/setup). If you
 have a new Mac with an Apple silicon chip, please see [these instructions](AppleSilicon.md).
 
-### Swift Package Manager (Beta)
+### Swift Package Manager
 
-Instructions for the Beta of [Swift Package Manager](https://swift.org/package-manager/)
-support can be found at [SwiftPackageManager.md](SwiftPackageManager.md).
+Instructions for [Swift Package Manager](https://swift.org/package-manager/) support can be
+found at [SwiftPackageManager.md](SwiftPackageManager.md).
 
 ### Installing from GitHub
 

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -1,10 +1,11 @@
-# Swift Package Manager for Firebase **Beta**
+# Swift Package Manager for Firebase
 
 ## Introduction
 
-Starting with the 6.31.0 release, Firebase supports installation via [Swift
-Package Manager](https://swift.org/package-manager/) in Beta status. Exiting Beta is targeted for
-the 8.0.0 release.
+Starting with the 8.0.0 release, Firebase officially supports installation via [Swift
+Package Manager](https://swift.org/package-manager/).
+
+Prior to version 8.0.0 (starting with version 6.31.0) support was in Beta.
 
 ## Requirements
 


### PR DESCRIPTION
This is alongside the 8.0.0 release - officially committing to support
of SwiftPM as a release mechanism for Firebase.