### PR TITLE
Fail the cmake build if reading the version from the podspec fails

### DIFF
--- a/cmake/podspec_rules.cmake
+++ b/cmake/podspec_rules.cmake
@@ -28,7 +28,7 @@ macro(podspec_version VARIABLE PODSPEC_FILE)
       FATAL_ERROR
       "Running the sed script ${PROJECT_SOURCE_DIR}/cmake/podspec_version.sed \
       on file ${PODSPEC_FILE} failed; ensure that the `sed` executable is \
-      installed and that its directoroy is present in the PATH environment \
+      installed and that its directory is present in the PATH environment \
       variable."
     )
   endif()
@@ -48,7 +48,7 @@ macro(firebase_version VARIABLE PODSPEC_FILE)
       FATAL_ERROR
       "Running the sed script ${PROJECT_SOURCE_DIR}/cmake/firebase_version.sed \
       on file ${PODSPEC_FILE} failed; ensure that the `sed` executable is \
-      installed and that its directoroy is present in the PATH environment \
+      installed and that its directory is present in the PATH environment \
       variable."
     )
   endif()

--- a/cmake/podspec_rules.cmake
+++ b/cmake/podspec_rules.cmake
@@ -23,6 +23,15 @@ macro(podspec_version VARIABLE PODSPEC_FILE)
     OUTPUT_VARIABLE ${VARIABLE}
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+  if(${VARIABLE} STREQUAL "")
+    message(
+      FATAL_ERROR
+      "Running the sed script ${PROJECT_SOURCE_DIR}/cmake/podspec_version.sed \
+      on file ${PODSPEC_FILE} failed; ensure that the `sed` executable is \
+      installed and that its directoroy is present in the PATH environment \
+      variable."
+    )
+  endif()
 endmacro()
 
 macro(firebase_version VARIABLE PODSPEC_FILE)
@@ -34,6 +43,15 @@ macro(firebase_version VARIABLE PODSPEC_FILE)
     OUTPUT_VARIABLE ${VARIABLE}
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+  if(${VARIABLE} STREQUAL "")
+    message(
+      FATAL_ERROR
+      "Running the sed script ${PROJECT_SOURCE_DIR}/cmake/firebase_version.sed \
+      on file ${PODSPEC_FILE} failed; ensure that the `sed` executable is \
+      installed and that its directoroy is present in the PATH environment \
+      variable."
+    )
+  endif()
 endmacro()
 
 function(podspec_prep_headers FRAMEWORK_NAME)


### PR DESCRIPTION
The cmake build assumes that the `sed` command is installed on the system; however, this is often not true on Windows. If the `sed` command is absent then the `FIRFirestore_VERSION` preprocessor variable is silently set to the empty string, which causes `firestore_version.cc` to fail to build.

This PR simply forces cmake to fail loudly if `sed` is not available, which is far easier to diagnose than the inevitable obscure downstream build failure.

Fixes #8066