### PR TITLE
Update Carthage distribution for 8.0.0

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -1,7 +1,5 @@
 # Firebase Carthage
 
-# **WARNING: Carthage May Be Discontinued - See [Discussion](https://github.com/firebase/firebase-ios-sdk/discussions/7129)**
-
 ## Context
 
 This page introduces and provides instructions for an **experimental** Firebase
@@ -35,6 +33,7 @@ Firebase components that you want to include in your app. Note that
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppDistributionBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json"
@@ -44,6 +43,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLModelDownloaderBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json"

--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseABTesting-885726e154cd826d.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseABTesting-2712cc2feb1f6d55.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseABTesting-d4016bb7e0c35bf2.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseABTesting-0e0b75b57559868e.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseABTesting-0e0b75b57559868e.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseABTesting-acaf9e9f1817cb03.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -57,5 +57,6 @@
   "6.8.1": "https://dl.google.com/dl/firebase/ios/carthage/6.8.1/AdMob-d76755368433e50e.zip",
   "6.9.0": "https://dl.google.com/dl/firebase/ios/carthage/6.9.0/AdMob-50597c9e7223ee44.zip",
   "7.0.0": "https://dl.google.com/dl/firebase/ios/carthage/7.0.0/Google-Mobile-Ads-SDK-57acca92672ef61b.zip",
-  "7.1.0": "https://dl.google.com/dl/firebase/ios/carthage/7.1.0/Google-Mobile-Ads-SDK-5c6542b7b9174033.zip"
+  "7.1.0": "https://dl.google.com/dl/firebase/ios/carthage/7.1.0/Google-Mobile-Ads-SDK-5c6542b7b9174033.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/Google-Mobile-Ads-SDK-665ae6f4a583c121.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -60,5 +60,6 @@
   "7.0.0": "https://dl.google.com/dl/firebase/ios/carthage/7.0.0/FirebaseAnalytics-13faccd30235aef6.zip",
   "7.1.0": "https://dl.google.com/dl/firebase/ios/carthage/7.1.0/FirebaseAnalytics-6ff5be548eef1a14.zip",
   "7.3.0": "https://dl.google.com/dl/firebase/ios/carthage/7.3.0/FirebaseAnalytics-08224b8e737b268b.zip",
-  "7.4.0": "https://dl.google.com/dl/firebase/ios/carthage/7.4.0/FirebaseAnalytics-b707977c5254fb87.zip"
+  "7.4.0": "https://dl.google.com/dl/firebase/ios/carthage/7.4.0/FirebaseAnalytics-b707977c5254fb87.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAnalytics-f0ef93c2b7eb9e33.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -1,2 +1,3 @@
 {
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppCheck-9ef1d217cf057203.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -12,5 +12,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseAppDistribution-2b4aa616703f4975.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseAppDistribution-110714a045f752bb.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseAppDistribution-66a1918322f1d208.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseAppDistribution-1a0219daa98184c1.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseAppDistribution-1a0219daa98184c1.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppDistribution-cff93abcd0bcc51c.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseAuth-9c0d43a1be8a09ac.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseAuth-5910ec72c7d625c4.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseAuth-d73c5a44b4e92631.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseAuth-d72f822f48030396.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseAuth-d72f822f48030396.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAuth-a7045e1dd08c2918.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -26,5 +26,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseCrashlytics-4e160db3e43c6207.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseCrashlytics-ee0212b959ac53af.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseCrashlytics-8ffe708337c31adb.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseCrashlytics-7b78fe4fd5db684c.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseCrashlytics-7b78fe4fd5db684c.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseCrashlytics-0b2006e8c1266f26.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseDatabase-f28fee7ce2d91801.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseDatabase-175d9e50c3b71b30.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseDatabase-5b8ac0f6ed9fe5ea.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseDatabase-94b87a6933636c21.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseDatabase-94b87a6933636c21.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseDatabase-29c3cbe67dac2b49.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseDynamicLinks-f7f041a920e23c3f.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseDynamicLinks-1dc89b25df3ee039.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseDynamicLinks-035d13e639a42cba.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseDynamicLinks-3265c6c3d3830db1.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseDynamicLinks-3265c6c3d3830db1.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseDynamicLinks-36c7657713d9e37d.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -67,5 +67,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseFirestore-b091240a18b2a168.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseFirestore-f449afca45e45a59.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseFirestore-79abcc00e58832ae.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseFirestore-171c65fcda202ac1.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseFirestore-171c65fcda202ac1.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseFirestore-6c7035fccbea27c0.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -64,5 +64,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseFunctions-467b5092ce0270fe.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseFunctions-3d1da3607016b4be.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseFunctions-4130cfda8bc2fbdb.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseFunctions-c41b84f579e98f85.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseFunctions-c41b84f579e98f85.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseFunctions-0a044bc62abb35ee.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -42,5 +42,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/GoogleSignIn-1636a9ad3669f722.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/GoogleSignIn-78819bde13bd6479.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/GoogleSignIn-d5dff491eaf67a7e.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/GoogleSignIn-209f7fcaf46ef01c.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/GoogleSignIn-209f7fcaf46ef01c.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/GoogleSignIn-83c079298ea5200b.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -54,5 +54,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseInAppMessaging-54050590a3e5d0f8.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseInAppMessaging-6db8e44a41a3d1db.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseInAppMessaging-f9be0a0cff49059d.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseInAppMessaging-f196e41b6ad1d348.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseInAppMessaging-f196e41b6ad1d348.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseInAppMessaging-7bb7459ed9f4d27d.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -1,2 +1,3 @@
 {
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMLModelDownloader-8f972757fb181320.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseMessaging-2c95f76f4fcd0d82.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseMessaging-85982036ad9f6d2c.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseMessaging-5fbeafb6d91b1e29.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseMessaging-0de4c5bf673a7052.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseMessaging-0de4c5bf673a7052.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMessaging-81be6b17214fe3d7.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -64,5 +64,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebasePerformance-da211c9d979f25e0.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebasePerformance-a90d25f23111f8dd.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebasePerformance-c42e77118c8b4689.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebasePerformance-e08197cf01f9319f.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebasePerformance-e08197cf01f9319f.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebasePerformance-922f579c8e605459.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseRemoteConfig-c1277debf683070a.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseRemoteConfig-f1ff5abf97a49deb.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseRemoteConfig-5774eaf72ab4cd58.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseRemoteConfig-10ebd4888b91c8f1.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseRemoteConfig-10ebd4888b91c8f1.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseRemoteConfig-a87a1dbfeadde790.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -65,5 +65,6 @@
   "7.5.0": "https://dl.google.com/dl/firebase/ios/carthage/7.5.0/FirebaseStorage-ef46729ad6576351.zip",
   "7.6.0": "https://dl.google.com/dl/firebase/ios/carthage/7.6.0/FirebaseStorage-edab02bc99437b4c.zip",
   "7.7.0": "https://dl.google.com/dl/firebase/ios/carthage/7.7.0/FirebaseStorage-f29ababab558a52d.zip",
-  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseStorage-cde6030474b7a1fd.zip"
+  "7.8.0": "https://dl.google.com/dl/firebase/ios/carthage/7.8.0/FirebaseStorage-cde6030474b7a1fd.zip",
+  "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseStorage-77cf411dfc43ee13.zip"
 }


### PR DESCRIPTION
This PR is the resulting build distribution from the fixes in #8084

Fix #7039
Fix #7576

Will publish the Carthage update when #8084 and this PR are approved.

Testing:
Unzipped the archive from https://github.com/firebase/firebase-ios-sdk/actions/runs/845683211

Edited the json files in a local directory:

<img width="1439" alt="Screen Shot 2021-05-15 at 5 57 09 PM" src="https://user-images.githubusercontent.com/73870/118382616-46b1ec80-b5ac-11eb-87f2-5c27af8e9d3a.png">

Edited the sample in Carthage.md like

<img width="1116" alt="Screen Shot 2021-05-15 at 6 14 40 PM" src="https://user-images.githubusercontent.com/73870/118382647-57626280-b5ac-11eb-9087-cb72e5c040e7.png">

Verified `carthage update` succeeded.
