### PR TITLE
FirebaseCombineSwift: Docs & API cleanup

### DIFF
--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -440,7 +440,7 @@
       ///   protocol. This is used for presenting the web context. If `nil`, a default `AuthUIDelegate`
       ///   will be used.
       /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
-      ///   successfully, or an error otherwise.
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
       /// - Remark: Possible error codes:
       ///   - `AuthErrorCodeOperationNotAllowed` - Indicates that email and password accounts are not enabled.
       ///     Enable them in the Auth section of the Firebase console.

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -469,7 +469,7 @@
         }
       }
 
-    #endif  // os(iOS) || targetEnvironment(macCatalyst)
+    #endif // os(iOS) || targetEnvironment(macCatalyst)
 
     /// Asynchronously signs in to Firebase with the given Auth token.
     ///

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -26,7 +26,7 @@
     ///
     /// The publisher emits values when:
     ///
-    /// - A user is registered,
+    /// - It is registered,
     /// - a user with a different UID from the current user has signed in, or
     /// - the current user has signed out.
     ///
@@ -50,7 +50,7 @@
     ///
     /// The publisher emits values when:
     ///
-    /// - A user is registered,
+    /// - It is registered,
     /// - a user with a different UID from the current user has signed in,
     /// - the ID token of the current user has been refreshed, or
     /// - the current user has signed out.

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -26,9 +26,9 @@
     ///
     /// The publisher emits values when:
     ///
-    /// - It is registered,
-    /// - A user with a different UID from the current user has signed in, or
-    /// - The current user has signed out.
+    /// - A user is registered,
+    /// - a user with a different UID from the current user has signed in, or
+    /// - the current user has signed out.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
@@ -49,14 +49,14 @@
     ///
     /// The publisher emits values when:
     ///
-    /// - It is registered,
-    /// - A user with a different UID from the current user has signed in,
-    /// - The ID token of the current user has been refreshed, or
-    /// - The current user has signed out.
+    /// - A user is registered,
+    /// - a user with a different UID from the current user has signed in,
+    /// - the ID token of the current user has been refreshed, or
+    /// - the current user has signed out.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `User` instance (if a different user as signed in or
+    /// - Returns: A publisher emitting a `User` instance (if a different user is signed in or
     ///   the ID token of the current user has changed) or `nil` (if the user has signed out)
     public func idTokenDidChangePublisher() -> AnyPublisher<User?, Never> {
       let subject = PassthroughSubject<User?, Never>()
@@ -70,13 +70,13 @@
         .eraseToAnyPublisher()
     }
 
-    /// Sets the currentUser on the calling Auth instance to the provided user object.
+    /// Sets the `currentUser` on the calling Auth instance to the provided `User` instance.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter user: The user object to be set as the current user of the calling Auth instance.
-    /// - Returns: A publisher that emits as soon as the user of the calling Auth instance has been
-    ///   updated or an error was encountered. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits when the user of the calling Auth instance has changed
+    ///   or an error was encountered. The publisher will emit on the **main** thread.
     @discardableResult
     public func updateCurrentUser(_ user: User) -> Future<Void, Error> {
       Future<Void, Error> { promise in
@@ -92,7 +92,7 @@
 
     // MARK: - Anonymous Authentication
 
-    /// Asynchronously creates and becomes an anonymous user.
+    /// Asynchronously creates an anonymous user and assigns it as the calling Auth instance's current user.
     ///
     /// If there is already an anonymous user signed in, that user will be returned instead.
     /// If there is any other existing user signed in, that user will be signed out.
@@ -156,13 +156,13 @@
       }
     }
 
-    /// Signs in using an email address and password.
+    /// Signs in a user with the given email address and password.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameters:
     ///   - email: The user's email address.
-    ///   - password: The user's desired password.
+    ///   - password: The user's password.
     /// - Returns: A publisher that emits the result of the sign in flow.
     /// - Remark:
     ///   Possible error codes:
@@ -208,6 +208,7 @@
     ///   - `AuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
+    @available(watchOS, unavailable)
     @discardableResult
     public func signIn(withEmail email: String,
                        link: String) -> Future<AuthDataResult, Error> {
@@ -231,6 +232,7 @@
     ///   - actionCodeSettings: An `ActionCodeSettings` object containing settings related to
     ///     handling action codes.
     /// - Returns: A publisher that emits whether the call was successful or not.
+    @available(watchOS, unavailable)
     @discardableResult
     public func sendSignInLink(toEmail email: String,
                                actionCodeSettings: ActionCodeSettings) -> Future<Void, Error> {
@@ -277,7 +279,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameters:
-    ///   - code: Out-of-band code given to the user outside of the app.
+    ///   - code: Out-of-band (OOB) code given to the user outside of the app.
     ///   - newPassword: The new password.
     /// - Returns: A publisher that emits whether the call was successful or not.
     /// - Remark: Possible error codes:
@@ -326,8 +328,8 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter code: The out of band code to check validity.
-    /// - Returns: A publisher that emits an error if the code could not be verified. If the code could be
-    ///   verified, the publisher will emit the email address of the account the code was issued for.
+    /// - Returns: A publisher that emits the email address of the account the code was issued for or an error if
+    ///   the code could not be verified.
     @discardableResult
     public func checkActionCode(code: String) -> Future<ActionCodeInfo, Error> {
       Future<ActionCodeInfo, Error> { promise in
@@ -345,10 +347,10 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Parameter code: The out of band code to be applied.
+    /// - Parameter code: The out-of-band code to be applied.
     /// - Returns: A publisher that emits an error if the code could not be applied.
-    /// - Remark: This method will not work for out of band codes which require an additional parameter,
-    ///   such as password reset code.
+    /// - Remark: This method will not work for out-of-band codes which require an additional parameter,
+    ///   such as password reset codes.
     @discardableResult
     public func applyActionCode(code: String) -> Future<Void, Error> {
       Future<Void, Error> { promise in
@@ -392,7 +394,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter email: The email address of the user.
-    /// - Parameter actionCodeSettings: An `ActionCodeSettings` object containing settings related t handling action codes.
+    /// - Parameter actionCodeSettings: An `ActionCodeSettings` object containing settings related to handling action codes.
     /// - Returns: A publisher that emits whether the call was successful or not.
     /// - Remark: Possible error codes:
     ///   - `AuthErrorCodeInvalidRecipientEmail` - Indicates an invalid recipient email was sent in the request.
@@ -420,7 +422,7 @@
 
     // MARK: - Other Authentication providers
 
-    #if !os(tvOS) && !os(macOS)
+    #if os(iOS) || targetEnvironment(macCatalyst)
 
       /// Signs in using the provided auth provider instance.
       ///
@@ -428,11 +430,11 @@
       ///
       /// - Parameters:
       ///   - provider: An instance of an auth provider used to initiate the sign-in flow.
-      ///   - uiDelegate: Optionally an instance of a class conforming to the `AuthUIDelegate`
+      ///   - uiDelegate: Optionally, an instance of a class conforming to the `AuthUIDelegate`
       ///   protocol. This is used for presenting the web context. If `nil`, a default `AuthUIDelegate`
       ///   will be used.
       /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
-      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+      ///   successfully, or an error otherwise.
       /// - Remark: Possible error codes:
       ///   - `AuthErrorCodeOperationNotAllowed` - Indicates that email and password accounts are not enabled.
       ///     Enable them in the Auth section of the Firebase console.
@@ -467,7 +469,7 @@
         }
       }
 
-    #endif
+    #endif  // os(iOS) || targetEnvironment(macCatalyst)
 
     /// Asynchronously signs in to Firebase with the given Auth token.
     ///
@@ -545,4 +547,5 @@
       }
     }
   }
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -18,7 +18,7 @@
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
   extension Auth {
     // MARK: - Authentication State Management
 
@@ -32,7 +32,8 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `User` instance (if the user has signed in) or `nil` (if the user has signed out)
+    /// - Returns: A publisher emitting a `User` instance (if the user has signed in) or `nil` (if the user has signed out).
+    /// The publisher will emit on the *main* thread.
     public func authStateDidChangePublisher() -> AnyPublisher<User?, Never> {
       let subject = PassthroughSubject<User?, Never>()
       let handle = addStateDidChangeListener { auth, user in
@@ -57,7 +58,8 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher emitting a `User` instance (if a different user is signed in or
-    ///   the ID token of the current user has changed) or `nil` (if the user has signed out)
+    ///   the ID token of the current user has changed) or `nil` (if the user has signed out).
+    ///   The publisher will emit on the *main* thread.
     public func idTokenDidChangePublisher() -> AnyPublisher<User?, Never> {
       let subject = PassthroughSubject<User?, Never>()
       let handle = addIDTokenDidChangeListener { auth, user in
@@ -70,7 +72,7 @@
         .eraseToAnyPublisher()
     }
 
-    /// Sets the `currentUser` on the calling Auth instance to the provided `User` instance.
+    /// Sets the `currentUser` on the calling Auth instance to the provided `user` object.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
@@ -99,7 +101,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher that emits the result of the sign in flow.
+    /// - Returns: A publisher that emits the result of the sign in flow. The publisher will emit on the *main* thread.
     /// - Remark:
     ///   Possible error codes:
     ///   - `AuthErrorCodeOperationNotAllowed` - Indicates that anonymous accounts are
@@ -128,7 +130,7 @@
     /// - Parameters:
     ///   - email: The user's email address.
     ///   - password: The user's desired password.
-    /// - Returns: A publisher that emits the result of the sign in flow.
+    /// - Returns: A publisher that emits the result of the sign in flow. The publisher will emit on the *main* thread.
     /// - Remark:
     ///   Possible error codes:
     ///   - `AuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
@@ -163,7 +165,7 @@
     /// - Parameters:
     ///   - email: The user's email address.
     ///   - password: The user's password.
-    /// - Returns: A publisher that emits the result of the sign in flow.
+    /// - Returns: A publisher that emits the result of the sign in flow. The publisher will emit on the *main* thread.
     /// - Remark:
     ///   Possible error codes:
     ///   - `AuthErrorCodeOperationNotAllowed` - Indicates that email and password
@@ -198,7 +200,7 @@
     /// - Parameters:
     ///   - email: The user's email address.
     ///   - link: The email sign-in link.
-    /// - Returns: A publisher that emits the result of the sign in flow.
+    /// - Returns: A publisher that emits the result of the sign in flow. The publisher will emit on the *main* thread.
     /// - Remark:
     ///   Possible error codes:
     ///   - `AuthErrorCodeOperationNotAllowed` - Indicates that email and password
@@ -231,7 +233,7 @@
     ///   - email: The email address of the user.
     ///   - actionCodeSettings: An `ActionCodeSettings` object containing settings related to
     ///     handling action codes.
-    /// - Returns: A publisher that emits whether the call was successful or not.
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     @available(watchOS, unavailable)
     @discardableResult
     public func sendSignInLink(toEmail email: String,
@@ -255,7 +257,7 @@
     ///
     /// - Parameter email: The email address for which to obtain a list of sign-in methods.
     /// - Returns: A publisher that emits a list of sign-in methods for the specified email
-    ///   address, or an error if one occurred.
+    ///   address, or an error if one occurred. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
     ///   - `AuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
     ///
@@ -281,10 +283,10 @@
     /// - Parameters:
     ///   - code: Out-of-band (OOB) code given to the user outside of the app.
     ///   - newPassword: The new password.
-    /// - Returns: A publisher that emits whether the call was successful or not.
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
     ///   - `AuthErrorCodeWeakPassword` - Indicates an attempt to set a password that is considered too weak.
-    ///   - `AuthErrorCodeOperationNotAllowed` - Indicates the administrator disabled sign in with the specified identity provider.
+    ///   - `AuthErrorCodeOperationNotAllowed` - Indicates the admin disabled sign in with the specified identity provider.
     ///   - `AuthErrorCodeExpiredActionCode` - Indicates the OOB code is expired.
     ///   - `AuthErrorCodeInvalidActionCode` - Indicates the OOB code is invalid.
     ///
@@ -310,6 +312,7 @@
     /// - Parameter code: The password reset code to be verified.
     /// - Returns: A publisher that emits an error if the code could not be verified. If the code could be
     ///   verified, the publisher will emit the email address of the account the code was issued for.
+    ///   The publisher will emit on the *main* thread.
     @discardableResult
     public func verifyPasswordResetCode(_ code: String) -> Future<String, Error> {
       Future<String, Error> { promise in
@@ -329,7 +332,7 @@
     ///
     /// - Parameter code: The out of band code to check validity.
     /// - Returns: A publisher that emits the email address of the account the code was issued for or an error if
-    ///   the code could not be verified.
+    ///   the code could not be verified. The publisher will emit on the *main* thread.
     @discardableResult
     public func checkActionCode(code: String) -> Future<ActionCodeInfo, Error> {
       Future<ActionCodeInfo, Error> { promise in
@@ -347,8 +350,8 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Parameter code: The out-of-band code to be applied.
-    /// - Returns: A publisher that emits an error if the code could not be applied.
+    /// - Parameter code: The out-of-band (OOB) code to be applied.
+    /// - Returns: A publisher that emits an error if the code could not be applied. The publisher will emit on the *main* thread.
     /// - Remark: This method will not work for out-of-band codes which require an additional parameter,
     ///   such as password reset codes.
     @discardableResult
@@ -369,7 +372,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter email: The email address of the user.
-    /// - Returns: A publisher that emits whether the call was successful or not.
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
     ///   - `AuthErrorCodeInvalidRecipientEmail` - Indicates an invalid recipient email was sent in the request.
     ///   - `AuthErrorCodeInvalidSender` - Indicates an invalid sender email is set in the console for this action.
@@ -394,15 +397,19 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter email: The email address of the user.
-    /// - Parameter actionCodeSettings: An `ActionCodeSettings` object containing settings related to handling action codes.
-    /// - Returns: A publisher that emits whether the call was successful or not.
+    /// - Parameter actionCodeSettings: An `ActionCodeSettings` object containing settings related to
+    /// handling action codes.
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
     ///   - `AuthErrorCodeInvalidRecipientEmail` - Indicates an invalid recipient email was sent in the request.
     ///   - `AuthErrorCodeInvalidSender` - Indicates an invalid sender email is set in the console for this action.
     ///   - `AuthErrorCodeInvalidMessagePayload` - Indicates an invalid email template for sending update email.
-    ///   - `AuthErrorCodeMissingIosBundleID` - Indicates that the iOS bundle ID is missing when `handleCodeInApp` is set to YES.
-    ///   - `AuthErrorCodeMissingAndroidPackageName` - Indicates that the android package name is missing when the `androidInstallApp` flag is set to true.
-    ///   - `AuthErrorCodeUnauthorizedDomain` - Indicates that the domain specified in the continue URL is not whitelisted in the Firebase console.
+    ///   - `AuthErrorCodeMissingIosBundleID` - Indicates that the iOS bundle ID is missing
+    ///   when `handleCodeInApp` is set to YES.
+    ///   - `AuthErrorCodeMissingAndroidPackageName` - Indicates that the android package name is missing
+    ///   when the `androidInstallApp` flag is set to true.
+    ///   - `AuthErrorCodeUnauthorizedDomain` - Indicates that the domain specified in the continue URL is not whitelisted
+    ///    in the Firebase console.
     ///   - `AuthErrorCodeInvalidContinueURI` - Indicates that the domain specified in the continue URI is not valid.
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
@@ -423,7 +430,6 @@
     // MARK: - Other Authentication providers
 
     #if os(iOS) || targetEnvironment(macCatalyst)
-
       /// Signs in using the provided auth provider instance.
       ///
       /// The publisher will emit events on the **main** thread.
@@ -468,7 +474,6 @@
           }
         }
       }
-
     #endif // os(iOS) || targetEnvironment(macCatalyst)
 
     /// Asynchronously signs in to Firebase with the given Auth token.
@@ -548,4 +553,4 @@
     }
   }
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -77,8 +77,8 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter user: The user object to be set as the current user of the calling Auth instance.
-    /// - Returns: A publisher that emits when the user of the calling Auth instance has changed
-    ///   or an error was encountered. The publisher will emit on the **main** thread.
+    /// - Returns: A publisher that emits when the user of the calling Auth instance has been updated or
+    /// an error was encountered. The publisher will emit on the **main** thread.
     @discardableResult
     public func updateCurrentUser(_ user: User) -> Future<Void, Error> {
       Future<Void, Error> { promise in

--- a/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
@@ -18,7 +18,7 @@
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, *)
+  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
   @available(watchOS, unavailable)
   extension GameCenterAuthProvider {
     /// Creates an `AuthCredential` for a Game Center sign in.
@@ -40,4 +40,4 @@
     }
   }
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
@@ -26,7 +26,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher that emits an `AuthCredential` when the credential is obtained
-    ///   successfully, or an error otherwise.
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     public class func getCredential() -> Future<AuthCredential, Error> {
       Future<AuthCredential, Error> { promise in
         self.getCredential { authCredential, error in

--- a/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/GameCenterAuthProvider+Combine.swift
@@ -18,15 +18,15 @@
   import FirebaseAuth
 
   @available(swift 5.0)
+  @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, *)
   @available(watchOS, unavailable)
-  @available(macOS 10.15, iOS 13, tvOS 13, *)
   extension GameCenterAuthProvider {
-    /// Creates a `AuthCredential` for a Game Center sign in.
+    /// Creates an `AuthCredential` for a Game Center sign in.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher that emits an `AuthCredential` when the credential is obtained
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///   successfully, or an error otherwise.
     public class func getCredential() -> Future<AuthCredential, Error> {
       Future<AuthCredential, Error> { promise in
         self.getCredential { authCredential, error in

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -20,7 +20,7 @@
     import FirebaseAuth
 
     @available(swift 5.0)
-    @available(iOS 13, macCatalyst 13, *)
+    @available(iOS 13.0, macCatalyst 13.0, *)
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -30,7 +30,8 @@
       /// The publisher will emit events on the **main** thread.
       ///
       /// - Returns: A publisher that emits a `MultiFactorSession` for a second factor
-      ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
+      ///   enrollment operation. This is used to identify the current user trying to enroll a second factor. The publisher will emit on
+      ///   the *main* thread.
       @discardableResult
       public func getSession() -> Future<MultiFactorSession, Error> {
         Future<MultiFactorSession, Error> { promise in
@@ -53,7 +54,7 @@
       ///     - assertion: The base class for asserting ownership of a second factor.
       ///     - displayName: An optional display name associated with the multi factor to enroll.
       ///
-      /// - Returns: A publisher that emits whether the call was successful or not.
+      /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
       @discardableResult
       public func enroll(with assertion: MultiFactorAssertion,
                          displayName: String?) -> Future<Void, Error> {
@@ -73,7 +74,8 @@
       /// The publisher will emit events on the **main** thread.
       ///
       /// - Parameter factorInfo: The structure used to represent a second factor entity from a client perspective.
-      /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
+      /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete. The publisher
+      /// will emit on the *main* thread.
       @discardableResult
       public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
         Future<Void, Error> { promise in
@@ -92,6 +94,7 @@
       /// The publisher will emit events on the **main** thread.
       ///
       /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
+      /// The publisher will emit on the *main* thread.
       @discardableResult
       public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
         Future<Void, Error> { promise in
@@ -108,4 +111,4 @@
 
   #endif // os(iOS) || targetEnvironment(macCatalyst)
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth) && !os(tvOS) && !os(macOS)
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+#if os(iOS) || targetEnvironment(macCatalyst)
 
   import Combine
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(iOS 13, watchOS 6, *)
-  @available(tvOS, unavailable)
+  @available(iOS 13, macCatalyst 13, *)
   @available(macOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   extension MultiFactor {
     /// Get a session for a second factor enrollment operation.
     ///
@@ -28,7 +31,6 @@
     ///
     /// - Returns: A publisher that emits a `MultiFactorSession` for a second factor
     ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
-    ///   The publisher will emit on the *main* thread.
     @discardableResult
     public func getSession() -> Future<MultiFactorSession, Error> {
       Future<MultiFactorSession, Error> { promise in
@@ -51,7 +53,7 @@
     ///     - assertion: The base class for asserting ownership of a second factor.
     ///     - displayName: An optional display name associated with the multi factor to enroll.
     ///
-    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits whether the call was successful or not.
     @discardableResult
     public func enroll(with assertion: MultiFactorAssertion,
                        displayName: String?) -> Future<Void, Error> {
@@ -71,7 +73,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter factorInfo: The structure used to represent a second factor entity from a client perspective.
-    /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
     @discardableResult
     public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
       Future<Void, Error> { promise in
@@ -89,7 +91,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher that emits when the request to send the verification email is complete. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
     @discardableResult
     public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
       Future<Void, Error> { promise in
@@ -103,4 +105,7 @@
       }
     }
   }
+
+#endif  // os(iOS) || targetEnvironment(macCatalyst)
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactor+Combine.swift
@@ -14,98 +14,98 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-#if os(iOS) || targetEnvironment(macCatalyst)
+  #if os(iOS) || targetEnvironment(macCatalyst)
 
-  import Combine
-  import FirebaseAuth
+    import Combine
+    import FirebaseAuth
 
-  @available(swift 5.0)
-  @available(iOS 13, macCatalyst 13, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension MultiFactor {
-    /// Get a session for a second factor enrollment operation.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Returns: A publisher that emits a `MultiFactorSession` for a second factor
-    ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
-    @discardableResult
-    public func getSession() -> Future<MultiFactorSession, Error> {
-      Future<MultiFactorSession, Error> { promise in
-        self.getSessionWithCompletion { session, error in
-          if let session = session {
-            promise(.success(session))
-          } else if let error = error {
-            promise(.failure(error))
+    @available(swift 5.0)
+    @available(iOS 13, macCatalyst 13, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension MultiFactor {
+      /// Get a session for a second factor enrollment operation.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Returns: A publisher that emits a `MultiFactorSession` for a second factor
+      ///   enrollment operation. This is used to identify the current user trying to enroll a second factor.
+      @discardableResult
+      public func getSession() -> Future<MultiFactorSession, Error> {
+        Future<MultiFactorSession, Error> { promise in
+          self.getSessionWithCompletion { session, error in
+            if let session = session {
+              promise(.success(session))
+            } else if let error = error {
+              promise(.failure(error))
+            }
+          }
+        }
+      }
+
+      /// Enrolls a second factor as identified by the `MultiFactorAssertion` parameter for the
+      /// current user.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameters:
+      ///     - assertion: The base class for asserting ownership of a second factor.
+      ///     - displayName: An optional display name associated with the multi factor to enroll.
+      ///
+      /// - Returns: A publisher that emits whether the call was successful or not.
+      @discardableResult
+      public func enroll(with assertion: MultiFactorAssertion,
+                         displayName: String?) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+          self.enroll(with: assertion, displayName: displayName) { error in
+            if let error = error {
+              promise(.failure(error))
+            } else {
+              promise(.success(()))
+            }
+          }
+        }
+      }
+
+      /// Unenroll the given multi factor.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameter factorInfo: The structure used to represent a second factor entity from a client perspective.
+      /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
+      @discardableResult
+      public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+          self.unenroll(with: factorInfo) { error in
+            if let error = error {
+              promise(.failure(error))
+            } else {
+              promise(.success(()))
+            }
+          }
+        }
+      }
+
+      /// Unenroll the given multi factor.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
+      @discardableResult
+      public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
+        Future<Void, Error> { promise in
+          self.unenroll(withFactorUID: factorUID) { error in
+            if let error = error {
+              promise(.failure(error))
+            } else {
+              promise(.success(()))
+            }
           }
         }
       }
     }
 
-    /// Enrolls a second factor as identified by the `MultiFactorAssertion` parameter for the
-    /// current user.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameters:
-    ///     - assertion: The base class for asserting ownership of a second factor.
-    ///     - displayName: An optional display name associated with the multi factor to enroll.
-    ///
-    /// - Returns: A publisher that emits whether the call was successful or not.
-    @discardableResult
-    public func enroll(with assertion: MultiFactorAssertion,
-                       displayName: String?) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.enroll(with: assertion, displayName: displayName) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
-    }
-
-    /// Unenroll the given multi factor.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameter factorInfo: The structure used to represent a second factor entity from a client perspective.
-    /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
-    @discardableResult
-    public func unenroll(with factorInfo: MultiFactorInfo) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.unenroll(with: factorInfo) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
-    }
-
-    /// Unenroll the given multi factor.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Returns: A publisher that emits when the request to send the unenrollment verification email is complete.
-    @discardableResult
-    public func unenroll(withFactorUID factorUID: String) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.unenroll(withFactorUID: factorUID) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
-    }
-  }
-
-#endif  // os(iOS) || targetEnvironment(macCatalyst)
+  #endif // os(iOS) || targetEnvironment(macCatalyst)
 
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -14,37 +14,37 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-#if os(iOS) || targetEnvironment(macCatalyst)
+  #if os(iOS) || targetEnvironment(macCatalyst)
 
-  import Combine
-  import FirebaseAuth
+    import Combine
+    import FirebaseAuth
 
-  @available(swift 5.0)
-  @available(iOS 13, macCatalyst 13, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension MultiFactorResolver {
-    /// A helper function that helps users sign in with a second factor using a `MultiFactorAssertion`.
-    /// This assertion confirms that the user has successfully enabled the second factor.
-    ///
-    /// - Parameter assertion: The base class for asserting ownership of a second factor.
-    /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
-    ///   successfully, or an error otherwise.
-    public func resolveSignIn(with assertion: MultiFactorAssertion)
-      -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.resolveSignIn(with: assertion) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
+    @available(swift 5.0)
+    @available(iOS 13, macCatalyst 13, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension MultiFactorResolver {
+      /// A helper function that helps users sign in with a second factor using a `MultiFactorAssertion`.
+      /// This assertion confirms that the user has successfully enabled the second factor.
+      ///
+      /// - Parameter assertion: The base class for asserting ownership of a second factor.
+      /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
+      ///   successfully, or an error otherwise.
+      public func resolveSignIn(with assertion: MultiFactorAssertion)
+        -> Future<AuthDataResult, Error> {
+        Future<AuthDataResult, Error> { promise in
+          self.resolveSignIn(with: assertion) { authDataResult, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let authDataResult = authDataResult {
+              promise(.success(authDataResult))
+            }
           }
         }
       }
     }
-  }
 
-#endif  // os(iOS) || targetEnvironment(macCatalyst)
+  #endif // os(iOS) || targetEnvironment(macCatalyst)
 
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -20,7 +20,7 @@
     import FirebaseAuth
 
     @available(swift 5.0)
-    @available(iOS 13, macCatalyst 13, *)
+    @available(iOS 13.0, macCatalyst 13.0, *)
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -30,7 +30,7 @@
       ///
       /// - Parameter assertion: The base class for asserting ownership of a second factor.
       /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
-      ///   successfully, or an error otherwise.
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
       public func resolveSignIn(with assertion: MultiFactorAssertion)
         -> Future<AuthDataResult, Error> {
         Future<AuthDataResult, Error> { promise in
@@ -47,4 +47,4 @@
 
   #endif // os(iOS) || targetEnvironment(macCatalyst)
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -26,7 +26,7 @@
     @available(watchOS, unavailable)
     extension MultiFactorResolver {
       /// A helper function that helps users sign in with a second factor using a `MultiFactorAssertion`.
-      /// This assertion confirms that the user has successfully enabled the second factor.
+      /// This assertion confirms that the user has successfully completed the second factor.
       ///
       /// - Parameter assertion: The base class for asserting ownership of a second factor.
       /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth) && !os(tvOS) && !os(macOS)
-  import Foundation
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+#if os(iOS) || targetEnvironment(macCatalyst)
 
   import Combine
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(iOS 13, watchOS 6, *)
-  @available(tvOS, unavailable)
+  @available(iOS 13, macCatalyst 13, *)
   @available(macOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   extension MultiFactorResolver {
-    /// A helper function to help users complete sign in with a second factor using an
-    /// `MultiFactorAssertion` confirming the user successfully completed the second factor
+    /// A helper function that helps users sign in with a second factor using a `MultiFactorAssertion`.
+    /// This assertion confirms that the user has successfully enabled the second factor.
     ///
     /// - Parameter assertion: The base class for asserting ownership of a second factor.
     /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
@@ -42,4 +44,7 @@
       }
     }
   }
+
+#endif  // os(iOS) || targetEnvironment(macCatalyst)
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
@@ -20,7 +20,7 @@
     import FirebaseAuth
 
     @available(swift 5.0)
-    @available(iOS 13, macCatalyst 13, *)
+    @available(iOS 13.0, macCatalyst 13.0, *)
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -48,4 +48,4 @@
 
   #endif // os(iOS) || targetEnvironment(macCatalyst)
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth) && !os(tvOS) && !os(macOS)
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+#if os(iOS) || targetEnvironment(macCatalyst)
 
   import Combine
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(iOS 13, watchOS 6, *)
-  @available(tvOS, unavailable)
+  @available(iOS 13, macCatalyst 13, *)
   @available(macOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   extension OAuthProvider {
     /// Used to obtain an auth credential via a mobile web flow.
     ///
@@ -41,4 +44,7 @@
       }
     }
   }
+
+#endif  // os(iOS) || targetEnvironment(macCatalyst)
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/OAuthProvider+Combine.swift
@@ -14,37 +14,38 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-#if os(iOS) || targetEnvironment(macCatalyst)
+  #if os(iOS) || targetEnvironment(macCatalyst)
 
-  import Combine
-  import FirebaseAuth
+    import Combine
+    import FirebaseAuth
 
-  @available(swift 5.0)
-  @available(iOS 13, macCatalyst 13, *)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension OAuthProvider {
-    /// Used to obtain an auth credential via a mobile web flow.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameter uiDelegate: An optional UI delegate used to presenet the mobile web flow.
-    /// - Returns: A publisher that emits an `AuthCredential` when the credential is obtained
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
-    public func getCredentialWith(_ uiDelegate: AuthUIDelegate?) -> Future<AuthCredential, Error> {
-      Future<AuthCredential, Error> { promise in
-        self.getCredentialWith(uiDelegate) { authCredential, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authCredential = authCredential {
-            promise(.success(authCredential))
+    @available(swift 5.0)
+    @available(iOS 13, macCatalyst 13, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension OAuthProvider {
+      /// Used to obtain an auth credential via a mobile web flow.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameter uiDelegate: An optional UI delegate used to presenet the mobile web flow.
+      /// - Returns: A publisher that emits an `AuthCredential` when the credential is obtained
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+      public func getCredentialWith(_ uiDelegate: AuthUIDelegate?)
+        -> Future<AuthCredential, Error> {
+        Future<AuthCredential, Error> { promise in
+          self.getCredentialWith(uiDelegate) { authCredential, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let authCredential = authCredential {
+              promise(.success(authCredential))
+            }
           }
         }
       }
     }
-  }
 
-#endif  // os(iOS) || targetEnvironment(macCatalyst)
+  #endif // os(iOS) || targetEnvironment(macCatalyst)
 
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -22,9 +22,9 @@
     import FirebaseAuth
 
     @available(swift 5.0)
-    @available(iOS 13, *)
-    @available(macCatalyst, unavailable)
+    @available(iOS 13.0, *)
     @available(macOS, unavailable)
+    @available(macCatalyst, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension PhoneAuthProvider {
@@ -144,4 +144,4 @@
 
   #endif // os(iOS)
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth) && !os(tvOS) && !os(macOS)
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+
+#if os(iOS)
+
   import Foundation
 
   import Combine
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(iOS 13, watchOS 6, *)
-  @available(tvOS, unavailable)
+  @available(iOS 13, *)
+  @available(macCatalyst, unavailable)
   @available(macOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   extension PhoneAuthProvider {
     /// Starts the phone number authentication flow by sending a verification code to the
     /// specified phone number.
@@ -136,4 +141,7 @@
       }
     }
   }
+
+#endif  // os(iOS)
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -14,134 +14,134 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-#if os(iOS)
+  #if os(iOS)
 
-  import Foundation
+    import Foundation
 
-  import Combine
-  import FirebaseAuth
+    import Combine
+    import FirebaseAuth
 
-  @available(swift 5.0)
-  @available(iOS 13, *)
-  @available(macCatalyst, unavailable)
-  @available(macOS, unavailable)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension PhoneAuthProvider {
-    /// Starts the phone number authentication flow by sending a verification code to the
-    /// specified phone number.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameters:
-    ///     - phoneNumber: The phone number to be verified.
-    ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
-    ///       by this method until the completion block is executed.
-    ///
-    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
-    ///
-    /// - Remark:
-    ///   Possible error codes:
-    ///
-    ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
-    ///      the Firebase Auth is invalid or has expired.
-    ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
-    ///      project has been exceeded.
-    ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
-    ///      invalid.
-    ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
-    @discardableResult
-    public func verifyPhoneNumber(_ phoneNumber: String,
-                                  uiDelegate: AuthUIDelegate? = nil)
-      -> Future<String, Error> {
-      Future<String, Error> { promise in
-        self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate) { verificationID, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let verificationID = verificationID {
-            promise(.success(verificationID))
+    @available(swift 5.0)
+    @available(iOS 13, *)
+    @available(macCatalyst, unavailable)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension PhoneAuthProvider {
+      /// Starts the phone number authentication flow by sending a verification code to the
+      /// specified phone number.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameters:
+      ///     - phoneNumber: The phone number to be verified.
+      ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
+      ///       by this method until the completion block is executed.
+      ///
+      /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+      ///
+      /// - Remark:
+      ///   Possible error codes:
+      ///
+      ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
+      ///      the Firebase Auth is invalid or has expired.
+      ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
+      ///      project has been exceeded.
+      ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
+      ///      invalid.
+      ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
+      @discardableResult
+      public func verifyPhoneNumber(_ phoneNumber: String,
+                                    uiDelegate: AuthUIDelegate? = nil)
+        -> Future<String, Error> {
+        Future<String, Error> { promise in
+          self.verifyPhoneNumber(phoneNumber, uiDelegate: uiDelegate) { verificationID, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let verificationID = verificationID {
+              promise(.success(verificationID))
+            }
+          }
+        }
+      }
+
+      /// Verify ownership of the second factor phone number by the current user.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameters:
+      ///     - phoneNumber: The phone number to be verified.
+      ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
+      ///       by this method until the completion block is executed.
+      ///     - session: A session to identify the MFA flow. For enrollment, this identifies the user
+      ///       trying to enroll. For sign-in, this identifies that the user already passed the first
+      ///       factor challenge.
+      ///
+      /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+      ///
+      /// - Remark:
+      ///   Possible error codes:
+      ///
+      ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
+      ///      the Firebase Auth is invalid or has expired.
+      ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
+      ///      project has been exceeded.
+      ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
+      ///      invalid.
+      ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
+      @discardableResult
+      public func verifyPhoneNumber(_ phoneNumber: String,
+                                    uiDelegate: AuthUIDelegate? = nil,
+                                    multiFactorSession: MultiFactorSession?)
+        -> Future<String, Error> {
+        Future<String, Error> { promise in
+          self.verifyPhoneNumber(
+            phoneNumber,
+            uiDelegate: uiDelegate,
+            multiFactorSession: multiFactorSession
+          ) { verificationID, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let verificationID = verificationID {
+              promise(.success(verificationID))
+            }
+          }
+        }
+      }
+
+      /// Verify ownership of the second factor phone number by the current user.
+      ///
+      /// The publisher will emit events on the **main** thread.
+      ///
+      /// - Parameters:
+      ///   - phoneNumber: The phone number to be verified.
+      ///   - UIDelegate: An object used to present the SFSafariViewController. The object is retained
+      ///   by this method until the completion block is executed.
+      ///   - multiFactorSession: session A session to identify the MFA flow. For enrollment, this identifies the user
+      ///   trying to enroll. For sign-in, this identifies that the user already passed the first factor challenge.
+      /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
+      ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+      @discardableResult
+      public func verifyPhoneNumber(with phoneMultiFactorInfo: PhoneMultiFactorInfo,
+                                    uiDelegate: AuthUIDelegate? = nil,
+                                    multiFactorSession: MultiFactorSession?)
+        -> Future<String, Error> {
+        Future<String, Error> { promise in
+          self.verifyPhoneNumber(with: phoneMultiFactorInfo,
+                                 uiDelegate: uiDelegate,
+                                 multiFactorSession: multiFactorSession) { verificationID, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let verificationID = verificationID {
+              promise(.success(verificationID))
+            }
           }
         }
       }
     }
 
-    /// Verify ownership of the second factor phone number by the current user.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameters:
-    ///     - phoneNumber: The phone number to be verified.
-    ///     - uiDelegate: An object used to present the `SFSafariViewController`. The object is retained
-    ///       by this method until the completion block is executed.
-    ///     - session: A session to identify the MFA flow. For enrollment, this identifies the user
-    ///       trying to enroll. For sign-in, this identifies that the user already passed the first
-    ///       factor challenge.
-    ///
-    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
-    ///
-    /// - Remark:
-    ///   Possible error codes:
-    ///
-    ///   - `FIRAuthErrorCodeCaptchaCheckFailed` - Indicates that the reCAPTCHA token obtained by
-    ///      the Firebase Auth is invalid or has expired.
-    ///   - `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
-    ///      project has been exceeded.
-    ///   - `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
-    ///      invalid.
-    ///   - `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
-    @discardableResult
-    public func verifyPhoneNumber(_ phoneNumber: String,
-                                  uiDelegate: AuthUIDelegate? = nil,
-                                  multiFactorSession: MultiFactorSession?)
-      -> Future<String, Error> {
-      Future<String, Error> { promise in
-        self.verifyPhoneNumber(
-          phoneNumber,
-          uiDelegate: uiDelegate,
-          multiFactorSession: multiFactorSession
-        ) { verificationID, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let verificationID = verificationID {
-            promise(.success(verificationID))
-          }
-        }
-      }
-    }
-
-    /// Verify ownership of the second factor phone number by the current user.
-    ///
-    /// The publisher will emit events on the **main** thread.
-    ///
-    /// - Parameters:
-    ///   - phoneNumber: The phone number to be verified.
-    ///   - UIDelegate: An object used to present the SFSafariViewController. The object is retained
-    ///   by this method until the completion block is executed.
-    ///   - multiFactorSession: session A session to identify the MFA flow. For enrollment, this identifies the user
-    ///   trying to enroll. For sign-in, this identifies that the user already passed the first factor challenge.
-    /// - Returns: A publisher that emits an `VerificationID` when the verification flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
-    @discardableResult
-    public func verifyPhoneNumber(with phoneMultiFactorInfo: PhoneMultiFactorInfo,
-                                  uiDelegate: AuthUIDelegate? = nil,
-                                  multiFactorSession: MultiFactorSession?)
-      -> Future<String, Error> {
-      Future<String, Error> { promise in
-        self.verifyPhoneNumber(with: phoneMultiFactorInfo,
-                               uiDelegate: uiDelegate,
-                               multiFactorSession: multiFactorSession) { verificationID, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let verificationID = verificationID {
-            promise(.success(verificationID))
-          }
-        }
-      }
-    }
-  }
-
-#endif  // os(iOS)
+  #endif // os(iOS)
 
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -18,7 +18,7 @@
   import FirebaseAuth
 
   @available(swift 5.0)
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
   extension User {
     /// Associates a user account from a third-party identity provider with this user and
     /// returns additional identity provider data.
@@ -101,7 +101,7 @@
     ///
     /// - Parameter provider: The provider ID of the provider to unlink.
     /// - Returns: A publisher that emits a `User` when the disassociation flow completed
-    ///   successfully, or an error otherwise.
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     ///
     ///   Possible error codes:
     ///
@@ -195,4 +195,4 @@
     }
   }
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -27,7 +27,7 @@
     ///
     /// - Parameter credential: The credential for the identity provider.
     /// - Returns: A publisher that emits an `AuthDataResult` when the association flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///   successfully, or an error otherwise.
     /// - Remark: Possible error codes:
     ///   - `FIRAuthErrorCodeProviderAlreadyLinked` - Indicates an attempt to link a provider of a type
     ///     already linked to this account.
@@ -50,14 +50,14 @@
     }
 
     /// Renews the user's authentication tokens by validating a fresh set of credentials supplied
-    /// by the user  and returns additional identity provider data.
+    /// by the user and returns additional identity provider data.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter credential: A user-supplied credential, which will be validated by the server. This can be
     ///   a successful third-party identity provider sign-in, or an email address and password.
     /// - Returns: A publisher that emits an `AuthDataResult` when the reauthentication flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///   successfully, or an error otherwise.
     /// - Remark: If the user associated with the supplied credential is different from the current user, or if the validation
     ///   of the supplied credentials fails; an error is returned and the current user remains signed in.
     ///
@@ -100,8 +100,8 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameter provider: The provider ID of the provider to unlink.
-    /// - Returns: A publisher that emits an `User` when the disassociation flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits a `User` when the disassociation flow completed
+    ///   successfully, or an error otherwise.
     ///
     ///   Possible error codes:
     ///
@@ -130,7 +130,7 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher that emits no type when the verification flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///   successfully, or an error otherwise.
     ///
     ///   Possible error codes:
     ///
@@ -162,7 +162,7 @@
     /// - Parameter actionCodeSettings: An `FIRActionCodeSettings` object containing settings related to
     ///   handling action codes.
     /// - Returns: A publisher that emits no type when the verification flow completed
-    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    ///   successfully, or an error otherwise.
     ///
     ///   Possible error codes:
     ///
@@ -194,4 +194,5 @@
       }
     }
   }
+
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/User+Combine.swift
@@ -27,7 +27,7 @@
     ///
     /// - Parameter credential: The credential for the identity provider.
     /// - Returns: A publisher that emits an `AuthDataResult` when the association flow completed
-    ///   successfully, or an error otherwise.
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
     ///   - `FIRAuthErrorCodeProviderAlreadyLinked` - Indicates an attempt to link a provider of a type
     ///     already linked to this account.

--- a/FirebaseCombineSwift/Sources/Core/Core.swift
+++ b/FirebaseCombineSwift/Sources/Core/Core.swift
@@ -23,5 +23,5 @@ import Foundation
 
 #endif
 
-// This is here to appease the compiler
+// This is here to appease the compiler.
 internal struct _Dummy {}

--- a/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
@@ -18,7 +18,7 @@
   import FirebaseFunctions
 
   @available(swift 5.0)
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
   extension HTTPSCallable {
     // MARK: - HTTPS Callable Functions
 
@@ -83,4 +83,4 @@
     }
   }
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseFunctions)

--- a/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
@@ -34,7 +34,7 @@
     /// regarding the app instance. To stop this, see `[FIRInstallations delete]`. It
     /// resumes with a new Instance ID the next time you call this method.
     ///
-    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance.
+    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func call() -> Future<HTTPSCallableResult, Error> {
       Future<HTTPSCallableResult, Error> { promise in
@@ -68,7 +68,7 @@
     /// resumes with a new Instance ID the next time you call this method.
     ///
     /// - Parameter data: The data passed into the Callable Function.
-    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance.
+    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func call(_ data: Any?) -> Future<HTTPSCallableResult, Error> {
       Future<HTTPSCallableResult, Error> { promise in

--- a/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
@@ -24,6 +24,8 @@
 
     /// Executes this Callable HTTPS trigger asynchronously without any parameters.
     ///
+    /// The publisher will emit on the **main** thread.
+    ///
     /// The request to the Cloud Functions backend made by this method automatically includes a
     /// Firebase Instance ID token to identify the app instance. If a user is logged in with Firebase
     /// Auth, an auth ID token for the user is also automatically included.
@@ -32,7 +34,7 @@
     /// regarding the app instance. To stop this, see `[FIRInstallations delete]`. It
     /// resumes with a new Instance ID the next time you call this method.
     ///
-    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance.
     @discardableResult
     public func call() -> Future<HTTPSCallableResult, Error> {
       Future<HTTPSCallableResult, Error> { promise in
@@ -48,12 +50,14 @@
 
     /// Executes this Callable HTTPS trigger asynchronously.
     ///
+    /// The publisher will emit on the **main** thread.
+    ///
     /// The data passed into the trigger can be any of the following types:
     /// - `nil`
     /// - `String`
     /// - `Number`
     /// - `Array<Any>`, where the contained objects are also one of these types.
-    /// - `Dictionary<String, Any>`, , where the contained objects are also one of these types.
+    /// - `Dictionary<String, Any>`, where the contained objects are also one of these types.
     ///
     /// The request to the Cloud Functions backend made by this method automatically includes a
     /// Firebase Instance ID token to identify the app instance. If a user is logged in with Firebase
@@ -64,7 +68,7 @@
     /// resumes with a new Instance ID the next time you call this method.
     ///
     /// - Parameter data: The data passed into the Callable Function.
-    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `HTTPSCallableResult` instance.
     @discardableResult
     public func call(_ data: Any?) -> Future<HTTPSCallableResult, Error> {
       Future<HTTPSCallableResult, Error> { promise in
@@ -78,4 +82,5 @@
       }
     }
   }
+
 #endif

--- a/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
@@ -19,7 +19,7 @@
   import FirebaseStorageSwift
 
   @available(swift 5.0)
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
   extension StorageReference {
     // MARK: - Uploads
 
@@ -268,4 +268,4 @@
     }
   }
 
-#endif
+#endif // canImport(Combine) && swift(>=5.0) && canImport(FirebaseStorage)

--- a/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
@@ -32,7 +32,7 @@
     ///   - uploadData: The Data to upload.
     ///   - metadata: metadata `StorageMetadata` containing additional information (MIME type, etc.)
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func putData(_ data: Data,
                         metadata: StorageMetadata? = nil) -> Future<StorageMetadata, Error> {
@@ -56,7 +56,7 @@
     ///   - fileURL: A `URL` representing the system file path of the object to be uploaded.
     ///   - metadata: `StorageMetadata` containing additional information (MIME type, etc.) about the object being uploaded.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func putFile(from fileURL: URL,
                         metadata: StorageMetadata? = nil)
@@ -85,7 +85,7 @@
     ///   - size: The maximum size in bytes to download. If the download exceeds this size
     ///     the task will be cancelled and an error will be returned.
     ///
-    /// - Returns: A publisher emitting a `Data` instance.
+    /// - Returns: A publisher emitting a `Data` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func getData(maxSize size: Int64) -> Future<Data, Error> {
       var task: StorageDownloadTask?
@@ -108,7 +108,7 @@
     ///   - fileURL: A file system URL representing the path the object should be downloaded to.
     ///
     /// - Returns: A publisher emitting a `URL`  pointing to the file path of the downloaded file
-    ///   on success.
+    ///   on success. The publisher will emit on the *main* thread.
     @discardableResult
     public func write(toFile fileURL: URL) -> Future<URL, Error> {
       var task: StorageDownloadTask?
@@ -129,7 +129,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `URL` instance.
+    /// - Returns: A publisher emitting a `URL` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func downloadURL() -> Future<URL, Error> {
       Future<URL, Error> { promise in
@@ -152,7 +152,7 @@
     /// - Remark:
     ///    `listAll` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance.
+    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func listAll() -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -177,7 +177,7 @@
     /// - Remark:
     ///    `list(maxResults:)` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance.
+    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func list(maxResults: Int64) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -190,7 +190,7 @@
     /// Resumes a previous call to `list(maxResults:)`, starting after a pagination token.
     /// Returns the next set of items (files) and prefixes (folders) under this `StorageReference.
     ///
-    /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+    /// Note that "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
     /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in Firebase Storage
     /// will be filtered out.
     ///
@@ -204,7 +204,7 @@
     /// - Remark:
     ///    `list(maxResults:pageToken:)` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance.
+    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func list(maxResults: Int64, pageToken: String) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -220,7 +220,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func getMetadata() -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
@@ -237,7 +237,7 @@
     /// - Parameters:
     ///   - metadata: A `StorageMetadata` object with the metadata to update.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
     @discardableResult
     public func updateMetadata(_ metadata: StorageMetadata) -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
@@ -253,7 +253,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher that emits whether the call was successful or not.
+    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
     @discardableResult
     public func delete() -> Future<Bool, Error> {
       Future<Bool, Error> { promise in

--- a/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/StorageReference+Combine.swift
@@ -20,11 +20,10 @@
 
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-
   extension StorageReference {
     // MARK: - Uploads
 
-    /// Asynchronously uploads data to the currently specified FIRStorageReference.
+    /// Asynchronously uploads data to the currently specified `StorageReference`.
     /// This is not recommended for large files, and one should instead upload a file from disk.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -33,13 +32,13 @@
     ///   - uploadData: The Data to upload.
     ///   - metadata: metadata `StorageMetadata` containing additional information (MIME type, etc.)
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance.
     @discardableResult
     public func putData(_ data: Data,
                         metadata: StorageMetadata? = nil) -> Future<StorageMetadata, Error> {
       var task: StorageUploadTask?
-      return Future<StorageMetadata, Error> { [weak self] promise in
-        task = self?.putData(data, metadata: metadata) { result in
+      return Future<StorageMetadata, Error> { promise in
+        task = self.putData(data, metadata: metadata) { result in
           promise(result)
         }
       }
@@ -57,14 +56,14 @@
     ///   - fileURL: A `URL` representing the system file path of the object to be uploaded.
     ///   - metadata: `StorageMetadata` containing additional information (MIME type, etc.) about the object being uploaded.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance.
     @discardableResult
     public func putFile(from fileURL: URL,
                         metadata: StorageMetadata? = nil)
       -> Future<StorageMetadata, Error> {
       var task: StorageUploadTask?
-      return Future<StorageMetadata, Error> { [weak self] promise in
-        task = self?.putFile(from: fileURL, metadata: metadata) { result in
+      return Future<StorageMetadata, Error> { promise in
+        task = self.putFile(from: fileURL, metadata: metadata) { result in
           promise(result)
         }
       }
@@ -78,7 +77,7 @@
 
     /// Asynchronously downloads the object at the `StorageReference` to an `Data` object in memory.
     /// An `Data` of the provided max size will be allocated, so ensure that the device has enough free
-    /// memory to complete the download. For downloading large files, writeToFile may be a better option.
+    /// memory to complete the download. For downloading large files, `writeToFile` may be a better option.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
@@ -86,12 +85,12 @@
     ///   - size: The maximum size in bytes to download. If the download exceeds this size
     ///     the task will be cancelled and an error will be returned.
     ///
-    /// - Returns: A publisher emitting a `Data` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `Data` instance.
     @discardableResult
     public func getData(maxSize size: Int64) -> Future<Data, Error> {
       var task: StorageDownloadTask?
-      return Future<Data, Error> { [weak self] promise in
-        task = self?.getData(maxSize: size) { result in
+      return Future<Data, Error> { promise in
+        task = self.getData(maxSize: size) { result in
           promise(result)
         }
       }
@@ -109,12 +108,12 @@
     ///   - fileURL: A file system URL representing the path the object should be downloaded to.
     ///
     /// - Returns: A publisher emitting a `URL`  pointing to the file path of the downloaded file
-    ///   on success. The publisher will emit on the *main* thread.
+    ///   on success.
     @discardableResult
     public func write(toFile fileURL: URL) -> Future<URL, Error> {
       var task: StorageDownloadTask?
-      return Future<URL, Error> { [weak self] promise in
-        task = self?.write(toFile: fileURL) { result in
+      return Future<URL, Error> { promise in
+        task = self.write(toFile: fileURL) { result in
           promise(result)
         }
       }
@@ -130,7 +129,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `URL` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `URL` instance.
     @discardableResult
     public func downloadURL() -> Future<URL, Error> {
       Future<URL, Error> { promise in
@@ -144,7 +143,7 @@
 
     /// List all items (files) and prefixes (folders) under this `StorageReference`.
     ///
-    /// This is a helper method for calling list() repeatedly until there are no more results.
+    /// This is a helper method for calling `list()` repeatedly until there are no more results.
     /// Consistency of the result is not guaranteed if objects are inserted or removed while this
     /// operation is executing. All results are buffered in memory.
     ///
@@ -153,7 +152,7 @@
     /// - Remark:
     ///    `listAll` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageListResult` instance.
     @discardableResult
     public func listAll() -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -165,8 +164,8 @@
 
     /// List up to `maxResults` items (files) and prefixes (folders) under this `StorageReference`.
     ///
-    /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+    /// Note that "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in Firebase Storage will be
     /// filtered.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -178,7 +177,7 @@
     /// - Remark:
     ///    `list(maxResults:)` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageListResult` instance.
     @discardableResult
     public func list(maxResults: Int64) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -192,8 +191,8 @@
     /// Returns the next set of items (files) and prefixes (folders) under this `StorageReference.
     ///
     /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-    /// filtered.
+    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in Firebase Storage
+    /// will be filtered out.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
@@ -205,7 +204,7 @@
     /// - Remark:
     ///    `list(maxResults:pageToken:)` is only available for projects using Firebase Rules Version 2.
     ///
-    /// - Returns: A publisher emitting a `StorageListResult` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageListResult` instance.
     @discardableResult
     public func list(maxResults: Int64, pageToken: String) -> Future<StorageListResult, Error> {
       Future<StorageListResult, Error> { promise in
@@ -221,7 +220,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance.
     @discardableResult
     public func getMetadata() -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
@@ -236,9 +235,9 @@
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Parameters:
-    ///   - metadata: An `StorageMetadata` object with the metadata to update.
+    ///   - metadata: A `StorageMetadata` object with the metadata to update.
     ///
-    /// - Returns: A publisher emitting a `StorageMetadata` instance. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher emitting a `StorageMetadata` instance.
     @discardableResult
     public func updateMetadata(_ metadata: StorageMetadata) -> Future<StorageMetadata, Error> {
       Future<StorageMetadata, Error> { promise in
@@ -254,7 +253,7 @@
     ///
     /// The publisher will emit events on the **main** thread.
     ///
-    /// - Returns: A publisher that emits whether the call was successful or not. The publisher will emit on the *main* thread.
+    /// - Returns: A publisher that emits whether the call was successful or not.
     @discardableResult
     public func delete() -> Future<Bool, Error> {
       Future<Bool, Error> { promise in
@@ -268,4 +267,5 @@
       }
     }
   }
+
 #endif


### PR DESCRIPTION
- Reviewed and cleaned up some of the documentation
- Tried to standardize/cleanup some of the`#if` compilation logic
- `FirebaseCombineSwift` now conditionally builds for all platforms (mainly had to get watchOS compiling)
- Removed remaining `weak` references to `self` after reading [this note](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseCombineSwift/DECISIONS.md#using-capture-lists) from `FirebaseCombineSwift/DECISIONS.md`

#no-changelog