### PR TITLE
Always build Carthage with Firebase zip distributions

### DIFF
--- a/ReleaseTooling/DEVELOP.md
+++ b/ReleaseTooling/DEVELOP.md
@@ -18,7 +18,6 @@ For release engineers (Googlers packaging an upcoming Firebase release) these co
 be used:
 -  `--custom-spec-repos https://github.com/firebase/SpecsStaging.git`
   - This pulls the latest podspecs from the CocoaPods staging area.
-- `--enable-carthage-build` Turns on generation of Carthage zips and json file updates.
 - `--keep-build-artifacts` Useful for debugging and verifying the zip build contents.
 
 Putting them all together, here's a common command to build a releaseable Zip file:
@@ -26,15 +25,14 @@ Putting them all together, here's a common command to build a releaseable Zip fi
 ```
 swift run zip-builder --update-pod-repo \
 --custom-spec-repos https://github.com/firebase/SpecsStaging.git \
---enable-carthage-build \
 --keep-build-artifacts
 ```
 
 #### Carthage
 
-Carthage binaries can also be built at the same time as the zip file by passing in `--enable-carthage-build`
-as a command line argument. This directory should contain JSON files describing versions and download
-locations for each product. This will result in a folder called "carthage" at the root where the zip directory exists
+Carthage binaries can also be built at the same time as the zip file. This directory should contain
+JSON files describing versions and download locations for each product. This will result in a folder
+called "carthage" at the root where the zip directory exists
 containing all the zip files and JSON files necessary for distribution.
 
 ## Firebase Releaser

--- a/ReleaseTooling/Sources/ZipBuilder/FirebaseBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FirebaseBuilder.swift
@@ -31,25 +31,20 @@ struct FirebaseBuilder {
   /// Wrapper around a generic zip builder that adds in Firebase specific steps including a
   /// multi-level zip file, a README, and optionally Carthage artifacts.
   func build(templateDir: URL,
-             carthageBuildOptions: CarthageBuildOptions?) {
+             carthageBuildOptions: CarthageBuildOptions) {
     // Build the zip file and get the path.
     do {
-      let artifacts = try zipBuilder.buildAndAssembleFirebaseRelease(templateDir: templateDir,
-                                                                     includeCarthage: carthageBuildOptions !=
-                                                                       nil)
+      let artifacts = try zipBuilder.buildAndAssembleFirebaseRelease(templateDir: templateDir)
       let firebaseVersion = artifacts.firebaseVersion
       let location = artifacts.zipDir
       print("Firebase \(firebaseVersion) directory is ready to be packaged: \(location)")
 
       // Package carthage if it's enabled.
-      var carthageRoot: URL?
-      if let carthageBuildOptions = carthageBuildOptions {
-        carthageRoot = CarthageUtils.packageCarthageRelease(
-          templateDir: zipBuilder.paths.templateDir,
-          artifacts: artifacts,
-          options: carthageBuildOptions
-        )
-      }
+      let carthageRoot = CarthageUtils.packageCarthageRelease(
+        templateDir: zipBuilder.paths.templateDir,
+        artifacts: artifacts,
+        options: carthageBuildOptions
+      )
 
       // Prepare the release directory for zip packaging.
       do {

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -53,12 +53,6 @@ struct ZipBuilderTool: ParsableCommand {
         help: ArgumentHelp("Whether or not to build dependencies of requested pods."))
   var buildDependencies: Bool
 
-  /// Flag to also build Carthage artifacts.
-  @Flag(default: false,
-        inversion: .prefixedEnableDisable,
-        help: ArgumentHelp("A flag specifying to build Carthage artifacts."))
-  var carthageBuild: Bool
-
   /// Flag to enable or disable Carthage version checks. Skipping the check can speed up dev
   /// iterations.
   @Flag(default: true,
@@ -306,12 +300,9 @@ struct ZipBuilderTool: ParsableCommand {
       // pod's podspec options.
       PlatformMinimum.useRecentVersions()
 
-      var carthageOptions: CarthageBuildOptions?
-      if carthageBuild {
-        let jsonDir = paths.repoDir.appendingPathComponents(["ReleaseTooling", "CarthageJSON"])
-        carthageOptions = CarthageBuildOptions(jsonDir: jsonDir,
-                                               isVersionCheckEnabled: carthageVersionCheck)
-      }
+      let jsonDir = paths.repoDir.appendingPathComponents(["ReleaseTooling", "CarthageJSON"])
+      let carthageOptions = CarthageBuildOptions(jsonDir: jsonDir,
+                                                 isVersionCheckEnabled: carthageVersionCheck)
 
       FirebaseBuilder(zipBuilder: builder).build(templateDir: paths.templateDir,
                                                  carthageBuildOptions: carthageOptions)

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -35,5 +35,5 @@ read -a specrepo <<< "${CUSTOM_SPEC_REPOS}"
 cd ReleaseTooling
 swift run zip-builder --keep-build-artifacts --update-pod-repo \
     --local-podspec-path "${REPO}" \
-    --enable-carthage-build --output-dir "${OUTPUT_DIR}" \
+    --output-dir "${OUTPUT_DIR}" \
     --custom-spec-repos  "${specrepo[@]}"


### PR DESCRIPTION
Follow up to #8084 to remove the `--enable-carthage-build` option and always build Carthage when building a Firebase zip distribution.

The other open comment in #8084 about the plist generation file requires more thought since it is being used both for xcframework builds and for the special Firebase framework that we're still assembling for Carthage.

Companion CL is cl/374299027