### PR TITLE
App Check: prevent concurrent token requests

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -179,17 +179,18 @@ NS_ASSUME_NONNULL_BEGIN
                             if (self.ongoingGetTokenOperation == nil) {
                               // Kick off a new handshake sequence only when there is no an ongoing
                               // handshake to avoid race conditions.
-                              self.ongoingGetTokenOperation = [self createGetTokenSequencePromise]
+                              self.ongoingGetTokenOperation =
+                                  [self createGetTokenSequencePromise]
 
-                              // Release the ongoing operation promise on completion.
-                              .then(^FIRAppCheckToken *(FIRAppCheckToken *token) {
-                                self.ongoingGetTokenOperation = nil;
-                                return token;
-                              })
-                              .recover(^NSError *(NSError *error) {
-                                self.ongoingGetTokenOperation = nil;
-                                return error;
-                              });
+                                      // Release the ongoing operation promise on completion.
+                                      .then(^FIRAppCheckToken *(FIRAppCheckToken *token) {
+                                        self.ongoingGetTokenOperation = nil;
+                                        return token;
+                                      })
+                                      .recover(^NSError *(NSError *error) {
+                                        self.ongoingGetTokenOperation = nil;
+                                        return error;
+                                      });
                             }
                             return self.ongoingGetTokenOperation;
                           }];

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -177,7 +177,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FBLPromise onQueue:self.queue
                           do:^id _Nullable {
                             if (self.ongoingGetTokenOperation == nil) {
-                              // Kick off a new handshake sequence only when there is no an ongoing
+                              // Kick off a new handshake sequence only when there is not an ongoing
                               // handshake to avoid race conditions.
                               self.ongoingGetTokenOperation =
                                   [self createGetTokenSequencePromise]

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -174,13 +174,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FBLPromise<FIRAppCheckToken *> *)getToken {
-  return [FBLPromise onQueue:self.queue do:^id _Nullable{
-    if (self.ongoingGetTokenOperation == nil) {
-      // Kick off a new handshake sequence only when there is no an ongoing handshake to avoid race conditions.
-      self.ongoingGetTokenOperation = [self createGetTokenSequencePromise];
-    }
-    return self.ongoingGetTokenOperation;
-  }];
+  return [FBLPromise onQueue:self.queue
+                          do:^id _Nullable {
+                            if (self.ongoingGetTokenOperation == nil) {
+                              // Kick off a new handshake sequence only when there is no an ongoing
+                              // handshake to avoid race conditions.
+                              self.ongoingGetTokenOperation = [self createGetTokenSequencePromise];
+                            }
+                            return self.ongoingGetTokenOperation;
+                          }];
 }
 
 - (FBLPromise<FIRAppCheckToken *> *)createGetTokenSequencePromise {

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -103,6 +103,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) id<FIRAppAttestKeyIDStorageProtocol> keyIDStorage;
 @property(nonatomic, readonly) id<FIRAppAttestArtifactStorageProtocol> artifactStorage;
 
+@property(nonatomic) FBLPromise<FIRAppCheckToken *> *ongoingGetTokenOperation;
+
 @property(nonatomic, readonly) dispatch_queue_t queue;
 
 @end
@@ -172,6 +174,16 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FBLPromise<FIRAppCheckToken *> *)getToken {
+  return [FBLPromise onQueue:self.queue do:^id _Nullable{
+    if (self.ongoingGetTokenOperation == nil) {
+      // Kick off a new handshake sequence only when there is no an ongoing handshake to avoid race conditions.
+      self.ongoingGetTokenOperation = [self createGetTokenSequencePromise];
+    }
+    return self.ongoingGetTokenOperation;
+  }];
+}
+
+- (FBLPromise<FIRAppCheckToken *> *)createGetTokenSequencePromise {
   // Check attestation state to decide on the next steps.
   return [self attestationState].thenOn(self.queue, ^id(FIRAppAttestProviderState *attestState) {
     switch (attestState.state) {

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -70,6 +70,8 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 @property(nonatomic, readonly, nullable) id<FIRAppCheckTokenRefresherProtocol> tokenRefresher;
 
+@property(nonatomic) FBLPromise<FIRAppCheckToken *> *ongoingRetrieveOrRefreshTokenPromise;
+
 @end
 
 @implementation FIRAppCheck
@@ -242,6 +244,17 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 #pragma mark - FAA token cache
 
 - (FBLPromise<FIRAppCheckToken *> *)retrieveOrRefreshTokenForcingRefresh:(BOOL)forcingRefresh {
+  return [FBLPromise do:^id _Nullable{
+    if (self.ongoingRetrieveOrRefreshTokenPromise == nil) {
+      // Kick off a new operation only when there is no an ongoing one.
+      self.ongoingRetrieveOrRefreshTokenPromise = [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh];
+    }
+    return self.ongoingRetrieveOrRefreshTokenPromise;
+  }];
+}
+
+
+- (FBLPromise<FIRAppCheckToken *> *)createRetrieveOrRefreshTokenPromiseForcingRefresh:(BOOL)forcingRefresh {
   return [self getCachedValidTokenForcingRefresh:forcingRefresh].recover(
       ^id _Nullable(NSError *_Nonnull error) {
         return [self refreshToken];

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -250,15 +250,15 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
       self.ongoingRetrieveOrRefreshTokenPromise =
           [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh]
 
-      // Release the ongoing operation promise on completion.
-      .then(^FIRAppCheckToken *(FIRAppCheckToken *token) {
-        self.ongoingRetrieveOrRefreshTokenPromise = nil;
-        return token;
-      })
-      .recover(^NSError *(NSError *error) {
-        self.ongoingRetrieveOrRefreshTokenPromise = nil;
-        return error;
-      });
+              // Release the ongoing operation promise on completion.
+              .then(^FIRAppCheckToken *(FIRAppCheckToken *token) {
+                self.ongoingRetrieveOrRefreshTokenPromise = nil;
+                return token;
+              })
+              .recover(^NSError *(NSError *error) {
+                self.ongoingRetrieveOrRefreshTokenPromise = nil;
+                return error;
+              });
     }
     return self.ongoingRetrieveOrRefreshTokenPromise;
   }];

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -246,7 +246,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 - (FBLPromise<FIRAppCheckToken *> *)retrieveOrRefreshTokenForcingRefresh:(BOOL)forcingRefresh {
   return [FBLPromise do:^id _Nullable {
     if (self.ongoingRetrieveOrRefreshTokenPromise == nil) {
-      // Kick off a new operation only when there is no an ongoing one.
+      // Kick off a new operation only when there is not an ongoing one.
       self.ongoingRetrieveOrRefreshTokenPromise =
           [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh]
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -244,17 +244,18 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 #pragma mark - FAA token cache
 
 - (FBLPromise<FIRAppCheckToken *> *)retrieveOrRefreshTokenForcingRefresh:(BOOL)forcingRefresh {
-  return [FBLPromise do:^id _Nullable{
+  return [FBLPromise do:^id _Nullable {
     if (self.ongoingRetrieveOrRefreshTokenPromise == nil) {
       // Kick off a new operation only when there is no an ongoing one.
-      self.ongoingRetrieveOrRefreshTokenPromise = [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh];
+      self.ongoingRetrieveOrRefreshTokenPromise =
+          [self createRetrieveOrRefreshTokenPromiseForcingRefresh:forcingRefresh];
     }
     return self.ongoingRetrieveOrRefreshTokenPromise;
   }];
 }
 
-
-- (FBLPromise<FIRAppCheckToken *> *)createRetrieveOrRefreshTokenPromiseForcingRefresh:(BOOL)forcingRefresh {
+- (FBLPromise<FIRAppCheckToken *> *)createRetrieveOrRefreshTokenPromiseForcingRefresh:
+    (BOOL)forcingRefresh {
   return [self getCachedValidTokenForcingRefresh:forcingRefresh].recover(
       ^id _Nullable(NSError *_Nonnull error) {
         return [self refreshToken];

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -590,7 +590,7 @@ API_AVAILABLE(ios(14.0))
       .andReturn([FBLPromise resolvedWith:storedArtifact]);
 
   // 4. Expect random challenge to be requested.
-  // 4.1. Create a pending promise to fulfil later.
+  // 4.1. Create a pending promise to fulfill later.
   FBLPromise<NSData *> *challengeRequestPromise = [FBLPromise pendingPromise];
   // 4.2. Stab getRandomChallenge method.
   OCMExpect([self.mockAPIService getRandomChallenge]).andReturn(challengeRequestPromise);

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -637,13 +637,11 @@ API_AVAILABLE(ios(14.0))
   OCMExpect([self.mockArtifactStorage getArtifactForKey:existingKeyID])
       .andReturn([FBLPromise resolvedWith:storedArtifact]);
 
-
   // 4. Expect random challenge to be requested.
   // 4.1. Create a pending promise to fulfil later.
   FBLPromise<NSData *> *challengeRequestPromise = [FBLPromise pendingPromise];
   // 4.2. Stab getRandomChallenge method.
-  OCMExpect([self.mockAPIService getRandomChallenge])
-      .andReturn(challengeRequestPromise);
+  OCMExpect([self.mockAPIService getRandomChallenge]).andReturn(challengeRequestPromise);
 
   // 5. Expect assertion to be requested.
   NSData *assertion = [@"generatedAssertion" dataUsingEncoding:NSUTF8StringEncoding];
@@ -664,10 +662,11 @@ API_AVAILABLE(ios(14.0))
   // 7. Call get token several times.
   NSInteger callsCount = 10;
   NSMutableArray *completionExpectations = [NSMutableArray arrayWithCapacity:callsCount];
+
   for (NSInteger i = 0; i < callsCount; i++) {
     // 7.1 Expect the completion to be called for each get token method called.
-    XCTestExpectation *completionExpectation =
-        [self expectationWithDescription:[NSString stringWithFormat:@"completionExpectation%@", @(i)]];
+    XCTestExpectation *completionExpectation = [self
+        expectationWithDescription:[NSString stringWithFormat:@"completionExpectation%@", @(i)]];
     [completionExpectations addObject:completionExpectation];
 
     // 7.2. Call get token.

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -592,7 +592,7 @@ API_AVAILABLE(ios(14.0))
   // 4. Expect random challenge to be requested.
   // 4.1. Create a pending promise to fulfill later.
   FBLPromise<NSData *> *challengeRequestPromise = [FBLPromise pendingPromise];
-  // 4.2. Stab getRandomChallenge method.
+  // 4.2. Stub getRandomChallenge method.
   OCMExpect([self.mockAPIService getRandomChallenge]).andReturn(challengeRequestPromise);
 
   // 5. Expect assertion to be requested.

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -335,18 +335,17 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
   // 5. Request token.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
-  [self.appCheck
-      getTokenForcingRefresh:NO
-                  completion:^(id<FIRAppCheckTokenResultInterop> result) {
-                    [getTokenExpectation fulfill];
+  [self.appCheck getTokenForcingRefresh:NO
+                             completion:^(id<FIRAppCheckTokenResultInterop> result) {
+                               [getTokenExpectation fulfill];
 
-                    XCTAssertNotNil(result);
-                    XCTAssertEqualObjects(result.token, kDummyToken);
+                               XCTAssertNotNil(result);
+                               XCTAssertEqualObjects(result.token, kDummyToken);
 
-                    // TODO: Expect a public domain error to be returned - not the
-                    // internal one.
-                    XCTAssertEqualObjects(result.error, providerError);
-                  }];
+                               // TODO: Expect a public domain error to be returned - not the
+                               // internal one.
+                               XCTAssertEqualObjects(result.error, providerError);
+                             }];
 
   // 6. Wait for expectations and validate mocks.
   [self waitForExpectations:@[ notificationExpectation, getTokenExpectation ] timeout:0.5];
@@ -559,7 +558,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
                                  XCTAssertNotNil(tokenResult);
                                  XCTAssertEqualObjects(tokenResult.error, storageError);
-      XCTAssertEqualObjects(tokenResult.token, kDummyToken);
+                                 XCTAssertEqualObjects(tokenResult.token, kDummyToken);
                                }];
   }
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -499,8 +499,7 @@
   // 3.1. Create a pending promise to resolve later.
   FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
   // 3.2. Stub storage set token method.
-  OCMExpect([self.mockStorage setToken:tokenToReturn])
-      .andReturn(storeTokenPromise);
+  OCMExpect([self.mockStorage setToken:tokenToReturn]).andReturn(storeTokenPromise);
 
   // 4. Expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
@@ -508,29 +507,33 @@
 
   // 5. Request token several times.
   NSInteger getTokenCallsCount = 10;
-  NSMutableArray *getTokenCompletionExpectations  = [NSMutableArray arrayWithCapacity:getTokenCallsCount];
+  NSMutableArray *getTokenCompletionExpectations =
+      [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
     // 5.1. Expect a completion to be called for each method call.
-    XCTestExpectation *getTokenExpectation = [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
+    XCTestExpectation *getTokenExpectation =
+        [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
     // 5.2. Call get token.
     [self.appCheck getTokenForcingRefresh:NO
                                completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
-      [getTokenExpectation fulfill];
+                                 [getTokenExpectation fulfill];
 
-      XCTAssertNotNil(tokenResult);
-      XCTAssertEqualObjects(tokenResult.token, tokenToReturn.token);
-      XCTAssertNil(tokenResult.error);
-    }];
+                                 XCTAssertNotNil(tokenResult);
+                                 XCTAssertEqualObjects(tokenResult.token, tokenToReturn.token);
+                                 XCTAssertNil(tokenResult.error);
+                               }];
   }
 
   // 5.3. Fulfill the pending promise to finish the get token operation.
   [storeTokenPromise fulfill:tokenToReturn];
 
   // 6. Wait for expectations and validate mocks.
-  [self waitForExpectations:[getTokenCompletionExpectations arrayByAddingObject:notificationExpectation] timeout:0.5];
+  [self waitForExpectations:[getTokenCompletionExpectations
+                                arrayByAddingObject:notificationExpectation]
+                    timeout:0.5];
   OCMVerifyAll(self.mockStorage);
   OCMVerifyAll(self.mockAppCheckProvider);
 }

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -502,14 +502,12 @@
   OCMExpect([self.mockStorage setToken:tokenToReturn])
       .andReturn(storeTokenPromise);
 
-  NSInteger getTokenCallsCount = 10;
-
   // 4. Expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
       [self tokenUpdateNotificationWithExpectedToken:tokenToReturn.token];
-  notificationExpectation.expectedFulfillmentCount = getTokenCallsCount;
 
   // 5. Request token several times.
+  NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations  = [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {


### PR DESCRIPTION
- prevent concurrent App Attest handshake operations
- prevent concurrent token refresh operations for any provider (on the App Check Core level)

#no-changelog