### PR TITLE
Fix setting of in-app message type in `FIRInAppMessagingImageOnlyDisplay` initializer

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2021-6 -- v.8.1.0
+- [fixed] Fixed bug where image-only messages had the wrong message type in message callbacks (#8081).
+
 # 2021-4 -- v.7.11.0
 - [fixed] Fixed SPM resource inclusion for in-app messages (#7715).
 

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -269,7 +269,7 @@
                          campaignName:campaignName
                     experimentPayload:experimentPayload
                   renderAsTestMessage:renderAsTestMessage
-                          messageType:FIRInAppMessagingDisplayMessageTypeModal
+                          messageType:FIRInAppMessagingDisplayMessageTypeImageOnly
                           triggerType:triggerType
                               appData:appData]) {
     _imageData = imageData;

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -423,7 +423,7 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
 
   FIRIAMRenderingEffectSetting *renderSetting6 =
       [FIRIAMRenderingEffectSetting getDefaultRenderingEffectSetting];
-  renderSetting6.viewMode = FIRIAMRenderAsBannerView;
+  renderSetting6.viewMode = FIRIAMRenderAsCardView;
 
   FIRIAMMessageRenderData *renderData6 =
       [[FIRIAMMessageRenderData alloc] initWithMessageID:@"m6"
@@ -1152,5 +1152,42 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
                        landscapeImageData:nil
                               triggerType:FIRInAppMessagingDisplayTriggerTypeOnAppForeground];
   XCTAssertNotNil(displayMessage.campaignInfo.experimentPayload);
+}
+
+- (void)testMessageDisplayTypes {
+  FIRInAppMessagingImageData *imageData =
+      [[FIRInAppMessagingImageData alloc] initWithImageURL:@"https://www.google.com"
+                                                 imageData:[NSData data]];
+  FIRInAppMessagingDisplayTriggerType analyticsTriggerType =
+      FIRInAppMessagingDisplayTriggerTypeOnAnalyticsEvent;
+
+  FIRInAppMessagingDisplayMessage *bannerMessage =
+      [self.displayExecutor displayMessageWithMessageDefinition:self.m1
+                                                      imageData:imageData
+                                             landscapeImageData:nil
+                                                    triggerType:analyticsTriggerType];
+
+  FIRInAppMessagingDisplayMessage *imageOnlyMessage =
+      [self.displayExecutor displayMessageWithMessageDefinition:self.m3
+                                                      imageData:imageData
+                                             landscapeImageData:nil
+                                                    triggerType:analyticsTriggerType];
+
+  FIRInAppMessagingDisplayMessage *modalMessage =
+      [self.displayExecutor displayMessageWithMessageDefinition:self.m2
+                                                      imageData:imageData
+                                             landscapeImageData:nil
+                                                    triggerType:analyticsTriggerType];
+
+  FIRInAppMessagingDisplayMessage *cardMessage =
+      [self.displayExecutor displayMessageWithMessageDefinition:self.m6
+                                                      imageData:imageData
+                                             landscapeImageData:nil
+                                                    triggerType:analyticsTriggerType];
+
+  XCTAssertEqual(bannerMessage.type, FIRInAppMessagingDisplayMessageTypeBanner);
+  XCTAssertEqual(imageOnlyMessage.type, FIRInAppMessagingDisplayMessageTypeImageOnly);
+  XCTAssertEqual(modalMessage.type, FIRInAppMessagingDisplayMessageTypeModal);
+  XCTAssertEqual(cardMessage.type, FIRInAppMessagingDisplayMessageTypeCard);
 }
 @end


### PR DESCRIPTION
Fixes #8081 .

Adds unit test coverage for all message initializers.