### PR TITLE
Drop the shared pointer for Bound

### DIFF
--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -527,15 +527,15 @@ BundledQuery BundleSerializer::DecodeBundledQuery(
   auto order_bys = DecodeOrderBy(reader, structured_query);
 
   auto start_at_bound = DecodeBound(reader, structured_query, "startAt");
-  std::shared_ptr<Bound> start_at;
+  absl::optional<Bound> start_at;
   if (start_at_bound.position().values_count > 0) {
-    start_at = std::make_shared<Bound>(std::move(start_at_bound));
+    start_at = std::move(start_at_bound);
   }
 
   auto end_at_bound = DecodeBound(reader, structured_query, "endAt");
-  std::shared_ptr<Bound> end_at;
+  absl::optional<Bound> end_at;
   if (end_at_bound.position().values_count > 0) {
-    end_at = std::make_shared<Bound>(std::move(end_at_bound));
+    end_at = std::move(end_at_bound);
   }
 
   int32_t limit = DecodeLimit(reader, structured_query);

--- a/Firestore/core/src/core/query.cc
+++ b/Firestore/core/src/core/query.cc
@@ -204,13 +204,12 @@ Query Query::WithLimitToLast(int32_t limit) const {
 
 Query Query::StartingAt(Bound bound) const {
   return Query(path_, collection_group_, filters_, explicit_order_bys_, limit_,
-               limit_type_, std::make_shared<Bound>(std::move(bound)), end_at_);
+               limit_type_, std::move(bound), end_at_);
 }
 
 Query Query::EndingAt(Bound bound) const {
   return Query(path_, collection_group_, filters_, explicit_order_bys_, limit_,
-               limit_type_, start_at_,
-               std::make_shared<Bound>(std::move(bound)));
+               limit_type_, start_at_, std::move(bound));
 }
 
 Query Query::AsCollectionQueryAtPath(ResourcePath path) const {
@@ -323,14 +322,14 @@ const Target& Query::ToTarget() const& {
       }
 
       // We need to swap the cursors to match the now-flipped query ordering.
-      auto new_start_at = (end_at_ != nullptr)
-                              ? std::make_shared<Bound>(Bound::FromValue(
-                                    end_at_->position(), !end_at_->before()))
-                              : nullptr;
-      auto new_end_at = (start_at_ != nullptr)
-                            ? std::make_shared<Bound>(Bound::FromValue(
-                                  start_at_->position(), !start_at_->before()))
-                            : nullptr;
+      auto new_start_at = end_at_
+                              ? absl::optional<Bound>{Bound::FromValue(
+                                    end_at_->position(), !end_at_->before())}
+                              : absl::nullopt;
+      auto new_end_at = start_at_
+                            ? absl::optional<Bound>{Bound::FromValue(
+                                  start_at_->position(), !start_at_->before())}
+                            : absl::nullopt;
 
       Target target(path(), collection_group(), filters(), new_order_bys,
                     limit_, new_start_at, new_end_at);

--- a/Firestore/core/src/core/query.h
+++ b/Firestore/core/src/core/query.h
@@ -66,8 +66,8 @@ class Query {
         OrderByList explicit_order_bys,
         int32_t limit,
         LimitType limit_type,
-        std::shared_ptr<Bound> start_at,
-        std::shared_ptr<Bound> end_at)
+        absl::optional<Bound> start_at,
+        absl::optional<Bound> end_at)
       : path_(std::move(path)),
         collection_group_(std::move(collection_group)),
         filters_(std::move(filters)),
@@ -158,11 +158,11 @@ class Query {
 
   int32_t limit() const;
 
-  const std::shared_ptr<Bound>& start_at() const {
+  const absl::optional<Bound>& start_at() const {
     return start_at_;
   }
 
-  const std::shared_ptr<Bound>& end_at() const {
+  const absl::optional<Bound>& end_at() const {
     return end_at_;
   }
 
@@ -270,10 +270,8 @@ class Query {
   int32_t limit_ = Target::kNoLimit;
   LimitType limit_type_ = LimitType::None;
 
-  // TODO(mutabledocuments): Make this an absl::optional since Bound already
-  // shares its memory
-  std::shared_ptr<Bound> start_at_;
-  std::shared_ptr<Bound> end_at_;
+  absl::optional<Bound> start_at_;
+  absl::optional<Bound> end_at_;
 
   // The corresponding Target of this Query instance.
   mutable std::shared_ptr<const Target> memoized_target;

--- a/Firestore/core/src/core/target.cc
+++ b/Firestore/core/src/core/target.cc
@@ -97,9 +97,8 @@ bool operator==(const Target& lhs, const Target& rhs) {
   return lhs.path() == rhs.path() &&
          util::Equals(lhs.collection_group(), rhs.collection_group()) &&
          lhs.filters() == rhs.filters() && lhs.order_bys() == rhs.order_bys() &&
-         lhs.limit() == rhs.limit() &&
-         util::Equals(lhs.start_at(), rhs.start_at()) &&
-         util::Equals(lhs.end_at(), rhs.end_at());
+         lhs.limit() == rhs.limit() && lhs.start_at() == rhs.start_at() &&
+         lhs.end_at() == rhs.end_at();
 }
 
 }  // namespace core

--- a/Firestore/core/src/core/target.h
+++ b/Firestore/core/src/core/target.h
@@ -81,11 +81,11 @@ class Target {
     return limit_;
   }
 
-  const std::shared_ptr<Bound>& start_at() const {
+  const absl::optional<Bound>& start_at() const {
     return start_at_;
   }
 
-  const std::shared_ptr<Bound>& end_at() const {
+  const absl::optional<Bound>& end_at() const {
     return end_at_;
   }
 
@@ -111,8 +111,8 @@ class Target {
          FilterList filters,
          OrderByList order_bys,
          int32_t limit,
-         std::shared_ptr<Bound> start_at,
-         std::shared_ptr<Bound> end_at)
+         absl::optional<Bound> start_at,
+         absl::optional<Bound> end_at)
       : path_(std::move(path)),
         collection_group_(std::move(collection_group)),
         filters_(std::move(filters)),
@@ -130,8 +130,8 @@ class Target {
   FilterList filters_;
   OrderByList order_bys_;
   int32_t limit_ = kNoLimit;
-  std::shared_ptr<Bound> start_at_;
-  std::shared_ptr<Bound> end_at_;
+  absl::optional<Bound> start_at_;
+  absl::optional<Bound> end_at_;
 
   mutable std::string canonical_id_;
 };

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -757,12 +757,12 @@ Target Serializer::DecodeStructuredQuery(
     limit = query.limit.value;
   }
 
-  std::shared_ptr<Bound> start_at;
+  absl::optional<Bound> start_at;
   if (query.start_at.values_count > 0) {
     start_at = DecodeBound(query.start_at);
   }
 
-  std::shared_ptr<Bound> end_at;
+  absl::optional<Bound> end_at;
   if (query.end_at.values_count > 0) {
     end_at = DecodeBound(query.end_at);
   }
@@ -1115,8 +1115,7 @@ google_firestore_v1_Cursor Serializer::EncodeBound(const Bound& bound) const {
   return result;
 }
 
-std::shared_ptr<Bound> Serializer::DecodeBound(
-    google_firestore_v1_Cursor& cursor) const {
+Bound Serializer::DecodeBound(google_firestore_v1_Cursor& cursor) const {
   google_firestore_v1_ArrayValue index_components;
   SetRepeatedField(&index_components.values, &index_components.values_count,
                    absl::Span<google_firestore_v1_Value>(cursor.values,
@@ -1124,8 +1123,7 @@ std::shared_ptr<Bound> Serializer::DecodeBound(
   // Prevent double-freeing of the cursors's fields. The fields are now owned by
   // the bound.
   ReleaseFieldOwnership(cursor.values, cursor.values_count);
-  return std::make_shared<Bound>(
-      Bound::FromValue(index_components, cursor.before));
+  return Bound::FromValue(index_components, cursor.before);
 }
 
 /* static */

--- a/Firestore/core/src/remote/serializer.h
+++ b/Firestore/core/src/remote/serializer.h
@@ -299,8 +299,7 @@ class Serializer {
       const google_firestore_v1_StructuredQuery_Order& order_by) const;
 
   google_firestore_v1_Cursor EncodeBound(const core::Bound& bound) const;
-  std::shared_ptr<core::Bound> DecodeBound(
-      google_firestore_v1_Cursor& cursor) const;
+  core::Bound DecodeBound(google_firestore_v1_Cursor& cursor) const;
 
   std::unique_ptr<remote::WatchChange> DecodeTargetChange(
       util::ReadContext* context,


### PR DESCRIPTION
Bound is now copyable and contains a shared pointer to the underlying Proto message, so we no longer need to make Bound a shared pointer itself