### PR TITLE
Fix an issue that notification open is not logged when app is closed

### DIFF
--- a/FirebaseMessaging/Apps/AdvancedSample/Podfile
+++ b/FirebaseMessaging/Apps/AdvancedSample/Podfile
@@ -13,6 +13,7 @@ end
 
 target 'AdvancedSample' do
   platform :ios, '13.0'
+  pod 'FirebaseAnalytics'
   shared_pods
 end
 
@@ -23,6 +24,7 @@ end
 
 target 'AppClips' do
   platform :ios, '13.0'
+  pod 'FirebaseAnalytics'
   shared_pods
 end
 

--- a/FirebaseMessaging/Apps/Sample/Podfile
+++ b/FirebaseMessaging/Apps/Sample/Podfile
@@ -11,5 +11,6 @@ target 'Sample' do
   pod 'FirebaseMessaging', :path => '../../../'
   pod 'FirebaseCoreDiagnostics', :path => '../../../'
   pod 'FirebaseInstallations', :path => '../../../'
+  pod 'FirebaseAnalytics'
 
 end

--- a/FirebaseMessaging/Apps/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/FirebaseMessaging/Apps/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -55,6 +55,10 @@
             argument = "-FIRDebugEnabled"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled "
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/FirebaseMessaging/Apps/Shared/AppDelegate.swift
+++ b/FirebaseMessaging/Apps/Shared/AppDelegate.swift
@@ -14,6 +14,7 @@
 
 import UIKit
 import FirebaseCore
+import FirebaseAnalytics
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -21,6 +22,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                    didFinishLaunchingWithOptions launchOptions: [UIApplication
                      .LaunchOptionsKey: Any]?) -> Bool {
     FirebaseApp.configure()
+    FirebaseAnalytics.Analytics.logEvent("test", parameters: nil)
+
     let center = UNUserNotificationCenter.current()
     center.delegate = self
 

--- a/FirebaseMessaging/Apps/Shared/AppDelegate.swift
+++ b/FirebaseMessaging/Apps/Shared/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                    didFinishLaunchingWithOptions launchOptions: [UIApplication
                      .LaunchOptionsKey: Any]?) -> Bool {
     FirebaseApp.configure()
-
     let center = UNUserNotificationCenter.current()
     center.delegate = self
 
@@ -42,14 +41,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     completionHandler([.alert, .sound])
   }
 
-  // MARK: UISceneSession Lifecycle
-
-  func application(_ application: UIApplication,
-                   configurationForConnecting connectingSceneSession: UISceneSession,
-                   options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
-    return UISceneConfiguration(name: "Default Configuration",
-                                sessionRole: connectingSceneSession.role)
+  func userNotificationCenter(_ center: UNUserNotificationCenter,
+                              didReceive response: UNNotificationResponse,
+                              withCompletionHandler completionHandler: @escaping () -> Void) {
+    completionHandler()
   }
 }

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [fixed] Fixed an issue that notification open is not logged correctly when app is completely shut off. (#7707, #8128).
+
 # 2021-04 -- v8.0.0
 - [changed] Remove the Instance ID dependency from Firebase Cloud Messaging. This is a breaking change for FCM users who use the deprecated Instance ID API to manage registration tokens. Users should migrate to FCM's token APIs by following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)
 

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# 2021-05 -- v8.1.0
 - [fixed] Fixed an issue that notification open is not logged to Analytics correctly when app is completely shut off. (#7707, #8128).
 
 # 2021-04 -- v8.0.0

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- [fixed] Fixed an issue that notification open is not logged correctly when app is completely shut off. (#7707, #8128).
+- [fixed] Fixed an issue that notification open is not logged to Analytics correctly when app is completely shut off. (#7707, #8128).
 
 # 2021-04 -- v8.0.0
 - [changed] Remove the Instance ID dependency from Firebase Cloud Messaging. This is a breaking change for FCM users who use the deprecated Instance ID API to manage registration tokens. Users should migrate to FCM's token APIs by following the migration guide: https://firebase.google.com/docs/projects/manage-installations#fid-iid. (#7836)

--- a/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
+++ b/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
@@ -189,6 +189,7 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a."
 + (void)logMessage:(NSDictionary *)notification
        toAnalytics:(id<FIRAnalyticsInterop> _Nullable)analytics {
   // iOS only because Analytics doesn't support other platforms.
+
 #if TARGET_OS_IOS
   if (![self canLogNotification:notification]) {
     return;
@@ -201,9 +202,12 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a."
   UIApplicationState applicationState = application.applicationState;
   switch (applicationState) {
     case UIApplicationStateInactive:
-      // App was either in background(suspended) or inactive and user tapped on a display
-      // notification.
-      [self logOpenNotification:notification toAnalytics:analytics];
+      // App was in background and in transition to open when user tapped
+      // on a display notification.
+      // Needs to check notification is displayed.
+      if ([[self class] isDisplayNotification:notification]) {
+        [self logOpenNotification:notification toAnalytics:analytics];
+      }
       break;
 
     case UIApplicationStateActive:
@@ -212,11 +216,27 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a."
       break;
 
     default:
-      // Only a silent notification (i.e. 'content-available' is true) can be received while the app
-      // is in the background. These messages aren't loggable anyway.
+      // App was either in background state or in transition from closed
+      // to open.
+      // Needs to check notification is displayed.
+      if ([[self class] isDisplayNotification:notification]) {
+        [self logOpenNotification:notification toAnalytics:analytics];
+      }
       break;
   }
 #endif
+}
+
++ (BOOL)isDisplayNotification:(NSDictionary *)notification {
+  NSDictionary *aps = notification[kApsKey];
+  if (!aps || ![aps isKindOfClass:[NSDictionary class]]) {
+    return NO;
+  }
+  NSDictionary *alert = aps[kApsAlertKey];
+  if (!alert || ![alert isKindOfClass:[NSDictionary class]]) {
+    return NO;
+  }
+  return (alert[@"body"] || alert[@"title"]);
 }
 
 @end

--- a/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
+++ b/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
@@ -28,8 +28,6 @@ static NSString *const kLogTag = @"FIRMessagingAnalytics";
 // aps Key
 static NSString *const kApsKey = @"aps";
 static NSString *const kApsAlertKey = @"alert";
-static NSString *const kApsTitleKey = @"title";
-static NSString *const kApsBodyKey = @"body";
 static NSString *const kApsSoundKey = @"sound";
 static NSString *const kApsBadgeKey = @"badge";
 static NSString *const kApsContentAvailableKey = @"badge";
@@ -235,10 +233,17 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a."
     return NO;
   }
   NSDictionary *alert = aps[kApsAlertKey];
-  if (!alert || ![alert isKindOfClass:[NSDictionary class]]) {
+  if (!alert) {
     return NO;
   }
-  return (alert[kApsBodyKey] || alert[kApsTitleKey]);
+  if ([alert isKindOfClass:[NSDictionary class]]) {
+    return alert.allKeys.count > 0;
+  }
+  // alert can be string sometimes (if only body is specified)
+  if ([alert isKindOfClass:[NSString class]]) {
+    return YES;
+  }
+  return NO;
 }
 
 @end

--- a/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
+++ b/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
@@ -28,6 +28,8 @@ static NSString *const kLogTag = @"FIRMessagingAnalytics";
 // aps Key
 static NSString *const kApsKey = @"aps";
 static NSString *const kApsAlertKey = @"alert";
+static NSString *const kApsTitleKey = @"title";
+static NSString *const kApsBodyKey = @"body";
 static NSString *const kApsSoundKey = @"sound";
 static NSString *const kApsBadgeKey = @"badge";
 static NSString *const kApsContentAvailableKey = @"badge";
@@ -236,7 +238,7 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a."
   if (!alert || ![alert isKindOfClass:[NSDictionary class]]) {
     return NO;
   }
-  return (alert[@"body"] || alert[@"title"]);
+  return (alert[kApsBodyKey] || alert[kApsTitleKey]);
 }
 
 @end

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
@@ -450,27 +450,37 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
 
 - (void)testDisplayNotification {
   NSDictionary *notification = @{
-    @"aps" : @{@"alert" : @"to check the reporting format"},
-  };
-  XCTAssertFalse([FIRMessagingAnalytics isDisplayNotification:notification]);
-  notification = @{
     @"google.c.a.e" : @"1",
   };
   XCTAssertFalse([FIRMessagingAnalytics isDisplayNotification:notification]);
+
+  notification = @{
+    @"aps" : @{@"alert" : @"to check the reporting format"},
+  };
+  XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+
   notification = @{
     @"google.c.a.e" : @"1",
     @"aps" : @{@"alert" : @{@"title" : @"Hello World"}},
   };
   XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+
   notification = @{
     @"google.c.a.e" : @"1",
     @"aps" : @{@"alert" : @{@"body" : @"This is the body of notification."}},
   };
   XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+
   notification = @{
     @"google.c.a.e" : @"1",
     @"aps" :
         @{@"alert" : @{@"title" : @"Hello World", @"body" : @"This is the body of notification."}},
+  };
+  XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+
+  notification = @{
+    @"google.c.a.e" : @"1",
+    @"aps" : @{@"alert" : @{@"subtitle" : @"Hello World"}},
   };
   XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
@@ -140,6 +140,7 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
     withNotification:(NSDictionary *)notification
          toAnalytics:(id<FIRAnalyticsInterop> _Nullable)analytics;
 ;
++ (BOOL)isDisplayNotification:(NSDictionary *)notification;
 
 @end
 
@@ -447,6 +448,32 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
                             toAnalytics:nil]);
 }
 
+- (void)testDisplayNotification {
+  NSDictionary *notification = @{
+    @"aps" : @{@"alert" : @"to check the reporting format"},
+  };
+  XCTAssertFalse([FIRMessagingAnalytics isDisplayNotification:notification]);
+  notification = @{
+    @"google.c.a.e" : @"1",
+  };
+  XCTAssertFalse([FIRMessagingAnalytics isDisplayNotification:notification]);
+  notification = @{
+    @"google.c.a.e" : @"1",
+    @"aps" : @{@"alert" : @{@"title" : @"Hello World"}},
+  };
+  XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+  notification = @{
+    @"google.c.a.e" : @"1",
+    @"aps" : @{@"alert" : @{@"body" : @"This is the body of notification."}},
+  };
+  XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+  notification = @{
+    @"google.c.a.e" : @"1",
+    @"aps" :
+        @{@"alert" : @{@"title" : @"Hello World", @"body" : @"This is the body of notification."}},
+  };
+  XCTAssertTrue([FIRMessagingAnalytics isDisplayNotification:notification]);
+}
 @end
 
 #endif


### PR DESCRIPTION
This fixes #8128 and #7707. Internal bug: b/157964197.

When app is completely closed and user taps on notification to open the app, the client SDK does not correctly capture the state to log notification open.

Also add analytics to sample app.

Added unit test and tested sending when app is closed, now notification_open is logged on analytics debug view console.