### PR TITLE
Fix lack of parse for fiam modal action button

### DIFF
--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -230,6 +230,8 @@
 
       imageURLStr = modalNode[@"imageUrl"];
       actionButtonText = modalNode[@"actionButton"][@"text"][@"text"];
+      btnTxtColor = [UIColor
+          firiam_colorWithHexString:modalNode[@"actionButton"][@"text"][@"hexColor"]];
       btnBgColor =
           [UIColor firiam_colorWithHexString:modalNode[@"actionButton"][@"buttonHexColor"]];
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -230,8 +230,8 @@
 
       imageURLStr = modalNode[@"imageUrl"];
       actionButtonText = modalNode[@"actionButton"][@"text"][@"text"];
-      btnTxtColor = [UIColor
-          firiam_colorWithHexString:modalNode[@"actionButton"][@"text"][@"hexColor"]];
+      btnTxtColor =
+          [UIColor firiam_colorWithHexString:modalNode[@"actionButton"][@"text"][@"hexColor"]];
       btnBgColor =
           [UIColor firiam_colorWithHexString:modalNode[@"actionButton"][@"buttonHexColor"]];
 

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -140,6 +140,8 @@
   XCTAssertEqualObjects(@"687787988989", sixth.renderData.messageID);
   XCTAssertEqualObjects(@"Super Bowl LV", sixth.renderData.name);
   XCTAssertEqualObjects(@"Eagles are going to win", sixth.renderData.contentData.titleText);
+  XCTAssertEqualObjects(sixth.renderData.renderingEffectSettings.btnTextColor,
+                        [UIColor firiam_colorWithHexString:@"#1a0dab"]);
   XCTAssertNil(sixth.renderData.contentData.bodyText);
   XCTAssertNil(sixth.appData);
   XCTAssertNotNil(sixth.experimentPayload);

--- a/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
+++ b/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
@@ -240,6 +240,16 @@
             "text": "Eagles are going to win",
             "hexColor": "#004953"
           },
+          "actionButton": {
+            "text": {
+              "text": "Open",
+              "hexColor": "#1a0dab"
+            },
+            "buttonHexColor": "#000000"
+          },
+          "action": {
+            "actionUrl": "https://www.google.com"
+          },
           "backgroundHexColor": "#ffffff"
         }
       },


### PR DESCRIPTION
Firebase user can set action button's text color on firebase console for Firebase InAppMessaging. But the parser is ignoring button text color.
This PR fixes a issues of parsing data of modal message.