### PR TITLE
Crashlytics fix os_name check for iPads

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [changed] Incorporated code quality changes around integer overflow, potential race conditions, and reinstalling signal handlers.
+- [fixed] Fixed an issue where iOS-only apps running on iPads would report iOS as their OS Name.
 
 # v8.0.0
 - [changed] Added a warning to upload-symbols when it detects a dSYM with hidden symbols.

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -62,7 +62,7 @@ NSString* FIRCLSApplicationGetFirebasePlatform(void) {
   // This check is necessary because iOS-only apps running on iPad
   // will report UIUserInterfaceIdiomPhone via UI_USER_INTERFACE_IDIOM().
   if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"]) {
-      return @"ipados";
+    return @"ipados";
   }
 #endif
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -59,6 +59,11 @@ NSString* FIRCLSApplicationGetFirebasePlatform(void) {
       UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
     return @"ipados";
   }
+  // This check is necessary because iOS-only apps running on iPad
+  // will report UIUserInterfaceIdiomPhone via UI_USER_INTERFACE_IDIOM().
+  if ([[UIDevice currentDevice].model.lowercaseString containsString:@"ipad"]) {
+      return @"ipados";
+  }
 #endif
 
   return firebasePlatform;


### PR DESCRIPTION
`UI_USER_INTERFACE_IDIOM` reports iOS when it's an iOS-only app running on an iPad.