### PR TITLE
Update merge branch in the Metrics Service

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -292,5 +292,5 @@ jobs:
         run: |
           if [ -d "${{steps.download.outputs.download-path}}" ]; then
           cd scripts/code_coverage_report/generate_code_coverage_report
-          swift run CoverageReportGenerator --merge "firebase/firebase-ios-sdk" --commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --xcresult-dir "/Users/runner/test/codecoverage" --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --branch "${GITHUB_REF##*/}"
+          swift run CoverageReportGenerator --merge "firebase/firebase-ios-sdk" --commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --xcresult-dir "/Users/runner/test/codecoverage" --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --branch "${{ github.head_ref }}"
           fi


### PR DESCRIPTION
GITHUB_REF will get a 'merge' branch due to pull_request , instead of a `master` branch.  
`github.head_ref` could fetch the merged branch, e.g. `master`. 
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context