### PR TITLE
Print FirebaseReleaser duration

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/main.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/main.swift
@@ -60,6 +60,9 @@ struct FirebaseReleaser: ParsableCommand {
   }
 
   func run() throws {
+    let startDate = Date()
+    print("Started at: \(startDate.dateTimeString())")
+
     if logOnly {
       Shell.setLogOnly()
     }
@@ -80,6 +83,10 @@ struct FirebaseReleaser: ParsableCommand {
     } else if publish {
       Push.publishPodsToTrunk(gitRoot: gitRoot)
     }
+
+    let finishDate = Date()
+    print("Finished at: \(finishDate.dateTimeString()). " +
+      "Duration: \(startDate.formattedDurationSince(finishDate))")
   }
 
   private func updateFirebasePod(newVersions: [String: String]) {

--- a/ReleaseTooling/Sources/Utils/Date+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/Date+Utils.swift
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// MARK: - Date formatting for logs.
+
+public extension Date {
+  func dateTimeString() -> String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .medium
+    return formatter.string(from: self)
+  }
+
+  func formattedDurationSince(_ date: Date) -> String {
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .abbreviated
+    formatter.allowedUnits = [.hour, .minute, .second]
+    let secondsSinceDate = date.timeIntervalSince(self)
+    return formatter.string(from: secondsSinceDate) ?? "\(round(secondsSinceDate)) sec"
+  }
+}


### PR DESCRIPTION
Prints time marks for `swift run firebase-releaser` command like:
```
Started at: 2021-05-25, 11:47:05 PM
... 
Finished at: 2021-05-30, 2:53:45 PM. Duration: 111 h 6 min. 40 sec.
```

#no-changelog