### PR TITLE
Fix deprecation warning when minimum deployment version is iOS 13+

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [changed] Incorporated code quality changes around integer overflow, potential race conditions, and reinstalling signal handlers.
 - [fixed] Fixed an issue where iOS-only apps running on iPads would report iOS as their OS Name.
+- [fixed] Fixed depcrecation warning for projects with minimum deployment version iOS 13 and up.
 
 # v8.0.0
 - [changed] Added a warning to upload-symbols when it detects a dSYM with hidden symbols.

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -56,7 +56,7 @@ NSString* FIRCLSApplicationGetFirebasePlatform(void) {
 
 #if TARGET_OS_IOS
   if ([firebasePlatform isEqualToString:@"ios"] &&
-      UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+      [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
     return @"ipados";
   }
   // This check is necessary because iOS-only apps running on iPad


### PR DESCRIPTION
Fixes #8161