### PR TITLE
App Check App Attest: handle attestation rejection

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.m
@@ -30,7 +30,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// TODO: Verify the following request fields.
 static NSString *const kRequestFieldArtifact = @"artifact";
 static NSString *const kRequestFieldAssertion = @"assertion";
 static NSString *const kRequestFieldAttestation = @"attestation_statement";
@@ -237,7 +236,6 @@ static NSString *const kHTTPMethodPost = @"POST";
 #pragma mark - Helpers
 
 - (NSString *)base64StringWithData:(NSData *)data {
-  // TODO: Need to encode in base64URL?
   return [data base64EncodedStringWithOptions:0];
 }
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppAttestRejectionError : NSError
+
+- (instancetype)init;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.m
@@ -21,7 +21,9 @@
 @implementation FIRAppAttestRejectionError
 
 - (instancetype)init {
-  return [self initWithDomain:kFIRAppCheckErrorDomain code:FIRAppCheckErrorCodeUnknown userInfo:nil];
+  return [self initWithDomain:kFIRAppCheckErrorDomain
+                         code:FIRAppCheckErrorCodeUnknown
+                     userInfo:nil];
 }
 
 @end

--- a/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.m
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h"
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+
+@implementation FIRAppAttestRejectionError
+
+- (instancetype)init {
+  return [self initWithDomain:kFIRAppCheckErrorDomain code:FIRAppCheckErrorCodeUnknown userInfo:nil];
+}
+
+@end

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -31,8 +31,12 @@
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestArtifactStorage.h"
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestKeyIDStorage.h"
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+
 #import "FirebaseAppCheck/Sources/Core/Utils/FIRAppCheckCryptoUtils.h"
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+#import "FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
@@ -222,37 +226,13 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Initial handshake sequence (attestation)
 
 - (FBLPromise<FIRAppCheckToken *> *)initialHandshakeWithKeyID:(nullable NSString *)keyID {
-  // 1. Request a random challenge and get App Attest key ID concurrently.
-  return [FBLPromise onQueue:self.queue
-                         all:@[
-                           // 1.1. Request random challenge.
-                           [self.APIService getRandomChallenge],
-                           // 1.2. Get App Attest key ID.
-                           [self generateAppAttestKeyIDIfNeeded:keyID]
-                         ]]
-      .thenOn(self.queue,
-              ^FBLPromise<FIRAppAttestKeyAttestationResult *> *(NSArray *challengeAndKeyID) {
-                // 2. Attest the key.
-                NSData *challenge = challengeAndKeyID.firstObject;
-                NSString *keyID = challengeAndKeyID.lastObject;
 
-                return [self attestKey:keyID challenge:challenge];
-              })
-      // TODO: Handle a possible key rejection - generate another key.
-      .thenOn(self.queue,
-              ^FBLPromise<NSArray *> *(FIRAppAttestKeyAttestationResult *result) {
-                // 3. Exchange the attestation to FAC token and pass the results to the next step.
-                NSArray *attestationResults = @[
-                  // 3.1. Just pass the attestation result to the next step.
-                  [FBLPromise resolvedWith:result],
-                  // 3.2. Exchange the attestation to FAC token.
-                  [self.APIService attestKeyWithAttestation:result.attestation
-                                                      keyID:result.keyID
-                                                  challenge:result.challenge]
-                ];
-
-                return [FBLPromise onQueue:self.queue all:attestationResults];
-              })
+  // 1. Attest the device. Retry once on 403 from Firebase backend (attestation rejection error).
+  return [FBLPromise onQueue:self.queue attempts:2 delay:0 condition:^BOOL(NSInteger attemptCount, NSError * _Nonnull error) {
+    return [error isKindOfClass:[FIRAppAttestRejectionError class]];
+  } retry:^id _Nullable{
+    return [self attestKeyGenerateIfNeededWithID:keyID];
+  }]
       .thenOn(self.queue, ^FBLPromise<FIRAppCheckToken *> *(NSArray *attestationResults) {
         // 4. Save the artifact and return the received FAC token.
 
@@ -297,6 +277,59 @@ NS_ASSUME_NONNULL_BEGIN
                                                         attestation:attestation];
         return [FBLPromise resolvedWith:result];
       });
+}
+
+- (FBLPromise<NSArray * /*[keyID, attestArtifact]*/> *)attestKeyGenerateIfNeededWithID:(nullable NSString *)keyID {
+  // 1. Request a random challenge and get App Attest key ID concurrently.
+  return [FBLPromise onQueue:self.queue
+                         all:@[
+                           // 1.1. Request random challenge.
+                           [self.APIService getRandomChallenge],
+                           // 1.2. Get App Attest key ID.
+                           [self generateAppAttestKeyIDIfNeeded:keyID]
+                         ]]
+      .thenOn(self.queue,
+              ^FBLPromise<FIRAppAttestKeyAttestationResult *> *(NSArray *challengeAndKeyID) {
+                // 2. Attest the key.
+                NSData *challenge = challengeAndKeyID.firstObject;
+                NSString *keyID = challengeAndKeyID.lastObject;
+
+                return [self attestKey:keyID challenge:challenge];
+              })
+      .thenOn(self.queue,
+              ^FBLPromise<NSArray *> *(FIRAppAttestKeyAttestationResult *result) {
+                // 3. Exchange the attestation to FAC token and pass the results to the next step.
+                NSArray *attestationResults = @[
+                  // 3.1. Just pass the attestation result to the next step.
+                  [FBLPromise resolvedWith:result],
+                  // 3.2. Exchange the attestation to FAC token.
+                  [self.APIService attestKeyWithAttestation:result.attestation
+                                                      keyID:result.keyID
+                                                  challenge:result.challenge]
+                ];
+
+                return [FBLPromise onQueue:self.queue all:attestationResults];
+      })
+  .recoverOn(self.queue, ^id(NSError *error) {
+    // If App Attest attestation was rejected then reset the attestation and throw a specific error.
+    FIRAppCheckHTTPError *HTTPError = (FIRAppCheckHTTPError *)error;
+    if([HTTPError isKindOfClass:[FIRAppCheckHTTPError class]] && HTTPError.HTTPResponse.statusCode == 403) {
+      // Reset the attestation.
+      return [self resetAttestation]
+      .thenOn(self.queue, ^NSError *(id result) {
+        // Throw the rejection error.
+        return [[FIRAppAttestRejectionError alloc] init];
+      });
+    }
+
+    // Otherwise just re-throw the error.
+    return error;
+  });
+}
+
+/// Resets stored key ID and attestation artifact.
+- (FBLPromise<NSNull *> *)resetAttestation {
+  return [FBLPromise resolvedWith:nil];
 }
 
 #pragma mark - Token refresh sequence (assertion)

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -229,7 +229,7 @@ NS_ASSUME_NONNULL_BEGIN
   // 1. Attest the device. Retry once on 403 from Firebase backend (attestation rejection error).
   __block NSString *keyIDForAttempt = keyID;
   return [FBLPromise onQueue:self.queue
-             attempts:2
+             attempts:1
              delay:0
              condition:^BOOL(NSInteger attemptCount, NSError *_Nonnull error) {
     // Reset keyID before retrying.

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -31,6 +31,7 @@
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestArtifactStorage.h"
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestKeyIDStorage.h"
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
+#import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
 #import "FirebaseAppCheck/Sources/Core/Utils/FIRAppCheckCryptoUtils.h"
 
@@ -205,6 +206,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [self attestationState].thenOn(self.queue, ^id(FIRAppAttestProviderState *attestState) {
     switch (attestState.state) {
       case FIRAppAttestAttestationStateUnsupported:
+        FIRAppCheckDebugLog(@"App Attest is not supported.");
         return attestState.appAttestUnsupportedError;
         break;
 
@@ -323,6 +325,7 @@ NS_ASSUME_NONNULL_BEGIN
         FIRAppCheckHTTPError *HTTPError = (FIRAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[FIRAppCheckHTTPError class]] &&
             HTTPError.HTTPResponse.statusCode == 403) {
+          FIRAppCheckDebugLog(@"App Attest attestation was rejected by backend. The existing attestation will be reset.");
           // Reset the attestation.
           return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
             // Throw the rejection error.

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -325,7 +325,8 @@ NS_ASSUME_NONNULL_BEGIN
         FIRAppCheckHTTPError *HTTPError = (FIRAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[FIRAppCheckHTTPError class]] &&
             HTTPError.HTTPResponse.statusCode == 403) {
-          FIRAppCheckDebugLog(@"App Attest attestation was rejected by backend. The existing attestation will be reset.");
+          FIRAppCheckDebugLog(@"App Attest attestation was rejected by backend. The existing "
+                              @"attestation will be reset.");
           // Reset the attestation.
           return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
             // Throw the rejection error.

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -232,8 +232,8 @@ NS_ASSUME_NONNULL_BEGIN
              attempts:1
              delay:0
              condition:^BOOL(NSInteger attemptCount, NSError *_Nonnull error) {
-    // Reset keyID before retrying.
-    keyIDForAttempt = nil;
+               // Reset keyID before retrying.
+               keyIDForAttempt = nil;
                return [error isKindOfClass:[FIRAppAttestRejectionError class]];
              }
              retry:^FBLPromise<NSArray * /*[keyID, attestArtifact]*/> *_Nullable {
@@ -337,8 +337,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Resets stored key ID and attestation artifact.
 - (FBLPromise<NSNull *> *)resetAttestation {
-  return [self.keyIDStorage setAppAttestKeyID:nil]
-  .thenOn(self.queue, ^id(id result) {
+  return [self.keyIDStorage setAppAttestKeyID:nil].thenOn(self.queue, ^id(id result) {
     return [self.artifactStorage setArtifact:nil forKey:@""];
   });
 }

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -206,7 +206,8 @@ NS_ASSUME_NONNULL_BEGIN
   return [self attestationState].thenOn(self.queue, ^id(FIRAppAttestProviderState *attestState) {
     switch (attestState.state) {
       case FIRAppAttestAttestationStateUnsupported:
-        FIRAppCheckDebugLog(@"App Attest is not supported.");
+        FIRAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeAppAttestNotSupported,
+                            @"App Attest is not supported.");
         return attestState.appAttestUnsupportedError;
         break;
 
@@ -325,7 +326,8 @@ NS_ASSUME_NONNULL_BEGIN
         FIRAppCheckHTTPError *HTTPError = (FIRAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[FIRAppCheckHTTPError class]] &&
             HTTPError.HTTPResponse.statusCode == 403) {
-          FIRAppCheckDebugLog(@"App Attest attestation was rejected by backend. The existing "
+          FIRAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeAttestationRejected,
+                              @"App Attest attestation was rejected by backend. The existing "
                               @"attestation will be reset.");
           // Reset the attestation.
           return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -337,7 +337,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Resets stored key ID and attestation artifact.
 - (FBLPromise<NSNull *> *)resetAttestation {
-  return [FBLPromise resolvedWith:nil];
+  return [self.keyIDStorage setAppAttestKeyID:nil]
+  .thenOn(self.queue, ^id(id result) {
+    return [self.artifactStorage setArtifact:nil forKey:@""];
+  });
 }
 
 #pragma mark - Token refresh sequence (assertion)

--- a/FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.m
+++ b/FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.m
@@ -143,9 +143,10 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
   NSInteger statusCode = response.HTTPResponse.statusCode;
   return [FBLPromise do:^id _Nullable {
     if (statusCode < 200 || statusCode >= 300) {
-      FIRLogDebug(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
-                  @"Unexpected API response: %@, body: %@.", response.HTTPResponse,
-                  [[NSString alloc] initWithData:response.HTTPBody encoding:NSUTF8StringEncoding]);
+      FIRAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode,
+                          @"Unexpected API response: %@, body: %@.", response.HTTPResponse,
+                          [[NSString alloc] initWithData:response.HTTPBody
+                                                encoding:NSUTF8StringEncoding]);
       return [FIRAppCheckErrorUtil APIErrorWithHTTPResponse:response.HTTPResponse
                                                        data:response.HTTPBody];
     }

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class FIRAppCheckHTTPError;
+
 NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXTERN NSErrorDomain const kFIRAppCheckErrorDomain NS_SWIFT_NAME(AppCheckErrorDomain);
@@ -29,8 +31,8 @@ void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 + (NSError *)cachedTokenNotFound;
 + (NSError *)cachedTokenExpired;
 
-+ (NSError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
-                                 data:(nullable NSData *)data;
++ (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
+                                              data:(nullable NSData *)data;
 
 + (NSError *)APIErrorWithNetworkError:(NSError *)networkError;
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -36,7 +36,7 @@ NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
 }
 
 + (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
-                                 data:(nullable NSData *)data {
+                                              data:(nullable NSData *)data {
   return [[FIRAppCheckHTTPError alloc] initWithHTTPResponse:HTTPResponse data:data];
 }
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -15,6 +15,7 @@
  */
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
 NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
 
@@ -34,15 +35,9 @@ NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
                      underlyingError:nil];
 }
 
-+ (NSError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
++ (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                  data:(nullable NSData *)data {
-  NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"";
-  NSString *failureReason =
-      [NSString stringWithFormat:@"Unexpected API response. HTTP code: %ld, body: \n%@",
-                                 (long)HTTPResponse.statusCode, body];
-  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
-                       failureReason:failureReason
-                     underlyingError:nil];
+  return [[FIRAppCheckHTTPError alloc] initWithHTTPResponse:HTTPResponse data:data];
 }
 
 + (NSError *)APIErrorWithNetworkError:(NSError *)networkError {

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckHTTPError : NSError
+
+@property(nonatomic, readonly) NSHTTPURLResponse *HTTPResponse;
+@property(nonatomic, readonly, nonnull) NSData *data;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse data:(nullable NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
@@ -22,19 +22,16 @@
 
 - (instancetype)initWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                 data:(nullable NSData *)data {
-  NSDictionary *userInfo = [[self class] userInfoWithHTTPResponse:HTTPResponse
-                                                                          data:data];
-  self = [super
-      initWithDomain:kFIRAppCheckErrorDomain
-                code:FIRAppCheckErrorCodeUnknown
-            userInfo:userInfo];
+  NSDictionary *userInfo = [[self class] userInfoWithHTTPResponse:HTTPResponse data:data];
+  self = [super initWithDomain:kFIRAppCheckErrorDomain
+                          code:FIRAppCheckErrorCodeUnknown
+                      userInfo:userInfo];
   if (self) {
     _HTTPResponse = HTTPResponse;
     _data = data;
   }
   return self;
 }
-
 
 + (NSDictionary *)userInfoWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                       data:(nullable NSData *)data {

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+
+@implementation FIRAppCheckHTTPError
+
+- (instancetype)initWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
+                                data:(nullable NSData *)data {
+  NSDictionary *userInfo = [[self class] userInfoWithHTTPResponse:HTTPResponse
+                                                                          data:data];
+  self = [super
+      initWithDomain:kFIRAppCheckErrorDomain
+                code:FIRAppCheckErrorCodeUnknown
+            userInfo:userInfo];
+  if (self) {
+    _HTTPResponse = HTTPResponse;
+    _data = data;
+  }
+  return self;
+}
+
+
++ (NSDictionary *)userInfoWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
+                                      data:(nullable NSData *)data {
+  NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  NSString *failureReason =
+      [NSString stringWithFormat:@"The server responded with an error: \n - URL: %@ \n - HTTP "
+                                 @"status code: %ld \n - Response body: %@",
+                                 HTTPResponse.URL, (long)HTTPResponse.statusCode, responseString];
+  return @{NSLocalizedFailureReasonErrorKey : failureReason};
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  return [[[self class] alloc] initWithHTTPResponse:self.HTTPResponse data:self.data];
+}
+
+#pragma mark - NSSecureCoding
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder {
+  NSHTTPURLResponse *HTTPResponse = [coder decodeObjectOfClass:[NSHTTPURLResponse class]
+                                                        forKey:@"HTTPResponse"];
+  if (!HTTPResponse) {
+    return nil;
+  }
+  NSData *data = [coder decodeObjectOfClass:[NSData class] forKey:@"data"];
+
+  return [self initWithHTTPResponse:HTTPResponse data:data];
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  [coder encodeObject:self.HTTPResponse forKey:@"HTTPResponse"];
+  [coder encodeObject:self.data forKey:@"data"];
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+@end

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -103,7 +103,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   id<FIRAppCheckProviderFactory> providerFactory = [FIRAppCheck providerFactory];
 
   if (providerFactory == nil) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeProviderFactoryIsMissing,
                 @"Cannot instantiate `FIRAppCheck` for app: %@ without a provider factory. "
                 @"Please register a provider factory using "
                 @"`AppCheck.setAppCheckProviderFactory(_ ,forAppName:)` method.",
@@ -113,7 +113,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
   id<FIRAppCheckProvider> appCheckProvider = [providerFactory createProviderWithApp:app];
   if (appCheckProvider == nil) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeProviderIsMissing,
                 @"Cannot instantiate `FIRAppCheck` for app: %@ without an app check provider. "
                 @"Please make sure the provide factory returns a valid app check provider.",
                 app.name);

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
@@ -22,3 +22,5 @@ extern FIRLoggerService kFIRLoggerAppCheck;
 
 // TODO: use specific codes when stabilized.
 extern NSString *const kFIRLoggerAppCheckMessageCodeUnknown;
+
+void FIRAppCheckDebugLog(NSString *message, ...);

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
@@ -20,7 +20,27 @@
 
 extern FIRLoggerService kFIRLoggerAppCheck;
 
-// TODO: use specific codes when stabilized.
-extern NSString *const kFIRLoggerAppCheckMessageCodeUnknown;
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnknown;
 
-void FIRAppCheckDebugLog(NSString *message, ...);
+// FIRAppCheck.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeProviderFactoryIsMissing;
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing;
+
+// FIRAppCheckAPIService.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode;
+
+// FIRAppCheckDebugProvider.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions;
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDebugProviderFailedExchange;
+
+// FIRAppCheckDebugProviderFactory.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeDebugToken;
+
+// FIRDeviceCheckProvider.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions;
+
+// FIRAppAttestProvider.m
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported;
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected;
+
+void FIRAppCheckDebugLog(NSString *messageCode, NSString *message, ...);

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -24,11 +24,32 @@ FIRLoggerService kFIRLoggerAppCheck = @"[Firebase/AppCheck]";
 
 NSString *const kFIRLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
 
-void FIRAppCheckDebugLog(NSString *message, ...) {
+// FIRAppCheck.m
+NSString *const kFIRLoggerAppCheckMessageCodeProviderFactoryIsMissing = @"I-FAA002001";
+NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing = @"I-FAA002002";
+
+// FIRAppCheckAPIService.m
+NSString *const kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode = @"I-FAA003001";
+
+// FIRAppCheckDebugProvider.m
+NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions = @"I-FAA004001";
+NSString *const kFIRLoggerAppCheckMessageDebugProviderFailedExchange = @"I-FAA004002";
+
+// FIRAppCheckDebugProviderFactory.m
+NSString *const kFIRLoggerAppCheckMessageCodeDebugToken = @"I-FAA005001";
+
+// FIRDeviceCheckProvider.m
+NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions = @"I-FAA006001";
+
+// FIRAppAttestProvider.m
+NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported = @"I-FAA007001";
+NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected = @"I-FAA007002";
+
+#pragma mark - Log functions
+void FIRAppCheckDebugLog(NSString *messageCode, NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
-              message, args_ptr);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, messageCode, message, args_ptr);
   va_end(args_ptr);
 }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -27,7 +27,8 @@ NSString *const kFIRLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
 void FIRAppCheckDebugLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown, message, args_ptr);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+              message, args_ptr);
   va_end(args_ptr);
 }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -16,6 +16,19 @@
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 FIRLoggerService kFIRLoggerAppCheck = @"[Firebase/AppCheck]";
 
 NSString *const kFIRLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
+
+void FIRAppCheckDebugLog(NSString *message, ...) {
+  va_list args_ptr;
+  va_start(args_ptr, message);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown, message, args_ptr);
+  va_end(args_ptr);
+}
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
@@ -53,7 +53,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   NSArray<NSString *> *missingOptionsFields =
       [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions,
                 @"Cannot instantiate `FIRAppCheckDebugProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);
@@ -119,8 +119,8 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
         return nil;
       })
       .catch(^void(NSError *error) {
-        FIRLogDebug(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
-                    @"Failed to exchange debug token to app check token: %@", error);
+        FIRAppCheckDebugLog(kFIRLoggerAppCheckMessageDebugProviderFailedExchange,
+                            @"Failed to exchange debug token to app check token: %@", error);
         handler(nil, error);
       });
 }

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
   FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
 
   // Print only locally generated token to avoid a valid token leak on CI.
-  FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+  FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
                 @"Firebase App Check debug token: '%@'.", [provider localDebugToken]);
 
   return provider;

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -65,7 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<NSString *> *missingOptionsFields =
       [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions,
+    FIRLogError(kFIRLoggerAppCheck,
+                kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions,
                 @"Cannot instantiate `FIRDeviceCheckProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<NSString *> *missingOptionsFields =
       [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeUnknown,
+    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions,
                 @"Cannot instantiate `FIRDeviceCheckProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
@@ -25,8 +25,8 @@
 #import "FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAttestationResponse.h"
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
-#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
 
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFixtureLoader.h"
 #import "SharedTestUtilities/Date/FIRDateTestUtils.h"
@@ -99,8 +99,9 @@
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
   GULURLSessionDataResponse *invalidAPIResponse = [self APIResponseWithCode:300
                                                                responseBody:responseBody];
-  FIRAppCheckHTTPError *APIError = [FIRAppCheckErrorUtil APIErrorWithHTTPResponse:invalidAPIResponse.HTTPResponse
-                                                                data:invalidAPIResponse.HTTPBody];
+  FIRAppCheckHTTPError *APIError =
+      [FIRAppCheckErrorUtil APIErrorWithHTTPResponse:invalidAPIResponse.HTTPResponse
+                                                data:invalidAPIResponse.HTTPBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:APIError];
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
@@ -26,6 +26,7 @@
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFixtureLoader.h"
 #import "SharedTestUtilities/Date/FIRDateTestUtils.h"
@@ -98,7 +99,7 @@
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
   GULURLSessionDataResponse *invalidAPIResponse = [self APIResponseWithCode:300
                                                                responseBody:responseBody];
-  NSError *APIError = [FIRAppCheckErrorUtil APIErrorWithHTTPResponse:invalidAPIResponse.HTTPResponse
+  FIRAppCheckHTTPError *APIError = [FIRAppCheckErrorUtil APIErrorWithHTTPResponse:invalidAPIResponse.HTTPResponse
                                                                 data:invalidAPIResponse.HTTPBody];
   // 2. Stub API Service Request to return prepared API response.
   [self stubMockAPIServiceRequestForChallengeRequestWithResponse:APIError];

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -445,7 +445,7 @@ API_AVAILABLE(ios(14.0))
   OCMExpect([self.mockStorage setAppAttestKeyID:nil]).andReturn([FBLPromise resolvedWith:nil]);
 
   // 4.2 Expect stored attestation artifact to be reset.
-  OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:keyID1]).andReturn([FBLPromise resolvedWith:nil]);
+  OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:@""]).andReturn([FBLPromise resolvedWith:nil]);
 
   // 5. Expect the App Attest key pair to be generated and attested.
   NSString *keyID2 = @"keyID2";

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -26,9 +26,12 @@
 #import "FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestService.h"
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestArtifactStorage.h"
 #import "FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestKeyIDStorage.h"
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Utils/FIRAppCheckCryptoUtils.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
@@ -419,6 +422,69 @@ API_AVAILABLE(ios(14.0))
   [self verifyAllMocks];
 }
 
+#pragma mark Rejected Attestation
+
+- (void)testGetToken_WhenAttestationIsRejected_ThenAttestationIsResetAndRetriedOnceSuccess {
+  // 1. Expect App Attest availability to be requested and stored key ID request to fail.
+  [self expectAppAttestAvailabilityToBeCheckedAndStoredKeyRequested];
+
+  // 2. Expect the App Attest key pair to be generated and attested.
+  NSString *keyID1 = @"keyID1";
+  NSData *attestationData1 = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
+  [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:keyID1 attestationData:attestationData1];
+
+  // 3. Expect exchange request to be sent.
+  FIRAppCheckHTTPError *APIError = [self attestationRejectionHTTPError];
+  OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData1
+                                                    keyID:keyID1
+                                                challenge:self.randomChallenge])
+      .andReturn([self rejectedPromiseWithError:APIError]);
+
+  // 4. Stored attestation to be reset.
+  // 4.1. Expect stored key ID to be reset.
+  OCMExpect([self.mockStorage setAppAttestKeyID:nil]).andReturn([FBLPromise resolvedWith:nil]);
+
+  // 4.2 Expect stored attestation artifact to be reset.
+  OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:keyID1]).andReturn([FBLPromise resolvedWith:nil]);
+
+  // 5. Expect the App Attest key pair to be generated and attested.
+  NSString *keyID2 = @"keyID2";
+  NSData *attestationData2 = [[NSUUID UUID].UUIDString dataUsingEncoding:NSUTF8StringEncoding];
+  [self expectAppAttestKeyGeneratedAndAttestedWithKeyID:keyID2 attestationData:attestationData2];
+
+  // 6. Expect exchange request to be sent.
+  FIRAppCheckToken *FACToken = [[FIRAppCheckToken alloc] initWithToken:@"FAC token"
+                                                        expirationDate:[NSDate date]];
+  NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
+  __auto_type attestKeyResponse =
+      [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
+  OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
+                                                    keyID:keyID2
+                                                challenge:self.randomChallenge])
+      .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+
+  // 7. Expect the artifact received from Firebase backend to be saved.
+  OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:keyID2])
+      .andReturn([FBLPromise resolvedWith:artifactData]);
+
+  // 8. Call get token.
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"completionExpectation"];
+  [self.provider
+      getTokenWithCompletion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
+        [completionExpectation fulfill];
+
+    XCTAssertEqualObjects(token.token, FACToken.token);
+    XCTAssertEqualObjects(token.expirationDate, FACToken.expirationDate);
+    XCTAssertNil(error);
+      }];
+
+  [self waitForExpectations:@[ completionExpectation ] timeout:0.5];
+
+  // 8. Verify mocks.
+  [self verifyAllMocks];
+}
+
 #pragma mark - FAC token refresh (assertion)
 
 - (void)testGetToken_WhenKeyRegistered_Success {
@@ -745,6 +811,15 @@ API_AVAILABLE(ios(14.0))
   OCMVerifyAll(self.mockArtifactStorage);
 }
 
+- (FIRAppCheckHTTPError *)attestationRejectionHTTPError {
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://localhost"]
+                                                            statusCode:403
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:nil];
+  NSData *responseBody = [@"Could not verify attestation" dataUsingEncoding:NSUTF8StringEncoding];
+  return [[FIRAppCheckHTTPError alloc] initWithHTTPResponse:response data:responseBody];
+}
+
 - (void)assertGetToken_WhenKeyRegistered_Success {
   // 1. Expect FIRAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
@@ -795,6 +870,39 @@ API_AVAILABLE(ios(14.0))
 
   // 8. Verify mocks.
   [self verifyAllMocks];
+}
+
+- (void)expectAppAttestAvailabilityToBeCheckedAndStoredKeyRequested {
+  // 1. Expect FIRAppAttestService.isSupported.
+  [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
+
+  // 2. Expect storage getAppAttestKeyID.
+  FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+  NSError *error = [NSError errorWithDomain:@"testGetToken_WhenNoExistingKey_Success"
+                                       code:NSNotFound
+                                   userInfo:nil];
+  [rejectedPromise reject:error];
+  OCMExpect([self.mockStorage getAppAttestKeyID]).andReturn(rejectedPromise);
+}
+
+- (void)expectAppAttestKeyGeneratedAndAttestedWithKeyID:(NSString *)keyID attestationData:(NSData *)attestationData {
+  // 1. Expect App Attest key to be generated.
+  id completionArg = [OCMArg invokeBlockWithArgs:keyID, [NSNull null], nil];
+  OCMExpect([self.mockAppAttestService generateKeyWithCompletionHandler:completionArg]);
+
+  // 2. Expect the key ID to be stored.
+  OCMExpect([self.mockStorage setAppAttestKeyID:keyID])
+      .andReturn([FBLPromise resolvedWith:keyID]);
+
+  // 3. Expect random challenge to be requested.
+  OCMExpect([self.mockAPIService getRandomChallenge])
+      .andReturn([FBLPromise resolvedWith:self.randomChallenge]);
+
+  // 4. Expect the key to be attested with the challenge.
+  id attestCompletionArg = [OCMArg invokeBlockWithArgs:attestationData, [NSNull null], nil];
+  OCMExpect([self.mockAppAttestService attestKey:keyID
+                                  clientDataHash:self.randomChallengeHash
+                               completionHandler:attestCompletionArg]);
 }
 
 @end

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -29,9 +29,9 @@
 #import "FirebaseAppCheck/Sources/Core/Utils/FIRAppCheckCryptoUtils.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
 
+#import "FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
-#import "FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
@@ -470,9 +470,9 @@ API_AVAILABLE(ios(14.0))
       getTokenWithCompletion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
         [completionExpectation fulfill];
 
-    XCTAssertEqualObjects(token.token, FACToken.token);
-    XCTAssertEqualObjects(token.expirationDate, FACToken.expirationDate);
-    XCTAssertNil(error);
+        XCTAssertEqualObjects(token.token, FACToken.token);
+        XCTAssertEqualObjects(token.expirationDate, FACToken.expirationDate);
+        XCTAssertNil(error);
       }];
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5];
@@ -514,8 +514,8 @@ API_AVAILABLE(ios(14.0))
   // 7. Stored attestation to be reset.
   [self expectAttestationReset];
 
-//  // 8. Don't expect the artifact received from Firebase backend to be saved.
-//  OCMReject([self.mockArtifactStorage setArtifact:OCMOCK_ANY forKey:OCMOCK_ANY]);
+  // 8. Don't expect the artifact received from Firebase backend to be saved.
+  OCMReject([self.mockArtifactStorage setArtifact:OCMOCK_ANY forKey:OCMOCK_ANY]);
 
   // 9. Call get token.
   XCTestExpectation *completionExpectation =
@@ -524,9 +524,9 @@ API_AVAILABLE(ios(14.0))
       getTokenWithCompletion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
         [completionExpectation fulfill];
 
-    XCTAssertNil(token);
-    FIRAppAttestRejectionError *expectedError = [[FIRAppAttestRejectionError alloc] init];
-    XCTAssertEqualObjects(error, expectedError);
+        XCTAssertNil(token);
+        FIRAppAttestRejectionError *expectedError = [[FIRAppAttestRejectionError alloc] init];
+        XCTAssertEqualObjects(error, expectedError);
       }];
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5];
@@ -862,10 +862,11 @@ API_AVAILABLE(ios(14.0))
 }
 
 - (FIRAppCheckHTTPError *)attestationRejectionHTTPError {
-  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://localhost"]
-                                                            statusCode:403
-                                                           HTTPVersion:@"HTTP/1.1"
-                                                          headerFields:nil];
+  NSHTTPURLResponse *response =
+      [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://localhost"]
+                                  statusCode:403
+                                 HTTPVersion:@"HTTP/1.1"
+                                headerFields:nil];
   NSData *responseBody = [@"Could not verify attestation" dataUsingEncoding:NSUTF8StringEncoding];
   return [[FIRAppCheckHTTPError alloc] initWithHTTPResponse:response data:responseBody];
 }
@@ -935,14 +936,14 @@ API_AVAILABLE(ios(14.0))
   OCMExpect([self.mockStorage getAppAttestKeyID]).andReturn(rejectedPromise);
 }
 
-- (void)expectAppAttestKeyGeneratedAndAttestedWithKeyID:(NSString *)keyID attestationData:(NSData *)attestationData {
+- (void)expectAppAttestKeyGeneratedAndAttestedWithKeyID:(NSString *)keyID
+                                        attestationData:(NSData *)attestationData {
   // 1. Expect App Attest key to be generated.
   id completionArg = [OCMArg invokeBlockWithArgs:keyID, [NSNull null], nil];
   OCMExpect([self.mockAppAttestService generateKeyWithCompletionHandler:completionArg]);
 
   // 2. Expect the key ID to be stored.
-  OCMExpect([self.mockStorage setAppAttestKeyID:keyID])
-      .andReturn([FBLPromise resolvedWith:keyID]);
+  OCMExpect([self.mockStorage setAppAttestKeyID:keyID]).andReturn([FBLPromise resolvedWith:keyID]);
 
   // 3. Expect random challenge to be requested.
   OCMExpect([self.mockAPIService getRandomChallenge])
@@ -960,7 +961,8 @@ API_AVAILABLE(ios(14.0))
   OCMExpect([self.mockStorage setAppAttestKeyID:nil]).andReturn([FBLPromise resolvedWith:nil]);
 
   // 2. Expect stored attestation artifact to be reset.
-  OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:@""]).andReturn([FBLPromise resolvedWith:nil]);
+  OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:@""])
+      .andReturn([FBLPromise resolvedWith:nil]);
 }
 
 @end

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -426,7 +426,7 @@ API_AVAILABLE(ios(14.0))
 
 - (void)testGetToken_WhenAttestationIsRejected_ThenAttestationIsResetAndRetriedOnceSuccess {
   // 1. Expect App Attest availability to be requested and stored key ID request to fail.
-  [self expectAppAttestAvailabilityToBeCheckedAndStoredKeyRequested];
+  [self expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested];
 
   // 2. Expect the App Attest key pair to be generated and attested.
   NSString *keyID1 = @"keyID1";
@@ -483,7 +483,7 @@ API_AVAILABLE(ios(14.0))
 
 - (void)testGetToken_WhenAttestationIsRejected_ThenAttestationIsResetAndRetriedOnceError {
   // 1. Expect App Attest availability to be requested and stored key ID request to fail.
-  [self expectAppAttestAvailabilityToBeCheckedAndStoredKeyRequested];
+  [self expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested];
 
   // 2. Expect the App Attest key pair to be generated and attested.
   NSString *keyID1 = @"keyID1";
@@ -923,7 +923,7 @@ API_AVAILABLE(ios(14.0))
   [self verifyAllMocks];
 }
 
-- (void)expectAppAttestAvailabilityToBeCheckedAndStoredKeyRequested {
+- (void)expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested {
   // 1. Expect FIRAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -342,8 +342,8 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                                XCTAssertNotNil(result);
                                XCTAssertEqualObjects(result.token, kDummyToken);
 
-                               // TODO: Expect a public domain error to be returned - not the
-                               // internal one.
+                               // TODO: When method is added to public API: expect a public domain
+                               // error to be returned - not the internal one.
                                XCTAssertEqualObjects(result.error, providerError);
                              }];
 


### PR DESCRIPTION
- reset stored attestation data on attestation rejection from Firebase backend
- outdated TODOs removed
- `kFIRLoggerAppCheckMessageCodeUnknown` replaced by specific unique codes in log messages