### PR TITLE
Migrate to individual platform flags.

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -111,10 +111,13 @@ struct ZipBuilderTool: ParsableCommand {
   @Option(default: "10.0", help: ArgumentHelp("The minimum supported tvOS version."))
   var minimumTVOSVersion: String
 
-  /// The list of platforms to build for.
-  @Option(parsing: .upToNextOption,
+  /// The list of platforms to build for, passed in individually.
+  @Option(name: .customLong("platform"),
+          parsing: .singleValue,
           help: ArgumentHelp("""
-          The list of platforms to build for. The default list is \
+          The list of platforms to build for, passed in individually. eg `--platform ios \
+          --platform tvos`.
+          The default list is \
           \(Platform.allCases.map { $0.name }).
           """))
   var platforms: [Platform]

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -41,7 +41,7 @@ do
 done
 echo "]" >>  "${ZIP_POD_JSON}"
 mkdir -p "${REPO}"/sdk_zip
-swift run zip-builder --keep-build-artifacts --update-pod-repo --platforms ios \
+swift run zip-builder --keep-build-artifacts --update-pod-repo --platform ios \
     --zip-pods "${ZIP_POD_JSON}" --output-dir "${REPO}"/sdk_zip --disable-build-dependencies
 
 unzip -o "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/


### PR DESCRIPTION
This makes it easier to dynamically include platforms in a bash script
since variable expansion with spaces can be a bit dangerous.

#no-changelog