### PR TITLE
Generate a JSON file with newly added lines not covered by tests.

### DIFF
--- a/scripts/code_coverage_report/generate_code_coverage_report/Package.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Package.swift
@@ -30,15 +30,15 @@ let package = Package(
       name: "UpdatedFilesCollector",
       targets: ["UpdatedFilesCollector"]
     ),
+    .executable(
+      name: "IncrementalCoverageReportGenerator",
+      targets: ["IncrementalCoverageReportGenerator"]
+    ),
   ],
   dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    // .package(url: /* package url */, from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
   ],
   targets: [
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .target(
       name: "CoverageReportGenerator",
       dependencies: [
@@ -50,6 +50,13 @@ let package = Package(
       name: "UpdatedFilesCollector",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]
+    ),
+    .target(
+      name: "IncrementalCoverageReportGenerator",
+      dependencies: [
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        "Utils",
       ]
     ),
     .target(

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -21,18 +21,23 @@ import Utils
 private enum Constants {}
 
 extension Constants {
-  static let XCRESULT_EXTENSION = "xcresult"
+  static let xcresultExtension = "xcresult"
   // Command to get line execution counts of a file in a xcresult bundle.
-  static let XCOV_COMMAND = "xcrun xccov view --archive --file "
+  static let xcovCommand = "xcrun xccov view --archive --file "
   // The pattern is to match text "line_index: execution_counts" from the
   // outcome of xcresult bundle, e.g. "305 : 0".
-  static let LINE_EXECUTION_COUNT_PATTERN = "([0-9]+)\\s*:\\s*([0-9*]+)"
+  static let lineExecutionCountPattern = "[0-9]+\\s*:\\s*([0-9*]+)"
+  // Pattern match to the first group, i.e "([0-9*]+)".
+  static let lineExecutionCountPatternGroup = 1
   // A file includes all newly added lines without tests covered.
-  static let DEFAULT_UNCOVERED_LINE_REPORT_FILE_NAME = "uncovered_file_lines.json"
+  static let defaultUncoveredLineReportFileName = "uncovered_file_lines.json"
 }
 
+/// A JSON file from git_diff_to_json.sh will be decoded to the following instance.
 struct FileIncrementalChanges: Codable {
+  // File with newly added lines
   let file: String
+  // Indices of newly added lines in this file
   let addedLines: [Int]
   enum CodingKeys: String, CodingKey {
     case file
@@ -42,26 +47,36 @@ struct FileIncrementalChanges: Codable {
 
 extension FileIncrementalChanges {
   static func dataModel(_ filePath: String) throws -> [FileIncrementalChanges] {
-    guard let data = JSONParser.readJSON(of: [FileIncrementalChanges].self, from: filePath)
+    guard let data = try JSONParser.readJSON(of: [FileIncrementalChanges].self, from: filePath)
     else { throw ValidationError("Badly data transform.") }
     return data
   }
 }
 
+/// `xccov` outcomes of a file from a xcresult bundle will be transfered
+/// to the following instance.
 struct LineCoverage: Codable {
   var fileName: String
+  // Line execution counts for lines in this file, the indices of the array are
+  // the (line indices - 1) of this  file.
   var coverage: [Int?]
+  // The source/xcresult bundle of the coverage
   var xcresultBundle: String
 }
 
 struct IncrementalCoverageReportGenerator: ParsableCommand {
+  @Option(help: "The root of the firebase-ios-sdk checked out git repo.", 
+          transform: URL.init(fileURLWithPath:)) 
+  var gitRoot: URL 
+
   @Option(
     help: "Root path of archived files in a xcresult bundle."
   )
   var fileArchiveRootPath: String
 
-  @Option(help: "A dir of xcresult bundles.")
-  var xcresultDir: String
+  @Option(help: "A dir of xcresult bundles.",
+          transform: URL.init(fileURLWithPath:)) 
+  var xcresultDir: URL
 
   @Option(
     help: """
@@ -75,73 +90,64 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
   @Option(
     help: "Uncovered line JSON file output path"
   )
-  var uncovered_line_file_json: String = Constants.DEFAULT_UNCOVERED_LINE_REPORT_FILE_NAME
+  var uncoveredLineFileJson: String = Constants.defaultUncoveredLineReportFileName
 
-  func readFile(_ fileURL: URL) -> String {
-    var fileContent = ""
-    do {
-      fileContent = try String(contentsOf: fileURL)
-    } catch {
-      print("Failed reading from URL: \(fileURL), Error: " + error.localizedDescription)
-    }
-    return fileContent
-  }
-
-  // This will transfer line executions report from a xcresult bundle to an array of LineCoverage.
-  // The output will have the file name, line execution counts and the xcresult bundle name.
-  func createLineCoverageRecord(from coverageFile: String, changedFile: String,
+  /// This will transfer line executions report from a xcresult bundle to an array of LineCoverage.
+  /// The output will have the file name, line execution counts and the xcresult bundle name.
+  func createLineCoverageRecord(from coverageFileURL: URL, changedFile: String,
                                 lineCoverage: [LineCoverage]? = nil) -> [LineCoverage] {
     // The indices of the array represent the (line index - 1), while the value is the execution counts.
+    // Unexecutable lines, e.g. comments, will be nil here.
     var lineExecutionCounts: [Int?] = []
-    if let dir = URL(string: "file://" + FileManager.default.currentDirectoryPath) {
-      let fileURL = dir.appendingPathComponent(coverageFile)
-      let inString = readFile(fileURL)
-      let lineCoverageRegex = try! NSRegularExpression(pattern: Constants
-        .LINE_EXECUTION_COUNT_PATTERN)
-      for line in inString.components(separatedBy: "\n") {
-        let range = NSRange(location: 0, length: line.utf16.count)
-        if let match = lineCoverageRegex.firstMatch(in: line, options: [], range: range) {
-          // Get the execution counts and append. Line indices are
-          // consecutive and so the array will have counts for each line
-          // and nil for unexecutable lines, e.g. comments.
-          let nsRange = match.range(at: 2)
-          if let range = Range(nsRange, in: line) {
-            lineExecutionCounts.append(Int(line[range]))
+    do {
+        let inString = try String(contentsOf: coverageFileURL)
+        let lineCoverageRegex = try! NSRegularExpression(pattern: Constants
+          .lineExecutionCountPattern)
+        for line in inString.components(separatedBy: "\n") {
+          let range = NSRange(location: 0, length: line.utf16.count)
+          if let match = lineCoverageRegex.firstMatch(in: line, options: [], range: range) {
+            // Get the execution counts and append. Line indices are
+            // consecutive and so the array will have counts for each line
+            // and nil for unexecutable lines, e.g. comments.
+            let nsRange = match.range(at: Constants.lineExecutionCountPatternGroup)
+            if let range = Range(nsRange, in: line) {
+              lineExecutionCounts.append(Int(line[range]))
+            }
           }
         }
-      }
-    }
+    } catch {
+        fatalError("Failed to open \(coverageFileURL): \(error)")
+    } 
     if var coverageData = lineCoverage {
       coverageData
         .append(LineCoverage(fileName: changedFile, coverage: lineExecutionCounts,
-                             xcresultBundle: coverageFile))
+                             xcresultBundle: coverageFileURL.path))
       return coverageData
     } else {
       return [LineCoverage(fileName: changedFile, coverage: lineExecutionCounts,
-                           xcresultBundle: coverageFile)]
+                           xcresultBundle: coverageFileURL.path)]
     }
   }
 
-  // This function is to get union of newly added file lines and lines execution counts, from a xcresult bundle.
-  // Return an array of LineCoverage, which includes uncovered line indices of a file and its xcresult bundle source.
-  func get_uncovered_file_lines(fromDiff changedFiles: [FileIncrementalChanges],
-                                fromXcresult xcresultPath: String,
+  /// This function is to get union of newly added file lines and lines execution counts, from a xcresult bundle.
+  /// Return an array of LineCoverage, which includes uncovered line indices of a file and its xcresult bundle source.
+  func getUncoveredFileLines(fromDiff changedFiles: [FileIncrementalChanges],
+                                xcresultPath: String,
                                 archiveRootPath rootPath: String) -> [LineCoverage?] {
-    var uncovered_files: [LineCoverage?] = []
+    var uncoveredFiles: [LineCoverage?] = []
     for change in changedFiles {
       let archiveFilePath = URL(string: rootPath)!.appendingPathComponent(change.file)
       print(archiveFilePath.absoluteString)
-      // temp_output_file is a temp file, with the xcresult bundle name, including line execution counts of a file
-      let temp_output_file = URL(fileURLWithPath: xcresultPath).deletingPathExtension()
-        .lastPathComponent
+      // tempOutputFile is a temp file, with the xcresult bundle name, including line execution counts of a file
+      let tempOutputFile = URL(fileURLWithPath: xcresultPath).deletingPathExtension()
       // Fetch line execution report of a file from a xcresult bundle into a temp file, which has the same name as the xcresult bundle.
       Shell.run(
-        "\(Constants.XCOV_COMMAND) \(archiveFilePath.absoluteString) \(xcresultPath) > \(temp_output_file)",
-        displayCommand: true,
+        "\(Constants.xcovCommand) \(archiveFilePath.absoluteString) \(xcresultPath) > \(tempOutputFile.path)",
+        displayCommand: false,
         displayFailureResult: false
       )
       for coverageFile in createLineCoverageRecord(
-        from: "\(temp_output_file)",
+        from: tempOutputFile,
         changedFile: change.file
       ) {
         var uncoveredLine: LineCoverage = LineCoverage(
@@ -151,42 +157,42 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
         )
         for addedLineIndex in change.addedLines {
           if addedLineIndex < coverageFile.coverage.count {
-            if let test_cover_run = coverageFile.coverage[addedLineIndex] {
-              if test_cover_run == 0 { uncoveredLine.coverage.append(addedLineIndex) }
-              print("\(addedLineIndex) : \(test_cover_run)")
+            if let testCoverRun = coverageFile.coverage[addedLineIndex] {
+              if testCoverRun == 0 { uncoveredLine.coverage.append(addedLineIndex) }
+              print("\(addedLineIndex) : \(testCoverRun)")
             }
           }
         }
-        if !uncoveredLine.coverage.isEmpty { uncovered_files.append(uncoveredLine) }
+        if !uncoveredLine.coverage.isEmpty { uncoveredFiles.append(uncoveredLine) }
       }
     }
-    return uncovered_files
+    return uncoveredFiles
   }
 
   func run() throws {
-    let enumerator = FileManager.default.enumerator(atPath: xcresultDir)
-    var uncovered_files: [LineCoverage?] = []
+    let enumerator = FileManager.default.enumerator(atPath: xcresultDir.path)
+    var uncoveredFiles: [LineCoverage?] = []
     // Search xcresult bundles from xcresultDir and get union of `git diff` report and xccov output to generate a list of lineCoverage including files and their uncovered lines.
     while let file = enumerator?.nextObject() as? String {
       var isDir: ObjCBool = false
-      let absoluteFilePath = xcresultDir + file
+      let absoluteFilePath = xcresultDir.appendingPathComponent(file, isDirectory: true).path
       if FileManager.default.fileExists(atPath: absoluteFilePath, isDirectory: &isDir) {
-        if isDir.boolValue, absoluteFilePath.hasSuffix(Constants.XCRESULT_EXTENSION) {
-          let uncovered_xcresult = get_uncovered_file_lines(
+        if isDir.boolValue, absoluteFilePath.hasSuffix(Constants.xcresultExtension) {
+          let uncoveredXcresult = getUncoveredFileLines(
             fromDiff: changedFiles,
-            fromXcresult: absoluteFilePath,
+            xcresultPath: absoluteFilePath,
             archiveRootPath: fileArchiveRootPath
           )
-          uncovered_files.append(contentsOf: uncovered_xcresult)
+          uncoveredFiles.append(contentsOf: uncoveredXcresult)
         }
       }
     }
-    // Output uncovered_files as a JSON file.
+    // Output uncoveredFiles as a JSON file.
     do {
-      let jsonData = try JSONEncoder().encode(uncovered_files)
+      let jsonData = try JSONEncoder().encode(uncoveredFiles)
       try String(data: jsonData, encoding: .utf8)!.write(
         to: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-          .appendingPathComponent(uncovered_line_file_json),
+          .appendingPathComponent(uncoveredLineFileJson),
         atomically: true,
         encoding: String.Encoding.utf8
       )

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ArgumentParser
+import Foundation
+import Utils
+
+private enum Constants {}
+
+extension Constants {
+  static let XCRESULT_EXTENSION = "xcresult"
+  // Command to get line execution counts of a file in a xcresult bundle.
+  static let XCOV_COMMAND = "xcrun xccov view --archive --file "
+  // The pattern is to match text "line_index: execution_counts" from the
+  // outcome of xcresult bundle, e.g. "305 : 0".
+  static let LINE_EXECUTION_COUNT_PATTERN = "([0-9]+)\\s*:\\s*([0-9*]+)"
+  // A file includes all newly added lines without tests covered.
+  static let DEFAULT_UNCOVERED_LINE_REPORT_FILE_NAME = "uncovered_file_lines.json"
+}
+
+struct FileIncrementalChanges: Codable {
+  let file: String
+  let addedLines: [Int]
+  enum CodingKeys: String, CodingKey {
+    case file
+    case addedLines = "added_lines"
+  }
+}
+
+extension FileIncrementalChanges {
+  static func dataModel(_ filePath: String) throws -> [FileIncrementalChanges] {
+    guard let data = JSONParser.readJSON(of: [FileIncrementalChanges].self, from: filePath)
+    else { throw ValidationError("Badly data transform.") }
+    return data
+  }
+}
+
+struct LineCoverage: Codable {
+  var fileName: String
+  var coverage: [Int?]
+  var xcresultBundle: String
+}
+
+struct IncrementalCoverageReportGenerator: ParsableCommand {
+  @Option(
+    help: "Root path of archived files in a xcresult bundle."
+  )
+  var fileArchiveRootPath: String
+
+  @Option(help: "A dir of xcresult bundles.")
+  var xcresultDir: String
+
+  @Option(
+    help: """
+    A JSON file with changed files and added line numbers. E.g. JSON file:
+    '[{"file": "FirebaseDatabase/Sources/Api/FIRDataSnapshot.m", "added_lines": [105,106,107,108,109]},{"file": "FirebaseDatabase/Sources/Core/Utilities/FPath.m", "added_lines": [304,305,306,307,308,309]}]'
+    """,
+    transform: FileIncrementalChanges.dataModel
+  )
+  var changedFiles: [FileIncrementalChanges]
+
+  @Option(
+    help: "Uncovered line JSON file output path"
+  )
+  var uncovered_line_file_json: String = Constants.DEFAULT_UNCOVERED_LINE_REPORT_FILE_NAME
+
+  func readFile(_ fileURL: URL) -> String {
+    var fileContent = ""
+    do {
+      fileContent = try String(contentsOf: fileURL)
+    } catch {
+      print("Failed reading from URL: \(fileURL), Error: " + error.localizedDescription)
+    }
+    return fileContent
+  }
+
+  // This will transfer line executions report from a xcresult bundle to an array of LineCoverage.
+  // The output will have the file name, line execution counts and the xcresult bundle name.
+  func createLineCoverageRecord(from coverageFile: String, changedFile: String,
+                                lineCoverage: [LineCoverage]? = nil) -> [LineCoverage] {
+    // The indices of the array represent the (line index - 1), while the value is the execution counts.
+    var lineExecutionCounts: [Int?] = []
+    if let dir = URL(string: "file://" + FileManager.default.currentDirectoryPath) {
+      let fileURL = dir.appendingPathComponent(coverageFile)
+      let inString = readFile(fileURL)
+      let lineCoverageRegex = try! NSRegularExpression(pattern: Constants
+        .LINE_EXECUTION_COUNT_PATTERN)
+      for line in inString.components(separatedBy: "\n") {
+        let range = NSRange(location: 0, length: line.utf16.count)
+        if let match = lineCoverageRegex.firstMatch(in: line, options: [], range: range) {
+          // Get the execution counts and append. Line indices are
+          // consecutive and so the array will have counts for each line
+          // and nil for unexecutable lines, e.g. comments.
+          let nsRange = match.range(at: 2)
+          if let range = Range(nsRange, in: line) {
+            lineExecutionCounts.append(Int(line[range]))
+          }
+        }
+      }
+    }
+    if var coverageData = lineCoverage {
+      coverageData
+        .append(LineCoverage(fileName: changedFile, coverage: lineExecutionCounts,
+                             xcresultBundle: coverageFile))
+      return coverageData
+    } else {
+      return [LineCoverage(fileName: changedFile, coverage: lineExecutionCounts,
+                           xcresultBundle: coverageFile)]
+    }
+  }
+
+  // This function is to get union of newly added file lines and lines execution counts, from a xcresult bundle.
+  // Return an array of LineCoverage, which includes uncovered line indices of a file and its xcresult bundle source.
+  func get_uncovered_file_lines(fromDiff changedFiles: [FileIncrementalChanges],
+                                fromXcresult xcresultPath: String,
+                                archiveRootPath rootPath: String) -> [LineCoverage?] {
+    var uncovered_files: [LineCoverage?] = []
+    for change in changedFiles {
+      let archiveFilePath = URL(string: rootPath)!.appendingPathComponent(change.file)
+      print(archiveFilePath.absoluteString)
+      // temp_output_file is a temp file, with the xcresult bundle name, including line execution counts of a file
+      let temp_output_file = URL(fileURLWithPath: xcresultPath).deletingPathExtension()
+        .lastPathComponent
+      // Fetch line execution report of a file from a xcresult bundle into a temp file, which has the same name as the xcresult bundle.
+      Shell.run(
+        "\(Constants.XCOV_COMMAND) \(archiveFilePath.absoluteString) \(xcresultPath) > \(temp_output_file)",
+        displayCommand: true,
+        displayFailureResult: false
+      )
+      for coverageFile in createLineCoverageRecord(
+        from: "\(temp_output_file)",
+        changedFile: change.file
+      ) {
+        var uncoveredLine: LineCoverage = LineCoverage(
+          fileName: coverageFile.fileName,
+          coverage: [],
+          xcresultBundle: coverageFile.xcresultBundle
+        )
+        for addedLineIndex in change.addedLines {
+          if addedLineIndex < coverageFile.coverage.count {
+            if let test_cover_run = coverageFile.coverage[addedLineIndex] {
+              if test_cover_run == 0 { uncoveredLine.coverage.append(addedLineIndex) }
+              print("\(addedLineIndex) : \(test_cover_run)")
+            }
+          }
+        }
+        if !uncoveredLine.coverage.isEmpty { uncovered_files.append(uncoveredLine) }
+      }
+    }
+    return uncovered_files
+  }
+
+  func run() throws {
+    let enumerator = FileManager.default.enumerator(atPath: xcresultDir)
+    var uncovered_files: [LineCoverage?] = []
+    // Search xcresult bundles from xcresultDir and get union of `git diff` report and xccov output to generate a list of lineCoverage including files and their uncovered lines.
+    while let file = enumerator?.nextObject() as? String {
+      var isDir: ObjCBool = false
+      let absoluteFilePath = xcresultDir + file
+      if FileManager.default.fileExists(atPath: absoluteFilePath, isDirectory: &isDir) {
+        if isDir.boolValue, absoluteFilePath.hasSuffix(Constants.XCRESULT_EXTENSION) {
+          let uncovered_xcresult = get_uncovered_file_lines(
+            fromDiff: changedFiles,
+            fromXcresult: absoluteFilePath,
+            archiveRootPath: fileArchiveRootPath
+          )
+          uncovered_files.append(contentsOf: uncovered_xcresult)
+        }
+      }
+    }
+    // Output uncovered_files as a JSON file.
+    do {
+      let jsonData = try JSONEncoder().encode(uncovered_files)
+      try String(data: jsonData, encoding: .utf8)!.write(
+        to: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+          .appendingPathComponent(uncovered_line_file_json),
+        atomically: true,
+        encoding: String.Encoding.utf8
+      )
+    } catch {
+      print("Uncovered lines are not able to be parsed into a JSON file.\n \(error)\n")
+    }
+  }
+}
+
+IncrementalCoverageReportGenerator.main()

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -71,7 +71,7 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
     A JSON file with changed files and added line numbers. E.g. JSON file:
     '[{"file": "FirebaseDatabase/Sources/Api/FIRDataSnapshot.m", "added_lines": [105,106,107,108,109]},{"file": "FirebaseDatabase/Sources/Core/Utilities/FPath.m", "added_lines": [304,305,306,307,308,309]}]'
     """,
-    transform: {try JSONParser.readJSON(of: [FileIncrementalChanges].self, from: $0)}
+    transform: { try JSONParser.readJSON(of: [FileIncrementalChanges].self, from: $0) }
   )
   var changedFiles: [FileIncrementalChanges]
 
@@ -146,7 +146,8 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
           // `xccov` report will not involve unexecutable lines which are at
           // the end of the file. That means if the last couple lines are
           // comments, these lines will not be in the `coverageFile.coverage`.
-          if addedLineIndex < coverageFile.coverage.count, let testCoverRun = coverageFile.coverage[addedLineIndex], testCoverRun == 0 {
+          if addedLineIndex < coverageFile.coverage.count,
+            let testCoverRun = coverageFile.coverage[addedLineIndex], testCoverRun == 0 {
             uncoveredLine.coverage.append(addedLineIndex)
           }
         }

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -27,7 +27,7 @@ extension Constants {
   // The pattern is to match text "line_index: execution_counts" from the
   // outcome of xcresult bundle, e.g. "305 : 0".
   static let lineExecutionCountPattern = "[0-9]+\\s*:\\s*([0-9*]+)"
-  // Pattern match to the first group, i.e "([0-9*]+)".
+  // Match to the group of the lineExecutionCountPattern, i.e "([0-9*]+)".
   static let lineExecutionCountPatternGroup = 1
   // A file includes all newly added lines without tests covered.
   static let defaultUncoveredLineReportFileName = "uncovered_file_lines.json"

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -143,6 +143,9 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
           xcresultBundle: coverageFile.xcresultBundle
         )
         for addedLineIndex in change.addedLines {
+          // `xccov` report will not involve unexecutable lines which are at
+          // the end of the file. That means if the last couple lines are
+          // comments, these lines will not be in the `coverageFile.coverage`.
           if addedLineIndex < coverageFile.coverage.count, let testCoverRun = coverageFile.coverage[addedLineIndex], testCoverRun == 0 {
             uncoveredLine.coverage.append(addedLineIndex)
           }

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -143,10 +143,8 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
           xcresultBundle: coverageFile.xcresultBundle
         )
         for addedLineIndex in change.addedLines {
-          if addedLineIndex < coverageFile.coverage.count {
-            if let testCoverRun = coverageFile.coverage[addedLineIndex], testCoverRun == 0 {
-              uncoveredLine.coverage.append(addedLineIndex)
-            }
+          if addedLineIndex < coverageFile.coverage.count, let testCoverRun = coverageFile.coverage[addedLineIndex], testCoverRun == 0 {
+            uncoveredLine.coverage.append(addedLineIndex)
           }
         }
         if !uncoveredLine.coverage.isEmpty { uncoveredFiles.append(uncoveredLine) }

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -35,7 +35,7 @@ extension Constants {
 
 /// A JSON file from git_diff_to_json.sh will be decoded to the following instance.
 struct FileIncrementalChanges: Codable {
-  // File with newly added lines
+  // Name of a file with newly added lines
   let file: String
   // Indices of newly added lines in this file
   let addedLines: [Int]

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -65,9 +65,9 @@ struct LineCoverage: Codable {
 }
 
 struct IncrementalCoverageReportGenerator: ParsableCommand {
-  @Option(help: "The root of the firebase-ios-sdk checked out git repo.", 
-          transform: URL.init(fileURLWithPath:)) 
-  var gitRoot: URL 
+  @Option(help: "The root of the firebase-ios-sdk checked out git repo.",
+          transform: URL.init(fileURLWithPath:))
+  var gitRoot: URL
 
   @Option(
     help: "Root path of archived files in a xcresult bundle."
@@ -75,7 +75,7 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
   var fileArchiveRootPath: String
 
   @Option(help: "A dir of xcresult bundles.",
-          transform: URL.init(fileURLWithPath:)) 
+          transform: URL.init(fileURLWithPath:))
   var xcresultDir: URL
 
   @Option(
@@ -100,24 +100,24 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
     // Unexecutable lines, e.g. comments, will be nil here.
     var lineExecutionCounts: [Int?] = []
     do {
-        let inString = try String(contentsOf: coverageFileURL)
-        let lineCoverageRegex = try! NSRegularExpression(pattern: Constants
-          .lineExecutionCountPattern)
-        for line in inString.components(separatedBy: "\n") {
-          let range = NSRange(location: 0, length: line.utf16.count)
-          if let match = lineCoverageRegex.firstMatch(in: line, options: [], range: range) {
-            // Get the execution counts and append. Line indices are
-            // consecutive and so the array will have counts for each line
-            // and nil for unexecutable lines, e.g. comments.
-            let nsRange = match.range(at: Constants.lineExecutionCountPatternGroup)
-            if let range = Range(nsRange, in: line) {
-              lineExecutionCounts.append(Int(line[range]))
-            }
+      let inString = try String(contentsOf: coverageFileURL)
+      let lineCoverageRegex = try! NSRegularExpression(pattern: Constants
+        .lineExecutionCountPattern)
+      for line in inString.components(separatedBy: "\n") {
+        let range = NSRange(location: 0, length: line.utf16.count)
+        if let match = lineCoverageRegex.firstMatch(in: line, options: [], range: range) {
+          // Get the execution counts and append. Line indices are
+          // consecutive and so the array will have counts for each line
+          // and nil for unexecutable lines, e.g. comments.
+          let nsRange = match.range(at: Constants.lineExecutionCountPatternGroup)
+          if let range = Range(nsRange, in: line) {
+            lineExecutionCounts.append(Int(line[range]))
           }
         }
+      }
     } catch {
-        fatalError("Failed to open \(coverageFileURL): \(error)")
-    } 
+      fatalError("Failed to open \(coverageFileURL): \(error)")
+    }
     if var coverageData = lineCoverage {
       coverageData
         .append(LineCoverage(fileName: changedFile, coverage: lineExecutionCounts,
@@ -132,8 +132,8 @@ struct IncrementalCoverageReportGenerator: ParsableCommand {
   /// This function is to get union of newly added file lines and lines execution counts, from a xcresult bundle.
   /// Return an array of LineCoverage, which includes uncovered line indices of a file and its xcresult bundle source.
   func getUncoveredFileLines(fromDiff changedFiles: [FileIncrementalChanges],
-                                xcresultPath: String,
-                                archiveRootPath rootPath: String) -> [LineCoverage?] {
+                             xcresultPath: String,
+                             archiveRootPath rootPath: String) -> [LineCoverage?] {
     var uncoveredFiles: [LineCoverage?] = []
     for change in changedFiles {
       let archiveFilePath = URL(string: rootPath)!.appendingPathComponent(change.file)

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+public enum JSONParser {
+  // Decode an instance from a JSON object.
+  public static func readJSON<T: Codable>(of _: T.Type, from data: Data) -> T? {
+    do {
+      let coverageReportSource = try JSONDecoder().decode(T.self, from: data)
+      return coverageReportSource
+    } catch {
+      print("Data for JSON are not able to be generated: \(error)\n")
+    }
+    return nil
+  }
+
+  // Decode an instance from a JSON file.
+  public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) -> T? {
+    do {
+      let fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath)
+        .appendingPathComponent(path)
+      let data = try Data(contentsOf: fileURL)
+      return readJSON(of: dataStruct, from: data)
+    } catch {
+      print("\(path) cannot be read: \(error)\n")
+    }
+    return nil
+  }
+}

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 public enum JSONParser {
-
   // Decode an instance from a JSON file.
   public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) throws -> T? {
     do {

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
@@ -19,13 +19,9 @@ import Foundation
 public enum JSONParser {
   // Decode an instance from a JSON file.
   public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) throws -> T {
-    do {
-      let fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath)
-        .appendingPathComponent(path)
-      let data = try Data(contentsOf: fileURL)
-      return try JSONDecoder().decode(dataStruct, from: data)
-    } catch {
-      fatalError("\(path) cannot be read: \(error)\n")
-    }
+    let fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath)
+      .appendingPathComponent(path)
+    let data = try Data(contentsOf: fileURL)
+    return try JSONDecoder().decode(dataStruct, from: data)
   }
 }

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
@@ -18,15 +18,14 @@ import Foundation
 
 public enum JSONParser {
   // Decode an instance from a JSON file.
-  public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) throws -> T? {
+  public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) throws -> T {
     do {
       let fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath)
         .appendingPathComponent(path)
       let data = try Data(contentsOf: fileURL)
       return try JSONDecoder().decode(dataStruct, from: data)
     } catch {
-      print("\(path) cannot be read: \(error)\n")
+      fatalError("\(path) cannot be read: \(error)\n")
     }
-    return nil
   }
 }

--- a/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
+++ b/scripts/code_coverage_report/generate_code_coverage_report/Sources/Utils/JSONParser.swift
@@ -17,24 +17,14 @@
 import Foundation
 
 public enum JSONParser {
-  // Decode an instance from a JSON object.
-  public static func readJSON<T: Codable>(of _: T.Type, from data: Data) -> T? {
-    do {
-      let coverageReportSource = try JSONDecoder().decode(T.self, from: data)
-      return coverageReportSource
-    } catch {
-      print("Data for JSON are not able to be generated: \(error)\n")
-    }
-    return nil
-  }
 
   // Decode an instance from a JSON file.
-  public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) -> T? {
+  public static func readJSON<T: Codable>(of dataStruct: T.Type, from path: String) throws -> T? {
     do {
       let fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath)
         .appendingPathComponent(path)
       let data = try Data(contentsOf: fileURL)
-      return readJSON(of: dataStruct, from: data)
+      return try JSONDecoder().decode(dataStruct, from: data)
     } catch {
       print("\(path) cannot be read: \(error)\n")
     }


### PR DESCRIPTION
The IncrementalCoverageReportGenerator will input 'git diff' JSON from #8160 and xcresult bundles from the [test_coverage workflow](https://github.com/firebase/firebase-ios-sdk/blob/master/.github/workflows/test_coverage.yml), e.g. artifacts from [a workflow run](https://github.com/firebase/firebase-ios-sdk/actions/runs/882836165).