### PR TITLE
Set valid format of notification sample

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
@@ -430,6 +430,7 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
 - (void)testLogMessage {
   NSDictionary *notification = @{
     @"google.c.a.e" : @"1",
+    @"aps" : @{@"alert" : @"to check the reporting format"},
   };
   [FIRMessagingAnalytics logMessage:notification toAnalytics:nil];
   OCMVerify([self.logClassMock logEvent:OCMOCK_ANY withNotification:notification toAnalytics:nil]);
@@ -439,6 +440,7 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
 - (void)testLogOpenNotification {
   NSDictionary *notification = @{
     @"google.c.a.e" : @"1",
+    @"aps" : @{@"alert" : @"to check the reporting format"},
   };
   [FIRMessagingAnalytics logOpenNotification:notification toAnalytics:nil];
 


### PR DESCRIPTION
In rare case the test is running when app is not in foreground, falling into the default application state where it checks if notification is a display one. So set the sample notification with valid display format to ensure tests are always passing.
#no-changelog
