### PR TITLE
Fix AppCheck Catalyst build on Xcode 12.4

### DIFF
--- a/.github/workflows/app_check.yml
+++ b/.github/workflows/app_check.yml
@@ -22,6 +22,17 @@ jobs:
     - name: FirebaseAppCheck
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAppCheck.podspec --platforms=${{ matrix.target }}
 
+  catalyst:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Setup project and Build for Catalyst
+      run: scripts/test_catalyst.sh FirebaseAppCheck test FirebaseAppCheck-Unit-unit
+
   diagnostics:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'

--- a/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
@@ -15,7 +15,7 @@
  */
 
 // Currently DCAppAttestService is available on iOS only.
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 
 #import <DeviceCheck/DeviceCheck.h>
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
@@ -15,7 +15,7 @@
  */
 
 // Currently DCAppAttestService is available on iOS only.
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 #import <DeviceCheck/DeviceCheck.h>
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/DCAppAttestService+FIRAppAttestService.h
@@ -31,4 +31,4 @@ API_UNAVAILABLE(macos, tvos, watchos)
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS
+#endif  // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -159,9 +159,9 @@ NS_ASSUME_NONNULL_BEGIN
                              APIService:appAttestAPIService
                            keyIDStorage:keyIDStorage
                         artifactStorage:artifactStorage];
-#else   // TARGET_OS_IOS
+#else   // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   return nil;
-#endif  // TARGET_OS_IOS
+#endif  // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 }
 
 #pragma mark - FIRAppCheckProvider

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -92,6 +92,7 @@ API_AVAILABLE(ios(14.0))
 
 #pragma mark - Init tests
 
+#if !TARGET_OS_MACCATALYST
 - (void)testInitWithValidApp {
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
   options.APIKey = @"api_key";
@@ -100,6 +101,7 @@ API_AVAILABLE(ios(14.0))
 
   XCTAssertNotNil([[FIRAppAttestProvider alloc] initWithApp:app]);
 }
+#endif  // !TARGET_OS_MACCATALYST
 
 #pragma mark - Initial handshake (attestation)
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -92,7 +92,9 @@ API_AVAILABLE(ios(14.0))
 
 #pragma mark - Init tests
 
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
+// Keychain dependent logic require additional configuration on Catalyst (enabling Keychain
+// sharing). For now, keychain dependent tests are disabled for Catalyst.
 - (void)testInitWithValidApp {
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
   options.APIKey = @"api_key";

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -46,7 +46,7 @@
   [super tearDown];
 }
 
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 
 - (void)testSetAndGetArtifact {
   [self assertSetGetForStorage];

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -46,6 +46,8 @@
   [super tearDown];
 }
 
+#if !TARGET_OS_MACCATALYST
+
 - (void)testSetAndGetArtifact {
   [self assertSetGetForStorage];
 }
@@ -185,5 +187,6 @@
   [storage2 setArtifact:nil forKey:keyID];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
 }
+#endif  // !TARGET_OS_MACCATALYST
 
 @end

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -125,6 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
+#if !TARGET_OS_MACCATALYST
 - (void)testSetAppCheckProviderFactoryWithDefaultApp {
   NSString *appName = kFIRDefaultAppName;
 
@@ -168,6 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
   OCMVerifyAll(self.mockProviderFactory);
   OCMVerifyAll(self.mockAppCheckProvider);
 }
+#endif  // !TARGET_OS_MACCATALYST
 
 #pragma mark - Helpers
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 - (void)testSetAppCheckProviderFactoryWithDefaultApp {
   NSString *appName = kFIRDefaultAppName;
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -45,6 +45,8 @@
   [super tearDown];
 }
 
+#if !TARGET_OS_MACCATALYST
+
 - (void)testSetAndGetToken {
   FIRAppCheckToken *tokenToStore = [[FIRAppCheckToken alloc] initWithToken:@"token"
                                                             expirationDate:[NSDate distantPast]];
@@ -93,5 +95,6 @@
   XCTAssertNil(getPromise.value);
   XCTAssertNil(getPromise.error);
 }
+#endif  // !TARGET_OS_MACCATALYST
 
 @end

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -45,7 +45,7 @@
   [super tearDown];
 }
 
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 
 - (void)testSetAndGetToken {
   FIRAppCheckToken *tokenToStore = [[FIRAppCheckToken alloc] initWithToken:@"token"


### PR DESCRIPTION
Fix #8175

Fix AppCheck Catalyst build and add CI.  This fixes a regression building the zip.

Interestingly, this failure does not repro on Xcode 12.5