### PR TITLE
Reduce ObjectValue copies

### DIFF
--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -46,6 +46,7 @@ using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::GetTypeOrder;
 using firebase::firestore::model::ObjectValue;
+using firebase::firestore::model::Mutation;
 using firebase::firestore::model::PatchMutation;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SetMutation;
@@ -130,9 +131,9 @@ FSTDocumentKeyReference *FSTTestRef(std::string projectID, std::string database,
 
 SetMutation FSTTestSetMutation(NSString *path, NSDictionary<NSString *, id> *values) {
   FSTUserDataReader *reader = FSTTestUserDataReader();
-  ParsedSetData result = [reader parsedSetData:values];
-  return SetMutation(FSTTestDocKey(path), result.data(), Precondition::None(),
-                     result.field_transforms());
+  Mutation mutation =
+      [reader parsedSetData:values].ToMutation(FSTTestDocKey(path), Precondition::None());
+  return SetMutation(mutation);
 }
 
 PatchMutation FSTTestPatchMutation(NSString *path,
@@ -147,15 +148,14 @@ PatchMutation FSTTestPatchMutation(NSString *path,
     }
   }];
 
-  FSTUserDataReader *reader = FSTTestUserDataReader();
-  ParsedUpdateData parsed = [reader parsedUpdateData:mutableValues];
-
   DocumentKey key = FSTTestDocKey(path);
-
   BOOL merge = !updateMask.empty();
   Precondition precondition = merge ? Precondition::None() : Precondition::Exists(true);
-  return PatchMutation(key, parsed.data(), parsed.fieldMask(), precondition,
-                       parsed.field_transforms());
+
+  FSTUserDataReader *reader = FSTTestUserDataReader();
+  Mutation mutation =
+      [reader parsedUpdateData:mutableValues].ToMutation(FSTTestDocKey(path), precondition);
+  return PatchMutation(mutation);
 }
 
 DeleteMutation FSTTestDeleteMutation(NSString *path) {

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -155,13 +155,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSDictionary<NSString *, id> *)dataWithServerTimestampBehavior:
     (FIRServerTimestampBehavior)serverTimestampBehavior {
-  absl::optional<ObjectValue> data = _snapshot.GetData();
+  absl::optional<google_firestore_v1_Value> data = _snapshot.GetValue(FieldPath::EmptyPath());
   if (!data) return nil;
 
   FSTUserDataWriter *dataWriter =
       [[FSTUserDataWriter alloc] initWithFirestore:_snapshot.firestore()
                            serverTimestampBehavior:serverTimestampBehavior];
-  return [dataWriter convertedValue:data->Get()];
+  return [dataWriter convertedValue:*data];
 }
 
 - (nullable id)valueForField:(id)field {

--- a/Firestore/Source/API/FSTUserDataReader.mm
+++ b/Firestore/Source/API/FSTUserDataReader.mm
@@ -195,10 +195,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return std::move(accumulator)
-        .MergeData(updateObject, FieldMask{std::move(validatedFieldPaths)});
+        .MergeData(std::move(updateObject), FieldMask{std::move(validatedFieldPaths)});
 
   } else {
-    return std::move(accumulator).MergeData(updateObject);
+    return std::move(accumulator).MergeData(std::move(updateObject));
   }
 }
 

--- a/Firestore/core/src/api/document_snapshot.cc
+++ b/Firestore/core/src/api/document_snapshot.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 /*
  * Copyright 2019 Google
  *
@@ -42,7 +44,7 @@ DocumentSnapshot DocumentSnapshot::FromNoDocument(
     std::shared_ptr<Firestore> firestore,
     model::DocumentKey key,
     SnapshotMetadata metadata) {
-  return DocumentSnapshot{std::move(firestore), key, absl::nullopt,
+  return DocumentSnapshot{std::move(firestore), std::move(key), absl::nullopt,
                           std::move(metadata)};
 }
 
@@ -77,15 +79,10 @@ const std::string& DocumentSnapshot::document_id() const {
   return internal_key_.path().last_segment();
 }
 
-absl::optional<ObjectValue> DocumentSnapshot::GetData() const {
-  return internal_document_ ? (*internal_document_)->data()
-                            : absl::optional<ObjectValue>{};
-}
-
 absl::optional<google_firestore_v1_Value> DocumentSnapshot::GetValue(
     const FieldPath& field_path) const {
   return internal_document_ ? (*internal_document_)->field(field_path)
-                            : absl::optional<google_firestore_v1_Value>{};
+                            : absl::nullopt;
 }
 
 bool operator==(const DocumentSnapshot& lhs, const DocumentSnapshot& rhs) {

--- a/Firestore/core/src/api/document_snapshot.h
+++ b/Firestore/core/src/api/document_snapshot.h
@@ -59,7 +59,6 @@ class DocumentSnapshot {
 
   DocumentReference CreateReference() const;
 
-  absl::optional<model::ObjectValue> GetData() const;
   absl::optional<google_firestore_v1_Value> GetValue(
       const model::FieldPath& field_path) const;
 

--- a/Firestore/core/src/core/view.cc
+++ b/Firestore/core/src/core/view.cc
@@ -149,7 +149,7 @@ ViewDocumentChanges View::ComputeDocumentChanges(
     bool change_applied = false;
     // Calculate change
     if (old_doc && new_doc) {
-      bool docs_equal = (*old_doc)->data() == (*new_doc)->data();
+      bool docs_equal = (*old_doc)->value() == (*new_doc)->value();
       if (!docs_equal) {
         if (!ShouldWaitForSyncedDocument(*new_doc, *old_doc)) {
           change_set.AddChange(

--- a/Firestore/core/src/local/local_serializer.cc
+++ b/Firestore/core/src/local/local_serializer.cc
@@ -136,7 +136,7 @@ google_firestore_v1_Document LocalSerializer::EncodeDocument(
   result.name = rpc_serializer_.EncodeKey(doc.key());
 
   // Encode Document.fields (unless it's empty)
-  const google_firestore_v1_MapValue& fields_map = doc.value().map_value;
+  google_firestore_v1_MapValue fields_map = doc.value().map_value;
   SetRepeatedField(
       &result.fields, &result.fields_count,
       absl::Span<google_firestore_v1_MapValue_FieldsEntry>(

--- a/Firestore/core/src/local/local_serializer.cc
+++ b/Firestore/core/src/local/local_serializer.cc
@@ -136,7 +136,7 @@ google_firestore_v1_Document LocalSerializer::EncodeDocument(
   result.name = rpc_serializer_.EncodeKey(doc.key());
 
   // Encode Document.fields (unless it's empty)
-  const google_firestore_v1_MapValue& fields_map = doc.data().Get().map_value;
+  const google_firestore_v1_MapValue& fields_map = doc.value().map_value;
   SetRepeatedField(
       &result.fields, &result.fields_count,
       absl::Span<google_firestore_v1_MapValue_FieldsEntry>(

--- a/Firestore/core/src/local/local_store.cc
+++ b/Firestore/core/src/local/local_store.cc
@@ -174,9 +174,9 @@ LocalWriteResult LocalStore::WriteLocally(std::vector<Mutation>&& mutations) {
       if (base_value) {
         // NOTE: The base state should only be applied if there's some existing
         // document to override, so use a Precondition of exists=true
-        base_mutations.push_back(PatchMutation(mutation.key(), *base_value,
-                                               base_value->ToFieldMask(),
-                                               Precondition::Exists(true)));
+        base_mutations.push_back(PatchMutation(
+            mutation.key(), std::move(*base_value), base_value->ToFieldMask(),
+            Precondition::Exists(true)));
       }
     }
 

--- a/Firestore/core/src/model/mutable_document.h
+++ b/Firestore/core/src/model/mutable_document.h
@@ -163,8 +163,8 @@ class MutableDocument {
     return has_local_mutations() || has_committed_mutations();
   }
 
-  const ObjectValue& data() const {
-    return *value_;
+  google_firestore_v1_Value value() const {
+    return value_->Get();
   }
 
   ObjectValue& data() {

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -454,8 +454,8 @@ TEST_F(BundleSerializerTest, DecodesNanDoubleValues) {
   BundleDocument actual =
       bundle_serializer.DecodeDocument(reader, Parse(json_string));
   EXPECT_OK(reader.status());
-  auto actual_value = actual.document().data().Get(
-      model::FieldPath::FromDotSeparatedString("foo"));
+  auto actual_value =
+      actual.document().field(model::FieldPath::FromDotSeparatedString("foo"));
   EXPECT_TRUE(model::IsNaNValue(*actual_value));
 }
 

--- a/Firestore/core/test/unit/local/remote_document_cache_test.cc
+++ b/Firestore/core/test/unit/local/remote_document_cache_test.cc
@@ -98,7 +98,7 @@ MATCHER_P(HasAtLeastDocs,
 }
 
 MATCHER_P(MatchesValue, expected, "") {
-  const google_firestore_v1_Value& actual_value = arg.value();
+  google_firestore_v1_Value actual_value = arg.value();
   return testing::Value(actual_value, Eq(expected));
 }
 

--- a/Firestore/core/test/unit/local/remote_document_cache_test.cc
+++ b/Firestore/core/test/unit/local/remote_document_cache_test.cc
@@ -98,7 +98,7 @@ MATCHER_P(HasAtLeastDocs,
 }
 
 MATCHER_P(MatchesValue, expected, "") {
-  const google_firestore_v1_Value& actual_value = arg.data().Get();
+  const google_firestore_v1_Value& actual_value = arg.value();
   return testing::Value(actual_value, Eq(expected));
 }
 


### PR DESCRIPTION
This PR reduces some implicit copies of ObjectValue that can be replaced with std::move. The only remaining callsites of ObjectValue copy-constructor are now in tests (and it is quite difficult to fix there).