### PR TITLE
Make a copy of sessionDetails to avoid the risk of losing object during acting on notification of sessionID change.

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 8.2.0
 * Update log messages with proper log levels.
+* Fix a crash on FPRSessionDetails. (#8139)
 
 # Version 8.1.0
 * Firebase Performance logs now contain URLs to see the performance data on the Firebase console.

--- a/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
@@ -33,6 +33,12 @@
   return self;
 }
 
+- (FPRSessionDetails *)copyWithZone:(NSZone*) zone {
+  id detailsCopy = [[[self class] allocWithZone:zone] initWithSessionId:_sessionId
+                                                                options:_options];
+  return detailsCopy;
+}
+
 - (NSUInteger)sessionLengthInMinutes {
   NSTimeInterval sessionLengthInSeconds = ABS([self.sessionCreationTime timeIntervalSinceNow]);
   return (sessionLengthInSeconds / 60);

--- a/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
@@ -34,8 +34,8 @@
 }
 
 - (FPRSessionDetails *)copyWithZone:(NSZone*) zone {
-  id detailsCopy = [[[self class] allocWithZone:zone] initWithSessionId:_sessionId
-                                                                options:_options];
+  id detailsCopy =
+    [[[self class] allocWithZone:zone] initWithSessionId:_sessionId options:_options];
   return detailsCopy;
 }
 

--- a/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
@@ -33,9 +33,9 @@
   return self;
 }
 
-- (FPRSessionDetails *)copyWithZone:(NSZone*) zone {
-  id detailsCopy =
-    [[[self class] allocWithZone:zone] initWithSessionId:_sessionId options:_options];
+- (FPRSessionDetails *)copyWithZone:(NSZone *)zone {
+  FPRSessionDetails *detailsCopy = [[[self class] allocWithZone:zone] initWithSessionId:_sessionId
+                                                                                options:_options];
   return detailsCopy;
 }
 

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -142,7 +142,7 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
     dispatch_async(self.sessionIdSerialQueue, ^{
       FPRSessionManager *sessionManager = [FPRSessionManager sharedInstance];
       FPRSessionDetails *sessionDetails = [sessionManager.sessionDetails copy];
-      if (sessionDetails && [sessionDetails isKindOfClass:[FPRSessionDetails class]]) {
+      if (sessionDetails) {
         [self.activeSessions addObject:sessionDetails];
       }
     });

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -141,8 +141,8 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
   if (self.traceStarted && !self.traceCompleted) {
     dispatch_async(self.sessionIdSerialQueue, ^{
       FPRSessionManager *sessionManager = [FPRSessionManager sharedInstance];
-      FPRSessionDetails *sessionDetails = sessionManager.sessionDetails;
-      if (sessionDetails) {
+      FPRSessionDetails *sessionDetails = [sessionManager.sessionDetails copy];
+      if (sessionDetails && [sessionDetails isKindOfClass:[FPRSessionDetails class]]) {
         [self.activeSessions addObject:sessionDetails];
       }
     });

--- a/FirebasePerformance/Sources/Timer/FIRTrace.m
+++ b/FirebasePerformance/Sources/Timer/FIRTrace.m
@@ -405,7 +405,7 @@
     dispatch_async(self.sessionIdSerialQueue, ^{
       FPRSessionManager *sessionManager = [FPRSessionManager sharedInstance];
       FPRSessionDetails *sessionDetails = [sessionManager.sessionDetails copy];
-      if (sessionDetails && [sessionDetails isKindOfClass:[FPRSessionDetails class]]) {
+      if (sessionDetails) {
         [self.activeSessions addObject:sessionDetails];
       }
     });

--- a/FirebasePerformance/Sources/Timer/FIRTrace.m
+++ b/FirebasePerformance/Sources/Timer/FIRTrace.m
@@ -404,8 +404,8 @@
   if ([self isTraceActive]) {
     dispatch_async(self.sessionIdSerialQueue, ^{
       FPRSessionManager *sessionManager = [FPRSessionManager sharedInstance];
-      FPRSessionDetails *sessionDetails = sessionManager.sessionDetails;
-      if (sessionDetails) {
+      FPRSessionDetails *sessionDetails = [sessionManager.sessionDetails copy];
+      if (sessionDetails && [sessionDetails isKindOfClass:[FPRSessionDetails class]]) {
         [self.activeSessions addObject:sessionDetails];
       }
     });


### PR DESCRIPTION
Fixes #8139