### PR TITLE
Support Unity generated Podfiles

### DIFF
--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -32,6 +32,7 @@
     "source": {
         "http": "https://dl.google.com/firebase/ios/analytics/86f6bb645de4aa4b/FirebaseAnalytics-8.0.0.tar.gz"
     },
+    "static_framework": true,
     "subspecs": [
         {
             "name": "AdIdSupport",

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -30,6 +30,7 @@
     "source": {
         "http": "https://dl.google.com/firebase/ios/analytics/bbfb73e03d64790f/GoogleAppMeasurement-8.0.0.tar.gz"
     },
+    "static_framework": true,
     "subspecs": [
         {
             "name": "AdIdSupport",


### PR DESCRIPTION
Unity generates Podfiles like:
```
target 'UnityFramework' do
  pod 'Google-Mobile-Ads-SDK', '~> 8.2'
end
target 'Unity-iPhone' do
end
use_frameworks!
```

This is problematic because it asks to link static framework into a dynamic framework and also linked directly to the app. There will then be two copies of the static framework which can cause non-deterministic behavior. Details at https://github.com/firebase/firebase-ios-sdk/blob/master/docs/firebase_in_libraries.md.

In theory, CocoaPods should treat static frameworks the same, whether or not they're source or binary. However, it turns out that adding `"static_framework": true` to the podspec will cause a binary framework to only get linked into the dynamic framework and not the app.