### PR TITLE
Update SPM distro to GDT 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,7 +144,7 @@ let package = Package(
     .package(
       name: "GoogleDataTransport",
       url: "https://github.com/google/GoogleDataTransport.git",
-      "8.4.0" ..< "9.0.0"
+      "9.0.0" ..< "10.0.0"
     ),
     .package(
       name: "GoogleUtilities",


### PR DESCRIPTION
We missed updating the SPM distribution to GDT 9 in the 8.0.0 release. The GDT breaking change API isn't relevant for Firebase, but the 9.0.1 update will fix GDT analyze issues.