### PR TITLE
Remove Swift flag from user agent

### DIFF
--- a/FirebaseCore/Sources/FIRFirebaseUserAgent.m
+++ b/FirebaseCore/Sources/FIRFirebaseUserAgent.m
@@ -91,8 +91,6 @@
   NSDictionary<NSString *, id> *info = [[NSBundle mainBundle] infoDictionary];
   NSString *xcodeVersion = info[@"DTXcodeBuild"];
   NSString *appleSdkVersion = info[@"DTSDKBuild"];
-
-  NSString *swiftFlagValue = [GULAppEnvironmentUtil hasSwiftRuntime] ? @"true" : @"false";
   NSString *isFromAppstoreFlagValue = [GULAppEnvironmentUtil isFromAppStore] ? @"true" : @"false";
 
   components[@"apple-platform"] = [GULAppEnvironmentUtil applePlatform];
@@ -101,7 +99,6 @@
   components[@"deploy"] = [GULAppEnvironmentUtil deploymentType];
   components[@"device"] = [GULAppEnvironmentUtil deviceModel];
   components[@"os-version"] = [GULAppEnvironmentUtil systemVersion];
-  components[@"swift"] = swiftFlagValue;
   components[@"xcode"] = xcodeVersion;
 
   return [components copy];

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -841,10 +841,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"InvalidLibrary`/1.0.0"]);
 }
 
-- (void)testFirebaseUserAgent_SwiftFlagWithNoSwift {
-  XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"swift/false"]);
-}
-
 - (void)testFirebaseUserAgent_ApplePlatformFlag {
   // When a Catalyst app is run on macOS then both `TARGET_OS_MACCATALYST` and `TARGET_OS_IOS` are
   // `true`.


### PR DESCRIPTION
Xcode 13 always returns true and we don't need more data to know that Swift is the future.

#no-changelog