### PR TITLE
Wrap Protobuf for Query Filters in Messages

### DIFF
--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -96,6 +96,7 @@ using firebase::firestore::nanopb::CheckedSize;
 using firebase::firestore::nanopb::MakeArray;
 using firebase::firestore::nanopb::MakeString;
 using firebase::firestore::nanopb::Message;
+using firebase::firestore::nanopb::SharedMessage;
 using firebase::firestore::util::MakeNSError;
 using firebase::firestore::util::MakeString;
 using firebase::firestore::util::StatusOr;
@@ -534,7 +535,8 @@ int32_t SaturatedLimitValue(NSInteger limit) {
                  allowArrays:filterOperator == Filter::Operator::In ||
                              filterOperator == Filter::Operator::NotIn];
   auto describer = [value] { return MakeString(NSStringFromClass([value class])); };
-  return Wrap(_query.Filter(fieldPath, filterOperator, std::move(fieldValue), describer));
+  return Wrap(_query.Filter(fieldPath, filterOperator,
+                            SharedMessage<google_firestore_v1_Value>{fieldValue}, describer));
 }
 
 /**

--- a/Firestore/core/src/api/query_core.cc
+++ b/Firestore/core/src/api/query_core.cc
@@ -240,6 +240,8 @@ Query Query::Filter(const FieldPath& field_path,
           Describe(op));
     } else if (op == Operator::In || op == Operator::NotIn) {
       ValidateDisjunctiveFilterElements(*value, op);
+      // TODO(mutabledocuments): See if we can remove this copy and modify the
+      // input values directly.
       google_firestore_v1_Value references{};
       references.which_value_type = google_firestore_v1_Value_array_value_tag;
       nanopb::SetRepeatedField(

--- a/Firestore/core/src/api/query_core.cc
+++ b/Firestore/core/src/api/query_core.cc
@@ -37,6 +37,7 @@
 #include "Firestore/core/src/util/exception.h"
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
+#include "absl/types/span.h"
 
 namespace firebase {
 namespace firestore {
@@ -227,9 +228,9 @@ std::unique_ptr<ListenerRegistration> Query::AddSnapshotListener(
       std::move(query_listener));
 }
 
-Query Query::Filter(FieldPath field_path,
+Query Query::Filter(const FieldPath& field_path,
                     Operator op,
-                    google_firestore_v1_Value value,
+                    nanopb::SharedMessage<google_firestore_v1_Value> value,
                     const std::function<std::string()>& type_describer) const {
   if (field_path.IsKeyFieldPath()) {
     if (IsArrayOperator(op)) {
@@ -238,22 +239,28 @@ Query Query::Filter(FieldPath field_path,
           "ID since document IDs are not arrays.",
           Describe(op));
     } else if (op == Operator::In || op == Operator::NotIn) {
-      ValidateDisjunctiveFilterElements(value, op);
-      google_firestore_v1_ArrayValue& array = value.array_value;
-      for (pb_size_t i = 0; i < array.values_count; ++i) {
-        array.values[i] =
-            ParseExpectedReferenceValue(array.values[i], type_describer);
-      }
+      ValidateDisjunctiveFilterElements(*value, op);
+      google_firestore_v1_Value references{};
+      references.which_value_type = google_firestore_v1_Value_array_value_tag;
+      nanopb::SetRepeatedField(
+          &references.array_value.values, &references.array_value.values_count,
+          absl::Span<google_firestore_v1_Value>(
+              value->array_value.values, value->array_value.values_count),
+          [&](const google_firestore_v1_Value& value) {
+            return ParseExpectedReferenceValue(value, type_describer);
+          });
+      value = nanopb::SharedMessage<google_firestore_v1_Value>{references};
     } else {
-      value = ParseExpectedReferenceValue(value, type_describer);
+      value = nanopb::SharedMessage<google_firestore_v1_Value>{
+          ParseExpectedReferenceValue(*value, type_describer)};
     }
   } else {
     if (IsDisjunctiveOperator(op)) {
-      ValidateDisjunctiveFilterElements(value, op);
+      ValidateDisjunctiveFilterElements(*value, op);
     }
   }
 
-  FieldFilter filter = FieldFilter::Create(field_path, op, value);
+  FieldFilter filter = FieldFilter::Create(field_path, op, std::move(value));
   ValidateNewFilter(filter);
 
   return Wrap(query_.AddingFilter(std::move(filter)));
@@ -428,7 +435,7 @@ google_firestore_v1_Value Query::ParseExpectedReferenceValue(
     }
     return RefValue(firestore_->database_id(), DocumentKey{path});
   } else if (GetTypeOrder(value) == TypeOrder::kReference) {
-    return value;
+    return model::DeepClone(value);
   } else {
     ThrowInvalidArgument(
         "Invalid query. When querying by document ID you must provide a "

--- a/Firestore/core/src/api/query_core.h
+++ b/Firestore/core/src/api/query_core.h
@@ -25,6 +25,7 @@
 #include "Firestore/core/src/core/core_fwd.h"
 #include "Firestore/core/src/core/filter.h"
 #include "Firestore/core/src/core/query.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -91,9 +92,9 @@ class Query {
    *
    * @return The created `Query`.
    */
-  Query Filter(model::FieldPath field_path,
+  Query Filter(const model::FieldPath& field_path,
                core::Filter::Operator op,
-               google_firestore_v1_Value value,
+               nanopb::SharedMessage<google_firestore_v1_Value> value,
                const std::function<std::string()>& type_describer) const;
 
   /**

--- a/Firestore/core/src/core/array_contains_any_filter.cc
+++ b/Firestore/core/src/core/array_contains_any_filter.cc
@@ -32,14 +32,17 @@ using model::Contains;
 using model::Document;
 using model::FieldPath;
 using model::IsArray;
+using nanopb::SharedMessage;
 
 using Operator = Filter::Operator;
 
 class ArrayContainsAnyFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::ArrayContainsAny, value) {
-    HARD_ASSERT(IsArray(value), "ArrayContainsAnyFilter expects an ArrayValue");
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(
+            std::move(field), Operator::ArrayContainsAny, std::move(value)) {
+    HARD_ASSERT(IsArray(this->value()),
+                "ArrayContainsAnyFilter expects an ArrayValue");
   }
 
   Type type() const override {
@@ -49,9 +52,10 @@ class ArrayContainsAnyFilter::Rep : public FieldFilter::Rep {
   bool Matches(const model::Document& doc) const override;
 };
 
-ArrayContainsAnyFilter::ArrayContainsAnyFilter(const model::FieldPath& field,
-                                               google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<Rep>(field, value)) {
+ArrayContainsAnyFilter::ArrayContainsAnyFilter(
+    const model::FieldPath& field,
+    SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<Rep>(field, std::move(value))) {
 }
 
 bool ArrayContainsAnyFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/array_contains_any_filter.h
+++ b/Firestore/core/src/core/array_contains_any_filter.h
@@ -21,6 +21,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -38,8 +39,9 @@ namespace core {
 class ArrayContainsAnyFilter : public FieldFilter {
  public:
   /** Creates a new array-contains-any filter. Takes ownership of `value`. */
-  ArrayContainsAnyFilter(const model::FieldPath& field,
-                         google_firestore_v1_Value value);
+  ArrayContainsAnyFilter(
+      const model::FieldPath& field,
+      nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/array_contains_filter.cc
+++ b/Firestore/core/src/core/array_contains_filter.cc
@@ -31,12 +31,14 @@ using model::Contains;
 using model::Document;
 using model::FieldPath;
 using model::IsArray;
+using nanopb::SharedMessage;
 using Operator = Filter::Operator;
 
 class ArrayContainsFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::ArrayContains, value) {
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(
+            std::move(field), Operator::ArrayContains, std::move(value)) {
   }
 
   Type type() const override {
@@ -46,9 +48,10 @@ class ArrayContainsFilter::Rep : public FieldFilter::Rep {
   bool Matches(const model::Document& doc) const override;
 };
 
-ArrayContainsFilter::ArrayContainsFilter(const model::FieldPath& field,
-                                         google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<const Rep>(field, value)) {
+ArrayContainsFilter::ArrayContainsFilter(
+    const model::FieldPath& field,
+    SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<const Rep>(field, std::move(value))) {
 }
 
 bool ArrayContainsFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/array_contains_filter.h
+++ b/Firestore/core/src/core/array_contains_filter.h
@@ -21,6 +21,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -39,7 +40,7 @@ class ArrayContainsFilter : public FieldFilter {
  public:
   /** Creates a new array-contains filter. Takes ownership of `value`. */
   ArrayContainsFilter(const model::FieldPath& field,
-                      google_firestore_v1_Value value);
+                      nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/field_filter.cc
+++ b/Firestore/core/src/core/field_filter.cc
@@ -86,7 +86,7 @@ FieldFilter FieldFilter::Create(
     const FieldPath& path,
     Operator op,
     SharedMessage<google_firestore_v1_Value> value_rhs) {
-  google_firestore_v1_Value& value = value_rhs.operator*();
+  google_firestore_v1_Value& value = *value_rhs;
   model::SortFields(value);
   if (path.IsKeyFieldPath()) {
     if (op == Filter::Operator::In) {

--- a/Firestore/core/src/core/field_filter.h
+++ b/Firestore/core/src/core/field_filter.h
@@ -43,9 +43,10 @@ class FieldFilter : public Filter {
   /**
    * Creates a Filter instance for the provided path, operator, and value.
    */
-  static FieldFilter Create(const model::FieldPath& path,
-                            Operator op,
-                            google_firestore_v1_Value value_rhs);
+  static FieldFilter Create(
+      const model::FieldPath& path,
+      Operator op,
+      nanopb::SharedMessage<google_firestore_v1_Value> value_rhs);
 
   explicit FieldFilter(const Filter& other);
 
@@ -109,7 +110,7 @@ class FieldFilter : public Filter {
      */
     Rep(model::FieldPath field,
         Operator op,
-        google_firestore_v1_Value value_rhs);
+        nanopb::SharedMessage<google_firestore_v1_Value> value_rhs);
 
     bool MatchesComparison(util::ComparisonResult comparison) const;
 

--- a/Firestore/core/src/core/in_filter.cc
+++ b/Firestore/core/src/core/in_filter.cc
@@ -32,14 +32,15 @@ using model::Contains;
 using model::Document;
 using model::FieldPath;
 using model::IsArray;
+using nanopb::SharedMessage;
 
 using Operator = Filter::Operator;
 
 class InFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::In, value) {
-    HARD_ASSERT(IsArray(value), "InFilter expects an ArrayValue");
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(std::move(field), Operator::In, std::move(value)) {
+    HARD_ASSERT(IsArray(this->value()), "InFilter expects an ArrayValue");
   }
 
   Type type() const override {
@@ -49,8 +50,9 @@ class InFilter::Rep : public FieldFilter::Rep {
   bool Matches(const model::Document& doc) const override;
 };
 
-InFilter::InFilter(const FieldPath& field, google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<const Rep>(field, value)) {
+InFilter::InFilter(const FieldPath& field,
+                   SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<const Rep>(field, std::move(value))) {
 }
 
 bool InFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/in_filter.h
+++ b/Firestore/core/src/core/in_filter.h
@@ -21,6 +21,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -37,7 +38,8 @@ namespace core {
 class InFilter : public FieldFilter {
  public:
   /** Creates a new 'in' filter. Takes ownership of `value`. */
-  InFilter(const model::FieldPath& field, google_firestore_v1_Value value);
+  InFilter(const model::FieldPath& field,
+           nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/key_field_filter.h
+++ b/Firestore/core/src/core/key_field_filter.h
@@ -21,6 +21,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -34,7 +35,7 @@ class KeyFieldFilter : public FieldFilter {
   /** Creates a new document key filter. Takes ownership of `value`. */
   KeyFieldFilter(const model::FieldPath& field,
                  core::Filter::Operator op,
-                 google_firestore_v1_Value value);
+                 nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/key_field_in_filter.cc
+++ b/Firestore/core/src/core/key_field_in_filter.cc
@@ -36,13 +36,14 @@ using model::FieldPath;
 using model::GetTypeOrder;
 using model::IsArray;
 using model::TypeOrder;
+using nanopb::SharedMessage;
 
 using Operator = Filter::Operator;
 
 class KeyFieldInFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::In, value) {
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(std::move(field), Operator::In, std::move(value)) {
     keys_ = ExtractDocumentKeysFromValue(this->value());
   }
 
@@ -56,9 +57,9 @@ class KeyFieldInFilter::Rep : public FieldFilter::Rep {
   std::unordered_set<DocumentKey, DocumentKeyHash> keys_;
 };
 
-KeyFieldInFilter::KeyFieldInFilter(const FieldPath& field,
-                                   google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<const Rep>(field, value)) {
+KeyFieldInFilter::KeyFieldInFilter(
+    const FieldPath& field, SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<const Rep>(field, std::move(value))) {
 }
 
 bool KeyFieldInFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/key_field_in_filter.h
+++ b/Firestore/core/src/core/key_field_in_filter.h
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/core/field_filter.h"
 #include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/model/model_fwd.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -36,7 +37,7 @@ class KeyFieldInFilter : public FieldFilter {
  public:
   /** Creates a new document keys filter. Takes ownership of `value`. */
   KeyFieldInFilter(const model::FieldPath& field,
-                   google_firestore_v1_Value value);
+                   nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/key_field_not_in_filter.cc
+++ b/Firestore/core/src/core/key_field_not_in_filter.cc
@@ -33,13 +33,14 @@ using model::Document;
 using model::DocumentKey;
 using model::DocumentKeyHash;
 using model::FieldPath;
+using nanopb::SharedMessage;
 
 using Operator = Filter::Operator;
 
 class KeyFieldNotInFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::NotIn, value) {
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(std::move(field), Operator::NotIn, std::move(value)) {
     keys_ = KeyFieldInFilter::ExtractDocumentKeysFromValue(this->value());
   }
 
@@ -53,9 +54,9 @@ class KeyFieldNotInFilter::Rep : public FieldFilter::Rep {
   std::unordered_set<DocumentKey, DocumentKeyHash> keys_;
 };
 
-KeyFieldNotInFilter::KeyFieldNotInFilter(const FieldPath& field,
-                                         google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<const Rep>(field, value)) {
+KeyFieldNotInFilter::KeyFieldNotInFilter(
+    const FieldPath& field, SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<const Rep>(field, std::move(value))) {
 }
 
 bool KeyFieldNotInFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/key_field_not_in_filter.h
+++ b/Firestore/core/src/core/key_field_not_in_filter.h
@@ -22,6 +22,7 @@
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
 #include "Firestore/core/src/model/model_fwd.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -34,7 +35,7 @@ class KeyFieldNotInFilter : public FieldFilter {
  public:
   /** Creates a new document keys not-in filter. Takes ownership of `value`. */
   KeyFieldNotInFilter(const model::FieldPath& field,
-                      google_firestore_v1_Value value);
+                      nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/core/not_in_filter.cc
+++ b/Firestore/core/src/core/not_in_filter.cc
@@ -33,14 +33,15 @@ using model::Document;
 using model::FieldPath;
 using model::IsArray;
 using model::NullValue;
+using nanopb::SharedMessage;
 
 using Operator = Filter::Operator;
 
 class NotInFilter::Rep : public FieldFilter::Rep {
  public:
-  Rep(FieldPath field, google_firestore_v1_Value value)
-      : FieldFilter::Rep(std::move(field), Operator::NotIn, value) {
-    HARD_ASSERT(IsArray(value), "NotInFilter expects an ArrayValue");
+  Rep(FieldPath field, SharedMessage<google_firestore_v1_Value> value)
+      : FieldFilter::Rep(std::move(field), Operator::NotIn, std::move(value)) {
+    HARD_ASSERT(IsArray(this->value()), "NotInFilter expects an ArrayValue");
   }
 
   Type type() const override {
@@ -51,8 +52,8 @@ class NotInFilter::Rep : public FieldFilter::Rep {
 };
 
 NotInFilter::NotInFilter(const FieldPath& field,
-                         google_firestore_v1_Value value)
-    : FieldFilter(std::make_shared<const Rep>(field, value)) {
+                         SharedMessage<google_firestore_v1_Value> value)
+    : FieldFilter(std::make_shared<const Rep>(field, std::move(value))) {
 }
 
 bool NotInFilter::Rep::Matches(const Document& doc) const {

--- a/Firestore/core/src/core/not_in_filter.h
+++ b/Firestore/core/src/core/not_in_filter.h
@@ -22,6 +22,7 @@
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/core/field_filter.h"
 #include "Firestore/core/src/model/model_fwd.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -33,7 +34,8 @@ namespace core {
 class NotInFilter : public FieldFilter {
  public:
   /** Creates a new not-in filter. Takes ownership of `value`. */
-  NotInFilter(const model::FieldPath& field, google_firestore_v1_Value value);
+  NotInFilter(const model::FieldPath& field,
+              nanopb::SharedMessage<google_firestore_v1_Value> value);
 
  private:
   class Rep;

--- a/Firestore/core/src/nanopb/message.h
+++ b/Firestore/core/src/nanopb/message.h
@@ -191,6 +191,7 @@ class Message {
  * A wrapper of Message objects that facilitates shared ownership of Protobuf
  * data.
  */
+ // TODO(mrschmidt): Add a template <typename const T> specialization
 template <typename T>
 class SharedMessage {
  public:

--- a/Firestore/core/src/nanopb/message.h
+++ b/Firestore/core/src/nanopb/message.h
@@ -188,8 +188,8 @@ class Message {
 };
 
 /**
- * A wrapper of const Message objects that facilitates shared ownership of
- * immutable Protobuf data.
+ * A wrapper of Message objects that facilitates shared ownership of Protobuf
+ * data.
  */
 template <typename T>
 class SharedMessage {
@@ -203,11 +203,24 @@ class SharedMessage {
   }
 
   /**
-   * Returns a pointer to the underlying Nanopb proto or null if the `Message`
-   * is moved-from.
+   * Returns a pointer to the underlying Nanopb proto.
+   */
+  T* get() {
+    return message_->get();
+  }
+
+  /**
+   * Returns a pointer to the underlying Nanopb proto.
    */
   const T* get() const {
     return message_->get();
+  }
+
+  /**
+   * Returns a reference to the underlying Nanopb proto.
+   */
+  T& operator*() {
+    return *get();
   }
 
   /**
@@ -217,12 +230,16 @@ class SharedMessage {
     return *get();
   }
 
+  T* operator->() {
+    return get();
+  }
+
   const T* operator->() const {
     return get();
   }
 
  private:
-  std::shared_ptr<const Message<T>> message_;
+  std::shared_ptr<Message<T>> message_;
 };
 
 template <typename T>

--- a/Firestore/core/test/unit/testutil/testutil.cc
+++ b/Firestore/core/test/unit/testutil/testutil.cc
@@ -41,6 +41,7 @@
 #include "Firestore/core/src/model/value_util.h"
 #include "Firestore/core/src/model/verify_mutation.h"
 #include "Firestore/core/src/nanopb/byte_string.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "Firestore/core/src/nanopb/nanopb_util.h"
 #include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/statusor.h"
@@ -65,6 +66,7 @@ using model::Precondition;
 using model::TransformOperation;
 using nanopb::ByteString;
 using nanopb::SetRepeatedField;
+using nanopb::SharedMessage;
 using util::StringFormat;
 
 /**
@@ -288,14 +290,17 @@ core::Filter::Operator OperatorFromString(absl::string_view s) {
 core::FieldFilter Filter(absl::string_view key,
                          absl::string_view op,
                          google_firestore_v1_Value value) {
-  return core::FieldFilter::Create(Field(key), OperatorFromString(op), value);
+  return core::FieldFilter::Create(
+      Field(key), OperatorFromString(op),
+      SharedMessage<google_firestore_v1_Value>{value});
 }
 
 core::FieldFilter Filter(absl::string_view key,
                          absl::string_view op,
                          google_firestore_v1_ArrayValue value) {
-  return core::FieldFilter::Create(Field(key), OperatorFromString(op),
-                                   Value(value));
+  return core::FieldFilter::Create(
+      Field(key), OperatorFromString(op),
+      SharedMessage<google_firestore_v1_Value>{Value(value)});
 }
 
 core::FieldFilter Filter(absl::string_view key,


### PR DESCRIPTION
This fixes a memory leak when we fail Query validation. 

The old flow was:
- Create nanopb struct
- Validate Query
- If valid, wrap in Message

This PR creates the Message first and then validates.