### PR TITLE
Use Message as input type for nanopb protos

### DIFF
--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -21,6 +21,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/model/model_fwd.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "absl/strings/string_view.h"
 
 @class FIRGeoPoint;
@@ -103,8 +104,9 @@ FSTUserDataReader *FSTTestUserDataReader();
 NSDateComponents *FSTTestDateComponents(
     int year, int month, int day, int hour, int minute, int second);
 
-/** Wraps a plain value into an FieldValue instance. */
-firebase::firestore::google_firestore_v1_Value FSTTestFieldValue(id _Nullable value);
+/** Wraps a plain value into a Message proto. */
+firebase::firestore::nanopb::Message<firebase::firestore::google_firestore_v1_Value>
+    FSTTestFieldValue(id _Nullable value);
 
 /** Wraps a NSDictionary value into an ObjectValue instance. */
 model::ObjectValue FSTTestObjectValue(NSDictionary<NSString *, id> *data);

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -50,6 +50,7 @@ using firebase::firestore::model::PatchMutation;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SetMutation;
 using firebase::firestore::model::TypeOrder;
+using firebase::firestore::nanopb::Message;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -106,7 +107,7 @@ FSTUserDataReader *FSTTestUserDataReader() {
   return reader;
 }
 
-google_firestore_v1_Value FSTTestFieldValue(id _Nullable value) {
+Message<google_firestore_v1_Value> FSTTestFieldValue(id _Nullable value) {
   FSTUserDataReader *reader = FSTTestUserDataReader();
   // HACK: We use parsedQueryValue: since it accepts scalars as well as arrays / objects, and
   // our tests currently use FSTTestFieldValue() pretty generically so we don't know the intent.
@@ -114,9 +115,9 @@ google_firestore_v1_Value FSTTestFieldValue(id _Nullable value) {
 }
 
 ObjectValue FSTTestObjectValue(NSDictionary<NSString *, id> *data) {
-  google_firestore_v1_Value wrapped = FSTTestFieldValue(data);
-  HARD_ASSERT(GetTypeOrder(wrapped) == TypeOrder::kMap, "Unsupported value: %s", data);
-  return ObjectValue(wrapped);
+  Message<google_firestore_v1_Value> wrapped = FSTTestFieldValue(data);
+  HARD_ASSERT(GetTypeOrder(*wrapped) == TypeOrder::kMap, "Unsupported value: %s", data);
+  return ObjectValue(std::move(wrapped));
 }
 
 DocumentKey FSTTestDocKey(NSString *path) {

--- a/Firestore/Source/API/FSTUserDataReader.h
+++ b/Firestore/Source/API/FSTUserDataReader.h
@@ -22,11 +22,13 @@
 #include "Firestore/core/src/core/core_fwd.h"
 #include "Firestore/core/src/model/database_id.h"
 #include "Firestore/core/src/model/model_fwd.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 @class FIRTimestamp;
 
 namespace core = firebase::firestore::core;
 namespace model = firebase::firestore::model;
+namespace nanopb = firebase::firestore::nanopb;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,7 +78,7 @@ typedef id _Nullable (^FSTPreConverterBlock)(id _Nullable);
 - (core::ParsedUpdateData)parsedUpdateData:(id)input;
 
 /** Parse a "query value" (e.g. value in a where filter or a value in a cursor bound). */
-- (firebase::firestore::google_firestore_v1_Value)parsedQueryValue:(id)input;
+- (nanopb::Message<firebase::firestore::google_firestore_v1_Value>)parsedQueryValue:(id)input;
 
 /**
  * Parse a "query value" (e.g. value in a where filter or a value in a cursor bound).
@@ -84,8 +86,9 @@ typedef id _Nullable (^FSTPreConverterBlock)(id _Nullable);
  * @param allowArrays Whether the query value is an array that may directly contain additional
  * arrays (e.g.) the operand of an `in` query).
  */
-- (firebase::firestore::google_firestore_v1_Value)parsedQueryValue:(id)input
-                                                       allowArrays:(bool)allowArrays;
+- (nanopb::Message<firebase::firestore::google_firestore_v1_Value>)parsedQueryValue:(id)input
+                                                                        allowArrays:
+                                                                            (bool)allowArrays;
 
 @end
 

--- a/Firestore/Source/API/FSTUserDataReader.mm
+++ b/Firestore/Source/API/FSTUserDataReader.mm
@@ -80,6 +80,7 @@ using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::TransformOperation;
 using firebase::firestore::nanopb::CheckedSize;
+using firebase::firestore::nanopb::Message;
 using firebase::firestore::remote::Serializer;
 using firebase::firestore::util::ThrowInvalidArgument;
 using firebase::firestore::util::ReadContext;
@@ -148,11 +149,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   ParseAccumulator accumulator{UserDataSource::Set};
-  absl::optional<google_firestore_v1_Value> updateData = [self parseData:input
-                                                                 context:accumulator.RootContext()];
+  auto updateData = [self parseData:input context:accumulator.RootContext()];
   HARD_ASSERT(updateData.has_value(), "Parsed data should not be nil.");
 
-  return std::move(accumulator).SetData(ObjectValue{*updateData});
+  return std::move(accumulator).SetData(ObjectValue{std::move(*updateData)});
 }
 
 - (ParsedSetData)parsedMergeData:(id)input fieldMask:(nullable NSArray<id> *)fieldMask {
@@ -164,11 +164,10 @@ NS_ASSUME_NONNULL_BEGIN
 
   ParseAccumulator accumulator{UserDataSource::MergeSet};
 
-  absl::optional<google_firestore_v1_Value> updateData = [self parseData:input
-                                                                 context:accumulator.RootContext()];
+  auto updateData = [self parseData:input context:accumulator.RootContext()];
   HARD_ASSERT(updateData.has_value(), "Parsed data should not be nil.");
 
-  ObjectValue updateObject{*updateData};
+  ObjectValue updateObject{std::move(*updateData)};
 
   if (fieldMask) {
     std::set<FieldPath> validatedFieldPaths;
@@ -230,11 +229,10 @@ NS_ASSUME_NONNULL_BEGIN
       // Add it to the field mask, but don't add anything to updateData.
       context.AddToFieldMask(std::move(path));
     } else {
-      absl::optional<google_firestore_v1_Value> parsedValue =
-          [self parseData:value context:context.ChildContext(path)];
+      auto parsedValue = [self parseData:value context:context.ChildContext(path)];
       if (parsedValue) {
         context.AddToFieldMask(path);
-        updateData.Set(path, *parsedValue);
+        updateData.Set(path, std::move(*parsedValue));
       }
     }
   }];
@@ -242,20 +240,19 @@ NS_ASSUME_NONNULL_BEGIN
   return std::move(accumulator).UpdateData(std::move(updateData));
 }
 
-- (google_firestore_v1_Value)parsedQueryValue:(id)input {
+- (Message<google_firestore_v1_Value>)parsedQueryValue:(id)input {
   return [self parsedQueryValue:input allowArrays:false];
 }
 
-- (google_firestore_v1_Value)parsedQueryValue:(id)input allowArrays:(bool)allowArrays {
+- (Message<google_firestore_v1_Value>)parsedQueryValue:(id)input allowArrays:(bool)allowArrays {
   ParseAccumulator accumulator{allowArrays ? UserDataSource::ArrayArgument
                                            : UserDataSource::Argument};
 
-  absl::optional<google_firestore_v1_Value> parsed = [self parseData:input
-                                                             context:accumulator.RootContext()];
+  auto parsed = [self parseData:input context:accumulator.RootContext()];
   HARD_ASSERT(parsed, "Parsed data should not be nil.");
   HARD_ASSERT(accumulator.field_transforms().empty(),
               "Field transforms should have been disallowed.");
-  return *parsed;
+  return std::move(*parsed);
 }
 
 /**
@@ -268,7 +265,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The parsed value, or nil if the value was a FieldValue sentinel that should not be
  *   included in the resulting parsed data.
  */
-- (absl::optional<google_firestore_v1_Value>)parseData:(id)input context:(ParseContext &&)context {
+- (absl::optional<Message<google_firestore_v1_Value>>)parseData:(id)input
+                                                        context:(ParseContext &&)context {
   input = self.preConverter(input);
   if ([input isKindOfClass:[NSDictionary class]]) {
     return [self parseDictionary:(NSDictionary *)input context:std::move(context)];
@@ -303,10 +301,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (google_firestore_v1_Value)parseDictionary:(NSDictionary<NSString *, id> *)dict
-                                     context:(ParseContext &&)context {
-  __block google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_map_value_tag;
+- (Message<google_firestore_v1_Value>)parseDictionary:(NSDictionary<NSString *, id> *)dict
+                                              context:(ParseContext &&)context {
+  __block Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_map_value_tag;
 
   if (dict.count == 0) {
     const FieldPath *path = context.path();
@@ -323,42 +321,41 @@ NS_ASSUME_NONNULL_BEGIN
       }
     }];
 
-    result.map_value.fields_count = count;
-    result.map_value.fields = nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(count);
+    result->map_value.fields_count = count;
+    result->map_value.fields = nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(count);
 
     __block pb_size_t index = 0;
     [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *) {
-      absl::optional<google_firestore_v1_Value> parsedValue =
-          [self parseData:value context:context.ChildContext(util::MakeString(key))];
+      auto parsedValue = [self parseData:value context:context.ChildContext(util::MakeString(key))];
       if (parsedValue) {
-        result.map_value.fields[index].key = nanopb::MakeBytesArray(util::MakeString(key));
-        result.map_value.fields[index].value = *parsedValue;
+        result->map_value.fields[index].key = nanopb::MakeBytesArray(util::MakeString(key));
+        result->map_value.fields[index].value = *parsedValue->release();
         ++index;
       }
     }];
   }
 
-  return result;
+  return std::move(result);
 }
 
-- (google_firestore_v1_Value)parseArray:(NSArray<id> *)array context:(ParseContext &&)context {
-  __block google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_array_value_tag;
-  result.array_value.values_count = CheckedSize([array count]);
-  result.array_value.values =
-      nanopb::MakeArray<google_firestore_v1_Value>(result.array_value.values_count);
+- (Message<google_firestore_v1_Value>)parseArray:(NSArray<id> *)array
+                                         context:(ParseContext &&)context {
+  __block Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_array_value_tag;
+  result->array_value.values_count = CheckedSize([array count]);
+  result->array_value.values =
+      nanopb::MakeArray<google_firestore_v1_Value>(result->array_value.values_count);
 
   [array enumerateObjectsUsingBlock:^(id entry, NSUInteger idx, BOOL *) {
-    absl::optional<google_firestore_v1_Value> parsedEntry =
-        [self parseData:entry context:context.ChildContext(idx)];
+    auto parsedEntry = [self parseData:entry context:context.ChildContext(idx)];
     if (!parsedEntry) {
       // Just include nulls in the array for fields being replaced with a sentinel.
       parsedEntry = NullValue();
     }
-    result.array_value.values[idx] = *parsedEntry;
+    result->array_value.values[idx] = *parsedEntry->release();
   }];
 
-  return result;
+  return std::move(result);
 }
 
 /**
@@ -398,21 +395,21 @@ NS_ASSUME_NONNULL_BEGIN
     context.AddToFieldTransforms(*context.path(), ServerTimestampTransform());
 
   } else if ([fieldValue isKindOfClass:[FSTArrayUnionFieldValue class]]) {
-    google_firestore_v1_ArrayValue parsedElements =
+    auto parsedElements =
         [self parseArrayTransformElements:((FSTArrayUnionFieldValue *)fieldValue).elements];
-    ArrayTransform arrayUnion(TransformOperation::Type::ArrayUnion, parsedElements);
+    ArrayTransform arrayUnion(TransformOperation::Type::ArrayUnion, std::move(parsedElements));
     context.AddToFieldTransforms(*context.path(), std::move(arrayUnion));
 
   } else if ([fieldValue isKindOfClass:[FSTArrayRemoveFieldValue class]]) {
-    google_firestore_v1_ArrayValue parsedElements =
+    auto parsedElements =
         [self parseArrayTransformElements:((FSTArrayRemoveFieldValue *)fieldValue).elements];
-    ArrayTransform arrayRemove(TransformOperation::Type::ArrayRemove, parsedElements);
+    ArrayTransform arrayRemove(TransformOperation::Type::ArrayRemove, std::move(parsedElements));
     context.AddToFieldTransforms(*context.path(), std::move(arrayRemove));
 
   } else if ([fieldValue isKindOfClass:[FSTNumericIncrementFieldValue class]]) {
     auto *numericIncrementFieldValue = (FSTNumericIncrementFieldValue *)fieldValue;
-    google_firestore_v1_Value operand = [self parsedQueryValue:numericIncrementFieldValue.operand];
-    NumericIncrementTransform numeric_increment(operand);
+    auto operand = [self parsedQueryValue:numericIncrementFieldValue.operand];
+    NumericIncrementTransform numeric_increment(std::move(operand));
 
     context.AddToFieldTransforms(*context.path(), std::move(numeric_increment));
 
@@ -431,7 +428,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return The parsed value.
  */
-- (google_firestore_v1_Value)parseScalarValue:(nullable id)input context:(ParseContext &&)context {
+- (Message<google_firestore_v1_Value>)parseScalarValue:(nullable id)input
+                                               context:(ParseContext &&)context {
   if (!input || [input isMemberOfClass:[NSNull class]]) {
     return NullValue();
 
@@ -535,79 +533,79 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (google_firestore_v1_Value)encodeBoolean:(bool)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_boolean_value_tag;
-  result.boolean_value = value;
+- (Message<google_firestore_v1_Value>)encodeBoolean:(bool)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_boolean_value_tag;
+  result->boolean_value = value;
   return result;
 }
 
-- (google_firestore_v1_Value)encodeInteger:(int64_t)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_integer_value_tag;
-  result.integer_value = value;
+- (Message<google_firestore_v1_Value>)encodeInteger:(int64_t)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_integer_value_tag;
+  result->integer_value = value;
   return result;
 }
 
-- (google_firestore_v1_Value)encodeDouble:(double)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_double_value_tag;
-  result.double_value = value;
+- (Message<google_firestore_v1_Value>)encodeDouble:(double)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_double_value_tag;
+  result->double_value = value;
   return result;
 }
 
-- (google_firestore_v1_Value)encodeTimestampValue:(Timestamp)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_timestamp_value_tag;
-  result.timestamp_value.seconds = value.seconds();
-  result.timestamp_value.nanos = value.nanoseconds();
+- (Message<google_firestore_v1_Value>)encodeTimestampValue:(Timestamp)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_timestamp_value_tag;
+  result->timestamp_value.seconds = value.seconds();
+  result->timestamp_value.nanos = value.nanoseconds();
   return result;
 }
 
-- (google_firestore_v1_Value)encodeStringValue:(const std::string &)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_string_value_tag;
-  result.string_value = nanopb::MakeBytesArray(value);
+- (Message<google_firestore_v1_Value>)encodeStringValue:(const std::string &)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_string_value_tag;
+  result->string_value = nanopb::MakeBytesArray(value);
   return result;
 }
 
-- (google_firestore_v1_Value)encodeBlob:(const nanopb::ByteString &)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_bytes_value_tag;
+- (Message<google_firestore_v1_Value>)encodeBlob:(const nanopb::ByteString &)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_bytes_value_tag;
   // Copy the blob so that pb_release can do the right thing.
-  result.bytes_value = nanopb::CopyBytesArray(value.get());
+  result->bytes_value = nanopb::CopyBytesArray(value.get());
   return result;
 }
 
-- (google_firestore_v1_Value)encodeReference:(const DatabaseId &)databaseId
-                                         key:(const DocumentKey &)key {
+- (Message<google_firestore_v1_Value>)encodeReference:(const DatabaseId &)databaseId
+                                                  key:(const DocumentKey &)key {
   HARD_ASSERT(_databaseID == databaseId, "Database %s cannot encode reference from %s",
               _databaseID.ToString(), databaseId.ToString());
 
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_reference_value_tag;
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_reference_value_tag;
 
   std::string referenceName = ResourcePath({"projects", databaseId.project_id(), "databases",
                                             databaseId.database_id(), "documents", key.ToString()})
                                   .CanonicalString();
-  result.reference_value = nanopb::MakeBytesArray(referenceName);
+  result->reference_value = nanopb::MakeBytesArray(referenceName);
   return result;
 }
 
-- (google_firestore_v1_Value)encodeGeoPoint:(const GeoPoint &)value {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_geo_point_value_tag;
-  result.geo_point_value.latitude = value.latitude();
-  result.geo_point_value.longitude = value.longitude();
+- (Message<google_firestore_v1_Value>)encodeGeoPoint:(const GeoPoint &)value {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_geo_point_value_tag;
+  result->geo_point_value.latitude = value.latitude();
+  result->geo_point_value.longitude = value.longitude();
   return result;
 }
 
-- (google_firestore_v1_ArrayValue)parseArrayTransformElements:(NSArray<id> *)elements {
+- (Message<google_firestore_v1_ArrayValue>)parseArrayTransformElements:(NSArray<id> *)elements {
   ParseAccumulator accumulator{UserDataSource::Argument};
 
-  google_firestore_v1_ArrayValue array_value{};
-  array_value.values_count = CheckedSize(elements.count);
-  array_value.values = nanopb::MakeArray<google_firestore_v1_Value>(array_value.values_count);
+  Message<google_firestore_v1_ArrayValue> array_value{};
+  array_value->values_count = CheckedSize(elements.count);
+  array_value->values = nanopb::MakeArray<google_firestore_v1_Value>(array_value->values_count);
 
   for (NSUInteger i = 0; i < elements.count; i++) {
     id element = elements[i];
@@ -615,11 +613,10 @@ NS_ASSUME_NONNULL_BEGIN
     // are not considered writes since they cannot contain any FieldValue sentinels, etc.
     ParseContext context = accumulator.RootContext();
 
-    absl::optional<google_firestore_v1_Value> parsedElement =
-        [self parseData:element context:context.ChildContext(i)];
+    auto parsedElement = [self parseData:element context:context.ChildContext(i)];
     HARD_ASSERT(parsedElement && accumulator.field_transforms().empty(),
                 "Failed to properly parse array transform element: %s", element);
-    array_value.values[i] = *parsedElement;
+    array_value->values[i] = *parsedElement->release();
   }
   return array_value;
 }

--- a/Firestore/core/src/api/query_core.h
+++ b/Firestore/core/src/api/query_core.h
@@ -189,7 +189,7 @@ class Query {
    * if the value is anything other than a Reference or String, or if the string
    * is malformed.
    */
-  google_firestore_v1_Value ParseExpectedReferenceValue(
+  nanopb::Message<google_firestore_v1_Value> ParseExpectedReferenceValue(
       const google_firestore_v1_Value& value,
       const std::function<std::string()>& type_describer) const;
 

--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -640,7 +640,7 @@ Bound BundleSerializer::DecodeBound(JsonReader& reader,
   std::vector<json> values = reader.RequiredArray("values", bound_json);
   bool before = reader.OptionalBool("before", bound_json);
 
-  SharedMessage<google_firestore_v1_ArrayValue> positions{{}};
+  auto positions = MakeSharedMessage<google_firestore_v1_ArrayValue>({});
   SetRepeatedField(
       &positions->values, &positions->values_count, values,
       [&](const json& j) { return *DecodeValue(reader, j).release(); });

--- a/Firestore/core/src/bundle/bundle_serializer.h
+++ b/Firestore/core/src/bundle/bundle_serializer.h
@@ -28,6 +28,7 @@
 #include "Firestore/core/src/core/core_fwd.h"
 #include "Firestore/core/src/model/resource_path.h"
 #include "Firestore/core/src/model/snapshot_version.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "Firestore/core/src/remote/serializer.h"
 #include "Firestore/core/src/util/read_context.h"
 #include "Firestore/third_party/nlohmann_json/json.hpp"
@@ -114,16 +115,16 @@ class BundleSerializer {
                                  const nlohmann::json& filter) const;
   core::FilterList DecodeCompositeFilter(JsonReader& reader,
                                          const nlohmann::json& filter) const;
-  google_firestore_v1_Value DecodeValue(JsonReader& reader,
-                                        const nlohmann::json& value) const;
+  nanopb::Message<google_firestore_v1_Value> DecodeValue(
+      JsonReader& reader, const nlohmann::json& value) const;
   core::Bound DecodeBound(JsonReader& reader,
                           const nlohmann::json& query,
                           const char* bound_name) const;
   model::ResourcePath DecodeName(JsonReader& reader,
                                  const nlohmann::json& name) const;
-  google_firestore_v1_ArrayValue DecodeArrayValue(
+  nanopb::Message<google_firestore_v1_ArrayValue> DecodeArrayValue(
       JsonReader& reader, const nlohmann::json& array_json) const;
-  google_firestore_v1_MapValue DecodeMapValue(
+  nanopb::Message<google_firestore_v1_MapValue> DecodeMapValue(
       JsonReader& reader, const nlohmann::json& map_json) const;
   pb_bytes_array_t* DecodeReferenceValue(JsonReader& reader,
                                          const std::string& ref_string) const;

--- a/Firestore/core/src/core/not_in_filter.cc
+++ b/Firestore/core/src/core/not_in_filter.cc
@@ -58,7 +58,7 @@ NotInFilter::NotInFilter(const FieldPath& field,
 
 bool NotInFilter::Rep::Matches(const Document& doc) const {
   const google_firestore_v1_ArrayValue& array_value = value().array_value;
-  if (Contains(array_value, NullValue())) {
+  if (Contains(array_value, *NullValue())) {
     return false;
   }
   absl::optional<google_firestore_v1_Value> maybe_lhs = doc->field(field());

--- a/Firestore/core/src/local/local_serializer.cc
+++ b/Firestore/core/src/local/local_serializer.cc
@@ -144,7 +144,8 @@ google_firestore_v1_Document LocalSerializer::EncodeDocument(
       [](const google_firestore_v1_MapValue_FieldsEntry& map_entry) {
         // TODO(mrschmidt): Figure out how to remove this copy
         return google_firestore_v1_Document_FieldsEntry{
-            nanopb::CopyBytesArray(map_entry.key), DeepClone(map_entry.value)};
+            nanopb::CopyBytesArray(map_entry.key),
+            *DeepClone(map_entry.value).release()};
       });
 
   result.has_update_time = true;

--- a/Firestore/core/src/model/delete_mutation.cc
+++ b/Firestore/core/src/model/delete_mutation.cc
@@ -43,7 +43,7 @@ void DeleteMutation::Rep::ApplyToRemoteDocument(
     MutableDocument& document, const MutationResult& mutation_result) const {
   VerifyKeyMatches(document);
 
-  HARD_ASSERT(mutation_result.transform_results().values_count == 0,
+  HARD_ASSERT(mutation_result.transform_results()->values_count == 0,
               "Transform results received by DeleteMutation.");
 
   // Unlike ApplyToLocalView, if we're applying a mutation to a remote document

--- a/Firestore/core/src/model/model_fwd.h
+++ b/Firestore/core/src/model/model_fwd.h
@@ -105,7 +105,7 @@ using DocumentUpdateMap =
     std::unordered_map<DocumentKey, MutableDocument, DocumentKeyHash>;
 
 // A map of FieldPaths to transforms. Sorted so it can be used in
-// ObjectValue::SetAll, which makes it more efficient as  it processes field
+// ObjectValue::SetAll, which makes it more efficient as it processes field
 // maps one layer at a time.
 using TransformMap =
     std::map<FieldPath,

--- a/Firestore/core/src/model/model_fwd.h
+++ b/Firestore/core/src/model/model_fwd.h
@@ -18,8 +18,10 @@
 #define FIRESTORE_CORE_SRC_MODEL_MODEL_FWD_H_
 
 #include <cstdint>
+#include <map>
 #include <unordered_map>
 
+#include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "absl/types/optional.h"
 
 namespace firebase {
@@ -46,6 +48,13 @@ template <typename K, typename C>
 class SortedSet;
 
 }  // namespace immutable
+
+namespace nanopb {
+
+template <typename T>
+class Message;
+
+}  // namespace nanopb
 
 namespace model {
 
@@ -94,6 +103,13 @@ using DocumentVersionMap =
 
 using DocumentUpdateMap =
     std::unordered_map<DocumentKey, MutableDocument, DocumentKeyHash>;
+
+// A map of FieldPaths to transforms. Sorted so it can be used in
+// ObjectValue::SetAll, which makes it more efficient as  it processes field
+// maps one layer at a time.
+using TransformMap =
+    std::map<FieldPath,
+             absl::optional<nanopb::Message<google_firestore_v1_Value>>>;
 
 }  // namespace model
 }  // namespace firestore

--- a/Firestore/core/src/model/mutable_document.cc
+++ b/Firestore/core/src/model/mutable_document.cc
@@ -20,13 +20,10 @@
 #include <sstream>
 
 #include "Firestore/core/src/model/value_util.h"
-#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
 namespace model {
-
-using nanopb::Message;
 
 MutableDocument MutableDocument::InvalidDocument(DocumentKey document_key) {
   return {std::move(document_key), DocumentType::kInvalid,

--- a/Firestore/core/src/model/mutable_document.cc
+++ b/Firestore/core/src/model/mutable_document.cc
@@ -20,10 +20,13 @@
 #include <sstream>
 
 #include "Firestore/core/src/model/value_util.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
 namespace model {
+
+using nanopb::Message;
 
 MutableDocument MutableDocument::InvalidDocument(DocumentKey document_key) {
   return {std::move(document_key), DocumentType::kInvalid,

--- a/Firestore/core/src/model/mutation.h
+++ b/Firestore/core/src/model/mutation.h
@@ -37,12 +37,6 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
-// A map of FieldPaths to transforms. Sorted so it can be used in
-// ObjectValue::SetAll, which is more efficient it the input map is sorted as
-// it processes field maps one layer at a time.
-using TransformMap =
-    std::map<FieldPath, absl::optional<google_firestore_v1_Value>>;
-
 class Document;
 class MutableDocument;
 
@@ -57,9 +51,10 @@ class MutableDocument;
 class MutationResult {
  public:
   /** Takes ownership of `transform_results`. */
-  MutationResult(SnapshotVersion version,
-                 google_firestore_v1_ArrayValue transform_results)
-      : version_(version), transform_results_{transform_results} {
+  MutationResult(
+      SnapshotVersion version,
+      nanopb::Message<google_firestore_v1_ArrayValue> transform_results)
+      : version_(version), transform_results_{std::move(transform_results)} {
   }
 
   MutationResult(MutationResult&& other) noexcept
@@ -88,8 +83,9 @@ class MutationResult {
    *
    * Will be nullopt if the mutation was not a TransformMutation.
    */
-  const google_firestore_v1_ArrayValue& transform_results() const {
-    return *transform_results_;
+  const nanopb::Message<google_firestore_v1_ArrayValue>& transform_results()
+      const {
+    return transform_results_;
   }
 
   std::string ToString() const;
@@ -298,7 +294,8 @@ class Mutation {
      */
     TransformMap ServerTransformResults(
         const ObjectValue& previous_data,
-        const google_firestore_v1_ArrayValue& server_transform_results) const;
+        const nanopb::Message<google_firestore_v1_ArrayValue>&
+            server_transform_results) const;
 
     /**
      * Creates a map of "transform results" (a transform result is a field

--- a/Firestore/core/src/model/mutation_batch.cc
+++ b/Firestore/core/src/model/mutation_batch.cc
@@ -52,8 +52,7 @@ void MutationBatch::ApplyToRemoteDocument(
   for (size_t i = 0; i < mutations_.size(); i++) {
     const Mutation& mutation = mutations_[i];
     if (mutation.key() == document.key()) {
-      const MutationResult& mutation_result = mutation_results[i];
-      mutation.ApplyToRemoteDocument(document, mutation_result);
+      mutation.ApplyToRemoteDocument(document, mutation_results[i]);
     }
   }
 }

--- a/Firestore/core/src/model/object_value.cc
+++ b/Firestore/core/src/model/object_value.cc
@@ -40,6 +40,7 @@ using nanopb::MakeArray;
 using nanopb::MakeBytesArray;
 using nanopb::MakeString;
 using nanopb::MakeStringView;
+using nanopb::Message;
 using nanopb::ReleaseFieldOwnership;
 using nanopb::SetRepeatedField;
 
@@ -79,7 +80,7 @@ google_firestore_v1_MapValue_FieldsEntry* FindEntry(
 
 size_t CalculateSizeOfUnion(
     const google_firestore_v1_MapValue& map_value,
-    const std::map<std::string, google_firestore_v1_Value>& upserts,
+    const std::map<std::string, Message<google_firestore_v1_Value>>& upserts,
     const std::set<std::string>& deletes) {
   // Compute the size of the map after applying all mutations. The final size is
   // the number of existing entries, plus the number of new entries
@@ -102,8 +103,8 @@ size_t CalculateSizeOfUnion(
  */
 void ApplyChanges(
     google_firestore_v1_MapValue* parent,
-    const std::map<std::string, google_firestore_v1_Value>& upserts,
-    const std::set<std::string>& deletes) {
+    std::map<std::string, Message<google_firestore_v1_Value>> upserts,
+    std::set<std::string> deletes) {
   // TODO(mrschmidt): Consider using `absl::btree_map` and `absl::btree_set` for
   // potentially better performance.
   auto source_count = parent->fields_count;
@@ -139,7 +140,7 @@ void ApplyChanges(
         FreeFieldsArray(&source_entry.value);
 
         target_entry.key = source_entry.key;
-        target_entry.value = upsert_it->second;
+        target_entry.value = *(upsert_it->second.release());
         SortFields(target_entry.value);
 
         ++upsert_it;
@@ -160,7 +161,7 @@ void ApplyChanges(
 
     // Otherwise, insert the next upsert.
     target_entry.key = MakeBytesArray(upsert_it->first);
-    target_entry.value = upsert_it->second;
+    target_entry.value = *(upsert_it->second.release());
     SortFields(target_entry.value);
 
     ++upsert_it;
@@ -180,9 +181,9 @@ ObjectValue::ObjectValue() {
   value_->map_value.fields = nullptr;
 }
 
-ObjectValue::ObjectValue(const google_firestore_v1_Value& value)
-    : value_(value) {
-  HARD_ASSERT(IsMap(value), "ObjectValues should be backed by a MapValue");
+ObjectValue::ObjectValue(Message<google_firestore_v1_Value> value)
+    : value_(std::move(value)) {
+  HARD_ASSERT(IsMap(*value_), "ObjectValues should be backed by a MapValue");
   SortFields(*value_);
 }
 
@@ -190,19 +191,20 @@ ObjectValue::ObjectValue(const ObjectValue& other)
     : value_(DeepClone(*other.value_)) {
 }
 
-ObjectValue ObjectValue::FromMapValue(google_firestore_v1_MapValue map_value) {
-  google_firestore_v1_Value value{};
-  value.which_value_type = google_firestore_v1_Value_map_value_tag;
-  value.map_value = map_value;
-  return ObjectValue{value};
+ObjectValue ObjectValue::FromMapValue(
+    Message<google_firestore_v1_MapValue> map_value) {
+  Message<google_firestore_v1_Value> value{};
+  value->which_value_type = google_firestore_v1_Value_map_value_tag;
+  value->map_value = *map_value.release();
+  return ObjectValue{std::move(value)};
 }
 
 ObjectValue ObjectValue::FromFieldsEntry(
     google_firestore_v1_Document_FieldsEntry* fields_entry, pb_size_t count) {
-  google_firestore_v1_Value value{};
-  value.which_value_type = google_firestore_v1_Value_map_value_tag;
+  Message<google_firestore_v1_Value> value{};
+  value->which_value_type = google_firestore_v1_Value_map_value_tag;
   SetRepeatedField(
-      &value.map_value.fields, &value.map_value.fields_count,
+      &value->map_value.fields, &value->map_value.fields_count,
       absl::Span<google_firestore_v1_Document_FieldsEntry>(fields_entry, count),
       [](const google_firestore_v1_Document_FieldsEntry& entry) {
         return google_firestore_v1_MapValue_FieldsEntry{entry.key, entry.value};
@@ -210,7 +212,7 @@ ObjectValue ObjectValue::FromFieldsEntry(
   // Prevent double-freeing of the document's fields. The fields are now owned
   // by ObjectValue.
   ReleaseFieldOwnership(fields_entry, count);
-  return ObjectValue{value};
+  return ObjectValue{std::move(value)};
 }
 
 FieldMask ObjectValue::ToFieldMask() const {
@@ -265,48 +267,47 @@ google_firestore_v1_Value ObjectValue::Get() const {
   return *value_;
 }
 
-void ObjectValue::Set(const FieldPath& path, google_firestore_v1_Value value) {
+void ObjectValue::Set(const FieldPath& path,
+                      Message<google_firestore_v1_Value> value) {
   HARD_ASSERT(!path.empty(), "Cannot set field for empty path on ObjectValue");
 
   google_firestore_v1_MapValue* parent_map = ParentMap(path.PopLast());
 
-  std::string last_segment = path.last_segment();
-  std::map<std::string, google_firestore_v1_Value> upserts{
-      {std::move(last_segment), value}};
+  std::map<std::string, Message<google_firestore_v1_Value>> upserts;
+  upserts[path.last_segment()] = std::move(value);
 
-  ApplyChanges(parent_map, upserts, /*deletes=*/{});
+  ApplyChanges(parent_map, std::move(upserts), /*deletes=*/{});
 }
 
-void ObjectValue::SetAll(
-    const std::map<FieldPath, absl::optional<google_firestore_v1_Value>>&
-        data) {
+void ObjectValue::SetAll(TransformMap data) {
   FieldPath parent;
 
-  std::map<std::string, google_firestore_v1_Value> upserts;
+  std::map<std::string, Message<google_firestore_v1_Value>> upserts;
   std::set<std::string> deletes;
 
-  for (const auto& it : data) {
+  for (auto& it : data) {
     const FieldPath& path = it.first;
-    const auto& value = it.second;
+    absl::optional<Message<google_firestore_v1_Value>> value =
+        std::move(it.second);
 
     if (!parent.IsImmediateParentOf(path)) {
       // Insert the accumulated changes at this parent location
       google_firestore_v1_MapValue* parent_map = ParentMap(parent);
-      ApplyChanges(parent_map, upserts, deletes);
+      ApplyChanges(parent_map, std::move(upserts), std::move(deletes));
       upserts.clear();
       deletes.clear();
       parent = path.PopLast();
     }
 
     if (value) {
-      upserts.emplace(path.last_segment(), *value);
+      upserts[path.last_segment()] = std::move(*value);
     } else {
       deletes.insert(path.last_segment());
     }
   }
 
   google_firestore_v1_MapValue* parent_map = ParentMap(parent);
-  ApplyChanges(parent_map, upserts, deletes);
+  ApplyChanges(parent_map, std::move(upserts), std::move(deletes));
 }
 
 void ObjectValue::Delete(const FieldPath& path) {
@@ -355,12 +356,12 @@ google_firestore_v1_MapValue* ObjectValue::ParentMap(const FieldPath& path) {
       parent = &entry->value;
     } else {
       // Create a new map value for the current segment.
-      google_firestore_v1_Value new_entry{};
-      new_entry.which_value_type = google_firestore_v1_Value_map_value_tag;
+      Message<google_firestore_v1_Value> new_entry{};
+      new_entry->which_value_type = google_firestore_v1_Value_map_value_tag;
 
-      std::map<std::string, google_firestore_v1_Value> upserts{
-          {segment, new_entry}};
-      ApplyChanges(&parent->map_value, upserts, /*deletes=*/{});
+      std::map<std::string, Message<google_firestore_v1_Value>> upserts;
+      upserts[segment] = std::move(new_entry);
+      ApplyChanges(&parent->map_value, std::move(upserts), /*deletes=*/{});
 
       parent = &(FindEntry(*parent, segment)->value);
     }

--- a/Firestore/core/src/model/object_value.cc
+++ b/Firestore/core/src/model/object_value.cc
@@ -183,7 +183,8 @@ ObjectValue::ObjectValue() {
 
 ObjectValue::ObjectValue(Message<google_firestore_v1_Value> value)
     : value_(std::move(value)) {
-  HARD_ASSERT(IsMap(*value_), "ObjectValues should be backed by a MapValue");
+  HARD_ASSERT(value_ && IsMap(*value_),
+              "ObjectValues should be backed by a MapValue");
   SortFields(*value_);
 }
 

--- a/Firestore/core/src/model/object_value.h
+++ b/Firestore/core/src/model/object_value.h
@@ -26,6 +26,7 @@
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/src/model/field_mask.h"
 #include "Firestore/core/src/model/field_path.h"
+#include "Firestore/core/src/model/model_fwd.h"
 #include "Firestore/core/src/model/value_util.h"
 #include "Firestore/core/src/nanopb/message.h"
 #include "Firestore/core/src/util/hard_assert.h"
@@ -41,8 +42,8 @@ class ObjectValue {
  public:
   ObjectValue();
 
-  /** Creates a new MutableObjectValue and takes ownership of `value`. */
-  explicit ObjectValue(const google_firestore_v1_Value& value);
+  /** Creates a new ObjectValue */
+  explicit ObjectValue(nanopb::Message<google_firestore_v1_Value> value);
 
   ObjectValue(ObjectValue&& other) noexcept = default;
   ObjectValue& operator=(ObjectValue&& other) noexcept = default;
@@ -54,7 +55,8 @@ class ObjectValue {
    * Creates a new ObjectValue that is backed by the given `map_value`.
    * ObjectValue takes on ownership of the data.
    */
-  static ObjectValue FromMapValue(google_firestore_v1_MapValue map_value);
+  static ObjectValue FromMapValue(
+      nanopb::Message<google_firestore_v1_MapValue> map_value);
 
   /**
    * Creates a new ObjectValue that is backed by the provided document fields.
@@ -84,12 +86,11 @@ class ObjectValue {
   /**
    * Sets the field to the provided value.
    *
-   * Takes ownership of value.
-   *
    * @param path The field path to set. The path must not be empty.
    * @param value The value to set.
    */
-  void Set(const FieldPath& path, google_firestore_v1_Value value);
+  void Set(const FieldPath& path,
+           nanopb::Message<google_firestore_v1_Value> value);
 
   /**
    * Sets the provided fields to the provided values. Fields set to `nullopt`
@@ -99,8 +100,7 @@ class ObjectValue {
    *
    * @param data A map of fields to values (or nullopt for deletes)
    */
-  void SetAll(const std::map<FieldPath,
-                             absl::optional<google_firestore_v1_Value>>& data);
+  void SetAll(TransformMap data);
 
   /**
    * Removes the field at the specified path. If there is no field at the

--- a/Firestore/core/src/model/patch_mutation.h
+++ b/Firestore/core/src/model/patch_mutation.h
@@ -26,6 +26,7 @@
 #include "Firestore/core/src/model/field_mask.h"
 #include "Firestore/core/src/model/model_fwd.h"
 #include "Firestore/core/src/model/mutation.h"
+#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {
@@ -106,8 +107,7 @@ class PatchMutation : public Mutation {
      * Returns this patch mutation as a list of field paths to values (or
      * nullopt for deletes).
      */
-    std::map<FieldPath, absl::optional<google_firestore_v1_Value>> GetPatch()
-        const;
+    TransformMap GetPatch() const;
 
     void ApplyToRemoteDocument(
         MutableDocument& document,

--- a/Firestore/core/src/model/patch_mutation.h
+++ b/Firestore/core/src/model/patch_mutation.h
@@ -26,7 +26,6 @@
 #include "Firestore/core/src/model/field_mask.h"
 #include "Firestore/core/src/model/model_fwd.h"
 #include "Firestore/core/src/model/mutation.h"
-#include "Firestore/core/src/nanopb/message.h"
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/model/server_timestamp_util.cc
+++ b/Firestore/core/src/model/server_timestamp_util.cc
@@ -25,20 +25,22 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+using nanopb::Message;
+
 const char kTypeKey[] = "__type__";
 const char kLocalWriteTimeKey[] = "__local_write_time__";
 const char kPreviousValueKey[] = "__previous_value__";
 const char kServerTimestampSentinel[] = "server_timestamp";
 
-google_firestore_v1_Value EncodeServerTimestamp(
+Message<google_firestore_v1_Value> EncodeServerTimestamp(
     const Timestamp& local_write_time,
     absl::optional<google_firestore_v1_Value> previous_value) {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_map_value_tag;
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_map_value_tag;
 
   pb_size_t count = previous_value ? 3 : 2;
 
-  auto& map_value = result.map_value;
+  auto& map_value = result->map_value;
   map_value.fields_count = count;
   map_value.fields =
       nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(count);
@@ -57,7 +59,7 @@ google_firestore_v1_Value EncodeServerTimestamp(
   if (previous_value) {
     ++field;
     field->key = nanopb::MakeBytesArray(kPreviousValueKey);
-    field->value = DeepClone(*previous_value);
+    field->value = *DeepClone(*previous_value).release();
   }
 
   return result;

--- a/Firestore/core/src/model/server_timestamp_util.h
+++ b/Firestore/core/src/model/server_timestamp_util.h
@@ -19,6 +19,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "absl/types/optional.h"
 
 namespace firebase {
@@ -29,7 +30,7 @@ namespace model {
 // sentinel fields in MapValues.
 
 /** Encodes the backing data for a server timestamp in a Value proto. */
-google_firestore_v1_Value EncodeServerTimestamp(
+nanopb::Message<google_firestore_v1_Value> EncodeServerTimestamp(
     const Timestamp& local_write_time,
     absl::optional<google_firestore_v1_Value> previous_value);
 /**

--- a/Firestore/core/src/model/set_mutation.cc
+++ b/Firestore/core/src/model/set_mutation.cc
@@ -75,7 +75,7 @@ void SetMutation::Rep::ApplyToRemoteDocument(
   auto transform_results = ServerTransformResults(
       document.data(), mutation_result.transform_results());
   ObjectValue new_data{DeepClone(value_.Get())};
-  new_data.SetAll(transform_results);
+  new_data.SetAll(std::move(transform_results));
   document
       .ConvertToFoundDocument(mutation_result.version(), std::move(new_data))
       .SetHasCommittedMutations();
@@ -92,7 +92,7 @@ void SetMutation::Rep::ApplyToLocalView(
   auto transform_results =
       LocalTransformResults(document.data(), local_write_time);
   ObjectValue new_data{DeepClone(value_.Get())};
-  new_data.SetAll(transform_results);
+  new_data.SetAll(std::move(transform_results));
   document
       .ConvertToFoundDocument(GetPostMutationVersion(document),
                               std::move(new_data))

--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -35,6 +35,7 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+using nanopb::Message;
 using Type = TransformOperation::Type;
 
 // MARK: - TransformOperation
@@ -65,19 +66,19 @@ class ServerTimestampTransform::Rep : public TransformOperation::Rep {
     return Type::ServerTimestamp;
   }
 
-  google_firestore_v1_Value ApplyToLocalView(
+  Message<google_firestore_v1_Value> ApplyToLocalView(
       const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp& local_write_time) const override {
     return EncodeServerTimestamp(local_write_time, previous_value);
   }
 
-  google_firestore_v1_Value ApplyToRemoteDocument(
+  Message<google_firestore_v1_Value> ApplyToRemoteDocument(
       const absl::optional<google_firestore_v1_Value>&,
-      const google_firestore_v1_Value& transform_result) const override {
+      Message<google_firestore_v1_Value> transform_result) const override {
     return transform_result;
   }
 
-  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+  absl::optional<nanopb::Message<google_firestore_v1_Value>> ComputeBaseValue(
       const absl::optional<google_firestore_v1_Value>&) const override {
     // Server timestamps are idempotent and don't require a base value.
     return absl::nullopt;
@@ -113,30 +114,30 @@ static_assert(sizeof(TransformOperation) == sizeof(ArrayTransform),
  */
 class ArrayTransform::Rep : public TransformOperation::Rep {
  public:
-  Rep(Type type, google_firestore_v1_ArrayValue elements)
-      : type_(type), elements_{elements} {
+  Rep(Type type, Message<google_firestore_v1_ArrayValue> elements)
+      : type_(type), elements_{std::move(elements)} {
   }
 
   Type type() const override {
     return type_;
   }
 
-  google_firestore_v1_Value ApplyToLocalView(
+  Message<google_firestore_v1_Value> ApplyToLocalView(
       const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp&) const override {
     return Apply(previous_value);
   }
 
-  google_firestore_v1_Value ApplyToRemoteDocument(
+  Message<google_firestore_v1_Value> ApplyToRemoteDocument(
       const absl::optional<google_firestore_v1_Value>& previous_value,
-      const google_firestore_v1_Value&) const override {
+      Message<google_firestore_v1_Value>) const override {
     // The server just sends null as the transform result for array operations,
     // so we have to calculate a result the same as we do for local
     // applications.
     return Apply(previous_value);
   }
 
-  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+  absl::optional<nanopb::Message<google_firestore_v1_Value>> ComputeBaseValue(
       const absl::optional<google_firestore_v1_Value>&) const override {
     // Array transforms are idempotent and don't require a base value.
     return absl::nullopt;
@@ -160,10 +161,10 @@ class ArrayTransform::Rep : public TransformOperation::Rep {
    * of type Array and an empty array if it's nil or any other type of
    * google_firestore_v1_Value.
    */
-  google_firestore_v1_ArrayValue CoercedFieldValueArray(
+  Message<google_firestore_v1_ArrayValue> CoercedFieldValueArray(
       const absl::optional<google_firestore_v1_Value>& value) const;
 
-  google_firestore_v1_Value Apply(
+  Message<google_firestore_v1_Value> Apply(
       const absl::optional<google_firestore_v1_Value>& previous_value) const;
 
   Type type_;
@@ -179,8 +180,9 @@ constexpr bool IsArrayTransform(Type type) {
 }  // namespace
 
 ArrayTransform::ArrayTransform(Type type,
-                               google_firestore_v1_ArrayValue elements)
-    : TransformOperation(std::make_shared<const Rep>(type, elements)) {
+                               Message<google_firestore_v1_ArrayValue> elements)
+    : TransformOperation(
+          std::make_shared<const Rep>(type, std::move(elements))) {
   HARD_ASSERT(IsArrayTransform(type), "Expected array transform type; got %s",
               type);
 }
@@ -230,7 +232,8 @@ std::string ArrayTransform::Rep::ToString() const {
   return absl::StrCat(name, "(", CanonicalId(*elements_), ")");
 }
 
-google_firestore_v1_ArrayValue ArrayTransform::Rep::CoercedFieldValueArray(
+Message<google_firestore_v1_ArrayValue>
+ArrayTransform::Rep::CoercedFieldValueArray(
     const absl::optional<google_firestore_v1_Value>& value) const {
   if (IsArray(value)) {
     return DeepClone(value->array_value);
@@ -240,50 +243,50 @@ google_firestore_v1_ArrayValue ArrayTransform::Rep::CoercedFieldValueArray(
   }
 }
 
-google_firestore_v1_Value ArrayTransform::Rep::Apply(
+Message<google_firestore_v1_Value> ArrayTransform::Rep::Apply(
     const absl::optional<google_firestore_v1_Value>& previous_value) const {
-  google_firestore_v1_ArrayValue array_value =
+  Message<google_firestore_v1_ArrayValue> array_value =
       CoercedFieldValueArray(previous_value);
   if (type_ == Type::ArrayUnion) {
     // Gather the list of elements that have to be added.
-    std::vector<google_firestore_v1_Value> new_elements;
+    std::vector<Message<google_firestore_v1_Value>> new_elements;
     for (pb_size_t i = 0; i < elements_->values_count; ++i) {
       const google_firestore_v1_Value& new_element = elements_->values[i];
-      if (!Contains(array_value, new_element) &&
+      if (!Contains(*array_value, new_element) &&
           !std::any_of(new_elements.begin(), new_elements.end(),
-                       [&](const google_firestore_v1_Value& value) {
-                         return value == new_element;
+                       [&](const Message<google_firestore_v1_Value>& value) {
+                         return *value == new_element;
                        })) {
-        new_elements.push_back(new_element);
+        new_elements.push_back(DeepClone(new_element));
       }
     }
 
     // Append the elements to the end of the list
-    size_t new_size = array_value.values_count + new_elements.size();
-    array_value.values = nanopb::ResizeArray<google_firestore_v1_Value>(
-        array_value.values, new_size);
-    for (const auto& element : new_elements) {
-      array_value.values[array_value.values_count] = DeepClone(element);
-      ++array_value.values_count;
+    size_t new_size = array_value->values_count + new_elements.size();
+    array_value->values = nanopb::ResizeArray<google_firestore_v1_Value>(
+        array_value->values, new_size);
+    for (auto& element : new_elements) {
+      array_value->values[array_value->values_count] = *element.release();
+      ++array_value->values_count;
     }
   } else {
     HARD_ASSERT(type_ == Type::ArrayRemove);
     pb_size_t new_index = 0;
-    for (pb_size_t old_index = 0; old_index < array_value.values_count;
+    for (pb_size_t old_index = 0; old_index < array_value->values_count;
          ++old_index) {
-      if (Contains(*elements_, array_value.values[old_index])) {
-        nanopb::FreeFieldsArray(&array_value.values[old_index]);
+      if (Contains(*elements_, array_value->values[old_index])) {
+        nanopb::FreeFieldsArray(&array_value->values[old_index]);
       } else {
-        array_value.values[new_index] = array_value.values[old_index];
+        array_value->values[new_index] = array_value->values[old_index];
         ++new_index;
       }
     }
-    array_value.values_count = new_index;
+    array_value->values_count = new_index;
   }
 
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_array_value_tag;
-  result.array_value = array_value;
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_array_value_tag;
+  result->array_value = *array_value.release();
   return result;
 }
 
@@ -294,7 +297,7 @@ static_assert(sizeof(TransformOperation) == sizeof(NumericIncrementTransform),
 
 class NumericIncrementTransform::Rep : public TransformOperation::Rep {
  public:
-  explicit Rep(google_firestore_v1_Value operand)
+  explicit Rep(Message<google_firestore_v1_Value> operand)
       : operand_(std::move(operand)) {
   }
 
@@ -302,17 +305,17 @@ class NumericIncrementTransform::Rep : public TransformOperation::Rep {
     return Type::Increment;
   }
 
-  google_firestore_v1_Value ApplyToLocalView(
+  Message<google_firestore_v1_Value> ApplyToLocalView(
       const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp& local_write_time) const override;
 
-  google_firestore_v1_Value ApplyToRemoteDocument(
+  Message<google_firestore_v1_Value> ApplyToRemoteDocument(
       const absl::optional<google_firestore_v1_Value>&,
-      const google_firestore_v1_Value& transform_result) const override {
+      Message<google_firestore_v1_Value> transform_result) const override {
     return transform_result;
   }
 
-  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+  absl::optional<nanopb::Message<google_firestore_v1_Value>> ComputeBaseValue(
       const absl::optional<google_firestore_v1_Value>& previous_value)
       const override;
 
@@ -321,23 +324,23 @@ class NumericIncrementTransform::Rep : public TransformOperation::Rep {
   bool Equals(const TransformOperation::Rep& other) const override;
 
   size_t Hash() const override {
-    return std::hash<std::string>()(CanonicalId(operand_));
+    return std::hash<std::string>()(CanonicalId(*operand_));
   }
 
   std::string ToString() const override {
-    return absl::StrCat("NumericIncrement(", operand_.ToString(), ")");
+    return absl::StrCat("NumericIncrement(", operand_->ToString(), ")");
   }
 
  private:
   friend class NumericIncrementTransform;
 
-  google_firestore_v1_Value operand_{};
+  Message<google_firestore_v1_Value> operand_{};
 };
 
 NumericIncrementTransform::NumericIncrementTransform(
-    google_firestore_v1_Value operand)
-    : TransformOperation(std::make_shared<Rep>(operand)) {
-  HARD_ASSERT(IsNumber(operand));
+    Message<google_firestore_v1_Value> operand)
+    : TransformOperation(std::make_shared<Rep>(std::move(operand))) {
+  HARD_ASSERT(IsNumber(this->operand()));
 }
 
 NumericIncrementTransform::NumericIncrementTransform(
@@ -348,7 +351,7 @@ NumericIncrementTransform::NumericIncrementTransform(
 }
 
 const google_firestore_v1_Value& NumericIncrementTransform::operand() const {
-  return static_cast<const Rep&>(rep()).operand_;
+  return *static_cast<const Rep&>(rep()).operand_;
 }
 
 namespace {
@@ -372,48 +375,50 @@ int64_t SafeIncrement(int64_t x, int64_t y) {
 }  // namespace
 
 double NumericIncrementTransform::Rep::OperandAsDouble() const {
-  if (IsDouble(operand_)) {
-    return operand_.double_value;
-  } else if (IsInteger(operand_)) {
-    return static_cast<double>(operand_.integer_value);
+  if (IsDouble(*operand_)) {
+    return operand_->double_value;
+  } else if (IsInteger(*operand_)) {
+    return static_cast<double>(operand_->integer_value);
   } else {
     HARD_FAIL("Expected 'operand' to be of numeric type, but was %s (type %s)",
-              CanonicalId(operand_), GetTypeOrder(operand_));
+              CanonicalId(*operand_), GetTypeOrder(*operand_));
   }
 }
 
-google_firestore_v1_Value NumericIncrementTransform::Rep::ApplyToLocalView(
+Message<google_firestore_v1_Value>
+NumericIncrementTransform::Rep::ApplyToLocalView(
     const absl::optional<google_firestore_v1_Value>& previous_value,
     const Timestamp& /* local_write_time */) const {
-  absl::optional<google_firestore_v1_Value> base_value =
-      ComputeBaseValue(previous_value);
-  google_firestore_v1_Value result{};
+  auto base_value = ComputeBaseValue(previous_value);
+  Message<google_firestore_v1_Value> result{};
 
   // Return an integer value only if the previous value and the operand is an
   // integer.
-  if (IsInteger(base_value) && IsInteger(operand_)) {
-    result.which_value_type = google_firestore_v1_Value_integer_value_tag;
-    result.integer_value =
-        SafeIncrement(base_value->integer_value, operand_.integer_value);
-  } else if (IsInteger(base_value)) {
-    result.which_value_type = google_firestore_v1_Value_double_value_tag;
-    result.double_value = base_value->integer_value + OperandAsDouble();
+  if (IsInteger(**base_value) && IsInteger(*operand_)) {
+    result->which_value_type = google_firestore_v1_Value_integer_value_tag;
+    result->integer_value =
+        SafeIncrement((*base_value)->integer_value, operand_->integer_value);
+  } else if (IsInteger(**base_value)) {
+    result->which_value_type = google_firestore_v1_Value_double_value_tag;
+    result->double_value = (*base_value)->integer_value + OperandAsDouble();
   } else {
-    HARD_ASSERT(IsDouble(base_value), "'base_value' is not of numeric type");
-    result.which_value_type = google_firestore_v1_Value_double_value_tag;
-    result.double_value = base_value->double_value + OperandAsDouble();
+    HARD_ASSERT(IsDouble(**base_value), "'base_value' is not of numeric type");
+    result->which_value_type = google_firestore_v1_Value_double_value_tag;
+    result->double_value = (*base_value)->double_value + OperandAsDouble();
   }
 
   return result;
 }
 
-absl::optional<google_firestore_v1_Value>
+absl::optional<Message<google_firestore_v1_Value>>
 NumericIncrementTransform::Rep::ComputeBaseValue(
     const absl::optional<google_firestore_v1_Value>& previous_value) const {
-  if (IsNumber(previous_value)) return previous_value;
+  if (IsNumber(previous_value)) {
+    return DeepClone(*previous_value);
+  }
 
-  google_firestore_v1_Value zero_value{};
-  zero_value.which_value_type = google_firestore_v1_Value_integer_value_tag;
+  Message<google_firestore_v1_Value> zero_value{};
+  zero_value->which_value_type = google_firestore_v1_Value_integer_value_tag;
   return zero_value;
 }
 
@@ -423,8 +428,8 @@ bool NumericIncrementTransform::Rep::Equals(
     return false;
   }
 
-  auto other_rep = static_cast<const NumericIncrementTransform::Rep&>(other);
-  return operand_ == other_rep.operand_;
+  return *operand_ ==
+         *static_cast<const NumericIncrementTransform::Rep&>(other).operand_;
 }
 
 }  // namespace model

--- a/Firestore/core/src/model/transform_operation.h
+++ b/Firestore/core/src/model/transform_operation.h
@@ -77,7 +77,7 @@ class TransformOperation {
    * Computes the local transform result against the provided `previous_value`,
    * optionally using the provided local_write_time.
    */
-  google_firestore_v1_Value ApplyToLocalView(
+  nanopb::Message<google_firestore_v1_Value> ApplyToLocalView(
       const absl::optional<google_firestore_v1_Value>& previous_value,
       const Timestamp& local_write_time) const {
     return rep().ApplyToLocalView(previous_value, local_write_time);
@@ -87,10 +87,11 @@ class TransformOperation {
    * Computes a final transform result after the transform has been acknowledged
    * by the server, potentially using the server-provided transform_result.
    */
-  google_firestore_v1_Value ApplyToRemoteDocument(
+  nanopb::Message<google_firestore_v1_Value> ApplyToRemoteDocument(
       const absl::optional<google_firestore_v1_Value>& previous_value,
-      const google_firestore_v1_Value& transform_result) const {
-    return rep().ApplyToRemoteDocument(previous_value, transform_result);
+      nanopb::Message<google_firestore_v1_Value> transform_result) const {
+    return rep().ApplyToRemoteDocument(previous_value,
+                                       std::move(transform_result));
   }
 
   /**
@@ -108,7 +109,7 @@ class TransformOperation {
    * @return a base value to store along with the mutation, or empty for
    *     idempotent transforms.
    */
-  absl::optional<google_firestore_v1_Value> ComputeBaseValue(
+  absl::optional<nanopb::Message<google_firestore_v1_Value>> ComputeBaseValue(
       const absl::optional<google_firestore_v1_Value>& previous_value) const {
     return rep().ComputeBaseValue(previous_value);
   }
@@ -136,17 +137,17 @@ class TransformOperation {
 
     virtual Type type() const = 0;
 
-    virtual google_firestore_v1_Value ApplyToLocalView(
+    virtual nanopb::Message<google_firestore_v1_Value> ApplyToLocalView(
         const absl::optional<google_firestore_v1_Value>& previous_value,
         const Timestamp& local_write_time) const = 0;
 
-    virtual google_firestore_v1_Value ApplyToRemoteDocument(
+    virtual nanopb::Message<google_firestore_v1_Value> ApplyToRemoteDocument(
         const absl::optional<google_firestore_v1_Value>& previous_value,
-        const google_firestore_v1_Value& transform_result) const = 0;
+        nanopb::Message<google_firestore_v1_Value> transform_result) const = 0;
 
-    virtual absl::optional<google_firestore_v1_Value> ComputeBaseValue(
-        const absl::optional<google_firestore_v1_Value>& previous_value)
-        const = 0;
+    virtual absl::optional<nanopb::Message<google_firestore_v1_Value>>
+    ComputeBaseValue(const absl::optional<google_firestore_v1_Value>&
+                         previous_value) const = 0;
 
     virtual bool Equals(const TransformOperation::Rep& other) const = 0;
 
@@ -180,7 +181,8 @@ class ServerTimestampTransform : public TransformOperation {
  */
 class ArrayTransform : public TransformOperation {
  public:
-  ArrayTransform(Type type, google_firestore_v1_ArrayValue array_value);
+  ArrayTransform(Type type,
+                 nanopb::Message<google_firestore_v1_ArrayValue> array_value);
 
   /**
    * Casts a TransformOperation to an ArrayTransform. This is a checked
@@ -204,7 +206,8 @@ class ArrayTransform : public TransformOperation {
  */
 class NumericIncrementTransform : public TransformOperation {
  public:
-  explicit NumericIncrementTransform(google_firestore_v1_Value operand);
+  explicit NumericIncrementTransform(
+      nanopb::Message<google_firestore_v1_Value> operand);
 
   /**
    * Casts a TransformOperation to a NumericIncrementTransform. This is a

--- a/Firestore/core/src/model/value_util.cc
+++ b/Firestore/core/src/model/value_util.cc
@@ -37,6 +37,7 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+using nanopb::Message;
 using util::ComparisonResult;
 
 TypeOrder GetTypeOrder(const google_firestore_v1_Value& value) {
@@ -495,9 +496,9 @@ bool Contains(google_firestore_v1_ArrayValue haystack,
   return false;
 }
 
-google_firestore_v1_Value NullValue() {
-  google_firestore_v1_Value null_value{};
-  null_value.which_value_type = google_firestore_v1_Value_null_value_tag;
+Message<google_firestore_v1_Value> NullValue() {
+  Message<google_firestore_v1_Value> null_value{};
+  null_value->which_value_type = google_firestore_v1_Value_null_value_tag;
   return null_value;
 }
 
@@ -505,10 +506,10 @@ bool IsNullValue(const google_firestore_v1_Value& value) {
   return value.which_value_type == google_firestore_v1_Value_null_value_tag;
 }
 
-google_firestore_v1_Value NaNValue() {
-  google_firestore_v1_Value nan_value{};
-  nan_value.which_value_type = google_firestore_v1_Value_double_value_tag;
-  nan_value.double_value = std::numeric_limits<double>::quiet_NaN();
+Message<google_firestore_v1_Value> NaNValue() {
+  Message<google_firestore_v1_Value> nan_value{};
+  nan_value->which_value_type = google_firestore_v1_Value_double_value_tag;
+  nan_value->double_value = std::numeric_limits<double>::quiet_NaN();
   return nan_value;
 }
 
@@ -517,21 +518,23 @@ bool IsNaNValue(const google_firestore_v1_Value& value) {
          std::isnan(value.double_value);
 }
 
-google_firestore_v1_Value RefValue(const model::DatabaseId& database_id,
-                                   const model::DocumentKey& document_key) {
-  google_firestore_v1_Value result{};
-  result.which_value_type = google_firestore_v1_Value_reference_value_tag;
-  result.string_value = nanopb::MakeBytesArray(util::StringFormat(
+Message<google_firestore_v1_Value> RefValue(
+    const model::DatabaseId& database_id,
+    const model::DocumentKey& document_key) {
+  Message<google_firestore_v1_Value> result{};
+  result->which_value_type = google_firestore_v1_Value_reference_value_tag;
+  result->string_value = nanopb::MakeBytesArray(util::StringFormat(
       "projects/%s/databases/%s/documents/%s", database_id.project_id(),
       database_id.database_id(), document_key.ToString()));
   return result;
 }
 
-google_firestore_v1_Value DeepClone(const google_firestore_v1_Value& source) {
-  google_firestore_v1_Value target = source;
+Message<google_firestore_v1_Value> DeepClone(
+    const google_firestore_v1_Value& source) {
+  Message<google_firestore_v1_Value> target{source};
   switch (source.which_value_type) {
     case google_firestore_v1_Value_string_value_tag:
-      target.string_value =
+      target->string_value =
           source.string_value
               ? nanopb::MakeBytesArray(source.string_value->bytes,
                                        source.string_value->size)
@@ -539,51 +542,52 @@ google_firestore_v1_Value DeepClone(const google_firestore_v1_Value& source) {
       break;
 
     case google_firestore_v1_Value_reference_value_tag:
-      target.reference_value = nanopb::MakeBytesArray(
+      target->reference_value = nanopb::MakeBytesArray(
           source.reference_value->bytes, source.reference_value->size);
       break;
 
     case google_firestore_v1_Value_bytes_value_tag:
-      target.bytes_value =
+      target->bytes_value =
           source.bytes_value ? nanopb::MakeBytesArray(source.bytes_value->bytes,
                                                       source.bytes_value->size)
                              : nullptr;
       break;
 
     case google_firestore_v1_Value_array_value_tag:
-      target.array_value.values_count = source.array_value.values_count;
-      target.array_value.values = nanopb::MakeArray<google_firestore_v1_Value>(
+      target->array_value.values_count = source.array_value.values_count;
+      target->array_value.values = nanopb::MakeArray<google_firestore_v1_Value>(
           source.array_value.values_count);
       for (pb_size_t i = 0; i < source.array_value.values_count; ++i) {
-        target.array_value.values[i] = DeepClone(source.array_value.values[i]);
+        target->array_value.values[i] =
+            *DeepClone(source.array_value.values[i]).release();
       }
       break;
 
     case google_firestore_v1_Value_map_value_tag:
-      target.map_value.fields_count = source.map_value.fields_count;
-      target.map_value.fields =
+      target->map_value.fields_count = source.map_value.fields_count;
+      target->map_value.fields =
           nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(
               source.map_value.fields_count);
       for (pb_size_t i = 0; i < source.map_value.fields_count; ++i) {
-        target.map_value.fields[i].key =
+        target->map_value.fields[i].key =
             nanopb::MakeBytesArray(source.map_value.fields[i].key->bytes,
                                    source.map_value.fields[i].key->size);
-        target.map_value.fields[i].value =
-            DeepClone(source.map_value.fields[i].value);
+        target->map_value.fields[i].value =
+            *DeepClone(source.map_value.fields[i].value).release();
       }
       break;
   }
   return target;
 }
 
-google_firestore_v1_ArrayValue DeepClone(
+Message<google_firestore_v1_ArrayValue> DeepClone(
     const google_firestore_v1_ArrayValue& source) {
-  google_firestore_v1_ArrayValue target = source;
-  target.values_count = source.values_count;
-  target.values =
+  Message<google_firestore_v1_ArrayValue> target{source};
+  target->values_count = source.values_count;
+  target->values =
       nanopb::MakeArray<google_firestore_v1_Value>(source.values_count);
   for (pb_size_t i = 0; i < source.values_count; ++i) {
-    target.values[i] = DeepClone(source.values[i]);
+    target->values[i] = *DeepClone(source.values[i]).release();
   }
   return target;
 }

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "absl/types/optional.h"
 
 namespace firebase {
@@ -89,26 +90,27 @@ bool Contains(google_firestore_v1_ArrayValue haystack,
               google_firestore_v1_Value needle);
 
 /** Returns a null Protobuf value. */
-google_firestore_v1_Value NullValue();
+nanopb::Message<google_firestore_v1_Value> NullValue();
 
 /** Returns `true` if `value` is null in its Protobuf representation. */
 bool IsNullValue(const google_firestore_v1_Value& value);
 
 /** Returns `NaN` in its Protobuf representation. */
-google_firestore_v1_Value NaNValue();
+nanopb::Message<google_firestore_v1_Value> NaNValue();
 
 /** Returns `true` if `value` is `NaN` in its Protobuf representation. */
 bool IsNaNValue(const google_firestore_v1_Value& value);
 
 /** Returns a Protobuf reference value representing the given location. */
-google_firestore_v1_Value RefValue(const DatabaseId& database_id,
-                                   const DocumentKey& document_key);
+nanopb::Message<google_firestore_v1_Value> RefValue(
+    const DatabaseId& database_id, const DocumentKey& document_key);
 
 /** Creates a copy of the contents of the Value proto. */
-google_firestore_v1_Value DeepClone(const google_firestore_v1_Value& source);
+nanopb::Message<google_firestore_v1_Value> DeepClone(
+    const google_firestore_v1_Value& source);
 
 /** Creates a copy of the contents of the ArrayValue proto. */
-google_firestore_v1_ArrayValue DeepClone(
+nanopb::Message<google_firestore_v1_ArrayValue> DeepClone(
     const google_firestore_v1_ArrayValue& source);
 
 /** Returns true if `value` is a INTEGER_VALUE. */

--- a/Firestore/core/src/nanopb/fields_array.h
+++ b/Firestore/core/src/nanopb/fields_array.h
@@ -135,7 +135,12 @@ inline const pb_field_t* FieldsArray<google_firestore_v1_Value>() {
 
 template <>
 inline const pb_field_t* FieldsArray<google_firestore_v1_ArrayValue>() {
-  return google_firestore_v1_Value_fields;
+  return google_firestore_v1_ArrayValue_fields;
+}
+
+template <>
+inline const pb_field_t* FieldsArray<google_firestore_v1_MapValue>() {
+  return google_firestore_v1_MapValue_fields;
 }
 
 template <>

--- a/Firestore/core/src/nanopb/message.h
+++ b/Firestore/core/src/nanopb/message.h
@@ -173,6 +173,11 @@ class Message {
     return proto_.ToString();
   }
 
+  /** Returns false if and only if Message has been moved from. */
+  constexpr explicit operator bool() const noexcept {
+    return owns_proto_;
+  }
+
  private:
   // Important: this function does *not* modify `owns_proto_`.
   void Free() {
@@ -189,7 +194,7 @@ class Message {
 
 template <typename T>
 Message<T> MakeMessage(const T& proto) {
-  return Message<T>(std::move(proto));
+  return Message<T>(proto);
 }
 
 /**

--- a/Firestore/core/src/nanopb/message.h
+++ b/Firestore/core/src/nanopb/message.h
@@ -187,6 +187,11 @@ class Message {
   T proto_{};
 };
 
+template <typename T>
+Message<T> MakeMessage(const T& proto) {
+  return Message<T>(std::move(proto));
+}
+
 /**
  * A wrapper of Message objects that facilitates shared ownership of Protobuf
  * data.
@@ -195,12 +200,9 @@ class Message {
 template <typename T>
 class SharedMessage {
  public:
-  /**
-   * Creates a `SharedMessage` object that wraps `proto`. Takes ownership of
-   * `proto`.
-   */
-  explicit SharedMessage(const T& proto)
-      : message_{std::make_shared<Message<T>>(proto)} {
+  /** Creates a `SharedMessage` object that wraps `proto`. */
+  SharedMessage(Message<T> message)  // NOLINT
+      : message_{std::make_shared<Message<T>>(*message.release())} {
   }
 
   /**
@@ -245,7 +247,7 @@ class SharedMessage {
 
 template <typename T>
 SharedMessage<T> MakeSharedMessage(const T& proto) {
-  return SharedMessage<T>(proto);
+  return SharedMessage<T>(Message<T>(proto));
 }
 
 template <typename T>

--- a/Firestore/core/src/nanopb/message.h
+++ b/Firestore/core/src/nanopb/message.h
@@ -173,7 +173,10 @@ class Message {
     return proto_.ToString();
   }
 
-  /** Returns false if and only if Message has been moved from. */
+  /**
+   * Returns false if the Message is not associated with a valid proto (for
+   * example, if it has been moved from).
+   */
   constexpr explicit operator bool() const noexcept {
     return owns_proto_;
   }

--- a/Firestore/core/src/nanopb/nanopb_util.h
+++ b/Firestore/core/src/nanopb/nanopb_util.h
@@ -127,7 +127,7 @@ void SetRepeatedField(T* _Nonnull* _Nonnull fields_array,
   *fields_array = nanopb::MakeArray<T>(*fields_count);
   auto* current = *fields_array;
   while (first != last) {
-    *current = converter(std::move(*first));
+    *current = converter(*first);
     ++current;
     ++first;
   }

--- a/Firestore/core/src/nanopb/nanopb_util.h
+++ b/Firestore/core/src/nanopb/nanopb_util.h
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "Firestore/core/src/nanopb/byte_string.h"
@@ -126,7 +127,7 @@ void SetRepeatedField(T* _Nonnull* _Nonnull fields_array,
   *fields_array = nanopb::MakeArray<T>(*fields_count);
   auto* current = *fields_array;
   while (first != last) {
-    *current = converter(*first);
+    *current = converter(std::move(*first));
     ++current;
     ++first;
   }

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -102,8 +102,10 @@ using model::VerifyMutation;
 using nanopb::ByteString;
 using nanopb::CheckedSize;
 using nanopb::MakeArray;
+using nanopb::MakeMessage;
 using nanopb::MakeSharedMessage;
 using nanopb::MakeStringView;
+using nanopb::Message;
 using nanopb::ReleaseFieldOwnership;
 using nanopb::SafeReadBoolean;
 using nanopb::SetRepeatedField;
@@ -282,7 +284,7 @@ google_firestore_v1_Document Serializer::EncodeDocument(
         // TODO(mrschmidt): Figure out how to remove this copy
         return google_firestore_v1_Document_FieldsEntry{
             nanopb::MakeBytesArray(entry.key->bytes, entry.key->size),
-            DeepClone(entry.value)};
+            *DeepClone(entry.value).release()};
       });
 
   // Skip Document.create_time and Document.update_time, since they're
@@ -539,16 +541,20 @@ Serializer::EncodeFieldTransform(const FieldTransform& field_transform) const {
       proto.which_transform_type =
           google_firestore_v1_DocumentTransform_FieldTransform_append_missing_elements_tag;  // NOLINT
       // TODO(mrschmidt): Figure out how to remove this copy
-      proto.append_missing_elements = DeepClone(
-          ArrayTransform(field_transform.transformation()).elements());
+      proto.append_missing_elements =
+          *DeepClone(
+               ArrayTransform(field_transform.transformation()).elements())
+               .release();
       return proto;
 
     case Type::ArrayRemove:
       proto.which_transform_type =
           google_firestore_v1_DocumentTransform_FieldTransform_remove_all_from_array_tag;  // NOLINT
       // TODO(mrschmidt): Figure out how to remove this copy
-      proto.remove_all_from_array = DeepClone(
-          ArrayTransform(field_transform.transformation()).elements());
+      proto.remove_all_from_array =
+          *DeepClone(
+               ArrayTransform(field_transform.transformation()).elements())
+               .release();
       return proto;
 
     case Type::Increment: {
@@ -581,8 +587,9 @@ FieldTransform Serializer::DecodeFieldTransform(
 
     case google_firestore_v1_DocumentTransform_FieldTransform_append_missing_elements_tag: {  // NOLINT
       FieldTransform field_transform(
-          std::move(field), ArrayTransform(TransformOperation::Type::ArrayUnion,
-                                           proto.append_missing_elements));
+          std::move(field),
+          ArrayTransform(TransformOperation::Type::ArrayUnion,
+                         MakeMessage(proto.append_missing_elements)));
       // Release field ownership to prevent double-freeing. The values are now
       // owned by the FieldTransform.
       proto.append_missing_elements = {};
@@ -593,7 +600,7 @@ FieldTransform Serializer::DecodeFieldTransform(
       FieldTransform field_transform(
           std::move(field),
           ArrayTransform(TransformOperation::Type::ArrayRemove,
-                         proto.remove_all_from_array));
+                         MakeMessage(proto.remove_all_from_array)));
       // Release field ownership to prevent double-freeing. The values are now
       // owned by the FieldTransform.
       proto.append_missing_elements = {};
@@ -601,8 +608,9 @@ FieldTransform Serializer::DecodeFieldTransform(
     }
 
     case google_firestore_v1_DocumentTransform_FieldTransform_increment_tag: {
-      return FieldTransform(std::move(field),
-                            NumericIncrementTransform(proto.increment));
+      return FieldTransform(
+          std::move(field),
+          NumericIncrementTransform(MakeMessage(proto.increment)));
     }
   }
 
@@ -877,7 +885,7 @@ google_firestore_v1_StructuredQuery_Filter Serializer::EncodeSingularFilter(
   result.field_filter.field.field_path = EncodeFieldPath(filter.field());
   result.field_filter.op = EncodeFieldFilterOperator(filter.op());
   // TODO(mrschmidt): Figure out how to remove this copy
-  result.field_filter.value = DeepClone(filter.value());
+  result.field_filter.value = *DeepClone(filter.value()).release();
 
   return result;
 }
@@ -906,20 +914,17 @@ Filter Serializer::DecodeUnaryFilter(
 
   switch (unary.op) {
     case google_firestore_v1_StructuredQuery_UnaryFilter_Operator_IS_NULL:
-      return FieldFilter::Create(std::move(field), Filter::Operator::Equal,
-                                 MakeSharedMessage(NullValue()));
+      return FieldFilter::Create(field, Filter::Operator::Equal, NullValue());
 
     case google_firestore_v1_StructuredQuery_UnaryFilter_Operator_IS_NAN:
-      return FieldFilter::Create(std::move(field), Filter::Operator::Equal,
-                                 MakeSharedMessage(NaNValue()));
+      return FieldFilter::Create(field, Filter::Operator::Equal, NaNValue());
 
     case google_firestore_v1_StructuredQuery_UnaryFilter_Operator_IS_NOT_NULL:
-      return FieldFilter::Create(std::move(field), Filter::Operator::NotEqual,
-                                 MakeSharedMessage(NullValue()));
+      return FieldFilter::Create(field, Filter::Operator::NotEqual,
+                                 NullValue());
 
     case google_firestore_v1_StructuredQuery_UnaryFilter_Operator_IS_NOT_NAN:
-      return FieldFilter::Create(std::move(field), Filter::Operator::NotEqual,
-                                 MakeSharedMessage(NaNValue()));
+      return FieldFilter::Create(field, Filter::Operator::NotEqual, NaNValue());
 
     default:
       context->Fail(StringFormat("Unrecognized UnaryFilter.op %s", unary.op));
@@ -1113,7 +1118,9 @@ google_firestore_v1_Cursor Serializer::EncodeBound(const Bound& bound) const {
       &result.values, &result.values_count,
       absl::Span<google_firestore_v1_Value>(bound.position()->values,
                                             bound.position()->values_count),
-      [](const google_firestore_v1_Value& value) { return DeepClone(value); });
+      [](const google_firestore_v1_Value& value) {
+        return *DeepClone(value).release();
+      });
   return result;
 }
 
@@ -1187,8 +1194,8 @@ MutationResult Serializer::DecodeMutationResult(
           ? DecodeVersion(context, write_result.update_time)
           : commit_version;
 
-  google_firestore_v1_ArrayValue transform_results{};
-  SetRepeatedField(&transform_results.values, &transform_results.values_count,
+  Message<google_firestore_v1_ArrayValue> transform_results{};
+  SetRepeatedField(&transform_results->values, &transform_results->values_count,
                    absl::Span<google_firestore_v1_Value>(
                        write_result.transform_results,
                        write_result.transform_results_count));
@@ -1196,7 +1203,7 @@ MutationResult Serializer::DecodeMutationResult(
   // the muation result.
   ReleaseFieldOwnership(write_result.transform_results,
                         write_result.transform_results_count);
-  return MutationResult(version, transform_results);
+  return MutationResult(version, std::move(transform_results));
 }
 
 std::vector<google_firestore_v1_ListenRequest_LabelsEntry>

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -798,7 +798,7 @@ TEST_F(BundleSerializerTest, DecodesArrayContainsFilter) {
 
 TEST_F(BundleSerializerTest, DecodesInFilter) {
   core::Query original = testutil::CollectionGroupQuery("colls").AddingFilter(
-      Filter("f1", "in", Array("f", "h")));
+      Filter("f1", "in", Value(Array("f", "h"))));
   VerifyNamedQueryRoundtrip(original);
 }
 
@@ -1009,32 +1009,31 @@ TEST_F(BundleSerializerTest, DecodeInvalidLimitQueriesFails) {
 }
 
 TEST_F(BundleSerializerTest, DecodesStartAtCursor) {
-  core::Query original = testutil::Query("colls")
-                             .AddingOrderBy(OrderBy("f1", "asc"))
-                             .StartingAt(core::Bound::FromValue(
-                                 MakeSharedMessage(Array("f1", 1000)),
-                                 /* is_before= */ true));
+  core::Query original =
+      testutil::Query("colls")
+          .AddingOrderBy(OrderBy("f1", "asc"))
+          .StartingAt(core::Bound::FromValue(Array("f1", 1000),
+                                             /* is_before= */ true));
 
   VerifyNamedQueryRoundtrip(original);
 }
 
 TEST_F(BundleSerializerTest, DecodesEndAtCursor) {
-  core::Query original = testutil::Query("colls")
-                             .AddingOrderBy(OrderBy("f1", "desc"))
-                             .EndingAt(core::Bound::FromValue(
-                                 MakeSharedMessage(Array("f1", "1000")),
-                                 /* is_before= */ false));
+  core::Query original =
+      testutil::Query("colls")
+          .AddingOrderBy(OrderBy("f1", "desc"))
+          .EndingAt(core::Bound::FromValue(Array("f1", "1000"),
+                                           /* is_before= */ false));
 
   VerifyNamedQueryRoundtrip(original);
 }
 
 TEST_F(BundleSerializerTest, DecodeInvalidCursorQueriesFails) {
-  std::string json_string =
-      NamedQueryJsonString(testutil::Query("colls")
-                               .AddingOrderBy(OrderBy("f1", "desc"))
-                               .EndingAt(core::Bound::FromValue(
-                                   MakeSharedMessage(Array("f1", "1000")),
-                                   /* is_before= */ false)));
+  std::string json_string = NamedQueryJsonString(
+      testutil::Query("colls")
+          .AddingOrderBy(OrderBy("f1", "desc"))
+          .EndingAt(core::Bound::FromValue(Array("f1", "1000"),
+                                           /* is_before= */ false)));
   auto json_copy = ReplacedCopy(json_string, "\"1000\"", "[]");
   auto reader = JsonReader();
   bundle_serializer.DecodeNamedQuery(reader, Parse(json_copy));

--- a/Firestore/core/test/unit/core/query_test.cc
+++ b/Firestore/core/test/unit/core/query_test.cc
@@ -784,14 +784,13 @@ TEST(QueryTest, CanonicalIDs) {
   auto limit = testutil::Query("coll").WithLimitToFirst(25);
   EXPECT_THAT(limit, HasCanonicalId("coll|f:|ob:__name__asc|l:25|lt:f"));
 
-  auto bounds =
-      testutil::Query("airports")
-          .AddingOrderBy(OrderBy("name", "asc"))
-          .AddingOrderBy(OrderBy("score", "desc"))
-          .StartingAt(Bound::FromValue(MakeSharedMessage(Array("OAK", 1000)),
-                                       /* is_before= */ true))
-          .EndingAt(Bound::FromValue(MakeSharedMessage(Array("SFO", 2000)),
-                                     /* is_before= */ false));
+  auto bounds = testutil::Query("airports")
+                    .AddingOrderBy(OrderBy("name", "asc"))
+                    .AddingOrderBy(OrderBy("score", "desc"))
+                    .StartingAt(Bound::FromValue(Array("OAK", 1000),
+                                                 /* is_before= */ true))
+                    .EndingAt(Bound::FromValue(Array("SFO", 2000),
+                                               /* is_before= */ false));
   EXPECT_THAT(bounds, HasCanonicalId("airports|f:|ob:nameascscoredesc__name__"
                                      "desc|lb:b:OAK1000|ub:a:SFO2000"));
 }
@@ -812,12 +811,10 @@ TEST(QueryTest, MatchesAllDocuments) {
   query = base_query.WithLimitToFirst(1);
   EXPECT_FALSE(query.MatchesAllDocuments());
 
-  query = base_query.StartingAt(
-      Bound::FromValue(MakeSharedMessage(Array("SFO")), true));
+  query = base_query.StartingAt(Bound::FromValue(Array("SFO"), true));
   EXPECT_FALSE(query.MatchesAllDocuments());
 
-  query = base_query.StartingAt(
-      Bound::FromValue(MakeSharedMessage(Array("OAK")), true));
+  query = base_query.StartingAt(Bound::FromValue(Array("OAK"), true));
   EXPECT_FALSE(query.MatchesAllDocuments());
 }
 

--- a/Firestore/core/test/unit/local/local_serializer_test.cc
+++ b/Firestore/core/test/unit/local/local_serializer_test.cc
@@ -79,6 +79,7 @@ using nanopb::ByteStringWriter;
 using nanopb::FreeNanopbMessage;
 using nanopb::MakeArray;
 using nanopb::MakeBytesArray;
+using nanopb::MakeMessage;
 using nanopb::MakeStdString;
 using nanopb::Message;
 using nanopb::ProtobufParse;
@@ -439,35 +440,29 @@ TEST_F(LocalSerializerTest, MultipleMutationsAreSquashed) {
   MutationBatch decoded = serializer.DecodeMutationBatch(&reader, *message);
   ASSERT_EQ(5, decoded.mutations().size());
 
-  {
-    Message<google_firestore_v1_Write> encoded{
-        remote_serializer.EncodeMutation(decoded.mutations()[0])};
-    ExpectSet(*encoded);
-    ExpectNoUpdateTransform(*encoded);
-  }
-  {
-    Message<google_firestore_v1_Write> encoded{
-        remote_serializer.EncodeMutation(decoded.mutations()[1])};
-    ExpectSet(*encoded);
-    ExpectUpdateTransform(*encoded);
-  }
-  {
-    Message<google_firestore_v1_Write> encoded{
-        remote_serializer.EncodeMutation(decoded.mutations()[2])};
-    ExpectDelete(*encoded);
-  }
-  {
-    Message<google_firestore_v1_Write> encoded{
-        remote_serializer.EncodeMutation(decoded.mutations()[3])};
-    ExpectPatch(*encoded);
-    ExpectUpdateTransform(*encoded);
-  }
-  {
-    Message<google_firestore_v1_Write> encoded{
-        remote_serializer.EncodeMutation(decoded.mutations()[4])};
-    ExpectPatch(*encoded);
-    ExpectNoUpdateTransform(*encoded);
-  }
+  Message<google_firestore_v1_Write> encoded{
+      remote_serializer.EncodeMutation(decoded.mutations()[0])};
+  ExpectSet(*encoded);
+  ExpectNoUpdateTransform(*encoded);
+
+  encoded =
+      MakeMessage(remote_serializer.EncodeMutation(decoded.mutations()[1]));
+  ExpectSet(*encoded);
+  ExpectUpdateTransform(*encoded);
+
+  encoded =
+      MakeMessage(remote_serializer.EncodeMutation(decoded.mutations()[2]));
+  ExpectDelete(*encoded);
+
+  encoded =
+      MakeMessage(remote_serializer.EncodeMutation(decoded.mutations()[3]));
+  ExpectPatch(*encoded);
+  ExpectUpdateTransform(*encoded);
+
+  encoded =
+      MakeMessage(remote_serializer.EncodeMutation(decoded.mutations()[4]));
+  ExpectPatch(*encoded);
+  ExpectNoUpdateTransform(*encoded);
 }
 
 TEST_F(LocalSerializerTest, EncodesMutationBatch) {

--- a/Firestore/core/test/unit/local/local_serializer_test.cc
+++ b/Firestore/core/test/unit/local/local_serializer_test.cc
@@ -365,10 +365,10 @@ TEST_F(LocalSerializerTest, SetMutationAndTransformMutationAreSquashed) {
   ASSERT_EQ(1, decoded.mutations().size());
   ASSERT_EQ(Mutation::Type::Set, decoded.mutations()[0].type());
 
-  google_firestore_v1_Write encoded =
-      remote_serializer.EncodeMutation(decoded.mutations()[0]);
-  ExpectSet(encoded);
-  ExpectUpdateTransform(encoded);
+  Message<google_firestore_v1_Write> encoded{
+      remote_serializer.EncodeMutation(decoded.mutations()[0])};
+  ExpectSet(*encoded);
+  ExpectUpdateTransform(*encoded);
 }
 
 // TODO(b/174608374): Remove these tests once we perform a schema migration.
@@ -386,10 +386,10 @@ TEST_F(LocalSerializerTest, PatchMutationAndTransformMutationAreSquashed) {
   ASSERT_EQ(1, decoded.mutations().size());
   ASSERT_EQ(Mutation::Type::Patch, decoded.mutations()[0].type());
 
-  google_firestore_v1_Write encoded =
-      remote_serializer.EncodeMutation(decoded.mutations()[0]);
-  ExpectPatch(encoded);
-  ExpectUpdateTransform(encoded);
+  Message<google_firestore_v1_Write> encoded{
+      remote_serializer.EncodeMutation(decoded.mutations()[0])};
+  ExpectPatch(*encoded);
+  ExpectUpdateTransform(*encoded);
 }
 
 // TODO(b/174608374): Remove these tests once we perform a schema migration.
@@ -438,21 +438,36 @@ TEST_F(LocalSerializerTest, MultipleMutationsAreSquashed) {
   auto message = Message<firestore_client_WriteBatch>::TryParse(&reader);
   MutationBatch decoded = serializer.DecodeMutationBatch(&reader, *message);
   ASSERT_EQ(5, decoded.mutations().size());
-  _google_firestore_v1_Write encoded =
-      remote_serializer.EncodeMutation(decoded.mutations()[0]);
-  ExpectSet(encoded);
-  ExpectNoUpdateTransform(encoded);
-  encoded = remote_serializer.EncodeMutation(decoded.mutations()[1]);
-  ExpectSet(encoded);
-  ExpectUpdateTransform(encoded);
-  encoded = remote_serializer.EncodeMutation(decoded.mutations()[2]);
-  ExpectDelete(encoded);
-  encoded = remote_serializer.EncodeMutation(decoded.mutations()[3]);
-  ExpectPatch(encoded);
-  ExpectUpdateTransform(encoded);
-  encoded = remote_serializer.EncodeMutation(decoded.mutations()[4]);
-  ExpectPatch(encoded);
-  ExpectNoUpdateTransform(encoded);
+
+  {
+    Message<google_firestore_v1_Write> encoded{
+        remote_serializer.EncodeMutation(decoded.mutations()[0])};
+    ExpectSet(*encoded);
+    ExpectNoUpdateTransform(*encoded);
+  }
+  {
+    Message<google_firestore_v1_Write> encoded{
+        remote_serializer.EncodeMutation(decoded.mutations()[1])};
+    ExpectSet(*encoded);
+    ExpectUpdateTransform(*encoded);
+  }
+  {
+    Message<google_firestore_v1_Write> encoded{
+        remote_serializer.EncodeMutation(decoded.mutations()[2])};
+    ExpectDelete(*encoded);
+  }
+  {
+    Message<google_firestore_v1_Write> encoded{
+        remote_serializer.EncodeMutation(decoded.mutations()[3])};
+    ExpectPatch(*encoded);
+    ExpectUpdateTransform(*encoded);
+  }
+  {
+    Message<google_firestore_v1_Write> encoded{
+        remote_serializer.EncodeMutation(decoded.mutations()[4])};
+    ExpectPatch(*encoded);
+    ExpectNoUpdateTransform(*encoded);
+  }
 }
 
 TEST_F(LocalSerializerTest, EncodesMutationBatch) {

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -1373,7 +1373,7 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
                               {testutil::Increment("sum", Value(1))}),
       testutil::PatchMutation(
           "foo/bar", Map(),
-          {testutil::ArrayUnion("array_union", std::move(array_union))}),
+          {testutil::ArrayUnion("array_union", array_union)}),
   });
 
   FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1, "array_union", Array("foo")))

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -68,6 +68,7 @@ using model::ResourcePath;
 using model::SnapshotVersion;
 using model::TargetId;
 using nanopb::ByteString;
+using nanopb::Message;
 using remote::DocumentWatchChange;
 using remote::FakeTargetMetadataProvider;
 using remote::RemoteEvent;
@@ -239,7 +240,7 @@ void LocalStoreTest::UpdateViews(int target_id, bool from_cache) {
 
 void LocalStoreTest::AcknowledgeMutationWithVersion(
     int64_t document_version,
-    absl::optional<google_firestore_v1_Value> transform_result) {
+    absl::optional<Message<google_firestore_v1_Value>> transform_result) {
   ASSERT_GT(batches_.size(), 0) << "Missing batch to acknowledge.";
   MutationBatch batch = batches_.front();
   batches_.erase(batches_.begin());
@@ -248,12 +249,12 @@ void LocalStoreTest::AcknowledgeMutationWithVersion(
       << "Acknowledging more than one mutation not supported.";
   SnapshotVersion version = testutil::Version(document_version);
 
-  google_firestore_v1_ArrayValue mutation_transform_result{};
+  Message<google_firestore_v1_ArrayValue> mutation_transform_result{};
   if (transform_result) {
-    mutation_transform_result = Array(*transform_result);
+    mutation_transform_result = Array(std::move(*transform_result));
   }
 
-  MutationResult mutation_result(version, mutation_transform_result);
+  MutationResult mutation_result(version, std::move(mutation_transform_result));
   std::vector<MutationResult> mutation_results;
   mutation_results.emplace_back(std::move(mutation_result));
   MutationBatchResult result(batch, version, std::move(mutation_results), {});
@@ -1365,12 +1366,14 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
       Doc("foo/bar", 1, Map("sum", 0, "array_union", Array())), {2}));
   FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 0, "array_union", Array())));
 
+  std::vector<Message<google_firestore_v1_Value>> array_union;
+  array_union.push_back(Value("foo"));
   WriteMutations({
       testutil::PatchMutation("foo/bar", Map(),
                               {testutil::Increment("sum", Value(1))}),
       testutil::PatchMutation(
           "foo/bar", Map(),
-          {testutil::ArrayUnion("array_union", {Value("foo")})}),
+          {testutil::ArrayUnion("array_union", std::move(array_union))}),
   });
 
   FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1, "array_union", Array("foo")))

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -1372,8 +1372,7 @@ TEST_P(LocalStoreTest, HoldsBackOnlyNonIdempotentTransforms) {
       testutil::PatchMutation("foo/bar", Map(),
                               {testutil::Increment("sum", Value(1))}),
       testutil::PatchMutation(
-          "foo/bar", Map(),
-          {testutil::ArrayUnion("array_union", array_union)}),
+          "foo/bar", Map(), {testutil::ArrayUnion("array_union", array_union)}),
   });
 
   FSTAssertChanged(Doc("foo/bar", 1, Map("sum", 1, "array_union", Array("foo")))

--- a/Firestore/core/test/unit/local/local_store_test.h
+++ b/Firestore/core/test/unit/local/local_store_test.h
@@ -86,9 +86,10 @@ class LocalStoreTest : public ::testing::TestWithParam<FactoryFunc> {
 
   void ApplyRemoteEvent(const remote::RemoteEvent& event);
   void NotifyLocalViewChanges(LocalViewChanges changes);
-  void AcknowledgeMutationWithVersion(int64_t document_version,
-                                      absl::optional<google_firestore_v1_Value>
-                                          transform_result = absl::nullopt);
+  void AcknowledgeMutationWithVersion(
+      int64_t document_version,
+      absl::optional<nanopb::Message<google_firestore_v1_Value>>
+          transform_result = absl::nullopt);
   void RejectMutation();
   model::TargetId AllocateQuery(core::Query query);
   local::TargetData GetTargetData(const core::Query& query);

--- a/Firestore/core/test/unit/local/remote_document_cache_test.h
+++ b/Firestore/core/test/unit/local/remote_document_cache_test.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 
@@ -55,15 +56,16 @@ class RemoteDocumentCacheTest : public ::testing::TestWithParam<FactoryFunc> {
 
  protected:
   model::MutableDocument SetTestDocument(absl::string_view path);
-  model::MutableDocument SetTestDocument(absl::string_view path,
-                                         google_firestore_v1_Value data);
+  model::MutableDocument SetTestDocument(
+      absl::string_view path, nanopb::Message<google_firestore_v1_Value> data);
   model::MutableDocument SetTestDocument(absl::string_view path,
                                          int update_time,
                                          int read_time);
-  model::MutableDocument SetTestDocument(absl::string_view path,
-                                         google_firestore_v1_Value data,
-                                         int update_time,
-                                         int read_time);
+  model::MutableDocument SetTestDocument(
+      absl::string_view path,
+      nanopb::Message<google_firestore_v1_Value> data,
+      int update_time,
+      int read_time);
   void SetAndReadTestDocument(absl::string_view path);
 
   std::unique_ptr<Persistence> persistence_;

--- a/Firestore/core/test/unit/model/document_test.cc
+++ b/Firestore/core/test/unit/model/document_test.cc
@@ -66,8 +66,8 @@ TEST(DocumentTest, ExtractsFields) {
               Map("name", "Jonny", "title", "scallywag")));
 
   EXPECT_EQ(doc.field(Field("desc")),
-            Value("Discuss all the project related stuff"));
-  EXPECT_EQ(doc.field(Field("owner.title")), Value("scallywag"));
+            *Value("Discuss all the project related stuff"));
+  EXPECT_EQ(doc.field(Field("owner.title")), *Value("scallywag"));
 }
 
 TEST(DocumentTest, Equality) {

--- a/Firestore/core/test/unit/nanopb/nanopb_util_test.cc
+++ b/Firestore/core/test/unit/nanopb/nanopb_util_test.cc
@@ -15,6 +15,7 @@
 
 #include "Firestore/core/src/nanopb/nanopb_util.h"
 #include "Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h"
+#include "Firestore/core/src/nanopb/message.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
 
 #include "gmock/gmock.h"
@@ -30,7 +31,8 @@ using testutil::Value;
 
 TEST(NanopbUtilTest, SetsRepeatedField) {
   Message<google_firestore_v1_ArrayValue> m;
-  std::vector<google_firestore_v1_Value> values{Value(1), Value(2), Value(3)};
+  std::vector<google_firestore_v1_Value> values{
+      *Value(1).release(), *Value(2).release(), *Value(3).release()};
   SetRepeatedField(&m->values, &m->values_count, values);
   EXPECT_EQ(values, std::vector<google_firestore_v1_Value>(
                         m->values, m->values + m->values_count));
@@ -40,10 +42,11 @@ TEST(NanopbUtilTest, SetsRepeatedFieldWithConverter) {
   Message<google_firestore_v1_ArrayValue> m;
   std::vector<int> values{1, 2, 3};
   SetRepeatedField(&m->values, &m->values_count, values,
-                   [](const int& v) { return Value(v); });
+                   [](const int& v) { return *Value(v).release(); });
   EXPECT_THAT(std::vector<google_firestore_v1_Value>(
                   m->values, m->values + m->values_count),
-              ElementsAre(Value(1), Value(2), Value(3)));
+              ElementsAre(*Value(1).release(), *Value(2).release(),
+                          *Value(3).release()));
 }
 
 }  //  namespace

--- a/Firestore/core/test/unit/remote/datastore_test.cc
+++ b/Firestore/core/test/unit/remote/datastore_test.cc
@@ -84,8 +84,9 @@ grpc::ByteBuffer MakeFakeDocument(const std::string& doc_name) {
       MakeArray<google_firestore_v1_Document_FieldsEntry>(doc.fields_count);
   google_firestore_v1_Document_FieldsEntry& entry = doc.fields[0];
 
+  Message<google_firestore_v1_Value> value = Value("bar");
   entry.key = serializer.EncodeString("foo");
-  entry.value = Value("bar");
+  entry.value = *value.release();
 
   return MakeByteBuffer(response);
 }

--- a/Firestore/core/test/unit/remote/serializer_test.cc
+++ b/Firestore/core/test/unit/remote/serializer_test.cc
@@ -410,6 +410,7 @@ class SerializerTest : public ::testing::Test {
     ExpectRoundTrip(model, proto);
   }
 
+ private:
   void ExpectSerializationRoundTrip(
       const Message<google_firestore_v1_Value>& model,
       const v1::Value& proto,

--- a/Firestore/core/test/unit/remote/serializer_test.cc
+++ b/Firestore/core/test/unit/remote/serializer_test.cc
@@ -173,16 +173,16 @@ class SerializerTest : public ::testing::Test {
   Serializer serializer;
 
   template <typename... Args>
-  void ExpectRoundTrip(const Args&... args) {
+  void ExpectRoundTrip(Args&&... args) {
     // First, serialize model with our (nanopb based) serializer, then
     // deserialize the resulting bytes with libprotobuf and ensure the result is
     // the same as the expected proto.
-    ExpectSerializationRoundTrip(args...);
+    ExpectSerializationRoundTrip(std::forward<Args>(args)...);
 
     // Next, serialize proto with libprotobuf, then deserialize the resulting
     // bytes with our (nanopb based) deserializer and ensure the result is the
     // same as the expected model.
-    ExpectDeserializationRoundTrip(args...);
+    ExpectDeserializationRoundTrip(std::forward<Args>(args)...);
   }
 
   void ExpectNoDocumentDeserializationRoundTrip(
@@ -245,9 +245,9 @@ class SerializerTest : public ::testing::Test {
     EXPECT_EQ(status.code(), reader.status().code());
   }
 
-  ByteString EncodeFieldValue(const google_firestore_v1_Value& fv) {
+  ByteString EncodeFieldValue(const Message<google_firestore_v1_Value>& fv) {
     ByteStringWriter writer;
-    writer.Write(google_firestore_v1_Value_fields, &fv);
+    writer.Write(google_firestore_v1_Value_fields, fv.get());
     return writer.Release();
   }
 
@@ -330,13 +330,17 @@ class SerializerTest : public ::testing::Test {
     return ProtobufParse<v1::Value>(bytes);
   }
 
-  v1::Value ValueProto(const google_firestore_v1_Value& value) {
+  v1::Value ValueProto(const Message<google_firestore_v1_Value>& value) {
     ByteString bytes = EncodeFieldValue(value);
     return ProtobufParse<v1::Value>(bytes);
   }
 
-  v1::Value ValueProto(const google_firestore_v1_ArrayValue& value) {
-    ByteString bytes = EncodeFieldValue(Value(value));
+  v1::Value ValueProto(const Message<google_firestore_v1_ArrayValue>& value) {
+    Message<google_firestore_v1_Value> message;
+    message->which_value_type = google_firestore_v1_Value_array_value_tag;
+    message->array_value = *value;
+    ByteString bytes = EncodeFieldValue(message);
+    message.release();
     return ProtobufParse<v1::Value>(bytes);
   }
 
@@ -365,9 +369,10 @@ class SerializerTest : public ::testing::Test {
   }
 
   void ExpectUnaryOperator(std::string op_str,
-                           const google_firestore_v1_Value& value,
+                           Message<google_firestore_v1_Value> value,
                            v1::StructuredQuery::UnaryFilter::Operator op) {
-    core::Query q = Query("docs").AddingFilter(Filter("prop", op_str, value));
+    core::Query q =
+        Query("docs").AddingFilter(Filter("prop", op_str, std::move(value)));
     TargetData model = CreateTargetData(std::move(q));
 
     v1::Target proto;
@@ -405,21 +410,21 @@ class SerializerTest : public ::testing::Test {
     ExpectRoundTrip(model, proto);
   }
 
- private:
-  void ExpectSerializationRoundTrip(const google_firestore_v1_Value& model,
-                                    const v1::Value& proto,
-                                    TypeOrder type) {
-    EXPECT_EQ(type, GetTypeOrder(model));
-    ByteString bytes = EncodeFieldValue(model);
+  void ExpectSerializationRoundTrip(
+      const Message<google_firestore_v1_Value>& model,
+      const v1::Value& proto,
+      TypeOrder type) {
+    EXPECT_EQ(type, GetTypeOrder(*model));
+    ByteString bytes = EncodeFieldValue(std::move(model));
     auto actual_proto = ProtobufParse<v1::Value>(bytes);
 
     EXPECT_TRUE(msg_diff.Compare(proto, actual_proto)) << message_differences;
   }
 
-  void ExpectDeserializationRoundTrip(const google_firestore_v1_Value& model,
-                                      const v1::Value& proto,
-                                      TypeOrder type) {
-    google_firestore_v1_Value expected = model;
+  void ExpectDeserializationRoundTrip(
+      const Message<google_firestore_v1_Value>& model,
+      const v1::Value& proto,
+      TypeOrder type) {
     ByteString bytes = ProtobufSerialize(proto);
     StringReader reader(bytes);
 
@@ -428,9 +433,10 @@ class SerializerTest : public ::testing::Test {
     EXPECT_EQ(type, GetTypeOrder(*message));
     // libprotobuf does not retain map ordering. We need to restore the
     // ordering.
-    SortFields(expected);
+    Message<google_firestore_v1_Value> expected = model::DeepClone(*model);
+    SortFields(*expected);
     SortFields(*message);
-    EXPECT_EQ(expected, *message);
+    EXPECT_EQ(*expected, *message);
   }
 
   void ExpectSerializationRoundTrip(
@@ -580,13 +586,13 @@ class SerializerTest : public ::testing::Test {
 };
 
 TEST_F(SerializerTest, EncodesNull) {
-  google_firestore_v1_Value model = Value(nullptr);
+  Message<google_firestore_v1_Value> model = Value(nullptr);
   ExpectRoundTrip(model, ValueProto(nullptr), TypeOrder::kNull);
 }
 
 TEST_F(SerializerTest, EncodesBool) {
   for (bool bool_value : {true, false}) {
-    google_firestore_v1_Value model = Value(bool_value);
+    Message<google_firestore_v1_Value> model = Value(bool_value);
     ExpectRoundTrip(model, ValueProto(bool_value), TypeOrder::kBoolean);
   }
 }
@@ -601,7 +607,7 @@ TEST_F(SerializerTest, EncodesIntegers) {
                              std::numeric_limits<int64_t>::max()};
 
   for (int64_t int_value : cases) {
-    google_firestore_v1_Value model = Value(int_value);
+    Message<google_firestore_v1_Value> model = Value(int_value);
     ExpectRoundTrip(model, ValueProto(int_value), TypeOrder::kNumber);
   }
 }
@@ -640,7 +646,7 @@ TEST_F(SerializerTest, EncodesDoubles) {
   };
 
   for (double double_value : cases) {
-    google_firestore_v1_Value model = Value(double_value);
+    Message<google_firestore_v1_Value> model = Value(double_value);
     ExpectRoundTrip(model, ValueProto(double_value), TypeOrder::kNumber);
   }
 }
@@ -663,7 +669,7 @@ TEST_F(SerializerTest, EncodesString) {
   };
 
   for (const std::string& string_value : cases) {
-    google_firestore_v1_Value model = Value(string_value);
+    Message<google_firestore_v1_Value> model = Value(string_value);
     ExpectRoundTrip(model, ValueProto(string_value), TypeOrder::kString);
   }
 }
@@ -680,7 +686,7 @@ TEST_F(SerializerTest, EncodesTimestamps) {
   };
 
   for (const Timestamp& ts_value : cases) {
-    google_firestore_v1_Value model = Value(ts_value);
+    Message<google_firestore_v1_Value> model = Value(ts_value);
     ExpectRoundTrip(model, ValueProto(ts_value), TypeOrder::kTimestamp);
   }
 }
@@ -693,7 +699,7 @@ TEST_F(SerializerTest, EncodesBlobs) {
   };
 
   for (const ByteString& blob_value : cases) {
-    google_firestore_v1_Value model = Value(blob_value);
+    Message<google_firestore_v1_Value> model = Value(blob_value);
     ExpectRoundTrip(model, ValueProto(blob_value), TypeOrder::kBlob);
   }
 }
@@ -701,20 +707,18 @@ TEST_F(SerializerTest, EncodesBlobs) {
 TEST_F(SerializerTest, EncodesNullBlobs) {
   ByteString blob;
   ASSERT_EQ(blob.get(), nullptr);  // Empty blobs are backed by a null buffer.
-  google_firestore_v1_Value model = Value(blob);
+  Message<google_firestore_v1_Value> model = Value(blob);
 
   // Avoid calling SerializerTest::EncodeFieldValue here because the Serializer
   // could be allocating an empty byte array. These assertions show that the
   // null blob really does materialize in the proto as null.
-  google_firestore_v1_Value proto = model;
-  ASSERT_EQ(proto.which_value_type, google_firestore_v1_Value_bytes_value_tag);
-  ASSERT_EQ(proto.bytes_value, nullptr);
+  ASSERT_EQ(model->which_value_type, google_firestore_v1_Value_bytes_value_tag);
+  ASSERT_EQ(model->bytes_value, nullptr);
 
   // Encoding a Value message containing a blob_value of null bytes results
   // in a non-empty message.
   ByteStringWriter writer;
-  writer.Write(google_firestore_v1_Value_fields, &proto);
-  FreeNanopbMessage(google_firestore_v1_Value_fields, &proto);
+  writer.Write(google_firestore_v1_Value_fields, model.get());
   ByteString bytes = writer.Release();
   ASSERT_GT(bytes.size(), 0);
 
@@ -726,15 +730,10 @@ TEST_F(SerializerTest, EncodesNullBlobs) {
 }
 
 TEST_F(SerializerTest, EncodesReferences) {
-  std::vector<google_firestore_v1_Value> cases{
+  Message<google_firestore_v1_Value> ref_value =
       RefValue(DatabaseId{kProjectId, kDatabaseId},
-               DocumentKey::FromPathString("baz/a")),
-  };
-
-  for (const auto& ref_value : cases) {
-    google_firestore_v1_Value model = ref_value;
-    ExpectRoundTrip(model, ValueProto(ref_value), TypeOrder::kReference);
-  }
+               DocumentKey::FromPathString("baz/a"));
+  ExpectRoundTrip(ref_value, ValueProto(ref_value), TypeOrder::kReference);
 }
 
 TEST_F(SerializerTest, EncodesGeoPoint) {
@@ -743,33 +742,34 @@ TEST_F(SerializerTest, EncodesGeoPoint) {
   };
 
   for (const GeoPoint& geo_value : cases) {
-    google_firestore_v1_Value model = Value(geo_value);
+    Message<google_firestore_v1_Value> model = Value(geo_value);
     ExpectRoundTrip(model, ValueProto(geo_value), TypeOrder::kGeoPoint);
   }
 }
 
 TEST_F(SerializerTest, EncodesArray) {
-  std::vector<google_firestore_v1_ArrayValue> cases{
-      // Empty Array.
-      Array(),
-      // Typical Array.
-      Array(true, "foo"),
-      // Nested Array. NB: the protos explicitly state that directly nested
-      // arrays are not allowed, however arrays *can* contain a map which
-      // contains another array.
-      Array("foo",
-            Map("nested array",
-                Array("nested array value 1", "nested array value 2")),
-            "bar")};
+  std::vector<Message<google_firestore_v1_ArrayValue>> cases;
 
-  for (const google_firestore_v1_ArrayValue& array_value : cases) {
-    google_firestore_v1_Value model = Value(array_value);
+  // Empty Array.
+  cases.push_back(Array());
+  // Typical Array.
+  cases.push_back(Array(true, "foo"));
+  // Nested Array. NB: the protos explicitly state that directly nested
+  // arrays are not allowed, however arrays *can* contain a map which
+  // contains another array.
+  cases.push_back(Array("foo",
+                        Map("nested array", Array("nested array value 1",
+                                                  "nested array value 2")),
+                        "bar"));
+
+  for (Message<google_firestore_v1_ArrayValue>& array_value : cases) {
+    Message<google_firestore_v1_Value> model = Value(std::move(array_value));
     ExpectRoundTrip(model, ValueProto(model), TypeOrder::kArray);
   }
 }
 
 TEST_F(SerializerTest, EncodesEmptyMap) {
-  google_firestore_v1_Value model = Map();
+  Message<google_firestore_v1_Value> model = Map();
 
   v1::Value proto;
   proto.mutable_map_value();
@@ -778,7 +778,7 @@ TEST_F(SerializerTest, EncodesEmptyMap) {
 }
 
 TEST_F(SerializerTest, EncodesNestedObjects) {
-  google_firestore_v1_Value model = Map(
+  Message<google_firestore_v1_Value> model = Map(
       "b", true, "d", std::numeric_limits<double>::max(), "i", 1, "n", nullptr,
       "s", "foo", "a", Array(2, "bar", Map("b", false)), "o",
       Map("d", 100, "nested", Map("e", std::numeric_limits<int64_t>::max())));
@@ -868,9 +868,9 @@ TEST_F(SerializerTest, EncodesFieldValuesWithRepeatedEntries) {
   EXPECT_OK(reader.status());
 
   // Ensure the decoded model is as expected.
-  google_firestore_v1_Value expected_model = Value(42);
+  Message<google_firestore_v1_Value> expected_model = Value(42);
   EXPECT_EQ(TypeOrder::kNumber, GetTypeOrder(*actual_model));
-  EXPECT_EQ(expected_model, *actual_model);
+  EXPECT_EQ(*expected_model, *actual_model);
 }
 
 TEST_F(SerializerTest, BadBoolValueInterpretedAsTrue) {
@@ -974,9 +974,9 @@ TEST_F(SerializerTest, BadFieldValueTagWithOtherValidTagsPresent) {
   EXPECT_OK(reader.status());
 
   // Ensure the decoded model is as expected.
-  google_firestore_v1_Value expected_model = Value(true);
+  Message<google_firestore_v1_Value> expected_model = Value(true);
   EXPECT_EQ(TypeOrder::kBoolean, GetTypeOrder(*actual_model));
-  EXPECT_EQ(expected_model, *actual_model);
+  EXPECT_EQ(*expected_model, *actual_model);
 }
 
 TEST_F(SerializerTest, IncompleteFieldValue) {
@@ -1317,13 +1317,11 @@ TEST_F(SerializerTest, EncodesSortOrders) {
 }
 
 TEST_F(SerializerTest, EncodesBounds) {
-  core::Query q =
-      Query("docs")
-          .StartingAt(Bound::FromValue(MakeSharedMessage(Array("prop", 42)),
-                                       /*is_before=*/false))
-          .EndingAt(
-              Bound::FromValue(MakeSharedMessage(Array("author", "dimond")),
-                               /*is_before=*/true));
+  core::Query q = Query("docs")
+                      .StartingAt(Bound::FromValue(Array("prop", 42),
+                                                   /*is_before=*/false))
+                      .EndingAt(Bound::FromValue(Array("author", "dimond"),
+                                                 /*is_before=*/true));
   TargetData model = CreateTargetData(std::move(q));
 
   v1::Target proto;
@@ -1470,9 +1468,10 @@ TEST_F(SerializerTest, EncodesListenRequestLabels) {
 }
 
 TEST_F(SerializerTest, DecodesMutationResult) {
-  google_firestore_v1_ArrayValue transformations = Array(true, 1234, "string");
+  Message<google_firestore_v1_ArrayValue> transformations =
+      Array(true, 1234, "string");
   auto version = Version(123456789);
-  MutationResult model(version, transformations);
+  MutationResult model(version, std::move(transformations));
 
   v1::WriteResult proto;
 
@@ -1683,8 +1682,7 @@ TEST_F(SerializerTest, EncodesPatchMutation) {
   auto& fields = *doc.mutable_fields();
   fields["a"] = ValueProto("b");
   fields["num"] = ValueProto(1);
-  auto nested = Map("thing'", Value(2));
-  fields["some"] = ValueProto(Map("de\\ep", nested));
+  fields["some"] = ValueProto(Map("de\\ep", Map("thing'", Value(2))));
 
   v1::DocumentMask& mask = *proto.mutable_update_mask();
   mask.add_field_paths("a");

--- a/Firestore/core/test/unit/testutil/testutil.cc
+++ b/Firestore/core/test/unit/testutil/testutil.cc
@@ -453,12 +453,12 @@ std::pair<std::string, TransformOperation> Increment(
 
 std::pair<std::string, TransformOperation> ArrayUnion(
     std::string field,
-    std::vector<Message<google_firestore_v1_Value>> operands) {
+    const std::vector<Message<google_firestore_v1_Value>>& operands) {
   Message<google_firestore_v1_ArrayValue> array_value;
   SetRepeatedField(&array_value->values, &array_value->values_count,
                    operands.begin(), operands.end(),
-                   [](Message<google_firestore_v1_Value> value) {
-                     return *value.release();
+                   [](const Message<google_firestore_v1_Value>& value) {
+                     return *DeepClone(*value).release();
                    });
   model::ArrayTransform transform(TransformOperation::Type::ArrayUnion,
                                   std::move(array_value));

--- a/Firestore/core/test/unit/testutil/testutil.h
+++ b/Firestore/core/test/unit/testutil/testutil.h
@@ -220,7 +220,7 @@ template <typename ValueType, typename... Args>
 void AddElements(nanopb::Message<google_firestore_v1_ArrayValue>& array_value,
                  pb_size_t pos,
                  ValueType value,
-                 Args... rest) {
+                 Args&&... rest) {
   array_value->values[pos] = *Value(std::move(value)).release();
   AddElements(array_value, ++pos, std::forward<Args>(rest)...);
 }
@@ -229,7 +229,7 @@ void AddElements(nanopb::Message<google_firestore_v1_ArrayValue>& array_value,
  * Inserts the elements into the given array.
  */
 template <typename... Args>
-nanopb::Message<google_firestore_v1_ArrayValue> MakeArray(Args... values) {
+nanopb::Message<google_firestore_v1_ArrayValue> MakeArray(Args&&... values) {
   nanopb::Message<google_firestore_v1_ArrayValue> array_value{};
   array_value->values_count = nanopb::CheckedSize(sizeof...(Args));
   array_value->values =

--- a/Firestore/core/test/unit/testutil/testutil.h
+++ b/Firestore/core/test/unit/testutil/testutil.h
@@ -402,7 +402,7 @@ std::pair<std::string, model::TransformOperation> Increment(
  */
 std::pair<std::string, model::TransformOperation> ArrayUnion(
     std::string field,
-    std::vector<nanopb::Message<google_firestore_v1_Value>> operands);
+    const std::vector<nanopb::Message<google_firestore_v1_Value>>& operands);
 
 model::DeleteMutation DeleteMutation(absl::string_view path);
 

--- a/Firestore/core/test/unit/testutil/testutil.h
+++ b/Firestore/core/test/unit/testutil/testutil.h
@@ -200,11 +200,8 @@ nanopb::Message<google_firestore_v1_Value> MakeMap(Args... key_value_pairs) {
 /**
  * Recursive base case for AddElements, below.
  */
-inline void AddElements(
-    nanopb::Message<google_firestore_v1_ArrayValue>& array_value,
-    pb_size_t pos) {
-  (void)array_value;
-  (void)pos;
+inline void AddElements(nanopb::Message<google_firestore_v1_ArrayValue>&,
+                        pb_size_t) {
 }
 
 /**


### PR DESCRIPTION
This fixes almost all leaks in the integration tests by changing the Value() helpers to return `Message<goog_firestore_v1_Value>` and bubbling this through the entire codebase. A side-effect is that it makes ownership of values much more clear. 

The few remaining leaks are in the spec tests and a single leak in bundle parsing. I am not sure whether they exist on`master` as well, but given the size of this PR we should fix them in a follow-up (if at all). We should do one more run and discuss after this has been merged.