### PR TITLE
Explicitly check that document and collection IDs given to the public API aren't empty

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Passing in an empty document ID, collection group ID, or collection
+  path will now result in a more readable error (#8218).
+
 # v7.9.0
 - [feature] Added support for Firestore Bundles via
   `FIRFirestore.loadBundle`, `FIRFirestore.loadBundleStream` and

--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -110,10 +110,17 @@ namespace testutil = firebase::firestore::testutil;
   FSTAssertThrows([baseDocRef collectionWithPath:nil], nilError);
 }
 
+- (void)testEmptyCollectionPathsFail {
+  FIRDocumentReference *baseDocRef = [self.db documentWithPath:@"foo/bar"];
+  NSString *emptyError = @"Collection path cannot be empty.";
+  FSTAssertThrows([self.db collectionWithPath:@""], emptyError);
+  FSTAssertThrows([baseDocRef collectionWithPath:@""], emptyError);
+}
+
 - (void)testWrongLengthCollectionPathsFail {
   FIRDocumentReference *baseDocRef = [self.db documentWithPath:@"foo/bar"];
   NSArray *badAbsolutePaths = @[ @"foo/bar", @"foo/bar/baz/quu" ];
-  NSArray *badRelativePaths = @[ @"", @"baz/quu" ];
+  NSArray *badRelativePaths = @[ @"baz/quu", @"baz/quu" ];
   NSArray *badPathLengths = @[ @2, @4 ];
   NSString *errorFormat = @"Invalid collection reference. Collection references must have an odd "
                           @"number of segments, but %@ has %@";
@@ -125,11 +132,32 @@ namespace testutil = firebase::firestore::testutil;
   }
 }
 
+- (void)testNilCollectionGroupPathsFail {
+  FIRDocumentReference *baseDocRef = [self.db documentWithPath:@"foo/bar"];
+  NSString *nilError = @"Collection path cannot be nil.";
+  FSTAssertThrows([self.db collectionWithPath:nil], nilError);
+  FSTAssertThrows([baseDocRef collectionWithPath:nil], nilError);
+}
+
+// - (void)testEmptyCollectionGroupPathsFail {
+//   FIRDocumentReference *baseDocRef = [self.db documentWithPath:@""];
+//   NSString *emptyError = @"Collection path cannot be empty.";
+//   FSTAssertThrows([self.db collectionWithPath:@""], emptyError);
+//   FSTAssertThrows([baseDocRef collectionWithPath:@""], emptyError);
+// }
+
 - (void)testNilDocumentPathsFail {
   FIRCollectionReference *baseCollectionRef = [self.db collectionWithPath:@"foo"];
   NSString *nilError = @"Document path cannot be nil.";
   FSTAssertThrows([self.db documentWithPath:nil], nilError);
   FSTAssertThrows([baseCollectionRef documentWithPath:nil], nilError);
+}
+
+- (void)testEmptyDocumentPathsFail {
+  FIRCollectionReference *baseCollectionRef = [self.db collectionWithPath:@"foo"];
+  NSString *emptyError = @"Document path cannot be empty.";
+  FSTAssertThrows([self.db documentWithPath:@""], emptyError);
+  FSTAssertThrows([baseCollectionRef documentWithPath:@""], emptyError);
 }
 
 - (void)testWrongLengthDocumentPathsFail {

--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -119,9 +119,9 @@ namespace testutil = firebase::firestore::testutil;
 
 - (void)testWrongLengthCollectionPathsFail {
   FIRDocumentReference *baseDocRef = [self.db documentWithPath:@"foo/bar"];
-  NSArray *badAbsolutePaths = @[ @"foo/bar", @"foo/bar/baz/quu" ];
-  NSArray *badRelativePaths = @[ @"baz/quu", @"baz/quu" ];
-  NSArray *badPathLengths = @[ @2, @4 ];
+  NSArray *badAbsolutePaths = @[ @"foo/bar/baz/quu", @"foo/bar/baz/quu/x/y" ];
+  NSArray *badRelativePaths = @[ @"baz/quu", @"baz/quu/x/y" ];
+  NSArray *badPathLengths = @[ @4, @6 ];
   NSString *errorFormat = @"Invalid collection reference. Collection references must have an odd "
                           @"number of segments, but %@ has %@";
   for (NSUInteger i = 0; i < badAbsolutePaths.count; i++) {
@@ -133,18 +133,14 @@ namespace testutil = firebase::firestore::testutil;
 }
 
 - (void)testNilCollectionGroupPathsFail {
-  FIRDocumentReference *baseDocRef = [self.db documentWithPath:@"foo/bar"];
-  NSString *nilError = @"Collection path cannot be nil.";
-  FSTAssertThrows([self.db collectionWithPath:nil], nilError);
-  FSTAssertThrows([baseDocRef collectionWithPath:nil], nilError);
+  NSString *nilError = @"Collection ID cannot be nil.";
+  FSTAssertThrows([self.db collectionGroupWithID:nil], nilError);
 }
 
-// - (void)testEmptyCollectionGroupPathsFail {
-//   FIRDocumentReference *baseDocRef = [self.db documentWithPath:@""];
-//   NSString *emptyError = @"Collection path cannot be empty.";
-//   FSTAssertThrows([self.db collectionWithPath:@""], emptyError);
-//   FSTAssertThrows([baseDocRef collectionWithPath:@""], emptyError);
-// }
+- (void)testEmptyCollectionGroupPathsFail {
+  NSString *emptyError = @"Collection ID cannot be empty.";
+  FSTAssertThrows([self.db collectionGroupWithID:@""], emptyError);
+}
 
 - (void)testNilDocumentPathsFail {
   FIRCollectionReference *baseCollectionRef = [self.db collectionWithPath:@"foo"];
@@ -162,9 +158,9 @@ namespace testutil = firebase::firestore::testutil;
 
 - (void)testWrongLengthDocumentPathsFail {
   FIRCollectionReference *baseCollectionRef = [self.db collectionWithPath:@"foo"];
-  NSArray *badAbsolutePaths = @[ @"foo", @"foo/bar/baz" ];
-  NSArray *badRelativePaths = @[ @"", @"bar/baz" ];
-  NSArray *badPathLengths = @[ @1, @3 ];
+  NSArray *badAbsolutePaths = @[ @"foo/bar/baz", @"foo/bar/baz/x/y" ];
+  NSArray *badRelativePaths = @[ @"bar/baz", @"bar/baz/x/y" ];
+  NSArray *badPathLengths = @[ @3, @5 ];
   NSString *errorFormat = @"Invalid document reference. Document references must have an even "
                           @"number of segments, but %@ has %@";
   for (NSUInteger i = 0; i < badAbsolutePaths.count; i++) {

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -104,6 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
   if (!documentPath) {
     ThrowInvalidArgument("Document path cannot be nil.");
   }
+  if (!documentPath.length) {
+    ThrowInvalidArgument("Document path cannot be empty.");
+  }
   DocumentReference child = self.reference.Document(util::MakeString(documentPath));
   return [[FIRDocumentReference alloc] initWithReference:std::move(child)];
 }

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -129,6 +129,9 @@ NS_ASSUME_NONNULL_BEGIN
   if (!collectionPath) {
     ThrowInvalidArgument("Collection path cannot be nil.");
   }
+  if (!collectionPath.length) {
+    ThrowInvalidArgument("Collection path cannot be empty.");
+  }
 
   CollectionReference child =
       _documentReference.GetCollectionReference(util::MakeString(collectionPath));

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -198,6 +198,9 @@ NS_ASSUME_NONNULL_BEGIN
   if (!collectionPath) {
     ThrowInvalidArgument("Collection path cannot be nil.");
   }
+  if (!collectionPath.length) {
+    ThrowInvalidArgument("Collection path cannot be empty.");
+  }
   if ([collectionPath containsString:@"//"]) {
     ThrowInvalidArgument("Invalid path (%s). Paths must not contain // in them.", collectionPath);
   }
@@ -210,6 +213,9 @@ NS_ASSUME_NONNULL_BEGIN
   if (!documentPath) {
     ThrowInvalidArgument("Document path cannot be nil.");
   }
+  if (!documentPath.length) {
+    ThrowInvalidArgument("Document path cannot be empty.");
+  }
   if ([documentPath containsString:@"//"]) {
     ThrowInvalidArgument("Invalid path (%s). Paths must not contain // in them.", documentPath);
   }
@@ -221,6 +227,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (FIRQuery *)collectionGroupWithID:(NSString *)collectionID {
   if (!collectionID) {
     ThrowInvalidArgument("Collection ID cannot be nil.");
+  }
+  if (!collectionID.length) {
+    ThrowInvalidArgument("Collection ID cannot be empty.");
   }
   if ([collectionID containsString:@"/"]) {
     ThrowInvalidArgument("Invalid collection ID (%s). Collection IDs must not contain / in them.",


### PR DESCRIPTION
Currently, the error would look like `Document references must have an even number of segments, but has 0`.

Fixes #8218.