### PR TITLE
Fix versioning bug in release tooling

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
@@ -97,7 +97,7 @@ struct InitializeRelease {
     }
   }
 
-  /// Update the existing version to the given version by writing to a given string usign the provided range.
+  /// Update the existing version to the given version by writing to a given string using the provided range.
   /// - Parameters:
   ///   - contents: A reference to a String containing a version that will be updated.
   ///   - range: The range containing a version substring that will be updated.

--- a/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
@@ -83,7 +83,7 @@ struct InitializeRelease {
         updateVersion(&contents, in: range, to: version)
 
       } else {
-        // Iterate through all the ranges of `pod`'s occurences.
+        // Iterate through all the ranges of `pod`'s occurrences.
         for range in contents.ranges(of: pod) {
           // Replace version in string like ss.dependency 'FirebaseCore', '6.3.0'.
           updateVersion(&contents, in: range, to: version)

--- a/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
@@ -93,20 +93,24 @@ struct InitializeRelease {
         contents.insert(contentsOf: "'" + version + "'", at: versionStartIndex)
       } else {
         // Replace version in string like ss.dependency 'FirebaseCore', '6.3.0'
-        guard let range = contents.range(of: pod) else {
+        // Obtain all the ranges of `pod`'s occurences.
+        guard let ranges = contents.ranges(of: pod) else {
           // This pod is not a top-level Firebase pod dependency.
           continue
         }
-        var versionStartIndex = contents.index(range.upperBound, offsetBy: 2)
-        while !contents[versionStartIndex].isWholeNumber {
-          versionStartIndex = contents.index(versionStartIndex, offsetBy: 1)
+
+        for range in ranges {
+          var versionStartIndex = contents.index(range.upperBound, offsetBy: 2)
+          while !contents[versionStartIndex].isWholeNumber {
+            versionStartIndex = contents.index(versionStartIndex, offsetBy: 1)
+          }
+          var versionEndIndex = contents.index(versionStartIndex, offsetBy: 1)
+          while contents[versionEndIndex] != "'" {
+            versionEndIndex = contents.index(versionEndIndex, offsetBy: 1)
+          }
+          contents.removeSubrange(versionStartIndex ... versionEndIndex)
+          contents.insert(contentsOf: version + "'", at: versionStartIndex)
         }
-        var versionEndIndex = contents.index(versionStartIndex, offsetBy: 1)
-        while contents[versionEndIndex] != "'" {
-          versionEndIndex = contents.index(versionEndIndex, offsetBy: 1)
-        }
-        contents.removeSubrange(versionStartIndex ... versionEndIndex)
-        contents.insert(contentsOf: version + "'", at: versionStartIndex)
       }
     }
     do {

--- a/ReleaseTooling/Sources/Utils/String+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/String+Utils.swift
@@ -22,7 +22,7 @@ public extension String {
   /// using the specified locale, if any.
   /// - Returns: An an optional array of ranges where each range corresponds to an occurence of the substring in the given string.
   func ranges<T: StringProtocol>(of substring: T, options: CompareOptions = .literal,
-                                 locale: Locale? = nil) -> [Range<Index>]? {
+                                 locale: Locale? = nil) -> [Range<Index>] {
     var ranges: [Range<Index>] = []
 
     let end = endIndex
@@ -43,6 +43,6 @@ public extension String {
       searchRange = shiftedStart ..< end
     }
 
-    return ranges.isEmpty ? nil : ranges
+    return ranges
   }
 }

--- a/ReleaseTooling/Sources/Utils/String+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/String+Utils.swift
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Utilities to simplify String operations.
+public extension String {
+  /// Finds and returns the ranges of all occurrences of a given string within a given range of the String, subject to given options,
+  /// using the specified locale, if any.
+  /// - Returns: An an optional array of ranges where each range corresponds to an occurence of the substring in the given string.
+  func ranges<T: StringProtocol>(of substring: T, options: CompareOptions = .literal,
+                                 locale: Locale? = nil) -> [Range<Index>]? {
+    var ranges: [Range<Index>] = []
+
+    let end = endIndex
+    var searchRange = startIndex ..< end
+
+    while searchRange.lowerBound < end {
+      guard let range = self.range(
+        of: substring,
+        options: options,
+        range: searchRange,
+        locale: locale
+      )
+      else { break }
+
+      ranges.append(range)
+
+      let shiftedStart = index(range.lowerBound, offsetBy: 1)
+      searchRange = shiftedStart ..< end
+    }
+
+    return ranges.isEmpty ? nil : ranges
+  }
+}


### PR DESCRIPTION
When the release tooling [iterates through all of the defined `Pods`](https://github.com/firebase/firebase-ios-sdk/blob/5aaf38c022718421c389cfafa4fe2776227966d2/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift#L74), it uses the `range(of:)` String API to find the first occurrence of the `pod` and then bumps the versioning. Because the API only finds the first occurrence, each pod will only get versioned bumped once. Because the `FirebaseAnalytics` substring now occurs in two places (after PR #7900 added `'FirebaseAnalytics/WithoutAdIDSupport'`):  

https://github.com/firebase/firebase-ios-sdk/blob/acf106a33d50e893f85a8563a19557b3df6110d1/Firebase.podspec#L37

and 

https://github.com/firebase/firebase-ios-sdk/blob/acf106a33d50e893f85a8563a19557b3df6110d1/Firebase.podspec#L72

it was only bumped once (the first occurrence). 

A new String API has been added to collect all of the ranges of the occurrences of a given substring.



Fixes #8179 