### PR TITLE
Fix a data race in `GrpcConnection` when retrieving the language token.

### DIFF
--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -189,7 +189,7 @@ class ClientLanguageToken {
     value_ = std::move(value);
   }
 
-  const std::string& Get() const {
+  std::string Get() const {
     Guard guard(mutex_);
     return value_;
   }


### PR DESCRIPTION
This is a backport of cr/377421930.

#no-changelog