### PR TITLE
Eliminate invalid subspec

### DIFF
--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -37,19 +37,17 @@
         {
             "name": "AdIdSupport",
             "dependencies": {
-                "FirebaseAnalytics/Base": "8.2.0",
                 "GoogleAppMeasurement": "8.2.0"
-            }
+            },
+            "vendored_frameworks": [
+                "Frameworks/FirebaseAnalytics.xcframework"
+            ]
         },
         {
             "name": "WithoutAdIdSupport",
             "dependencies": {
-                "FirebaseAnalytics/Base": "8.2.0",
                 "GoogleAppMeasurement/WithoutAdIdSupport": "8.2.0"
-            }
-        },
-        {
-            "name": "Base",
+            },
             "vendored_frameworks": [
                 "Frameworks/FirebaseAnalytics.xcframework"
             ]


### PR DESCRIPTION
FirebaseAnalyics.podspec.json failed to validate because the Base subspec did not depend on GoogleAppMeasurement.

This PR eliminates that unnecessary podspec.

I'm not sure why this issue wasn't caught before. Two possibilities: `pod spec lint` is non-deterministic or something about FirebaseAnalytics.xcframework changed to introduce a build dependency on GoogleAppMeasurement in a blank project.