### PR TITLE
App Check: Token API for 3P  use

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+- [added] Token API for 3P use. (#8266)
 # 8.2.0 -- M98
 - [added] Apple's App Attest attestation provider support. (#8133)
 - [changed] Token auto-refresh optimizations. (#8232)

--- a/FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestArtifactStorage.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestArtifactStorage.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBLPromise<ValueType>;
+@class GULKeychainStorage;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/// A default initializer.
+/// Default convenience initializer.
 /// @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
 /// the key to store the token for the storage instance.
 /// @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
@@ -55,6 +56,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppName:(NSString *)appName
                           appID:(NSString *)appID
                     accessGroup:(nullable NSString *)accessGroup;
+
+/// Designated initializer.
+/// @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
+/// the key to store the token for the storage instance.
+/// @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
+/// as a part of the key to store the token for the storage instance.
+/// @param keychainStorage An instance of `GULKeychainStorage` used as an underlying secure storage.
+/// @param accessGroup The Keychain Access Group.
+- (instancetype)initWithAppName:(NSString *)appName
+                          appID:(NSString *)appID
+                keychainStorage:(GULKeychainStorage *)keychainStorage
+                    accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
@@ -20,15 +20,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXTERN NSErrorDomain const kFIRAppCheckErrorDomain NS_SWIFT_NAME(AppCheckErrorDomain);
-
 void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 
 @interface FIRAppCheckErrorUtil : NSObject
 
-// Internal errors.
++ (NSError *)publicDomainErrorWithError:(NSError *)error;
+
+// MARK: - Internal errors
 
 + (NSError *)cachedTokenNotFound;
+
 + (NSError *)cachedTokenExpired;
 
 + (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
@@ -49,21 +50,5 @@ void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 + (NSError *)appAttestKeyIDNotFound;
 
 @end
-
-typedef NS_ERROR_ENUM(kFIRAppCheckErrorDomain, FIRAppCheckErrorCode){
-    /// An unknown or non-actionable error.
-    FIRAppCheckErrorCodeUnknown = 0,
-
-    /// A network connection error.
-    FIRAppCheckErrorCodeServerUnreachable = 1,
-
-    /// Invalid configuration error.
-    FIRAppCheckErrorCodeInvalidConfiguration = 2,
-
-    /// System keychain access error.
-    FIRAppCheckErrorCodeKeychain = 3,
-
-    /// Selected app attestation provider is not supported on the current platform or OS version.
-    FIRAppCheckErrorCodeUnsupported = 4} NS_SWIFT_NAME(AppCheckErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
@@ -32,6 +32,8 @@ void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (NSError *)cachedTokenExpired;
 
++ (NSError *)keychainErrorWithError:(NSError *)error;
+
 + (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                               data:(nullable NSData *)data;
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 
 #import <GoogleUtilities/GULKeychainUtils.h>
 
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
 @implementation FIRAppCheckErrorUtil
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -14,12 +14,24 @@
  * limitations under the License.
  */
 
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
+
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
-NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
-
 @implementation FIRAppCheckErrorUtil
+
++ (NSError *)publicDomainErrorWithError:(NSError *)error {
+  if ([error.domain isEqualToString:FIRAppCheckErrorDomain]) {
+    return error;
+  }
+
+  NSString *failureReason = error.userInfo[NSLocalizedFailureReasonErrorKey];
+
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:error];
+}
 
 + (NSError *)cachedTokenNotFound {
   NSString *failureReason = [NSString stringWithFormat:@"Cached token not found."];
@@ -42,7 +54,7 @@ NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
 
 + (NSError *)APIErrorWithNetworkError:(NSError *)networkError {
   NSString *failureReason = [NSString stringWithFormat:@"API request error."];
-  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeServerUnreachable
                        failureReason:failureReason
                      underlyingError:networkError];
 }
@@ -102,7 +114,7 @@ NSString *const kFIRAppCheckErrorDomain = @"com.firebase.appCheck";
   userInfo[NSUnderlyingErrorKey] = underlyingError;
   userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
 
-  return [NSError errorWithDomain:kFIRAppCheckErrorDomain code:code userInfo:userInfo];
+  return [NSError errorWithDomain:FIRAppCheckErrorDomain code:code userInfo:userInfo];
 }
 
 @end

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -47,6 +47,13 @@
                      underlyingError:nil];
 }
 
++ (NSError *)keychainErrorWithError:(NSError *)error {
+  NSString *failureReason = [NSString stringWithFormat:@"Keychain access error."];
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeKeychain
+                       failureReason:failureReason
+                     underlyingError:error];
+}
+
 + (FIRAppCheckHTTPError *)APIErrorWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                               data:(nullable NSData *)data {
   return [[FIRAppCheckHTTPError alloc] initWithHTTPResponse:HTTPResponse data:data];

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrors.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrors.m
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
-#import "FirebaseAppCheck/Sources/AppAttestProvider/Errors/FIRAppAttestRejectionError.h"
-
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
-
-@implementation FIRAppAttestRejectionError
-
-- (instancetype)init {
-  return [self initWithDomain:FIRAppCheckErrorDomain code:FIRAppCheckErrorCodeUnknown userInfo:nil];
-}
-
-@end
+NSErrorDomain const FIRAppCheckErrorDomain = @"com.firebase.appCheck";

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
 @implementation FIRAppCheckHTTPError
 
 - (instancetype)initWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                 data:(nullable NSData *)data {
   NSDictionary *userInfo = [[self class] userInfoWithHTTPResponse:HTTPResponse data:data];
-  self = [super initWithDomain:kFIRAppCheckErrorDomain
+  self = [super initWithDomain:FIRAppCheckErrorDomain
                           code:FIRAppCheckErrorCodeUnknown
                       userInfo:userInfo];
   if (self) {

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.m
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
-#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
 @implementation FIRAppCheckHTTPError
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -187,9 +187,9 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   return (FIRAppCheck *)appCheck;
 }
 
-- (void)appCheckTokenForcingRefresh:(BOOL)forcingRefresh
-                         completion:(void (^)(FIRAppCheckToken *_Nullable token,
-                                              NSError *_Nullable error))handler {
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                      NSError *_Nullable error))handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
       .then(^id _Nullable(FIRAppCheckToken *token) {
         handler(token, nil);

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -187,9 +187,9 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   return (FIRAppCheck *)appCheck;
 }
 
-- (void)getAppCheckTokenForcingRefresh:(BOOL)forcingRefresh
-                            completion:(void (^)(FIRAppCheckToken *_Nullable token,
-                                                 NSError *_Nullable error))handler {
+- (void)appCheckTokenForcingRefresh:(BOOL)forcingRefresh
+                         completion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                              NSError *_Nullable error))handler {
   [self retrieveOrRefreshTokenForcingRefresh:forcingRefresh]
       .then(^id _Nullable(FIRAppCheckToken *token) {
         handler(token, nil);

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -60,11 +60,10 @@ NS_SWIFT_NAME(AppCheck)
 /// error, indicating a revoked token.
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
-- (void)getAppCheckTokenForcingRefresh:(BOOL)forcingRefresh
-                            completion:(void (^)(FIRAppCheckToken *_Nullable token,
-                                                 NSError *_Nullable error))handler
-    NS_SWIFT_ASYNC_NAME(appCheckToken(forcingRefresh:))
-        NS_SWIFT_NAME(appCheckToken(forcingRefresh:completion:));
+- (void)appCheckTokenForcingRefresh:(BOOL)forcingRefresh
+                         completion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                              NSError *_Nullable error))handler
+    NS_SWIFT_NAME(appCheckToken(forcingRefresh:completion:));
 
 /// Sets the `AppCheckProviderFactory` to use to generate
 /// `AppCheckDebugProvider` objects.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -60,10 +60,10 @@ NS_SWIFT_NAME(AppCheck)
 /// error, indicating a revoked token.
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
-- (void)appCheckTokenForcingRefresh:(BOOL)forcingRefresh
-                         completion:(void (^)(FIRAppCheckToken *_Nullable token,
-                                              NSError *_Nullable error))handler
-    NS_SWIFT_NAME(appCheckToken(forcingRefresh:completion:));
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:
+                     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Sets the `AppCheckProviderFactory` to use to generate
 /// `AppCheckDebugProvider` objects.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -17,9 +17,22 @@
 #import <Foundation/Foundation.h>
 
 @class FIRApp;
+@class FIRAppCheckToken;
 @protocol FIRAppCheckProviderFactory;
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// A notification with the specified name is sent to the default notification center
+/// (`NotificationCenter.default`) each time a Firebase app check token is refreshed.
+/// The user info dictionary contains `kFIRAppCheckTokenNotificationKey` and
+/// `kFIRAppCheckAppNameNotificationKey` keys.
+FOUNDATION_EXPORT const NSNotificationName
+    FIRAppCheckAppCheckTokenDidChangeNotification NS_SWIFT_NAME(AppCheckTokenDidChange);
+
+/// `userInfo` key for the `FirebaseApp.name` in `AppCheckTokenDidChangeNotification`.
+FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenNotificationKey NS_SWIFT_NAME(AppCheckTokenNotificationKey);
+/// `userInfo` key for the `AppCheckToken` in `AppCheckTokenDidChangeNotification`.
+FOUNDATION_EXPORT NSString *const kFIRAppCheckAppNameNotificationKey NS_SWIFT_NAME(AppCheckAppNameNotificationKey);
 
 NS_SWIFT_NAME(AppCheck)
 @interface FIRAppCheck : NSObject
@@ -37,6 +50,21 @@ NS_SWIFT_NAME(AppCheck)
 /// @returns An instance of `AppCheck` corresponding to the passed application.
 /// @throw Throws an exception if required `FirebaseApp` options are missing.
 + (nullable instancetype)appCheckWithApp:(FIRApp *)firebaseApp NS_SWIFT_NAME(appCheck(app:));
+
+/// Requests Firebase app check token. This method should *only* be used if you need to authorize
+/// requests to a non-Firebase backend. Requests to Firebase backend are authorized automatically if
+/// configured.
+/// @param forcingRefresh If `YES`,  a new Firebase app check token is requested and the token
+/// cache is ignored. If `NO`, the cached token is used if it exists and has not expired yet. In
+/// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
+/// error, indicating a revoked token.
+/// @param handler The completion handler. Includes the app check token if the request succeeds,
+/// or an error if the request fails.
+- (void)getAppCheckTokenForcingRefresh:(BOOL)forcingRefresh
+                            completion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                                 NSError *_Nullable error))handler
+    NS_SWIFT_ASYNC_NAME(appCheckToken(forcingRefresh:))
+        NS_SWIFT_NAME(appCheckToken(forcingRefresh:completion:));
 
 /// Sets the `AppCheckProviderFactory` to use to generate
 /// `AppCheckDebugProvider` objects.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/// Firebase app check error domain.
+FOUNDATION_EXTERN NSErrorDomain const FIRAppCheckErrorDomain NS_SWIFT_NAME(AppCheckErrorDomain);
+
+typedef NS_ERROR_ENUM(FIRAppCheckErrorDomain, FIRAppCheckErrorCode){
+    /// An unknown or non-actionable error.
+    FIRAppCheckErrorCodeUnknown = 0,
+
+    /// A network connection error.
+    FIRAppCheckErrorCodeServerUnreachable = 1,
+
+    /// Invalid configuration error. Currently, an exception is thrown but this error is reserved
+    /// for future implementations of invalid
+    ///  configuration detection.
+    FIRAppCheckErrorCodeInvalidConfiguration = 2,
+
+    /// System keychain access error. Ensure that the app has proper keychain access.
+    FIRAppCheckErrorCodeKeychain = 3,
+
+    /// Selected app attestation provider is not supported on the current platform or OS version.
+    FIRAppCheckErrorCodeUnsupported = 4
+
+} NS_SWIFT_NAME(AppCheckErrorCode);

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
@@ -27,8 +27,7 @@ typedef NS_ERROR_ENUM(FIRAppCheckErrorDomain, FIRAppCheckErrorCode){
     FIRAppCheckErrorCodeServerUnreachable = 1,
 
     /// Invalid configuration error. Currently, an exception is thrown but this error is reserved
-    /// for future implementations of invalid
-    ///  configuration detection.
+    /// for future implementations of invalid configuration detection.
     FIRAppCheckErrorCodeInvalidConfiguration = 2,
 
     /// System keychain access error. Ensure that the app has proper keychain access.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FirebaseAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FirebaseAppCheck.h
@@ -15,6 +15,7 @@
  */
 
 #import "FIRAppCheck.h"
+#import "FIRAppCheckErrors.h"
 #import "FIRAppCheckProvider.h"
 #import "FIRAppCheckProviderFactory.h"
 #import "FIRAppCheckToken.h"

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
@@ -27,6 +27,7 @@
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckToken+Internal.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFixtureLoader.h"
 #import "SharedTestUtilities/Date/FIRDateTestUtils.h"
@@ -113,7 +114,7 @@
   XCTAssertNil(promise.value);
 
   // Assert error is as expected.
-  XCTAssertEqualObjects(promise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(promise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(promise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect response body and HTTP status code to be included in the error.
@@ -191,7 +192,7 @@
   XCTAssertNil(promise.value);
 
   // Assert error is as expected.
-  XCTAssertEqualObjects(promise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(promise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(promise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect missing field name to be included in the error.

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-#import <GoogleUtilities/GULKeychainStorage.h>
-#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import <GoogleUtilities/GULKeychainStorage.h>
 
 #import "FBLPromise+Testing.h"
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -120,50 +120,48 @@
 }
 
 - (void)testGetArtifact_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppAttestArtifactStorage *artifactStorage =
       [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
 
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
                                      accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Get artifact and verify results.
   __auto_type getPromise = [artifactStorage getArtifactForKey:@"key"];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
   XCTAssertNotNil(getPromise.error);
   XCTAssertEqualObjects(getPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 - (void)testSetArtifact_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppAttestArtifactStorage *artifactStorage =
       [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
-
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
                                accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Set artifact and verify results.
   NSData *artifact = [@"artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type setPromise = [artifactStorage setArtifact:artifact forKey:@"key"];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
@@ -171,38 +169,33 @@
   XCTAssertEqualObjects(setPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 - (void)testRemoveArtifact_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppAttestArtifactStorage *artifactStorage =
       [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
 
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Remove artifact and verify results.
   __auto_type setPromise = [artifactStorage setArtifact:nil forKey:@"key"];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
   XCTAssertNotNil(setPromise.error);
   XCTAssertEqualObjects(setPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 #pragma mark - Helpers

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckAPIServiceTests.m
@@ -24,6 +24,7 @@
 
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
 
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFixtureLoader.h"
@@ -154,7 +155,7 @@
 
   XCTAssertTrue(requestPromise.isRejected);
   XCTAssertNotNil(requestPromise.error);
-  XCTAssertEqualObjects(requestPromise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(requestPromise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(requestPromise.error.code, FIRAppCheckErrorCodeUnknown);
   XCTAssertEqualObjects(requestPromise.error.userInfo[NSUnderlyingErrorKey], networkError);
 
@@ -187,7 +188,7 @@
   XCTAssertNil(requestPromise.value);
 
   XCTAssertNotNil(requestPromise.error);
-  XCTAssertEqualObjects(requestPromise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(requestPromise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(requestPromise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect response body and HTTP status code to be included in the error.
@@ -246,7 +247,7 @@
   XCTAssertNil(tokenPromise.value);
 
   XCTAssertNotNil(tokenPromise.error);
-  XCTAssertEqualObjects(tokenPromise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(tokenPromise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(tokenPromise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect response body and HTTP status code to be included in the error.
@@ -281,7 +282,7 @@
   XCTAssertNil(tokenPromise.value);
 
   XCTAssertNotNil(tokenPromise.error);
-  XCTAssertEqualObjects(tokenPromise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(tokenPromise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(tokenPromise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect missing field name to be included in the error.

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckAPIServiceTests.m
@@ -156,7 +156,7 @@
   XCTAssertTrue(requestPromise.isRejected);
   XCTAssertNotNil(requestPromise.error);
   XCTAssertEqualObjects(requestPromise.error.domain, FIRAppCheckErrorDomain);
-  XCTAssertEqual(requestPromise.error.code, FIRAppCheckErrorCodeUnknown);
+  XCTAssertEqual(requestPromise.error.code, FIRAppCheckErrorCodeServerUnreachable);
   XCTAssertEqualObjects(requestPromise.error.userInfo[NSUnderlyingErrorKey], networkError);
 
   OCMVerifyAll(self.mockURLSession);

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -22,9 +22,10 @@
 
 #import "FBLPromise+Testing.h"
 
+#import "FirebaseAppCheck/Sources/Core/Storage/FIRAppCheckStorage.h"
+
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckToken+Internal.h"
-#import "FirebaseAppCheck/Sources/Core/Storage/FIRAppCheckStorage.h"
 
 @interface FIRAppCheckStorageTests : XCTestCase
 @property(nonatomic) NSString *appName;

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-#import <GoogleUtilities/GULKeychainStorage.h>
-#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import <GoogleUtilities/GULKeychainStorage.h>
 
 #import "FBLPromise+Testing.h"
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -80,48 +80,46 @@
 }
 
 - (void)testGetToken_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppCheckStorage *storage = [[FIRAppCheckStorage alloc] initWithAppName:self.appName
                                                                       appID:self.appID
                                                             keychainStorage:mockKeychainStorage
                                                                 accessGroup:nil];
-
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage getObjectForKey:[OCMArg any]
                                      objectClass:[OCMArg any]
                                      accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Get token and verify results.
   __auto_type getPromise = [storage getToken];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
   XCTAssertNotNil(getPromise.error);
   XCTAssertEqualObjects(getPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 - (void)testSetToken_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppCheckStorage *storage = [[FIRAppCheckStorage alloc] initWithAppName:self.appName
                                                                       appID:self.appID
                                                             keychainStorage:mockKeychainStorage
                                                                 accessGroup:nil];
 
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage setObject:[OCMArg any]
                                     forKey:[OCMArg any]
                                accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Set token and verify results.
   FIRAppCheckToken *tokenToStore = [[FIRAppCheckToken alloc] initWithToken:@"token"
                                                             expirationDate:[NSDate distantPast]
                                                             receivedAtDate:[NSDate date]];
@@ -131,37 +129,32 @@
   XCTAssertEqualObjects(getPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 - (void)testRemoveToken_KeychainError {
+  // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-
   FIRAppCheckStorage *storage = [[FIRAppCheckStorage alloc] initWithAppName:self.appName
                                                                       appID:self.appID
                                                             keychainStorage:mockKeychainStorage
                                                                 accessGroup:nil];
 
+  // 2. Create and expect keychain error.
   NSError *gulsKeychainError = [NSError errorWithDomain:@"com.guls.keychain" code:-1 userInfo:nil];
-
   OCMExpect([mockKeychainStorage removeObjectForKey:[OCMArg any] accessGroup:[OCMArg any]])
       .andReturn([FBLPromise resolvedWith:gulsKeychainError]);
 
+  // 3. Remove token and verify results.
   __auto_type getPromise = [storage setToken:nil];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
   XCTAssertNotNil(getPromise.error);
   XCTAssertEqualObjects(getPromise.error,
                         [FIRAppCheckErrorUtil keychainErrorWithError:gulsKeychainError]);
 
+  // 4. Verify storage mock.
   OCMVerifyAll(mockKeychainStorage);
-
-  // Clean-up keychain storage mock.
-  [mockKeychainStorage stopMocking];
-  mockKeychainStorage = nil;
 }
 
 - (void)testSetTokenPerApp {

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -334,7 +334,6 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
   // 2. Expect token requested from app check provider.
   FIRAppCheckToken *expectedToken = [self validToken];
-
   id completionArg = [OCMArg invokeBlockWithArgs:expectedToken, [NSNull null], nil];
   OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -204,6 +204,14 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   [FIRApp resetApps];
 }
 
+#pragma mark - Public Get Token
+
+//- (void)testGetToken_WhenNoCache_Success {
+//
+//}
+
+#pragma mark - FIRAppCheckInterop Get Token
+
 - (void)testGetToken_WhenNoCache_Success {
   // 1. Expect token to be requested from storage.
   OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -215,7 +215,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenNoCache_withExpectedToken:expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -242,7 +242,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
       [self configuredExpectations_GetTokenForcingRefreshWhenCacheIsValid_withExpectedToken:
                 expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:YES
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -264,7 +264,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenCachedTokenExpired_withExpectedToken:expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -286,7 +286,8 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenError_withError:providerError andToken:cachedToken];
-  // 2. Request token and verify results.
+
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -309,7 +310,8 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenError_withError:serverError andToken:nil];
-  // 2. Request token and verify results.
+
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -337,14 +339,14 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
 
   // 3. Expect new token to be stored.
-  OCMExpect([self.mockStorage setToken:[OCMArg any]])
+  OCMExpect([self.mockStorage setToken:expectedToken])
       .andReturn([FBLPromise resolvedWith:keychainError]);
 
   // 4. Don't expect token update notification to be sent.
-  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""];
-  notificationExpectation.inverted = YES;
+  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""
+                                                                                   isInverted:YES];
 
-  // 5. Request token and verify results.
+  // 5. Request token and verify result.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
   [self.appCheck
       tokenForcingRefresh:NO
@@ -369,7 +371,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenError_withError:providerError andToken:nil];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -394,7 +396,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenNoCache_withExpectedToken:expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck getTokenForcingRefresh:NO
                              completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                [expectations.lastObject fulfill];
@@ -419,7 +421,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
       [self configuredExpectations_GetTokenForcingRefreshWhenCacheIsValid_withExpectedToken:
                 expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck getTokenForcingRefresh:YES
                              completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                [expectations.lastObject fulfill];
@@ -440,7 +442,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenCachedTokenExpired_withExpectedToken:expectedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck getTokenForcingRefresh:NO
                              completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                [expectations.lastObject fulfill];
@@ -462,7 +464,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenError_withError:providerError andToken:cachedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       getTokenForcingRefresh:NO
                   completion:^(id<FIRAppCheckTokenResultInterop> result) {
@@ -530,8 +532,8 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
   // 4. Don't expect token update notification to be sent.
-  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""];
-  notificationExpectation.inverted = YES;
+  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""
+                                                                                   isInverted:YES];
 
   // 5. Trigger refresh and expect the result.
   if (self.tokenRefreshHandler == nil) {
@@ -587,93 +589,77 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 #pragma mark - Merging multiple get token requests
 
 - (void)testGetToken_WhenCalledSeveralTimesSuccess_ThenThereIsOnlyOneOperation {
-  // 1. Expect token to be requested from storage.
-  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);
+  // 1. Expect a token to be requested and stored.
+  NSArray * /*[expectedToken, storeTokenPromise]*/ expectedTokenAndPromise =
+      [self expectTokenRequestFromAppCheckProvider];
+  FIRAppCheckToken *expectedToken = expectedTokenAndPromise.firstObject;
+  FBLPromise *storeTokenPromise = expectedTokenAndPromise.lastObject;
 
-  // 2. Expect token requested from app check provider.
-  FIRAppCheckToken *tokenToReturn = [self validToken];
-  id completionArg = [OCMArg invokeBlockWithArgs:tokenToReturn, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
-
-  // 3. Expect new token to be stored.
-  // 3.1. Create a pending promise to resolve later.
-  FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
-  // 3.2. Stub storage set token method.
-  OCMExpect([self.mockStorage setToken:tokenToReturn]).andReturn(storeTokenPromise);
-
-  // 4. Expect token update notification to be sent.
+  // 2. Expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
-      [self tokenUpdateNotificationWithExpectedToken:tokenToReturn.token];
+      [self tokenUpdateNotificationWithExpectedToken:expectedToken.token];
 
-  // 5. Request token several times.
+  // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations =
       [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
-    // 5.1. Expect a completion to be called for each method call.
+    // 3.1. Expect a completion to be called for each method call.
     XCTestExpectation *getTokenExpectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
-    // 5.2. Request token and verify result.
+    // 3.2. Request token and verify result.
     [self.appCheck
         tokenForcingRefresh:NO
                  completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
                    [getTokenExpectation fulfill];
                    XCTAssertNotNil(token);
-                   XCTAssertEqualObjects(token.token, tokenToReturn.token);
+                   XCTAssertEqualObjects(token.token, expectedToken.token);
                    XCTAssertNil(error);
                  }];
   }
 
-  // 5.3. Fulfill the pending promise to finish the get token operation.
-  [storeTokenPromise fulfill:tokenToReturn];
+  // 3.3. Fulfill the pending promise to finish the get token operation.
+  [storeTokenPromise fulfill:expectedToken];
 
-  // 6. Wait for expectations and validate mocks.
-  [self waitForExpectations:[getTokenCompletionExpectations
-                                arrayByAddingObject:notificationExpectation]
-                    timeout:0.5];
+  // 4. Wait for expectations and validate mocks.
+  NSArray *expectations =
+      [getTokenCompletionExpectations arrayByAddingObject:notificationExpectation];
+  [self waitForExpectations:expectations timeout:0.5];
   [self verifyAllMocks];
 
-  // 7. Check a get token call after.
+  // 5. Check a get token call after.
   [self assertGetToken_WhenCachedTokenIsValid_Success];
 }
 
 - (void)testGetToken_WhenCalledSeveralTimesError_ThenThereIsOnlyOneOperation {
-  // 1. Expect token to be requested from storage.
-  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);
+  // 1. Expect a token to be requested and stored.
+  NSArray * /*[expectedToken, storeTokenPromise]*/ expectedTokenAndPromise =
+      [self expectTokenRequestFromAppCheckProvider];
+  FIRAppCheckToken *expectedToken = expectedTokenAndPromise.firstObject;
+  FBLPromise *storeTokenPromise = expectedTokenAndPromise.lastObject;
 
-  // 2. Expect token requested from app check provider.
-  FIRAppCheckToken *tokenToReturn = [self validToken];
-  id completionArg = [OCMArg invokeBlockWithArgs:tokenToReturn, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
-
-  // 3. Expect new token to be stored.
-  // 3.1. Create a pending promise to resolve later.
-  FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
-  // 3.2. Stub storage set token method.
-  OCMExpect([self.mockStorage setToken:tokenToReturn]).andReturn(storeTokenPromise);
-  // 3.3. Create an expected error to be rejected with later.
+  // 1.1. Create an expected error to be rejected with later.
   NSError *storageError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
 
-  // 4. Don't expect token update notification to be sent.
+  // 2. Don't expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
-      [self tokenUpdateNotificationWithExpectedToken:tokenToReturn.token];
-  notificationExpectation.inverted = YES;
+      [self tokenUpdateNotificationWithExpectedToken:expectedToken.token isInverted:YES];
 
-  // 5. Request token several times.
+  // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations =
       [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
-    // 5.1. Expect a completion to be called for each method call.
+    // 3.1. Expect a completion to be called for each method call.
     XCTestExpectation *getTokenExpectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
-    // 5.2. Request token and verify result.
+    // 3.2. Request token and verify result.
     [self.appCheck
         tokenForcingRefresh:NO
                  completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -686,107 +672,90 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                  }];
   }
 
-  // 5.3. Reject the pending promise to finish the get token operation.
+  // 3.3. Reject the pending promise to finish the get token operation.
   [storeTokenPromise reject:storageError];
 
-  // 6. Wait for expectations and validate mocks.
-  [self waitForExpectations:[getTokenCompletionExpectations
-                                arrayByAddingObject:notificationExpectation]
-                    timeout:0.5];
+  // 4. Wait for expectations and validate mocks.
+  NSArray *expectations =
+      [getTokenCompletionExpectations arrayByAddingObject:notificationExpectation];
+  [self waitForExpectations:expectations timeout:0.5];
   [self verifyAllMocks];
 
-  // 7. Check a get token call after.
+  // 5. Check a get token call after.
   [self assertGetToken_WhenCachedTokenIsValid_Success];
 }
 
 - (void)testInteropGetToken_WhenCalledSeveralTimesSuccess_ThenThereIsOnlyOneOperation {
-  // 1. Expect token to be requested from storage.
-  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);
+  // 1. Expect a token to be requested and stored.
+  NSArray * /*[expectedToken, storeTokenPromise]*/ expectedTokenAndPromise =
+      [self expectTokenRequestFromAppCheckProvider];
+  FIRAppCheckToken *expectedToken = expectedTokenAndPromise.firstObject;
+  FBLPromise *storeTokenPromise = expectedTokenAndPromise.lastObject;
 
-  // 2. Expect token requested from app check provider.
-  FIRAppCheckToken *tokenToReturn = [self validToken];
-  id completionArg = [OCMArg invokeBlockWithArgs:tokenToReturn, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
-
-  // 3. Expect new token to be stored.
-  // 3.1. Create a pending promise to resolve later.
-  FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
-  // 3.2. Stub storage set token method.
-  OCMExpect([self.mockStorage setToken:tokenToReturn]).andReturn(storeTokenPromise);
-
-  // 4. Expect token update notification to be sent.
+  // 2. Expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
-      [self tokenUpdateNotificationWithExpectedToken:tokenToReturn.token];
+      [self tokenUpdateNotificationWithExpectedToken:expectedToken.token];
 
-  // 5. Request token several times.
+  // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations =
       [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
-    // 5.1. Expect a completion to be called for each method call.
+    // 3.1. Expect a completion to be called for each method call.
     XCTestExpectation *getTokenExpectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
-    // 5.2. Request token and verify result.
+    // 3.2. Request token and verify result.
     [self.appCheck getTokenForcingRefresh:NO
                                completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                  [getTokenExpectation fulfill];
                                  XCTAssertNotNil(tokenResult);
-                                 XCTAssertEqualObjects(tokenResult.token, tokenToReturn.token);
+                                 XCTAssertEqualObjects(tokenResult.token, expectedToken.token);
                                  XCTAssertNil(tokenResult.error);
                                }];
   }
 
-  // 5.3. Fulfill the pending promise to finish the get token operation.
-  [storeTokenPromise fulfill:tokenToReturn];
+  // 3.3. Fulfill the pending promise to finish the get token operation.
+  [storeTokenPromise fulfill:expectedToken];
 
-  // 6. Wait for expectations and validate mocks.
-  [self waitForExpectations:[getTokenCompletionExpectations
-                                arrayByAddingObject:notificationExpectation]
-                    timeout:0.5];
+  // 4. Wait for expectations and validate mocks.
+  NSArray *expectations =
+      [getTokenCompletionExpectations arrayByAddingObject:notificationExpectation];
+  [self waitForExpectations:expectations timeout:0.5];
   [self verifyAllMocks];
 
-  // 7. Check a get token call after.
+  // 5. Check a get token call after.
   [self assertInteropGetToken_WhenCachedTokenIsValid_Success];
 }
 
 - (void)testInteropGetToken_WhenCalledSeveralTimesError_ThenThereIsOnlyOneOperation {
-  // 1. Expect token to be requested from storage.
-  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);
+  // 1. Expect a token to be requested and stored.
+  NSArray * /*[expectedToken, storeTokenPromise]*/ expectedTokenAndPromise =
+      [self expectTokenRequestFromAppCheckProvider];
+  FIRAppCheckToken *expectedToken = expectedTokenAndPromise.firstObject;
+  FBLPromise *storeTokenPromise = expectedTokenAndPromise.lastObject;
 
-  // 2. Expect token requested from app check provider.
-  FIRAppCheckToken *tokenToReturn = [[FIRAppCheckToken alloc] initWithToken:[NSUUID UUID].UUIDString
-                                                             expirationDate:[NSDate distantFuture]];
-  id completionArg = [OCMArg invokeBlockWithArgs:tokenToReturn, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
-
-  // 3. Expect new token to be stored.
-  // 3.1. Create a pending promise to resolve later.
-  FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
-  // 3.2. Stub storage set token method.
-  OCMExpect([self.mockStorage setToken:tokenToReturn]).andReturn(storeTokenPromise);
-  // 3.3. Create an expected error to be rejected with later.
+  // 1.1. Create an expected error to be reject the store token promise with later.
   NSError *storageError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
 
-  // 4. Don't expect token update notification to be sent.
+  // 2. Don't expect token update notification to be sent.
   XCTestExpectation *notificationExpectation =
-      [self tokenUpdateNotificationWithExpectedToken:tokenToReturn.token];
-  notificationExpectation.inverted = YES;
+      [self tokenUpdateNotificationWithExpectedToken:expectedToken.token isInverted:YES];
 
-  // 5. Request token several times.
+  // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
   NSMutableArray *getTokenCompletionExpectations =
       [NSMutableArray arrayWithCapacity:getTokenCallsCount];
 
   for (NSInteger i = 0; i < getTokenCallsCount; i++) {
-    // 5.1. Expect a completion to be called for each method call.
+    // 3.1. Expect a completion to be called for each method call.
     XCTestExpectation *getTokenExpectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"getToken%@", @(i)]];
     [getTokenCompletionExpectations addObject:getTokenExpectation];
 
-    // 5.2. Request token and verify result.
+    // 3.2. Request token and verify result.
     [self.appCheck getTokenForcingRefresh:NO
                                completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                  [getTokenExpectation fulfill];
@@ -796,16 +765,16 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                                }];
   }
 
-  // 5.3. Reject the pending promise to finish the get token operation.
+  // 3.3. Reject the pending promise to finish the get token operation.
   [storeTokenPromise reject:storageError];
 
-  // 6. Wait for expectations and validate mocks.
-  [self waitForExpectations:[getTokenCompletionExpectations
-                                arrayByAddingObject:notificationExpectation]
-                    timeout:0.5];
+  // 4. Wait for expectations and validate mocks.
+  NSArray *expectations =
+      [getTokenCompletionExpectations arrayByAddingObject:notificationExpectation];
+  [self waitForExpectations:expectations timeout:0.5];
   [self verifyAllMocks];
 
-  // 7. Check a get token call after.
+  // 5. Check a get token call after.
   [self assertInteropGetToken_WhenCachedTokenIsValid_Success];
 }
 
@@ -834,6 +803,11 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 }
 
 - (XCTestExpectation *)tokenUpdateNotificationWithExpectedToken:(NSString *)expectedToken {
+  return [self tokenUpdateNotificationWithExpectedToken:expectedToken isInverted:NO];
+}
+
+- (XCTestExpectation *)tokenUpdateNotificationWithExpectedToken:(NSString *)expectedToken
+                                                     isInverted:(BOOL)isInverted {
   XCTestExpectation *expectation =
       [self expectationForNotification:[self.appCheck tokenDidChangeNotificationName]
                                 object:nil
@@ -848,7 +822,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                                  XCTAssertEqualObjects(notification.object, self.appCheck);
                                  return YES;
                                }];
-
+  expectation.inverted = isInverted;
   return expectation;
 }
 
@@ -859,7 +833,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenCacheTokenIsValid_withExpectedToken:cachedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck
       tokenForcingRefresh:NO
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
@@ -881,7 +855,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   NSArray * /*[tokenNotification, getToken]*/ expectations =
       [self configuredExpectations_GetTokenWhenCacheTokenIsValid_withExpectedToken:cachedToken];
 
-  // 2. Request token and verify results.
+  // 2. Request token and verify result.
   [self.appCheck getTokenForcingRefresh:NO
                              completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
                                [expectations.lastObject fulfill];
@@ -893,26 +867,6 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   // 3. Wait for expectations and validate mocks.
   [self waitForExpectations:expectations timeout:0.5];
   [self verifyAllMocks];
-}
-
-- (NSArray<XCTestExpectation *> *)
-    configuredExpectations_GetTokenWhenCacheTokenIsValid_withExpectedToken:
-        (FIRAppCheckToken *)expectedToken {
-  // 1. Expect token to be requested from storage.
-  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:expectedToken]);
-
-  // 2. Don't expect token requested from app check provider.
-  OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
-
-  // 3. Don't expect token update notification to be sent.
-  XCTestExpectation *tokenNotificationExpectation =
-      [self tokenUpdateNotificationWithExpectedToken:@""];
-  tokenNotificationExpectation.inverted = YES;
-
-  // 4. Request token and verify results.
-  XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
-
-  return @[ tokenNotificationExpectation, getTokenExpectation ];
 }
 
 - (NSArray<XCTestExpectation *> *)configuredExpectations_GetTokenWhenNoCache_withExpectedToken:
@@ -932,7 +886,26 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   XCTestExpectation *tokenNotificationExpectation =
       [self tokenUpdateNotificationWithExpectedToken:expectedToken.token];
 
-  // 5. Request token and verify results.
+  // 5. Expect token request to be completed.
+  XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
+
+  return @[ tokenNotificationExpectation, getTokenExpectation ];
+}
+
+- (NSArray<XCTestExpectation *> *)
+    configuredExpectations_GetTokenWhenCacheTokenIsValid_withExpectedToken:
+        (FIRAppCheckToken *)expectedToken {
+  // 1. Expect token to be requested from storage.
+  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:expectedToken]);
+
+  // 2. Don't expect token requested from app check provider.
+  OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
+
+  // 3. Don't expect token update notification to be sent.
+  XCTestExpectation *tokenNotificationExpectation =
+      [self tokenUpdateNotificationWithExpectedToken:@"" isInverted:YES];
+
+  // 4. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
   return @[ tokenNotificationExpectation, getTokenExpectation ];
@@ -979,13 +952,13 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
       .andReturn([FBLPromise resolvedWith:expectedToken]);
 
   // 4. Expect token update notification to be sent.
-  XCTestExpectation *tokenNotificationExpectation =
+  XCTestExpectation *notificationExpectation =
       [self tokenUpdateNotificationWithExpectedToken:expectedToken.token];
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
-  return @[ tokenNotificationExpectation, getTokenExpectation ];
+  return @[ notificationExpectation, getTokenExpectation ];
 }
 
 - (NSArray<XCTestExpectation *> *)
@@ -1001,14 +974,32 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   // 3. Don't expect token requested from app check provider.
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
-  // 4. Don't expect token update notification to be sent.
-  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""];
-  notificationExpectation.inverted = YES;
+  // 4. Expect token update notification to be sent.
+  XCTestExpectation *notificationExpectation = [self tokenUpdateNotificationWithExpectedToken:@""
+                                                                                   isInverted:YES];
 
-  // 5. Request token and verify results.
+  // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
 
   return @[ notificationExpectation, getTokenExpectation ];
+}
+
+- (NSArray *)expectTokenRequestFromAppCheckProvider {
+  // 1. Expect token to be requested from storage.
+  OCMExpect([self.mockStorage getToken]).andReturn([FBLPromise resolvedWith:nil]);
+
+  // 2. Expect token requested from app check provider.
+  FIRAppCheckToken *expectedToken = [self validToken];
+  id completionArg = [OCMArg invokeBlockWithArgs:expectedToken, [NSNull null], nil];
+  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
+
+  // 3. Expect new token to be stored.
+  // 3.1. Create a pending promise to resolve later.
+  FBLPromise<FIRAppCheckToken *> *storeTokenPromise = [FBLPromise pendingPromise];
+  // 3.2. Stub storage set token method.
+  OCMExpect([self.mockStorage setToken:expectedToken]).andReturn(storeTokenPromise);
+
+  return @[ expectedToken, storeTokenPromise ];
 }
 
 - (void)verifyAllMocks {

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckAPIServiceTests.m
@@ -25,6 +25,7 @@
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFixtureLoader.h"
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
@@ -217,7 +218,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   XCTAssertNil(tokenPromise.value);
 
   XCTAssertNotNil(tokenPromise.error);
-  XCTAssertEqualObjects(tokenPromise.error.domain, kFIRAppCheckErrorDomain);
+  XCTAssertEqualObjects(tokenPromise.error.domain, FIRAppCheckErrorDomain);
   XCTAssertEqual(tokenPromise.error.code, FIRAppCheckErrorCodeUnknown);
 
   // Expect response body and HTTP status code to be included in the error.

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
@@ -27,11 +27,6 @@ class AppCheckTests: XCTestCase {
     let firebaseOptions = FirebaseOptions(contentsOfFile: "path")!
     FirebaseApp.configure(name: "AppName", options: firebaseOptions)
   }
-
-  func asyncUsageExample() async throws {
-    let token = try await AppCheck.appCheck().appCheckToken(forcingRefresh: true)
-    XCTAssertTrue(token.isKind(of: AppCheckToken.self))
-  }
 }
 
 class DummyAppCheckProvider: NSObject, AppCheckProvider {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
@@ -26,6 +26,14 @@ class AppCheckTests: XCTestCase {
 
     let firebaseOptions = FirebaseOptions(contentsOfFile: "path")!
     FirebaseApp.configure(name: "AppName", options: firebaseOptions)
+
+    AppCheck.appCheck().token(forcingRefresh: true) { token, error in
+      // ...
+    }
+  }
+
+  func asyncGetTokenUsageExample() async throws {
+    _ = try await AppCheck.appCheck().token(forcingRefresh: true)
   }
 }
 

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
@@ -32,10 +32,11 @@ class AppCheckTests: XCTestCase {
     }
   }
 
-  @available(iOS 15.0, *)
-  func asyncGetTokenUsageExample() async throws {
-    _ = try await AppCheck.appCheck().token(forcingRefresh: true)
-  }
+  #if swift(>=5.5)
+    func asyncGetTokenUsageExample() async throws {
+      _ = try await AppCheck.appCheck().token(forcingRefresh: true)
+    }
+  #endif // swift(>=5.5)
 }
 
 class DummyAppCheckProvider: NSObject, AppCheckProvider {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
@@ -27,6 +27,11 @@ class AppCheckTests: XCTestCase {
     let firebaseOptions = FirebaseOptions(contentsOfFile: "path")!
     FirebaseApp.configure(name: "AppName", options: firebaseOptions)
   }
+
+  func asyncUsageExample() async throws {
+    let token = try await AppCheck.appCheck().appCheckToken(forcingRefresh: true)
+    XCTAssertTrue(token.isKind(of: AppCheckToken.self))
+  }
 }
 
 class DummyAppCheckProvider: NSObject, AppCheckProvider {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckTests.swift
@@ -32,6 +32,7 @@ class AppCheckTests: XCTestCase {
     }
   }
 
+  @available(iOS 15.0, *)
   func asyncGetTokenUsageExample() async throws {
     _ = try await AppCheck.appCheck().token(forcingRefresh: true)
   }


### PR DESCRIPTION
- Added Public Get Token API for 3P use
- Refactored `AppCheckTests.m` to share testing infra between new public get token API and interop get token API
- Added API-reviewed error enum
- Add error handling for keychain related errors
- Add tests for above addition

b/190653133