### PR TITLE
Crashlytics remove unnecessary Analytics header

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSAnalyticsManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSAnalyticsManager.h
@@ -14,8 +14,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class FIRCLSSettings;


### PR DESCRIPTION
We use forward declarations instead, so the header isn't needed. In addition, this was giving errors in the flutter plugin https://github.com/FirebaseExtended/flutterfire/pull/5900

```
@protocol FIRAnalyticsInterop;
@protocol FIRAnalyticsInteropListener;
```

#no-changelog
