### PR TITLE
[App Distribution] Reset sign in flag on unauthorized error

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error.
+
 # v7.3.0-beta
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthenticated error.
 - [fixed] Crash caused by trying to parse response as JSON when response is nil (#6996).

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error.
+- [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error (#8270).
 
 # v7.3.0-beta
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthenticated error.

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -253,6 +253,11 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
                            @"to sign in again.");
             [self signOutTester];
           }
+          else if ([error code] == FIRFADApiErrorUnauthorized) {
+            FIRFADErrorLog(@"Tester is not authorized to view releases for this app. Tester will "
+                           @"need to sign in again.");
+            [self signOutTester];
+          }
 
           dispatch_async(dispatch_get_main_queue(), ^{
             completion(nil, [self mapFetchReleasesError:error]);

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -252,8 +252,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
             FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need "
                            @"to sign in again.");
             [self signOutTester];
-          }
-          else if ([error code] == FIRFADApiErrorUnauthorized) {
+          } else if ([error code] == FIRFADApiErrorUnauthorized) {
             FIRFADErrorLog(@"Tester is not authorized to view releases for this app. Tester will "
                            @"need to sign in again.");
             [self signOutTester];


### PR DESCRIPTION
Check for an Unauthorized error and sign out the Tester from the fetchNewLatestRelease.
