### PR TITLE
Add Package.resolved to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ DerivedData
 *.ipa
 
 # Swift Package Manager
+Package.resolved
 */.build
 ReleaseTooling/.swiftpm
 ReleaseTooling/Packages


### PR DESCRIPTION
Enable clean workspace when developing with Swift Package Manager