### PR TITLE
Revert "Support Unity generated Podfiles (#8193)"

### DIFF
--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -32,7 +32,6 @@
     "source": {
         "http": "https://dl.google.com/firebase/ios/analytics/19ed8dba01e90708/FirebaseAnalytics-8.1.1.tar.gz"
     },
-    "static_framework": true,
     "subspecs": [
         {
             "name": "AdIdSupport",

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -30,7 +30,6 @@
     "source": {
         "http": "https://dl.google.com/firebase/ios/analytics/2962dad7aa0f51fb/GoogleAppMeasurement-8.1.1.tar.gz"
     },
-    "static_framework": true,
     "subspecs": [
         {
             "name": "AdIdSupport",


### PR DESCRIPTION
This reverts commit 500ea2d38452e5f8a01d3d17a87976574a8983c3.

Adding the `static_framework` attribute causes some Podfiles to start to fail to install.  An example is the [Firebase Functions Quickstart](https://github.com/firebase/quickstart-ios/tree/master/functions).  More details internally at b/191680865.

The fix is already deployed to SpecsStaging, and this PR should still be cherry-picked to the release-8.2 after merging.