### PR TITLE
Punt pause task to the end of the queue

### DIFF
--- a/FirebaseStorage/Sources/FIRStorage.m
+++ b/FirebaseStorage/Sources/FIRStorage.m
@@ -166,6 +166,7 @@ static GTMSessionFetcherRetryBlock _retryWhenOffline;
     _scheme = kFIRStorageScheme;
     _port = @(kFIRStoragePort);
     _fetcherServiceForApp = nil;  // Configured in `ensureConfigured()`
+    // Must be a serial queue.
     _dispatchQueue = dispatch_queue_create("com.google.firebase.storage", DISPATCH_QUEUE_SERIAL);
     _maxDownloadRetryTime = 600.0;
     _maxDownloadRetryInterval =

--- a/FirebaseStorage/Sources/FIRStorageDownloadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageDownloadTask.m
@@ -169,11 +169,11 @@
     strongSelf.state = FIRStorageTaskStatePausing;
     [strongSelf.fetcher stopFetching];
     // Give the resume callback a chance to run (if scheduled)
-    [strongSelf dispatchAsync:^{
+    dispatch_after(0.001 * NSEC_PER_SEC, strongSelf.dispatchQueue, ^{
       strongSelf.state = FIRStorageTaskStatePaused;
       FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
       [strongSelf fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];
-    }];
+    });
   }];
 }
 

--- a/FirebaseStorage/Sources/FIRStorageDownloadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageDownloadTask.m
@@ -165,13 +165,15 @@
 - (void)pause {
   __weak FIRStorageDownloadTask *weakSelf = self;
   [self dispatchAsync:^() {
-    weakSelf.state = FIRStorageTaskStatePausing;
-    [weakSelf.fetcher stopFetching];
+    __strong FIRStorageDownloadTask *strongSelf = weakSelf;
+    strongSelf.state = FIRStorageTaskStatePausing;
+    [strongSelf.fetcher stopFetching];
     // Give the resume callback a chance to run (if scheduled)
-    [weakSelf.fetcher waitForCompletionWithTimeout:0.001];
-    weakSelf.state = FIRStorageTaskStatePaused;
-    FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
-    [weakSelf fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];
+    [strongSelf dispatchAsync:^{
+      strongSelf.state = FIRStorageTaskStatePaused;
+      FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
+      [strongSelf fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];
+    }];
   }];
 }
 

--- a/FirebaseStorage/Sources/FIRStorageDownloadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageDownloadTask.m
@@ -166,8 +166,7 @@
   __weak FIRStorageDownloadTask *weakSelf = self;
   [self dispatchAsync:^() {
     __strong FIRStorageDownloadTask *strongSelf = weakSelf;
-    if (!strongSelf ||
-        strongSelf.state == FIRStorageTaskStatePaused ||
+    if (!strongSelf || strongSelf.state == FIRStorageTaskStatePaused ||
         strongSelf.state == FIRStorageTaskStatePausing) {
       return;
     }

--- a/FirebaseStorage/Sources/FIRStorageDownloadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageDownloadTask.m
@@ -169,7 +169,7 @@
     strongSelf.state = FIRStorageTaskStatePausing;
     [strongSelf.fetcher stopFetching];
     // Give the resume callback a chance to run (if scheduled)
-    dispatch_after(0.001 * NSEC_PER_SEC, strongSelf.dispatchQueue, ^{
+    dispatch_after(0.015 * NSEC_PER_SEC, strongSelf.dispatchQueue, ^{
       strongSelf.state = FIRStorageTaskStatePaused;
       FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
       [strongSelf fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];


### PR DESCRIPTION
Fixes #8294, probably.

It's unclear to me exactly what the original implementation did, though it's likely it [slept](https://github.com/google/gtm-session-fetcher/blob/main/Source/GTMSessionFetcher.m#L2055) the thread instead of allowing other closures to execute first.