### PR TITLE
Don't leak memory when all fields are deleted

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -226,7 +226,7 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
   } else if (!kRunBenchmarkTests && [tags containsObject:kBenchmarkTag]) {
     return NO;
   }
-  return NO;
+  return YES;
 }
 
 - (void)setUpForSpecWithConfig:(NSDictionary *)config {

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -226,7 +226,7 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
   } else if (!kRunBenchmarkTests && [tags containsObject:kBenchmarkTag]) {
     return NO;
   }
-  return YES;
+  return NO;
 }
 
 - (void)setUpForSpecWithConfig:(NSDictionary *)config {

--- a/Firestore/core/src/model/object_value.cc
+++ b/Firestore/core/src/model/object_value.cc
@@ -168,6 +168,13 @@ void ApplyChanges(
     ++target_index;
   }
 
+  // Delete any remaining fields in the original Map. This only includes fields
+  // that were deleted.
+  for (pb_size_t source_index = target_count; source_index < source_count;
+       ++source_index) {
+    FreeFieldsArray(&source_fields[source_index]);
+  }
+
   free(parent->fields);
   parent->fields = target_fields;
   parent->fields_count = CheckedSize(target_count);

--- a/Firestore/core/src/model/object_value.cc
+++ b/Firestore/core/src/model/object_value.cc
@@ -118,8 +118,8 @@ void ApplyChanges(
   auto upsert_it = upserts.begin();
 
   // Merge the existing data with the deletes and updates
-  for (pb_size_t source_index = 0, target_index = 0;
-       target_index < target_count;) {
+  pb_size_t source_index = 0, target_index = 0;
+  while (target_index < target_count) {
     auto& target_entry = target_fields[target_index];
 
     if (source_index < source_count) {
@@ -168,10 +168,9 @@ void ApplyChanges(
     ++target_index;
   }
 
-  // Delete any remaining fields in the original Map. This only includes fields
+  // Delete any remaining fields in the original map. This only includes fields
   // that were deleted.
-  for (pb_size_t source_index = target_count; source_index < source_count;
-       ++source_index) {
+  for (; source_index < source_count; ++source_index) {
     FreeFieldsArray(&source_fields[source_index]);
   }
 


### PR DESCRIPTION
When the new size of a fields map is less than the old size, we currently leak memory. This PR removes the memory allocated for the "overflow" entries.