### PR TITLE
Support array / dictionary values in Remote Config defaults

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -152,6 +152,20 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
         [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
         NSString *strValue = [dateFormatter stringFromDate:(NSDate *)value];
         valueData = [(NSString *)strValue dataUsingEncoding:NSUTF8StringEncoding];
+      } else if ([value isKindOfClass:[NSArray class]]) {
+        NSError *error;
+        valueData = [NSJSONSerialization dataWithJSONObject:value options:0 error:&error];
+        if (error) {
+          FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000075",
+                      @"Invalid array value for key '%@'", key);
+        }
+      } else if ([value isKindOfClass:[NSDictionary class]]) {
+        NSError *error;
+        valueData = [NSJSONSerialization dataWithJSONObject:value options:0 error:&error];
+        if (error) {
+          FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000075",
+                      @"Invalid dictionary value for key '%@'", key);
+        }
       } else {
         continue;
       }

--- a/FirebaseRemoteConfig/Tests/Unit/Defaults-testInfo.plist
+++ b/FirebaseRemoteConfig/Tests/Unit/Defaults-testInfo.plist
@@ -16,5 +16,20 @@
 	<string>To setup default config.</string>
 	<key>format</key>
 	<string>key to value.</string>
+	<key>arrayValue</key>
+	<array>
+		<string>foo</string>
+		<string>bar</string>
+		<string>baz</string>
+	</array>
+	<key>dictValue</key>
+	<dict>
+		<key>foo</key>
+		<string>foo</string>
+		<key>bar</key>
+		<string>bar</string>
+		<key>baz</key>
+		<string>baz</string>
+	</dict>
 </dict>
 </plist>

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1178,6 +1178,10 @@ static NSString *UTCToLocal(NSString *utcTime) {
     XCTAssertEqualObjects(_configInstances[i][@"FileInfo"].stringValue,
                           @"To setup default config.");
     XCTAssertEqualObjects(_configInstances[i][@"format"].stringValue, @"key to value.");
+    XCTAssertEqualObjects(_configInstances[i][@"arrayValue"].JSONValue,
+                          ((id) @[@"foo", @"bar", @"baz"]));
+    XCTAssertEqualObjects(_configInstances[i][@"dictValue"].JSONValue,
+                          ((id) @{@"foo": @"foo", @"bar": @"bar", @"baz": @"baz"}));
 
     // If given a wrong file name, the default will not be set and kept as previous results.
     [_configInstances[i] setDefaultsFromPlistFileName:@""];


### PR DESCRIPTION
Issue: https://github.com/firebase/firebase-ios-sdk/issues/8306