### PR TITLE
Update more workflows for new crashlytics qs location

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -204,6 +204,8 @@ jobs:
         LEGACY: true
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics swift)
     - name: Remove data before upload
+      env:
+        LEGACY: true
       run: scripts/remove_data.sh crashlytics release_testing
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -196,8 +196,8 @@ jobs:
       run: |
         mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
-        cp Crashlytics/run quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
-        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
+        cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
         ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics)
     - name: Test swift quickstart
       env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -194,7 +194,7 @@ jobs:
       env:
         LEGACY: true
       run: |
-        mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
+        mkdir -p quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
         cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
         cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,6 +2,8 @@ name: prerelease
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/prerelease.yml'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,8 +2,6 @@ name: prerelease
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/prerelease.yml'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -179,6 +179,8 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
           bot-access.txt "$bot_token_secret"
     - name: Setup testing repo and quickstart
+      env:
+        LEGACY: true
       run: |
           botaccess=`cat bot-access.txt`
           BOT_TOKEN="${botaccess}" scripts/setup_quickstart.sh Crashlytics prerelease_testing
@@ -189,6 +191,8 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Test objc quickstart
+      env:
+        LEGACY: true
       run: |
         mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
@@ -196,6 +200,8 @@ jobs:
         cp Crashlytics/upload-symbols quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
         ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics)
     - name: Test swift quickstart
+      env:
+        LEGACY: true
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics swift)
     - name: Remove data before upload
       run: scripts/remove_data.sh crashlytics release_testing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,8 @@ jobs:
       run: |
         mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
-        cp Crashlytics/run quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
-        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
+        cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
         ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics)
     - name: Test swift quickstart
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
         LEGACY: true
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics swift)
     - name: Remove data before upload
+      env:
+        LEGACY: true
       run: scripts/remove_data.sh crashlytics release_testing
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'scripts/release_testing_setup.sh'
+    - '.github/workflows/release.yml'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
       env:
         LEGACY: true
       run: |
-        mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
+        mkdir -p quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
         cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
         cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,8 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
           bot-access.txt "$bot_token_secret"
     - name: Setup testing repo and quickstart
+      env:
+        LEGACY: true
       run: |
           botaccess=`cat bot-access.txt`
           BOT_TOKEN="${botaccess}" scripts/setup_quickstart.sh Crashlytics nightly_release_testing
@@ -141,6 +143,8 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Test objc quickstart
+      env:
+        LEGACY: true
       run: |
         mkdir -p quickstart-ios/crashlytics/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
@@ -148,6 +152,8 @@ jobs:
         cp Crashlytics/upload-symbols quickstart-ios/crashlytics/Pods/FirebaseCrashlytics/
         ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics)
     - name: Test swift quickstart
+      env:
+        LEGACY: true
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics swift)
     - name: Remove data before upload
       run: scripts/remove_data.sh crashlytics release_testing

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -259,6 +259,8 @@ jobs:
     # - name: Test Swift Quickstart
     #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
     - name: Remove data before upload
+      env:
+        LEGACY: true
       if: ${{ failure() }}
       run: scripts/remove_data.sh crashlytics
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -237,10 +237,10 @@ jobs:
               SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-              cp quickstart-ios/crashlytics/Firebase/run quickstart-ios/crashlytics
-              cp quickstart-ios/crashlytics/Firebase/upload-symbols quickstart-ios/crashlytics
-              chmod +x quickstart-ios/crashlytics/run
-              chmod +x quickstart-ios/crashlytics/upload-symbols
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
     # TODO(#8057): Restore Swift Quickstart
     # - name: Setup swift quickstart
     #   run: |

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -231,6 +231,8 @@ jobs:
         mkdir -p "${HOME}"/ios_frameworks/
         find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
     - name: Setup quickstart
+      env:
+        LEGACY: true
       run: |
               SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
@@ -251,6 +253,8 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
         quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Test Quickstart
+      env:
+        LEGACY: true
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
     # - name: Test Swift Quickstart
     #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)

--- a/scripts/remove_data.sh
+++ b/scripts/remove_data.sh
@@ -16,9 +16,17 @@ set -xe
 
 SDK="$1"
 MODE=${2-}
+
+DIR="${SDK}"
+
+if [[ ! -z "$LEGACY" ]]; then
+  DIR="${SDK}/Legacy${SDK}Quickstart"
+fi
+
+
 if [ "$MODE" == "release_testing" ]; then
   echo "Update podfiles release_testing."
-  sed -i "" "s/https:\/\/.*@github.com\/FirebasePrivate\/SpecsTesting.git/https:\/\/github.com\/FirebasePrivate\/SpecsTesting.git/g" quickstart-ios/"${SDK}"/Podfile quickstart-ios/"${SDK}"/Podfile.lock
+  sed -i "" "s/https:\/\/.*@github.com\/FirebasePrivate\/SpecsTesting.git/https:\/\/github.com\/FirebasePrivate\/SpecsTesting.git/g" quickstart-ios/"${DIR}"/Podfile quickstart-ios/"${DIR}"/Podfile.lock
 fi
-rm -f quickstart-ios/"${SDK}"/GoogleService-Info.plist
+rm -f quickstart-ios/"${DIR}"/GoogleService-Info.plist
 rm -f quickstart-ios/TestUtils/FIREGSignInInfo.h

--- a/scripts/setup_quickstart.sh
+++ b/scripts/setup_quickstart.sh
@@ -31,10 +31,13 @@ SAMPLE=$1
 RELEASE_TESTING=${2-}
 
 WORKSPACE_DIR="quickstart-ios/${SAMPLE}"
+PODFILE="quickstart-ios/"$SAMPLE"/Podfile"
 
 if [[ ! -z "${LEGACY:-}" ]]; then
   WORKSPACE_DIR="quickstart-ios/${SAMPLE}/Legacy${SAMPLE}Quickstart"
+  PODFILE="quickstart-ios/"$SAMPLE"/Legacy${SAMPLE}Quickstart/Podfile"
 fi
+
 
 # Installations is the only quickstart that doesn't need a real
 # GoogleService-Info.plist for its tests.
@@ -48,13 +51,13 @@ if check_secrets || [[ ${SAMPLE} == "installations" ]]; then
   $scripts_dir/localize_podfile.swift "$WORKSPACE_DIR"/Podfile "$RELEASE_TESTING"
   if [ "$RELEASE_TESTING" == "nightly_release_testing" ]; then
     set +x
-    sed -i "" '1i\'$'\n'"source 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting.git'"$'\n' quickstart-ios/"$SAMPLE"/Podfile
+    sed -i "" '1i\'$'\n'"source 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting.git'"$'\n' "$PODFILE"
     set -x
     echo "Source of Podfile for nightly release testing is updated."
   fi
   if [ "$RELEASE_TESTING" == "prerelease_testing" ]; then
     set +x
-    sed -i "" '1i\'$'\n'"source 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsReleasing.git'"$'\n' quickstart-ios/"$SAMPLE"/Podfile
+    sed -i "" '1i\'$'\n'"source 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsReleasing.git'"$'\n' "$PODFILE"
     set -x
     echo "Source of Podfile for prerelease testing is updated."
   fi

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -18,12 +18,13 @@ REPO=`pwd`
 if [ ! -d "quickstart-ios" ]; then
   git clone https://github.com/firebase/quickstart-ios.git
 fi
+QS_SCRIPTS="${REPO}"/quickstart-ios/scripts
 cd quickstart-ios/"${SAMPLE}"
 if [[ ! -z "$LEGACY" ]]; then
   cd "Legacy${SAMPLE}Quickstart"
 fi
-chmod +x ../scripts/info_script.rb
-ruby ../scripts/info_script.rb "${SAMPLE}"
+chmod +x "${QS_SCRIPTS}"/info_script.rb
+ruby "${QS_SCRIPTS}"/info_script.rb "${SAMPLE}"
 
 mkdir -p Firebase/
 # Create non Firebase Frameworks and move to Firebase/ dir.
@@ -44,13 +45,13 @@ do
 done
 
 if [[ "${SAMPLE}" == "Authentication" ]]; then
-../scripts/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path usr/lib/libc++.dylib
-../scripts/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path accelerate.framework --source_tree DEVELOPER_FRAMEWORKS_DIR
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path usr/lib/libc++.dylib
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path accelerate.framework --source_tree DEVELOPER_FRAMEWORKS_DIR
 fi
 
 if [[ "${SAMPLE}" == "Firestore" ]]; then
-../scripts/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseAuthUI.bundle
-../scripts/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseEmailAuthUI.bundle
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseAuthUI.bundle
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseEmailAuthUI.bundle
 fi
 
-../scripts/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/
+"${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -20,11 +20,13 @@ if [ ! -d "quickstart-ios" ]; then
 fi
 QS_SCRIPTS="${REPO}"/quickstart-ios/scripts
 cd quickstart-ios/"${SAMPLE}"
+
+chmod +x "${QS_SCRIPTS}"/info_script.rb
+ruby "${QS_SCRIPTS}"/info_script.rb "${SAMPLE}" "${LEGACY:-}"
+
 if [[ ! -z "$LEGACY" ]]; then
   cd "Legacy${SAMPLE}Quickstart"
 fi
-chmod +x "${QS_SCRIPTS}"/info_script.rb
-ruby "${QS_SCRIPTS}"/info_script.rb "${SAMPLE}"
 
 mkdir -p Firebase/
 # Create non Firebase Frameworks and move to Firebase/ dir.
@@ -50,8 +52,8 @@ if [[ "${SAMPLE}" == "Authentication" ]]; then
 fi
 
 if [[ "${SAMPLE}" == "Firestore" ]]; then
-  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseAuthUI.bundle
-  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseUI.xcframework/Resources/FirebaseEmailAuthUI.bundle
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseAuthUI.xcframework/Resources/FirebaseAuthUI.bundle
+  "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/FirebaseEmailAuthUI.xcframework/Resources/FirebaseEmailAuthUI.bundle
 fi
 
 "${QS_SCRIPTS}"/add_framework_script.rb --sdk "${SAMPLE}" --target "${TARGET}" --framework_path Firebase/

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -20,7 +20,7 @@ if [ ! -d "quickstart-ios" ]; then
 fi
 cd quickstart-ios/"${SAMPLE}"
 if [[ ! -z "$LEGACY" ]]; then
-  cd "/Legacy${SAMPLE}Quickstart"
+  cd "Legacy${SAMPLE}Quickstart"
 fi
 chmod +x ../scripts/info_script.rb
 ruby ../scripts/info_script.rb "${SAMPLE}"

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -19,6 +19,9 @@ if [ ! -d "quickstart-ios" ]; then
   git clone https://github.com/firebase/quickstart-ios.git
 fi
 cd quickstart-ios/"${SAMPLE}"
+if [[ ! -z "$LEGACY" ]]; then
+  cd "/Legacy${SAMPLE}Quickstart"
+fi
 chmod +x ../scripts/info_script.rb
 ruby ../scripts/info_script.rb "${SAMPLE}"
 

--- a/scripts/test_quickstart_framework.sh
+++ b/scripts/test_quickstart_framework.sh
@@ -28,10 +28,12 @@ source scripts/check_secrets.sh
 
 if check_secrets; then
   cd quickstart-ios
+  if [[ -n "${LEGACY:-}" ]]; then
+    cd "Legacy${sample}Quickstart"
+  fi
   if [ "$platform" = "swift" ]; then
     have_secrets=true SAMPLE="$sample" SWIFT_SUFFIX="Swift" scripts/framework_test.sh
   else
     have_secrets=true SAMPLE="$sample" scripts/framework_test.sh
   fi
-
 fi

--- a/scripts/test_quickstart_framework.sh
+++ b/scripts/test_quickstart_framework.sh
@@ -28,9 +28,6 @@ source scripts/check_secrets.sh
 
 if check_secrets; then
   cd quickstart-ios
-  if [[ -n "${LEGACY:-}" ]]; then
-    cd "Legacy${sample}Quickstart"
-  fi
   if [ "$platform" = "swift" ]; then
     have_secrets=true SAMPLE="$sample" SWIFT_SUFFIX="Swift" scripts/framework_test.sh
   else


### PR DESCRIPTION
Update zip, release, and prerelease workflows for new crashlytics qs location

Please also review https://github.com/firebase/quickstart-ios/pull/1209

We really need to define a set of self-contained functions in the quickstart repo that can be called without side-effects or knowing directory structures.

Fix #8302