### PR TITLE
Fix API availability in AppCheck API build tests

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -66,7 +66,7 @@ final class AppCheckAPITests: NSObject {
 
     // Get token (async/await)
     #if swift(>=5.5)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         async {
           do {
@@ -100,7 +100,7 @@ final class AppCheckAPITests: NSObject {
 
       // Get token (async/await)
       #if swift(>=5.5)
-        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 15.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           async {
             do {
@@ -172,7 +172,7 @@ final class AppCheckAPITests: NSObject {
 
       // Get token (async/await)
       #if swift(>=5.5)
-        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 15.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           async {
             do {


### PR DESCRIPTION
I realized I labeled the API availability incorrectly for these tests. AppCheck is iOS only at the moment.

#no-changelog