### PR TITLE
Add tests for Update methods with empty dictionaries.

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -60,6 +60,27 @@ using firebase::firestore::util::TimerId;
   XCTAssertEqualObjects(result.data, finalData);
 }
 
+- (void)testCanUpdateAnExistingDocumentWithEmptyDictionary {
+  FIRDocumentReference *doc = [self.db documentWithPath:@"rooms/eros"];
+  NSDictionary<NSString *, id> *initialData =
+      @{@"desc" : @"Description", @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+  NSDictionary<NSString *, id> *updateData = @{};
+
+  [self writeDocumentRef:doc data:initialData];
+
+  XCTestExpectation *updateCompletion = [self expectationWithDescription:@"updateData"];
+  [doc updateData:updateData
+       completion:^(NSError *_Nullable error) {
+         XCTAssertNil(error);
+         [updateCompletion fulfill];
+       }];
+  [self awaitExpectations];
+
+  FIRDocumentSnapshot *result = [self readDocumentForRef:doc];
+  XCTAssertTrue(result.exists);
+  XCTAssertEqualObjects(result.data, initialData);
+}
+
 - (void)testCanUpdateAnUnknownDocument {
   [self readerAndWriterOnDocumentRef:^(FIRDocumentReference *readerRef,
                                        FIRDocumentReference *writerRef) {

--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
@@ -119,6 +119,22 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqualObjects(snapshot.data, (@{@"foo" : @"bar", @"baz" : @42}));
 }
 
+- (void)testUpdateWithEmptyDictionary {
+  FIRDocumentReference *doc = [self documentRef];
+  [self writeDocumentRef:doc data:@{@"foo" : @"bar"}];
+  XCTestExpectation *batchExpectation = [self expectationWithDescription:@"batch written"];
+  FIRWriteBatch *batch = [doc.firestore batch];
+  [batch updateData:@{} forDocument:doc];
+  [batch commitWithCompletion:^(NSError *error) {
+    XCTAssertNil(error);
+    [batchExpectation fulfill];
+  }];
+  [self awaitExpectations];
+  FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
+  XCTAssertTrue(snapshot.exists);
+  XCTAssertEqualObjects(snapshot.data, (@{@"foo" : @"bar"}));
+}
+
 - (void)testCannotUpdateNonexistentDocuments {
   FIRDocumentReference *doc = [self documentRef];
   XCTestExpectation *batchExpectation = [self expectationWithDescription:@"batch written"];

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -89,6 +89,10 @@ TransactionStage update2 = ^(FIRTransaction *transaction, FIRDocumentReference *
   [transaction updateData:@{@"foo" : @"bar2"} forDocument:doc];
 };
 
+TransactionStage update3 = ^(FIRTransaction *transaction, FIRDocumentReference *doc) {
+  [transaction updateData:@{} forDocument:doc];
+};
+
 TransactionStage set1 = ^(FIRTransaction *transaction, FIRDocumentReference *doc) {
   [transaction setData:@{@"foo" : @"bar1"} forDocument:doc];
 };
@@ -267,7 +271,7 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
   for (TransactionStage stage in self.stages) {
     if (stage == delete1) {
       [seqList addObject:@"delete"];
-    } else if (stage == update1 || stage == update2) {
+    } else if (stage == update1 || stage == update2 || stage == update3) {
       [seqList addObject:@"update"];
     } else if (stage == set1 || stage == set2) {
       [seqList addObject:@"set"];
@@ -292,6 +296,8 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
 
   [[[tt withExistingDoc] runWithStages:@[ get, update1, delete1 ]] expectNoDoc];
   [[[tt withExistingDoc] runWithStages:@[ get, update1, update2 ]] expectDoc:@{@"foo" : @"bar2"}];
+  [[[tt withExistingDoc] runWithStages:@[ get, update1, update2, update3 ]]
+      expectDoc:@{@"foo" : @"bar2"}];
   [[[tt withExistingDoc] runWithStages:@[ get, update1, set2 ]] expectDoc:@{@"foo" : @"bar2"}];
 
   [[[tt withExistingDoc] runWithStages:@[ get, set1, delete1 ]] expectNoDoc];
@@ -331,6 +337,8 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
 
   [[[tt withExistingDoc] runWithStages:@[ update1, delete1 ]] expectNoDoc];
   [[[tt withExistingDoc] runWithStages:@[ update1, update2 ]] expectDoc:@{@"foo" : @"bar2"}];
+  [[[tt withExistingDoc] runWithStages:@[ update1, update2, update3 ]]
+      expectDoc:@{@"foo" : @"bar2"}];
   [[[tt withExistingDoc] runWithStages:@[ update1, set2 ]] expectDoc:@{@"foo" : @"bar2"}];
 
   [[[tt withExistingDoc] runWithStages:@[ set1, delete1 ]] expectNoDoc];


### PR DESCRIPTION
The Update methods (document update, batch update, transaction update) are allowed to take an empty dictionary -- in which case they do not apply any updates to the document.