### PR TITLE
Fix the handling of Unicode characters in log and assertion messages

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.4.0
+- [fixed] Fixed handling of Unicode characters in log and assertion messages
+  (#8372).
+
 # v8.2.0
 - [changed] Passing in an empty document ID, collection group ID, or collection
   path will now result in a more readable error (#8218).

--- a/Firestore/core/src/util/exception_apple.mm
+++ b/Firestore/core/src/util/exception_apple.mm
@@ -60,8 +60,8 @@ ABSL_ATTRIBUTE_NORETURN void ObjcThrowHandler(ExceptionType type,
         handleFailureInFunction:MakeNSString(func)
                            file:MakeNSString(file)
                      lineNumber:line
-                    description:@"%@: %s", ExceptionName(type),
-                                message.c_str()];
+                    description:@"%@: %@", ExceptionName(type),
+                                MakeNSString(message)];
     std::terminate();
   } else {
     @throw MakeException(type, message);  // NOLINT

--- a/Firestore/core/src/util/log_apple.mm
+++ b/Firestore/core/src/util/log_apple.mm
@@ -85,7 +85,7 @@ bool LogIsLoggable(LogLevel level) {
 }
 
 void LogMessage(LogLevel level, const std::string& message) {
-  LogMessageV(level, @"%s", message.c_str());
+  LogMessageV(level, @"%@", MakeNSString(message));
 }
 
 }  // namespace util


### PR DESCRIPTION
Currently, any UTF-8 characters outside the ascii set may be encoded incorrectly.