### PR TITLE
Cherrypick 8.3.1 SPM patch into master

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 8.3.1
+- [fixed] Swift Package Manager only release to fix an 8.3.0 tagging issue impacting some users. (#8367)
+
 # Firebase 8.2.0
 - [fixed] Stop flooding Swift Package Manager projects with Firebase test schemes. (#8167)
 - [fixed] Removed "Invalid Exclude" warnings for Swift Package Manager using Xcode 13 beta 1.

--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,7 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
-      .exact("8.3.0")
+      .exact("8.3.1")
     ),
     .package(
       name: "GoogleDataTransport",


### PR DESCRIPTION
Cherrypicking latest [8.3.1 patch commit](../commit/ed87539cda9cfb3a3de1be22354c6e74760db91b) from [`release-8.3`](../commits/release-8.3) branch to keep `master` in sync for M100.

#no-changelog