### PR TITLE
Convert Objective-C Classes to Nanopb

### DIFF
--- a/FirebasePerformance/Sources/FPRClient.m
+++ b/FirebasePerformance/Sources/FPRClient.m
@@ -209,8 +209,8 @@
     return;
   }
   dispatch_group_async(self.eventsQueueGroup, self.eventsQueue, ^{
-    FPRMSGNetworkRequestMetric *networkRequestMetric = FPRGetNetworkRequestMetric(trace);
-    if (networkRequestMetric) {
+    if (trace.hasValidResponseCode) {
+      FPRMSGNetworkRequestMetric *networkRequestMetric = FPRGetNetworkRequestMetric(trace);
       int64_t duration = networkRequestMetric.hasTimeToResponseCompletedUs
                              ? networkRequestMetric.timeToResponseCompletedUs
                              : 0;
@@ -237,7 +237,10 @@
   }
   dispatch_group_async(self.eventsQueueGroup, self.eventsQueue, ^{
     FPRMSGPerfMetric *metric = FPRGetPerfMetricMessage(self.config.appID);
-    FPRMSGGaugeMetric *gaugeMetric = FPRGetGaugeMetric(gaugeData, sessionId);
+    FPRMSGGaugeMetric *gaugeMetric = nil;
+    if ((gaugeData != nil && gaugeData.count != 0) && (sessionId != nil && sessionId.length != 0)) {
+      gaugeMetric = FPRGetGaugeMetric(gaugeData, sessionId);
+    }
     metric.gaugeMetric = gaugeMetric;
     [self processAndLogEvent:metric];
   });

--- a/FirebasePerformance/Sources/FPRClient.m
+++ b/FirebasePerformance/Sources/FPRClient.m
@@ -209,7 +209,7 @@
     return;
   }
   dispatch_group_async(self.eventsQueueGroup, self.eventsQueue, ^{
-    if (trace.hasValidResponseCode) {
+    if ([trace isValid]) {
       FPRMSGNetworkRequestMetric *networkRequestMetric = FPRGetNetworkRequestMetric(trace);
       int64_t duration = networkRequestMetric.hasTimeToResponseCompletedUs
                              ? networkRequestMetric.timeToResponseCompletedUs

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.h
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.h
@@ -24,33 +24,83 @@
 
 #import "FirebasePerformance/Sources/Protogen/nanopb/perf_metric.nanopb.h"
 
+/**nanopb struct of encoded NSDictionary<NSString *, NSString *>.*/
 typedef struct {
   pb_bytes_array_t* _Nonnull key;
   pb_bytes_array_t* _Nonnull value;
 } StringToStringMap;
 
+/**nanopb struct of encoded NSDictionary<NSString *, NSNumber *>.*/
 typedef struct {
   pb_bytes_array_t* _Nonnull key;
   bool has_value;
   int64_t value;
 } StringToNumberMap;
 
+/** Callocs a pb_bytes_array and copies the given NSData bytes into the bytes array.
+ *
+ * @note Memory needs to be free manually, through pb_free or pb_release.
+ * @param data The data to copy into the new bytes array.
+ * @return pb_byte array
+ */
 extern pb_bytes_array_t* _Nullable FPREncodeData(NSData* _Nonnull data);
 
+/** Callocs a pb_bytes_array and copies the given NSString's bytes into the bytes array.
+ *
+ * @note Memory needs to be free manually, through pb_free or pb_release.
+ * @param string The string to encode as pb_bytes.
+ * @return pb_byte array
+ */
 extern pb_bytes_array_t* _Nullable FPREncodeString(NSString* _Nonnull string);
 
+/** Creates a NSData object by copying the given bytes array and returns the reference.
+ *
+ * @param pbData The pbData to dedoded as NSData
+ * @return A reference to NSData
+ */
 extern NSData* _Nullable FPRDecodeData(pb_bytes_array_t* _Nonnull pbData);
 
+/** Creates a NSString object by copying the given bytes array and returns the reference.
+ *
+ * @param pbData The pbData to dedoded as NSString
+ * @return A reference to the NSString
+ */
 extern NSString* _Nullable FPRDecodeString(pb_bytes_array_t* _Nonnull pbData);
 
+/** Creates a NSDictionary by copying the given bytes from the StringToStringMap object and returns
+ * the reference.
+ *
+ * @param map The reference to a StringToStringMap object to be decoded.
+ * @param count The number of entries in the dictionary.
+ * @return A reference to the dictionary
+ */
 extern NSDictionary<NSString*, NSString*>* _Nullable FPRDecodeStringToStringMap(
     StringToStringMap* _Nullable map, NSInteger count);
 
+/** Callocs a nanopb StringToStringMap and copies the given NSDictionary bytes into the
+ * StringToStringMap.
+ *
+ * @param dict The dict to copy into the new StringToStringMap.
+ * @return A reference to StringToStringMap
+ */
 extern StringToStringMap* _Nullable FPREncodeStringToStringMap(NSDictionary* _Nullable dict);
 
+/** Creates a NSDictionary by copying the given bytes from the StringToNumberMap object and returns
+ * the reference.
+ *
+ * @param map The reference to a StringToNumberMap object to be decoded.
+ * @param count The number of entries in the dictionary.
+ * @return A reference to the dictionary
+ */
 extern NSDictionary<NSString*, NSNumber*>* _Nullable FPRDecodeStringToNumberMap(
     StringToNumberMap* _Nullable map, NSInteger count);
 
+/** Callocs a nanopb StringToNumberMap and copies the given NSDictionary bytes into the
+ * StringToStringMap.
+ *
+ * @param dict The dict to copy into the new StringToNumberMap.
+ * @return A reference to StringToNumberMap
+ */
 extern StringToNumberMap* _Nullable FPREncodeStringToNumberMap(NSDictionary* _Nullable dict);
 
 /** Creates a new firebase_perf_v1_PerfMetric struct populated with system metadata.

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.h
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.h
@@ -1,0 +1,94 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <TargetConditionals.h>
+#if __has_include("CoreTelephony/CTTelephonyNetworkInfo.h") && !TARGET_OS_MACCATALYST
+#define TARGET_HAS_MOBILE_CONNECTIVITY
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#endif
+
+#import "FirebasePerformance/Sources/AppActivity/FPRTraceBackgroundActivityTracker.h"
+#import "FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h"
+#import "FirebasePerformance/Sources/Public/FIRTrace.h"
+
+#import "FirebasePerformance/Sources/Protogen/nanopb/perf_metric.nanopb.h"
+
+typedef struct {
+  pb_bytes_array_t* _Nonnull key;
+  pb_bytes_array_t* _Nonnull value;
+} StringToStringMap;
+
+typedef struct {
+  pb_bytes_array_t* _Nonnull key;
+  bool has_value;
+  int64_t value;
+} StringToNumberMap;
+
+extern pb_bytes_array_t* _Nullable FPREncodeData(NSData* _Nonnull data);
+
+extern pb_bytes_array_t* _Nullable FPREncodeString(NSString* _Nonnull string);
+
+extern NSData* _Nullable FPRDecodeData(pb_bytes_array_t* _Nonnull pbData);
+
+extern NSString* _Nullable FPRDecodeString(pb_bytes_array_t* _Nonnull pbData);
+
+extern NSDictionary<NSString*, NSString*>* _Nullable FPRDecodeStringToStringMap(
+    StringToStringMap* _Nullable map, NSInteger count);
+
+extern StringToStringMap* _Nullable FPREncodeStringToStringMap(NSDictionary* _Nullable dict);
+
+extern NSDictionary<NSString*, NSNumber*>* _Nullable FPRDecodeStringToNumberMap(
+    StringToNumberMap* _Nullable map, NSInteger count);
+
+extern StringToNumberMap* _Nullable FPREncodeStringToNumberMap(NSDictionary* _Nullable dict);
+
+/** Creates a new firebase_perf_v1_PerfMetric struct populated with system metadata.
+ *  @param appID The Google app id to put into the message
+ *  @return A firebase_perf_v1_PerfMetric struct.
+ */
+extern firebase_perf_v1_PerfMetric GetPerfMetricMessage(NSString* _Nonnull appID);
+
+/** Creates a new firebase_perf_v1_ApplicationInfo struct populated with system metadata.
+ *  @return A firebase_perf_v1_ApplicationInfo struct.
+ */
+extern firebase_perf_v1_ApplicationInfo GetApplicationInfoMessage(void);
+
+/** Converts the FIRTrace object to a firebase_perf_v1_TraceMetric struct.
+ *  @return A firebase_perf_v1_TraceMetric struct.
+ */
+extern firebase_perf_v1_TraceMetric GetTraceMetric(FIRTrace* _Nonnull trace);
+
+/** Converts the FPRNetworkTrace object to a firebase_perf_v1_NetworkRequestMetric struct.
+ *  @return A firebase_perf_v1_NetworkRequestMetric struct.
+ */
+extern firebase_perf_v1_NetworkRequestMetric GetNetworkRequestMetric(
+    FPRNetworkTrace* _Nonnull trace);
+
+/** Converts the gaugeData array object to a firebase_perf_v1_GaugeMetric struct.
+ *  @return A firebase_perf_v1_GaugeMetric struct.
+ */
+extern firebase_perf_v1_GaugeMetric GetGaugeMetric(NSArray* _Nonnull gaugeData,
+                                                   NSString* _Nonnull sessionId);
+
+/** Converts the FPRTraceState to a firebase_perf_v1_ApplicationProcessState struct.
+ *  @return A firebase_perf_v1_ApplicationProcessState struct.
+ */
+extern firebase_perf_v1_ApplicationProcessState ApplicationProcessState(FPRTraceState state);
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+/** Obtain a CTTelephonyNetworkInfo object to determine device network attributes.
+ *  @return CTTelephonyNetworkInfo object.
+ */
+extern CTTelephonyNetworkInfo* _Nullable NetworkInfo(void);
+#endif

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -483,13 +483,13 @@ NSArray<FPRSessionDetails *> *MakeFirstSessionVerbose(NSArray<FPRSessionDetails 
   NSMutableArray<FPRSessionDetails *> *orderedSessions =
       [[NSMutableArray<FPRSessionDetails *> alloc] initWithArray:sessions];
 
-  __block NSInteger firstVerboseSessionIndex = -1;
-  [sessions enumerateObjectsUsingBlock:^(FPRSessionDetails *session, NSUInteger idx, BOOL *stop) {
-    if ([session isVerbose]) {
-      firstVerboseSessionIndex = idx;
-      *stop = YES;
+  NSInteger firstVerboseSessionIndex = -1;
+  for (int i = 0; i < [sessions count]; i++) {
+    if ([sessions[i] isVerbose]) {
+      firstVerboseSessionIndex = i;
+      break;
     }
-  }];
+  }
 
   if (firstVerboseSessionIndex > 0) {
     FPRSessionDetails *verboseSession = orderedSessions[firstVerboseSessionIndex];

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -142,6 +142,7 @@ struct _firebase_perf_v1_PerfSession *FPREncodePerfSessions(NSArray<FPRSessionDe
 firebase_perf_v1_PerfMetric GetPerfMetricMessage(NSString *appID) {
   firebase_perf_v1_PerfMetric perfMetricMessage = firebase_perf_v1_PerfMetric_init_default;
   perfMetricMessage.application_info = GetApplicationInfoMessage();
+  perfMetricMessage.has_application_info = true;
   perfMetricMessage.application_info.google_app_id = FPREncodeString(appID);
 
   return perfMetricMessage;

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -1,0 +1,501 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebasePerformance/Sources/FPRNanoPbUtils.h"
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#endif
+#import <SystemConfiguration/SystemConfiguration.h>
+
+#import "FirebasePerformance/Sources/Common/FPRConstants.h"
+#import "FirebasePerformance/Sources/FIRPerformance+Internal.h"
+#import "FirebasePerformance/Sources/FPRDataUtils.h"
+#import "FirebasePerformance/Sources/Public/FIRPerformance.h"
+#import "FirebasePerformance/Sources/Timer/FIRTrace+Internal.h"
+#import "FirebasePerformance/Sources/Timer/FIRTrace+Private.h"
+
+#import "FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeData.h"
+#import "FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeData.h"
+
+#define BYTES_TO_KB(x) (x / 1024)
+
+static firebase_perf_v1_NetworkRequestMetric_HttpMethod FPRHTTPMethodForString(
+    NSString *methodString);
+static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType(void);
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkType(void);
+#endif
+NSArray<FPRSessionDetails *> *FPRMakeFirstSessionVerbose(NSArray<FPRSessionDetails *> *sessions);
+
+#pragma mark - Nanopb decode and encode helper methods
+
+pb_bytes_array_t *FPREncodeData(NSData *data) {
+  pb_bytes_array_t *pbBytesArray = calloc(1, PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
+  if (pbBytesArray != NULL) {
+    [data getBytes:pbBytesArray->bytes length:data.length];
+    pbBytesArray->size = (pb_size_t)data.length;
+  }
+  return pbBytesArray;
+}
+
+pb_bytes_array_t *FPREncodeString(NSString *string) {
+  NSData *stringBytes = [string dataUsingEncoding:NSUTF8StringEncoding];
+  return FPREncodeData(stringBytes);
+}
+
+NSData *FPRDecodeData(pb_bytes_array_t *pbData) {
+  NSData *data = [NSData dataWithBytes:&(pbData->bytes) length:pbData->size];
+  return data;
+}
+
+NSString *FPRDecodeString(pb_bytes_array_t *pbData) {
+  NSData *data = FPRDecodeData(pbData);
+  return [NSString stringWithCString:[data bytes] encoding:NSUTF8StringEncoding];
+}
+
+StringToStringMap *_Nullable FPREncodeStringToStringMap(NSDictionary *_Nullable dict) {
+  StringToStringMap *map = calloc(dict.count, sizeof(StringToStringMap));
+  __block NSUInteger index = 0;
+  [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+    map[index].key = FPREncodeString(key);
+    map[index].value = FPREncodeString(value);
+    index++;
+  }];
+  return map;
+}
+
+NSDictionary<NSString *, NSString *> *FPRDecodeStringToStringMap(StringToStringMap *map,
+                                                                 NSInteger count) {
+  NSMutableDictionary<NSString *, NSString *> *dict = [NSMutableDictionary dictionary];
+  for (int i = 0; i < count; i++) {
+    NSString *key = FPRDecodeString(map[i].key);
+    NSString *value = FPRDecodeString(map[i].value);
+    dict[key] = value;
+  }
+  return [dict copy];
+}
+
+StringToNumberMap *_Nullable FPREncodeStringToNumberMap(NSDictionary *_Nullable dict) {
+  StringToNumberMap *map = calloc(dict.count, sizeof(StringToNumberMap));
+  __block NSUInteger index = 0;
+  [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
+    map[index].key = FPREncodeString(key);
+    map[index].value = [value longLongValue];
+    map[index].has_value = true;
+    index++;
+  }];
+  return map;
+}
+
+NSDictionary<NSString *, NSNumber *> *_Nullable FPRDecodeStringToNumberMap(
+    StringToNumberMap *_Nullable map, NSInteger count) {
+  NSMutableDictionary<NSString *, NSNumber *> *dict = [NSMutableDictionary dictionary];
+  for (int i = 0; i < count; i++) {
+    if (map[i].has_value) {
+      NSString *key = FPRDecodeString(map[i].key);
+      NSNumber *value = [NSNumber numberWithLongLong:map[i].value];
+      dict[key] = value;
+    }
+  }
+  return [dict copy];
+}
+
+struct _firebase_perf_v1_PerfSession *FPREncodePerfSessions(NSArray<FPRSessionDetails *> *sessions,
+                                                            NSInteger count) {
+  struct _firebase_perf_v1_PerfSession *perfSessions =
+      calloc(count, sizeof(firebase_perf_v1_PerfSession));
+  __block NSUInteger perfSessionIndex = 0;
+
+  [sessions enumerateObjectsUsingBlock:^(FPRSessionDetails *_Nonnull session, NSUInteger index,
+                                         BOOL *_Nonnull stop) {
+    perfSessions[perfSessionIndex].session_id = FPREncodeString(session.sessionId);
+    perfSessions[perfSessionIndex].session_verbosity_count = 0;
+    if ((session.options & FPRSessionOptionsEvents) ||
+        (session.options & FPRSessionOptionsGauges)) {
+      perfSessions[perfSessionIndex].session_verbosity =
+          calloc(perfSessions[perfSessionIndex].session_verbosity_count,
+                 sizeof(firebase_perf_v1_SessionVerbosity));
+      perfSessions[perfSessionIndex].session_verbosity[0] =
+          firebase_perf_v1_SessionVerbosity_GAUGES_AND_SYSTEM_EVENTS;
+      perfSessions[perfSessionIndex].session_verbosity_count = 1;
+    }
+    perfSessionIndex++;
+  }];
+  return perfSessions;
+}
+
+#pragma mark - Public methods
+
+firebase_perf_v1_PerfMetric GetPerfMetricMessage(NSString *appID) {
+  firebase_perf_v1_PerfMetric perfMetricMessage = firebase_perf_v1_PerfMetric_init_default;
+  perfMetricMessage.application_info = GetApplicationInfoMessage();
+  perfMetricMessage.application_info.google_app_id = FPREncodeString(appID);
+
+  return perfMetricMessage;
+}
+
+firebase_perf_v1_ApplicationInfo GetApplicationInfoMessage() {
+  firebase_perf_v1_ApplicationInfo appInfoMessage = firebase_perf_v1_ApplicationInfo_init_default;
+  firebase_perf_v1_IosApplicationInfo iosAppInfo = firebase_perf_v1_IosApplicationInfo_init_default;
+  NSBundle *mainBundle = [NSBundle mainBundle];
+  iosAppInfo.bundle_short_version =
+      FPREncodeString([mainBundle infoDictionary][@"CFBundleShortVersionString"]);
+  iosAppInfo.sdk_version = FPREncodeString([NSString stringWithUTF8String:kFPRSDKVersion]);
+  iosAppInfo.network_connection_info.network_type = FPRNetworkConnectionInfoNetworkType();
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+  CTTelephonyNetworkInfo *networkInfo = NetworkInfo();
+  CTCarrier *provider = networkInfo.subscriberCellularProvider;
+  NSString *mccMnc = FPRValidatedMccMnc(provider.mobileCountryCode, provider.mobileNetworkCode);
+  if (mccMnc) {
+    iosAppInfo.mcc_mnc = FPREncodeString(mccMnc);
+  }
+  if (iosAppInfo.network_connection_info.network_type ==
+      firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE) {
+    iosAppInfo.network_connection_info.mobile_subtype = FPRCellularNetworkType();
+  }
+#endif
+  appInfoMessage.ios_app_info = iosAppInfo;
+
+  NSDictionary<NSString *, NSString *> *attributes =
+      [[FIRPerformance sharedInstance].attributes mutableCopy];
+  appInfoMessage.custom_attributes_count = attributes.count;
+  appInfoMessage.custom_attributes =
+      (struct _firebase_perf_v1_ApplicationInfo_CustomAttributesEntry *)FPREncodeStringToStringMap(
+          attributes);
+
+  return appInfoMessage;
+}
+
+firebase_perf_v1_TraceMetric GetTraceMetric(FIRTrace *trace) {
+  firebase_perf_v1_TraceMetric traceMetric = firebase_perf_v1_TraceMetric_init_default;
+  traceMetric.name = FPREncodeString(trace.name);
+
+  // Set if the trace is an internally created trace.
+  traceMetric.is_auto = trace.isInternal;
+  traceMetric.has_is_auto = true;
+
+  // Convert the trace duration from seconds to microseconds.
+  traceMetric.duration_us = trace.totalTraceTimeInterval * USEC_PER_SEC;
+  traceMetric.has_duration_us = true;
+
+  // Convert the start time from seconds to microseconds.
+  traceMetric.client_start_time_us = trace.startTimeSinceEpoch * USEC_PER_SEC;
+  traceMetric.has_client_start_time_us = true;
+
+  // Filling counters
+  NSDictionary<NSString *, NSNumber *> *counters = trace.counters;
+  traceMetric.counters_count = counters.count;
+  traceMetric.counters =
+      (struct _firebase_perf_v1_TraceMetric_CountersEntry *)FPREncodeStringToNumberMap(counters);
+
+  // Filling subtraces
+  traceMetric.subtraces_count = [trace.stages count];
+  struct _firebase_perf_v1_TraceMetric *subtraces =
+      calloc(traceMetric.subtraces_count, sizeof(firebase_perf_v1_TraceMetric));
+  __block NSUInteger subtraceIndex = 0;
+  [trace.stages
+      enumerateObjectsUsingBlock:^(FIRTrace *_Nonnull stage, NSUInteger idx, BOOL *_Nonnull stop) {
+        subtraces[subtraceIndex] = GetTraceMetric(stage);
+        subtraceIndex++;
+      }];
+  traceMetric.subtraces = subtraces;
+
+  // Filling custom attributes
+  NSDictionary<NSString *, NSString *> *attributes = [trace.attributes mutableCopy];
+  traceMetric.custom_attributes_count = attributes.count;
+  traceMetric.custom_attributes =
+      (struct _firebase_perf_v1_TraceMetric_CustomAttributesEntry *)FPREncodeStringToStringMap(
+          attributes);
+
+  // Filling session details
+  NSArray<FPRSessionDetails *> *orderedSessions = FPRMakeFirstSessionVerbose(trace.sessions);
+  traceMetric.perf_sessions_count = [orderedSessions count];
+  traceMetric.perf_sessions =
+      FPREncodePerfSessions(orderedSessions, traceMetric.perf_sessions_count);
+
+  return traceMetric;
+}
+
+firebase_perf_v1_NetworkRequestMetric GetNetworkRequestMetric(FPRNetworkTrace *trace) {
+  firebase_perf_v1_NetworkRequestMetric networkMetric =
+      firebase_perf_v1_NetworkRequestMetric_init_default;
+  networkMetric.url = FPREncodeString(trace.trimmedURLString);
+  networkMetric.http_method = FPRHTTPMethodForString(trace.URLRequest.HTTPMethod);
+  networkMetric.has_http_method = true;
+
+  // Convert the start time from seconds to microseconds.
+  networkMetric.client_start_time_us = trace.startTimeSinceEpoch * USEC_PER_SEC;
+  networkMetric.has_client_start_time_us = true;
+
+  networkMetric.request_payload_bytes = trace.requestSize;
+  networkMetric.has_request_payload_bytes = true;
+  networkMetric.response_payload_bytes = trace.responseSize;
+  networkMetric.has_response_payload_bytes = true;
+
+  networkMetric.http_response_code = trace.responseCode;
+  networkMetric.has_http_response_code = true;
+  networkMetric.response_content_type = FPREncodeString(trace.responseContentType);
+
+  if (trace.responseError) {
+    networkMetric.network_client_error_reason =
+        firebase_perf_v1_NetworkRequestMetric_NetworkClientErrorReason_GENERIC_CLIENT_ERROR;
+    networkMetric.has_network_client_error_reason = true;
+  }
+
+  NSTimeInterval requestTimeUs =
+      USEC_PER_SEC *
+      [trace timeIntervalBetweenCheckpointState:FPRNetworkTraceCheckpointStateInitiated
+                                       andState:FPRNetworkTraceCheckpointStateRequestCompleted];
+  if (requestTimeUs > 0) {
+    networkMetric.time_to_request_completed_us = requestTimeUs;
+    networkMetric.has_time_to_request_completed_us = true;
+  }
+
+  NSTimeInterval responseIntiationTimeUs =
+      USEC_PER_SEC *
+      [trace timeIntervalBetweenCheckpointState:FPRNetworkTraceCheckpointStateInitiated
+                                       andState:FPRNetworkTraceCheckpointStateResponseReceived];
+  if (responseIntiationTimeUs > 0) {
+    networkMetric.time_to_response_initiated_us = responseIntiationTimeUs;
+    networkMetric.has_time_to_response_initiated_us = true;
+  }
+
+  NSTimeInterval responseCompletedUs =
+      USEC_PER_SEC *
+      [trace timeIntervalBetweenCheckpointState:FPRNetworkTraceCheckpointStateInitiated
+                                       andState:FPRNetworkTraceCheckpointStateResponseCompleted];
+  if (responseCompletedUs > 0) {
+    networkMetric.time_to_response_completed_us = responseCompletedUs;
+    networkMetric.has_time_to_response_completed_us = true;
+  }
+
+  // Filling custom attributes
+  NSDictionary<NSString *, NSString *> *attributes = [trace.attributes mutableCopy];
+  networkMetric.custom_attributes_count = attributes.count;
+  networkMetric.custom_attributes =
+      (struct _firebase_perf_v1_NetworkRequestMetric_CustomAttributesEntry *)
+          FPREncodeStringToStringMap(attributes);
+
+  // Filling session details
+  NSArray<FPRSessionDetails *> *orderedSessions = FPRMakeFirstSessionVerbose(trace.sessions);
+  networkMetric.perf_sessions_count = [orderedSessions count];
+  networkMetric.perf_sessions =
+      FPREncodePerfSessions(orderedSessions, networkMetric.perf_sessions_count);
+
+  return networkMetric;
+}
+
+firebase_perf_v1_GaugeMetric GetGaugeMetric(NSArray *gaugeData, NSString *sessionId) {
+  firebase_perf_v1_GaugeMetric gaugeMetric = firebase_perf_v1_GaugeMetric_init_default;
+  gaugeMetric.session_id = FPREncodeString(sessionId);
+
+  __block NSInteger cpuReadingsCount = 0;
+  __block NSInteger memoryReadingsCount = 0;
+
+  struct _firebase_perf_v1_CpuMetricReading *cpuReadings =
+      calloc([gaugeData count], sizeof(firebase_perf_v1_CpuMetricReading));
+  struct _firebase_perf_v1_IosMemoryReading *memoryReadings =
+      calloc([gaugeData count], sizeof(firebase_perf_v1_IosMemoryReading));
+  [gaugeData enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    if ([obj isKindOfClass:[FPRCPUGaugeData class]]) {
+      FPRCPUGaugeData *gaugeData = (FPRCPUGaugeData *)obj;
+      cpuReadings[cpuReadingsCount].client_time_us =
+          gaugeData.collectionTime.timeIntervalSince1970 * USEC_PER_SEC;
+      cpuReadings[cpuReadingsCount].has_client_time_us = true;
+      cpuReadings[cpuReadingsCount].system_time_us = gaugeData.systemTime;
+      cpuReadings[cpuReadingsCount].has_system_time_us = true;
+      cpuReadings[cpuReadingsCount].user_time_us = gaugeData.userTime;
+      cpuReadings[cpuReadingsCount].has_user_time_us = true;
+      cpuReadingsCount++;
+    }
+
+    if ([obj isKindOfClass:[FPRMemoryGaugeData class]]) {
+      FPRMemoryGaugeData *gaugeData = (FPRMemoryGaugeData *)obj;
+      memoryReadings[memoryReadingsCount].client_time_us =
+          gaugeData.collectionTime.timeIntervalSince1970 * USEC_PER_SEC;
+      memoryReadings[memoryReadingsCount].has_client_time_us = true;
+      memoryReadings[memoryReadingsCount].used_app_heap_memory_kb =
+          (int32_t)BYTES_TO_KB(gaugeData.heapUsed);
+      memoryReadings[memoryReadingsCount].has_used_app_heap_memory_kb = true;
+      memoryReadings[memoryReadingsCount].free_app_heap_memory_kb =
+          (int32_t)BYTES_TO_KB(gaugeData.heapAvailable);
+      memoryReadings[memoryReadingsCount].has_free_app_heap_memory_kb = true;
+      memoryReadingsCount++;
+    }
+  }];
+  cpuReadings = realloc(cpuReadings, cpuReadingsCount * sizeof(firebase_perf_v1_CpuMetricReading));
+  memoryReadings =
+      realloc(memoryReadings, memoryReadingsCount * sizeof(firebase_perf_v1_IosMemoryReading));
+
+  gaugeMetric.cpu_metric_readings = cpuReadings;
+  gaugeMetric.cpu_metric_readings_count = cpuReadingsCount;
+  gaugeMetric.ios_memory_readings = memoryReadings;
+  gaugeMetric.ios_memory_readings_count = memoryReadingsCount;
+  return gaugeMetric;
+}
+
+firebase_perf_v1_ApplicationProcessState ApplicationProcessState(FPRTraceState state) {
+  firebase_perf_v1_ApplicationProcessState processState =
+      firebase_perf_v1_ApplicationProcessState_APPLICATION_PROCESS_STATE_UNKNOWN;
+  switch (state) {
+    case FPRTraceStateForegroundOnly:
+      processState = firebase_perf_v1_ApplicationProcessState_FOREGROUND;
+      break;
+
+    case FPRTraceStateBackgroundOnly:
+      processState = firebase_perf_v1_ApplicationProcessState_BACKGROUND;
+      break;
+
+    case FPRTraceStateBackgroundAndForeground:
+      processState = firebase_perf_v1_ApplicationProcessState_FOREGROUND_BACKGROUND;
+      break;
+
+    default:
+      break;
+  }
+
+  return processState;
+}
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+CTTelephonyNetworkInfo *NetworkInfo() {
+  static CTTelephonyNetworkInfo *networkInfo;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    networkInfo = [[CTTelephonyNetworkInfo alloc] init];
+  });
+  return networkInfo;
+}
+#endif
+
+#pragma mark - Nanopb creation utilities
+
+/** Converts the network method string to a value defined in the enum
+ *  firebase_perf_v1_NetworkRequestMetric_HttpMethod.
+ *  @return Enum value of the method string. If there is no mapping value defined for the method
+ * firebase_perf_v1_NetworkRequestMetric_HttpMethod_HTTP_METHOD_UNKNOWN is returned.
+ */
+static firebase_perf_v1_NetworkRequestMetric_HttpMethod FPRHTTPMethodForString(
+    NSString *methodString) {
+  static NSDictionary<NSString *, NSNumber *> *HTTPToFPRNetworkTraceMethod;
+  static dispatch_once_t onceToken = 0;
+  dispatch_once(&onceToken, ^{
+    HTTPToFPRNetworkTraceMethod = @{
+      @"GET" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_GET),
+      @"POST" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_POST),
+      @"PUT" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_PUT),
+      @"DELETE" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_DELETE),
+      @"HEAD" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_HEAD),
+      @"PATCH" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_PATCH),
+      @"OPTIONS" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_OPTIONS),
+      @"TRACE" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_TRACE),
+      @"CONNECT" : @(firebase_perf_v1_NetworkRequestMetric_HttpMethod_CONNECT),
+    };
+  });
+
+  NSNumber *HTTPMethod = HTTPToFPRNetworkTraceMethod[methodString];
+  if (HTTPMethod == nil) {
+    return firebase_perf_v1_NetworkRequestMetric_HttpMethod_HTTP_METHOD_UNKNOWN;
+  }
+  return HTTPMethod.intValue;
+}
+
+/** Get the current network connection type in firebase_perf_v1_NetworkConnectionInfo_NetworkType
+ * format.
+ *  @return Current network connection type.
+ */
+static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType() {
+  firebase_perf_v1_NetworkConnectionInfo_NetworkType networkType =
+      firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
+
+  static SCNetworkReachabilityRef reachabilityRef = 0;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    reachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorSystemDefault, "google.com");
+  });
+
+  SCNetworkReachabilityFlags reachabilityFlags = 0;
+  SCNetworkReachabilityGetFlags(reachabilityRef, &reachabilityFlags);
+
+  // Parse the network flags to set the network type.
+  if (reachabilityFlags & kSCNetworkReachabilityFlagsReachable) {
+    if (reachabilityFlags & kSCNetworkReachabilityFlagsIsWWAN) {
+      networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE;
+    } else {
+      networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_WIFI;
+    }
+  }
+
+  return networkType;
+}
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+/** Get the current cellular network connection type in
+ * firebase_perf_v1_NetworkConnectionInfo_MobileSubtype format.
+ *  @return Current cellular network connection type.
+ */
+static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkType() {
+  static NSDictionary<NSString *, NSNumber *> *cellularNetworkToMobileSubtype;
+  static dispatch_once_t onceToken = 0;
+  dispatch_once(&onceToken, ^{
+    cellularNetworkToMobileSubtype = @{
+      CTRadioAccessTechnologyGPRS : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_GPRS),
+      CTRadioAccessTechnologyEdge : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_EDGE),
+      CTRadioAccessTechnologyWCDMA : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_CDMA),
+      CTRadioAccessTechnologyHSDPA : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_HSDPA),
+      CTRadioAccessTechnologyHSUPA : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_HSUPA),
+      CTRadioAccessTechnologyCDMA1x : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_CDMA),
+      CTRadioAccessTechnologyCDMAEVDORev0 :
+          @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_EVDO_0),
+      CTRadioAccessTechnologyCDMAEVDORevA :
+          @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_EVDO_A),
+      CTRadioAccessTechnologyCDMAEVDORevB :
+          @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_EVDO_B),
+      CTRadioAccessTechnologyeHRPD : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_EHRPD),
+      CTRadioAccessTechnologyLTE : @(firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_LTE)
+    };
+  });
+
+  NSString *networkString = NetworkInfo().currentRadioAccessTechnology;
+  NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
+  return cellularNetworkType.intValue;
+}
+#endif
+
+/** Reorders the list of sessions to make sure the first session is verbose if at least one session
+ *  in the list is verbose.
+ *  @return Ordered list of sessions.
+ */
+NSArray<FPRSessionDetails *> *MakeFirstSessionVerbose(NSArray<FPRSessionDetails *> *sessions) {
+  NSMutableArray<FPRSessionDetails *> *orderedSessions =
+      [[NSMutableArray<FPRSessionDetails *> alloc] initWithArray:sessions];
+
+  __block NSInteger firstVerboseSessionIndex = -1;
+  [sessions enumerateObjectsUsingBlock:^(FPRSessionDetails *session, NSUInteger idx, BOOL *stop) {
+    if ([session isVerbose]) {
+      firstVerboseSessionIndex = idx;
+      *stop = YES;
+    }
+  }];
+
+  if (firstVerboseSessionIndex > 0) {
+    FPRSessionDetails *verboseSession = orderedSessions[firstVerboseSessionIndex];
+    [orderedSessions removeObjectAtIndex:firstVerboseSessionIndex];
+    [orderedSessions insertObject:verboseSession atIndex:0];
+  }
+
+  return [orderedSessions copy];
+}

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h
@@ -184,5 +184,11 @@ typedef NS_ENUM(NSInteger, FPRNetworkTraceCheckpointState) {
  */
 - (NSTimeInterval)timeIntervalBetweenCheckpointState:(FPRNetworkTraceCheckpointState)startState
                                             andState:(FPRNetworkTraceCheckpointState)endState;
+/**
+ * Checks if the network trace is valid.
+ *
+ * @return true if the network trace is valid.
+ */
+- (BOOL)isValid;
 
 @end

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -443,4 +443,8 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
   }
 }
 
+- (BOOL)isValid {
+  return _hasValidResponseCode;
+}
+
 @end

--- a/FirebasePerformance/Tests/Unit/FPRNanoPbUtilsTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRNanoPbUtilsTest.m
@@ -1,0 +1,491 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "FirebasePerformance/Sources/FIRPerformance+Internal.h"
+#import "FirebasePerformance/Sources/FPRDataUtils.h"
+#import "FirebasePerformance/Sources/FPRNanoPbUtils.h"
+#import "FirebasePerformance/Sources/Public/FIRPerformance.h"
+
+#import "FirebasePerformance/Sources/Common/FPRConstants.h"
+#import "FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace+Private.h"
+#import "FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h"
+#import "FirebasePerformance/Sources/Timer/FIRTrace+Internal.h"
+#import "FirebasePerformance/Sources/Timer/FIRTrace+Private.h"
+
+#import "FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeData.h"
+#import "FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeData.h"
+
+#import "FirebasePerformance/Tests/Unit/FPRTestCase.h"
+
+#import <OCMock/OCMock.h>
+
+@interface FPRNanoPbUtilsTest : FPRTestCase
+
+@end
+
+@implementation FPRNanoPbUtilsTest
+
+- (void)setUp {
+  [super setUp];
+  FIRPerformance *performance = [FIRPerformance sharedInstance];
+  [performance setDataCollectionEnabled:YES];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  FIRPerformance *performance = [FIRPerformance sharedInstance];
+  [performance setDataCollectionEnabled:NO];
+}
+
+/** Validates that a firebase_perf_v1_PerfMetric creation is successful. */
+- (void)testPerfMetricMessageCreation {
+  NSString *appID = @"RandomAppID";
+  firebase_perf_v1_PerfMetric perfMetric = GetPerfMetricMessage(appID);
+  XCTAssertEqualObjects(FPRDecodeString(perfMetric.application_info.google_app_id), appID);
+}
+
+/** Tests if the application information is populated when creating a firebase_perf_v1_PerfMetric.
+ */
+- (void)testApplicationInfoMessage {
+  firebase_perf_v1_PerfMetric event = GetPerfMetricMessage(@"appid");
+  firebase_perf_v1_ApplicationInfo appInfo = event.application_info;
+  XCTAssertEqualObjects(FPRDecodeString(appInfo.google_app_id), @"appid");
+  XCTAssertTrue(appInfo.ios_app_info.sdk_version != NULL);
+  XCTAssertTrue(appInfo.ios_app_info.bundle_short_version != NULL);
+  XCTAssertTrue(appInfo.ios_app_info.mcc_mnc == NULL || appInfo.ios_app_info.mcc_mnc->size == 6);
+  XCTAssertTrue(appInfo.ios_app_info.network_connection_info.network_type !=
+                firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE);
+  if (appInfo.ios_app_info.network_connection_info.network_type ==
+      firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE) {
+    XCTAssertTrue(appInfo.ios_app_info.network_connection_info.mobile_subtype !=
+                  firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE);
+  }
+}
+
+/** Validates that ApplicationInfoMessage carries global attributes. */
+- (void)testApplicationInfoMessageWithAttributes {
+  FIRPerformance *performance = [FIRPerformance sharedInstance];
+  [performance setValue:@"bar1" forAttribute:@"foo1"];
+  [performance setValue:@"bar2" forAttribute:@"foo2"];
+  firebase_perf_v1_PerfMetric event = GetPerfMetricMessage(@"appid");
+  firebase_perf_v1_ApplicationInfo appInfo = event.application_info;
+  XCTAssertEqual(appInfo.custom_attributes_count, 2);
+  NSDictionary *attributes = FPRDecodeStringToStringMap(
+      (StringToStringMap *)appInfo.custom_attributes, appInfo.custom_attributes_count);
+  XCTAssertEqualObjects(attributes[@"foo1"], @"bar1");
+  XCTAssertEqualObjects(attributes[@"foo2"], @"bar2");
+  [performance removeAttribute:@"foo1"];
+  [performance removeAttribute:@"foo2"];
+}
+
+/** Tests if mccMnc validation is catching non numerals. */
+- (void)testMccMncOnlyHasNumbers {
+  NSString *mccMnc = FPRValidatedMccMnc(@"123", @"MKV");
+  XCTAssertNil(mccMnc);
+  mccMnc = FPRValidatedMccMnc(@"ABC", @"123");
+  XCTAssertNil(mccMnc);
+}
+
+/** Tests if mccMnc validation is working. */
+- (void)testMccMnc {
+  NSString *mccMnc = FPRValidatedMccMnc(@"123", @"22");
+  XCTAssertNotNil(mccMnc);
+  mccMnc = FPRValidatedMccMnc(@"123", @"223");
+  XCTAssertNotNil(mccMnc);
+}
+
+/** Tests if mccMnc validation catches improper lengths. */
+- (void)testMccMncLength {
+  NSString *mccMnc = FPRValidatedMccMnc(@"12", @"22");
+  XCTAssertNil(mccMnc);
+  mccMnc = FPRValidatedMccMnc(@"123", @"2");
+  XCTAssertNil(mccMnc);
+}
+
+/** Validates that a valid FIRTrace object to firebase_perf_v1_TraceMetric conversion is successful.
+ */
+- (void)testTraceMetricMessageCreation {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  [trace startStageNamed:@"1"];
+  [trace startStageNamed:@"2"];
+  [trace incrementMetric:@"c1" byInt:2];
+  [trace setValue:@"bar" forAttribute:@"foo"];
+  [trace stop];
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertEqualObjects(FPRDecodeString(traceMetric.name), @"Random");
+  XCTAssertEqual(traceMetric.subtraces_count, 2);
+  XCTAssertEqual(traceMetric.counters_count, 1);
+  NSDictionary *counters = FPRDecodeStringToNumberMap((StringToNumberMap *)traceMetric.counters,
+                                                      traceMetric.counters_count);
+  XCTAssertEqual([counters[@"c1"] intValue], 2);
+  XCTAssertEqualObjects(FPRDecodeString(traceMetric.subtraces[0].name), @"1");
+  XCTAssertEqualObjects(FPRDecodeString(traceMetric.subtraces[1].name), @"2");
+  XCTAssertTrue(traceMetric.custom_attributes != NULL);
+  XCTAssertEqual(traceMetric.custom_attributes_count, 1);
+  NSDictionary *attributes = FPRDecodeStringToStringMap(
+      (StringToStringMap *)traceMetric.custom_attributes, traceMetric.custom_attributes_count);
+  XCTAssertEqualObjects(attributes[@"foo"], @"bar");
+}
+
+/** Validates that a valid FIRTrace object to firebase_perf_v1_TraceMetric conversion has required
+ * fields. */
+- (void)testTraceMetricMessageCreationHasRequiredFields {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  [trace incrementMetric:@"c1" byInt:2];
+  [trace stop];
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertTrue(traceMetric.name != NULL);
+  XCTAssertTrue(traceMetric.has_client_start_time_us);
+  XCTAssertTrue(traceMetric.has_duration_us);
+  XCTAssertTrue(traceMetric.has_is_auto);
+}
+
+/** Validates the session details inside trace metric. */
+- (void)testTraceMetricMessageHasSessionDetails {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  [trace incrementMetric:@"c1" byInt:2];
+
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 =
+      [[FPRSessionDetails alloc] initWithSessionId:@"b" options:FPRSessionOptionsGauges];
+
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+  [trace stop];
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertTrue(traceMetric.perf_sessions != NULL);
+  XCTAssertTrue(traceMetric.perf_sessions_count >= 2);
+}
+
+/** Validates that the FPRNetworkTrace object to firebase_perf_v1_NetworkRequestMetric conversion is
+ * successful. */
+- (void)testNetworkTraceMetricMessage {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertEqualObjects(FPRDecodeString(networkMetric.url), URL.absoluteString);
+  XCTAssertEqual(networkMetric.http_method, firebase_perf_v1_NetworkRequestMetric_HttpMethod_GET);
+  XCTAssertEqual(
+      networkMetric.network_client_error_reason,
+      firebase_perf_v1_NetworkRequestMetric_NetworkClientErrorReason_GENERIC_CLIENT_ERROR);
+  XCTAssertEqual(networkMetric.http_response_code, 404);
+  XCTAssertEqualObjects(FPRDecodeString(networkMetric.response_content_type), @"text/json");
+}
+
+/** Validates that the FPRNetworkTrace object to Proto conversion has required fields for a valid
+ * response.
+ */
+- (void)testNetworkTraceMetricMessageHasAllRequiredFields {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertTrue(networkMetric.url != NULL);
+  XCTAssertTrue(networkMetric.has_client_start_time_us);
+  XCTAssertTrue(networkMetric.has_http_method);
+  XCTAssertTrue(networkMetric.has_response_payload_bytes);
+  XCTAssertTrue(networkMetric.has_network_client_error_reason);
+  XCTAssertTrue(networkMetric.has_http_response_code);
+  XCTAssertTrue(networkMetric.response_content_type != NULL);
+  XCTAssertTrue(networkMetric.has_time_to_response_completed_us);
+}
+
+/** Validates that application process state conversion to firebase_perf_v1_ApplicationProcessState
+ * enum type is successful. */
+- (void)testApplicationProcessStateConversion {
+  XCTAssertEqual(firebase_perf_v1_ApplicationProcessState_BACKGROUND,
+                 ApplicationProcessState(FPRTraceStateBackgroundOnly));
+  XCTAssertEqual(firebase_perf_v1_ApplicationProcessState_FOREGROUND,
+                 ApplicationProcessState(FPRTraceStateForegroundOnly));
+  XCTAssertEqual(firebase_perf_v1_ApplicationProcessState_FOREGROUND_BACKGROUND,
+                 ApplicationProcessState(FPRTraceStateBackgroundAndForeground));
+  XCTAssertEqual(firebase_perf_v1_ApplicationProcessState_APPLICATION_PROCESS_STATE_UNKNOWN,
+                 ApplicationProcessState(FPRTraceStateUnknown));
+
+  // Try with some random value should say the application state is unknown.
+  XCTAssertEqual(firebase_perf_v1_ApplicationProcessState_APPLICATION_PROCESS_STATE_UNKNOWN,
+                 ApplicationProcessState(100));
+}
+
+#ifdef TARGET_HAS_MOBILE_CONNECTIVITY
+/** Validates if network object creation works. */
+- (void)testNetworkInfoObjectCreation {
+  XCTAssertNotNil(NetworkInfo());
+}
+#endif
+
+/** Validates the session details inside trace metric. */
+- (void)testNetworkRequestMetricMessageHasSessionDetails {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 =
+      [[FPRSessionDetails alloc] initWithSessionId:@"b" options:FPRSessionOptionsGauges];
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertTrue(networkMetric.perf_sessions != NULL);
+  XCTAssertTrue(networkMetric.perf_sessions_count >= 2);
+}
+
+/** Validates the gauge metric proto packaging works with proper conversions. */
+- (void)testMemoryMetricProtoConversion {
+  NSMutableArray *gauges = [[NSMutableArray alloc] init];
+  NSDate *date = [NSDate date];
+  FPRMemoryGaugeData *memoryData = [[FPRMemoryGaugeData alloc] initWithCollectionTime:date
+                                                                             heapUsed:5 * 1024
+                                                                        heapAvailable:10 * 1024];
+  [gauges addObject:memoryData];
+
+  firebase_perf_v1_GaugeMetric gaugeMetric = GetGaugeMetric(gauges, @"abc");
+  XCTAssertEqual(gaugeMetric.cpu_metric_readings_count, 0);
+  XCTAssertEqual(gaugeMetric.ios_memory_readings_count, 1);
+  XCTAssertEqual(gaugeMetric.ios_memory_readings[0].used_app_heap_memory_kb, 5);
+  XCTAssertEqual(gaugeMetric.ios_memory_readings[0].free_app_heap_memory_kb, 10);
+}
+
+/** Validates the gauge metric proto packaging works. */
+- (void)testGaugeMetricProtoPacking {
+  NSMutableArray *gauges = [[NSMutableArray alloc] init];
+  for (int i = 0; i < 5; i++) {
+    NSDate *date = [NSDate date];
+    FPRCPUGaugeData *cpuData = [[FPRCPUGaugeData alloc] initWithCollectionTime:date
+                                                                    systemTime:100
+                                                                      userTime:200];
+    FPRMemoryGaugeData *memoryData = [[FPRMemoryGaugeData alloc] initWithCollectionTime:date
+                                                                               heapUsed:100
+                                                                          heapAvailable:200];
+    [gauges addObject:cpuData];
+    [gauges addObject:memoryData];
+  }
+  firebase_perf_v1_GaugeMetric gaugeMetric = GetGaugeMetric(gauges, @"abc");
+  XCTAssertEqual(gaugeMetric.cpu_metric_readings_count, 5);
+  XCTAssertEqual(gaugeMetric.ios_memory_readings_count, 5);
+}
+
+/** Validates if the first session is a verbose session for a trace. */
+- (void)testOrderingOfSessionsForTrace {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 =
+      [[FPRSessionDetails alloc] initWithSessionId:@"b" options:FPRSessionOptionsGauges];
+
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+  [trace stop];
+
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertTrue(traceMetric.perf_sessions != NULL);
+  XCTAssertTrue(traceMetric.perf_sessions_count >= 2);
+
+  struct _firebase_perf_v1_PerfSession perfSession = traceMetric.perf_sessions[0];
+  XCTAssertEqual(perfSession.session_verbosity[0],
+                 firebase_perf_v1_SessionVerbosity_GAUGES_AND_SYSTEM_EVENTS);
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"b");
+}
+
+/** Validates the verbosity ordering when no sessions are verbose. */
+- (void)testOrderingOfNonVerboseSessionsForTrace {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 = [[FPRSessionDetails alloc] initWithSessionId:@"b"
+                                                                     options:FPRSessionOptionsNone];
+
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+  [trace stop];
+
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertTrue(traceMetric.perf_sessions != NULL);
+  XCTAssertTrue(traceMetric.perf_sessions_count >= 2);
+
+  struct _firebase_perf_v1_PerfSession perfSession = traceMetric.perf_sessions[0];
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"a");
+  XCTAssertEqual(perfSession.session_verbosity_count, 0);
+}
+
+/** Validates if a session is not verbose, do not populate the session verbosity array. */
+- (void)testVerbosityArrayEmptyWhenTheSessionIsNotVerbose {
+  FIRTrace *trace = [[FIRTrace alloc] initWithName:@"Random"];
+  [trace start];
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+
+  trace.activeSessions = [@[ session1 ] mutableCopy];
+  [trace stop];
+
+  firebase_perf_v1_TraceMetric traceMetric = GetTraceMetric(trace);
+  XCTAssertTrue(traceMetric.perf_sessions != NULL);
+  XCTAssertTrue(traceMetric.perf_sessions_count >= 1);
+
+  struct _firebase_perf_v1_PerfSession perfSession = traceMetric.perf_sessions[0];
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"a");
+  XCTAssertEqual(perfSession.session_verbosity_count, 0);
+}
+
+/** Validates if the first session is a verbose session for a network trace. */
+- (void)testOrderingOfSessionsForNetworkTrace {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 =
+      [[FPRSessionDetails alloc] initWithSessionId:@"b" options:FPRSessionOptionsGauges];
+
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertTrue(networkMetric.perf_sessions != NULL);
+  XCTAssertTrue(networkMetric.perf_sessions_count >= 2);
+
+  struct _firebase_perf_v1_PerfSession perfSession = networkMetric.perf_sessions[0];
+  XCTAssertEqual(perfSession.session_verbosity[0],
+                 firebase_perf_v1_SessionVerbosity_GAUGES_AND_SYSTEM_EVENTS);
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"b");
+}
+
+/** Validates the verbosity ordering when no sessions are verbose for a network trace. */
+- (void)testOrderingOfNonVerboseSessionsForNetworkTrace {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+  FPRSessionDetails *session2 = [[FPRSessionDetails alloc] initWithSessionId:@"b"
+                                                                     options:FPRSessionOptionsNone];
+
+  trace.activeSessions = [@[ session1, session2 ] mutableCopy];
+
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertTrue(networkMetric.perf_sessions != NULL);
+  XCTAssertTrue(networkMetric.perf_sessions_count >= 2);
+
+  struct _firebase_perf_v1_PerfSession perfSession = networkMetric.perf_sessions[0];
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"a");
+  XCTAssertEqual(perfSession.session_verbosity_count, 0);
+}
+
+/** Validates if a session is not verbose, do not populate the session verbosity array for network
+ *  trace.
+ */
+- (void)testVerbosityArrayEmptyWhenTheSessionIsNotVerboseForNetworkTrace {
+  NSURL *URL = [NSURL URLWithString:@"https://abc.com"];
+  NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
+  FPRNetworkTrace *trace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
+  [trace start];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateInitiated];
+  [trace checkpointState:FPRNetworkTraceCheckpointStateResponseReceived];
+
+  NSDictionary<NSString *, NSString *> *headerFields = @{@"Content-Type" : @"text/json"};
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URLRequest.URL
+                                                            statusCode:404
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:headerFields];
+  NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:-200 userInfo:nil];
+
+  FPRSessionDetails *session1 = [[FPRSessionDetails alloc] initWithSessionId:@"a"
+                                                                     options:FPRSessionOptionsNone];
+
+  trace.activeSessions = [@[ session1 ] mutableCopy];
+
+  [trace didReceiveData:[NSData data]];
+  [trace didCompleteRequestWithResponse:response error:error];
+
+  firebase_perf_v1_NetworkRequestMetric networkMetric = GetNetworkRequestMetric(trace);
+  XCTAssertTrue(networkMetric.perf_sessions != NULL);
+  XCTAssertTrue(networkMetric.perf_sessions_count >= 1);
+
+  struct _firebase_perf_v1_PerfSession perfSession = networkMetric.perf_sessions[0];
+  XCTAssertEqualObjects(FPRDecodeString(perfSession.session_id), @"a");
+  XCTAssertEqual(perfSession.session_verbosity_count, 0);
+}
+
+@end


### PR DESCRIPTION
### How to review this PR?
Similar to how Objective-C classes are converted to protos, this PR converts Objective-C classes to Nanopb struct.
Please refer to [FPRProtoUtils.h](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebasePerformance/Sources/FPRProtoUtils.h), [FPRProtoUtils.m](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebasePerformance/Sources/FPRProtoUtils.m), and [FPRProtoUtilsTest.m](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebasePerformance/Tests/Unit/FPRProtoUtilsTest.m)