### PR TITLE
Turn off failing travis FIAM tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,23 +101,6 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      if: type = cron
-      env:
-        - PROJECT=InAppMessaging PLATFORM=iPad METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh


### PR DESCRIPTION
Something about #8351 caused travis infra to fail.  See https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/774672431 

Since travis is going away and these tests are running on GHA, deleting to get travis green again.

Note `pod lib lint` is still running for FIAM on travis.

#no-changelog