### PR TITLE
Bump travis to 12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,14 +101,6 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
-    - stage: test
-      env:
         - PROJECT=GoogleUtilitiesComponents METHOD=pod-lib-lint
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilitiesComponents.podspec
@@ -152,18 +144,6 @@ jobs:
         - POD_CONFIG_DIR=Cocoapods_multiprojects_staticLibs
       script:
         - travis_retry ./CocoapodsIntegrationTest/scripts/build_with_environment.sh --gemfile=./CocoapodsIntegrationTest/TestEnvironments/${POD_CONFIG_DIR}/Gemfile --podfile=./CocoapodsIntegrationTest/TestEnvironments/${POD_CONFIG_DIR}/Podfile
-
-  allow_failures:
-    # Run fuzz tests only on cron jobs.
-    - stage: test
-#      if: type = cron
-      env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=fuzz
-      before_install:
-        - ./scripts/install_prereqs.sh
-      script:
-        # The travis_wait is necessary because fuzzing runs for 40 minutes.
-        - travis_wait 45 ./scripts/fuzzing_ci.sh
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode11
+osx_image: xcode12.5
 language: objective-c
 cache:
   bundler: true

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 8.5.0
+- [fixed] Fixed an analyze issue introduced in Xcode 12.5. (#8411)
+
 # 8.2.0
 - [fixed] Fixed analyze issues introduced in Xcode 12.5. (#8210)
 - [fixed] Fixed a bug in the link with email link, Game Center, and phone auth flows. (#8196)

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -263,7 +263,7 @@ extern NSString *const FIRPhoneMultiFactorID;
   } else {
     errorData = nil;
   }
-  if (error != NULL) {
+  if (error != NULL && errorData != nil) {
     NSError *jsonError;
     NSDictionary *errorDict = [NSJSONSerialization JSONObjectWithData:errorData
                                                               options:0


### PR DESCRIPTION
Bump travis from unsupported Xcode 11 to Xcode 12.5
Fix uncovered Auth analyze issue.
Disable Firestore testing since it is too slow to complete and is fully ported to GitHub Actions

#no-changelog