### PR TITLE
Use GoogleAppMeasurement main branch instead of release tag for CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,6 +143,8 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
+      // Please keep the version specification aligned with
+      // scripts/setup_spm_test_app_measurement.sh.
       .exact("8.3.1")
     ),
     .package(

--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,7 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
-      .branch("main")
+      .exact("8.3.1")
     ),
     .package(
       name: "GoogleDataTransport",

--- a/Package.swift
+++ b/Package.swift
@@ -143,7 +143,7 @@ let package = Package(
     .package(
       name: "GoogleAppMeasurement",
       url: "https://github.com/google/GoogleAppMeasurement.git",
-      .exact("8.3.1")
+      .branch("main")
     ),
     .package(
       name: "GoogleDataTransport",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -648,6 +648,7 @@ case "$product-$platform-$method" in
 
   # Note that the combine tests require setting the minimum iOS and tvOS version to 13.0
   *-*-spm)
+    "${scripts_dir}/setup_spm_test_app_measurement.sh"
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
@@ -657,6 +658,7 @@ case "$product-$platform-$method" in
     ;;
 
   *-*-spmbuildonly)
+    "${scripts_dir}/setup_spm_test_app_measurement.sh"
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \

--- a/scripts/setup_spm_test_app_measurement.sh
+++ b/scripts/setup_spm_test_app_measurement.sh
@@ -20,4 +20,3 @@
 # until after testing.
 
 sed -i '' 's#exact("[0-9.]*#branch("main#' Package.swift
- 

--- a/scripts/setup_spm_test_app_measurement.sh
+++ b/scripts/setup_spm_test_app_measurement.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement
+# so that the release process can defer publish the GoogleAppMeasurement tag
+# until after testing.
+
+sed -i '' 's#exact("[0-9.]*#branch("main#' Package.swift
+ 

--- a/scripts/setup_spm_test_app_measurement.sh
+++ b/scripts/setup_spm_test_app_measurement.sh
@@ -19,4 +19,6 @@
 # so that the release process can defer publish the GoogleAppMeasurement tag
 # until after testing.
 
+# For example: Change `.exact("8.3.1")` to `.branch("main")`
+
 sed -i '' 's#exact("[0-9.]*#branch("main#' Package.swift


### PR DESCRIPTION
Use GoogleAppMeasurement main branch instead of release tag for CI.  This enables us to use CI for release tagging without tagging the GoogleAppMeasurement repository until release and avoid needing to make last minute commits to the firebase repo to update to the new tag. b/194422721