### PR TITLE
[#8482] Fixed Crash Caused by Invalid IAM Image URL

### DIFF
--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -668,6 +668,14 @@
                                             imageData:imageData
                                    landscapeImageData:landscapeImageData
                                           triggerType:triggerType];
+
+        // A final `nil`-check, performed to avoid crashing the client app.
+        if (!displayMessage) {
+          FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400043",
+                      @"Failed to construct a non-nil display message.");
+          return;
+        }
+
         [self.messageDisplayComponent displayMessage:displayMessage displayDelegate:self];
       }];
 }


### PR DESCRIPTION
[Closes #8482]

* Fixed a bug where an invalid image URL string in an in-app message crashed the client app
* A URL string is considered invalid if the `[NSURL URLWithString:]` method produces `nil`