### PR TITLE
Fix getData crashing in offline

### DIFF
--- a/FirebaseDatabase/Sources/Core/FSyncTree.m
+++ b/FirebaseDatabase/Sources/Core/FSyncTree.m
@@ -731,7 +731,7 @@ static const NSUInteger kFSizeThresholdForCompoundHash = 1024;
     if (cacheNode == nil || cacheNode.node.isEmpty) {
         return nil;
     }
-    return cacheNode.node;
+    return cacheNode.indexedNode;
 }
 
 - (id<FNode>)getServerValue:(FQuerySpec *)query {


### PR DESCRIPTION
Fixes #8357 

The issue was that `node` property of `FCacheNode` pokes one level deeper than needed in this case: (FCacheNode.m:66)

```
- (id<FNode>)node {
    return self.indexedNode.node;
}
```

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
