### PR TITLE
[#8485] Added URL Recovery for IAM URLs

### DIFF
--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -287,12 +287,10 @@
       return nil;
     }
 
-    NSURL *imageURL = (imageURLStr.length == 0) ? nil : [NSURL URLWithString:imageURLStr];
-    NSURL *landscapeImageURL =
-        (landscapeImageURLStr.length == 0) ? nil : [NSURL URLWithString:landscapeImageURLStr];
-    NSURL *actionURL = (actionURLStr.length == 0) ? nil : [NSURL URLWithString:actionURLStr];
-    NSURL *secondaryActionURL =
-        (secondaryActionURLStr.length == 0) ? nil : [NSURL URLWithString:secondaryActionURLStr];
+    NSURL *imageURL = [self imageURLFromURLString:imageURLStr];
+    NSURL *landscapeImageURL = [self imageURLFromURLString:landscapeImageURLStr];
+    NSURL *actionURL = [self urlFromURLString:actionURLStr];
+    NSURL *secondaryActionURL = [self urlFromURLString:secondaryActionURLStr];
     FIRIAMRenderingEffectSetting *renderEffect =
         [FIRIAMRenderingEffectSetting getDefaultRenderingEffectSetting];
     renderEffect.viewMode = mode;
@@ -376,6 +374,28 @@
     return nil;
   }
 }
+
+- (nullable NSURL *)imageURLFromURLString:(NSString *)string {
+  NSURL *url = [self urlFromURLString:string];
+
+  // Image URLs must be valid HTTPS links, according to the Firebase Console.
+  if (![url.scheme.lowercaseString isEqualToString:@"https"]) return nil;
+
+  return url;
+}
+
+- (nullable NSURL *)urlFromURLString:(NSString *)string {
+  NSString *sanitizedString = [self sanitizedURLStringFromString:string];
+
+  if (sanitizedString.length == 0) return nil;
+
+  return [NSURL URLWithString:sanitizedString];
+}
+
+- (NSString *)sanitizedURLStringFromString:(NSString *)string {
+  return [string stringByReplacingOccurrencesOfString:@" " withString:@""];
+}
+
 @end
 
 #endif  // TARGET_OS_IOS || TARGET_OS_TV

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -72,7 +72,7 @@
   XCTAssertEqualWithAccuracy([fetchWaitTime doubleValue],
                              nextFetchEpochTimeInResponse / 1000 - currentMoment, 0.1);
 
-  XCTAssertEqual(6, [results count]);
+  XCTAssertEqual(7, [results count]);
   XCTAssertEqual(0, discardCount);
 
   FIRIAMMessageDefinition *first = results[0];
@@ -147,6 +147,14 @@
   XCTAssertNotNil(sixth.experimentPayload);
   XCTAssertEqual(FIRIAMRenderAsModalView, sixth.renderData.renderingEffectSettings.viewMode);
   XCTAssertEqual(1, sixth.renderTriggers.count);
+
+  FIRIAMMessageDefinition *seventh = results[6];
+  XCTAssertEqualObjects(@"https://example.com/recoverable_image_url",
+                        seventh.renderData.contentData.imageURL.absoluteString);
+  XCTAssertEqualObjects(nil, seventh.renderData.contentData.landscapeImageURL.absoluteString);
+  XCTAssertEqualObjects(@"http://example.com/recoverable_action_url_without_https",
+                        seventh.renderData.contentData.actionURL.absoluteString);
+  XCTAssertEqualObjects(nil, seventh.renderData.contentData.secondaryActionURL.absoluteString);
 }
 
 - (void)testParsingTestMessage {

--- a/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
+++ b/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
@@ -258,6 +258,53 @@
           "fiamTrigger": "ON_FOREGROUND"
         }
       ]
+    },
+    {
+      "vanillaPayload": {
+        "campaignId": "1234567890",
+        "campaignStartTimeMillis": "1519934650000",
+        "campaignEndTimeMillis": "9223372036854775807",
+        "campaignName": "URL Validation"
+      },
+      "content": {
+        "card": {
+          "title": {
+            "text": "Let’s check some weird URLs!",
+            "hexColor": "#004953"
+          },
+          "portraitImageUrl": " https:// example.com/ recoverable_image_url ",
+          "landscapeImageUrl": "http://example.com/image_url_without_https.jpg",
+          "primaryActionButton": {
+            "text": {
+              "text": "Malformatted but Recoverable URL",
+              "hexColor": "#000000"
+            },
+            "buttonHexColor": "#ffffff"
+          },
+          "secondaryActionButton": {
+            "text": {
+              "text": "Invalid URL",
+              "hexColor": "#000000"
+            },
+            "buttonHexColor": "#ffffff"
+          },
+          "primaryAction": {
+            "actionUrl": "http:// example.com / recoverable_action_url_without_https "
+          },
+          "secondaryAction": {
+            "actionUrl": "NOT ^ A ^ URL"
+          },
+          "backgroundHexColor": "#ffffff"
+        }
+      },
+      "priority": {
+        "value": 1
+      },
+      "triggeringConditions": [
+        {
+          "fiamTrigger": "ON_FOREGROUND"
+        }
+      ]
     }
   ],
   "expirationEpochTimestampMillis": "1537896430193"


### PR DESCRIPTION
[Closes #8485]

* URL strings in in-app messages are sanitized and, when possible, recovered before they’re used in the `NSURL` initializer
* Added validation for image URLs, which must use the HTTPS scheme, according to the Firebase Console
* Updated `FIRIAMFetchResponseParserTests` to test URL validation and recovery