### PR TITLE
Configure macOS test keychain for keychain dependent workflows

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: Build and test
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }}

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -25,6 +25,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: Install GoogleService-Info.plist
       run: |
         mkdir -p FirebaseInstallations/Source/Tests/Resources

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: Install GoogleService-Info.plist
       run: |
         mkdir FirebaseMLModelDownloader/Tests/Integration/Resources


### PR DESCRIPTION
Fixes some failures from https://github.com/firebase/firebase-ios-sdk/issues/8471#issuecomment-893449537.