### PR TITLE
FirebaseInAppMessagingSwift: explicitly import UIKit

### DIFF
--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -74,6 +74,8 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
 
+  s.framework = 'UIKit'
+
   s.dependency 'FirebaseCore', '~> 8.0'
   s.dependency 'FirebaseInstallations', '~> 8.0'
   s.dependency 'FirebaseABTesting', '~> 8.0'

--- a/FirebaseInAppMessaging/Swift/Source/SwiftUIPreviewHelpers.swift
+++ b/FirebaseInAppMessaging/Swift/Source/SwiftUIPreviewHelpers.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import UIKit
+
 import FirebaseInAppMessaging
 
 @available(iOS 13.0, tvOS 13.0, *)

--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -33,5 +33,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
       unit_tests.requires_app_host = true
    end
 
+  s.framework = 'UIKit'
+
   s.dependency 'FirebaseInAppMessaging', '~> 8.0-beta'
 end


### PR DESCRIPTION
Fixes the [failure](https://github.com/firebase/firebase-ios-sdk/runs/3250028778?check_suite_focus=true) from https://github.com/firebase/firebase-ios-sdk/issues/8471#issuecomment-893449537.