### PR TITLE
Apply keychain fixes to cron tests

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -131,6 +131,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: PodLibLint Auth Cron
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
 

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -110,6 +110,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: Install GoogleService-Info.plist
       run: |
         mkdir -p FirebaseInstallations/Source/Tests/Resources

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -47,6 +47,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
     - name: Install GoogleService-Info.plist
       run: |
         mkdir FirebaseMLModelDownloader/Tests/Integration/Resources


### PR DESCRIPTION
The keychain setup fixes in #8496 should also be done for the cron jobs.

Fix #8471