### PR TITLE
There are no longer special instructions for Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ pod 'FirebaseMessaging', :path => '/path/to/firebase-ios-sdk'
 ### Carthage (iOS only)
 
 Instructions for the experimental Carthage distribution are at
-[Carthage](Carthage.md). If you have a new Mac with an Apple silicon chip, please see
-[these instructions](AppleSilicon.md).
+[Carthage](Carthage.md).
 
 ### Using Firebase from a Framework or a library
 


### PR DESCRIPTION
Fix #8514 

There are no longer special instructions for Apple Silicon Macs. The standard distributions now work for all Macs.