### PR TITLE
Don't define a `util` namespace alias in the global namespace.

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -29,6 +29,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::TimerId;
 
 @interface FIRDatabaseTests : FSTIntegrationTestCase
@@ -1404,7 +1405,7 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testRestartFirestoreLeadsToNewInstance {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRApp *app = testutil::AppForUnitTesting(MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
   FIRFirestore *sameInstance = [FIRFirestore firestoreForApp:app];
   firestore.settings = [FSTIntegrationTestCase settings];
@@ -1429,7 +1430,7 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testAppDeleteLeadsToFirestoreTermination {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRApp *app = testutil::AppForUnitTesting(MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
   firestore.settings = [FSTIntegrationTestCase settings];
   NSDictionary<NSString *, id> *data =
@@ -1443,7 +1444,7 @@ using firebase::firestore::util::TimerId;
 
 // Ensures b/172958106 doesn't regress.
 - (void)testDeleteAppWorksWhenLastReferenceToFirestoreIsInListener {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRApp *app = testutil::AppForUnitTesting(MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
 
   FIRDocumentReference *doc = [firestore documentWithPath:@"abc/123"];
@@ -1462,7 +1463,7 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testTerminateCanBeCalledMultipleTimes {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRApp *app = testutil::AppForUnitTesting(MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
 
   [firestore terminateWithCompletion:[self completionForExpectationWithName:@"Terminate1"]];
@@ -1485,7 +1486,7 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testCanRemoveListenerAfterTermination {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRApp *app = testutil::AppForUnitTesting(MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
   firestore.settings = [FSTIntegrationTestCase settings];
 

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -31,11 +31,13 @@
 #include "Firestore/core/src/util/exception.h"
 #include "Firestore/core/src/util/string_apple.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::api::CollectionReference;
 using firebase::firestore::api::DocumentReference;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::model::ResourcePath;
+using firebase::firestore::util::MakeCallback;
+using firebase::firestore::util::MakeNSString;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -85,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)collectionID {
-  return util::MakeNSString(self.reference.collection_id());
+  return MakeNSString(self.reference.collection_id());
 }
 
 - (FIRDocumentReference *_Nullable)parent {
@@ -97,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)path {
-  return util::MakeNSString(self.reference.path());
+  return MakeNSString(self.reference.path());
 }
 
 - (FIRDocumentReference *)documentWithPath:(NSString *)documentPath {
@@ -107,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!documentPath.length) {
     ThrowInvalidArgument("Document path cannot be empty.");
   }
-  DocumentReference child = self.reference.Document(util::MakeString(documentPath));
+  DocumentReference child = self.reference.Document(MakeString(documentPath));
   return [[FIRDocumentReference alloc] initWithReference:std::move(child)];
 }
 
@@ -120,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
                                        (nullable void (^)(NSError *_Nullable error))completion {
   ParsedSetData parsed = [self.firestore.dataReader parsedSetData:data];
   DocumentReference docRef =
-      self.reference.AddDocument(std::move(parsed), util::MakeCallback(completion));
+      self.reference.AddDocument(std::move(parsed), MakeCallback(completion));
   return [[FIRDocumentReference alloc] initWithReference:std::move(docRef)];
 }
 

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -136,8 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
     ThrowInvalidArgument("Collection path cannot be empty.");
   }
 
-  CollectionReference child =
-      _documentReference.GetCollectionReference(MakeString(collectionPath));
+  CollectionReference child = _documentReference.GetCollectionReference(MakeString(collectionPath));
   return [[FIRCollectionReference alloc] initWithReference:std::move(child)];
 }
 

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -44,7 +44,6 @@
 #include "Firestore/core/src/util/statusor.h"
 #include "Firestore/core/src/util/string_apple.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::api::CollectionReference;
 using firebase::firestore::api::DocumentReference;
 using firebase::firestore::api::DocumentSnapshot;
@@ -59,6 +58,10 @@ using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ResourcePath;
+using firebase::firestore::util::MakeCallback;
+using firebase::firestore::util::MakeNSString;
+using firebase::firestore::util::MakeString;
+using firebase::firestore::util::StatusOr;
 using firebase::firestore::util::StatusOr;
 using firebase::firestore::util::StatusOrCallback;
 using firebase::firestore::util::ThrowInvalidArgument;
@@ -114,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)documentID {
-  return util::MakeNSString(_documentReference.document_id());
+  return MakeNSString(_documentReference.document_id());
 }
 
 - (FIRCollectionReference *)parent {
@@ -122,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)path {
-  return util::MakeNSString(_documentReference.Path());
+  return MakeNSString(_documentReference.Path());
 }
 
 - (FIRCollectionReference *)collectionWithPath:(NSString *)collectionPath {
@@ -134,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   CollectionReference child =
-      _documentReference.GetCollectionReference(util::MakeString(collectionPath));
+      _documentReference.GetCollectionReference(MakeString(collectionPath));
   return [[FIRCollectionReference alloc] initWithReference:std::move(child)];
 }
 
@@ -162,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
   auto dataReader = self.firestore.dataReader;
   ParsedSetData parsed = merge ? [dataReader parsedMergeData:documentData fieldMask:nil]
                                : [dataReader parsedSetData:documentData];
-  _documentReference.SetData(std::move(parsed), util::MakeCallback(completion));
+  _documentReference.SetData(std::move(parsed), MakeCallback(completion));
 }
 
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
@@ -170,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
      completion:(nullable void (^)(NSError *_Nullable error))completion {
   ParsedSetData parsed = [self.firestore.dataReader parsedMergeData:documentData
                                                           fieldMask:mergeFields];
-  _documentReference.SetData(std::move(parsed), util::MakeCallback(completion));
+  _documentReference.SetData(std::move(parsed), MakeCallback(completion));
 }
 
 - (void)updateData:(NSDictionary<id, id> *)fields {
@@ -180,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateData:(NSDictionary<id, id> *)fields
         completion:(nullable void (^)(NSError *_Nullable error))completion {
   ParsedUpdateData parsed = [self.firestore.dataReader parsedUpdateData:fields];
-  _documentReference.UpdateData(std::move(parsed), util::MakeCallback(completion));
+  _documentReference.UpdateData(std::move(parsed), MakeCallback(completion));
 }
 
 - (void)deleteDocument {
@@ -188,7 +191,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)deleteDocumentWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
-  _documentReference.DeleteDocument(util::MakeCallback(completion));
+  _documentReference.DeleteDocument(MakeCallback(completion));
 }
 
 - (void)getDocumentWithCompletion:(FIRDocumentSnapshotBlock)completion {
@@ -231,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
             [[FIRDocumentSnapshot alloc] initWithSnapshot:std::move(maybe_snapshot).ValueOrDie()];
         block_(result, nil);
       } else {
-        block_(nil, util::MakeNSError(maybe_snapshot.status()));
+        block_(nil, MakeNSError(maybe_snapshot.status()));
       }
     }
 

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -45,7 +45,6 @@
 #include "Firestore/core/src/util/log.h"
 #include "Firestore/core/src/util/string_apple.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::google_firestore_v1_Value;
 using firebase::firestore::api::DocumentSnapshot;
 using firebase::firestore::api::Firestore;
@@ -59,6 +58,7 @@ using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::remote::Serializer;
 using firebase::firestore::nanopb::MakeNSData;
+using firebase::firestore::util::MakeNSString;
 using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 using firebase::firestore::google_firestore_v1_Value;
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)documentID {
-  return util::MakeNSString(_snapshot.document_id());
+  return MakeNSString(_snapshot.document_id());
 }
 
 @dynamic metadata;

--- a/Firestore/Source/API/FIRFieldPath.mm
+++ b/Firestore/Source/API/FIRFieldPath.mm
@@ -28,8 +28,9 @@
 #include "Firestore/core/src/util/hashing.h"
 #include "Firestore/core/src/util/string_apple.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::model::FieldPath;
+using firebase::firestore::util::Hash;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -51,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
   std::vector<std::string> converted;
   converted.reserve(fieldNames.count);
   for (NSString *fieldName in fieldNames) {
-    converted.emplace_back(util::MakeString(fieldName));
+    converted.emplace_back(MakeString(fieldName));
   }
 
   return [self initPrivate:FieldPath::FromSegments(std::move(converted))];
@@ -70,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)pathWithDotSeparatedString:(NSString *)path {
   return
-      [[FIRFieldPath alloc] initPrivate:FieldPath::FromDotSeparatedString(util::MakeString(path))];
+      [[FIRFieldPath alloc] initPrivate:FieldPath::FromDotSeparatedString(MakeString(path))];
 }
 
 - (id)copyWithZone:(__unused NSZone *_Nullable)zone {
@@ -90,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSUInteger)hash {
-  return util::Hash(_internalValue);
+  return Hash(_internalValue);
 }
 
 - (const firebase::firestore::model::FieldPath &)internalValue {

--- a/Firestore/Source/API/FIRFieldPath.mm
+++ b/Firestore/Source/API/FIRFieldPath.mm
@@ -70,8 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)pathWithDotSeparatedString:(NSString *)path {
-  return
-      [[FIRFieldPath alloc] initPrivate:FieldPath::FromDotSeparatedString(MakeString(path))];
+  return [[FIRFieldPath alloc] initPrivate:FieldPath::FromDotSeparatedString(MakeString(path))];
 }
 
 - (id)copyWithZone:(__unused NSZone *_Nullable)zone {

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -59,7 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDatabaseID:(model::DatabaseId)databaseID
                     persistenceKey:(std::string)persistenceKey
                credentialsProvider:(std::shared_ptr<auth::CredentialsProvider>)credentialsProvider
-                       workerQueue:(std::shared_ptr<firebase::firestore::util::AsyncQueue>)workerQueue
+                       workerQueue:
+                           (std::shared_ptr<firebase::firestore::util::AsyncQueue>)workerQueue
           firebaseMetadataProvider:
               (std::unique_ptr<remote::FirebaseMetadataProvider>)firebaseMetadataProvider
                        firebaseApp:(FIRApp *)app

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -39,7 +39,6 @@ namespace api = firebase::firestore::api;
 namespace auth = firebase::firestore::auth;
 namespace model = firebase::firestore::model;
 namespace remote = firebase::firestore::remote;
-namespace util = firebase::firestore::util;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -60,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDatabaseID:(model::DatabaseId)databaseID
                     persistenceKey:(std::string)persistenceKey
                credentialsProvider:(std::shared_ptr<auth::CredentialsProvider>)credentialsProvider
-                       workerQueue:(std::shared_ptr<util::AsyncQueue>)workerQueue
+                       workerQueue:(std::shared_ptr<firebase::firestore::util::AsyncQueue>)workerQueue
           firebaseMetadataProvider:
               (std::unique_ptr<remote::FirebaseMetadataProvider>)firebaseMetadataProvider
                        firebaseApp:(FIRApp *)app
@@ -74,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)terminateInternalWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
-- (const std::shared_ptr<util::AsyncQueue> &)workerQueue;
+- (const std::shared_ptr<firebase::firestore::util::AsyncQueue> &)workerQueue;
 
 @property(nonatomic, assign, readonly) std::shared_ptr<api::Firestore> wrapped;
 

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -433,7 +433,7 @@ NS_ASSUME_NONNULL_BEGIN
       if (!progress.error_status().ok()) {
         LOG_WARN("Progress set to Error, but error_status() is ok()");
         error = MakeNSError(firebase::firestore::Error::kErrorUnknown,
-                                  "Loading bundle failed with unknown error");
+                            "Loading bundle failed with unknown error");
       } else {
         error = MakeNSError(progress.error_status());
       }

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -25,8 +25,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 namespace api = firebase::firestore::api;
-namespace util = firebase::firestore::util;
 using api::Settings;
+using util::MakeString;
 using util::ThrowInvalidArgument;
 
 // Public constant
@@ -115,7 +115,7 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
 
 - (Settings)internalSettings {
   Settings settings;
-  settings.set_host(util::MakeString(_host));
+  settings.set_host(MakeString(_host));
   settings.set_ssl_enabled(_sslEnabled);
   settings.set_persistence_enabled(_persistenceEnabled);
   settings.set_cache_size_bytes(_cacheSizeBytes);

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -26,8 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 namespace api = firebase::firestore::api;
 using api::Settings;
-using util::MakeString;
-using util::ThrowInvalidArgument;
+using firebase::firestore::util::MakeString;
+using firebase::firestore::util::ThrowInvalidArgument;
 
 // Public constant
 ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -60,7 +60,6 @@
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 
-namespace util = firebase::firestore::util;
 namespace nanopb = firebase::firestore::nanopb;
 using firebase::firestore::api::Firestore;
 using firebase::firestore::api::Query;
@@ -510,7 +509,7 @@ int32_t SaturatedLimitValue(NSInteger limit) {
             [[FIRQuerySnapshot alloc] initWithSnapshot:std::move(maybe_snapshot).ValueOrDie()];
         block_(result, nil);
       } else {
-        block_(nil, util::MakeNSError(maybe_snapshot.status()));
+        block_(nil, MakeNSError(maybe_snapshot.status()));
       }
     }
 

--- a/Firestore/Source/API/FIRWriteBatch.mm
+++ b/Firestore/Source/API/FIRWriteBatch.mm
@@ -26,8 +26,8 @@
 
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
-using firebase::firestore::core::DelayedConstructor;
-using firebase::firestore::core::MakeCallback;
+using firebase::firestore::util::DelayedConstructor;
+using firebase::firestore::util::MakeCallback;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/API/FIRWriteBatch.mm
+++ b/Firestore/Source/API/FIRWriteBatch.mm
@@ -24,9 +24,10 @@
 #include "Firestore/core/src/util/delayed_constructor.h"
 #include "Firestore/core/src/util/error_apple.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
+using firebase::firestore::core::DelayedConstructor;
+using firebase::firestore::core::MakeCallback;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -51,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FIRWriteBatch {
-  util::DelayedConstructor<api::WriteBatch> _writeBatch;
+  DelayedConstructor<api::WriteBatch> _writeBatch;
 }
 
 - (instancetype)initWithDataReader:(FSTUserDataReader *)dataReader
@@ -107,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)commitWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
-  _writeBatch->Commit(util::MakeCallback(completion));
+  _writeBatch->Commit(MakeCallback(completion));
 }
 
 @end

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -36,12 +36,12 @@
 #include "Firestore/core/src/util/hard_assert.h"
 #include "absl/memory/memory.h"
 
-namespace util = firebase::firestore::util;
 using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::FirebaseCredentialsProvider;
 using firebase::firestore::remote::FirebaseMetadataProviderApple;
 using firebase::firestore::util::AsyncQueue;
 using firebase::firestore::util::Executor;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!firestore) {
       std::string queue_name{"com.google.firebase.firestore"};
       if (!self.app.isDefaultApp) {
-        absl::StrAppend(&queue_name, ".", util::MakeString(self.app.name));
+        absl::StrAppend(&queue_name, ".", MakeString(self.app.name));
       }
 
       auto executor = Executor::CreateSerial(queue_name.c_str());
@@ -102,8 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
 
       auto firebaseMetadataProvider = absl::make_unique<FirebaseMetadataProviderApple>(self.app);
 
-      model::DatabaseId databaseID{util::MakeString(projectID), util::MakeString(database)};
-      std::string persistenceKey = util::MakeString(self.app.name);
+      model::DatabaseId databaseID{MakeString(projectID), MakeString(database)};
+      std::string persistenceKey = MakeString(self.app.name);
       firestore = [[FIRFirestore alloc] initWithDatabaseID:std::move(databaseID)
                                             persistenceKey:std::move(persistenceKey)
                                        credentialsProvider:std::move(credentialsProvider)

--- a/Firestore/Source/API/FSTUserDataReader.mm
+++ b/Firestore/Source/API/FSTUserDataReader.mm
@@ -57,7 +57,6 @@
 #include "absl/strings/match.h"
 #include "absl/types/optional.h"
 
-namespace util = firebase::firestore::util;
 namespace nanopb = firebase::firestore::nanopb;
 using firebase::Timestamp;
 using firebase::TimestampInternal;
@@ -82,6 +81,7 @@ using firebase::firestore::model::TransformOperation;
 using firebase::firestore::nanopb::CheckedSize;
 using firebase::firestore::nanopb::Message;
 using firebase::firestore::remote::Serializer;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 using firebase::firestore::util::ReadContext;
 using firebase::firestore::google_firestore_v1_Value;
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
       FieldPath path;
 
       if ([fieldPath isKindOfClass:[NSString class]]) {
-        path = FieldPath::FromDotSeparatedString(util::MakeString(fieldPath));
+        path = FieldPath::FromDotSeparatedString(MakeString(fieldPath));
       } else if ([fieldPath isKindOfClass:[FIRFieldPath class]]) {
         path = static_cast<FIRFieldPath *>(fieldPath).internalValue;
       } else {
@@ -217,7 +217,7 @@ NS_ASSUME_NONNULL_BEGIN
     FieldPath path;
 
     if ([key isKindOfClass:[NSString class]]) {
-      path = FieldPath::FromDotSeparatedString(util::MakeString(key));
+      path = FieldPath::FromDotSeparatedString(MakeString(key));
     } else if ([key isKindOfClass:[FIRFieldPath class]]) {
       path = ((FIRFieldPath *)key).internalValue;
     } else {
@@ -327,9 +327,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     __block pb_size_t index = 0;
     [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *) {
-      auto parsedValue = [self parseData:value context:context.ChildContext(util::MakeString(key))];
+      auto parsedValue = [self parseData:value context:context.ChildContext(MakeString(key))];
       if (parsedValue) {
-        result->map_value.fields[index].key = nanopb::MakeBytesArray(util::MakeString(key));
+        result->map_value.fields[index].key = nanopb::MakeBytesArray(MakeString(key));
         result->map_value.fields[index].value = *parsedValue->release();
         ++index;
       }
@@ -499,7 +499,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
   } else if ([input isKindOfClass:[NSString class]]) {
-    std::string inputString = util::MakeString(input);
+    std::string inputString = MakeString(input);
     return [self encodeStringValue:inputString];
 
   } else if ([input isKindOfClass:[NSDate class]]) {

--- a/Firestore/Source/API/FSTUserDataWriter.mm
+++ b/Firestore/Source/API/FSTUserDataWriter.mm
@@ -37,7 +37,6 @@
 @class FIRTimestamp;
 
 namespace api = firebase::firestore::api;
-namespace util = firebase::firestore::util;
 namespace model = firebase::firestore::model;
 namespace nanopb = firebase::firestore::nanopb;
 
@@ -49,6 +48,7 @@ using firebase::firestore::google_firestore_v1_ArrayValue;
 using firebase::firestore::google_firestore_v1_MapValue;
 using firebase::firestore::google_firestore_v1_Value;
 using firebase::firestore::google_protobuf_Timestamp;
+using firebase::firestore::util::MakeNSString;
 using model::DatabaseId;
 using model::DocumentKey;
 using model::GetLocalWriteTime;
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
                  ? @(value.integer_value)
                  : @(value.double_value);
     case TypeOrder::kString:
-      return util::MakeNSString(MakeStringView(value.string_value));
+      return MakeNSString(MakeStringView(value.string_value));
     case TypeOrder::kBlob:
       return MakeNSData(value.bytes_value);
     case TypeOrder::kGeoPoint:
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
   for (pb_size_t i = 0; i < mapValue.fields_count; ++i) {
     absl::string_view key = MakeStringView(mapValue.fields[i].key);
     const google_firestore_v1_Value &value = mapValue.fields[i].value;
-    result[util::MakeNSString(key)] = [self convertedValue:value];
+    result[MakeNSString(key)] = [self convertedValue:value];
   }
   return result;
 }


### PR DESCRIPTION
This would conflict with any definition of a `util` namespace imported from a header. While this applies to other aliases as well, `util` is the one most likely to clash and the one that has actually caused problems.

#no-changelog