### PR TITLE
First pass at Swift cancellation

### DIFF
--- a/FirebaseStorageSwift/Sources/AsyncAwait.swift
+++ b/FirebaseStorageSwift/Sources/AsyncAwait.swift
@@ -86,7 +86,7 @@ public enum StorageError: Error {
         }
       }, onCancel: { [storageTask] in
         // A possible race condition here. `onCancel` and `operation` are performed concurrently,
-        // so it's possible for `storageTask` still be `nil` but `Task.isCancelled` still be `false`, 
+        // so it's possible for `storageTask` still be `nil` but `Task.isCancelled` still be `false`,
         // so `storageTask` can be initialized and started after `onCancel` block has been
         // performed.
         storageTask?.cancel()

--- a/FirebaseStorageSwift/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageAsyncAwait.swift
@@ -193,12 +193,17 @@ import XCTest
       let task = Task { () -> StorageMetadata in
         try await ref.putFileAsync(from: fileURL)
       }
-      task.cancel()
+
+      // Cancel the task after a while.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        task.cancel()
+      }
+
       do {
         _ = try await task.value
         XCTFail("Unexpected success from putFileCancel")
       } catch {
-        XCTAssertEqual(error as! StorageError, StorageError.cancelled)
+        XCTAssert(error is CancellationError)
       }
     }
 

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -193,6 +193,26 @@ class StorageResultTests: StorageIntegrationCommon {
     waitForExpectations()
   }
 
+  func testSimplePutFileCancel() throws {
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    let task = ref.putFile(from: fileURL) { result in
+      switch result {
+      case .success:
+        XCTFail("Unexpected success from putFileCancel")
+      case let .failure(error as NSError):
+        XCTAssertEqual(error.code, StorageErrorCode.cancelled.rawValue)
+        expectation.fulfill()
+      }
+    }
+    task.cancel()
+    waitForExpectations()
+  }
+
   func testAttemptToUploadDirectoryShouldFail() throws {
     // This `.numbers` file is actually a directory.
     let fileName = "HomeImprovement.numbers"


### PR DESCRIPTION
Investigate feasibility of Swift cancellation implementation as a wrapper over existing APIs.

We're going to put this PR on hold pending more customer input and additional Swift Concurrency evolution. In the meantime, cancellation continues to be available via the original API.

Thanks to @maksymmalyhin 's last commit,  inspired by https://github.com/apple/swift-evolution/blob/main/proposals/0300-continuation.md#additional-examples, we believe we're on track to a solution. The race condition in the comments could be solved by exposing the FIRStorageUploadTask init API https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorage/Sources/FIRStorageReference.m#L227, call it before to get the task, and then pass the task into a modified putFile API. The two new public APIs could be prefixed with double underscores to indicate they're not for public consumption.

Beyond that, it is still an open question about how to implement cancellation for the auto-generated APIs from Objective C.  I don't see anything about overriding or modifying the generated functions at https://github.com/apple/swift-evolution/blob/main/proposals/0297-concurrency-objc.md.