### PR TITLE
Fix double '/' in path produced by spm sample crashlytics build script

### DIFF
--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -50,7 +50,7 @@ in the `Build Settings` tab.
 <img src="docs/resources/SPMObjC.png">
 
 If you're using FirebaseCrashlytics, you can use
-`${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
+`${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
 as the run script that allows Xcode to upload your project's dSYM files.
 
 Another option is to use the


### PR DESCRIPTION

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

fixes #8533

Updates the spm installation instructions.

Currently the Build phase outlined for dsym upload produces an extra `/` before `SourcePackages`

### Testing

New path that will be output:

![Screen Shot 2021-08-16 at 7 10 10 PM](https://user-images.githubusercontent.com/18543934/129640200-a592136e-ecee-4b57-a34e-304c1160c4cd.png)

### API Changes

 n/a
