### PR TITLE
Fix nightly build

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthServiceTest.m
@@ -38,6 +38,7 @@ static NSString *const kVersionInfo = @"1.0";
     NSMutableArray<FIRMessagingDeviceCheckinCompletion> *checkinHandlers;
 @property(nonatomic, readwrite, strong) FIRMessagingCheckinService *checkinService;
 @property(nonatomic, readwrite, strong) FIRMessagingCheckinStore *checkinStore;
+@property(nonatomic, readwrite, strong) FIRMessagingCheckinPreferences *checkinPreferences;
 @end
 
 @interface FIRMessagingAuthServiceTest : XCTestCase
@@ -46,6 +47,7 @@ static NSString *const kVersionInfo = @"1.0";
 @property(nonatomic, readwrite, strong) FIRMessagingCheckinService *checkinService;
 @property(nonatomic, readwrite, strong) id mockCheckinService;
 @property(nonatomic, readwrite, strong) id mockStore;
+
 @property(nonatomic, readwrite, copy) FIRMessagingDeviceCheckinCompletion checkinCompletion;
 
 @end
@@ -56,8 +58,12 @@ static NSString *const kVersionInfo = @"1.0";
   [super setUp];
   _authService = [[FIRMessagingAuthService alloc] init];
   _mockStore = OCMPartialMock(_authService.checkinStore);
-
   _mockCheckinService = OCMPartialMock(_authService.checkinService);
+  // Ensure cached checkin is reset when testing initial checkin call.
+  FIRMessagingCheckinPreferences *preferences =
+      [[FIRMessagingCheckinPreferences alloc] initWithDeviceID:@"" secretToken:@""];
+  _authService.checkinPreferences = preferences;
+
   // The tests here are to focus on checkin interval not locale change, so always set locale as
   // non-changed.
   [[NSUserDefaults standardUserDefaults] setObject:FIRMessagingCurrentLocale()
@@ -81,7 +87,7 @@ static NSString *const kVersionInfo = @"1.0";
   FIRMessagingCheckinPreferences *checkinPreferences = [self validCheckinPreferences];
 
   OCMStub([self.mockCheckinService
-              checkinWithExistingCheckin:self.checkinService.checkinPreferences
+              checkinWithExistingCheckin:[OCMArg any]
                               completion:([OCMArg checkWithBlock:^BOOL(id obj) {
                                 [checkinExpectation fulfill];
                                 self.checkinCompletion = obj;
@@ -110,7 +116,7 @@ static NSString *const kVersionInfo = @"1.0";
       [self expectationWithDescription:@"Did receive error after checkin"];
 
   FIRMessagingCheckinPreferences *checkinPreferences = [self validCheckinPreferences];
-  OCMStub([self.mockCheckinService checkinWithExistingCheckin:self.checkinService.checkinPreferences
+  OCMStub([self.mockCheckinService checkinWithExistingCheckin:[OCMArg any]
                                                    completion:[OCMArg checkWithBlock:^BOOL(id obj) {
                                                      [checkinFailureExpectation fulfill];
                                                      self.checkinCompletion = obj;
@@ -140,7 +146,7 @@ static NSString *const kVersionInfo = @"1.0";
   __block int checkinHandlerInvocationCount = 0;
 
   FIRMessagingCheckinPreferences *checkinPreferences = [self validCheckinPreferences];
-  OCMStub([self.mockCheckinService checkinWithExistingCheckin:self.checkinService.checkinPreferences
+  OCMStub([self.mockCheckinService checkinWithExistingCheckin:[OCMArg any]
                                                    completion:[OCMArg checkWithBlock:^BOOL(id obj) {
                                                      self.checkinCompletion = obj;
                                                      return obj != nil;
@@ -184,7 +190,7 @@ static NSString *const kVersionInfo = @"1.0";
       [self expectationWithDescription:@"Did call checkin service"];
 
   FIRMessagingCheckinPreferences *checkinPreferences = [self validCheckinPreferences];
-  OCMStub([self.mockCheckinService checkinWithExistingCheckin:self.checkinService.checkinPreferences
+  OCMStub([self.mockCheckinService checkinWithExistingCheckin:[OCMArg any]
                                                    completion:[OCMArg checkWithBlock:^BOOL(id obj) {
                                                      self.checkinCompletion = obj;
                                                      return obj != nil;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthServiceTest.m
@@ -47,7 +47,6 @@ static NSString *const kVersionInfo = @"1.0";
 @property(nonatomic, readwrite, strong) FIRMessagingCheckinService *checkinService;
 @property(nonatomic, readwrite, strong) id mockCheckinService;
 @property(nonatomic, readwrite, strong) id mockStore;
-
 @property(nonatomic, readwrite, copy) FIRMessagingDeviceCheckinCompletion checkinCompletion;
 
 @end

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -160,8 +160,9 @@ static NSString *const kValidImageURL =
   OCMStub([_mockUtilClass isAppExtension]).andReturn(YES);
   NSDictionary *fakeMessageInfo = @{@"aps" : @{}};
 
-  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
   OCMReject([_mockExtensionHelper bundleIdentifierByRemovingLastPartFrom:[OCMArg any]]);
+  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
+  OCMVerifyAll(_mockExtensionHelper);
 }
 
 - (void)testDeliveryMetricsLoggingWithInvalidMessageID {
@@ -172,8 +173,9 @@ static NSString *const kValidImageURL =
     @"google.c.fid" : @"fakeFIDForTest",
     @"google.c.sender.id" : @123456789
   };
-  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
   OCMReject([_mockExtensionHelper bundleIdentifierByRemovingLastPartFrom:[OCMArg any]]);
+  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
+  OCMVerifyAll(_mockExtensionHelper);
 }
 
 - (void)testDeliveryMetricsLoggingWithInvalidFID {
@@ -183,8 +185,9 @@ static NSString *const kValidImageURL =
     @"fcm_options" : @{@"image" : @"https://google.com"},
     @"google.c.sender.id" : @123456789
   };
-  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
   OCMReject([_mockExtensionHelper bundleIdentifierByRemovingLastPartFrom:[OCMArg any]]);
+  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
+  OCMVerifyAll(_mockExtensionHelper);
 }
 
 - (void)testDeliveryMetricsLoggingWithDisplayPayload {
@@ -196,9 +199,9 @@ static NSString *const kValidImageURL =
     @"google.c.fid" : @"fakeFIDForTest",
     @"google.c.sender.id" : @123456789
   };
-
-  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
   OCMExpect([_mockExtensionHelper bundleIdentifierByRemovingLastPartFrom:[OCMArg any]]);
+  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
+  OCMVerifyAll(_mockExtensionHelper);
 }
 
 - (void)testDeliveryMetricsLoggingWithDataPayload {
@@ -210,8 +213,9 @@ static NSString *const kValidImageURL =
     @"google.c.fid" : @"fakeFIDForTest",
     @"google.c.sender.id" : @123456789
   };
-  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
   OCMReject([_mockExtensionHelper bundleIdentifierByRemovingLastPartFrom:[OCMArg any]]);
+  [_mockExtensionHelper exportDeliveryMetricsToBigQueryWithMessageInfo:fakeMessageInfo];
+  OCMVerifyAll(_mockExtensionHelper);
 }
 
 @end


### PR DESCRIPTION
Fixes #8525. #no-changelog

We need to adjust unit test after we fixed the checkin issue. When we moved the checkinStore under authService, the stub parameter no longer take effect so we should use [OCMArg any] instead for the stub method to be triggered.


