### PR TITLE
Functions: don't send dummy FAC token

### DIFF
--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,7 +1,6 @@
-# v8.7.1
-- [changed] Don't set the App Check header in the case of App Check error. (#8558)
 # v8.7.0
 - [fixed] Add watchOS support (#8499).
+- [changed] Don't set the App Check header in the case of App Check error (#8558). 
 
 # v8.3.0
 - [fixed] Fixed an issue where subclassing Functions was unusable (#8265).

--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v8.7.1
+- [changed] Don't set the App Check header in the case of App Check error. (#8558)
 # v8.7.0
 - [fixed] Add watchOS support (#8499).
 

--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v8.7.0
 - [fixed] Add watchOS support (#8499).
-- [changed] Don't set the App Check header in the case of App Check error (#8558). 
+- [changed] Don't set the App Check header in the case of App Check error (#8558).
 
 # v8.3.0
 - [fixed] Fixed an issue where subclassing Functions was unusable (#8265).

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -151,7 +151,7 @@
 
 #pragma mark - App Check integration
 
-- (void)testCallFunctionWhenAppCheckIsInstalled {
+- (void)testCallFunctionWhenAppCheckIsInstalledAndFACTokenSuccess {
   _appCheckFake.tokenResult = [[FIRAppCheckTokenResultFake alloc] initWithToken:@"valid_token"
                                                                           error:nil];
 
@@ -172,6 +172,45 @@
     NSString *appCheckTokenHeader =
         [fetcherToTest.request valueForHTTPHeaderField:@"X-Firebase-AppCheck"];
     XCTAssertEqualObjects(appCheckTokenHeader, @"valid_token");
+
+    testResponse(nil, nil, networkError);
+  };
+
+  XCTestExpectation *completionExpectation =
+      [self expectationWithDescription:@"completionExpectation"];
+  [_functions callFunction:@"fake_func"
+                withObject:nil
+                   timeout:10
+                completion:^(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error) {
+                  XCTAssertEqualObjects(error, networkError);
+                  [completionExpectation fulfill];
+                }];
+
+  [self waitForExpectations:@[ httpRequestExpectation, completionExpectation ] timeout:1.5];
+}
+
+- (void)testCallFunctionWhenAppCheckIsInstalledAndFACTokenError {
+  NSError *appCheckError = [NSError errorWithDomain:self.name code:-1 userInfo:nil];
+  _appCheckFake.tokenResult = [[FIRAppCheckTokenResultFake alloc] initWithToken:@"dummy_token"
+                                                                          error:appCheckError];
+
+  NSError *networkError = [NSError errorWithDomain:self.name
+                                              code:-2
+                                          userInfo:nil];
+
+  XCTestExpectation *httpRequestExpectation =
+      [self expectationWithDescription:@"HTTPRequestExpectation"];
+  __weak __auto_type weakSelf = self;
+  _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
+                                GTMSessionFetcherTestResponse _Nonnull testResponse) {
+    // Fixes retain cycle warning for Xcode 11 and earlier.
+    // __unused to avoid warning in Xcode 12+.
+    __unused __auto_type self = weakSelf;
+    [httpRequestExpectation fulfill];
+
+    NSString *appCheckTokenHeader =
+        [fetcherToTest.request valueForHTTPHeaderField:@"X-Firebase-AppCheck"];
+    XCTAssertNil(appCheckTokenHeader);
 
     testResponse(nil, nil, networkError);
   };

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -161,12 +161,8 @@
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
-  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
-    // Fixes retain cycle warning for Xcode 11 and earlier.
-    // __unused to avoid warning in Xcode 12+.
-    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =
@@ -198,12 +194,8 @@
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
-  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
-    // Fixes retain cycle warning for Xcode 11 and earlier.
-    // __unused to avoid warning in Xcode 12+.
-    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =
@@ -234,12 +226,8 @@
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
 
-  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
-    // Fixes retain cycle warning for Xcode 11 and earlier.
-    // __unused to avoid warning in Xcode 12+.
-    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -194,9 +194,7 @@
   _appCheckFake.tokenResult = [[FIRAppCheckTokenResultFake alloc] initWithToken:@"dummy_token"
                                                                           error:appCheckError];
 
-  NSError *networkError = [NSError errorWithDomain:self.name
-                                              code:-2
-                                          userInfo:nil];
+  NSError *networkError = [NSError errorWithDomain:self.name code:-2 userInfo:nil];
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];

--- a/Functions/Example/Tests/FUNContextProviderTests.m
+++ b/Functions/Example/Tests/FUNContextProviderTests.m
@@ -132,8 +132,8 @@
     XCTAssertNil(error);
     XCTAssertNil(context.authToken);
     XCTAssertNil(context.FCMToken);
-    // Expect a dummy token to be passed even in the case of app check error.
-    XCTAssertEqualObjects(context.appCheckToken, self.appCheckTokenError.token);
+    // Don't expect any token in the case of App Check error.
+    XCTAssertNil(context.appCheckToken);
     [expectation fulfill];
   }];
 
@@ -181,8 +181,8 @@
 
     XCTAssertNil(context.authToken);
     XCTAssert([context.FCMToken isEqualToString:self.messagingFake.FCMToken]);
-    // Expect a dummy token to be passed even in the case of app check error.
-    XCTAssertEqualObjects(context.appCheckToken, self.appCheckTokenError.token);
+    // Don't expect any token in the case of App Check error.
+    XCTAssertNil(context.appCheckToken);
     [expectation fulfill];
   }];
 

--- a/Functions/FirebaseFunctions/FUNContext.m
+++ b/Functions/FirebaseFunctions/FUNContext.m
@@ -101,10 +101,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     [_appCheck getTokenForcingRefresh:NO
                            completion:^(id<FIRAppCheckTokenResultInterop> _Nonnull tokenResult) {
-      // Send only valid token to functions.
-      if (tokenResult.error == nil) {
-        appCheckToken = tokenResult.token;
-      }
+                             // Send only valid token to functions.
+                             if (tokenResult.error == nil) {
+                               appCheckToken = tokenResult.token;
+                             }
 
                              dispatch_group_leave(dispatchGroup);
                            }];

--- a/Functions/FirebaseFunctions/FUNContext.m
+++ b/Functions/FirebaseFunctions/FUNContext.m
@@ -101,7 +101,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     [_appCheck getTokenForcingRefresh:NO
                            completion:^(id<FIRAppCheckTokenResultInterop> _Nonnull tokenResult) {
-                             appCheckToken = tokenResult.token;
+      // Send only valid token to functions.
+      if (tokenResult.error == nil) {
+        appCheckToken = tokenResult.token;
+      }
 
                              dispatch_group_leave(dispatchGroup);
                            }];


### PR DESCRIPTION
Fixes https://github.com/FirebaseExtended/flutterfire/issues/6794 for Apple platforms.

b/197236400