### PR TITLE
Handle the case when refreshToken is null

### DIFF
--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.h
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.h
@@ -82,7 +82,7 @@ typedef void (^FIRFetchAccessTokenCallback)(NSString *_Nullable token,
 - (instancetype)initWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
                                  accessToken:(nullable NSString *)accessToken
                    accessTokenExpirationDate:(nullable NSDate *)accessTokenExpirationDate
-                                refreshToken:(NSString *)refreshToken;
+                                refreshToken:(nullable NSString *)refreshToken;
 
 /** @fn fetchAccessTokenForcingRefresh:callback:
     @brief Fetch a fresh ephemeral access token for the ID associated with this instance. The token

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -45,6 +45,11 @@ static NSString *const kRefreshTokenKey = @"refreshToken";
  */
 static NSString *const kAccessTokenKey = @"accessToken";
 
+/** @var kRefreshTokenError
+    @brief Missing refresh token error message.
+ */
+static NSString *const kRefreshTokenError = @"Refresh token not present.";
+
 /** @var kAccessTokenExpirationDateKey
     @brief The key used to encode the access token expiration date for NSSecureCoding.
  */
@@ -186,30 +191,30 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
                                         requestConfiguration:_requestConfiguration];
   } else {
     NSError *error = [FIRAuthErrorUtils errorWithCode:FIRAuthInternalErrorCodeInternalError
-                                              message:@"Refresh token not present."];
+                                              message:kRefreshTokenError];
     callback(nil, error, NO);
     return;
   }
   [FIRAuthBackend
-      secureToken:request
-         callback:^(FIRSecureTokenResponse *_Nullable response, NSError *_Nullable error) {
-           BOOL tokenUpdated = NO;
-           NSString *newAccessToken = response.accessToken;
-           if (newAccessToken.length && ![newAccessToken isEqualToString:self->_accessToken]) {
-             self->_accessToken = [newAccessToken copy];
-             self->_accessTokenExpirationDate = response.approximateExpirationDate;
-             tokenUpdated = YES;
-             FIRLogDebug(kFIRLoggerAuth, @"I-AUT000017",
-                         @"Updated access token. Estimated expiration date: %@, current date: %@",
-                         self->_accessTokenExpirationDate, [NSDate date]);
-           }
-           NSString *newRefreshToken = response.refreshToken;
-           if (newRefreshToken.length && ![newRefreshToken isEqualToString:self->_refreshToken]) {
-             self->_refreshToken = [newRefreshToken copy];
-             tokenUpdated = YES;
-           }
-           callback(newAccessToken, error, tokenUpdated);
-         }];
+    secureToken:request
+       callback:^(FIRSecureTokenResponse *_Nullable response, NSError *_Nullable error) {
+         BOOL tokenUpdated = NO;
+         NSString *newAccessToken = response.accessToken;
+         if (newAccessToken.length && ![newAccessToken isEqualToString:self->_accessToken]) {
+           self->_accessToken = [newAccessToken copy];
+           self->_accessTokenExpirationDate = response.approximateExpirationDate;
+           tokenUpdated = YES;
+           FIRLogDebug(kFIRLoggerAuth, @"I-AUT000017",
+                       @"Updated access token. Estimated expiration date: %@, current date: %@",
+                       self->_accessTokenExpirationDate, [NSDate date]);
+         }
+         NSString *newRefreshToken = response.refreshToken;
+         if (newRefreshToken.length && ![newRefreshToken isEqualToString:self->_refreshToken]) {
+           self->_refreshToken = [newRefreshToken copy];
+           tokenUpdated = YES;
+         }
+         callback(newAccessToken, error, tokenUpdated);
+       }];
 }
 
 - (BOOL)hasValidAccessToken {

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -181,35 +181,35 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
   if (_refreshToken.length) {
     request = [FIRSecureTokenRequest refreshRequestWithRefreshToken:_refreshToken
                                                requestConfiguration:_requestConfiguration];
-  } else if (_authorizationCode.length){
+  } else if (_authorizationCode.length) {
     request = [FIRSecureTokenRequest authCodeRequestWithCode:_authorizationCode
                                         requestConfiguration:_requestConfiguration];
   } else {
-      NSError *error = [FIRAuthErrorUtils errorWithCode:FIRAuthInternalErrorCodeInternalError
-                                                message:@"Refresh token not present."];
-      callback(nil, error, NO);
-      return;
+    NSError *error = [FIRAuthErrorUtils errorWithCode:FIRAuthInternalErrorCodeInternalError
+                                              message:@"Refresh token not present."];
+    callback(nil, error, NO);
+    return;
   }
   [FIRAuthBackend
-    secureToken:request
-       callback:^(FIRSecureTokenResponse *_Nullable response, NSError *_Nullable error) {
-         BOOL tokenUpdated = NO;
-         NSString *newAccessToken = response.accessToken;
-         if (newAccessToken.length && ![newAccessToken isEqualToString:self->_accessToken]) {
-           self->_accessToken = [newAccessToken copy];
-           self->_accessTokenExpirationDate = response.approximateExpirationDate;
-           tokenUpdated = YES;
-           FIRLogDebug(kFIRLoggerAuth, @"I-AUT000017",
-                       @"Updated access token. Estimated expiration date: %@, current date: %@",
-                       self->_accessTokenExpirationDate, [NSDate date]);
-         }
-         NSString *newRefreshToken = response.refreshToken;
-         if (newRefreshToken.length && ![newRefreshToken isEqualToString:self->_refreshToken]) {
-           self->_refreshToken = [newRefreshToken copy];
-           tokenUpdated = YES;
-         }
-         callback(newAccessToken, error, tokenUpdated);
-       }];
+      secureToken:request
+         callback:^(FIRSecureTokenResponse *_Nullable response, NSError *_Nullable error) {
+           BOOL tokenUpdated = NO;
+           NSString *newAccessToken = response.accessToken;
+           if (newAccessToken.length && ![newAccessToken isEqualToString:self->_accessToken]) {
+             self->_accessToken = [newAccessToken copy];
+             self->_accessTokenExpirationDate = response.approximateExpirationDate;
+             tokenUpdated = YES;
+             FIRLogDebug(kFIRLoggerAuth, @"I-AUT000017",
+                         @"Updated access token. Estimated expiration date: %@, current date: %@",
+                         self->_accessTokenExpirationDate, [NSDate date]);
+           }
+           NSString *newRefreshToken = response.refreshToken;
+           if (newRefreshToken.length && ![newRefreshToken isEqualToString:self->_refreshToken]) {
+             self->_refreshToken = [newRefreshToken copy];
+             tokenUpdated = YES;
+           }
+           callback(newAccessToken, error, tokenUpdated);
+         }];
 }
 
 - (BOOL)hasValidAccessToken {

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -48,7 +48,7 @@ static NSString *const kAccessTokenKey = @"accessToken";
 /** @var kRefreshTokenError
     @brief Missing refresh token error message.
  */
-static NSString *const kRefreshTokenError = @"Refresh token not present.";
+static NSString *const kRefreshTokenError = @"No refresh token is available.";
 
 /** @var kAccessTokenExpirationDateKey
     @brief The key used to encode the access token expiration date for NSSecureCoding.

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -282,7 +282,11 @@ static void callInMainThreadWithAuthDataResultAndError(
   user.auth = auth;
   user.tenantID = auth.tenantID;
   user.requestConfiguration = auth.requestConfiguration;
-  if (refreshToken.length) {
+  if (!refreshToken.length) {
+    [user updateWithIDToken:accessToken];
+    callback(user, nil);
+    return;
+  }
     [user
         internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
           if (error) {
@@ -306,10 +310,6 @@ static void callInMainThreadWithAuthDataResultAndError(
                                   callback(user, nil);
                                 }];
         }];
-  } else {
-    [user updateWithIDToken:accessToken];
-    callback(user, nil);
-  }
 }
 
 - (instancetype)initWithTokenService:(FIRSecureTokenService *)tokenService {

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -282,29 +282,34 @@ static void callInMainThreadWithAuthDataResultAndError(
   user.auth = auth;
   user.tenantID = auth.tenantID;
   user.requestConfiguration = auth.requestConfiguration;
-  [user internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
-    if (error) {
-      callback(nil, error);
-      return;
+    if (refreshToken.length) {
+      [user internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
+        if (error) {
+          callback(nil, error);
+          return;
+        }
+        FIRGetAccountInfoRequest *getAccountInfoRequest =
+            [[FIRGetAccountInfoRequest alloc] initWithAccessToken:accessToken
+                                             requestConfiguration:auth.requestConfiguration];
+        [FIRAuthBackend
+            getAccountInfo:getAccountInfoRequest
+                  callback:^(FIRGetAccountInfoResponse *_Nullable response, NSError *_Nullable error) {
+                    if (error) {
+                      // No need to sign out user here for errors because the user hasn't been signed in
+                      // yet.
+                      callback(nil, error);
+                      return;
+                    }
+                    user.anonymous = anonymous;
+                    [user updateWithGetAccountInfoResponse:response];
+                    callback(user, nil);
+                  }];
+      }];
+    } else {
+        [user updateWithIDToken:accessToken];
+        callback(user, nil);
     }
-    FIRGetAccountInfoRequest *getAccountInfoRequest =
-        [[FIRGetAccountInfoRequest alloc] initWithAccessToken:accessToken
-                                         requestConfiguration:auth.requestConfiguration];
-    [FIRAuthBackend
-        getAccountInfo:getAccountInfoRequest
-              callback:^(FIRGetAccountInfoResponse *_Nullable response, NSError *_Nullable error) {
-                if (error) {
-                  // No need to sign out user here for errors because the user hasn't been signed in
-                  // yet.
-                  callback(nil, error);
-                  return;
-                }
-                user.anonymous = anonymous;
-                [user updateWithGetAccountInfoResponse:response];
-                callback(user, nil);
-              }];
-  }];
-}
+  }
 
 - (instancetype)initWithTokenService:(FIRSecureTokenService *)tokenService {
   self = [super init];
@@ -468,6 +473,12 @@ static void callInMainThreadWithAuthDataResultAndError(
   _multiFactor = [[FIRMultiFactor alloc] initWithMFAEnrollments:user.MFAEnrollments];
   _multiFactor.user = self;
 #endif
+}
+
+- (void)updateWithIDToken:(NSString *)token {
+  FIRAuthTokenResult *tokenResult = [FIRAuthTokenResult tokenResultWithToken:token];
+  NSDictionary *tokenClaims = tokenResult.claims;
+  _userID = tokenClaims[@"user_id"];
 }
 
 /** @fn executeUserUpdateWithChanges:callback:

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -500,47 +500,47 @@ static void callInMainThreadWithAuthDataResultAndError(
         callback(error);
         return;
       }
-      [self internalGetTokenWithCallback:^(NSString *_Nullable accessToken,
-                                           NSError *_Nullable error) {
-        if (error) {
-          complete();
-          callback(error);
-          return;
-        }
-        FIRAuthRequestConfiguration *configuration = self->_auth.requestConfiguration;
-        // Mutate setAccountInfoRequest in block:
-        FIRSetAccountInfoRequest *setAccountInfoRequest =
-            [[FIRSetAccountInfoRequest alloc] initWithRequestConfiguration:configuration];
-        setAccountInfoRequest.accessToken = accessToken;
-        changeBlock(user, setAccountInfoRequest);
-        // Execute request:
-        [FIRAuthBackend
-            setAccountInfo:setAccountInfoRequest
-                  callback:^(FIRSetAccountInfoResponse *_Nullable response,
-                             NSError *_Nullable error) {
-                    if (error) {
-                      [self signOutIfTokenIsInvalidWithError:error];
+      [self
+        internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
+          if (error) {
+            complete();
+            callback(error);
+            return;
+          }
+          FIRAuthRequestConfiguration *configuration = self->_auth.requestConfiguration;
+          // Mutate setAccountInfoRequest in block:
+          FIRSetAccountInfoRequest *setAccountInfoRequest =
+              [[FIRSetAccountInfoRequest alloc] initWithRequestConfiguration:configuration];
+          setAccountInfoRequest.accessToken = accessToken;
+          changeBlock(user, setAccountInfoRequest);
+          // Execute request:
+          [FIRAuthBackend
+              setAccountInfo:setAccountInfoRequest
+                    callback:^(FIRSetAccountInfoResponse *_Nullable response,
+                               NSError *_Nullable error) {
+                      if (error) {
+                        [self signOutIfTokenIsInvalidWithError:error];
+                        complete();
+                        callback(error);
+                        return;
+                      }
+                      if (response.IDToken && response.refreshToken) {
+                        FIRSecureTokenService *tokenService = [[FIRSecureTokenService alloc]
+                            initWithRequestConfiguration:configuration
+                                             accessToken:response.IDToken
+                               accessTokenExpirationDate:response.approximateExpirationDate
+                                            refreshToken:response.refreshToken];
+                        [self setTokenService:tokenService
+                                     callback:^(NSError *_Nullable error) {
+                                       complete();
+                                       callback(error);
+                                     }];
+                        return;
+                      }
                       complete();
-                      callback(error);
-                      return;
-                    }
-                    if (response.IDToken && response.refreshToken) {
-                      FIRSecureTokenService *tokenService = [[FIRSecureTokenService alloc]
-                          initWithRequestConfiguration:configuration
-                                           accessToken:response.IDToken
-                             accessTokenExpirationDate:response.approximateExpirationDate
-                                          refreshToken:response.refreshToken];
-                      [self setTokenService:tokenService
-                                   callback:^(NSError *_Nullable error) {
-                                     complete();
-                                     callback(error);
-                                   }];
-                      return;
-                    }
-                    complete();
-                    callback(nil);
-                  }];
-      }];
+                      callback(nil);
+                    }];
+        }];
     }];
   }];
 }
@@ -836,11 +836,11 @@ static void callInMainThreadWithAuthDataResultAndError(
                                              }
                                              // Successful reauthenticate
                                              [self
-                                                 setTokenService:authResult.user->_tokenService
-                                                        callback:^(NSError *_Nullable error) {
-                                                          callInMainThreadWithAuthDataResultAndError(
-                                                              completion, authResult, error);
-                                                        }];
+                                               setTokenService:authResult.user->_tokenService
+                                                      callback:^(NSError *_Nullable error) {
+                                                        callInMainThreadWithAuthDataResultAndError(
+                                                            completion, authResult, error);
+                                                      }];
                                            }];
   });
 }

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -287,29 +287,28 @@ static void callInMainThreadWithAuthDataResultAndError(
     callback(user, nil);
     return;
   }
-    [user
-        internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
-          if (error) {
-            callback(nil, error);
-            return;
-          }
-          FIRGetAccountInfoRequest *getAccountInfoRequest =
-              [[FIRGetAccountInfoRequest alloc] initWithAccessToken:accessToken
-                                               requestConfiguration:auth.requestConfiguration];
-          [FIRAuthBackend getAccountInfo:getAccountInfoRequest
-                                callback:^(FIRGetAccountInfoResponse *_Nullable response,
-                                           NSError *_Nullable error) {
-                                  if (error) {
-                                    // No need to sign out user here for errors because the user
-                                    // hasn't been signed in yet.
-                                    callback(nil, error);
-                                    return;
-                                  }
-                                  user.anonymous = anonymous;
-                                  [user updateWithGetAccountInfoResponse:response];
-                                  callback(user, nil);
-                                }];
-        }];
+  [user internalGetTokenWithCallback:^(NSString *_Nullable accessToken, NSError *_Nullable error) {
+    if (error) {
+      callback(nil, error);
+      return;
+    }
+    FIRGetAccountInfoRequest *getAccountInfoRequest =
+        [[FIRGetAccountInfoRequest alloc] initWithAccessToken:accessToken
+                                         requestConfiguration:auth.requestConfiguration];
+    [FIRAuthBackend
+        getAccountInfo:getAccountInfoRequest
+              callback:^(FIRGetAccountInfoResponse *_Nullable response, NSError *_Nullable error) {
+                if (error) {
+                  // No need to sign out user here for errors because the user
+                  // hasn't been signed in yet.
+                  callback(nil, error);
+                  return;
+                }
+                user.anonymous = anonymous;
+                [user updateWithGetAccountInfoResponse:response];
+                callback(user, nil);
+              }];
+  }];
 }
 
 - (instancetype)initWithTokenService:(FIRSecureTokenService *)tokenService {

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -85,6 +85,11 @@ static NSString *const kAPIKey = @"FAKE_API_KEY";
  */
 static NSString *const kAccessToken = @"ACCESS_TOKEN";
 
+/** @var kEncodedAccessToken
+    @brief A fake access token containing user_id as payload
+ */
+static NSString *const kEncodedAccessToken = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwidXNlcl9pZCI6InRlc3RfcGFzc3Rocm91Z2giLCJpYXQiOjE1MTYyMzkwMjJ9.4uNq61PQNjbtaEB7Kv28B0krzvF6F6JxyaWFC_cS57A";
+
 /** @var kNewAccessToken
     @brief Another fake access token used to simulate token refreshed via automatic token refresh.
  */
@@ -1513,6 +1518,38 @@ static const NSTimeInterval kWaitInterval = .5;
   OCMVerifyAll(_mockBackend);
 }
 
+/** @fn testSignInWithCustomTokenSuccessNoRefreshToken
+    @brief Tests the flow of a successful @c signInWithCustomToken:completion: call without a refresh token.
+ */
+- (void)testSignInWithCustomTokenWithoutRefreshTokenSuccess {
+  OCMExpect([_mockBackend verifyCustomToken:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyCustomTokenRequest *_Nullable request,
+                       FIRVerifyCustomTokenResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.token, kCustomToken);
+        XCTAssertTrue(request.returnSecureToken);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockVeriyCustomTokenResponse = OCMClassMock([FIRVerifyCustomTokenResponse class]);
+          [self stubTokensWithMockResponseNoRefreshToken:mockVeriyCustomTokenResponse];
+          callback(mockVeriyCustomTokenResponse, nil);
+        });
+      });
+  // If refreshToken is not present, GetAccountInfo is not invoked.
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth]
+      signInWithCustomToken:kCustomToken
+                 completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                   XCTAssertTrue([NSThread isMainThread]);
+                   [self assertUserFromIDToken:result.user];
+                   XCTAssertNil(error);
+                   [expectation fulfill];
+                 }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  [self assertUserFromIDToken:[FIRAuth auth].currentUser];
+  OCMVerifyAll(_mockBackend);
+}
+
 /** @fn testSignInWithCustomTokenFailure
     @brief Tests the flow of a failed @c signInWithCustomToken:completion: call.
  */
@@ -2476,6 +2513,13 @@ static const NSTimeInterval kWaitInterval = .5;
   OCMStub([mockResponse refreshToken]).andReturn(kRefreshToken);
 }
 
+- (void)stubTokensWithMockResponseNoRefreshToken:(id)mockResponse {
+  OCMStub([mockResponse IDToken]).andReturn(kEncodedAccessToken);
+  OCMStub([mockResponse approximateExpirationDate])
+      .andReturn([NSDate dateWithTimeIntervalSinceNow:kAccessTokenTimeToLive]);
+  OCMStub([mockResponse refreshToken]).andReturn(nil);
+}
+
 /** @fn expectGetAccountInfo
     @brief Expects a GetAccountInfo request on the mock backend and calls back with fake account
         data.
@@ -2519,6 +2563,17 @@ static const NSTimeInterval kWaitInterval = .5;
   XCTAssertEqualObjects(user.uid, kLocalID);
   XCTAssertEqualObjects(user.displayName, kDisplayName);
   XCTAssertEqualObjects(user.email, kEmail);
+  XCTAssertFalse(user.anonymous);
+  XCTAssertEqual(user.providerData.count, 0u);
+}
+
+/** @fn assertUserFromIDToken
+    @brief Asserts the given FIRUser matching the fake data returned by a IDToken.
+    @param user The user object to be verified.
+ */
+- (void)assertUserFromIDToken:(FIRUser *)user {
+  XCTAssertNotNil(user);
+  XCTAssertEqualObjects(user.uid, @"test_passthrough");
   XCTAssertFalse(user.anonymous);
   XCTAssertEqual(user.providerData.count, 0u);
 }

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -1533,12 +1533,13 @@ static const NSTimeInterval kWaitInterval = .5;
         XCTAssertEqualObjects(request.token, kCustomToken);
         XCTAssertTrue(request.returnSecureToken);
         dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-          id mockVeriyCustomTokenResponse = OCMClassMock([FIRVerifyCustomTokenResponse class]);
-          [self stubTokensWithMockResponseNoRefreshToken:mockVeriyCustomTokenResponse];
-          callback(mockVeriyCustomTokenResponse, nil);
+          id mockVerifyCustomTokenResponse = OCMClassMock([FIRVerifyCustomTokenResponse class]);
+          [self stubTokensWithMockResponseNoRefreshToken:mockVerifyCustomTokenResponse];
+          callback(mockVerifyCustomTokenResponse, nil);
         });
       });
   // If refreshToken is not present, GetAccountInfo is not invoked.
+  OCMReject([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
   [[FIRAuth auth]

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -1521,7 +1521,7 @@ static const NSTimeInterval kWaitInterval = .5;
   OCMVerifyAll(_mockBackend);
 }
 
-/** @fn testSignInWithCustomTokenSuccessNoRefreshToken
+/** @fn testSignInWithCustomTokenWithoutRefreshTokenSuccess
     @brief Tests the flow of a successful @c signInWithCustomToken:completion: call without a
    refresh token.
  */
@@ -2517,6 +2517,10 @@ static const NSTimeInterval kWaitInterval = .5;
   OCMStub([mockResponse refreshToken]).andReturn(kRefreshToken);
 }
 
+/** @fn stubTokensWithMockResponseNoRefreshToken
+    @brief Creates stubs on the mock response object with only access token, no refresh token.
+    @param mockResponse The mock response object.
+ */
 - (void)stubTokensWithMockResponseNoRefreshToken:(id)mockResponse {
   OCMStub([mockResponse IDToken]).andReturn(kEncodedAccessToken);
   OCMStub([mockResponse approximateExpirationDate])

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -88,7 +88,10 @@ static NSString *const kAccessToken = @"ACCESS_TOKEN";
 /** @var kEncodedAccessToken
     @brief A fake access token containing user_id as payload
  */
-static NSString *const kEncodedAccessToken = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwidXNlcl9pZCI6InRlc3RfcGFzc3Rocm91Z2giLCJpYXQiOjE1MTYyMzkwMjJ9.4uNq61PQNjbtaEB7Kv28B0krzvF6F6JxyaWFC_cS57A";
+static NSString *const kEncodedAccessToken =
+    @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    @"eyJzdWIiOiJ0ZXN0IiwidXNlcl9pZCI6InRlc3RfcGFzc3Rocm91Z2giLCJpYXQiOjE1MTYyMzkwMjJ9."
+    @"4uNq61PQNjbtaEB7Kv28B0krzvF6F6JxyaWFC_cS57A";
 
 /** @var kNewAccessToken
     @brief Another fake access token used to simulate token refreshed via automatic token refresh.
@@ -1519,7 +1522,8 @@ static const NSTimeInterval kWaitInterval = .5;
 }
 
 /** @fn testSignInWithCustomTokenSuccessNoRefreshToken
-    @brief Tests the flow of a successful @c signInWithCustomToken:completion: call without a refresh token.
+    @brief Tests the flow of a successful @c signInWithCustomToken:completion: call without a
+   refresh token.
  */
 - (void)testSignInWithCustomTokenWithoutRefreshTokenSuccess {
   OCMExpect([_mockBackend verifyCustomToken:[OCMArg any] callback:[OCMArg any]])

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1506,7 +1506,6 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @fn testGetIDTokenResultForcingRefreshNoRefreshTokenFailure
     @brief Tests the flow of a failed @c getIDTokenResultForcingRefresh:completion: call.
- The failure reason is no refresh token is available.
  */
 - (void)testGetIDTokenResultForcingRefreshFailureNoRefreshToken {
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
@@ -1516,6 +1515,9 @@ static const NSTimeInterval kExpectationTimeout = 2;
                                            NSError *_Nullable error) {
                                 XCTAssertTrue([NSThread isMainThread]);
                                 XCTAssertNil(tokenResult);
+                                XCTAssertEqual(error.code, FIRAuthInternalErrorCodeInternalError);
+                                XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey],
+                                               @"No refresh token is available.");
                                 XCTAssertNil([FIRAuth auth].currentUser);
                               }];
     [expectation fulfill];

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1371,10 +1371,9 @@ static const NSTimeInterval kExpectationTimeout = 2;
                                            NSError *_Nullable error) {
                                 XCTAssertTrue([NSThread isMainThread]);
                                 XCTAssertNil(tokenResult);
-                                XCTAssertEqual(error.code, FIRAuthInternalErrorCodeInternalError);
-                                XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey],
-                                               @"No refresh token is available.");
-                                XCTAssertNil([FIRAuth auth].currentUser);
+                                XCTAssertEqual(error.code, FIRAuthErrorCodeInternalError);
+                                XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey],
+                                                      @"No refresh token is available.");
                                 [expectation fulfill];
                               }];
   }];
@@ -3016,8 +3015,6 @@ static const NSTimeInterval kExpectationTimeout = 2;
           callback(mockVerifyCustomTokenResponse, nil);
         });
       });
-  // If refreshToken is not present, GetAccountInfo is not invoked.
-  OCMReject([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]]);
   [[FIRAuth auth] signOut:NULL];
   [[FIRAuth auth]
       signInWithCustomToken:kCustomToken

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1360,15 +1360,37 @@ static const NSTimeInterval kExpectationTimeout = 2;
   OCMVerifyAll(_mockBackend);
 }
 
+/** @fn testGetIDTokenResultForcingRefreshNoRefreshTokenFailure
+    @brief Tests the flow of a failed @c getIDTokenResultForcingRefresh:completion: call.
+ */
+- (void)testGetIDTokenResultForcingRefreshFailureNoRefreshToken {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [self signInWithMockVerifyCustomTokenNoRefreshTokenResponse:^(FIRUser *user) {
+    [user getIDTokenResultForcingRefresh:YES
+                              completion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                           NSError *_Nullable error) {
+                                XCTAssertTrue([NSThread isMainThread]);
+                                XCTAssertNil(tokenResult);
+                                XCTAssertEqual(error.code, FIRAuthInternalErrorCodeInternalError);
+                                XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey],
+                                               @"No refresh token is available.");
+                                XCTAssertNil([FIRAuth auth].currentUser);
+                                [expectation fulfill];
+                              }];
+  }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
+}
+
 /** @fn testGetIDTokenResultForcingRefreshFailure
     @brief Tests the flow successful @c getIDTokenResultForcingRefresh:completion: calls.
  */
 - (void)testGetIDTokenResultForcingRefreshSuccess {
   [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessToken];
-  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength415];
-  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength416];
-  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength523];
-  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenWithBase64URLCharacter];
+  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength415];
+  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength416];
+  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength523];
+  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenWithBase64URLCharacter];
 }
 
 /** @fn testGetIDTokenResultSuccessWithBase64EncodedURL
@@ -1500,28 +1522,6 @@ static const NSTimeInterval kExpectationTimeout = 2;
                                                                        [expectation fulfill];
                                                                      }];
                                            }];
-  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
-  OCMVerifyAll(_mockBackend);
-}
-
-/** @fn testGetIDTokenResultForcingRefreshNoRefreshTokenFailure
-    @brief Tests the flow of a failed @c getIDTokenResultForcingRefresh:completion: call.
- */
-- (void)testGetIDTokenResultForcingRefreshFailureNoRefreshToken {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  [self signInWithMockVerifyCustomTokenNoRefreshTokenResponse:^(FIRUser *user) {
-    [user getIDTokenResultForcingRefresh:YES
-                              completion:^(FIRAuthTokenResult *_Nullable tokenResult,
-                                           NSError *_Nullable error) {
-                                XCTAssertTrue([NSThread isMainThread]);
-                                XCTAssertNil(tokenResult);
-                                XCTAssertEqual(error.code, FIRAuthInternalErrorCodeInternalError);
-                                XCTAssertEqual(error.userInfo[NSLocalizedDescriptionKey],
-                                               @"No refresh token is available.");
-                                XCTAssertNil([FIRAuth auth].currentUser);
-                              }];
-    [expectation fulfill];
-  }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   OCMVerifyAll(_mockBackend);
 }

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1509,19 +1509,19 @@ static const NSTimeInterval kExpectationTimeout = 2;
  The failure reason is no refresh token is available.
  */
 - (void)testGetIDTokenResultForcingRefreshFailureNoRefreshToken {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-    [self signInWithMockVerifyCustomTokenNoRefreshTokenResponse:^(FIRUser *user) {
-        [user getIDTokenResultForcingRefresh:YES
-                                    completion:^(FIRAuthTokenResult *_Nullable tokenResult,
-                                                 NSError *_Nullable error) {
-            XCTAssertTrue([NSThread isMainThread]);
-            XCTAssertNil(tokenResult);
-            XCTAssertNil([FIRAuth auth].currentUser);
-          }];
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
-    OCMVerifyAll(_mockBackend);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [self signInWithMockVerifyCustomTokenNoRefreshTokenResponse:^(FIRUser *user) {
+    [user getIDTokenResultForcingRefresh:YES
+                              completion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                           NSError *_Nullable error) {
+                                XCTAssertTrue([NSThread isMainThread]);
+                                XCTAssertNil(tokenResult);
+                                XCTAssertNil([FIRAuth auth].currentUser);
+                              }];
+    [expectation fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
 }
 
 /** @fn testReloadFailure
@@ -3002,31 +3002,30 @@ static const NSTimeInterval kExpectationTimeout = 2;
         parameter.
  */
 - (void)signInWithMockVerifyCustomTokenNoRefreshTokenResponse:(void (^)(FIRUser *user))completion {
-    OCMExpect([_mockBackend verifyCustomToken:[OCMArg any] callback:[OCMArg any]])
-        .andCallBlock2(^(FIRVerifyCustomTokenRequest *_Nullable request,
-                         FIRVerifyCustomTokenResponseCallback callback) {
-          XCTAssertEqualObjects(request.APIKey, kAPIKey);
-          XCTAssertEqualObjects(request.token, kCustomToken);
-          XCTAssertTrue(request.returnSecureToken);
-          dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-            id mockVerifyCustomTokenResponse = OCMClassMock([FIRVerifyCustomTokenResponse class]);
-            [self stubTokensWithMockResponseNoRefreshToken:mockVerifyCustomTokenResponse];
-            callback(mockVerifyCustomTokenResponse, nil);
-          });
+  OCMExpect([_mockBackend verifyCustomToken:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyCustomTokenRequest *_Nullable request,
+                       FIRVerifyCustomTokenResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.token, kCustomToken);
+        XCTAssertTrue(request.returnSecureToken);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockVerifyCustomTokenResponse = OCMClassMock([FIRVerifyCustomTokenResponse class]);
+          [self stubTokensWithMockResponseNoRefreshToken:mockVerifyCustomTokenResponse];
+          callback(mockVerifyCustomTokenResponse, nil);
         });
-    // If refreshToken is not present, GetAccountInfo is not invoked.
-    OCMReject([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]]);
-    [[FIRAuth auth] signOut:NULL];
-    [[FIRAuth auth]
-        signInWithCustomToken:kCustomToken
-                   completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
-                     XCTAssertTrue([NSThread isMainThread]);
-                     [self assertUserFromIDToken:result.user];
-                     XCTAssertNil(error);
-                     completion(result.user);
-                   }];
+      });
+  // If refreshToken is not present, GetAccountInfo is not invoked.
+  OCMReject([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]]);
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth]
+      signInWithCustomToken:kCustomToken
+                 completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                   XCTAssertTrue([NSThread isMainThread]);
+                   [self assertUserFromIDToken:result.user];
+                   XCTAssertNil(error);
+                   completion(result.user);
+                 }];
 }
-
 
 /** @fn dictionaryWithUserInfoArray:
     @brief Converts an array of @c FIRUserInfo into a dictionary that indexed by provider IDs.
@@ -3066,7 +3065,6 @@ static const NSTimeInterval kExpectationTimeout = 2;
       .andReturn([NSDate dateWithTimeIntervalSinceNow:kAccessTokenTimeToLive]);
   OCMStub([mockResponse refreshToken]).andReturn(nil);
 }
-
 
 /** @fn assertUserGoogle
     @brief Asserts the given FIRUser matching the fake data returned by

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1387,10 +1387,10 @@ static const NSTimeInterval kExpectationTimeout = 2;
  */
 - (void)testGetIDTokenResultForcingRefreshSuccess {
   [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessToken];
-  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength415];
-  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength416];
-  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength523];
-  //[self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenWithBase64URLCharacter];
+  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength415];
+  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength416];
+  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenLength523];
+  [self getIDTokenResultForcingRefreshSuccessWithIDToken:kAccessTokenWithBase64URLCharacter];
 }
 
 /** @fn testGetIDTokenResultSuccessWithBase64EncodedURL


### PR DESCRIPTION
Handle the case when refreshToken is null for Custom Auth. 
If refresh token is absent, we won't send a getAccountInfoRequest to populate FIRUser fields. Instead, a FIRUser is created from a Firebase ID token, with only the user_id field populated from the ID token.
#no-changelog 