### PR TITLE
Create a random delay before initiating a remote config fetch.

### DIFF
--- a/FirebasePerformance/Sources/Configurations/FPRRemoteConfigFlags+Private.h
+++ b/FirebasePerformance/Sources/Configurations/FPRRemoteConfigFlags+Private.h
@@ -24,7 +24,7 @@ static NSString *const kFPRConfigPrefix = @"com.fireperf";
 static NSInteger const kFPRConfigFetchIntervalInSeconds = 12 * 60 * 60;
 
 /** Interval after which the configurations can be fetched. Specified in seconds. */
-static NSInteger const kFPRConfigAppStartDelayInSeconds = 1 * 30;
+static NSInteger const kFPRMinAppStartConfigFetchDelayInSeconds = 1 * 30;
 
 /** This extension should only be used for testing. */
 @interface FPRRemoteConfigFlags ()
@@ -37,6 +37,9 @@ static NSInteger const kFPRConfigAppStartDelayInSeconds = 1 * 30;
 
 /** @brief User defaults used for caching. */
 @property(nonatomic) NSUserDefaults *userDefaults;
+
+/** @brief Number of seconds delayed until the first config is made during app start. */
+@property(nonatomic) NSTimeInterval appStartConfigFetchDelayInSeconds;
 
 /**
  * Creates an instance of FPRRemoteConfigFlags.

--- a/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
+++ b/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
@@ -65,6 +65,7 @@
 
   FPRRemoteConfigFlags *configFlags =
       [[FPRRemoteConfigFlags alloc] initWithRemoteConfig:(FIRRemoteConfig *)remoteConfig];
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   configurations.remoteConfigFlags = configFlags;
 
   NSData *valueData = [@"false" dataUsingEncoding:NSUTF8StringEncoding];

--- a/FirebasePerformance/Tests/Unit/Instruments/FIRHTTPMetricTests.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FIRHTTPMetricTests.m
@@ -93,6 +93,7 @@
 
   FPRRemoteConfigFlags *configFlags =
       [[FPRRemoteConfigFlags alloc] initWithRemoteConfig:(FIRRemoteConfig *)remoteConfig];
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   configurations.remoteConfigFlags = configFlags;
 
   NSData *valueData = [@"false" dataUsingEncoding:NSUTF8StringEncoding];

--- a/FirebasePerformance/Tests/Unit/Timer/FIRTraceTest.m
+++ b/FirebasePerformance/Tests/Unit/Timer/FIRTraceTest.m
@@ -73,6 +73,7 @@
 
   FPRRemoteConfigFlags *configFlags =
       [[FPRRemoteConfigFlags alloc] initWithRemoteConfig:(FIRRemoteConfig *)remoteConfig];
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   configurations.remoteConfigFlags = configFlags;
 
   NSData *valueData = [@"false" dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
**Rationale:**
This is required to ensure that a remote notification does not trigger multiple config fetches from remote config at the same time.