### PR TITLE
Enable prerelease in postsubmit

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,6 +2,8 @@ name: prerelease
 
 on:
   pull_request:
+    # closed will be triggered when a pull request is merged. This is to keep https://github.com/firebase/SpecsTesting up to date.
+    types: [closed]
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times


### PR DESCRIPTION
This will trigger `update_SpecsTesting_repo` job in postsubmit. 
The other jobs will still run nightly.