### PR TITLE
Fix RemoteConfig multithreading

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -41,10 +41,10 @@
   RCNConfigDBManager *_DBManager;
   /// Current bundle identifier;
   NSString *_bundleIdentifier;
-  /// Dispatch semaphore to block all config reads until we have read from the database. This only
+  /// Blocks all config reads until we have read from the database. This only
   /// potentially blocks on the first read. Should be a no-wait for all subsequent reads once we
   /// have data read into memory from the database.
-  dispatch_semaphore_t _configLoadFromDBSemaphore;
+  dispatch_group_t _dispatch_group;
   /// Boolean indicating if initial DB load of fetched,active and default config has succeeded.
   BOOL _isConfigLoadFromDBCompleted;
   /// Boolean indicating that the load from database has initiated at least once.
@@ -86,7 +86,8 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
       _bundleIdentifier = @"";
     }
     _DBManager = DBManager;
-    _configLoadFromDBSemaphore = dispatch_semaphore_create(0);
+    // Waits for both config and Personalization data to load.
+    _dispatch_group = dispatch_group_create();
     [self loadConfigFromMainTable];
   }
   return self;
@@ -112,6 +113,7 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
   NSAssert(!_isDatabaseLoadAlreadyInitiated, @"Database load has already been initiated");
   _isDatabaseLoadAlreadyInitiated = true;
 
+  dispatch_group_enter(_dispatch_group);
   [_DBManager
       loadMainWithBundleIdentifier:_bundleIdentifier
                  completionHandler:^(BOOL success, NSDictionary *fetchedConfig,
@@ -119,15 +121,17 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
                    self->_fetchedConfig = [fetchedConfig mutableCopy];
                    self->_activeConfig = [activeConfig mutableCopy];
                    self->_defaultConfig = [defaultConfig mutableCopy];
-                   dispatch_semaphore_signal(self->_configLoadFromDBSemaphore);
+                   dispatch_group_leave(self->_dispatch_group);
                  }];
 
   // TODO(karenzeng): Refactor personalization to be returned in loadMainWithBundleIdentifier above
+  dispatch_group_enter(_dispatch_group);
   [_DBManager loadPersonalizationWithCompletionHandler:^(
                   BOOL success, NSDictionary *fetchedPersonalization,
                   NSDictionary *activePersonalization, NSDictionary *defaultConfig) {
     self->_fetchedPersonalization = [fetchedPersonalization copy];
     self->_activePersonalization = [activePersonalization copy];
+    dispatch_group_leave(self->_dispatch_group);
   }];
 }
 
@@ -359,12 +363,11 @@ static const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
 /// configs until load is done.
 /// @return Database load completion status.
 - (BOOL)checkAndWaitForInitialDatabaseLoad {
-  /// Wait on semaphore until done. This should be a no-op for subsequent calls.
+  /// Wait until load is done. This should be a no-op for subsequent calls.
   if (!_isConfigLoadFromDBCompleted) {
-    long result = dispatch_semaphore_wait(
-        _configLoadFromDBSemaphore,
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDatabaseLoadTimeoutSecs * NSEC_PER_SEC)));
-    if (result != 0) {
+    intptr_t isErrorOrTimeout =
+        dispatch_group_wait(_dispatch_group, kDatabaseLoadTimeoutSecs * NSEC_PER_SEC);
+    if (isErrorOrTimeout) {
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000048",
                   @"Timed out waiting for fetched config to be loaded from DB");
       return false;

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -868,6 +868,9 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
   dispatch_async(_databaseOperationQueue, ^{
     RCNConfigDBManager *strongSelf = weakSelf;
     if (!strongSelf) {
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        handler(NO, [NSMutableDictionary new], [NSMutableDictionary new], nil);
+      });
       return;
     }
 
@@ -898,7 +901,7 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
     }
 
     if (handler) {
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         handler(YES, fetchedPersonalization, activePersonalization, nil);
       });
     }
@@ -972,6 +975,9 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
   dispatch_async(_databaseOperationQueue, ^{
     RCNConfigDBManager *strongSelf = weakSelf;
     if (!strongSelf) {
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        handler(NO, [NSDictionary new], [NSDictionary new], [NSDictionary new]);
+      });
       return;
     }
     __block NSDictionary *fetchedConfig =


### PR DESCRIPTION
Sorry, here is story:
Some time ago I had to use FirebaseRemoteConfig 7.4.0.
So I encountered problem https://github.com/firebase/firebase-ios-sdk/pull/7975 and fixed it on my own in private fork.
Here is PR to adjust current master with parts of my fix. 
I hope it will increase thread safety, and will possibly fix https://github.com/firebase/firebase-ios-sdk/issues/7977. 
Please read on for details.

### Discussion

#### (I) Main idea

Replace 
`semaphore 'wait/signal'`
with
`dispatch_group 'enter/wait/leave'`

#### (II) General thoughts

_Semaphore_ is one of most generic synchronisation mechanisms, so it can be used to solve probably any synch problem.
But _semaphore_ requires to thoroughly craft special code for every small slightly non-trivial problem.
On other side _dispatch_group_ is not so generic, but it's already crafted specially for case that we have in `RCNConfigContent.m`.
It's purpose of `dispatch_group 'enter/wait/leave'` to ensure that some threads blocked until some other threads complete their work.
So I believe that this out of the box solution will be less error prone.

#### (III) Concrete caveats with current code in master in `RCNConfigContent.m`

Caveat 1.
```
[_DBManager
      loadMainWithBundleIdentifier:_bundleIdentifier
                 completionHandler:^(BOOL success, NSDictionary *fetchedConfig,
                                     NSDictionary *activeConfig, NSDictionary *defaultConfig) {
                   self->_fetchedConfig = [fetchedConfig mutableCopy];
                   self->_activeConfig = [activeConfig mutableCopy];
                   self->_defaultConfig = [defaultConfig mutableCopy];
                   dispatch_semaphore_signal(self->_configLoadFromDBSemaphore);
                 }];

  // TODO(karenzeng): Refactor personalization to be returned in loadMainWithBundleIdentifier above
  [_DBManager loadPersonalizationWithCompletionHandler:^(
                  BOOL success, NSDictionary *fetchedPersonalization,
                  NSDictionary *activePersonalization, NSDictionary *defaultConfig) {
    self->_fetchedPersonalization = [fetchedPersonalization copy];
    self->_activePersonalization = [activePersonalization copy];
  }];
```
`loadPersonalizationWithCompletionHandler` has no synch with semaphore. So later in `checkAndWaitForInitialDatabaseLoad` we have no guarantees that `loadPersonalizationWithCompletionHandler` completion finished.

 Caveat 2.
```
- (BOOL)checkAndWaitForInitialDatabaseLoad {
  /// Wait on semaphore until done. This should be a no-op for subsequent calls.
  if (!_isConfigLoadFromDBCompleted) {
    long result = dispatch_semaphore_wait(
        _configLoadFromDBSemaphore,
        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDatabaseLoadTimeoutSecs * NSEC_PER_SEC)));
    if (result != 0) {
      FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000048",
                  @"Timed out waiting for fetched config to be loaded from DB");
      return false;
    }
    _isConfigLoadFromDBCompleted = true;
  }
  return true;
}
```
Let's imagine we have multiple threads waiting for semaphore. When `dispatch_semaphore_signal` fired from `loadMainWithBundleIdentifier` it will wake _only one_ thread. So all other thread will wait until timeout. In later calls of cause `_isConfigLoadFromDBCompleted` will save situation, but some first calls will possibly be stuck.

#### (IV) Details on this PR

1. Changes in`RCNConfigContent.m` remove caveats (1) and (2) 
2. Changes in`RCNConfigDBManager.m` address slightly different but related to work of `checkAndWaitForInitialDatabaseLoad` moments:
2.1. Change: two new `handler(NO, ...` make potential work of subsequent `return` statement more consistent.
2.2. Change: replacement `dispatch_async(dispatch_get_main_queue()...` with `dispatch_async(dispatch_get_global_queue` should increase general performance of RemoteConfig because initialisation of RemoteConfig often runs while app launching and main thread is very busy.

### Testing

  * All tests in RemoteConfig pass with changes from this PR.
  * Did not added new tests as it's very hard to test multithreading.

### API Changes

  * No APi changes.
