### PR TITLE
Skip binary measurement job for fork

### DIFF
--- a/.github/workflows/health_metrics.yml
+++ b/.github/workflows/health_metrics.yml
@@ -47,7 +47,7 @@ jobs:
   binary_size_metrics:
     needs: check
     # Prevent the job from being triggered in fork.
-    if: always() && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event.pull_request.head.repo.full_name == github.repository && (github.event.action != 'closed' || github.event.pull_request.merged)
     runs-on: macos-11
     strategy:
       matrix:


### PR DESCRIPTION
Reference:
https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363