### PR TITLE
Fix implementation of `Hash` for DocumentSnapshot.

### DIFF
--- a/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.mm
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEquals {
   FIRDocumentSnapshot *base = FSTTestDocSnapshot("rooms/foo", 1, @{@"a" : @1}, NO, NO);
   FIRDocumentSnapshot *baseDup = FSTTestDocSnapshot("rooms/foo", 1, @{@"a" : @1}, NO, NO);
+  FIRDocumentSnapshot *baseChangedData = FSTTestDocSnapshot("rooms/foo", 1, @{@"b" : @1}, NO, NO);
   FIRDocumentSnapshot *nilData = FSTTestDocSnapshot("rooms/foo", 1, nil, NO, NO);
   FIRDocumentSnapshot *nilDataDup = FSTTestDocSnapshot("rooms/foo", 1, nil, NO, NO);
   FIRDocumentSnapshot *differentPath = FSTTestDocSnapshot("rooms/bar", 1, @{@"a" : @1}, NO, NO);
@@ -46,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertNotEqualObjects(base, fromCache);
 
   XCTAssertEqual([base hash], [baseDup hash]);
+  XCTAssertNotEqual([base hash], [baseChangedData hash]);
   XCTAssertEqual([nilData hash], [nilDataDup hash]);
   XCTAssertNotEqual([base hash], [nilData hash]);
   XCTAssertNotEqual([base hash], [differentPath hash]);

--- a/Firestore/core/src/model/mutable_document.cc
+++ b/Firestore/core/src/model/mutable_document.cc
@@ -102,7 +102,7 @@ MutableDocument MutableDocument::Clone() const {
 }
 
 size_t MutableDocument::Hash() const {
-  return key_.Hash();
+  return util::Hash(document_type_, key_, version_, *value_, document_state_);
 }
 
 std::string MutableDocument::ToString() const {


### PR DESCRIPTION
The implementation of the `Hash` function for DocumentSnapshots has regressed. Without this fix two document snapshots with the same key and different content have the same hash.

The previous implementation took all parameters (key, type, version, data, state) into account for calculating the hash. See [here](https://github.com/firebase/firebase-ios-sdk/blob/04ab074265633049d5518866515e3bd7fc0de246/Firestore/core/src/model/document.cc#L88) and [here](https://github.com/firebase/firebase-ios-sdk/blob/04ab074265633049d5518866515e3bd7fc0de246/Firestore/core/src/model/maybe_document.cc#L33).

I verified that the test added in the PR fails without the code change, and passes with the code change.

#no-changelog