### PR TITLE
Add back fix for g3 warnings

### DIFF
--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -161,8 +161,11 @@
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
+  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
+    // __unused to avoid warning in Xcode 12+ in g3.
+    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =
@@ -225,9 +228,11 @@
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
-
+  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
+    // __unused to avoid warning in Xcode 12+ in g3.
+    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =


### PR DESCRIPTION
Looks like we still need to do the weak self bit to avoid a fatal buildtime warning that occurs when copybara'ing into g3. 

#no-changelog