### PR TITLE
Add back fix for g3 warnings (pt 2)

### DIFF
--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -197,8 +197,11 @@
 
   XCTestExpectation *httpRequestExpectation =
       [self expectationWithDescription:@"HTTPRequestExpectation"];
+  __weak __auto_type weakSelf = self;
   _fetcherService.testBlock = ^(GTMSessionFetcher *_Nonnull fetcherToTest,
                                 GTMSessionFetcherTestResponse _Nonnull testResponse) {
+    // __unused to avoid warning in Xcode 12+ in g3.
+    __unused __auto_type self = weakSelf;
     [httpRequestExpectation fulfill];
 
     NSString *appCheckTokenHeader =


### PR DESCRIPTION
I missed one warning!
#no-changelog