### PR TITLE
Fall back to reCAPTCHA verification in phone auth if push notification is not received

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fall back to reCAPTCHA for phone auth app verification if the push notification is not received before the timeout. (#8653)
+
 # 8.6.0
 - [fixed] Annotated platform-level availability using `API_UNAVAILABLE` instead of conditionally compiling certain methods with `#if` directives (#8451).
 

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -629,8 +629,12 @@ extern NSString *const FIRPhoneMultiFactorID;
                                              FIRLogWarning(kFIRLoggerAuth, @"I-AUT000014",
                                                            @"Failed to receive remote notification "
                                                            @"to verify app identity within "
-                                                           @"%.0f second(s)",
+                                                           @"%.0f second(s), falling back to "
+                                                           @"reCAPTCHA verification.",
                                                            timeout);
+                                             [self reCAPTCHAFlowWithUIDelegate:UIDelegate
+                                                                    completion:completion];
+                                             return;
                                            }
                                            completion(credential, nil, nil);
                                          }];


### PR DESCRIPTION
For phone auth app verification, if the push notification is not received before the timeout, fall back to reCAPTCHA for app verification.

[Google-internal bug: b/198507858]