### PR TITLE
Add workflow to update Firebase C++ SDK deps when iOS SDK release is published

### DIFF
--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,10 +1,14 @@
+# Whenever a new Firebase iOS SDK is released, this workflow triggers *another*
+# workflow on the Firebase C++ SDK, which will check for the iOS version update
+# and create a PR updating its iOS dependencies if the version number has
+# changed.
 name: update-cpp-sdk-on-release
 on:
   release:
     types: [ published ]
 
 jobs:
-  trigger-cpp-sdk-update:
+  trigger_cpp_sdk_update:
     # Only when a new release (not just the CocoaPods-* tag) is published.
     if: ${{ (github.event_name == 'release' && !contains(github.ref, 'CocoaPods')) }}
     # Fetch an authentication token for firebase-workflow-trigger, then use that

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,12 +1,5 @@
 name: update-cpp-sdk-on-ios-sdk-release
-
 on:
-  push:
-    tags:
-      - CocoaPods-*.*.*
-    tags-ignore:
-      - *-nightly
-      - *-beta
   workflow_dispatch:
     # Temporarily included for testing purposes.
     inputs:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -2,10 +2,14 @@ name: update-cpp-sdk-on-ios-sdk-release
 
 on:
   push:
-    tags: [CocoaPods-*.*.*]
-    tags-ignore: [*-nightly], *-beta]
+    tags:
+      - CocoaPods-*.*.*
+    tags-ignore:
+      - *-nightly
+      - *-beta
   workflow_dispatch:
     # Temporarily included for testing purposes.
+    inputs:
 
 jobs:
   trigger-cpp-sdk-update:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,5 +1,11 @@
 name: update-cpp-sdk-on-ios-sdk-release
 on:
+  push:
+    tags:
+      - CocoaPods-*.*.*
+    tags-ignore:
+      - CocoaPods-*.*.*-nightly
+      - CocoaPods-*.*.*-beta
   workflow_dispatch:
     # Temporarily included for testing purposes.
     inputs:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -2,10 +2,7 @@ name: update-cpp-sdk-on-ios-sdk-release
 on:
   push:
     tags:
-      - CocoaPods-*.*.*
-    tags-ignore:
-      - CocoaPods-*.*.*-nightly
-      - CocoaPods-*.*.*-beta
+      - CocoaPods-[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
     # Temporarily included for testing purposes.
     inputs:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -3,14 +3,13 @@ on:
   push:
     tags:
       - CocoaPods-[0-9]+.[0-9]+.[0-9]+
-  workflow_dispatch:
-    # Temporarily included for testing purposes.
-    inputs:
+  pull_request:
+    types: [ edited ]
 
 jobs:
   trigger-cpp-sdk-update:
     # Only when a new tag was pushed to the repo.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
+    # if: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
     # Fetch an authentication token for firebase-workflow-trigger, then use that
     # token to trigger the update-dependencies workflow in firebase-cpp-sdk.
     name: Trigger C++ SDK update

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
           private_key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          repository: firebase/firebase-cpp-sdk
 
       - name: Trigger firebase-cpp-sdk update
         run: |

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,0 +1,38 @@
+name: Update C++ SDK on iOS SDK release
+
+on:
+  push:
+    tags: [CocoaPods-*.*.*]
+    tags-ignore: [*-nightly], *-beta]
+  workflow_dispatch:
+    # Temporarily included for testing purposes.
+
+jobs:
+  trigger-cpp-sdk-update:
+    # Only when a new tag was pushed to the repo.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
+    # Fetch an authentication token for firebase-workflow-trigger, then use that
+    # token to trigger the update-dependencies workflow in firebase-cpp-sdk.
+    name: Trigger C++ SDK update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get firebase-workflow-trigger token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
+          private_key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Check out firebase-cpp-sdk
+        uses: actions/checkout@v2.3.1
+        with:
+          repo: firebase-cpp-sdk
+
+      - name: Trigger firebase-cpp-sdk update
+        run: |
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update_dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A ${verbose_flag}

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,15 +1,15 @@
 name: update-cpp-sdk-on-release
 on:
-  push:
-    tags:
-      - CocoaPods-[0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [ published ]
+  # Temporary trigger just for testing.
   pull_request:
     types: [ edited ]
 
 jobs:
   trigger-cpp-sdk-update:
-    # Only when a new tag was pushed to the repo.
-    # if: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
+    # Only when a new release (not just the CocoaPods-* tag) is published.
+    # if: ${{ (github.event_name == 'release' && !contains(github.ref, 'CocoaPods')) }}
     # Fetch an authentication token for firebase-workflow-trigger, then use that
     # token to trigger the update-dependencies workflow in firebase-cpp-sdk.
     name: Trigger C++ SDK update

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
-          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS -p comment 'Updated by firebase-ios-sdk ${{ github.ref }} release.' 1 -s 10 -A
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS 1 -p comment "Triggered by [firebase-ios-sdk $GITHUB_REF release]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." -s 10 -A

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,4 +1,4 @@
-name: Update C++ SDK on iOS SDK release
+name: Update CPP SDK on iOS SDK release
 
 on:
   push:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Check out firebase-cpp-sdk
         uses: actions/checkout@v2.3.1
         with:
-          repo: firebase-cpp-sdk
+          repository: firebase/firebase-cpp-sdk
+          ref: main
 
       - name: Trigger firebase-cpp-sdk update
         run: |

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -15,13 +15,6 @@ jobs:
     name: Trigger C++ SDK update
     runs-on: ubuntu-latest
     steps:
-      - name: Get firebase-workflow-trigger token
-        uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
-          private_key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
-
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -32,6 +25,13 @@ jobs:
         with:
           repository: firebase/firebase-cpp-sdk
           ref: main
+
+      - name: Get firebase-workflow-trigger token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}
+          private_key: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
 
       - name: Trigger firebase-cpp-sdk update
         run: |

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -2,14 +2,11 @@ name: update-cpp-sdk-on-release
 on:
   release:
     types: [ published ]
-  # Temporary trigger just for testing.
-  pull_request:
-    types: [ edited ]
 
 jobs:
   trigger-cpp-sdk-update:
     # Only when a new release (not just the CocoaPods-* tag) is published.
-    # if: ${{ (github.event_name == 'release' && !contains(github.ref, 'CocoaPods')) }}
+    if: ${{ (github.event_name == 'release' && !contains(github.ref, 'CocoaPods')) }}
     # Fetch an authentication token for firebase-workflow-trigger, then use that
     # token to trigger the update-dependencies workflow in firebase-cpp-sdk.
     name: Trigger C++ SDK update
@@ -36,4 +33,4 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
-          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS -p comment 'Updated by firebase-ios-sdk ${{ github.ref }} release.' 1 -s 10 -A

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,4 +1,4 @@
-name: Update CPP SDK on iOS SDK release
+name: update-cpp-sdk-on-ios-sdk-release
 
 on:
   push:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
-          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update_dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A ${verbose_flag}
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update_dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
-          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS 1 -p comment "Triggered by [firebase-ios-sdk $GITHUB_REF release]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." -s 10 -A
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS 1 -p comment "[Triggered]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) by [firebase-ios-sdk $GITHUB_REF release]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF)." -s 10 -A

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,4 +1,4 @@
-name: cpp-sdk-update-on-cocoapods-tag
+name: update-cpp-sdk-on-release
 on:
   push:
     tags:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
-          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update_dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A
+          python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 0 -p updateiOS 1 -s 10 -A

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -1,4 +1,4 @@
-name: update-cpp-sdk-on-ios-sdk-release
+name: cpp-sdk-update-on-cocoapods-tag
 on:
   push:
     tags:


### PR DESCRIPTION
Whenever a  release is published (except for CocoaPods-* releases), trigger the C++ SDK to do an iOS dependency update, pulling latest deps from public Cocoapods HEAD.

It requests a token that has access to firebase-cpp-sdk and uses that token to trigger the C++ update-dependencies workflow.

(Android equivalent is here: https://github.com/firebase/firebase-android-sdk/pull/2977)