### PR TITLE
Switch to Xcode 13 for all CI jobs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ source 'https://rubygems.org'
 # favorite editor. See https://github.com/firebase/firebase-ios-sdk/pull/8498
 # for examples.
 
+# TODO(yifanyang): Delete this line after all jobs are triggered and passed on GitHub Actions.
+
 # gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "9cebcde577f56aa26f27d8aa501b51fdd4d6abdb"
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"

--- a/scripts/setup_bundler.sh
+++ b/scripts/setup_bundler.sh
@@ -18,7 +18,10 @@
 # To test another version of Xcode for all of CI:
 # - Add any edit, like a blank line, to Gemfile.
 # - Uncomment the following line and choose the alternative Xcode version.
-#sudo xcode-select -s /Applications/Xcode_13.0.app/Contents/Developer
+
+# TODO(yifanyang): Remove once Xcode 13 becomes the default version in macOS 11.
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
+sudo xcode-select -s /Applications/Xcode_13.0.app/Contents/Developer
 
 bundle update --bundler # ensure bundler version is high enough for Gemfile.lock
 bundle install


### PR DESCRIPTION
Upon submission of [#4087](https://github.com/actions/virtual-environments/pull/4087), Xcode 13 is officially supported on GitHub Actions.

[`zip.yml`](https://github.com/firebase/firebase-ios-sdk/blob/master/.github/workflows/zip.yml) seems to be intentionally left out of the Xcode upgrade in #8543. I suppose it is still the case now.