### PR TITLE
[FDL] Refactoring and fixing url validation

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v8.8.0
-- [fixed] Firebase dynamic links with custom domain will only work if the custom domai has a trailing '/'. (#7087)
+- [fixed] Firebase dynamic links with custom domain will only work if the custom domain has a trailing '/'. (#7087)
 
 # v8.7.0
 - [added] Refactoring and adding helper class. (#8432)

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v8.7.1
+# v8.8.0
 - [fixed] Firebase dynamic links with custom domain will only work if the custom domai has a trailing '/'. (#7087)
 
 # v8.7.0

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.7.1
+- [fixed] Firebase dynamic links with custom domain will only work if the custom domai has a trailing '/'. (#7087)
+
 # v8.7.0
 - [added] Refactoring and adding helper class. (#8432)
 

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -214,6 +214,10 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
                          options:NSCaseInsensitiveSearch | NSAnchoredSearch]
                .location) == 0) {
         NSString *urlWithoutDomainURIPrefix = [urlStr substringFromIndex:domainURIPrefixStr.length];
+
+        //For a valid custom domain DL Suffix:
+        //1. At least one path exists OR
+        //2. Should have a link query param with an http/https link
         BOOL matchesRegularExpression =
             ([urlWithoutDomainURIPrefix
                  rangeOfString:@"((\\/[A-Za-z0-9]+)|((\\?|\\/\\?)link=https?.*))"
@@ -230,7 +234,7 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
   return customDomainMatchFound;
 }
 
-/*We are validating following domains in proper format.
+/* We are validating following domains in proper format.
  *.page.link
  *.app.goo.gl
  *.page.link/i/

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -204,30 +204,24 @@ NSString *FIRDLDeviceTimezone() {
 BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
   BOOL customDomainMatchFound = false;
   for (NSURL *allowedCustomDomain in FIRDLCustomDomains) {
-    // All custom domain host names should match at a minimum.
+    // Atleast one custom domain host name should match at a minimum.
     if ([allowedCustomDomain.host isEqualToString:URL.host]) {
       NSString *urlStr = URL.absoluteString;
       NSString *domainURIPrefixStr = allowedCustomDomain.absoluteString;
 
       // Next, do a string compare to check if entire domainURIPrefix matches as well.
-      if (([URL.absoluteString rangeOfString:allowedCustomDomain.absoluteString
+      if (([urlStr rangeOfString:domainURIPrefixStr
                                      options:NSCaseInsensitiveSearch | NSAnchoredSearch]
                .location) == 0) {
-        // The (short) URL needs to be longer than the domainURIPrefix, it's first character after
-        // the domainURIPrefix needs to be '/' and should be followed by at-least one more
-        // character.
-        if (urlStr.length > domainURIPrefixStr.length + 1 &&
-            ([urlStr characterAtIndex:domainURIPrefixStr.length] == '/')) {
-          // Check if there are any more '/' after the first '/'trailing the
-          // domainURIPrefix. This does not apply to unique match links copied from the clipboard.
-          // The clipboard links will have '?link=' after the domainURIPrefix.
-          NSString *urlWithoutDomainURIPrefix =
-              [urlStr substringFromIndex:domainURIPrefixStr.length + 1];
-          if ([urlWithoutDomainURIPrefix rangeOfString:@"/"].location == NSNotFound ||
-              [urlWithoutDomainURIPrefix rangeOfString:@"?link="].location != NSNotFound) {
-            customDomainMatchFound = true;
-            break;
-          }
+
+        NSString *urlWithoutDomainURIPrefix =
+            [urlStr substringFromIndex:domainURIPrefixStr.length];
+        BOOL matchesRegularExpression =
+            ([urlWithoutDomainURIPrefix rangeOfString:@"((\\/[A-Za-z0-9]+)|((\\?|\\/\\?)link=https?.*))" options:NSRegularExpressionSearch].location != NSNotFound);
+
+        if(matchesRegularExpression){
+          customDomainMatchFound = true;
+          break;
         }
       }
     }
@@ -235,33 +229,57 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
   return customDomainMatchFound;
 }
 
+/*We are validating following domains in proper format.
+ *.page.link
+ *.app.goo.gl
+ *.page.link/i/
+ *.app.goo.gl/i/
+ */
+BOOL FIRDLIsAValidDLWithFDLDomain(NSURL *_Nullable URL){
+  BOOL matchesRegularExpression = false;
+  NSString *urlStr = URL.absoluteString;
+
+  if([URL.host containsString:@".page.link"] || [URL.host containsString:@".app.goo.gl"]){
+  //Matches the *.page.link and *.app.goo.gl domains.
+  matchesRegularExpression =
+      ([urlStr rangeOfString:@"^https?://[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))((\\/?\\?link=https?.*)|(\\/[a-zA-Z0-9]+)((\\/?\\?.*=.*)?$|$))" options:NSRegularExpressionSearch].location != NSNotFound);
+
+  if(!matchesRegularExpression){
+    //Matches the *.page.link/i/ and *.app.goo.gl/i/ domains.
+    matchesRegularExpression =
+        ([urlStr rangeOfString:@"^https?:\\/\\/[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))\\/i\\/.*$" options:NSRegularExpressionSearch].location != NSNotFound);
+  }
+  }
+
+  return matchesRegularExpression;
+}
+
+/*
+ DL can be parsed if it :
+ 1. Has http(s)://goo.gl/app* or http(s)://page.link/app* format
+ 2. OR http(s)://$DomainPrefix.page.link or http(s)://$DomainPrefix.app.goo.gl domain with specific format
+ 3. OR the domain is a listed custom domain
+ */
 BOOL FIRDLCanParseUniversalLinkURL(NSURL *_Nullable URL) {
   // Handle universal links with format |https://goo.gl/app/<appcode>?<parameters>|.
   // Also support page.link format.
   BOOL isDDLWithAppcodeInPath = ([URL.host isEqual:@"goo.gl"] || [URL.host isEqual:@"page.link"]) &&
                                 [URL.path hasPrefix:@"/app"];
-  // Handle universal links with format |https://<appcode>.app.goo.gl?<parameters>| and page.link.
-  BOOL isDDLWithSubdomain =
-      [URL.host hasSuffix:@".app.goo.gl"] || [URL.host hasSuffix:@".page.link"];
 
-  // Handle universal links for custom domains.
-  BOOL isDDLWithCustomDomain = FIRDLIsURLForAllowedCustomDomain(URL);
-
-  return isDDLWithAppcodeInPath || isDDLWithSubdomain || isDDLWithCustomDomain;
+  return isDDLWithAppcodeInPath || FIRDLIsAValidDLWithFDLDomain(URL) || FIRDLIsURLForAllowedCustomDomain(URL);
 }
 
 BOOL FIRDLMatchesShortLinkFormat(NSURL *URL) {
-  // Short Durable Link URLs always have a path.
-  BOOL hasPath = URL.path.length > 0;
-  BOOL matchesRegularExpression =
-      ([URL.path rangeOfString:@"/[^/]+" options:NSRegularExpressionSearch].location != NSNotFound);
-  // Must be able to parse (also checks if the URL conforms to *.app.goo.gl/* or goo.gl/app/*)
-  BOOL canParse = FIRDLCanParseUniversalLinkURL(URL) | FIRDLIsURLForAllowedCustomDomain(URL);
-  ;
+  // Short Durable Link URLs always have a path or it should be a custom domain.
+  BOOL hasPathOrCustomDomain = URL.path.length > 0 || FIRDLIsURLForAllowedCustomDomain(URL);
+
+  // Must be able to parse (also checks if the URL conforms to *.app.goo.gl/* or goo.gl/app/* or *.page.link or custom domain with valid suffix)
+  BOOL canParse = FIRDLCanParseUniversalLinkURL(URL);
+
   // Path cannot be prefixed with /link/dismiss
   BOOL isDismiss = [[URL.path lowercaseString] hasPrefix:@"/link/dismiss"];
 
-  return hasPath && matchesRegularExpression && !isDismiss && canParse;
+  return hasPathOrCustomDomain && !isDismiss && canParse;
 }
 
 NSString *FIRDLMatchTypeStringFromServerString(NSString *_Nullable serverMatchTypeString) {

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -204,7 +204,7 @@ NSString *FIRDLDeviceTimezone() {
 BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
   BOOL customDomainMatchFound = false;
   for (NSURL *allowedCustomDomain in FIRDLCustomDomains) {
-    // Atleast one custom domain host name should match at a minimum.
+    // At least one custom domain host name should match at a minimum.
     if ([allowedCustomDomain.host isEqualToString:URL.host]) {
       NSString *urlStr = URL.absoluteString;
       NSString *domainURIPrefixStr = allowedCustomDomain.absoluteString;

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -211,15 +211,16 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
 
       // Next, do a string compare to check if entire domainURIPrefix matches as well.
       if (([urlStr rangeOfString:domainURIPrefixStr
-                                     options:NSCaseInsensitiveSearch | NSAnchoredSearch]
+                         options:NSCaseInsensitiveSearch | NSAnchoredSearch]
                .location) == 0) {
-
-        NSString *urlWithoutDomainURIPrefix =
-            [urlStr substringFromIndex:domainURIPrefixStr.length];
+        NSString *urlWithoutDomainURIPrefix = [urlStr substringFromIndex:domainURIPrefixStr.length];
         BOOL matchesRegularExpression =
-            ([urlWithoutDomainURIPrefix rangeOfString:@"((\\/[A-Za-z0-9]+)|((\\?|\\/\\?)link=https?.*))" options:NSRegularExpressionSearch].location != NSNotFound);
+            ([urlWithoutDomainURIPrefix
+                 rangeOfString:@"((\\/[A-Za-z0-9]+)|((\\?|\\/\\?)link=https?.*))"
+                       options:NSRegularExpressionSearch]
+                 .location != NSNotFound);
 
-        if(matchesRegularExpression){
+        if (matchesRegularExpression) {
           customDomainMatchFound = true;
           break;
         }
@@ -235,20 +236,26 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
  *.page.link/i/
  *.app.goo.gl/i/
  */
-BOOL FIRDLIsAValidDLWithFDLDomain(NSURL *_Nullable URL){
+BOOL FIRDLIsAValidDLWithFDLDomain(NSURL *_Nullable URL) {
   BOOL matchesRegularExpression = false;
   NSString *urlStr = URL.absoluteString;
 
-  if([URL.host containsString:@".page.link"] || [URL.host containsString:@".app.goo.gl"]){
-  //Matches the *.page.link and *.app.goo.gl domains.
-  matchesRegularExpression =
-      ([urlStr rangeOfString:@"^https?://[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))((\\/?\\?link=https?.*)|(\\/[a-zA-Z0-9]+)((\\/?\\?.*=.*)?$|$))" options:NSRegularExpressionSearch].location != NSNotFound);
-
-  if(!matchesRegularExpression){
-    //Matches the *.page.link/i/ and *.app.goo.gl/i/ domains.
+  if ([URL.host containsString:@".page.link"] || [URL.host containsString:@".app.goo.gl"]) {
+    // Matches the *.page.link and *.app.goo.gl domains.
     matchesRegularExpression =
-        ([urlStr rangeOfString:@"^https?:\\/\\/[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))\\/i\\/.*$" options:NSRegularExpressionSearch].location != NSNotFound);
-  }
+        ([urlStr rangeOfString:@"^https?://[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))((\\/"
+                               @"?\\?link=https?.*)|(\\/[a-zA-Z0-9]+)((\\/?\\?.*=.*)?$|$))"
+                       options:NSRegularExpressionSearch]
+             .location != NSNotFound);
+
+    if (!matchesRegularExpression) {
+      // Matches the *.page.link/i/ and *.app.goo.gl/i/ domains.
+      matchesRegularExpression =
+          ([urlStr rangeOfString:
+                       @"^https?:\\/\\/[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))\\/i\\/.*$"
+                         options:NSRegularExpressionSearch]
+               .location != NSNotFound);
+    }
   }
 
   return matchesRegularExpression;
@@ -257,7 +264,8 @@ BOOL FIRDLIsAValidDLWithFDLDomain(NSURL *_Nullable URL){
 /*
  DL can be parsed if it :
  1. Has http(s)://goo.gl/app* or http(s)://page.link/app* format
- 2. OR http(s)://$DomainPrefix.page.link or http(s)://$DomainPrefix.app.goo.gl domain with specific format
+ 2. OR http(s)://$DomainPrefix.page.link or http(s)://$DomainPrefix.app.goo.gl domain with specific
+ format
  3. OR the domain is a listed custom domain
  */
 BOOL FIRDLCanParseUniversalLinkURL(NSURL *_Nullable URL) {
@@ -266,14 +274,16 @@ BOOL FIRDLCanParseUniversalLinkURL(NSURL *_Nullable URL) {
   BOOL isDDLWithAppcodeInPath = ([URL.host isEqual:@"goo.gl"] || [URL.host isEqual:@"page.link"]) &&
                                 [URL.path hasPrefix:@"/app"];
 
-  return isDDLWithAppcodeInPath || FIRDLIsAValidDLWithFDLDomain(URL) || FIRDLIsURLForAllowedCustomDomain(URL);
+  return isDDLWithAppcodeInPath || FIRDLIsAValidDLWithFDLDomain(URL) ||
+         FIRDLIsURLForAllowedCustomDomain(URL);
 }
 
 BOOL FIRDLMatchesShortLinkFormat(NSURL *URL) {
   // Short Durable Link URLs always have a path or it should be a custom domain.
   BOOL hasPathOrCustomDomain = URL.path.length > 0 || FIRDLIsURLForAllowedCustomDomain(URL);
 
-  // Must be able to parse (also checks if the URL conforms to *.app.goo.gl/* or goo.gl/app/* or *.page.link or custom domain with valid suffix)
+  // Must be able to parse (also checks if the URL conforms to *.app.goo.gl/* or goo.gl/app/* or
+  // *.page.link or custom domain with valid suffix)
   BOOL canParse = FIRDLCanParseUniversalLinkURL(URL);
 
   // Path cannot be prefixed with /link/dismiss

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -254,6 +254,8 @@ BOOL FIRDLIsAValidDLWithFDLDomain(NSURL *_Nullable URL) {
 
     if (!matchesRegularExpression) {
       // Matches the *.page.link/i/ and *.app.goo.gl/i/ domains.
+      // Checks whether the URL is of the format :
+      // http(s)://$DOMAIN(.page.link or .app.goo.gl)/i/$ANYTHING
       matchesRegularExpression =
           ([urlStr rangeOfString:
                        @"^https?:\\/\\/[a-zA-Z0-9]+((\\.app\\.goo\\.gl)|(\\.page\\.link))\\/i\\/.*$"

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -215,9 +215,9 @@ BOOL FIRDLIsURLForAllowedCustomDomain(NSURL *_Nullable URL) {
                .location) == 0) {
         NSString *urlWithoutDomainURIPrefix = [urlStr substringFromIndex:domainURIPrefixStr.length];
 
-        //For a valid custom domain DL Suffix:
-        //1. At least one path exists OR
-        //2. Should have a link query param with an http/https link
+        // For a valid custom domain DL Suffix:
+        // 1. At least one path exists OR
+        // 2. Should have a link query param with an http/https link
         BOOL matchesRegularExpression =
             ([urlWithoutDomainURIPrefix
                  rangeOfString:@"((\\/[A-Za-z0-9]+)|((\\?|\\/\\?)link=https?.*))"

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -1556,8 +1556,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
     @"https://google.com/one?",               // Short FDL starting with 'https://google.com'
     @"https://google.com/one/mylink",         // Short FDL starting with  'https://google.com/one'
     @"https://a.firebase.com/mypath/mylink",  // Short FDL starting https://a.firebase.com/mypath
-    @"https://google.com?link=https://somedomain",
-    @"https://google.com/?link=https://somedomain",
+    @"https://google.com?link=https://somedomain", @"https://google.com/?link=https://somedomain",
     @"https://google.com/somepath?link=https://somedomain",
     @"https://google.com/somepath/?link=https://somedomain",
     @"https://google.com/somepath/somepath2?link=https://somedomain",
@@ -1600,8 +1599,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
     @"https://a.firebase.com/mypathabc",  // No matching domainURIPrefix: Invalid subdomain.
     @"mydomain.com",                      // https scheme not specified for domainURIPrefix.
     @"http://mydomain",                   // Domain not in plist. No path after domainURIPrefix.
-    @"https://somecustom.com?",
-    @"https://somecustom.com/?",
+    @"https://somecustom.com?", @"https://somecustom.com/?",
     @"https://somecustom.com?somekey=someval"
   ];
 

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -491,7 +491,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 //  https://a.firebase.com/mypath
 - (void)testDynamicLinkFromUniversalLinkURLWithCustomDomainLink {
   self.service = [[FIRDynamicLinks alloc] init];
-  NSString *durableDeepLinkString = @"https://a.firebase.com/mypath/?link=abcd";
+  NSString *durableDeepLinkString = @"https://a.firebase.com/mypath/?link=http://abcd";
   NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
 
   SwizzleDynamicLinkNetworkingWithMock();
@@ -501,14 +501,14 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   XCTAssertNotNil(dynamicLink);
   NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
-  XCTAssertEqualObjects(@"abcd", deepLinkURLString,
+  XCTAssertEqualObjects(@"http://abcd", deepLinkURLString,
                         @"ddl url parameter and deep link url should be the same");
   UnswizzleDynamicLinkNetworking();
 }
 
 - (void)testDynamicLinkFromUniversalLinkURLCompletionWithCustomDomainLink {
   self.service = [[FIRDynamicLinks alloc] init];
-  NSString *durableDeepLinkString = @"https://a.firebase.com/mypath/?link=abcd";
+  NSString *durableDeepLinkString = @"https://a.firebase.com/mypath/?link=http://abcd";
   NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
 
   SwizzleDynamicLinkNetworkingWithMock();
@@ -523,7 +523,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
                              NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
                              XCTAssertEqualObjects(
-                                 @"abcd", deepLinkURLString,
+                                 @"http://abcd", deepLinkURLString,
                                  @"ddl url parameter and deep link url should be the same");
                              [expectation fulfill];
                            }];
@@ -1099,9 +1099,27 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
-- (void)testMatchesShortLinkFormat {
+- (void)testPassMatchesShortLinkFormatForDDLDomains {
   NSArray<NSString *> *urlStrings =
-      @[ @"https://test.app.goo.gl/xyz", @"https://test.app.goo.gl/xyz?link=" ];
+      @[ @"https://someapp.app.goo.gl/somepath",
+         @"https://someapp.app.goo.gl/link",
+         @"https://someapp.app.goo.gl/somepath?link=https://somedomain",
+         @"https://someapp.app.goo.gl/somepath?somekey=somevalue",
+         @"https://someapp.app.goo.gl/somepath/?link=https://somedomain",
+         @"https://someapp.app.goo.gl/somepath/?somekey=somevalue",
+         @"https://someapp.page.link/somepath",
+         @"https://someapp.page.link/link",
+         @"https://someapp.page.link/somepath?link=https://somedomain",
+         @"https://someapp.page.link/somepath?somekey=somevalue",
+         @"https://someapp.page.link/somepath/?link=https://somedomain",
+         @"https://someapp.page.link/somepath/?somekey=somevalue",
+         @"http://someapp.page.link/somepath",
+         @"http://someapp.page.link/link",
+         @"http://someapp.page.link/somepath?link=https://somedomain",
+         @"http://someapp.page.link/somepath?somekey=somevalue",
+         @"http://someapp.page.link/somepath/?link=http://somedomain",
+         @"http://someapp.page.link/somepath/?somekey=somevalue"
+      ];
 
   for (NSString *urlString in urlStrings) {
     NSURL *url = [NSURL URLWithString:urlString];
@@ -1112,6 +1130,47 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   }
 }
 
+- (void)testFailMatchesShortLinkFormat {
+  NSArray<NSString *> *urlStrings = @[
+    @"https://someapp.app.goo.gl",
+    @"https://someapp.app.goo.gl/",
+    @"https://someapp.app.goo.gl?",
+    @"https://someapp.app.goo.gl/?",
+    @"https://someapp.app.goo.gl?somekey=somevalue",
+    @"https://someapp.app.goo.gl/?somekey=somevalue",
+    @"https://someapp.app.goo.gl/somepath/somepath2",
+    @"https://someapp.app.goo.gl/somepath/somepath2?somekey=somevalue",
+    @"https://someapp.app.goo.gl/somepath/somepath2?link=https://somedomain",
+    @"https://someapp.page.link",
+    @"https://someapp.page.link/",
+    @"https://someapp.page.link?",
+    @"https://someapp.page.link/?",
+    @"https://someapp.page.link?somekey=somevalue",
+    @"https://someapp.page.link/?somekey=somevalue",
+    @"https://someapp.page.link/somepath/somepath2",
+    @"https://someapp.page.link/somepath/somepath2?somekey=somevalue",
+    @"https://someapp.page.link/somepath/somepath2?link=https://somedomain",
+    @"https://www.google.com/maps/place/@1,1/My+Home/",
+    @"https://mydomain.com/t439gfde",
+    @"https://goo.gl/309dht4",
+    @"https://59eh.goo.gl/309dht4",
+    @"https://app.59eh.goo.gl/309dht4",
+    @"https://goo.gl/i/309dht4",
+    @"https://page.link/i/309dht4",
+    @"https://fjo3eh.goo.gl/i/309dht4",
+    @"https://app.fjo3eh.goo.gl/i/309dht4",
+    @"https://1234.page.link/link/dismiss"
+  ];
+
+  for (NSString *urlString in urlStrings) {
+    NSURL *url = [NSURL URLWithString:urlString];
+    BOOL matchesShortLinkFormat = [self.service matchesShortLinkFormat:url];
+
+    XCTAssertFalse(matchesShortLinkFormat,
+                   @"Non-DDL domain URL matched short link format with URL: %@", url);
+  }
+}
+
 // Custom domain entries in plist file:
 //  https://google.com
 //  https://google.com/one
@@ -1119,9 +1178,12 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 - (void)testFailMatchesShortLinkFormatForCustomDomains {
   NSArray<NSString *> *urlStrings = @[
     @"https://google.com",
-    @"https://google.com?link=",
     @"https://a.firebase.com",
-    @"https://a.firebase.com/mypath?link=",
+    @"https://google.com/",
+    @"https://google.com?",
+    @"https://google.com/?",
+    @"https://google.com?utm_campgilink=someval",
+    @"https://google.com?somekey=someval",
   ];
 
   for (NSString *urlString in urlStrings) {
@@ -1139,10 +1201,20 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 //  https://a.firebase.com/mypath
 - (void)testPassMatchesShortLinkFormatForCustomDomains {
   NSArray<NSString *> *urlStrings = @[
-    @"https://google.com/xyz", @"https://google.com/xyz/?link=", @"https://google.com/xyz?link=",
-    @"https://google.com/one/xyz", @"https://google.com/one/xyz?link=",
-    @"https://google.com/one?utm_campaignlink=", @"https://google.com/mylink",
-    @"https://google.com/one/mylink", @"https://a.firebase.com/mypath/mylink"
+    @"https://google.com/xyz",
+    @"https://google.com/xyz/?link=https://somedomain",
+    @"https://google.com?link=https://somedomain",
+    @"https://google.com/?link=https://somedomain",
+    @"https://google.com/xyz?link=https://somedomain",
+    @"https://google.com/xyz/?link=https://somedomain",
+    @"https://google.com/one/xyz",
+    @"https://google.com/one/xyz?link=https://somedomain",
+    @"https://google.com/one/xyz/?link=https://somedomain",
+    @"https://google.com/one?utm_campaignlink=https://somedomain",
+    @"https://google.com/one/?utm_campaignlink=https://somedomain",
+    @"https://google.com/mylink",
+    @"https://google.com/one/mylink",
+    @"https://a.firebase.com/mypath/mylink"
   ];
 
   for (NSString *urlString in urlStrings) {
@@ -1151,37 +1223,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
     XCTAssertTrue(matchesShortLinkFormat,
                   @"Non-DDL domain URL matched short link format with URL: %@", url);
-  }
-}
-
-- (void)testPassMatchesShortLinkFormat {
-  NSArray<NSString *> *urlStrings = @[
-    @"https://test.app.goo.gl/xyz",
-    @"https://test.app.goo.gl/xyz?link=",
-  ];
-
-  for (NSString *urlString in urlStrings) {
-    NSURL *url = [NSURL URLWithString:urlString];
-    BOOL matchesShortLinkFormat = [self.service matchesShortLinkFormat:url];
-
-    XCTAssertTrue(matchesShortLinkFormat,
-                  @"Non-DDL domain URL matched short link format with URL: %@", url);
-  }
-}
-
-- (void)testFailMatchesShortLinkFormat {
-  NSArray<NSString *> *urlStrings = @[
-    @"https://test.app.goo.gl", @"https://test.app.goo.gl?link=", @"https://test.app.goo.gl/",
-    @"https://sample.page.link?link=https://google.com/test&ibi=com.google.sample&ius=79306483",
-    @"https://sample.page.link/?link=https://google.com/test&ibi=com.google.sample&ius=79306483"
-  ];
-
-  for (NSString *urlString in urlStrings) {
-    NSURL *url = [NSURL URLWithString:urlString];
-    BOOL matchesShortLinkFormat = [self.service matchesShortLinkFormat:url];
-
-    XCTAssertFalse(matchesShortLinkFormat,
-                   @"Non-DDL domain URL matched short link format with URL: %@", url);
   }
 }
 
@@ -1525,9 +1566,9 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   ];
 
   NSArray<NSString *> *longFDLURLStrings = @[
-    @"https://a.firebase.com/mypath/?link=abcd&test=1",  // Long FDL starting with
+    @"https://a.firebase.com/mypath/?link=https://abcd&test=1",  // Long FDL starting with
                                                          // https://a.firebase.com/mypath
-    @"https://google.com/?link=abcd",  // Long FDL starting with  'https://google.com'
+    @"https://google.com/?link=http://abcd",  // Long FDL starting with  'https://google.com'
   ];
   for (NSString *urlString in urlStrings) {
     NSURL *url = [NSURL URLWithString:urlString];
@@ -1553,8 +1594,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
     @"google.com",                         // Valid domain. No scheme.
     @"https://google.com",                 // Valid domain. No path after domainURIPrefix.
     @"https://google.com/",                // Valid domain. No path after domainURIPrefix.
-    @"https://google.com/one/",            // Valid domain. No path after domainURIPrefix.
-    @"https://google.com/one/two/mylink",  // domainURIPrefix not exact match.
     @"https://google.co.in/mylink",        // No matching domainURIPrefix.
     @"https://firebase.com/mypath",        // No matching domainURIPrefix: Invalid (sub)domain.
     @"https://b.firebase.com/mypath",      // No matching domainURIPrefix: Invalid subdomain.

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -1100,26 +1100,22 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 }
 
 - (void)testPassMatchesShortLinkFormatForDDLDomains {
-  NSArray<NSString *> *urlStrings =
-      @[ @"https://someapp.app.goo.gl/somepath",
-         @"https://someapp.app.goo.gl/link",
-         @"https://someapp.app.goo.gl/somepath?link=https://somedomain",
-         @"https://someapp.app.goo.gl/somepath?somekey=somevalue",
-         @"https://someapp.app.goo.gl/somepath/?link=https://somedomain",
-         @"https://someapp.app.goo.gl/somepath/?somekey=somevalue",
-         @"https://someapp.page.link/somepath",
-         @"https://someapp.page.link/link",
-         @"https://someapp.page.link/somepath?link=https://somedomain",
-         @"https://someapp.page.link/somepath?somekey=somevalue",
-         @"https://someapp.page.link/somepath/?link=https://somedomain",
-         @"https://someapp.page.link/somepath/?somekey=somevalue",
-         @"http://someapp.page.link/somepath",
-         @"http://someapp.page.link/link",
-         @"http://someapp.page.link/somepath?link=https://somedomain",
-         @"http://someapp.page.link/somepath?somekey=somevalue",
-         @"http://someapp.page.link/somepath/?link=http://somedomain",
-         @"http://someapp.page.link/somepath/?somekey=somevalue"
-      ];
+  NSArray<NSString *> *urlStrings = @[
+    @"https://someapp.app.goo.gl/somepath", @"https://someapp.app.goo.gl/link",
+    @"https://someapp.app.goo.gl/somepath?link=https://somedomain",
+    @"https://someapp.app.goo.gl/somepath?somekey=somevalue",
+    @"https://someapp.app.goo.gl/somepath/?link=https://somedomain",
+    @"https://someapp.app.goo.gl/somepath/?somekey=somevalue",
+    @"https://someapp.page.link/somepath", @"https://someapp.page.link/link",
+    @"https://someapp.page.link/somepath?link=https://somedomain",
+    @"https://someapp.page.link/somepath?somekey=somevalue",
+    @"https://someapp.page.link/somepath/?link=https://somedomain",
+    @"https://someapp.page.link/somepath/?somekey=somevalue", @"http://someapp.page.link/somepath",
+    @"http://someapp.page.link/link", @"http://someapp.page.link/somepath?link=https://somedomain",
+    @"http://someapp.page.link/somepath?somekey=somevalue",
+    @"http://someapp.page.link/somepath/?link=http://somedomain",
+    @"http://someapp.page.link/somepath/?somekey=somevalue"
+  ];
 
   for (NSString *urlString in urlStrings) {
     NSURL *url = [NSURL URLWithString:urlString];
@@ -1201,20 +1197,15 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 //  https://a.firebase.com/mypath
 - (void)testPassMatchesShortLinkFormatForCustomDomains {
   NSArray<NSString *> *urlStrings = @[
-    @"https://google.com/xyz",
-    @"https://google.com/xyz/?link=https://somedomain",
-    @"https://google.com?link=https://somedomain",
-    @"https://google.com/?link=https://somedomain",
+    @"https://google.com/xyz", @"https://google.com/xyz/?link=https://somedomain",
+    @"https://google.com?link=https://somedomain", @"https://google.com/?link=https://somedomain",
     @"https://google.com/xyz?link=https://somedomain",
-    @"https://google.com/xyz/?link=https://somedomain",
-    @"https://google.com/one/xyz",
+    @"https://google.com/xyz/?link=https://somedomain", @"https://google.com/one/xyz",
     @"https://google.com/one/xyz?link=https://somedomain",
     @"https://google.com/one/xyz/?link=https://somedomain",
     @"https://google.com/one?utm_campaignlink=https://somedomain",
-    @"https://google.com/one/?utm_campaignlink=https://somedomain",
-    @"https://google.com/mylink",
-    @"https://google.com/one/mylink",
-    @"https://a.firebase.com/mypath/mylink"
+    @"https://google.com/one/?utm_campaignlink=https://somedomain", @"https://google.com/mylink",
+    @"https://google.com/one/mylink", @"https://a.firebase.com/mypath/mylink"
   ];
 
   for (NSString *urlString in urlStrings) {
@@ -1567,7 +1558,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   NSArray<NSString *> *longFDLURLStrings = @[
     @"https://a.firebase.com/mypath/?link=https://abcd&test=1",  // Long FDL starting with
-                                                         // https://a.firebase.com/mypath
+                                                                 // https://a.firebase.com/mypath
     @"https://google.com/?link=http://abcd",  // Long FDL starting with  'https://google.com'
   ];
   for (NSString *urlString in urlStrings) {
@@ -1591,15 +1582,15 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   //  https://a.firebase.com/mypath
 
   NSArray<NSString *> *urlStrings = @[
-    @"google.com",                         // Valid domain. No scheme.
-    @"https://google.com",                 // Valid domain. No path after domainURIPrefix.
-    @"https://google.com/",                // Valid domain. No path after domainURIPrefix.
-    @"https://google.co.in/mylink",        // No matching domainURIPrefix.
-    @"https://firebase.com/mypath",        // No matching domainURIPrefix: Invalid (sub)domain.
-    @"https://b.firebase.com/mypath",      // No matching domainURIPrefix: Invalid subdomain.
-    @"https://a.firebase.com/mypathabc",   // No matching domainURIPrefix: Invalid subdomain.
-    @"mydomain.com",                       // https scheme not specified for domainURIPrefix.
-    @"http://mydomain",                    // Domain not in plist. No path after domainURIPrefix.
+    @"google.com",                        // Valid domain. No scheme.
+    @"https://google.com",                // Valid domain. No path after domainURIPrefix.
+    @"https://google.com/",               // Valid domain. No path after domainURIPrefix.
+    @"https://google.co.in/mylink",       // No matching domainURIPrefix.
+    @"https://firebase.com/mypath",       // No matching domainURIPrefix: Invalid (sub)domain.
+    @"https://b.firebase.com/mypath",     // No matching domainURIPrefix: Invalid subdomain.
+    @"https://a.firebase.com/mypathabc",  // No matching domainURIPrefix: Invalid subdomain.
+    @"mydomain.com",                      // https scheme not specified for domainURIPrefix.
+    @"http://mydomain",                   // Domain not in plist. No path after domainURIPrefix.
   ];
 
   for (NSString *urlString in urlStrings) {

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -1552,8 +1552,17 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   NSArray<NSString *> *urlStrings = @[
     @"https://google.com/mylink",             // Short FDL starting with 'https://google.com'
     @"https://google.com/one",                // Short FDL starting with 'https://google.com'
+    @"https://google.com/one/",               // Short FDL starting with 'https://google.com'
+    @"https://google.com/one?",               // Short FDL starting with 'https://google.com'
     @"https://google.com/one/mylink",         // Short FDL starting with  'https://google.com/one'
     @"https://a.firebase.com/mypath/mylink",  // Short FDL starting https://a.firebase.com/mypath
+    @"https://google.com?link=https://somedomain",
+    @"https://google.com/?link=https://somedomain",
+    @"https://google.com/somepath?link=https://somedomain",
+    @"https://google.com/somepath/?link=https://somedomain",
+    @"https://google.com/somepath/somepath2?link=https://somedomain",
+    @"https://google.com/somepath/somepath2/?link=https://somedomain",
+    @"https://google.com/somepath?utm_campgilink=someval"
   ];
 
   NSArray<NSString *> *longFDLURLStrings = @[
@@ -1591,6 +1600,9 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
     @"https://a.firebase.com/mypathabc",  // No matching domainURIPrefix: Invalid subdomain.
     @"mydomain.com",                      // https scheme not specified for domainURIPrefix.
     @"http://mydomain",                   // Domain not in plist. No path after domainURIPrefix.
+    @"https://somecustom.com?",
+    @"https://somecustom.com/?",
+    @"https://somecustom.com?somekey=someval"
   ];
 
   for (NSString *urlString in urlStrings) {


### PR DESCRIPTION
[FDL] Refactoring and fixing url validation

- Refactored the existing code to use Regex to validate FDL URL formats.

- Added checks to make sure the 'link' query param is having an http/https prefix input.
        == This is going to be breaking the existing SDK's unintended behavior to support links with non http/https content. The existing SDK was constructing the Dynamic link eventhough the backend response to resolve the link is not successfull.

- Added support for URL(s) with Query string starting with '?' alone. Previously it was supporting '/?' formats only. This fixes https://github.com/firebase/firebase-ios-sdk/issues/7087

- Added more test cases to be in sync with FDL backend validation.

- Removed invalid test inputs and corrected few test cases to make the input in proper format.