### PR TITLE
[Messaging] Fix flaky `FIRMessagingTokenManagerTest` tests

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
@@ -70,6 +70,7 @@
 }
 
 - (void)tearDown {
+  [_messaging.tokenManager stopAllTokenOperations];
   [_mockCheckinStore stopMocking];
   [_mockAuthService stopMocking];
   [_testUtil cleanupAfterTest:self];

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
@@ -31,6 +31,10 @@
 
 @interface FIRMessagingTokenManager (ExposedForTest)
 
+@property(nonatomic, readonly, strong) NSOperationQueue *tokenOperations;
+
+- (void)didDeleteFCMScopedTokensForCheckin:(FIRMessagingCheckinPreferences *)checkin;
+
 - (void)resetCredentialsIfNeeded;
 
 @end
@@ -70,7 +74,6 @@
 }
 
 - (void)tearDown {
-  [_messaging.tokenManager stopAllTokenOperations];
   [_mockCheckinStore stopMocking];
   [_mockAuthService stopMocking];
   [_testUtil cleanupAfterTest:self];
@@ -152,6 +155,10 @@
   OCMStub([_mockAuthService checkinPreferences]).andReturn(checkinPreferences);
   // Plist file doesn't exist, meaning this is a fresh install.
   OCMStub([_mockCheckinStore hasCheckinPlist]).andReturn(NO);
+  // Expect reset operation but do nothing to avoid flakes due to delayed operation queue.
+  OCMExpect(
+      [_mockTokenManager didDeleteFCMScopedTokensForCheckin:[OCMArg isEqual:checkinPreferences]])
+      .andDo(nil);
 
   [_messaging.tokenManager resetCredentialsIfNeeded];
   OCMVerifyAll(_mockCheckinStore);

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
@@ -31,8 +31,6 @@
 
 @interface FIRMessagingTokenManager (ExposedForTest)
 
-@property(nonatomic, readonly, strong) NSOperationQueue *tokenOperations;
-
 - (void)didDeleteFCMScopedTokensForCheckin:(FIRMessagingCheckinPreferences *)checkin;
 
 - (void)resetCredentialsIfNeeded;


### PR DESCRIPTION
_Figured I'd leave a write up since this flake took me awhile..._

**The reason for the flake:** 
`FIRMessagingTokenManager` enqueues operations on an internally managed NSOperation queue. Sometimes, operations enqueued by one test haven't run yet by the time the test has completed. 

> **Some context**
> Specifically, three out of the four tests from `FIRMessagingTokenManagerTest.m` call:
> ```objc
> [_messaging.tokenManager resetCredentialsIfNeeded];
> ```
> which–**for some test code paths**–kicks off an async token delete operation. Prior to calling `resetCredentialsIfNeeded`, 
we set up some stubs and expects that will later be verified after `resetCredentialsIfNeeded` is called. 

When a token deletion operation starts, it calls the shared instance of Installations. In cases where the test that enqueued 
the operations has already ended, the shared instance of Installations no longer has a Firebase app that it belongs to. This 
causes  a runtime exception. 

Interestingly, when you look at how this test flakes in a nightly, you don't see any failure logs printed. `xcpretty` seems to filter out the app crash. But, after looking back at the nightly logs, there is a hint to the restart that occurs after the test app crashes.

<details>
<summary>Snippet from flaky nightly</summary>
<br>

You can see that only three of the 4 tests of `FIRMessagingTokenManagerTest` ran and the test suite process was restarted.

```
FIRMessagingTokenManagerTest
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
Selected tests
Test Suite MessagingUnit.xctest started  ⬅️ 💥 `testResetCredentialsWithNoCachedCheckin` crashed and caused a restart. 
FIRMessagingTokenManagerTest
    ✓ testResetCredentialsWithoutFreshInstall (0.033 seconds)
    ✓ testTokenChangeMethod (0.010 seconds)
FIRMessagingTokenOperationsTest
    ✓ testHTTPAuthHeaderGenerationFromCheckin (0.004 seconds)
    ✓ testServerResetCommand (0.010 seconds)
    ✓ testThatAnAlreadyCancelledOperationFinishesWithoutStarting (0.006 seconds)
    ✓ testThatOptionsDictionaryIsIncludedWithFetchRequest (0.008 seconds)
    ✓ testThatTokenOperationsAuthHeaderStringMatchesCheckin (0.008 seconds)
    ✓ testThatTokenOperationWithoutCheckInFails (0.006 seconds)
    ✓ testTokenFetchOperationFirebaseUserAgentAndHeartbeatHeader (0.008 seconds)
FIRMessagingTokenStoreTest
    ✓ testRemoveCachedToken (0.004 seconds)
    ✓ testRemoveCheckinPreferences (0.010 seconds)
    ✓ testSaveCheckinAuthID (0.006 seconds)
    ✓ testSaveToken (0.006 seconds)
FIRMessagingUtilitiesTest
    ✓ testAPNSTupleStringReturnsNilIfDeviceTokenNil (0.005 seconds)
    ✓ testAPNSTupleStringReturnsValidData (0.003 seconds)
    ✓ testAppIdentifierReturnsEmptyStringWhenNotFound (0.003 seconds)
    ✓ testAppIdentifierReturnsExpectedValue (0.003 seconds)
    ✓ testAppVersionReturnsEmptyStringWhenNotFound (0.003 seconds)
    ✓ testAppVersionReturnsExpectedValue (0.004 seconds)
    ✓ testLocaleHasChanged (0.008 seconds)


Executed 137 tests, with 1 failure (0 unexpected) in 0.149 (0.190) seconds
2021-09-12 06:07:50.091 xcodebuild[10394:176649] [MT] IDETestOperationsObserverDebug: 58.679 elapsed -- Testing started completed.
2021-09-12 06:07:50.091 xcodebuild[10394:176649] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2021-09-12 06:07:50.091 xcodebuild[10394:176649] [MT] IDETestOperationsObserverDebug: 58.679 sec, +58.679 sec -- end
Failing tests:
	MessagingUnit:
		-[FIRMessagingTokenManagerTest testResetCredentialsWithNoCachedCheckin] 

** TEST FAILED **
```
</details>


<details>
<summary>The crash is more clearly visible in the <code>xcodebuild.log</code> file.</summary>
<br>

This was obtained from running `./scripts/build.sh MessagingUnit iOS spm` locally.

```
Test Case '-[FIRMessagingTokenManagerTest testResetCredentialsWithFreshInstall]' started.
  15 2021-09-21 12:52:43.070514-0400 xctest[58354:1671292] *** Terminating app due to uncaught exception 'com.firebase.installations', reason: 'The default FirebaseApp instance must be configured before the defaultFirebaseApp instance can be initialized.
  16 *** First throw call stack:                                                     
  17 (                                                                               
  18   0   CoreFoundation                      0x00007fff203fbbb4 __exceptionPreprocess + 242
  19   1   libobjc.A.dylib                     0x00007fff2019ebe7 objc_exception_throw + 48
  20   2   CoreFoundation                      0x00007fff203fba92 -[NSException initWithCoder:] + 0
  21   3   MessagingUnit                       0x000000010e0957a2 +[FIRInstallations installations] + 98
  22   4   MessagingUnit                       0x000000010e0e6f71 -[FIRMessagingTokenOperation start] + 305
  23   5   Foundation                          0x00007fff207e29c7 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 17
  24   6   Foundation                          0x00007fff207e250c __NSOQSchedule_f + 182
  25   7   libdispatch.dylib                   0x00007fff20110876 _dispatch_call_block_and_release + 12
  26   8   libdispatch.dylib                   0x00007fff20111a56 _dispatch_client_callout + 8
  27   9   libdispatch.dylib                   0x00007fff2011461d _dispatch_continuation_pop + 482
  28   10  libdispatch.dylib                   0x00007fff20113cb3 _dispatch_async_redirect_invoke + 750
  29   11  libdispatch.dylib                   0x00007fff2012207e _dispatch_root_queue_drain + 405
  30   12  libdispatch.dylib                   0x00007fff201229c8 _dispatch_worker_thread2 + 155
  31   13  libsystem_pthread.dylib             0x00007fff6bfeb417 _pthread_wqthread + 244
  32   14  libsystem_pthread.dylib             0x00007fff6bfea42f start_wqthread + 15
  33 )         
```
</details>

--- 

**The solution:**

So, it doesn't seem that we actually need that delete operation to be executed, we just want to know that it was indeed enqueued with the proper info. So I set up and an OCMExpect to expect the operation was enqueued without actually performing the operation queue's tasks.

> At first, I tried draining the operation queue in the teardown method but that didn't seem to work well. Locally, I could get 
> this to work when running multiple iterations of the tests. But on GHA, this solution did not work that well for whatever reason. 
>
>  There were also some more flakes that emerged from the way `FIRInstallations` was mocked and being used in the operation queue's operations.

I used CI in #8669 as a testing environment. 
<details>
<summary>Verifying the flake has been fixed</summary>
<br>

🟥 **Without** the fix in this PR: 
```
FIRMessagingTokenManagerTest
    ✓ testResetCredentialsWithFreshInstall (0.022 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.008 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.008 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.008 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.010 seconds) 
    ✓ testResetCredentialsWithFreshInstall (0.010 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.010 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.009 seconds)
    ✓ testResetCredentialsWithFreshInstall (0.010 seconds)
Selected tests
Test Suite MessagingUnit.xctest started ⬅️ 💥 Restart from sneaky crash.
FIRMessagingTokenManagerTest
    ✓ testResetCredentialsWithNoCachedCheckin (0.020 seconds)
    ✓ testResetCredentialsWithNoCachedCheckin (0.008 seconds)
    ✓ testResetCredentialsWithNoCachedCheckin (0.008 seconds)
    ✓ testResetCredentialsWithNoCachedCheckin (0.007 seconds)
    ✓ testResetCredentialsWithNoCachedCheckin (0.007 seconds)

```

🟢 **With** this PR: 

Ran each test 1000 times with no failures. See this GHA [messaging / spm (iOS) (pull_request)](https://github.com/firebase/firebase-ios-sdk/pull/8669/checks?check_run_id=3678724539)

</details>

--- 
**Debugging tips:** 

I used Xcode 13's test iteration feature both locally and on GHA. Here's a [good article](https://www.avanderlee.com/debugging/flaky-tests-test-repetitions/).

Ensure GHA is running on Xcode 13, then pass `-test-iterations #`  to `xcodebuild` like what I did [here](https://github.com/firebase/firebase-ios-sdk/pull/8669/files#diff-3d64996115d0ac3b74e36f57ce6b00d6b4982614c41b1ed39eab8ef43b2e9a2bR656).

--- 
Fixes #8652
#no-changelog