### PR TITLE
Fix device-only build warning

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.9.0
+- [fixed] Fix device-only build warning for unused `processIsTranslated` function. (#8694)
+
 # v8.8.0
 - [fixed] Firebase dynamic links with custom domain will only work if the custom domain has a trailing '/'. (#7087)
 

--- a/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
@@ -155,6 +155,7 @@ NSString *GINFingerprintJSMethodString(void) {
 // and -1 when an error occurs.
 // From:
 // https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+#if TARGET_OS_SIMULATOR
 static int processIsTranslated() {
   int ret = 0;
   size_t size = sizeof(ret);
@@ -164,6 +165,7 @@ static int processIsTranslated() {
   }
   return ret;
 }
+#endif
 
 @end
 


### PR DESCRIPTION
Fix #8694

Our CI missed this because it doesn't do a device build