### PR TITLE
Improve error logging for FIRAuthInternalErrorCodeUnexpectedErrorResponse errors

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
+- [changed] Improved error logging. (#8704)
+
+# 8.8.0
 - [fixed] Fall back to reCAPTCHA for phone auth app verification if the push notification is not received before the timeout. (#8653)
 
 # 8.6.0
-- [fixed] Annotated platform-level availability using `API_UNAVAILABLE` instead of conditionally compiling certain methods with `#if` directives (#8451).
+- [fixed] Annotated platform-level availability using `API_UNAVAILABLE` instead of conditionally compiling certain methods with `#if` directives. (#8451)
 
 # 8.5.0
 - [fixed] Fixed an analyze issue introduced in Xcode 12.5. (#8411)

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -1003,126 +1003,127 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   [_RPCIssuer
-    asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
-                                       URL:[request requestURL]
-                                      body:bodyData
-                               contentType:kJSONContentType
-                         completionHandler:^(NSData *data, NSError *error) {
-                           // If there is an error with no body data at all, then this must be a
-                           // network error.
-                           if (error && !data) {
-                             callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
-                             return;
-                           }
-
-                           // Try to decode the HTTP response data which may contain either a
-                           // successful response or error message.
-                           NSError *jsonError;
-                           NSDictionary *dictionary =
-                               [NSJSONSerialization JSONObjectWithData:data
-                                                               options:NSJSONReadingMutableLeaves
-                                                                 error:&jsonError];
-                           if (!dictionary) {
-                             if (error) {
-                               // We have an error, but we couldn't decode the body, so we have no
-                               // additional information other than the raw response and the
-                               // original NSError (the jsonError is infered by the error code
-                               // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
-                               callback([FIRAuthErrorUtils unexpectedErrorResponseWithData:data
-                                                                           underlyingError:error]);
-                             } else {
-                               // This is supposed to be a "successful" response, but we couldn't
-                               // deserialize the body.
-                               callback([FIRAuthErrorUtils unexpectedResponseWithData:data
-                                                                      underlyingError:jsonError]);
+      asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
+                                         URL:[request requestURL]
+                                        body:bodyData
+                                 contentType:kJSONContentType
+                           completionHandler:^(NSData *data, NSError *error) {
+                             // If there is an error with no body data at all, then this must be a
+                             // network error.
+                             if (error && !data) {
+                               callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
+                               return;
                              }
-                             return;
-                           }
-                           if (![dictionary isKindOfClass:[NSDictionary class]]) {
+
+                             // Try to decode the HTTP response data which may contain either a
+                             // successful response or error message.
+                             NSError *jsonError;
+                             NSDictionary *dictionary =
+                                 [NSJSONSerialization JSONObjectWithData:data
+                                                                 options:NSJSONReadingMutableLeaves
+                                                                   error:&jsonError];
+                             if (!dictionary) {
+                               if (error) {
+                                 // We have an error, but we couldn't decode the body, so we have no
+                                 // additional information other than the raw response and the
+                                 // original NSError (the jsonError is infered by the error code
+                                 // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithData:data
+                                                     underlyingError:error]);
+                               } else {
+                                 // This is supposed to be a "successful" response, but we couldn't
+                                 // deserialize the body.
+                                 callback([FIRAuthErrorUtils unexpectedResponseWithData:data
+                                                                        underlyingError:jsonError]);
+                               }
+                               return;
+                             }
+                             if (![dictionary isKindOfClass:[NSDictionary class]]) {
+                               if (error) {
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithDeserializedResponse:dictionary
+                                                                     underlyingError:error]);
+                               } else {
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedResponseWithDeserializedResponse:dictionary]);
+                               }
+                               return;
+                             }
+
+                             // At this point we either have an error with successfully decoded
+                             // details in the body, or we have a response which must pass further
+                             // validation before we know it's truly successful. We deal with the
+                             // case where we have an error with successfully decoded error details
+                             // first:
                              if (error) {
+                               NSDictionary *errorDictionary = dictionary[kErrorKey];
+                               if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
+                                 id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
+                                 if ([errorMessage isKindOfClass:[NSString class]]) {
+                                   NSString *errorMessageString = (NSString *)errorMessage;
+
+                                   // Contruct client error.
+                                   NSError *clientError = [[self class]
+                                       clientErrorWithServerErrorMessage:errorMessageString
+                                                         errorDictionary:errorDictionary
+                                                                response:response];
+                                   if (clientError) {
+                                     callback(clientError);
+                                     return;
+                                   }
+                                 }
+                                 // Not a message we know, return the message directly.
+                                 if (errorMessage) {
+                                   NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
+                                       unexpectedErrorResponseWithDeserializedResponse:
+                                           errorDictionary
+                                                                       underlyingError:error];
+                                   callback(unexpecterErrorResponse);
+                                   return;
+                                 }
+                               }
+                               // No error message at all, return the decoded response.
                                callback([FIRAuthErrorUtils
                                    unexpectedErrorResponseWithDeserializedResponse:dictionary
                                                                    underlyingError:error]);
-                             } else {
+                               return;
+                             }
+
+                             // Finally, we try to populate the response object with the JSON
+                             // values.
+                             if (![response setWithDictionary:dictionary error:&error]) {
                                callback([FIRAuthErrorUtils
-                                   unexpectedResponseWithDeserializedResponse:dictionary]);
+                                   RPCResponseDecodingErrorWithDeserializedResponse:dictionary
+                                                                    underlyingError:error]);
+                               return;
                              }
-                             return;
-                           }
-
-                           // At this point we either have an error with successfully decoded
-                           // details in the body, or we have a response which must pass further
-                           // validation before we know it's truly successful. We deal with the
-                           // case where we have an error with successfully decoded error details
-                           // first:
-                           if (error) {
-                             NSDictionary *errorDictionary = dictionary[kErrorKey];
-                             if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
-                               id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
-                               if ([errorMessage isKindOfClass:[NSString class]]) {
-                                 NSString *errorMessageString = (NSString *)errorMessage;
-
-                                 // Contruct client error.
-                                 NSError *clientError = [[self class]
-                                     clientErrorWithServerErrorMessage:errorMessageString
-                                                       errorDictionary:errorDictionary
-                                                              response:response];
-                                 if (clientError) {
-                                   callback(clientError);
-                                   return;
-                                 }
-                               }
-                               // Not a message we know, return the message directly.
-                               if (errorMessage) {
-                                 NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithDeserializedResponse:
-                                         errorDictionary
-                                                                     underlyingError:error];
-                                 callback(unexpecterErrorResponse);
-                                 return;
-                               }
-                             }
-                             // No error message at all, return the decoded response.
-                             callback([FIRAuthErrorUtils
-                                 unexpectedErrorResponseWithDeserializedResponse:dictionary
-                                                                 underlyingError:error]);
-                             return;
-                           }
-
-                           // Finally, we try to populate the response object with the JSON
-                           // values.
-                           if (![response setWithDictionary:dictionary error:&error]) {
-                             callback([FIRAuthErrorUtils
-                                 RPCResponseDecodingErrorWithDeserializedResponse:dictionary
-                                                                  underlyingError:error]);
-                             return;
-                           }
-                           // In case returnIDPCredential of a verifyAssertion request is set to
-                           // @YES, the server may return a 200 with a response that may contain a
-                           // server error.
-                           if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
-                             FIRVerifyAssertionRequest *verifyAssertionRequest =
-                                 (FIRVerifyAssertionRequest *)request;
-                             if (verifyAssertionRequest.returnIDPCredential) {
-                               NSString *errorMessage =
-                                   dictionary[kReturnIDPCredentialErrorMessageKey];
-                               if ([errorMessage isKindOfClass:[NSString class]]) {
-                                 NSString *errorString = (NSString *)errorMessage;
-                                 NSError *clientError =
-                                     [[self class] clientErrorWithServerErrorMessage:errorString
-                                                                     errorDictionary:@{}
-                                                                            response:response];
-                                 if (clientError) {
-                                   callback(clientError);
-                                   return;
+                             // In case returnIDPCredential of a verifyAssertion request is set to
+                             // @YES, the server may return a 200 with a response that may contain a
+                             // server error.
+                             if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
+                               FIRVerifyAssertionRequest *verifyAssertionRequest =
+                                   (FIRVerifyAssertionRequest *)request;
+                               if (verifyAssertionRequest.returnIDPCredential) {
+                                 NSString *errorMessage =
+                                     dictionary[kReturnIDPCredentialErrorMessageKey];
+                                 if ([errorMessage isKindOfClass:[NSString class]]) {
+                                   NSString *errorString = (NSString *)errorMessage;
+                                   NSError *clientError =
+                                       [[self class] clientErrorWithServerErrorMessage:errorString
+                                                                       errorDictionary:@{}
+                                                                              response:response];
+                                   if (clientError) {
+                                     callback(clientError);
+                                     return;
+                                   }
                                  }
                                }
                              }
-                           }
-                           // Success! The response object originally passed in can be used by the
-                           // caller.
-                           callback(nil);
-                         }];
+                             // Success! The response object originally passed in can be used by the
+                             // caller.
+                             callback(nil);
+                           }];
 }
 
 /** @fn clientErrorWithServerErrorMessage:errorDictionary:

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -1003,127 +1003,125 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   [_RPCIssuer
-      asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
-                                         URL:[request requestURL]
-                                        body:bodyData
-                                 contentType:kJSONContentType
-                           completionHandler:^(NSData *data, NSError *error) {
-                             // If there is an error with no body data at all, then this must be a
-                             // network error.
-                             if (error && !data) {
-                               callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
-                               return;
-                             }
+    asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
+                                       URL:[request requestURL]
+                                      body:bodyData
+                               contentType:kJSONContentType
+                         completionHandler:^(NSData *data, NSError *error) {
+                           // If there is an error with no body data at all, then this must be a
+                           // network error.
+                           if (error && !data) {
+                             callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
+                             return;
+                           }
 
-                             // Try to decode the HTTP response data which may contain either a
-                             // successful response or error message.
-                             NSError *jsonError;
-                             NSDictionary *dictionary =
-                                 [NSJSONSerialization JSONObjectWithData:data
-                                                                 options:NSJSONReadingMutableLeaves
-                                                                   error:&jsonError];
-                             if (!dictionary) {
-                               if (error) {
-                                 // We have an error, but we couldn't decode the body, so we have no
-                                 // additional information other than the raw response and the
-                                 // original NSError (the jsonError is infered by the error code
-                                 // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithData:data
-                                                     underlyingError:error]);
-                               } else {
-                                 // This is supposed to be a "successful" response, but we couldn't
-                                 // deserialize the body.
-                                 callback([FIRAuthErrorUtils unexpectedResponseWithData:data
-                                                                        underlyingError:jsonError]);
-                               }
-                               return;
-                             }
-                             if (![dictionary isKindOfClass:[NSDictionary class]]) {
-                               if (error) {
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithDeserializedResponse:dictionary
-                                                                     underlyingError:error]);
-                               } else {
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedResponseWithDeserializedResponse:dictionary]);
-                               }
-                               return;
-                             }
-
-                             // At this point we either have an error with successfully decoded
-                             // details in the body, or we have a response which must pass further
-                             // validation before we know it's truly successful. We deal with the
-                             // case where we have an error with successfully decoded error details
-                             // first:
+                           // Try to decode the HTTP response data which may contain either a
+                           // successful response or error message.
+                           NSError *jsonError;
+                           NSDictionary *dictionary =
+                               [NSJSONSerialization JSONObjectWithData:data
+                                                               options:NSJSONReadingMutableLeaves
+                                                                 error:&jsonError];
+                           if (!dictionary) {
                              if (error) {
-                               NSDictionary *errorDictionary = dictionary[kErrorKey];
-                               if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
-                                 id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
-                                 if ([errorMessage isKindOfClass:[NSString class]]) {
-                                   NSString *errorMessageString = (NSString *)errorMessage;
-
-                                   // Contruct client error.
-                                   NSError *clientError = [[self class]
-                                       clientErrorWithServerErrorMessage:errorMessageString
-                                                         errorDictionary:errorDictionary
-                                                                response:response];
-                                   if (clientError) {
-                                     callback(clientError);
-                                     return;
-                                   }
-                                 }
-                                 // Not a message we know, return the message directly.
-                                 if (errorMessage) {
-                                   NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
-                                       unexpectedErrorResponseWithDeserializedResponse:
-                                           errorDictionary
-                                                                       underlyingError:error];
-                                   callback(unexpecterErrorResponse);
-                                   return;
-                                 }
-                               }
-                               // No error message at all, return the decoded response.
+                               // We have an error, but we couldn't decode the body, so we have no
+                               // additional information other than the raw response and the
+                               // original NSError (the jsonError is infered by the error code
+                               // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
+                               callback([FIRAuthErrorUtils unexpectedErrorResponseWithData:data
+                                                                           underlyingError:error]);
+                             } else {
+                               // This is supposed to be a "successful" response, but we couldn't
+                               // deserialize the body.
+                               callback([FIRAuthErrorUtils unexpectedResponseWithData:data
+                                                                      underlyingError:jsonError]);
+                             }
+                             return;
+                           }
+                           if (![dictionary isKindOfClass:[NSDictionary class]]) {
+                             if (error) {
                                callback([FIRAuthErrorUtils
                                    unexpectedErrorResponseWithDeserializedResponse:dictionary
                                                                    underlyingError:error]);
-                               return;
-                             }
-
-                             // Finally, we try to populate the response object with the JSON
-                             // values.
-                             if (![response setWithDictionary:dictionary error:&error]) {
+                             } else {
                                callback([FIRAuthErrorUtils
-                                   RPCResponseDecodingErrorWithDeserializedResponse:dictionary
-                                                                    underlyingError:error]);
-                               return;
+                                   unexpectedResponseWithDeserializedResponse:dictionary]);
                              }
-                             // In case returnIDPCredential of a verifyAssertion request is set to
-                             // @YES, the server may return a 200 with a response that may contain a
-                             // server error.
-                             if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
-                               FIRVerifyAssertionRequest *verifyAssertionRequest =
-                                   (FIRVerifyAssertionRequest *)request;
-                               if (verifyAssertionRequest.returnIDPCredential) {
-                                 NSString *errorMessage =
-                                     dictionary[kReturnIDPCredentialErrorMessageKey];
-                                 if ([errorMessage isKindOfClass:[NSString class]]) {
-                                   NSString *errorString = (NSString *)errorMessage;
-                                   NSError *clientError =
-                                       [[self class] clientErrorWithServerErrorMessage:errorString
-                                                                       errorDictionary:@{}
-                                                                              response:response];
-                                   if (clientError) {
-                                     callback(clientError);
-                                     return;
-                                   }
+                             return;
+                           }
+
+                           // At this point we either have an error with successfully decoded
+                           // details in the body, or we have a response which must pass further
+                           // validation before we know it's truly successful. We deal with the
+                           // case where we have an error with successfully decoded error details
+                           // first:
+                           if (error) {
+                             NSDictionary *errorDictionary = dictionary[kErrorKey];
+                             if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
+                               id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
+                               if ([errorMessage isKindOfClass:[NSString class]]) {
+                                 NSString *errorMessageString = (NSString *)errorMessage;
+
+                                 // Contruct client error.
+                                 NSError *clientError = [[self class]
+                                     clientErrorWithServerErrorMessage:errorMessageString
+                                                       errorDictionary:errorDictionary
+                                                              response:response];
+                                 if (clientError) {
+                                   callback(clientError);
+                                   return;
+                                 }
+                               }
+                               // Not a message we know, return the message directly.
+                               if (errorMessage) {
+                                 NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithDeserializedResponse:errorDictionary
+                                                                     underlyingError:error];
+                                 callback(unexpecterErrorResponse);
+                                 return;
+                               }
+                             }
+                             // No error message at all, return the decoded response.
+                             callback([FIRAuthErrorUtils
+                                 unexpectedErrorResponseWithDeserializedResponse:dictionary
+                                                                 underlyingError:error]);
+                             return;
+                           }
+
+                           // Finally, we try to populate the response object with the JSON
+                           // values.
+                           if (![response setWithDictionary:dictionary error:&error]) {
+                             callback([FIRAuthErrorUtils
+                                 RPCResponseDecodingErrorWithDeserializedResponse:dictionary
+                                                                  underlyingError:error]);
+                             return;
+                           }
+                           // In case returnIDPCredential of a verifyAssertion request is set to
+                           // @YES, the server may return a 200 with a response that may contain a
+                           // server error.
+                           if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
+                             FIRVerifyAssertionRequest *verifyAssertionRequest =
+                                 (FIRVerifyAssertionRequest *)request;
+                             if (verifyAssertionRequest.returnIDPCredential) {
+                               NSString *errorMessage =
+                                   dictionary[kReturnIDPCredentialErrorMessageKey];
+                               if ([errorMessage isKindOfClass:[NSString class]]) {
+                                 NSString *errorString = (NSString *)errorMessage;
+                                 NSError *clientError =
+                                     [[self class] clientErrorWithServerErrorMessage:errorString
+                                                                     errorDictionary:@{}
+                                                                            response:response];
+                                 if (clientError) {
+                                   callback(clientError);
+                                   return;
                                  }
                                }
                              }
-                             // Success! The response object originally passed in can be used by the
-                             // caller.
-                             callback(nil);
-                           }];
+                           }
+                           // Success! The response object originally passed in can be used by the
+                           // caller.
+                           callback(nil);
+                         }];
 }
 
 /** @fn clientErrorWithServerErrorMessage:errorDictionary:

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -1003,127 +1003,126 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   [_RPCIssuer
-      asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
-                                         URL:[request requestURL]
-                                        body:bodyData
-                                 contentType:kJSONContentType
-                           completionHandler:^(NSData *data, NSError *error) {
-                             // If there is an error with no body data at all, then this must be a
-                             // network error.
-                             if (error && !data) {
-                               callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
-                               return;
-                             }
+    asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
+                                       URL:[request requestURL]
+                                      body:bodyData
+                               contentType:kJSONContentType
+                         completionHandler:^(NSData *data, NSError *error) {
+                           // If there is an error with no body data at all, then this must be a
+                           // network error.
+                           if (error && !data) {
+                             callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
+                             return;
+                           }
 
-                             // Try to decode the HTTP response data which may contain either a
-                             // successful response or error message.
-                             NSError *jsonError;
-                             NSDictionary *dictionary =
-                                 [NSJSONSerialization JSONObjectWithData:data
-                                                                 options:NSJSONReadingMutableLeaves
-                                                                   error:&jsonError];
-                             if (!dictionary) {
-                               if (error) {
-                                 // We have an error, but we couldn't decode the body, so we have no
-                                 // additional information other than the raw response and the
-                                 // original NSError (the jsonError is infered by the error code
-                                 // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithData:data
-                                                     underlyingError:error]);
-                               } else {
-                                 // This is supposed to be a "successful" response, but we couldn't
-                                 // deserialize the body.
-                                 callback([FIRAuthErrorUtils unexpectedResponseWithData:data
-                                                                        underlyingError:jsonError]);
-                               }
-                               return;
-                             }
-                             if (![dictionary isKindOfClass:[NSDictionary class]]) {
-                               if (error) {
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithDeserializedResponse:dictionary
-                                                                     underlyingError:error]);
-                               } else {
-                                 callback([FIRAuthErrorUtils
-                                     unexpectedResponseWithDeserializedResponse:dictionary]);
-                               }
-                               return;
-                             }
-
-                             // At this point we either have an error with successfully decoded
-                             // details in the body, or we have a response which must pass further
-                             // validation before we know it's truly successful. We deal with the
-                             // case where we have an error with successfully decoded error details
-                             // first:
+                           // Try to decode the HTTP response data which may contain either a
+                           // successful response or error message.
+                           NSError *jsonError;
+                           NSDictionary *dictionary =
+                               [NSJSONSerialization JSONObjectWithData:data
+                                                               options:NSJSONReadingMutableLeaves
+                                                                 error:&jsonError];
+                           if (!dictionary) {
                              if (error) {
-                               NSDictionary *errorDictionary = dictionary[kErrorKey];
-                               if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
-                                 id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
-                                 if ([errorMessage isKindOfClass:[NSString class]]) {
-                                   NSString *errorMessageString = (NSString *)errorMessage;
-
-                                   // Contruct client error.
-                                   NSError *clientError = [[self class]
-                                       clientErrorWithServerErrorMessage:errorMessageString
-                                                         errorDictionary:errorDictionary
-                                                                response:response];
-                                   if (clientError) {
-                                     callback(clientError);
-                                     return;
-                                   }
-                                 }
-                                 // Not a message we know, return the message directly.
-                                 if (errorMessage) {
-                                   NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
-                                       unexpectedErrorResponseWithDeserializedResponse:
-                                           errorDictionary
-                                                                       underlyingError:error];
-                                   callback(unexpecterErrorResponse);
-                                   return;
-                                 }
-                               }
-                               // No error message at all, return the decoded response.
+                               // We have an error, but we couldn't decode the body, so we have no
+                               // additional information other than the raw response and the
+                               // original NSError (the jsonError is infered by the error code
+                               // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
+                               callback([FIRAuthErrorUtils unexpectedErrorResponseWithData:data
+                                                                           underlyingError:error]);
+                             } else {
+                               // This is supposed to be a "successful" response, but we couldn't
+                               // deserialize the body.
+                               callback([FIRAuthErrorUtils unexpectedResponseWithData:data
+                                                                      underlyingError:jsonError]);
+                             }
+                             return;
+                           }
+                           if (![dictionary isKindOfClass:[NSDictionary class]]) {
+                             if (error) {
                                callback([FIRAuthErrorUtils
                                    unexpectedErrorResponseWithDeserializedResponse:dictionary
                                                                    underlyingError:error]);
-                               return;
-                             }
-
-                             // Finally, we try to populate the response object with the JSON
-                             // values.
-                             if (![response setWithDictionary:dictionary error:&error]) {
+                             } else {
                                callback([FIRAuthErrorUtils
-                                   RPCResponseDecodingErrorWithDeserializedResponse:dictionary
-                                                                    underlyingError:error]);
-                               return;
+                                   unexpectedResponseWithDeserializedResponse:dictionary]);
                              }
-                             // In case returnIDPCredential of a verifyAssertion request is set to
-                             // @YES, the server may return a 200 with a response that may contain a
-                             // server error.
-                             if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
-                               FIRVerifyAssertionRequest *verifyAssertionRequest =
-                                   (FIRVerifyAssertionRequest *)request;
-                               if (verifyAssertionRequest.returnIDPCredential) {
-                                 NSString *errorMessage =
-                                     dictionary[kReturnIDPCredentialErrorMessageKey];
-                                 if ([errorMessage isKindOfClass:[NSString class]]) {
-                                   NSString *errorString = (NSString *)errorMessage;
-                                   NSError *clientError =
-                                       [[self class] clientErrorWithServerErrorMessage:errorString
-                                                                       errorDictionary:@{}
-                                                                              response:response];
-                                   if (clientError) {
-                                     callback(clientError);
-                                     return;
-                                   }
+                             return;
+                           }
+
+                           // At this point we either have an error with successfully decoded
+                           // details in the body, or we have a response which must pass further
+                           // validation before we know it's truly successful. We deal with the
+                           // case where we have an error with successfully decoded error details
+                           // first:
+                           if (error) {
+                             NSDictionary *errorDictionary = dictionary[kErrorKey];
+                             if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
+                               id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
+                               if ([errorMessage isKindOfClass:[NSString class]]) {
+                                 NSString *errorMessageString = (NSString *)errorMessage;
+
+                                 // Contruct client error.
+                                 NSError *clientError = [[self class]
+                                     clientErrorWithServerErrorMessage:errorMessageString
+                                                       errorDictionary:errorDictionary
+                                                              response:response];
+                                 if (clientError) {
+                                   callback(clientError);
+                                   return;
+                                 }
+                               }
+                               // Not a message we know, return the message directly.
+                               if (errorMessage) {
+                                 NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithDeserializedResponse:
+                                         errorDictionary
+                                                                     underlyingError:error];
+                                 callback(unexpecterErrorResponse);
+                                 return;
+                               }
+                             }
+                             // No error message at all, return the decoded response.
+                             callback([FIRAuthErrorUtils
+                                 unexpectedErrorResponseWithDeserializedResponse:dictionary
+                                                                 underlyingError:error]);
+                             return;
+                           }
+
+                           // Finally, we try to populate the response object with the JSON
+                           // values.
+                           if (![response setWithDictionary:dictionary error:&error]) {
+                             callback([FIRAuthErrorUtils
+                                 RPCResponseDecodingErrorWithDeserializedResponse:dictionary
+                                                                  underlyingError:error]);
+                             return;
+                           }
+                           // In case returnIDPCredential of a verifyAssertion request is set to
+                           // @YES, the server may return a 200 with a response that may contain a
+                           // server error.
+                           if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
+                             FIRVerifyAssertionRequest *verifyAssertionRequest =
+                                 (FIRVerifyAssertionRequest *)request;
+                             if (verifyAssertionRequest.returnIDPCredential) {
+                               NSString *errorMessage =
+                                   dictionary[kReturnIDPCredentialErrorMessageKey];
+                               if ([errorMessage isKindOfClass:[NSString class]]) {
+                                 NSString *errorString = (NSString *)errorMessage;
+                                 NSError *clientError =
+                                     [[self class] clientErrorWithServerErrorMessage:errorString
+                                                                     errorDictionary:@{}
+                                                                            response:response];
+                                 if (clientError) {
+                                   callback(clientError);
+                                   return;
                                  }
                                }
                              }
-                             // Success! The response object originally passed in can be used by the
-                             // caller.
-                             callback(nil);
-                           }];
+                           }
+                           // Success! The response object originally passed in can be used by the
+                           // caller.
+                           callback(nil);
+                         }];
 }
 
 /** @fn clientErrorWithServerErrorMessage:errorDictionary:

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -1003,123 +1003,127 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   [_RPCIssuer
-    asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
-                                       URL:[request requestURL]
-                                      body:bodyData
-                               contentType:kJSONContentType
-                         completionHandler:^(NSData *data, NSError *error) {
-                           // If there is an error with no body data at all, then this must be a
-                           // network error.
-                           if (error && !data) {
-                             callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
-                             return;
-                           }
-
-                           // Try to decode the HTTP response data which may contain either a
-                           // successful response or error message.
-                           NSError *jsonError;
-                           NSDictionary *dictionary =
-                               [NSJSONSerialization JSONObjectWithData:data
-                                                               options:NSJSONReadingMutableLeaves
-                                                                 error:&jsonError];
-                           if (!dictionary) {
-                             if (error) {
-                               // We have an error, but we couldn't decode the body, so we have no
-                               // additional information other than the raw response and the
-                               // original NSError (the jsonError is infered by the error code
-                               // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
-                               callback([FIRAuthErrorUtils unexpectedErrorResponseWithData:data
-                                                                           underlyingError:error]);
-                             } else {
-                               // This is supposed to be a "successful" response, but we couldn't
-                               // deserialize the body.
-                               callback([FIRAuthErrorUtils unexpectedResponseWithData:data
-                                                                      underlyingError:jsonError]);
+      asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
+                                         URL:[request requestURL]
+                                        body:bodyData
+                                 contentType:kJSONContentType
+                           completionHandler:^(NSData *data, NSError *error) {
+                             // If there is an error with no body data at all, then this must be a
+                             // network error.
+                             if (error && !data) {
+                               callback([FIRAuthErrorUtils networkErrorWithUnderlyingError:error]);
+                               return;
                              }
-                             return;
-                           }
-                           if (![dictionary isKindOfClass:[NSDictionary class]]) {
-                             if (error) {
-                               callback([FIRAuthErrorUtils
-                                   unexpectedErrorResponseWithDeserializedResponse:dictionary]);
-                             } else {
-                               callback([FIRAuthErrorUtils
-                                   unexpectedResponseWithDeserializedResponse:dictionary]);
+
+                             // Try to decode the HTTP response data which may contain either a
+                             // successful response or error message.
+                             NSError *jsonError;
+                             NSDictionary *dictionary =
+                                 [NSJSONSerialization JSONObjectWithData:data
+                                                                 options:NSJSONReadingMutableLeaves
+                                                                   error:&jsonError];
+                             if (!dictionary) {
+                               if (error) {
+                                 // We have an error, but we couldn't decode the body, so we have no
+                                 // additional information other than the raw response and the
+                                 // original NSError (the jsonError is infered by the error code
+                                 // (FIRAuthErrorCodeUnexpectedHTTPResponse, and is irrelevant.)
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithData:data
+                                                     underlyingError:error]);
+                               } else {
+                                 // This is supposed to be a "successful" response, but we couldn't
+                                 // deserialize the body.
+                                 callback([FIRAuthErrorUtils unexpectedResponseWithData:data
+                                                                        underlyingError:jsonError]);
+                               }
+                               return;
                              }
-                             return;
-                           }
+                             if (![dictionary isKindOfClass:[NSDictionary class]]) {
+                               if (error) {
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedErrorResponseWithDeserializedResponse:dictionary
+                                                                     underlyingError:error]);
+                               } else {
+                                 callback([FIRAuthErrorUtils
+                                     unexpectedResponseWithDeserializedResponse:dictionary]);
+                               }
+                               return;
+                             }
 
-                           // At this point we either have an error with successfully decoded
-                           // details in the body, or we have a response which must pass further
-                           // validation before we know it's truly successful. We deal with the
-                           // case where we have an error with successfully decoded error details
-                           // first:
-                           if (error) {
-                             NSDictionary *errorDictionary = dictionary[kErrorKey];
-                             if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
-                               id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
-                               if ([errorMessage isKindOfClass:[NSString class]]) {
-                                 NSString *errorMessageString = (NSString *)errorMessage;
+                             // At this point we either have an error with successfully decoded
+                             // details in the body, or we have a response which must pass further
+                             // validation before we know it's truly successful. We deal with the
+                             // case where we have an error with successfully decoded error details
+                             // first:
+                             if (error) {
+                               NSDictionary *errorDictionary = dictionary[kErrorKey];
+                               if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
+                                 id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
+                                 if ([errorMessage isKindOfClass:[NSString class]]) {
+                                   NSString *errorMessageString = (NSString *)errorMessage;
 
-                                 // Contruct client error.
-                                 NSError *clientError = [[self class]
-                                     clientErrorWithServerErrorMessage:errorMessageString
-                                                       errorDictionary:errorDictionary
-                                                              response:response];
-                                 if (clientError) {
-                                   callback(clientError);
+                                   // Contruct client error.
+                                   NSError *clientError = [[self class]
+                                       clientErrorWithServerErrorMessage:errorMessageString
+                                                         errorDictionary:errorDictionary
+                                                                response:response];
+                                   if (clientError) {
+                                     callback(clientError);
+                                     return;
+                                   }
+                                 }
+                                 // Not a message we know, return the message directly.
+                                 if (errorMessage) {
+                                   NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
+                                       unexpectedErrorResponseWithDeserializedResponse:
+                                           errorDictionary
+                                                                       underlyingError:error];
+                                   callback(unexpecterErrorResponse);
                                    return;
                                  }
                                }
-                               // Not a message we know, return the message directly.
-                               if (errorMessage) {
-                                 NSError *unexpecterErrorResponse = [FIRAuthErrorUtils
-                                     unexpectedErrorResponseWithDeserializedResponse:
-                                         errorDictionary];
-                                 callback(unexpecterErrorResponse);
-                                 return;
-                               }
+                               // No error message at all, return the decoded response.
+                               callback([FIRAuthErrorUtils
+                                   unexpectedErrorResponseWithDeserializedResponse:dictionary
+                                                                   underlyingError:error]);
+                               return;
                              }
-                             // No error message at all, return the decoded response.
-                             callback([FIRAuthErrorUtils
-                                 unexpectedErrorResponseWithDeserializedResponse:dictionary]);
-                             return;
-                           }
 
-                           // Finally, we try to populate the response object with the JSON
-                           // values.
-                           if (![response setWithDictionary:dictionary error:&error]) {
-                             callback([FIRAuthErrorUtils
-                                 RPCResponseDecodingErrorWithDeserializedResponse:dictionary
-                                                                  underlyingError:error]);
-                             return;
-                           }
-                           // In case returnIDPCredential of a verifyAssertion request is set to
-                           // @YES, the server may return a 200 with a response that may contain a
-                           // server error.
-                           if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
-                             FIRVerifyAssertionRequest *verifyAssertionRequest =
-                                 (FIRVerifyAssertionRequest *)request;
-                             if (verifyAssertionRequest.returnIDPCredential) {
-                               NSString *errorMessage =
-                                   dictionary[kReturnIDPCredentialErrorMessageKey];
-                               if ([errorMessage isKindOfClass:[NSString class]]) {
-                                 NSString *errorString = (NSString *)errorMessage;
-                                 NSError *clientError =
-                                     [[self class] clientErrorWithServerErrorMessage:errorString
-                                                                     errorDictionary:@{}
-                                                                            response:response];
-                                 if (clientError) {
-                                   callback(clientError);
-                                   return;
+                             // Finally, we try to populate the response object with the JSON
+                             // values.
+                             if (![response setWithDictionary:dictionary error:&error]) {
+                               callback([FIRAuthErrorUtils
+                                   RPCResponseDecodingErrorWithDeserializedResponse:dictionary
+                                                                    underlyingError:error]);
+                               return;
+                             }
+                             // In case returnIDPCredential of a verifyAssertion request is set to
+                             // @YES, the server may return a 200 with a response that may contain a
+                             // server error.
+                             if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
+                               FIRVerifyAssertionRequest *verifyAssertionRequest =
+                                   (FIRVerifyAssertionRequest *)request;
+                               if (verifyAssertionRequest.returnIDPCredential) {
+                                 NSString *errorMessage =
+                                     dictionary[kReturnIDPCredentialErrorMessageKey];
+                                 if ([errorMessage isKindOfClass:[NSString class]]) {
+                                   NSString *errorString = (NSString *)errorMessage;
+                                   NSError *clientError =
+                                       [[self class] clientErrorWithServerErrorMessage:errorString
+                                                                       errorDictionary:@{}
+                                                                              response:response];
+                                   if (clientError) {
+                                     callback(clientError);
+                                     return;
+                                   }
                                  }
                                }
                              }
-                           }
-                           // Success! The response object originally passed in can be used by the
-                           // caller.
-                           callback(nil);
-                         }];
+                             // Success! The response object originally passed in can be used by the
+                             // caller.
+                             callback(nil);
+                           }];
 }
 
 /** @fn clientErrorWithServerErrorMessage:errorDictionary:

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
@@ -90,6 +90,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)unexpectedErrorResponseWithDeserializedResponse:(id)deserializedResponse;
 
+/** @fn unexpectedErrorResponseWithDeserializedResponse:underlyingError:
+    @brief Constructs an @c NSError with the @c FIRAuthInternalErrorCodeUnexpectedErrorResponse
+        code, and populated @c FIRAuthErrorUserInfoDeserializedResponseKey and
+        @c NSUnderlyingErrorKey keys in the @c NSError.userInfo dictionary.
+    @param deserializedResponse The value of the @c FIRAuthErrorUserInfoDeserializedResponseKey key.
+    @param underlyingError The value of the @c NSUnderlyingErrorKey key.
+    @remarks This error is used when a network request results in an error, and the body data was
+        deserializable as JSON, but couldn't be decoded as an error.
+ */
++ (NSError *)unexpectedErrorResponseWithDeserializedResponse:(id)deserializedResponse
+                                             underlyingError:(NSError *)underlyingError;
+
 /** @fn malformedJWTErrorWithToken:underlyingError:
     @brief Constructs an @c NSError with the code set to @c FIRAuthErrorCodeMalformedJWT and
         populates the userInfo dictionary with an error message, the bad token, and an underlying

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -1013,6 +1013,19 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
   return [self errorWithCode:FIRAuthInternalErrorCodeUnexpectedErrorResponse userInfo:userInfo];
 }
 
++ (NSError *)unexpectedErrorResponseWithDeserializedResponse:(id)deserializedResponse
+                                             underlyingError:(NSError *)underlyingError {
+  NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+  if (deserializedResponse) {
+    userInfo[FIRAuthErrorUserInfoDeserializedResponseKey] = deserializedResponse;
+  }
+  if (underlyingError) {
+    userInfo[NSUnderlyingErrorKey] = underlyingError;
+  }
+  return [self errorWithCode:FIRAuthInternalErrorCodeUnexpectedErrorResponse
+                    userInfo:[userInfo copy]];
+}
+
 + (NSError *)malformedJWTErrorWithToken:(NSString *)token
                         underlyingError:(NSError *_Nullable)underlyingError {
   NSMutableDictionary *userInfo =

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
@@ -575,10 +575,10 @@ static NSString *const kTestValue = @"TestValue";
 /** @fn testNonDictionaryErrorResponse
     @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization is not a dictionary, and an error was
-        expected. We are expecting to receive an @c NSError with the code
-        @c FIRAuthErrorCodeUnexpectedErrorServerResponse with the decoded response in the
-        @c NSError.userInfo dictionary associated with the key
-        @c FIRAuthErrorUserInfoDecodedResponseKey.
+        expected. We are expecting to receive the original network error wrapped in an @c NSError
+        with the code @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded response
+        in the @c NSError.userInfo dictionary associated with the key
+        @c FIRAuthErrorUserInfoDeserializedResponseKey.
  */
 - (void)testNonDictionaryErrorResponse {
   FIRFakeRequest *request = [FIRFakeRequest fakeRequest];
@@ -613,7 +613,9 @@ static NSString *const kTestValue = @"TestValue";
   XCTAssertEqual(underlyingError.code, FIRAuthInternalErrorCodeUnexpectedErrorResponse);
 
   NSError *underlyingUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
-  XCTAssertNil(underlyingUnderlyingError);
+  XCTAssertNotNil(underlyingUnderlyingError);
+  XCTAssertEqualObjects(underlyingUnderlyingError.domain, kFakeErrorDomain);
+  XCTAssertEqual(underlyingUnderlyingError.code, kFakeErrorCode);
 
   id deserializedResponse = underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey];
   XCTAssertNotNil(deserializedResponse);
@@ -677,9 +679,9 @@ static NSString *const kTestValue = @"TestValue";
     @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
         we get an error message indicating captcha is required. The backend should not be returning
         this error to mobile clients. If it does, we should wrap it in an @c NSError with the code
-        @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded error message in the
+        @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded error message in the
         @c NSError.userInfo dictionary associated with the key
-        @c FIRAuthErrorUserInfoDecodedErrorResponseKey.
+        @c FIRAuthErrorUserInfoDeserializedResponseKey.
  */
 - (void)testCaptchaRequiredResponse {
   FIRFakeRequest *request = [FIRFakeRequest fakeRequest];
@@ -709,7 +711,9 @@ static NSString *const kTestValue = @"TestValue";
   XCTAssertEqual(underlyingError.code, FIRAuthInternalErrorCodeUnexpectedErrorResponse);
 
   NSError *underlyingUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
-  XCTAssertNil(underlyingUnderlyingError);
+  XCTAssertNotNil(underlyingUnderlyingError);
+  XCTAssertEqualObjects(underlyingUnderlyingError.domain, kFakeErrorDomain);
+  XCTAssertEqual(underlyingUnderlyingError.code, kFakeErrorCode);
 
   id deserializedResponse = underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey];
   XCTAssertNotNil(deserializedResponse);
@@ -756,9 +760,9 @@ static NSString *const kTestValue = @"TestValue";
         we get an error message indicating captcha is required and an invalid password was entered.
         The backend should not be returning this error to mobile clients. If it does, we should wrap
         it in an @c NSError with the code
-        @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded error message in the
+        @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded error message in the
         @c NSError.userInfo dictionary associated with the key
-        @c FIRAuthErrorUserInfoDecodedErrorResponseKey.
+        @c FIRAuthErrorUserInfoDeserializedResponseKey.
  */
 - (void)testCaptchaRequiredInvalidPasswordResponse {
   FIRFakeRequest *request = [FIRFakeRequest fakeRequest];
@@ -789,7 +793,9 @@ static NSString *const kTestValue = @"TestValue";
   XCTAssertEqual(underlyingError.code, FIRAuthInternalErrorCodeUnexpectedErrorResponse);
 
   NSError *underlyingUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
-  XCTAssertNil(underlyingUnderlyingError);
+  XCTAssertNotNil(underlyingUnderlyingError);
+  XCTAssertEqualObjects(underlyingUnderlyingError.domain, kFakeErrorDomain);
+  XCTAssertEqual(underlyingUnderlyingError.code, kFakeErrorCode);
 
   id deserializedResponse = underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey];
   XCTAssertNotNil(deserializedResponse);
@@ -804,9 +810,10 @@ static NSString *const kTestValue = @"TestValue";
     @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization represents a valid error response (and an
         error was indicated) but we didn't receive an error message we know about. We are expecting
-        an @c NSError with the code @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded
+        to receive the original network error wrapped in an @c NSError with the code
+        @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded
         error message in the @c NSError.userInfo dictionary associated with the key
-        @c FIRAuthErrorUserInfoDecodedErrorResponseKey.
+        @c FIRAuthErrorUserInfoDeserializedResponseKey.
  */
 - (void)testDecodableErrorResponseWithUnknownMessage {
   FIRFakeRequest *request = [FIRFakeRequest fakeRequest];
@@ -838,7 +845,9 @@ static NSString *const kTestValue = @"TestValue";
   XCTAssertEqual(underlyingError.code, FIRAuthInternalErrorCodeUnexpectedErrorResponse);
 
   NSError *underlyingUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
-  XCTAssertNil(underlyingUnderlyingError);
+  XCTAssertNotNil(underlyingUnderlyingError);
+  XCTAssertEqualObjects(underlyingUnderlyingError.domain, kFakeErrorDomain);
+  XCTAssertEqual(underlyingUnderlyingError.code, kFakeErrorCode);
 
   id deserializedResponse = underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey];
   XCTAssertNotNil(deserializedResponse);
@@ -852,10 +861,11 @@ static NSString *const kTestValue = @"TestValue";
 /** @fn testErrorResponseWithNoErrorMessage
     @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization is a dictionary, and an error was indicated,
-        but no error information was present in the decoded response. We are expecting an @c NSError
-        with the code @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded
+        but no error information was present in the decoded response. We are expecting to receive
+        the original network error wrapped in an @c NSError with the code
+        @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded
         response message in the @c NSError.userInfo dictionary associated with the key
-        @c FIRAuthErrorUserInfoDecodedResponseKey.
+        @c FIRAuthErrorUserInfoDeserializedResponseKey.
  */
 - (void)testErrorResponseWithNoErrorMessage {
   FIRFakeRequest *request = [FIRFakeRequest fakeRequest];
@@ -885,7 +895,9 @@ static NSString *const kTestValue = @"TestValue";
   XCTAssertEqual(underlyingError.code, FIRAuthInternalErrorCodeUnexpectedErrorResponse);
 
   NSError *underlyingUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
-  XCTAssertNil(underlyingUnderlyingError);
+  XCTAssertNotNil(underlyingUnderlyingError);
+  XCTAssertEqualObjects(underlyingUnderlyingError.domain, kFakeErrorDomain);
+  XCTAssertEqual(underlyingUnderlyingError.code, kFakeErrorCode);
 
   id deserializedResponse = underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey];
   XCTAssertNotNil(deserializedResponse);


### PR DESCRIPTION
Add `NSUnderlyingError ` to `FIRAuthInternalErrorCodeUnexpectedErrorResponse` errors.