### PR TITLE
Support multi-factor authentication with email link sign in

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -811,8 +811,23 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                  if (error) {
                    callback(nil, error);
                  } else {
+                   if (!response.IDToken && response.MFAInfo) {
+  #if TARGET_OS_IOS
+                     NSMutableArray<FIRMultiFactorInfo *> *multiFactorInfo = [NSMutableArray array];
+                     for (FIRAuthProtoMFAEnrollment *MFAEnrollment in response.MFAInfo) {
+                       FIRPhoneMultiFactorInfo *info =
+                           [[FIRPhoneMultiFactorInfo alloc] initWithProto:MFAEnrollment];
+                       [multiFactorInfo addObject:info];
+                     }
+                     NSError *multiFactorRequiredError = [FIRAuthErrorUtils
+                         secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
+                                                                  hints:multiFactorInfo];
+                     callback(nil, multiFactorRequiredError);
+  #endif
+                 } else {
                    callback(response, nil);
                  }
+                }
                }];
 }
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -805,30 +805,31 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)emailLinkSignin:(FIREmailLinkSignInRequest *)request
                callback:(FIREmailLinkSigninResponseCallback)callback {
   FIREmailLinkSignInResponse *response = [[FIREmailLinkSignInResponse alloc] init];
-  [self postWithRequest:request
-               response:response
-               callback:^(NSError *error) {
-                 if (error) {
-                   callback(nil, error);
-                 } else {
-                   if (!response.IDToken && response.MFAInfo) {
-  #if TARGET_OS_IOS
-                     NSMutableArray<FIRMultiFactorInfo *> *multiFactorInfo = [NSMutableArray array];
-                     for (FIRAuthProtoMFAEnrollment *MFAEnrollment in response.MFAInfo) {
-                       FIRPhoneMultiFactorInfo *info =
-                           [[FIRPhoneMultiFactorInfo alloc] initWithProto:MFAEnrollment];
-                       [multiFactorInfo addObject:info];
-                     }
-                     NSError *multiFactorRequiredError = [FIRAuthErrorUtils
-                         secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
-                                                                  hints:multiFactorInfo];
-                     callback(nil, multiFactorRequiredError);
-  #endif
+  [self
+      postWithRequest:request
+             response:response
+             callback:^(NSError *error) {
+               if (error) {
+                 callback(nil, error);
+               } else {
+                 if (!response.IDToken && response.MFAInfo) {
+#if TARGET_OS_IOS
+                   NSMutableArray<FIRMultiFactorInfo *> *multiFactorInfo = [NSMutableArray array];
+                   for (FIRAuthProtoMFAEnrollment *MFAEnrollment in response.MFAInfo) {
+                     FIRPhoneMultiFactorInfo *info =
+                         [[FIRPhoneMultiFactorInfo alloc] initWithProto:MFAEnrollment];
+                     [multiFactorInfo addObject:info];
+                   }
+                   NSError *multiFactorRequiredError = [FIRAuthErrorUtils
+                       secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
+                                                                hints:multiFactorInfo];
+                   callback(nil, multiFactorRequiredError);
+#endif
                  } else {
                    callback(response, nil);
                  }
-                }
-               }];
+               }
+             }];
 }
 
 - (void)secureToken:(FIRSecureTokenRequest *)request

--- a/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h
@@ -55,8 +55,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, assign) BOOL isNewUser;
 
+/** @property MFAPendingCredential
+    @brief An opaque string that functions as proof that the user has successfully passed the first
+   factor check.
+*/
 @property(nonatomic, strong, readonly, nullable) NSString *MFAPendingCredential;
 
+/** @property MFAInfo
+    @brief Info on which multi-factor authentication providers are enabled.
+*/
 @property(nonatomic, strong, readonly, nullable) NSArray<FIRAuthProtoMFAEnrollment *> *MFAInfo;
 
 @end

--- a/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCResponse.h"
+#import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,6 +40,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, strong, readonly, nullable) NSString *refreshToken;
 
+/** @property localID
+    @brief The Firebase Auth user ID.
+ */
+@property(nonatomic, strong, readonly, nullable) NSString *localID;
+
 /** @property approximateExpirationDate
     @brief The approximate expiration date of the access token.
  */
@@ -48,6 +54,10 @@ NS_ASSUME_NONNULL_BEGIN
     @brief Flag indicating that the user signing in is a new user and not a returning user.
  */
 @property(nonatomic, assign) BOOL isNewUser;
+
+@property(nonatomic, strong, readonly, nullable) NSString *MFAPendingCredential;
+
+@property(nonatomic, strong, readonly, nullable) NSArray<FIRAuthProtoMFAEnrollment *> *MFAInfo;
 
 @end
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.m
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIREmailLinkSignInResponse
 
 - (BOOL)setWithDictionary:(NSDictionary *)dictionary error:(NSError *_Nullable *_Nullable)error {
+  _localID = [dictionary[@"localId"] copy];
   _email = [dictionary[@"email"] copy];
   _IDToken = [dictionary[@"idToken"] copy];
   _isNewUser = [dictionary[@"isNewUser"] boolValue];
@@ -29,6 +30,18 @@ NS_ASSUME_NONNULL_BEGIN
       [dictionary[@"expiresIn"] isKindOfClass:[NSString class]]
           ? [NSDate dateWithTimeIntervalSinceNow:[dictionary[@"expiresIn"] doubleValue]]
           : nil;
+    if (dictionary[@"mfaInfo"] != nil) {
+      NSMutableArray<FIRAuthProtoMFAEnrollment *> *MFAInfo = [NSMutableArray array];
+      NSArray *MFAInfoDataArray = dictionary[@"mfaInfo"];
+      for (NSDictionary *MFAInfoData in MFAInfoDataArray) {
+        FIRAuthProtoMFAEnrollment *MFAEnrollment =
+            [[FIRAuthProtoMFAEnrollment alloc] initWithDictionary:MFAInfoData];
+        [MFAInfo addObject:MFAEnrollment];
+      }
+      _MFAInfo = MFAInfo;
+    }
+    _MFAPendingCredential = [dictionary[@"mfaPendingCredential"] copy];
+
   return YES;
 }
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.m
@@ -30,17 +30,17 @@ NS_ASSUME_NONNULL_BEGIN
       [dictionary[@"expiresIn"] isKindOfClass:[NSString class]]
           ? [NSDate dateWithTimeIntervalSinceNow:[dictionary[@"expiresIn"] doubleValue]]
           : nil;
-    if (dictionary[@"mfaInfo"] != nil) {
-      NSMutableArray<FIRAuthProtoMFAEnrollment *> *MFAInfo = [NSMutableArray array];
-      NSArray *MFAInfoDataArray = dictionary[@"mfaInfo"];
-      for (NSDictionary *MFAInfoData in MFAInfoDataArray) {
-        FIRAuthProtoMFAEnrollment *MFAEnrollment =
-            [[FIRAuthProtoMFAEnrollment alloc] initWithDictionary:MFAInfoData];
-        [MFAInfo addObject:MFAEnrollment];
-      }
-      _MFAInfo = MFAInfo;
+  if (dictionary[@"mfaInfo"] != nil) {
+    NSMutableArray<FIRAuthProtoMFAEnrollment *> *MFAInfo = [NSMutableArray array];
+    NSArray *MFAInfoDataArray = dictionary[@"mfaInfo"];
+    for (NSDictionary *MFAInfoData in MFAInfoDataArray) {
+      FIRAuthProtoMFAEnrollment *MFAEnrollment =
+          [[FIRAuthProtoMFAEnrollment alloc] initWithDictionary:MFAInfoData];
+      [MFAInfo addObject:MFAEnrollment];
     }
-    _MFAPendingCredential = [dictionary[@"mfaPendingCredential"] copy];
+    _MFAInfo = MFAInfo;
+  }
+  _MFAPendingCredential = [dictionary[@"mfaPendingCredential"] copy];
 
   return YES;
 }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionResponse.h
@@ -205,8 +205,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *pendingToken;
 
+/** @property MFAPendingCredential
+    @brief An opaque string that functions as proof that the user has successfully passed the first
+   factor check.
+*/
 @property(nonatomic, strong, readonly, nullable) NSString *MFAPendingCredential;
 
+/** @property MFAInfo
+    @brief Info on which multi-factor authentication providers are enabled.
+*/
 @property(nonatomic, strong, readonly, nullable) NSArray<FIRAuthProtoMFAEnrollment *> *MFAInfo;
 
 @end

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordResponse.h
@@ -66,8 +66,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, strong, readonly, nullable) NSURL *photoURL;
 
+/** @property MFAPendingCredential
+    @brief An opaque string that functions as proof that the user has successfully passed the first
+   factor check.
+*/
 @property(nonatomic, strong, readonly, nullable) NSString *MFAPendingCredential;
 
+/** @property MFAInfo
+    @brief Info on which multi-factor authentication providers are enabled.
+*/
 @property(nonatomic, strong, readonly, nullable) NSArray<FIRAuthProtoMFAEnrollment *> *MFAInfo;
 
 @end


### PR DESCRIPTION
### Discussion

Motivation of this pull request is to support MFA with email link sign in. Unfortunately, firebase-ios-sdk does not support email link sign in with MFA even if the document mentioned as supported (https://cloud.google.com/identity-platform/docs/ios/mfa). This issue is already reported in https://github.com/firebase/firebase-ios-sdk/issues/7770

I found a reason of this issue and fix it as follows:
- Store `mfaInfo` in `FIREmailLinkSignInResponse`.
  - [here](https://github.com/firebase/firebase-ios-sdk/compare/master...0x0c:feature/support-mfa-with-email-link-signin?expand=1#diff-636a0b9aac20361cfebaf481eae8a0cf4c1943c52850348529236761c09baa41R33) and [here](https://github.com/firebase/firebase-ios-sdk/compare/master...0x0c:feature/support-mfa-with-email-link-signin?expand=1#diff-ac59cabb48dcc0709f92b5016955dad18caca6ed6ddcd7df0daf2ab63556c838R19)
  - These codes are copied from [`FIRVerifyPasswordResponse`](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordResponse.m#L24).
- Handle an error when MFA is needed. 
  - [here](https://github.com/firebase/firebase-ios-sdk/compare/master...0x0c:feature/support-mfa-with-email-link-signin?expand=1#diff-1a5639fd7fcb3842f98c88038ab9596a17700c9629b1eaff6c7c17957c4c37ddR813)
  - These codes are copied from [here](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseAuth/Sources/Backend/FIRAuthBackend.m#L787).

### Testing

All tests are passed (`FirebaseAuth-Unit-unit`). I tested email link sign in feature and MFA with my sample project and I confirmed it works. I uploaded [MCVE](https://stackoverflow.com/help/minimal-reproducible-example). See [this repo](https://github.com/firebase/firebase-ios-sdk/issues/7770#issuecomment-922483315).

### API Changes

There are no api changes.

Please let me know if I have mistake :)