### PR TITLE
Enable binary data upload in post submit

### DIFF
--- a/.github/workflows/health_metrics.yml
+++ b/.github/workflows/health_metrics.yml
@@ -47,7 +47,8 @@ jobs:
   binary_size_metrics:
     needs: check
     # Prevent the job from being triggered in fork.
-    if: github.event.pull_request.head.repo.full_name == github.repository && (github.event.action != 'closed' || github.event.pull_request.merged)
+    # always() will trigger this job when `needs` are skipped in a `merge` pull_request event.
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository && (github.event.action != 'closed' || github.event.pull_request.merged)
     runs-on: macos-11
     strategy:
       matrix:
@@ -89,7 +90,6 @@ jobs:
   pod-lib-lint-abtesting:
     needs: check
     # Don't run on private repo unless it is a PR.
-    # always() will trigger this job when `needs` are skipped in a `merge` pull_request event.
     if: always() && github.repository == 'Firebase/firebase-ios-sdk' && (needs.check.outputs.abtesting_run_job == 'true'|| github.event.pull_request.merged)
     runs-on: macos-11
     strategy:


### PR DESCRIPTION
Found binary size reports have more question marks than expected. 
This seemed to be caused by binary size data which were not uploaded properly, since `needs:check` kept the binary data job from being run in post submits, which uploaded binary data to Metrics Service. The lack of data in base commits eventually lead to questions marks in reports.
The `check` job is helping check changing files in a PR and so to determine jobs to be run and this is not applicable in post submit and `always()` will run the binary job regardless of `needs:check`.