### PR TITLE
Force GoogleUtilities and GDT update for SPM

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 8.8.1
+- [fixed] Swift Package Manager only release to force GoogleUtilities and GoogleDataTransport
+  to be updated to latest current bug-fix versions.
+
 # Firebase 8.3.1
 - [fixed] Swift Package Manager only release to fix an 8.3.0 tagging issue impacting some users. (#8367)
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 8.8.1
 - [fixed] Swift Package Manager only release to force GoogleUtilities and GoogleDataTransport
-  to be updated to latest current bug-fix versions.
+  to be updated to latest current bug-fix versions. (#8728)
 
 # Firebase 8.3.1
 - [fixed] Swift Package Manager only release to fix an 8.3.0 tagging issue impacting some users. (#8367)

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "8.8.0"
+let firebaseVersion = "8.8.1"
 
 let package = Package(
   name: "Firebase",
@@ -154,12 +154,12 @@ let package = Package(
     .package(
       name: "GoogleDataTransport",
       url: "https://github.com/google/GoogleDataTransport.git",
-      "9.0.0" ..< "10.0.0"
+      "9.1.1" ..< "10.0.0"
     ),
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.4.0" ..< "8.0.0"
+      "7.5.2" ..< "8.0.0"
     ),
     .package(
       name: "GTMSessionFetcher",


### PR DESCRIPTION
Planning to publish an 8.8.1 only SPM release after LGTMs.

I'll merge to master and make a similar CocoaPods update for 8.9.0 - less urgent since `pod update` always updates to latest when updating Firebase.

Additional context at #8636