### PR TITLE
Merge 8.8.1 to master

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 8.8.1
+- [fixed] Swift Package Manager only release to force GoogleUtilities and GoogleDataTransport
+  to be updated to latest current bug-fix versions. (#8728)
+
 # Firebase 8.3.1
 - [fixed] Swift Package Manager only release to fix an 8.3.0 tagging issue impacting some users. (#8367)
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "8.8.0"
+let firebaseVersion = "8.8.1"
 
 let package = Package(
   name: "Firebase",
@@ -149,12 +149,12 @@ let package = Package(
     .package(
       name: "GoogleDataTransport",
       url: "https://github.com/google/GoogleDataTransport.git",
-      "9.0.0" ..< "10.0.0"
+      "9.1.1" ..< "10.0.0"
     ),
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.4.0" ..< "8.0.0"
+      "7.5.2" ..< "8.0.0"
     ),
     .package(
       name: "GTMSessionFetcher",


### PR DESCRIPTION
After publishing the 8.8.1 tag and SPM distribution, merge back to master.