### PR TITLE
AppCheck: backoff wrapper implementation draft 

### DIFF
--- a/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h
+++ b/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBLPromise<ValueType>;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Backoff type. Indicates
+typedef NS_ENUM(NSUInteger, FIRAppCheckBackoffType) {
+  FIRAppCheckBackoffTypeNone,
+  FIRAppCheckBackoffType1Day,
+  FIRAppCheckBackoffTypeExponential
+};
+
+/// Creates a promise for an operation to apply the backoff to.
+typedef FBLPromise *_Nonnull (^FIRAppCheckBackoffOperationProvider)(void);
+
+/// Converts an error to a backoff type.
+typedef FIRAppCheckBackoffType (^FIRAppCheckBackoffErrorHandler)(NSError *error);
+
+/// A block returning a date. Is used  instead of `+[NSDate date]` for better testability of logic
+/// dependent on the current time.
+typedef NSDate *_Nonnull (^FIRAppCheckDateProvider)(void);
+
+@protocol FIRAppCheckBackoffWrapperProtocol <NSObject>
+
+///
+/// @return A promise that is either:
+///   - is a promise returned by the promise provider if no backoff is required
+///   - is rejected if the backoff is needed
+- (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider
+           errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler;
+
+/// After calling this method the next call of `[backoff:errorHandler:]` method will always attempt
+/// an operation even if a backoff was needed.
+- (void)resetBackoff;
+
+/// The default Firebase services error handler. It keeps track of network errors and
+/// `FIRAppCheckHTTPError.HTTPResponse.statusCode.statusCode` value to return the appropriate
+/// backoff type for the standard Firebase App Check backend response codes.
+- (FIRAppCheckBackoffErrorHandler)defaultErrorHandler;
+
+@end
+
+/// Provides a backoff implementation. Keeps track of the operation successes and failures to either
+/// create and perform the operation promise or fails with a backoff error when the backoff is
+/// needed.
+@interface FIRAppCheckBackoffWrapper : NSObject <FIRAppCheckBackoffWrapperProtocol>
+
+/// Initializes the wrapper with `+[FIRAppCheckBackoffWrapper currentDateProvider]`.
+- (instancetype)init;
+
+- (instancetype)initWithDateProvider:(FIRAppCheckDateProvider)dateProvider
+    NS_DESIGNATED_INITIALIZER;
+
+/// A date provider that returns `+[NSDate date]`.
++ (FIRAppCheckDateProvider)currentDateProvider;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
+++ b/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
@@ -26,6 +26,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static NSTimeInterval const k24Hours = 24 * 60 * 60;
+
 /// A class representing an operation result with data required for the backoff calculation.
 @interface FIRAppCheckBackoffOperationFailure : NSObject
 
@@ -180,11 +182,24 @@ NS_ASSUME_NONNULL_BEGIN
         return YES;
         break;
 
+      case FIRAppCheckBackoffType1Day:
+        return [self hasTimeIntervalPassedSinceLastFailure:k24Hours];
+        break;
+
         // TODO: Implement other cases.
       default:
         return YES;
     }
   }
+}
+
+- (BOOL)hasTimeIntervalPassedSinceLastFailure:(NSTimeInterval)timeInterval {
+  NSDate *failureDate = self.lastFailure.finishDate;
+  // Return YES if there has not been a failure yet.
+  if (failureDate == nil) return YES;
+
+  NSTimeInterval timeSinceFailure = [self.dateProvider() timeIntervalSinceDate:failureDate];
+  return timeSinceFailure >= timeInterval;
 }
 
 - (FBLPromise *)retryDisallowedPromiseWithError:(NSError *)error {

--- a/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
+++ b/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
@@ -16,11 +16,87 @@
 
 #import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+#import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+
 NS_ASSUME_NONNULL_BEGIN
+
+/// A class representing an operation result with data required for the backoff calculation.
+@interface FIRAppCheckBackoffOperationFailure : NSObject
+
+/// The operation finish date.
+@property(nonatomic, readonly) NSDate *finishDate;
+
+/// The operation error. If `nil` then the operation succeeded.
+@property(nonatomic, readonly) NSError *error;
+
+/// A backoff type calculated based on the error.
+@property(nonatomic, readonly) FIRAppCheckBackoffType backoffType;
+
+/// Number of retries. Is 0 for the first attempt and incremented with each error. Is reset back to
+/// 0 on success.
+@property(nonatomic, readonly) NSInteger retryCount;
+
+/// Designated initializer.
+- (instancetype)initWithFinishDate:(NSDate *)finishDate
+                             error:(NSError *)error
+                       backoffType:(FIRAppCheckBackoffType)backoffType
+                        retryCount:(NSInteger)retryCount NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Creates a new result with incremented retryCount and specified error and backoff type.
++ (instancetype)nextRetryFailureWithFailure:
+                    (nullable FIRAppCheckBackoffOperationFailure *)previousFailure
+                                 finishDate:(NSDate *)finishDate
+                                      error:(NSError *)error
+                                backoffType:(FIRAppCheckBackoffType)backoffType;
+
+@end
+
+@implementation FIRAppCheckBackoffOperationFailure
+
+- (instancetype)initWithFinishDate:(NSDate *)finishDate
+                             error:(NSError *)error
+                       backoffType:(FIRAppCheckBackoffType)backoffType
+                        retryCount:(NSInteger)retryCount {
+  self = [super init];
+  if (self) {
+    _finishDate = finishDate;
+    _error = error;
+    _retryCount = retryCount;
+    _backoffType = backoffType;
+  }
+  return self;
+}
+
++ (instancetype)nextRetryFailureWithFailure:
+                    (nullable FIRAppCheckBackoffOperationFailure *)previousFailure
+                                 finishDate:(NSDate *)finishDate
+                                      error:(NSError *)error
+                                backoffType:(FIRAppCheckBackoffType)backoffType {
+  NSInteger newRetryCount = previousFailure ? previousFailure.retryCount + 1 : 0;
+
+  return [[self alloc] initWithFinishDate:finishDate
+                                    error:error
+                              backoffType:backoffType
+                               retryCount:newRetryCount];
+}
+
+@end
 
 @interface FIRAppCheckBackoffWrapper ()
 
+/// Current date provider. Is used instead of `+[NSDate date]` for testability.
 @property(nonatomic, readonly) FIRAppCheckDateProvider dateProvider;
+
+/// Last operation result.
+@property(nonatomic, nullable) FIRAppCheckBackoffOperationFailure *lastFailure;
 
 @end
 
@@ -46,7 +122,36 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider
            errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler {
-  return operationProvider();
+  if (![self isNextOperationAllowed]) {
+    // Backing off - skip the operation and return an error straight away.
+    return [self retryDisallowedPromiseWithError:self.lastFailure.error];
+  }
+
+  __auto_type operationPromise = operationProvider();
+  return operationPromise
+      .thenOn(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
+              ^id(id result) {
+                @synchronized(self) {
+                  // Reset failure on success.
+                  self.lastFailure = nil;
+                }
+
+                // Return the result.
+                return result;
+              })
+      .recoverOn(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^NSError *(NSError *error) {
+        @synchronized(self) {
+          // Update the last failure to calculate the backoff.
+          self.lastFailure =
+              [FIRAppCheckBackoffOperationFailure nextRetryFailureWithFailure:self.lastFailure
+                                                                   finishDate:self.dateProvider()
+                                                                        error:error
+                                                                  backoffType:errorHandler(error)];
+        }
+
+        // Re-throw the error.
+        return error;
+      });
 }
 
 - (FIRAppCheckBackoffErrorHandler)defaultErrorHandler {
@@ -56,7 +161,40 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)resetBackoff {
-  // TODO: Implement.
+  @synchronized(self) {
+    self.lastFailure = nil;
+  }
+}
+
+#pragma mark -
+
+- (BOOL)isNextOperationAllowed {
+  @synchronized(self) {
+    if (self.lastFailure == nil) {
+      // It is first attempt. Always allow it.
+      return YES;
+    }
+
+    switch (self.lastFailure.backoffType) {
+      case FIRAppCheckBackoffTypeNone:
+        return YES;
+        break;
+
+        // TODO: Implement other cases.
+      default:
+        return YES;
+    }
+  }
+}
+
+- (FBLPromise *)retryDisallowedPromiseWithError:(NSError *)error {
+  NSString *reason =
+      [NSString stringWithFormat:@"To many attempts. Underlying error: %@",
+                                 error.localizedDescription ?: error.localizedFailureReason];
+  NSError *retryDisallowedError = [FIRAppCheckErrorUtil errorWithFailureReason:reason];
+  FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+  [rejectedPromise reject:retryDisallowedError];
+  return rejectedPromise;
 }
 
 @end

--- a/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
+++ b/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckBackoffWrapper ()
+
+@property(nonatomic, readonly) FIRAppCheckDateProvider dateProvider;
+
+@end
+
+@implementation FIRAppCheckBackoffWrapper
+
+- (instancetype)init {
+  return [self initWithDateProvider:[FIRAppCheckBackoffWrapper currentDateProvider]];
+}
+
+- (instancetype)initWithDateProvider:(FIRAppCheckDateProvider)dateProvider {
+  self = [super init];
+  if (self) {
+    _dateProvider = [dateProvider copy];
+  }
+  return self;
+}
+
++ (FIRAppCheckDateProvider)currentDateProvider {
+  return ^NSDate *(void) {
+    return [NSDate date];
+  };
+}
+
+- (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider
+           errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler {
+  return operationProvider();
+}
+
+- (FIRAppCheckBackoffErrorHandler)defaultErrorHandler {
+  return ^FIRAppCheckBackoffType(NSError *error) {
+    return FIRAppCheckBackoffTypeNone;
+  };
+}
+
+- (void)resetBackoff {
+  // TODO: Implement.
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -108,18 +108,25 @@ NS_ASSUME_NONNULL_BEGIN
                                          NSError *_Nullable error))handler {
   [self.backoffWrapper
            backoff:^FBLPromise *_Nonnull {
-             return [self deviceToken];
+             return [self getTokenPromise];
            }
       errorHandler:[self.backoffWrapper defaultErrorHandler]]
-      .then(^FBLPromise<FIRAppCheckToken *> *(NSData *deviceToken) {
-        return [self.APIService appCheckTokenWithDeviceToken:deviceToken];
-      })
+      // Call the handler with either token or error.
       .then(^id(FIRAppCheckToken *appCheckToken) {
         handler(appCheckToken, nil);
         return nil;
       })
       .catch(^void(NSError *error) {
         handler(nil, error);
+      });
+}
+
+- (FBLPromise<FIRAppCheckToken *> *)getTokenPromise {
+  // Get DeviceCheck token
+  return [self deviceToken]
+      // Exchange DeviceCheck token for FAC token.
+      .then(^FBLPromise<FIRAppCheckToken *> *(NSData *deviceToken) {
+        return [self.APIService appCheckTokenWithDeviceToken:deviceToken];
       });
 }
 

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -29,6 +29,7 @@
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h"
 
 #import "FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.h"
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.h"
@@ -42,9 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRDeviceCheckProvider ()
 @property(nonatomic, readonly) id<FIRDeviceCheckAPIServiceProtocol> APIService;
 @property(nonatomic, readonly) id<FIRDeviceCheckTokenGenerator> deviceTokenGenerator;
+@property(nonatomic, readonly) id<FIRAppCheckBackoffWrapperProtocol> backoffWrapper;
 
 - (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
               deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
+                    backoffWrapper:(id<FIRAppCheckBackoffWrapperProtocol>)backoffWrapper
     NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -52,17 +55,22 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRDeviceCheckProvider
 
 - (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
-              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator {
+              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
+                    backoffWrapper:(id<FIRAppCheckBackoffWrapperProtocol>)backoffWrapper {
   self = [super init];
   if (self) {
     _APIService = APIService;
     _deviceTokenGenerator = deviceTokenGenerator;
+    _backoffWrapper = backoffWrapper;
   }
   return self;
 }
 
 - (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService {
-  return [self initWithAPIService:APIService deviceTokenGenerator:[DCDevice currentDevice]];
+  FIRAppCheckBackoffWrapper *backoffWrapper = [[FIRAppCheckBackoffWrapper alloc] init];
+  return [self initWithAPIService:APIService
+             deviceTokenGenerator:[DCDevice currentDevice]
+                   backoffWrapper:backoffWrapper];
 }
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
@@ -98,7 +106,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
                                          NSError *_Nullable error))handler {
-  [self deviceToken]
+  [self.backoffWrapper
+           backoff:^FBLPromise *_Nonnull {
+             return [self deviceToken];
+           }
+      errorHandler:[self.backoffWrapper defaultErrorHandler]]
       .then(^FBLPromise<FIRAppCheckToken *> *(NSData *deviceToken) {
         return [self.APIService appCheckTokenWithDeviceToken:deviceToken];
       })

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckBackoffWrapperTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckBackoffWrapperTests.m
@@ -61,6 +61,7 @@
 
 - (void)tearDown {
   self.backoffWrapper = nil;
+  self.operation = nil;
 
   [super tearDown];
 }
@@ -168,7 +169,7 @@
   [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffType1Day];
 
   // 4.2. Move current date.
-  self.currentDate = [self.currentDate dateByAddingTimeInterval:11 * 60 * 60 + 59 * 60];
+  self.currentDate = [self.currentDate dateByAddingTimeInterval:12 * 60 * 60 + 1 * 60];
 
   // 4.3. Compose operation with backoff.
   operationWithBackoff = [self.backoffWrapper

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckBackoffWrapperTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckBackoffWrapperTests.m
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBLPromise+Testing.h"
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
+
+@interface FIRAppCheckBackoffWrapperTests : XCTestCase
+
+@property(nonatomic, nullable) FIRAppCheckBackoffWrapper *backoffWrapper;
+
+@property(nonatomic) NSDate *currentDate;
+
+/// `NSObject` subclass for resolve the `self.operation` with in the case of success or `NSError`
+/// for a failure.
+@property(nonatomic) id operationResult;
+/// Operation to apply backoff to. It configure with the helper methods during tests.
+@property(nonatomic) FBLPromise *operation;
+/// Expectation to fulfill when operation is completed. It is configured with the `self.operation`
+/// in setup helpers.
+@property(nonatomic) XCTestExpectation *operationFinishExpectation;
+
+/// Test error handler that returns `self.errorHandlerResult` and fulfills
+/// `self.errorHandlerExpectation`.
+@property(nonatomic, copy) FIRAppCheckBackoffErrorHandler errorHandler;
+/// Expectation to fulfill when error handlers is executed.
+@property(nonatomic) XCTestExpectation *errorHandlerExpectation;
+
+@end
+
+@implementation FIRAppCheckBackoffWrapperTests
+
+- (void)setUp {
+  [super setUp];
+
+  __auto_type __weak weakSelf = self;
+  self.backoffWrapper = [[FIRAppCheckBackoffWrapper alloc] initWithDateProvider:^NSDate *_Nonnull {
+    return weakSelf.currentDate ?: [NSDate date];
+  }];
+}
+
+- (void)tearDown {
+  self.backoffWrapper = nil;
+
+  [super tearDown];
+}
+
+- (void)testBackoffFirstOperationAlwaysExecuted {
+  // 1. Set up operation success.
+  [self setUpOperationSuccess];
+  [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffTypeNone];
+  self.errorHandlerExpectation.inverted = YES;
+
+  // 3. Compose operation with backoff.
+  __auto_type operationWithBackoff = [self.backoffWrapper
+           backoff:^FBLPromise *() {
+             return self.operation;
+           }
+      errorHandler:self.errorHandler];
+
+  // 4. Wait for operation to complete and check.
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  XCTAssertEqualObjects(operationWithBackoff.value, self.operationResult);
+}
+
+- (void)testBackoff1DayBackoffAfterFailure {
+  // 0. Set current date.
+  self.currentDate = [NSDate date];
+
+  // 1. Check initial failure.
+  // 1.1. Set up operation failure.
+  [self setUpOperationError];
+  [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffType1Day];
+
+  // 1.3. Compose operation with backoff.
+  __auto_type operationWithBackoff = [self.backoffWrapper
+           backoff:^FBLPromise *() {
+             return self.operation;
+           }
+      errorHandler:self.errorHandler];
+
+  // 1.4. Wait for operation to complete.
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 1.5. Expect the promise to be rejected with the operation error.
+  XCTAssertEqualObjects(operationWithBackoff.error, self.operationResult);
+
+  // 2. Check backoff in 12 hours.
+  // 2.1. Set up another operation.
+  [self setUpOperationError];
+  [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffType1Day];
+
+  // Don't expect operation to be called.
+  self.operationFinishExpectation.inverted = YES;
+
+  // 2.2. Move current date.
+  self.currentDate = [self.currentDate dateByAddingTimeInterval:12 * 60 * 60];
+
+  // 2.3. Compose operation with backoff.
+  operationWithBackoff = [self.backoffWrapper
+           backoff:^FBLPromise *() {
+             return self.operation;
+           }
+      errorHandler:self.errorHandler];
+
+  // 2.4. Wait for operation to complete.
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 2.5. Expect the promise to be rejected with a backoff error.
+  XCTAssertTrue(operationWithBackoff.isRejected);
+  XCTAssert([operationWithBackoff.error.localizedDescription
+      hasPrefix:@"To many attempts. Underlying error:"]);
+
+  // 3. Check backoff one minute before allowing retry.
+  // 3.1. Set up another operation.
+  [self setUpOperationError];
+  [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffType1Day];
+
+  // Don't expect operation to be called.
+  self.operationFinishExpectation.inverted = YES;
+
+  // 3.2. Move current date.
+  self.currentDate = [self.currentDate dateByAddingTimeInterval:11 * 60 * 60 + 59 * 60];
+
+  // 3.3. Compose operation with backoff.
+  operationWithBackoff = [self.backoffWrapper
+           backoff:^FBLPromise *() {
+             return self.operation;
+           }
+      errorHandler:self.errorHandler];
+
+  // 3.4. Wait for operation to complete.
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 3.5. Expect the promise to be rejected with a backoff error.
+  XCTAssertTrue(operationWithBackoff.isRejected);
+  XCTAssert([operationWithBackoff.error.localizedDescription
+      hasPrefix:@"To many attempts. Underlying error:"]);
+
+  // 4. Check backoff one minute after allowing retry.
+  // 4.1. Set up another operation.
+  [self setUpOperationError];
+  [self setUpErrorHandlerWithBackoffType:FIRAppCheckBackoffType1Day];
+
+  // 4.2. Move current date.
+  self.currentDate = [self.currentDate dateByAddingTimeInterval:11 * 60 * 60 + 59 * 60];
+
+  // 4.3. Compose operation with backoff.
+  operationWithBackoff = [self.backoffWrapper
+           backoff:^FBLPromise *() {
+             return self.operation;
+           }
+      errorHandler:self.errorHandler];
+
+  // 4.4. Wait for operation to complete and check failure.
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 4.5. Expect the promise to be rejected with the operation error.
+  XCTAssertEqualObjects(operationWithBackoff.error, self.operationResult);
+}
+
+#pragma mark - Helpers
+
+- (void)setUpErrorHandlerWithBackoffType:(FIRAppCheckBackoffType)backoffType {
+  __auto_type __weak weakSelf = self;
+  self.errorHandlerExpectation = [self expectationWithDescription:@"Error handler"];
+  self.errorHandler = ^FIRAppCheckBackoffType(NSError *_Nonnull error) {
+    [weakSelf.errorHandlerExpectation fulfill];
+    return backoffType;
+  };
+}
+
+- (void)setUpOperationSuccess {
+  self.operationFinishExpectation = [self expectationWithDescription:@"Operation performed"];
+  self.operationResult = [[NSObject alloc] init];
+  __auto_type __weak weakSelf = self;
+  self.operation = [FBLPromise do:^id(void) {
+    [weakSelf.operationFinishExpectation fulfill];
+    return weakSelf.operationResult;
+  }];
+}
+
+- (void)setUpOperationError {
+  self.operationFinishExpectation = [self expectationWithDescription:@"Operation performed"];
+  self.operationResult = [NSError errorWithDomain:self.name code:-1 userInfo:nil];
+  __auto_type __weak weakSelf = self;
+  self.operation = [FBLPromise do:^id(void) {
+    [weakSelf.operationFinishExpectation fulfill];
+    return weakSelf.operationResult;
+  }];
+}
+
+@end

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -19,11 +19,11 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckToken+Internal.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckTokenGenerator.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h"
-#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
@@ -36,7 +36,7 @@ API_UNAVAILABLE(watchos)
 @property(nonatomic) id fakeTokenGenerator;
 @property(nonatomic) id fakeBackoffWrapper;
 
-    @end
+@end
 
 @interface FIRDeviceCheckProvider (Tests)
 
@@ -54,9 +54,9 @@ API_UNAVAILABLE(watchos)
   self.fakeAPIService = OCMProtocolMock(@protocol(FIRDeviceCheckAPIServiceProtocol));
   self.fakeTokenGenerator = OCMProtocolMock(@protocol(FIRDeviceCheckTokenGenerator));
 
-  //TODO: replace with a mock.
+  // TODO: replace with a mock.
   self.fakeBackoffWrapper = [[FIRAppCheckBackoffWrapper alloc] init];
-  //OCMProtocolMock(@protocol(FIRAppCheckBackoffWrapperProtocol));
+  // OCMProtocolMock(@protocol(FIRAppCheckBackoffWrapperProtocol));
 
   self.provider = [[FIRDeviceCheckProvider alloc] initWithAPIService:self.fakeAPIService
                                                 deviceTokenGenerator:self.fakeTokenGenerator

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -23,21 +23,26 @@
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckTokenGenerator.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h"
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0))
 API_UNAVAILABLE(watchos)
 @interface FIRDeviceCheckProviderTests : XCTestCase
+
 @property(nonatomic) FIRDeviceCheckProvider *provider;
 @property(nonatomic) id fakeAPIService;
 @property(nonatomic) id fakeTokenGenerator;
-@end
+@property(nonatomic) id fakeBackoffWrapper;
+
+    @end
 
 @interface FIRDeviceCheckProvider (Tests)
 
 - (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
-              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator;
+              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
+                    backoffWrapper:(id<FIRAppCheckBackoffWrapperProtocol>)backoffWrapper;
 
 @end
 
@@ -48,8 +53,14 @@ API_UNAVAILABLE(watchos)
 
   self.fakeAPIService = OCMProtocolMock(@protocol(FIRDeviceCheckAPIServiceProtocol));
   self.fakeTokenGenerator = OCMProtocolMock(@protocol(FIRDeviceCheckTokenGenerator));
+
+  //TODO: replace with a mock.
+  self.fakeBackoffWrapper = [[FIRAppCheckBackoffWrapper alloc] init];
+  //OCMProtocolMock(@protocol(FIRAppCheckBackoffWrapperProtocol));
+
   self.provider = [[FIRDeviceCheckProvider alloc] initWithAPIService:self.fakeAPIService
-                                                deviceTokenGenerator:self.fakeTokenGenerator];
+                                                deviceTokenGenerator:self.fakeTokenGenerator
+                                                      backoffWrapper:self.fakeBackoffWrapper];
 }
 
 - (void)tearDown {

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -164,6 +164,8 @@ API_UNAVAILABLE(watchos)
   // 4. Verify fakes.
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
+
+  // TODO: Test backoff.
 }
 
 - (void)testGetTokenWhenAPIServiceFails {
@@ -196,11 +198,14 @@ API_UNAVAILABLE(watchos)
   // 4. Verify fakes.
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
+
+  // TODO: Test backoff.
 }
 
 #pragma mark - Backoff tests
 
-- (void)testGetTokenBackoffSuccess {
+// TODO: Implement.
+- (void)testGetTokenBackoff {
   // 1. Configure backoff.
   self.fakeBackoffWrapper.isNextOperationAllowed = NO;
   //  self.fakeBackoffWrapper.

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckBackoffWrapperFake : NSObject<FIRAppCheckBackoffWrapperProtocol>
+
+/// If `YES` then the next operation passed to `[backoff:errorHandler:]` method will be performed. If `NO` then it will fail with a backoff error.
+@property(nonatomic) BOOL isNextOperationAllowed;
+
+/// Result of the last performed operation if it succeeded.
+@property(nonatomic, nullable, readonly) id operationResult;
+
+/// Error of the last performed operation if it failed.
+@property(nonatomic, nullable, readonly) NSError *operationError;
+
+/// Assign expectation to fulfill on  `[backoff:errorHandler:]` method call to this property.
+@property(nonatomic, nullable) XCTestExpectation *backoffExpectation;
+
+/// Assign expectation to fulfill on  `[resetBackoff]` method call to this property.
+@property(nonatomic, nullable) XCTestExpectation *resetBackoffExpectation;
+
+/// Assign expectation to fulfill on  `[defaultErrorHandler]` method call to this property.
+@property(nonatomic, nullable) XCTestExpectation *defaultErrorHandlerExpectation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
@@ -20,12 +20,12 @@
 
 #import "FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.h"
 
-
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FIRAppCheckBackoffWrapperFake : NSObject<FIRAppCheckBackoffWrapperProtocol>
+@interface FIRAppCheckBackoffWrapperFake : NSObject <FIRAppCheckBackoffWrapperProtocol>
 
-/// If `YES` then the next operation passed to `[backoff:errorHandler:]` method will be performed. If `NO` then it will fail with a backoff error.
+/// If `YES` then the next operation passed to `[backoff:errorHandler:]` method will be performed.
+/// If `NO` then it will fail with a backoff error.
 @property(nonatomic) BOOL isNextOperationAllowed;
 
 /// Result of the last performed operation if it succeeded.

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h
@@ -34,14 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// Error of the last performed operation if it failed.
 @property(nonatomic, nullable, readonly) NSError *operationError;
 
+/// Default error handler.
+@property(nonatomic, copy) FIRAppCheckBackoffErrorHandler defaultErrorHandler;
+
 /// Assign expectation to fulfill on  `[backoff:errorHandler:]` method call to this property.
 @property(nonatomic, nullable) XCTestExpectation *backoffExpectation;
 
 /// Assign expectation to fulfill on  `[resetBackoff]` method call to this property.
 @property(nonatomic, nullable) XCTestExpectation *resetBackoffExpectation;
-
-/// Assign expectation to fulfill on  `[defaultErrorHandler]` method call to this property.
-@property(nonatomic, nullable) XCTestExpectation *defaultErrorHandlerExpectation;
 
 @end
 

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #import "SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h"
 
 #if __has_include(<FBLPromises/FBLPromises.h>)
@@ -27,24 +26,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAppCheckBackoffWrapperFake
 
-- (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler {
+- (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider
+           errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler {
   [self.backoffExpectation fulfill];
 
   if (self.isNextOperationAllowed) {
     return operationProvider()
-      .then(^id(id value) {
-        self->_operationResult = value;
-        self->_operationError = nil;
-        return value;
-      })
-      .recover(^id(NSError *error) {
-        self->_operationError = error;
-        self->_operationResult = nil;
-        return error;
-      });
+        .then(^id(id value) {
+          self->_operationResult = value;
+          self->_operationError = nil;
+          return value;
+        })
+        .recover(^id(NSError *error) {
+          self->_operationError = error;
+          self->_operationResult = nil;
+          return error;
+        });
   } else {
     FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
-    NSError *error = [NSError errorWithDomain:@"FIRAppCheckBackoffWrapperFake.backoff" code:-1 userInfo:nil];
+    NSError *error = [NSError errorWithDomain:@"FIRAppCheckBackoffWrapperFake.backoff"
+                                         code:-1
+                                     userInfo:nil];
     [rejectedPromise reject:error];
     return rejectedPromise;
   }

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import "SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.h"
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FIRAppCheckBackoffWrapperFake
+
+- (FBLPromise *)backoff:(FIRAppCheckBackoffOperationProvider)operationProvider errorHandler:(FIRAppCheckBackoffErrorHandler)errorHandler {
+  [self.backoffExpectation fulfill];
+
+  if (self.isNextOperationAllowed) {
+    return operationProvider();
+  } else {
+    FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+    NSError *error = [NSError errorWithDomain:@"FIRAppCheckBackoffWrapperFake.backoff" code:-1 userInfo:nil];
+    [rejectedPromise reject:error];
+    return rejectedPromise;
+  }
+}
+
+- (FIRAppCheckBackoffErrorHandler)defaultErrorHandler {
+  <#code#>
+}
+
+- (void)resetBackoff {
+  <#code#>
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckBackoffWrapperFake.m
@@ -31,7 +31,17 @@ NS_ASSUME_NONNULL_BEGIN
   [self.backoffExpectation fulfill];
 
   if (self.isNextOperationAllowed) {
-    return operationProvider();
+    return operationProvider()
+      .then(^id(id value) {
+        self->_operationResult = value;
+        self->_operationError = nil;
+        return value;
+      })
+      .recover(^id(NSError *error) {
+        self->_operationError = error;
+        self->_operationResult = nil;
+        return error;
+      });
   } else {
     FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
     NSError *error = [NSError errorWithDomain:@"FIRAppCheckBackoffWrapperFake.backoff" code:-1 userInfo:nil];
@@ -41,11 +51,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FIRAppCheckBackoffErrorHandler)defaultErrorHandler {
-  <#code#>
+  if (_defaultErrorHandler) {
+    return _defaultErrorHandler;
+  }
+
+  return ^FIRAppCheckBackoffType(NSError *error) {
+    return FIRAppCheckBackoffTypeNone;
+  };
 }
 
 - (void)resetBackoff {
-  <#code#>
+  [self.resetBackoffExpectation fulfill];
 }
 
 @end


### PR DESCRIPTION
- `FIRAppCheckBackoffWrapper` introduced. The implementation will be refined in the following PRs
- `FIRAppCheckBackoffWrapper` integrated with `FIRDeviceCheckProvider`
- some tests. More tests to be added in the following PRs