### PR TITLE
Add GHA workflow for submitting release info to metric service.

### DIFF
--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -1,4 +1,4 @@
-name: health_metrics
+name: health-metrics-presubmit
 
 on:
   pull_request:

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -1,0 +1,31 @@
+name: health-metrics-release
+
+on:
+  release:
+    types: [published]
+
+env:
+  gpg_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
+
+jobs:
+  release-diffing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+      - name: Authenticate Google Cloud SDK
+        run: |
+          scripts/decrypt_gha_secret.sh \
+            scripts/gha-encrypted/metrics_service_access.json.gpg \
+            service_account.json \
+            "${{ env.gpg_passphrase }}"
+          gcloud auth activate-service-account --key-file service_account.json
+      - name: Produce health metric diff reports
+        uses: yifanyang/github-actions/health-metrics/release-diffing@master
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          commit: ${{ github.sha }}
+          releaseId: ${{ github.event.release.id }}


### PR DESCRIPTION
Add a GitHub Actions workflow file for submitting the tags information (name, commit sha1) to the SDK metric service.

- The custom action `yifanyang/github-actions/health-metrics/release-diffing` is defined [here](https://github.com/yifanyang/github-actions/pull/1/files). I intend to have it reused across all Android/Apple/Web SDK repositories. For now, I'm putting it in my personal repository `yifanyang/github-actions`, but will figure out later where the best location for the code is.
- I'm using [`setup-gcloud`](https://github.com/google-github-actions/setup-gcloud) GitHub Action to set up Google Cloud SDK. However, due to the fact that we store secrets as encrypted files, the authentication step is a bit different from what [`setup-gcloud`](https://github.com/google-github-actions/setup-gcloud) suggested. I'd like to double check whether the current way in PR looks good.
- At the moment, on the metric service end, only the logic of persisting release information is implemented. The logic for rendering a diff report and post it back to release page is still in progress. Upon submission of this PR, we will be start to see tags stored in the database, but won't see the diff report just yet.