### PR TITLE
Exclude CMakeLists.txt to prevent an SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1050,7 +1050,7 @@ let package = Package(
             ],
             path: "FirebaseAppCheck/Sources",
             exclude: [
-              "Interop/CMakeLists.txt"
+              "Interop/CMakeLists.txt",
             ],
             publicHeadersPath: "Public",
             cSettings: [


### PR DESCRIPTION
Introduced in #8749 

#no-changelog