### PR TITLE
Disable resource management for binary pods

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -808,13 +808,15 @@ struct ZipBuilder {
     }
     var frameworks: [URL] = []
 
+    // TODO: packageAllResources is disabled for binary frameworks since it's not needed for Firebase
+    // and it does not yet support xcframeworks.
     // Package all resources into the frameworks since that's how Carthage needs it packaged.
-    do {
-      // TODO: Figure out if we need to exclude bundles here or not.
-      try ResourcesManager.packageAllResources(containedIn: podInfo.installedLocation)
-    } catch {
-      fatalError("Tried to package resources for \(podName) but it failed: \(error)")
-    }
+//    do {
+//      // TODO: Figure out if we need to exclude bundles here or not.
+//      try ResourcesManager.packageAllResources(containedIn: podInfo.installedLocation)
+//    } catch {
+//      fatalError("Tried to package resources for \(podName) but it failed: \(error)")
+//    }
 
     // Copy each of the frameworks to a known temporary directory and store the location.
     for framework in podInfo.binaryFrameworks {


### PR DESCRIPTION
Fix #8796 

Facebook switched to binary xcframework pods in their 12.0.0 release and that exposed a crash in code that probably doesn't need to run that was reorganizing resources in binary frameworks. xcframework support was never added and I'm not sure we even need the original code.  

Disabling for now.