### PR TITLE
pod update for quickstart testing

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -9,6 +9,7 @@ on:
     - 'FirebaseMessaging/Sources/Interop/*.h'
     - 'FirebaseTestingSupport/Functions/**'
     - 'FirebaseCombineSwift/Sources/Functions/**'
+    - 'scripts/setup_quickstart.sh'
     - 'Gemfile*'
 
   schedule:

--- a/scripts/setup_quickstart.sh
+++ b/scripts/setup_quickstart.sh
@@ -68,11 +68,7 @@ if check_secrets || [[ ${SAMPLE} == "installations" ]]; then
 
   bundle update --bundler
   bundle install
-  if [ -n "$RELEASE_TESTING" ]; then
-    bundle exec pod update --silent
-  else
-    bundle exec pod install
-  fi
+  pod update
 
   if [[ ! -z "${LEGACY:-}" ]]; then
     cd ..


### PR DESCRIPTION
Fix #8809 

Run `pod update` instead of `pod install` for all quickstart testing. After running `localize_podfiles`, we should make sure that `Podfile.lock` contents don't prevent updates for dependencies.

Also don't be `quiet` so that logging can help with diagnosis.