### PR TITLE
Run auth qs with Xcode 13 required by Facebook sdk 12.0.1

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -140,6 +140,9 @@ jobs:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
+      # Facebook SDK 12.0.1 requires Xcode 13
+    - name: Xcode 13.0
+      run: sudo xcode-select -s /Applications/Xcode_13.0.app/Contents/Developer
     - name: Get framework dir
       uses: actions/download-artifact@v1
       with:


### PR DESCRIPTION
Fix #8813

See also https://github.com/facebook/facebook-ios-sdk/issues/1911 and https://github.com/firebase/quickstart-ios/pull/1313