### PR TITLE
Attempt at fixing issue with getting next and previous push id

### DIFF
--- a/FirebaseDatabase/Sources/Api/FIRDatabaseQuery.m
+++ b/FirebaseDatabase/Sources/Api/FIRDatabaseQuery.m
@@ -219,7 +219,8 @@
                     userInfo:nil];
         }
         if ([startAfterValue isKindOfClass:[NSString class]]) {
-            startAfterValue = [FNextPushId from:methodName successor:startAfterValue];
+            startAfterValue = [FNextPushId from:methodName
+                                      successor:startAfterValue];
         }
     } else {
         if (childKey == nil) {

--- a/FirebaseDatabase/Sources/Api/FIRDatabaseQuery.m
+++ b/FirebaseDatabase/Sources/Api/FIRDatabaseQuery.m
@@ -207,6 +207,7 @@
 
 - (FIRDatabaseQuery *)queryStartingAfterValue:(id)startAfterValue
                                      childKey:(NSString *)childKey {
+    NSString *methodName = @"queryStartingAfterValue:childKey:";
     if ([self.queryParams.index isEqual:[FKeyIndex keyIndex]]) {
         if (childKey != nil) {
             @throw [[NSException alloc]
@@ -218,16 +219,15 @@
                     userInfo:nil];
         }
         if ([startAfterValue isKindOfClass:[NSString class]]) {
-            startAfterValue = [FNextPushId successor:startAfterValue];
+            startAfterValue = [FNextPushId from:methodName successor:startAfterValue];
         }
     } else {
         if (childKey == nil) {
             childKey = [FUtilities maxName];
         } else {
-            childKey = [FNextPushId successor:childKey];
+            childKey = [FNextPushId from:methodName successor:childKey];
         }
     }
-    NSString *methodName = @"queryStartingAfterValue:childKey:";
     if (childKey != nil && ![childKey isEqual:[FUtilities maxName]]) {
         [FValidation validateFrom:methodName validKey:childKey];
     }
@@ -294,6 +294,7 @@
 
 - (FIRDatabaseQuery *)queryEndingBeforeValue:(id)endValue
                                     childKey:(NSString *)childKey {
+    NSString *methodName = @"queryEndingBeforeValue:childKey:";
     if ([self.queryParams.index isEqual:[FKeyIndex keyIndex]]) {
         if (childKey != nil) {
             @throw [[NSException alloc]
@@ -304,16 +305,15 @@
                     userInfo:nil];
         }
         if ([endValue isKindOfClass:[NSString class]]) {
-            endValue = [FNextPushId predecessor:endValue];
+            endValue = [FNextPushId from:methodName predecessor:endValue];
         }
     } else {
         if (childKey == nil) {
             childKey = [FUtilities minName];
         } else {
-            childKey = [FNextPushId predecessor:childKey];
+            childKey = [FNextPushId from:methodName predecessor:childKey];
         }
     }
-    NSString *methodName = @"queryEndingBeforeValue:childKey:";
     if (childKey != nil && ![childKey isEqual:[FUtilities minName]]) {
         [FValidation validateFrom:methodName validKey:childKey];
     }

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.h
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.h
@@ -20,8 +20,8 @@
 
 + (NSString *)get:(NSTimeInterval)now;
 
-+ (NSString *)successor:(NSString *)key;
++ (NSString *)from:(NSString *)fn successor:(NSString *)key;
 
-+ (NSString *)predecessor:(NSString *)key;
++ (NSString *)from:(NSString *)fn predecessor:(NSString *)key;
 
 @end

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -106,7 +106,8 @@ static NSInteger const MAX_KEY_LEN = 786;
         break;
 
     case 0x2E:
-        plusOne = 0x2F;
+    case 0x2F:
+        plusOne = 0x30;
         break;
 
     case 0x5B:
@@ -115,10 +116,6 @@ static NSInteger const MAX_KEY_LEN = 786;
 
     case 0x5D:
         plusOne = 0x5E;
-        break;
-
-    case 0x2F:
-        plusOne = 0x30;
         break;
 
     case 0x7F:
@@ -219,6 +216,7 @@ static NSInteger const MAX_KEY_LEN = 786;
         break;
 
     case 0x2E:
+    case 0x2F:
         minusOne = 0x2D;
         break;
 
@@ -228,10 +226,6 @@ static NSInteger const MAX_KEY_LEN = 786;
 
     case 0x5D:
         minusOne = 0x5C;
-        break;
-
-    case 0x2F:
-        minusOne = 0x2E;
         break;
 
     case 0x7F:

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -229,7 +229,7 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
         minusOne = 0x5A;
         break;
 
-    case 0x5B: // ']'
+    case 0x5D: // ']'
         minusOne = 0x5C;
         break;
 

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -105,25 +105,25 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
     BOOL removePreviousCharacter = NO;
     BOOL replaceWithLowestSurrogatePair = NO;
     switch (plusOne) {
-    case 0x23:
-    case 0x24:
+    case 0x23: // '#'
+    case 0x24: // '$'
         plusOne = 0x25;
         break;
 
-    case 0x2E:
-    case 0x2F:
+    case 0x2E: // '.'
+    case 0x2F: // '/'
         plusOne = 0x30;
         break;
 
-    case 0x5B:
+    case 0x5B: // '['
         plusOne = 0x5C;
         break;
 
-    case 0x5D:
+    case 0x5D: // ']'
         plusOne = 0x5E;
         break;
 
-    case 0x7F:
+    case 0x7F: // control character: del
         plusOne = 0x80;
         break;
 
@@ -215,25 +215,25 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
     BOOL replaceWithHighestSurrogatePair = NO;
     switch (minusOne) {
     // NOTE: We already handled the case of min char (0x20)
-    case 0x23:
-    case 0x24:
+    case 0x23: // '#'
+    case 0x24: // '$'
         minusOne = 0x22;
         break;
 
-    case 0x2E:
-    case 0x2F:
+    case 0x2E: // '.'
+    case 0x2F: // '/'
         minusOne = 0x2D;
         break;
 
-    case 0x5B:
+    case 0x5B: // '['
         minusOne = 0x5A;
         break;
 
-    case 0x5D:
+    case 0x5B: // ']'
         minusOne = 0x5C;
         break;
 
-    case 0x7F:
+    case 0x7F: // control character: del
         minusOne = 0x7E;
         break;
 

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -16,6 +16,7 @@
 
 #import "FirebaseDatabase/Sources/Utilities/FNextPushId.h"
 #import "FirebaseDatabase/Sources/Utilities/FUtilities.h"
+#import "FirebaseDatabase/Sources/Utilities/FValidation.h"
 
 static NSString *const PUSH_CHARS =
     @"-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
@@ -65,8 +66,8 @@ static NSInteger const MAX_KEY_LEN = 786;
     return [NSString stringWithString:id];
 }
 
-+ (NSString *)successor:(NSString *_Nonnull)key {
-    // TODO: Wouldn't it be good to perform actual key validation on the input?
++ (NSString *)from:(NSString *)fn successor:(NSString *_Nonnull)key {
+    [FValidation validateFrom:fn validKey:key];
     NSInteger keyAsInt;
     if ([FUtilities tryParseString:key asInt:&keyAsInt]) {
         if (keyAsInt == [FUtilities int32max]) {
@@ -177,9 +178,8 @@ static NSInteger const MAX_KEY_LEN = 786;
     return [next substringWithRange:NSMakeRange(0, length)];
 }
 
-// `key` is assumed to be non-empty.
-+ (NSString *)predecessor:(NSString *_Nonnull)key {
-    // TODO: Wouldn't it be good to perform actual key validation on the input?
++ (NSString *)from:(NSString *)fn predecessor:(NSString *_Nonnull)key {
+    [FValidation validateFrom:fn validKey:key];
     NSInteger keyAsInt;
     if ([FUtilities tryParseString:key asInt:&keyAsInt]) {
         if (keyAsInt == [FUtilities int32min]) {

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -142,8 +142,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
             // Error, encountered low surrogate without matching high surrogate
         } else {
             unichar high = [next characterAtIndex:i - 1];
-            if (high ==
-                HIGH_SURROGATE_PAIR_END) { /* highest value for the high part of the pair */
+            if (high == HIGH_SURROGATE_PAIR_END) { /* highest value for the high
+                                                      part of the pair */
                 // Replace pair with 0xE000 (the value of plusOne)
                 removePreviousCharacter = YES;
             } else {
@@ -152,8 +152,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
                 [next replaceCharactersInRange:NSMakeRange(i - 1, i)
                                     withString:highStr];
-                plusOne =
-                LOW_SURROGATE_PAIR_START; /* lowest value for the low part of the pair */
+                plusOne = LOW_SURROGATE_PAIR_START; /* lowest value for the low
+                                                       part of the pair */
             }
         }
         break;
@@ -161,7 +161,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
     NSString *sourcePlusOne =
         replaceWithLowestSurrogatePair
-            ? [NSString stringWithFormat:@"%C%C", HIGH_SURROGATE_PAIR_START, LOW_SURROGATE_PAIR_START]
+            ? [NSString stringWithFormat:@"%C%C", HIGH_SURROGATE_PAIR_START,
+                                         LOW_SURROGATE_PAIR_START]
             : [NSString stringWithFormat:@"%C", plusOne];
 
     NSInteger replaceLocation = i;
@@ -244,16 +245,16 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
     case HIGH_SURROGATE_PAIR_END: // 0xDBFF
         // If the previous character is the lowest high surrogate value
-        // then we decrement to the non-surrogate value 0xD7FF by replacing the surrogate
-        // pair by the single value 0xD7FF (HIGH_SURROGATE_PAIR_START - 1)
-        // Otherwise we decrement the high surrogate value and set the low
+        // then we decrement to the non-surrogate value 0xD7FF by replacing the
+        // surrogate pair by the single value 0xD7FF (HIGH_SURROGATE_PAIR_START
+        // - 1) Otherwise we decrement the high surrogate value and set the low
         // surrogate value to the highest.
         if (i == 0) {
             // Error, found low surrogate without matching high surrogate
         } else {
             unichar high = [next characterAtIndex:i - 1];
-            if (high ==
-                HIGH_SURROGATE_PAIR_START) { /* lowest value for the high part of the pair */
+            if (high == HIGH_SURROGATE_PAIR_START) { /* lowest value for the
+                                                        high part of the pair */
                 // Replace pair with single 0xD7FF value
                 removePreviousCharacter = YES;
                 minusOne = HIGH_SURROGATE_PAIR_START - 1;
@@ -263,8 +264,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
                 [next replaceCharactersInRange:NSMakeRange(i - 1, i)
                                     withString:highStr];
-                minusOne =
-                LOW_SURROGATE_PAIR_END; /* highest value for the low part of the pair */
+                minusOne = LOW_SURROGATE_PAIR_END; /* highest value for the low
+                                                      part of the pair */
             }
         }
         break;
@@ -272,7 +273,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
     NSString *sourceMinusOne =
         replaceWithHighestSurrogatePair
-            ? [NSString stringWithFormat:@"%C%C", HIGH_SURROGATE_PAIR_END, LOW_SURROGATE_PAIR_END]
+            ? [NSString stringWithFormat:@"%C%C", HIGH_SURROGATE_PAIR_END,
+                                         LOW_SURROGATE_PAIR_END]
             : [NSString stringWithFormat:@"%C", minusOne];
 
     NSInteger replaceLocation = i;

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -168,17 +168,17 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
     NSInteger replaceLocation = i;
     NSInteger replaceLength = 1;
     if (removePreviousCharacter) {
-        replaceLocation--;
-        replaceLength++;
+        --replaceLocation;
+        ++replaceLength;
     }
 
     [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
                         withString:sourcePlusOne];
     NSInteger length = i + 1;
     if (removePreviousCharacter) {
-        length--;
+        --length;
     } else if (replaceWithLowestSurrogatePair) {
-        length++;
+        ++length;
     }
     return [next substringWithRange:NSMakeRange(0, length)];
 }
@@ -280,8 +280,8 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
     NSInteger replaceLocation = i;
     NSInteger replaceLength = 1;
     if (removePreviousCharacter) {
-        replaceLocation--;
-        replaceLength++;
+        --replaceLocation;
+        ++replaceLength;
     }
 
     [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
@@ -289,9 +289,9 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
 
     NSInteger length = i + 1;
     if (removePreviousCharacter) {
-        length--;
+        --length;
     } else if (replaceWithHighestSurrogatePair) {
-        length++;
+        ++length;
     }
     return [next stringByPaddingToLength:MAX_KEY_LEN
                               withString:MAX_PUSH_CHAR

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -20,9 +20,9 @@
 static NSString *const PUSH_CHARS =
     @"-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
 
-static NSString *const MIN_PUSH_CHAR = @"-";
+static NSString *const MIN_PUSH_CHAR = @" ";
 
-static NSString *const MAX_PUSH_CHAR = @"z";
+static NSString *const MAX_PUSH_CHAR = @"\uFFFF";
 
 static NSInteger const MAX_KEY_LEN = 786;
 
@@ -66,6 +66,7 @@ static NSInteger const MAX_KEY_LEN = 786;
 }
 
 + (NSString *)successor:(NSString *_Nonnull)key {
+    // TODO: Wouldn't it be good to perform actual key validation on the input?
     NSInteger keyAsInt;
     if ([FUtilities tryParseString:key asInt:&keyAsInt]) {
         if (keyAsInt == [FUtilities int32max]) {
@@ -93,19 +94,92 @@ static NSInteger const MAX_KEY_LEN = 786;
         return [FUtilities maxName];
     }
 
-    NSString *source =
-        [NSString stringWithFormat:@"%C", [next characterAtIndex:i]];
-    NSInteger sourceIndex = [PUSH_CHARS rangeOfString:source].location;
-    NSString *sourcePlusOne = [NSString
-        stringWithFormat:@"%C", [PUSH_CHARS characterAtIndex:sourceIndex + 1]];
+    unichar character = [next characterAtIndex: i];
+    unichar plusOne = character + 1;
+    BOOL removePreviousCharacter = NO;
+    BOOL replaceWithLowestSurrogatePair = NO;
+    switch (plusOne) {
+        case 0x23:
+        case 0x24:
+            plusOne = 0x25;
+            break;
 
-    [next replaceCharactersInRange:NSMakeRange(i, i + 1)
+        case 0x2E:
+            plusOne = 0x2F;
+            break;
+
+        case 0x5B:
+            plusOne = 0x5C;
+            break;
+
+        case 0x5D:
+            plusOne = 0x5E;
+            break;
+
+        case 0x2F:
+            plusOne = 0x30;
+            break;
+
+        case 0x7F:
+            plusOne = 0x80;
+            break;
+
+        case 0xD800:
+            // We added one to 0xD7FF and entered surrogate pair zone
+            // Add the lowest surrogate pair here
+            replaceWithLowestSurrogatePair = YES;
+
+        case 0xE000:
+            // If the previous character is the highest high surrogate value
+            // then we increment to the value 0xE000 by replacing the surrogate
+            // pair by the single value 0xE000
+            // Otherwise we increment the high surrogate value and set the low
+            // surrogate value to the lowest.
+            if (i == 0) {
+                // Error, it appears that we encountered half a surrogate
+                // pair at index 0. Invalid input string...
+            } else {
+                unichar high = [next characterAtIndex: i - 1];
+                if (high == 0xDBFF) { /* highest value for the high part of the pair */
+                    // Replace pair with single 0xE000 value
+                    removePreviousCharacter = YES;
+                } else {
+                    high += 1;
+                    NSString *highStr = [NSString stringWithFormat:@"%C", high];
+
+                    [next replaceCharactersInRange:NSMakeRange(i - 1, i)
+                                        withString:highStr];
+                    plusOne = 0xDC00; /* lowest value for the low part of the pair */
+                }
+            }
+            break;
+    }
+
+    NSString *sourcePlusOne = replaceWithLowestSurrogatePair ?
+        [NSString stringWithFormat:@"%C%C", 0xD800, 0xDC00] :
+        [NSString stringWithFormat:@"%C", plusOne];
+
+    NSInteger replaceLocation = i;
+    NSInteger replaceLength = 1;
+    if (removePreviousCharacter) {
+        replaceLocation --;
+        replaceLength ++;
+    }
+
+    [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
                         withString:sourcePlusOne];
-    return [next substringWithRange:NSMakeRange(0, i + 1)];
+    NSInteger length = i + 1;
+    if (removePreviousCharacter) {
+        length -= i;
+    } else if (replaceWithLowestSurrogatePair) {
+        length += 1;
+    }
+    return [next substringWithRange:NSMakeRange(0, length)];
 }
 
 // `key` is assumed to be non-empty.
 + (NSString *)predecessor:(NSString *_Nonnull)key {
+    // TODO: Wouldn't it be good to perform actual key validation on the input?
     NSInteger keyAsInt;
     if ([FUtilities tryParseString:key asInt:&keyAsInt]) {
         if (keyAsInt == [FUtilities int32min]) {
@@ -129,13 +203,91 @@ static NSInteger const MAX_KEY_LEN = 786;
     // Replace the last character with its immedate predecessor, and fill the
     // suffix of the key with MAX_PUSH_CHAR. This is the lexicographically
     // largest possible key smaller than `key`.
-    unichar curr = [next characterAtIndex:next.length - 1];
-    NSRange dstRange = NSMakeRange([next length] - 1, 1);
-    NSRange srcRange =
-        [PUSH_CHARS rangeOfString:[NSString stringWithFormat:@"%C", curr]];
-    srcRange.location -= 1;
-    [next replaceCharactersInRange:dstRange
-                        withString:[PUSH_CHARS substringWithRange:srcRange]];
+    NSUInteger i = next.length - 1;
+    unichar character = [next characterAtIndex: i];
+    unichar minusOne = character - 1;
+    BOOL removePreviousCharacter = NO;
+    BOOL replaceWithHighestSurrogatePair = NO;
+    switch (minusOne) {
+        // NOTE: We already handled the case of min char (0x20)
+        case 0x23:
+        case 0x24:
+            minusOne = 0x22;
+            break;
+
+        case 0x2E:
+            minusOne = 0x2D;
+            break;
+
+        case 0x5B:
+            minusOne = 0x5A;
+            break;
+
+        case 0x5D:
+            minusOne = 0x5C;
+            break;
+
+        case 0x2F:
+            minusOne = 0x2E;
+            break;
+
+        case 0x7F:
+            minusOne = 0x7E;
+            break;
+
+        case 0xDFFF:
+            // Previously we had 0xE000 which is a single utf16 character,
+            // this needs to be replaced with the highest surrogate pair:
+            replaceWithHighestSurrogatePair = YES;
+            break;
+
+        case 0xDBFF:
+            // If the previous character is the lowest high surrogate value
+            // then we decrement to the value 0xD7FF by replacing the surrogate
+            // pair by the single value 0xD7FF
+            // Otherwise we decrement the high surrogate value and set the low
+            // surrogate value to the highest.
+            if (i == 0) {
+                // Error, it appears that we encountered half a surrogate
+                // pair at index 0. Invalid input string...
+            } else {
+                unichar high = [next characterAtIndex: i - 1];
+                if (high == 0xD800) { /* lowest value for the high part of the pair */
+                    // Replace pair with single 0xD7FF value
+                    removePreviousCharacter = YES;
+                    minusOne = 0xD7FF;
+                } else {
+                    high -= 1;
+                    NSString *highStr = [NSString stringWithFormat:@"%C", high];
+
+                    [next replaceCharactersInRange:NSMakeRange(i - 1, i)
+                                        withString:highStr];
+                    minusOne = 0xDFFF; /* highest value for the low part of the pair */
+                }
+            }
+            break;
+    }
+
+    NSString *sourceMinusOne = replaceWithHighestSurrogatePair ?
+    [NSString stringWithFormat:@"%C%C", 0xDBFF, 0xDFFF] :
+    [NSString stringWithFormat:@"%C", minusOne];
+
+    NSInteger replaceLocation = i;
+    NSInteger replaceLength = 1;
+    if (removePreviousCharacter) {
+        replaceLocation --;
+        replaceLength ++;
+    }
+
+    [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
+                        withString:sourceMinusOne];
+
+    NSInteger length = i + 1;
+    if (removePreviousCharacter) {
+        length --;
+    } else if (replaceWithHighestSurrogatePair) {
+        length ++;
+    }
     return [next stringByPaddingToLength:MAX_KEY_LEN
                               withString:MAX_PUSH_CHAR
                          startingAtIndex:0];

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -95,76 +95,79 @@ static NSInteger const MAX_KEY_LEN = 786;
         return [FUtilities maxName];
     }
 
-    unichar character = [next characterAtIndex: i];
+    unichar character = [next characterAtIndex:i];
     unichar plusOne = character + 1;
     BOOL removePreviousCharacter = NO;
     BOOL replaceWithLowestSurrogatePair = NO;
     switch (plusOne) {
-        case 0x23:
-        case 0x24:
-            plusOne = 0x25;
-            break;
+    case 0x23:
+    case 0x24:
+        plusOne = 0x25;
+        break;
 
-        case 0x2E:
-            plusOne = 0x2F;
-            break;
+    case 0x2E:
+        plusOne = 0x2F;
+        break;
 
-        case 0x5B:
-            plusOne = 0x5C;
-            break;
+    case 0x5B:
+        plusOne = 0x5C;
+        break;
 
-        case 0x5D:
-            plusOne = 0x5E;
-            break;
+    case 0x5D:
+        plusOne = 0x5E;
+        break;
 
-        case 0x2F:
-            plusOne = 0x30;
-            break;
+    case 0x2F:
+        plusOne = 0x30;
+        break;
 
-        case 0x7F:
-            plusOne = 0x80;
-            break;
+    case 0x7F:
+        plusOne = 0x80;
+        break;
 
-        case 0xD800:
-            // We added one to 0xD7FF and entered surrogate pair zone
-            // Add the lowest surrogate pair here
-            replaceWithLowestSurrogatePair = YES;
+    case 0xD800:
+        // We added one to 0xD7FF and entered surrogate pair zone
+        // Add the lowest surrogate pair here
+        replaceWithLowestSurrogatePair = YES;
 
-        case 0xE000:
-            // If the previous character is the highest high surrogate value
-            // then we increment to the value 0xE000 by replacing the surrogate
-            // pair by the single value 0xE000
-            // Otherwise we increment the high surrogate value and set the low
-            // surrogate value to the lowest.
-            if (i == 0) {
-                // Error, it appears that we encountered half a surrogate
-                // pair at index 0. Invalid input string...
+    case 0xE000:
+        // If the previous character is the highest high surrogate value
+        // then we increment to the value 0xE000 by replacing the surrogate
+        // pair by the single value 0xE000
+        // Otherwise we increment the high surrogate value and set the low
+        // surrogate value to the lowest.
+        if (i == 0) {
+            // Error, it appears that we encountered half a surrogate
+            // pair at index 0. Invalid input string...
+        } else {
+            unichar high = [next characterAtIndex:i - 1];
+            if (high ==
+                0xDBFF) { /* highest value for the high part of the pair */
+                // Replace pair with single 0xE000 value
+                removePreviousCharacter = YES;
             } else {
-                unichar high = [next characterAtIndex: i - 1];
-                if (high == 0xDBFF) { /* highest value for the high part of the pair */
-                    // Replace pair with single 0xE000 value
-                    removePreviousCharacter = YES;
-                } else {
-                    high += 1;
-                    NSString *highStr = [NSString stringWithFormat:@"%C", high];
+                high += 1;
+                NSString *highStr = [NSString stringWithFormat:@"%C", high];
 
-                    [next replaceCharactersInRange:NSMakeRange(i - 1, i)
-                                        withString:highStr];
-                    plusOne = 0xDC00; /* lowest value for the low part of the pair */
-                }
+                [next replaceCharactersInRange:NSMakeRange(i - 1, i)
+                                    withString:highStr];
+                plusOne =
+                    0xDC00; /* lowest value for the low part of the pair */
             }
-            break;
+        }
+        break;
     }
 
-    NSString *sourcePlusOne = replaceWithLowestSurrogatePair ?
-        [NSString stringWithFormat:@"%C%C", 0xD800, 0xDC00] :
-        [NSString stringWithFormat:@"%C", plusOne];
+    NSString *sourcePlusOne =
+        replaceWithLowestSurrogatePair
+            ? [NSString stringWithFormat:@"%C%C", 0xD800, 0xDC00]
+            : [NSString stringWithFormat:@"%C", plusOne];
 
     NSInteger replaceLocation = i;
     NSInteger replaceLength = 1;
     if (removePreviousCharacter) {
-        replaceLocation --;
-        replaceLength ++;
+        replaceLocation--;
+        replaceLength++;
     }
 
     [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
@@ -204,79 +207,82 @@ static NSInteger const MAX_KEY_LEN = 786;
     // suffix of the key with MAX_PUSH_CHAR. This is the lexicographically
     // largest possible key smaller than `key`.
     NSUInteger i = next.length - 1;
-    unichar character = [next characterAtIndex: i];
+    unichar character = [next characterAtIndex:i];
     unichar minusOne = character - 1;
     BOOL removePreviousCharacter = NO;
     BOOL replaceWithHighestSurrogatePair = NO;
     switch (minusOne) {
-        // NOTE: We already handled the case of min char (0x20)
-        case 0x23:
-        case 0x24:
-            minusOne = 0x22;
-            break;
+    // NOTE: We already handled the case of min char (0x20)
+    case 0x23:
+    case 0x24:
+        minusOne = 0x22;
+        break;
 
-        case 0x2E:
-            minusOne = 0x2D;
-            break;
+    case 0x2E:
+        minusOne = 0x2D;
+        break;
 
-        case 0x5B:
-            minusOne = 0x5A;
-            break;
+    case 0x5B:
+        minusOne = 0x5A;
+        break;
 
-        case 0x5D:
-            minusOne = 0x5C;
-            break;
+    case 0x5D:
+        minusOne = 0x5C;
+        break;
 
-        case 0x2F:
-            minusOne = 0x2E;
-            break;
+    case 0x2F:
+        minusOne = 0x2E;
+        break;
 
-        case 0x7F:
-            minusOne = 0x7E;
-            break;
+    case 0x7F:
+        minusOne = 0x7E;
+        break;
 
-        case 0xDFFF:
-            // Previously we had 0xE000 which is a single utf16 character,
-            // this needs to be replaced with the highest surrogate pair:
-            replaceWithHighestSurrogatePair = YES;
-            break;
+    case 0xDFFF:
+        // Previously we had 0xE000 which is a single utf16 character,
+        // this needs to be replaced with the highest surrogate pair:
+        replaceWithHighestSurrogatePair = YES;
+        break;
 
-        case 0xDBFF:
-            // If the previous character is the lowest high surrogate value
-            // then we decrement to the value 0xD7FF by replacing the surrogate
-            // pair by the single value 0xD7FF
-            // Otherwise we decrement the high surrogate value and set the low
-            // surrogate value to the highest.
-            if (i == 0) {
-                // Error, it appears that we encountered half a surrogate
-                // pair at index 0. Invalid input string...
+    case 0xDBFF:
+        // If the previous character is the lowest high surrogate value
+        // then we decrement to the value 0xD7FF by replacing the surrogate
+        // pair by the single value 0xD7FF
+        // Otherwise we decrement the high surrogate value and set the low
+        // surrogate value to the highest.
+        if (i == 0) {
+            // Error, it appears that we encountered half a surrogate
+            // pair at index 0. Invalid input string...
+        } else {
+            unichar high = [next characterAtIndex:i - 1];
+            if (high ==
+                0xD800) { /* lowest value for the high part of the pair */
+                // Replace pair with single 0xD7FF value
+                removePreviousCharacter = YES;
+                minusOne = 0xD7FF;
             } else {
-                unichar high = [next characterAtIndex: i - 1];
-                if (high == 0xD800) { /* lowest value for the high part of the pair */
-                    // Replace pair with single 0xD7FF value
-                    removePreviousCharacter = YES;
-                    minusOne = 0xD7FF;
-                } else {
-                    high -= 1;
-                    NSString *highStr = [NSString stringWithFormat:@"%C", high];
+                high -= 1;
+                NSString *highStr = [NSString stringWithFormat:@"%C", high];
 
-                    [next replaceCharactersInRange:NSMakeRange(i - 1, i)
-                                        withString:highStr];
-                    minusOne = 0xDFFF; /* highest value for the low part of the pair */
-                }
+                [next replaceCharactersInRange:NSMakeRange(i - 1, i)
+                                    withString:highStr];
+                minusOne =
+                    0xDFFF; /* highest value for the low part of the pair */
             }
-            break;
+        }
+        break;
     }
 
-    NSString *sourceMinusOne = replaceWithHighestSurrogatePair ?
-    [NSString stringWithFormat:@"%C%C", 0xDBFF, 0xDFFF] :
-    [NSString stringWithFormat:@"%C", minusOne];
+    NSString *sourceMinusOne =
+        replaceWithHighestSurrogatePair
+            ? [NSString stringWithFormat:@"%C%C", 0xDBFF, 0xDFFF]
+            : [NSString stringWithFormat:@"%C", minusOne];
 
     NSInteger replaceLocation = i;
     NSInteger replaceLength = 1;
     if (removePreviousCharacter) {
-        replaceLocation --;
-        replaceLength ++;
+        replaceLocation--;
+        replaceLength++;
     }
 
     [next replaceCharactersInRange:NSMakeRange(replaceLocation, replaceLength)
@@ -284,9 +290,9 @@ static NSInteger const MAX_KEY_LEN = 786;
 
     NSInteger length = i + 1;
     if (removePreviousCharacter) {
-        length --;
+        length--;
     } else if (replaceWithHighestSurrogatePair) {
-        length ++;
+        length++;
     }
     return [next stringByPaddingToLength:MAX_KEY_LEN
                               withString:MAX_PUSH_CHAR

--- a/FirebaseDatabase/Tests/Unit/FNextPushIdTest.m
+++ b/FirebaseDatabase/Tests/Unit/FNextPushIdTest.m
@@ -21,7 +21,7 @@
 #import "FirebaseDatabase/Sources/Utilities/FValidation.h"
 
 @interface FValidation (Test)
-    + (BOOL)isValidKey:(NSString *)key;
++ (BOOL)isValidKey:(NSString *)key;
 @end
 
 @interface FNextPushIdTest : XCTestCase
@@ -38,7 +38,7 @@ static NSInteger MAX_KEY_LEN = 786;
 
 - (void)testSuccessorSpecialValues {
   NSString *maxIntegerKeySuccessor =
-    [FNextPushId from:@"test" successor:[NSString stringWithFormat:@"%d", INTEGER_32_MAX]];
+      [FNextPushId from:@"test" successor:[NSString stringWithFormat:@"%d", INTEGER_32_MAX]];
   XCTAssertEqualObjects(maxIntegerKeySuccessor, MIN_PUSH_CHAR,
                         @"successor(INTEGER_32_MAX) == MIN_PUSH_CHAR");
   NSString *maxKey = [@"" stringByPaddingToLength:MAX_KEY_LEN
@@ -54,9 +54,10 @@ static NSInteger MAX_KEY_LEN = 786;
   NSString *expected = [NSString stringWithFormat:@"abc%@", MIN_PUSH_CHAR];
   XCTAssertEqualObjects(expected, actual, @"successor(abc) == abc + MIN_PUSH_CHAR");
 
-  actual = [FNextPushId from:@"test" successor:[@"abc" stringByPaddingToLength:MAX_KEY_LEN
-                                                       withString:MAX_PUSH_CHAR
-                                                  startingAtIndex:0]];
+  actual = [FNextPushId from:@"test"
+                   successor:[@"abc" stringByPaddingToLength:MAX_KEY_LEN
+                                                  withString:MAX_PUSH_CHAR
+                                             startingAtIndex:0]];
   expected = @"abd";
   XCTAssertEqualObjects(expected, actual,
                         @"successor(abc + MAX_PUSH_CHAR repeated MAX_KEY_LEN - 3 times) == abd");
@@ -71,7 +72,8 @@ static NSInteger MAX_KEY_LEN = 786;
   NSString *actual = [FNextPushId from:@"test" predecessor:MIN_PUSH_CHAR];
   NSString *expected = [NSString stringWithFormat:@"%d", INTEGER_32_MAX];
   XCTAssertEqualObjects(expected, actual, @"predecessor(MIN_PUSH_CHAR) == INTEGER_32_MAX");
-  actual = [FNextPushId from:@"test" predecessor:[NSString stringWithFormat:@"%ld", INTEGER_32_MIN]];
+  actual = [FNextPushId from:@"test"
+                 predecessor:[NSString stringWithFormat:@"%ld", INTEGER_32_MIN]];
   expected = [FUtilities minName];
   XCTAssertEqualObjects(expected, actual, @"predecessor(INTEGER_32_MIN) == MIN_NAME");
 }
@@ -85,7 +87,8 @@ static NSInteger MAX_KEY_LEN = 786;
       expected, actual,
       @"predecessor(abc) = abb + { MAX_PUSH_CHAR repeated MAX_KEY_LEN - 3 times }");
 
-  actual = [FNextPushId from:@"test" predecessor:[NSString stringWithFormat:@"abc%@", MIN_PUSH_CHAR]];
+  actual = [FNextPushId from:@"test"
+                 predecessor:[NSString stringWithFormat:@"abc%@", MIN_PUSH_CHAR]];
   expected = @"abc";
   XCTAssertEqualObjects(expected, actual, @"predecessor(abc + MIN_PUSH_CHAR) == abc");
 }
@@ -93,76 +96,80 @@ static NSInteger MAX_KEY_LEN = 786;
 - (void)testPredecessorWild {
   NSString *actual = [FNextPushId from:@"test" predecessor:@"\uE000"];
   NSString *expected = [@"\U0010FFFF" stringByPaddingToLength:MAX_KEY_LEN
-                                            withString:MAX_PUSH_CHAR
-                                       startingAtIndex:0];
-  
+                                                   withString:MAX_PUSH_CHAR
+                                              startingAtIndex:0];
+
   XCTAssertEqualObjects(
       expected, actual,
       @"predecessor(\uE000) = \U0010FFFF + { MAX_PUSH_CHAR repeated MAX_KEY_LEN - 2 times }");
 
-  actual = [FNextPushId from:@"test" predecessor: @"\U00010000"];
+  actual = [FNextPushId from:@"test" predecessor:@"\U00010000"];
   expected = [@"\uD7FF" stringByPaddingToLength:MAX_KEY_LEN
                                      withString:MAX_PUSH_CHAR
                                 startingAtIndex:0];
-  XCTAssertEqualObjects(expected, actual, @"predecessor(U00010000) == \uD7FF + { MAX_PUSH_CHAR repeated MAX_KEY_LEN - 2 times }");
+  XCTAssertEqualObjects(
+      expected, actual,
+      @"predecessor(U00010000) == \uD7FF + { MAX_PUSH_CHAR repeated MAX_KEY_LEN - 2 times }");
 
-    actual = [FNextPushId from:@"test" predecessor: [[NSString alloc] initWithFormat:@"%C", 0x80]];
-    expected = [[[NSString alloc] initWithFormat:@"%C", 0x7E] stringByPaddingToLength:MAX_KEY_LEN
-                                       withString:MAX_PUSH_CHAR
-                                  startingAtIndex:0];
-    XCTAssertEqualObjects(expected, actual, @"predecessor(u0080 + MIN_PUSH_CHAR) == abc");
-
+  actual = [FNextPushId from:@"test" predecessor:[[NSString alloc] initWithFormat:@"%C", 0x80]];
+  expected = [[[NSString alloc] initWithFormat:@"%C", 0x7E] stringByPaddingToLength:MAX_KEY_LEN
+                                                                         withString:MAX_PUSH_CHAR
+                                                                    startingAtIndex:0];
+  XCTAssertEqualObjects(expected, actual, @"predecessor(u0080 + MIN_PUSH_CHAR) == abc");
 }
 
 - (void)testPredecessorOrdering {
-    // Start _after_ space because otherwise we have to consider integer interpretation.
-    for (unichar i = 0x21; i < 0xD800; i++) {
-        NSString *key = [[NSString alloc] initWithFormat:@"%C", i];
-        if (![FValidation isValidKey:key]) { continue; }
-        NSString *predecessor = [FNextPushId from:@"test" predecessor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
-        XCTAssertEqual(r, NSOrderedDescending);
+  // Start _after_ space because otherwise we have to consider integer interpretation.
+  for (unichar i = 0x21; i < 0xD800; i++) {
+    NSString *key = [[NSString alloc] initWithFormat:@"%C", i];
+    if (![FValidation isValidKey:key]) {
+      continue;
     }
-    for (NSInteger i = 0xE000; i <= 0xFFFF; i++) {
-        NSString *key = [[NSString alloc] initWithFormat:@"%C", (unichar)i];
-        NSString *predecessor = [FNextPushId from:@"test" predecessor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
-        XCTAssertEqual(r, NSOrderedDescending);
-    }
-    for (UTF32Char i = 0x10000; i <= 0x10FFFF; i++) {
-        UniChar c[2];
-        CFStringGetSurrogatePairForLongCharacter(i, c);
-        NSString *key = [[NSString alloc] initWithCharacters:c length:2];
-        NSString *predecessor = [FNextPushId from:@"test" predecessor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
-        XCTAssertEqual(r, NSOrderedDescending);
-    }
+    NSString *predecessor = [FNextPushId from:@"test" predecessor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
+    XCTAssertEqual(r, NSOrderedDescending);
+  }
+  for (NSInteger i = 0xE000; i <= 0xFFFF; i++) {
+    NSString *key = [[NSString alloc] initWithFormat:@"%C", (unichar)i];
+    NSString *predecessor = [FNextPushId from:@"test" predecessor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
+    XCTAssertEqual(r, NSOrderedDescending);
+  }
+  for (UTF32Char i = 0x10000; i <= 0x10FFFF; i++) {
+    UniChar c[2];
+    CFStringGetSurrogatePairForLongCharacter(i, c);
+    NSString *key = [[NSString alloc] initWithCharacters:c length:2];
+    NSString *predecessor = [FNextPushId from:@"test" predecessor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:predecessor];
+    XCTAssertEqual(r, NSOrderedDescending);
+  }
 }
 
 - (void)testSuccessorOrdering {
-    for (unichar i = 0x20; i < 0xD800; i++) {
-        NSString *key = [[NSString alloc] initWithFormat:@"%C", i];
-        if (![FValidation isValidKey:key]) { continue; }
-        NSString *successor = [FNextPushId from:@"test" successor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
-        XCTAssertEqual(r, NSOrderedAscending);
+  for (unichar i = 0x20; i < 0xD800; i++) {
+    NSString *key = [[NSString alloc] initWithFormat:@"%C", i];
+    if (![FValidation isValidKey:key]) {
+      continue;
     }
-    for (NSInteger i = 0xE000; i <= 0xFFFF; i++) {
-        NSString *key = [[NSString alloc] initWithFormat:@"%C", (unichar)i];
-        NSString *successor = [FNextPushId from:@"test" successor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
-        XCTAssertEqual(r, NSOrderedAscending);
-    }
-    // Stop before last, because otherwise we get to [LAST_KEY]
-    for (UTF32Char i = 0x10000; i < 0x10FFFF; i++) {
-        UniChar c[2];
-        CFStringGetSurrogatePairForLongCharacter(i, c);
-        NSString *key = [[NSString alloc] initWithCharacters:c length:2];
-        NSString *successor = [FNextPushId from:@"test" successor: key];
-        NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
-        XCTAssertEqual(r, NSOrderedAscending);
-    }
+    NSString *successor = [FNextPushId from:@"test" successor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
+    XCTAssertEqual(r, NSOrderedAscending);
+  }
+  for (NSInteger i = 0xE000; i <= 0xFFFF; i++) {
+    NSString *key = [[NSString alloc] initWithFormat:@"%C", (unichar)i];
+    NSString *successor = [FNextPushId from:@"test" successor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
+    XCTAssertEqual(r, NSOrderedAscending);
+  }
+  // Stop before last, because otherwise we get to [LAST_KEY]
+  for (UTF32Char i = 0x10000; i < 0x10FFFF; i++) {
+    UniChar c[2];
+    CFStringGetSurrogatePairForLongCharacter(i, c);
+    NSString *key = [[NSString alloc] initWithCharacters:c length:2];
+    NSString *successor = [FNextPushId from:@"test" successor:key];
+    NSComparisonResult r = [FUtilities compareKey:key toKey:successor];
+    XCTAssertEqual(r, NSOrderedAscending);
+  }
 }
-
 
 @end

--- a/FirebaseDatabase/Tests/Unit/FNextPushIdTest.m
+++ b/FirebaseDatabase/Tests/Unit/FNextPushIdTest.m
@@ -93,7 +93,7 @@ static NSInteger MAX_KEY_LEN = 786;
   XCTAssertEqualObjects(expected, actual, @"predecessor(abc + MIN_PUSH_CHAR) == abc");
 }
 
-- (void)testPredecessorWild {
+- (void)testPredecessorUnicode {
   NSString *actual = [FNextPushId from:@"test" predecessor:@"\uE000"];
   NSString *expected = [@"\U0010FFFF" stringByPaddingToLength:MAX_KEY_LEN
                                                    withString:MAX_PUSH_CHAR


### PR DESCRIPTION
This is an attempt at fixing #8790. It's not very polished yet, and the test is currently too slow (loops over all single unicode character strings).