### PR TITLE
Fix Fireperf flaky tests

### DIFF
--- a/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
@@ -125,6 +125,7 @@
 
   // Trigger the RC config fetch
   remoteConfig.lastFetchTime = nil;
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   [configFlags update];
 
   XCTAssertNil([[FPRNetworkTrace alloc] initWithURLRequest:self.testURLRequest]);

--- a/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
+++ b/FirebasePerformance/Tests/Unit/Gauges/FPRGaugeManagerTests.m
@@ -75,6 +75,7 @@
 
   // Trigger the RC config fetch
   remoteConfig.lastFetchTime = nil;
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   [configFlags update];
 
   [FPRGaugeManager sharedInstance].isColdStart = NO;

--- a/FirebasePerformance/Tests/Unit/Instruments/FIRHTTPMetricTests.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FIRHTTPMetricTests.m
@@ -103,6 +103,7 @@
 
   // Trigger the RC config fetch
   remoteConfig.lastFetchTime = nil;
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   [configFlags update];
 
   XCTAssertNil([[FIRHTTPMetric alloc] initWithURL:self.sampleURL HTTPMethod:FIRHTTPMethodGET]);

--- a/FirebasePerformance/Tests/Unit/Timer/FIRTraceTest.m
+++ b/FirebasePerformance/Tests/Unit/Timer/FIRTraceTest.m
@@ -83,6 +83,7 @@
 
   // Trigger the RC config fetch
   remoteConfig.lastFetchTime = nil;
+  configFlags.appStartConfigFetchDelayInSeconds = 0.0;
   [configFlags update];
 
   XCTAssertNil([[FIRTrace alloc] initWithName:@"Random"]);


### PR DESCRIPTION
Fix: The Fireperf SDK introduced random delay before remote config fetch in #8593 where `timeSinceAppStart` needs to be greater than `appStartConfigFetchDelayInSeconds` to trigger a RC fetch. This fix added `appStartConfigFetchDelayInSeconds = 0` to make sure RC fetch is triggered every time from the tests.

Context: #8810 

#no-changelog