### PR TITLE
Added support to ZipBuilder for adding watchOS and watchOS Simulator slices

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -23,8 +23,8 @@ import Foundation
 public let shared = Manifest(
   version: "8.9.0",
   pods: [
-    Pod("FirebaseCoreDiagnostics", zip: true),
-    Pod("FirebaseCore", zip: true),
+    Pod("FirebaseCoreDiagnostics", platforms: ["ios", "macos", "tvos", "watchos"], zip: true),
+    Pod("FirebaseCore", platforms: ["ios", "macos", "tvos", "watchos"], zip: true),
     Pod("FirebaseInstallations", zip: true),
     Pod("GoogleAppMeasurement", isClosedSource: true, platforms: ["ios"]),
     Pod("FirebaseAnalytics", isClosedSource: true, platforms: ["ios"], zip: true),
@@ -34,7 +34,7 @@ public let shared = Manifest(
     Pod("FirebaseRemoteConfig", zip: true),
     Pod("FirebaseAppDistribution", isBeta: true, platforms: ["ios"], zip: true),
     Pod("FirebaseAuth", zip: true),
-    Pod("FirebaseCrashlytics", zip: true),
+    Pod("FirebaseCrashlytics", platforms: ["ios", "macos", "tvos", "watchos"], zip: true),
     Pod("FirebaseDatabase", zip: true),
     Pod("FirebaseDatabaseSwift", isBeta: true),
     Pod("FirebaseDynamicLinks", platforms: ["ios"], zip: true),
@@ -48,7 +48,7 @@ public let shared = Manifest(
     Pod("FirebaseStorage", zip: true),
     Pod("FirebaseStorageSwift", isBeta: true),
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
-    Pod("Firebase", allowWarnings: true, zip: true),
+    Pod("Firebase", allowWarnings: true, platforms: ["ios", "macos", "tvos", "watchos"], zip: true),
   ]
 )
 

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -49,7 +49,7 @@ enum CocoaPodUtils {
 
     init(name: String,
          version: String?,
-         platforms: Set<String> = ["ios", "macos", "tvos", "watchos"]) {
+         platforms: Set<String> = ["ios", "macos", "tvos"]) {
       self.name = name
       self.version = version
       self.platforms = platforms
@@ -61,7 +61,7 @@ enum CocoaPodUtils {
       if let platforms = try container.decodeIfPresent(Set<String>.self, forKey: .platforms) {
         self.platforms = platforms
       } else {
-        platforms = ["ios", "macos", "tvos", "watchos"]
+        platforms = ["ios", "macos", "tvos"]
       }
       if let version = try container.decodeIfPresent(String.self, forKey: .version) {
         self.version = version

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -49,7 +49,7 @@ enum CocoaPodUtils {
 
     init(name: String,
          version: String?,
-         platforms: Set<String> = ["ios", "macos", "tvos"]) {
+         platforms: Set<String> = ["ios", "macos", "tvos", "watchos"]) {
       self.name = name
       self.version = version
       self.platforms = platforms
@@ -61,7 +61,7 @@ enum CocoaPodUtils {
       if let platforms = try container.decodeIfPresent(Set<String>.self, forKey: .platforms) {
         self.platforms = platforms
       } else {
-        platforms = ["ios", "macos", "tvos"]
+        platforms = ["ios", "macos", "tvos", "watchos"]
       }
       if let version = try container.decodeIfPresent(String.self, forKey: .version) {
         self.version = version

--- a/ReleaseTooling/Sources/ZipBuilder/Platform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/Platform.swift
@@ -21,12 +21,14 @@ enum Platform: CaseIterable {
   case iOS
   case macOS
   case tvOS
+  case watchOS
 
   var platformTargets: [TargetPlatform] {
     switch self {
     case .iOS: return [.iOSDevice, .iOSSimulator] + (SkipCatalyst.skip ? [] : [.catalyst])
     case .macOS: return [.macOS]
     case .tvOS: return [.tvOSDevice, .tvOSSimulator]
+    case .watchOS: return [.watchOSDevice, .watchOSSimulator]
     }
   }
 
@@ -36,6 +38,7 @@ enum Platform: CaseIterable {
     case .iOS: return "ios"
     case .macOS: return "macos"
     case .tvOS: return "tvos"
+    case .watchOS: return "watchos"
     }
   }
 
@@ -45,6 +48,7 @@ enum Platform: CaseIterable {
     case .iOS: return PlatformMinimum.minimumIOSVersion
     case .macOS: return PlatformMinimum.minimumMacOSVersion
     case .tvOS: return PlatformMinimum.minimumTVOSVersion
+    case .watchOS: return PlatformMinimum.minimumWatchOSVersion
     }
   }
 }
@@ -53,10 +57,12 @@ class PlatformMinimum {
   fileprivate static var minimumIOSVersion = ""
   fileprivate static var minimumMacOSVersion = ""
   fileprivate static var minimumTVOSVersion = ""
-  static func initialize(ios: String, macos: String, tvos: String) {
+  fileprivate static var minimumWatchOSVersion = ""
+  static func initialize(ios: String, macos: String, tvos: String, watchos: String) {
     minimumIOSVersion = ios
     minimumMacOSVersion = macos
     minimumTVOSVersion = tvos
+    minimumWatchOSVersion = watchos
   }
 
   /// Useful to disable minimum version checking on pod installation. Pods still get built with
@@ -65,6 +71,7 @@ class PlatformMinimum {
     minimumIOSVersion = "14.0"
     minimumMacOSVersion = "11.0"
     minimumTVOSVersion = "14.0"
+    minimumWatchOSVersion = "8.0"
   }
 }
 

--- a/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
@@ -73,7 +73,7 @@ enum TargetPlatform: CaseIterable {
     case .tvOSDevice: return "appletvos"
     case .tvOSSimulator: return "appletvsimulator"
     case .watchOSDevice: return "watchos"
-    case .watchOSSimulator: return "watchossimulator"
+    case .watchOSSimulator: return "watchsimulator"
     }
   }
 

--- a/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
@@ -30,6 +30,10 @@ enum TargetPlatform: CaseIterable {
   case tvOSDevice
   /// Binaries to target tvOS simulators.
   case tvOSSimulator
+  /// Binaries to target watchOS
+  case watchOSDevice
+  /// Binaries to target watchOS simulators
+  case watchOSSimulator
 
   /// Valid architectures to be built for the platform.
   var archs: [Architecture] {
@@ -42,6 +46,8 @@ enum TargetPlatform: CaseIterable {
     case .macOS: return [.x86_64, .arm64]
     case .tvOSDevice: return [.arm64]
     case .tvOSSimulator: return [.x86_64, .arm64]
+    case .watchOSDevice: return [.armv7k]
+    case .watchOSSimulator: return [.x86_64, .arm64]
     }
   }
 
@@ -52,6 +58,7 @@ enum TargetPlatform: CaseIterable {
     case .iOSDevice: return true
     case .macOS: return true
     case .tvOSDevice: return true
+    case .watchOSDevice: return true
     default: return false
     }
   }
@@ -65,6 +72,8 @@ enum TargetPlatform: CaseIterable {
     case .macOS: return "macosx"
     case .tvOSDevice: return "appletvos"
     case .tvOSSimulator: return "appletvsimulator"
+    case .watchOSDevice: return "watchos"
+    case .watchOSSimulator: return "watchossimulator"
     }
   }
 
@@ -85,6 +94,8 @@ enum TargetPlatform: CaseIterable {
     case .macOS: return "Release"
     case .tvOSDevice: return "Release-appletvos"
     case .tvOSSimulator: return "Release-appletvsimulator"
+    case .watchOSDevice: return "Release-watchos"
+    case .watchOSSimulator: return "Release-watchsimulator"
     }
   }
 }
@@ -96,4 +107,5 @@ enum Architecture: String, CaseIterable {
   case i386
   case x86_64
   case x86_64h // x86_64h, Haswell, used for Mac Catalyst
+  case armv7k
 }

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -110,6 +110,10 @@ struct ZipBuilderTool: ParsableCommand {
   /// The minimum tvOS Version to build for.
   @Option(default: "10.0", help: ArgumentHelp("The minimum supported tvOS version."))
   var minimumTVOSVersion: String
+  
+  /// The minimum watchOS Version to build for.
+  @Option(default: "7.0", help: ArgumentHelp("The minimum supported watchOS version."))
+  var minimumWatchOSVersion: String
 
   /// The list of platforms to build for.
   @Option(parsing: .upToNextOption,
@@ -264,7 +268,8 @@ struct ZipBuilderTool: ParsableCommand {
       // Set the platform minimum versions.
       PlatformMinimum.initialize(ios: minimumIOSVersion,
                                  macos: minimumMacOSVersion,
-                                 tvos: minimumTVOSVersion)
+                                 tvos: minimumTVOSVersion,
+                                 watchos: minimumWatchOSVersion)
 
       let (installedPods, frameworks, _) =
         builder.buildAndAssembleZip(podsToInstall: podsToBuild,

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -110,7 +110,7 @@ struct ZipBuilderTool: ParsableCommand {
   /// The minimum tvOS Version to build for.
   @Option(default: "10.0", help: ArgumentHelp("The minimum supported tvOS version."))
   var minimumTVOSVersion: String
-  
+
   /// The minimum watchOS Version to build for.
   @Option(default: "7.0", help: ArgumentHelp("The minimum supported watchOS version."))
   var minimumWatchOSVersion: String


### PR DESCRIPTION
This was first mentioned in #8731. @paulb777 said that ZipBuilder needed to be updated to add watchOS and watchOS Simulator slices. I believe that this Pull Request implements these changes.

Unfortunately I've been unable to test - running `swift run zip-builder` on my machine, even with a fresh clone, causes a crash somewhere deep in Ruby. I've searched for every mention of `tvOS` and re-implemented for `watchOS`. If this doesn't 100% work, then perhaps it will get you most of the way there.

I implemented this because my app requires iOS 10 support, which means I cannot use SPM distribution. However, watchOS support appears to only be distributed in the SPM version of the frameworks.