### PR TITLE
[Heartbeat Logging] Implement `HeartbeatInfo` data structure

### DIFF
--- a/HeartbeatLogging/Sources/Heartbeat.swift
+++ b/HeartbeatLogging/Sources/Heartbeat.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// An enumeration of time periods.
-internal enum TimePeriod: Int, CaseIterable, Codable {
+enum TimePeriod: Int, CaseIterable, Codable {
   /// The raw value is the number of calendar days within each time period.
   // TODO: Enable disabled types in future iterations.
   case daily = 1 // , case weekly = 7, monthly = 28
@@ -28,7 +28,7 @@ internal enum TimePeriod: Int, CaseIterable, Codable {
 }
 
 /// A structure representing SDK usage.
-internal struct Heartbeat: Codable, Equatable {
+struct Heartbeat: Codable, Equatable {
   /// The version of the model. Used for decoding/encoding. Manually incremented when model changes.
   private static let version: Int = 0
 


### PR DESCRIPTION
The `HeartbeatInfo` data model is basically a ring buffer of heartbeats. Its goal is to be optimized for limit on write with constant* time `append`s. 

Since there may be multiple `type`s of heartbeats: i.e. daily, weekly, monthly, a cache is used to store the last heartbeat for each `type`. This prevents the need to iterate through the buffer's contents to find when the last, e.g. `daily`, heartbeat was logged. I'm happy to remove the cacheing optimization if it's not worth it though.

I'd appreciate feedback on how I expressed how to decide _when_ we want to log a new heartbeat. 

This PR is next step from #8822, then I'll continue on to building test suite and refining.

#no-changelog