### PR TITLE
Fix tvos deployment target and 8.9.0 release note update

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -24,7 +24,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.social_media_url = 'https://twitter.com/Firebase'
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '10.0'
+  s.tvos.deployment_target = '12.0'
 
   s.cocoapods_version = '>= 1.4.0'
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Firebase 8.9.0
+- [added] Firebase introduces beta support for tvOS, macOS, and Catalyst.
+  watchOS continues to be available with community support. Individual product
+  details at
+  https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform (#583)
+- [changed] The minimum support tvOS version is now 12.0.
 - [fixed] Force GoogleUtilities and GoogleDataTransport CocoaPods dependencies
   to be updated to latest minor versions. (#8733)
 


### PR DESCRIPTION
Since the default subspec for the Firebase pod is Core which depends on Analytics which needs 12.

This Firebase.podspec successfully stages to SpecsStaging