### PR TITLE
Add specsstaging source to size measurement

### DIFF
--- a/scripts/health_metrics/generate_code_coverage_report/Sources/BinarySizeReportGenerator/BinarySizeReportGeneration.swift
+++ b/scripts/health_metrics/generate_code_coverage_report/Sources/BinarySizeReportGenerator/BinarySizeReportGeneration.swift
@@ -87,7 +87,7 @@ func CreateMetricsRequestData(of sdks: [String], type: String,
     // that `.stdout` will print out logs in the console while pipe can assign logs a
     // variable.
     Shell.run(
-      "cd cocoapods-size && python3 measure_cocoapod_size.py --cocoapods \(sdk) --cocoapods_source_config ../cocoapods_source_config.json --json \(Constants.cocoapodSizeReportFile)",
+      "cd cocoapods-size && python3 measure_cocoapod_size.py --cocoapods \(sdk) --spec_repos specsstaging master --cocoapods_source_config ../cocoapods_source_config.json --json \(Constants.cocoapodSizeReportFile)",
       stdout: .stdout
     )
     let SDKBinarySize = try JSONParser.readJSON(


### PR DESCRIPTION
This is to resolve #8834. Specsstaging repo will be added as a source for size measurement. 