### PR TITLE
Update the type to Cocoapods

### DIFF
--- a/scripts/health_metrics/generate_code_coverage_report/Sources/BinarySizeReportGenerator/BinarySizeReportGeneration.swift
+++ b/scripts/health_metrics/generate_code_coverage_report/Sources/BinarySizeReportGenerator/BinarySizeReportGeneration.swift
@@ -110,7 +110,7 @@ public func CreateMetricsRequestData(SDK: [String], SDKRepoDir: URL,
   try CreatePodConfigJSON(of: SDK, from: SDKRepoDir)
   let data = try CreateMetricsRequestData(
     of: SDK,
-    type: "Cocoapods",
+    type: "CocoaPods",
     log: logPath
   )
   return data


### PR DESCRIPTION
We potentially might have framework and other size measurements in the future. Specify it in order to differentiate from other types of sizes, e.g. framework.