### PR TITLE
Fix AppCheckAPITests for Xcode 13.0 macos/Catalyst

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -65,7 +65,7 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    #if swift(>=5.5)
+    #if compiler(>=5.5) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -99,7 +99,7 @@ final class AppCheckAPITests {
       }
 
       // Get token (async/await)
-      #if swift(>=5.5)
+      #if compiler(>=5.5) && canImport(_Concurrency)
         if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
@@ -171,7 +171,7 @@ final class AppCheckAPITests {
           }
         }
         // Get token (async/await)
-        #if swift(>=5.5)
+        #if compiler(>=5.5) && canImport(_Concurrency)
           if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
             // async/await is a Swift 5.5+ feature available on iOS 15+
             Task {


### PR DESCRIPTION
Fix #8832 -  last night's nightly failure

#no-changelog
