### PR TITLE
Fix dep version in FirebaseAnalyticsSwift.podspec

### DIFF
--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -29,5 +29,5 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     'FirebaseAnalyticsSwift/Sources/*.swift',
   ]
 
-  s.dependency 'FirebaseAnalytics', '~> 8.0'
+  s.dependency 'FirebaseAnalytics', '~> 8.9'
 end


### PR DESCRIPTION
FirebaseAnalyticsSwift now requires at least FirebaseAnalytics 8.9.0 for non-iOS platform support

#no-changelog