### PR TITLE
Fix URL handling bug when path is a substring of host

### DIFF
--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.10.0
+- [fixed] Fixed URL handling bug when path is a substring of host. (#8874)
+
 # v8.7.0
 - [fixed] Fixed Firebase App Check token periodic refresh. (#8544)
 

--- a/FirebaseDatabase/Sources/Utilities/FUtilities.m
+++ b/FirebaseDatabase/Sources/Utilities/FUtilities.m
@@ -154,9 +154,12 @@ void firebaseJobsTroll(void) {
 
     // Sanitize the database URL by removing the path component, which may
     // contain invalid URL characters.
-    NSRange lastMatch = [url rangeOfString:originalPathString options:NSBackwardsSearch];
-    NSString *sanitizedUrlWithoutPath = (lastMatch.location != NSNotFound) ?
-        [url stringByReplacingCharactersInRange:lastMatch withString: @""] : url;
+    NSRange lastMatch = [url rangeOfString:originalPathString
+                                   options:NSBackwardsSearch];
+    NSString *sanitizedUrlWithoutPath =
+        (lastMatch.location != NSNotFound)
+            ? [url stringByReplacingCharactersInRange:lastMatch withString:@""]
+            : url;
 
     NSURLComponents *urlComponents =
         [NSURLComponents componentsWithString:sanitizedUrlWithoutPath];

--- a/FirebaseDatabase/Sources/Utilities/FUtilities.m
+++ b/FirebaseDatabase/Sources/Utilities/FUtilities.m
@@ -154,9 +154,10 @@ void firebaseJobsTroll(void) {
 
     // Sanitize the database URL by removing the path component, which may
     // contain invalid URL characters.
-    NSString *sanitizedUrlWithoutPath =
-        [url stringByReplacingOccurrencesOfString:originalPathString
-                                       withString:@""];
+    NSRange lastMatch = [url rangeOfString:originalPathString options:NSBackwardsSearch];
+    NSString *sanitizedUrlWithoutPath = (lastMatch.location != NSNotFound) ?
+        [url stringByReplacingCharactersInRange:lastMatch withString: @""] : url;
+
     NSURLComponents *urlComponents =
         [NSURLComponents componentsWithString:sanitizedUrlWithoutPath];
     if (!urlComponents) {

--- a/FirebaseDatabase/Sources/Utilities/FUtilities.m
+++ b/FirebaseDatabase/Sources/Utilities/FUtilities.m
@@ -158,7 +158,7 @@ void firebaseJobsTroll(void) {
                                    options:NSBackwardsSearch];
     NSString *sanitizedUrlWithoutPath =
         (lastMatch.location != NSNotFound)
-            ? [url stringByReplacingCharactersInRange:lastMatch withString:@""]
+            ? [url substringToIndex:lastMatch.location]
             : url;
 
     NSURLComponents *urlComponents =

--- a/FirebaseDatabase/Tests/Unit/FUtilitiesTest.m
+++ b/FirebaseDatabase/Tests/Unit/FUtilitiesTest.m
@@ -84,6 +84,14 @@
   XCTAssertTrue(parsedUrl.repoInfo.secure);
 }
 
+- (void)testUrlParsedWithPathPartOfHost {
+  FParsedUrl *parsedUrl = [FUtilities parseUrl:@"https://sample.firebaseio.com/a"];
+  XCTAssertEqualObjects(parsedUrl.repoInfo.host, @"sample.firebaseio.com");
+  XCTAssertEqualObjects(parsedUrl.repoInfo.namespace, @"sample");
+  XCTAssertTrue(parsedUrl.repoInfo.secure);
+  XCTAssertEqualObjects(parsedUrl.path, [FPath pathWithString:@"a"]);
+}
+
 - (void)testDefaultCacheSizeIs10MB {
   XCTAssertEqual([FTestHelpers defaultConfig].persistenceCacheSizeBytes,
                  (NSUInteger)10 * 1024 * 1024);

--- a/FirebaseDatabase/Tests/Unit/FUtilitiesTest.m
+++ b/FirebaseDatabase/Tests/Unit/FUtilitiesTest.m
@@ -92,6 +92,22 @@
   XCTAssertEqualObjects(parsedUrl.path, [FPath pathWithString:@"a"]);
 }
 
+- (void)testUrlParsedWithPathPartOfHost2 {
+  FParsedUrl *parsedUrl = [FUtilities parseUrl:@"https://sample.firebaseio.com/"];
+  XCTAssertEqualObjects(parsedUrl.repoInfo.host, @"sample.firebaseio.com");
+  XCTAssertEqualObjects(parsedUrl.repoInfo.namespace, @"sample");
+  XCTAssertTrue(parsedUrl.repoInfo.secure);
+  XCTAssertEqualObjects(parsedUrl.path, [FPath pathWithString:@""]);
+}
+
+- (void)testUrlParsedWithPathPartOfHost3 {
+  FParsedUrl *parsedUrl = [FUtilities parseUrl:@"https://sample.firebaseio.com"];
+  XCTAssertEqualObjects(parsedUrl.repoInfo.host, @"sample.firebaseio.com");
+  XCTAssertEqualObjects(parsedUrl.repoInfo.namespace, @"sample");
+  XCTAssertTrue(parsedUrl.repoInfo.secure);
+  XCTAssertEqualObjects(parsedUrl.path, [FPath pathWithString:@""]);
+}
+
 - (void)testDefaultCacheSizeIs10MB {
   XCTAssertEqual([FTestHelpers defaultConfig].persistenceCacheSizeBytes,
                  (NSUInteger)10 * 1024 * 1024);


### PR DESCRIPTION
Fix #8874 

Change logic to only replace the last match in the URL string instead of all of them