### PR TITLE
Core and zip updates for 8.9.1 - Fix zip builder for patch distributions

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -41,7 +41,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '8.9.0'
+    ss.dependency 'FirebaseCore', '8.9.1'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '8.9.0'
+  s.version          = '8.9.1'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "8.9.0",
+  version: "8.9.1",
   pods: [
     Pod("FirebaseCoreDiagnostics", zip: true),
     Pod("FirebaseCore", zip: true),

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import Utils
+import FirebaseManifest
 
 /// CocoaPod related utility functions. The enum type is used as a namespace here instead of having
 /// root functions, and no cases should be added to it.
@@ -474,6 +475,9 @@ enum CocoaPodUtils {
     """
 
     var versionsSpecified = false
+    let firebaseVersion = FirebaseManifest.shared.version
+    let versionChunks = firebaseVersion.split(separator: ".")
+    let minorVersion = "\(versionChunks[0]).\(versionChunks[1]).0"
 
     // Loop through the subspecs passed in and use the actual Pod name.
     for pod in pods {
@@ -483,7 +487,14 @@ enum CocoaPodUtils {
         FileManager.default.fileExists(atPath: localURL.appendingPathComponent(podspec).path) {
         podfile += "  pod '\(pod.name)', :path => '\(localURL.path)'"
       } else if let podVersion = pod.version {
-        podfile += "  pod '\(pod.name)', '\(podVersion)'"
+        // To support Firebase patch versions, the allow patch updates
+        // for all pods except Firebase and FirebaseCore.
+        var podfileVersion = podVersion
+        if pod.name != "Firebase" && pod.name != "FirebaseCore" {
+          podfileVersion = podfileVersion.replacingOccurrences(of: firebaseVersion, with: minorVersion)
+          podfileVersion = "~> \(podfileVersion)"
+        }
+        podfile += "  pod '\(pod.name)', '\(podfileVersion)'"
       } else if pod.name.starts(with: "Firebase"),
         let localURL = localPodspecPath,
         FileManager.default

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -487,10 +487,14 @@ enum CocoaPodUtils {
         FileManager.default.fileExists(atPath: localURL.appendingPathComponent(podspec).path) {
         podfile += "  pod '\(pod.name)', :path => '\(localURL.path)'"
       } else if let podVersion = pod.version {
-        // To support Firebase patch versions, the allow patch updates
-        // for all pods except Firebase and FirebaseCore.
+        // To support Firebase patch versions in the Firebase zip distribution, allow patch updates
+        // for all pods except Firebase and FirebaseCore. The Firebase Swift pods are not yet in the
+        // zip distribution.
         var podfileVersion = podVersion
-        if pod.name.starts(with: "Firebase"), pod.name != "Firebase", pod.name != "FirebaseCore" {
+        if pod.name.starts(with: "Firebase"),
+          !pod.name.hasSuffix("Swift"),
+          pod.name != "Firebase",
+          pod.name != "FirebaseCore" {
           podfileVersion = podfileVersion.replacingOccurrences(
             of: firebaseVersion,
             with: minorVersion

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -490,8 +490,11 @@ enum CocoaPodUtils {
         // To support Firebase patch versions, the allow patch updates
         // for all pods except Firebase and FirebaseCore.
         var podfileVersion = podVersion
-        if pod.name != "Firebase" && pod.name != "FirebaseCore" {
-          podfileVersion = podfileVersion.replacingOccurrences(of: firebaseVersion, with: minorVersion)
+        if pod.name != "Firebase", pod.name != "FirebaseCore" {
+          podfileVersion = podfileVersion.replacingOccurrences(
+            of: firebaseVersion,
+            with: minorVersion
+          )
           podfileVersion = "~> \(podfileVersion)"
         }
         podfile += "  pod '\(pod.name)', '\(podfileVersion)'"

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -490,7 +490,7 @@ enum CocoaPodUtils {
         // To support Firebase patch versions, the allow patch updates
         // for all pods except Firebase and FirebaseCore.
         var podfileVersion = podVersion
-        if pod.name != "Firebase", pod.name != "FirebaseCore" {
+        if pod.name.starts(with: "Firebase"), pod.name != "Firebase", pod.name != "FirebaseCore" {
           podfileVersion = podfileVersion.replacingOccurrences(
             of: firebaseVersion,
             with: minorVersion


### PR DESCRIPTION
Update FirebaseCore to get version right and version in Manifest so zip build succeeds

Also fix zip builder to handle the mixed Firebase patch versions that occur when building a zip release for a Firebase patch release.

Fix #8885 

#no-changelog