### PR TITLE
Upload binary size data

### DIFF
--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -56,8 +56,6 @@ jobs:
         target: [iOS]
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: refs/tags/v8.9.0
     - name: Access to Metrics Service
       run: |
         # Install gcloud sdk

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -72,7 +72,7 @@ jobs:
         gcloud auth activate-service-account --key-file metrics-access.json
     - name: Build and test
       run: |
-        echo "${GITHUB_SHA}"
+        ./scripts/health_metrics/create_binary_size_report.sh
       env:
         PULL_REQUEST_NUM: ${{ github.event.pull_request.number }}
         BASE_COMMIT: ${{ needs.check.outputs.target_branch_head }}

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -50,16 +50,14 @@ jobs:
           fi
 
   binary_size_metrics:
-    needs: check
-    # Prevent the job from being triggered in fork.
-    # always() will trigger this job when `needs` are skipped in a `merge` pull_request event.
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository && (github.event.action != 'closed' || github.event.pull_request.merged)
     runs-on: macos-11
     strategy:
       matrix:
         target: [iOS]
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: refs/tags/v8.9.0
     - name: Access to Metrics Service
       run: |
         # Install gcloud sdk
@@ -74,23 +72,7 @@ jobs:
         gcloud auth activate-service-account --key-file metrics-access.json
     - name: Build and test
       run: |
-        FirebaseABTesting=${{ needs.check.outputs.abtesting_run_job }} \
-        FirebaseAnalytics=${{ needs.check.outputs.analytics_run_job }} \
-        FirebaseAppCheck=${{ needs.check.outputs.appcheck_run_job }} \
-        FirebaseAppDistribution=${{ needs.check.outputs.appdistribution_run_job }} \
-        FirebaseAuth=${{ needs.check.outputs.auth_run_job }} \
-        FirebaseCrashlytics=${{ needs.check.outputs.crashlytics_run_job }} \
-        FirebaseDatabase=${{ needs.check.outputs.database_run_job }} \
-        FirebaseDynamicLinks=${{ needs.check.outputs.dynamiclinks_run_job }} \
-        FirebaseFirestore=${{ needs.check.outputs.firestore_run_job }} \
-        FirebaseFunctions=${{ needs.check.outputs.functions_run_job}} \
-        FirebaseInAppMessaging=${{ needs.check.outputs.inappmessaging_run_job }} \
-        FirebaseInstallations=${{ needs.check.outputs.installations_run_job }} \
-        FirebaseMessaging=${{ needs.check.outputs.messaging_run_job}} \
-        FirebasePerformance=${{ needs.check.outputs.performance_run_job }} \
-        FirebaseRemoteConfig=${{ needs.check.outputs.remoteconfig_run_job }} \
-        FirebaseStorage=${{ needs.check.outputs.storage_run_job }} \
-        ./scripts/health_metrics/create_binary_size_report.sh
+        echo "${GITHUB_SHA}"
       env:
         PULL_REQUEST_NUM: ${{ github.event.pull_request.number }}
         BASE_COMMIT: ${{ needs.check.outputs.target_branch_head }}

--- a/scripts/health_metrics/create_binary_size_report.sh
+++ b/scripts/health_metrics/create_binary_size_report.sh
@@ -36,5 +36,5 @@ if [ -n "$BINARY_SIZE_SDK" ]; then
   cd scripts/health_metrics/generate_code_coverage_report/
   git clone https://github.com/google/cocoapods-size
   swift build
-    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "2064534407804195d62f48531155ef41ddf1ce22" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch release-8.9
+    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "839cc6b0cd80b0b8bf81fe9bd82b743b25dc6446" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch release-8.9
 fi

--- a/scripts/health_metrics/create_binary_size_report.sh
+++ b/scripts/health_metrics/create_binary_size_report.sh
@@ -36,9 +36,5 @@ if [ -n "$BINARY_SIZE_SDK" ]; then
   cd scripts/health_metrics/generate_code_coverage_report/
   git clone https://github.com/google/cocoapods-size
   swift build
-  if [[ "${POSTSUBMIT}" == true ]]; then
-    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch release-8.9
-  else
-    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --presubmit "firebase/firebase-ios-sdk" --head-commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --pull-request-num "${PULL_REQUEST_NUM}" --base-commit "${BASE_COMMIT}"
-  fi
+    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "2064534407804195d62f48531155ef41ddf1ce22" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch release-8.9
 fi

--- a/scripts/health_metrics/create_binary_size_report.sh
+++ b/scripts/health_metrics/create_binary_size_report.sh
@@ -27,60 +27,17 @@ BINARY_SIZE_SDK=()
 # file path, in `scripts/health_metrics/code_coverage_file_list.json` is updated.
 # In postsubmits, all SDKs should be measured, so binary size data of all SDKs should be uploaded to a
 # merged commit. Next time a new PR can compare the head of the PR to a commit on the base branch.
-if [[ "${POSTSUBMIT}" == true || "${FirebaseABTesting}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseABTesting')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseAnalytics}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseAnalytics')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseAppCheck}" == 'true' ]]; then
+BINARY_SIZE_SDK+=('FirebaseAnalytics')
   BINARY_SIZE_SDK+=('FirebaseAppCheck')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseAppDistribution}" == 'true' ]]; then
   BINARY_SIZE_SDK+=('FirebaseAppDistribution')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseAuth}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseAuth')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseCrashlytics}" == 'true' ]]; then
   BINARY_SIZE_SDK+=('FirebaseCrashlytics')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseDatabase}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseDatabase')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseDynamicLinks}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseDynamicLinks')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseFirestore}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseFirestore')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseFunctions}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseFunctions')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseInAppMessaging}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseInAppMessaging')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseInstallations}" == 'true' ]]; then
   BINARY_SIZE_SDK+=('FirebaseInstallations')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseMessaging}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseMessaging')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebasePerformance}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebasePerformance');
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseRemoteConfig}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseRemoteConfig')
-fi
-if [[ "${POSTSUBMIT}" == true || "${FirebaseStorage}" == 'true' ]]; then
-  BINARY_SIZE_SDK+=('FirebaseStorage')
-fi
 if [ -n "$BINARY_SIZE_SDK" ]; then
   cd scripts/health_metrics/generate_code_coverage_report/
   git clone https://github.com/google/cocoapods-size
   swift build
   if [[ "${POSTSUBMIT}" == true ]]; then
-    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch "${SOURCE_BRANCH}"
+    .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --merge "firebase/firebase-ios-sdk" --head-commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --source-branch release-8.9
   else
     .build/debug/BinarySizeReportGenerator --binary-size-tool-dir cocoapods-size/  --sdk-repo-dir "${GITHUB_WORKSPACE}" --sdk ${BINARY_SIZE_SDK[@]} --presubmit "firebase/firebase-ios-sdk" --head-commit "${GITHUB_SHA}" --token $(gcloud auth print-identity-token) --log-link "https://github.com/firebase/firebase-ios-sdk/actions/runs/${GITHUB_RUN_ID}" --pull-request-num "${PULL_REQUEST_NUM}" --base-commit "${BASE_COMMIT}"
   fi


### PR DESCRIPTION
8.9.1 version from branch `release-8.9` is still running the old version of CI which did not upload the new added SDK sizes. Manually trigger the workflow to upload these size data.