### PR TITLE
Update health-metrics-release.yml

### DIFF
--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -23,7 +23,7 @@ jobs:
             "${{ env.gpg_passphrase }}"
           gcloud auth activate-service-account --key-file service_account.json
       - name: Produce health metric diff reports
-        uses: yifanyang/github-actions/health-metrics/release-diffing@master
+        uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
         with:
           repo: ${{ github.repository }}
           ref: ${{ github.ref }}


### PR DESCRIPTION
[launch/4116012](http://launch/4116012 ) is approved, and the custom action is now hosted at [FirebaseExtended/github-actions](https://github.com/FirebaseExtended/github-actions).