### PR TITLE
Fix for issue #8907 InApp message is shown every new session 

### DIFF
--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -316,8 +316,9 @@
 
 - (void)recordValidImpression:(NSString *)messageID withMessageName:(NSString *)messageName {
   if (!self.impressionRecorded) {
-    [self.displayBookKeeper recordNewImpressionForMessage:messageID
-                              withStartTimestampInSeconds:[self.timeFetcher currentTimestampInSeconds]];
+    [self.displayBookKeeper
+        recordNewImpressionForMessage:messageID
+          withStartTimestampInSeconds:[self.timeFetcher currentTimestampInSeconds]];
     self.impressionRecorded = YES;
     [self.messageCache removeMessageWithId:messageID];
     // Log an impression analytics event as well.

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -317,7 +317,7 @@
 - (void)recordValidImpression:(NSString *)messageID withMessageName:(NSString *)messageName {
   if (!self.impressionRecorded) {
     [self.displayBookKeeper recordNewImpressionForMessage:messageID
-                              withStartTimestampInSeconds:self.lastDisplayTime];
+                              withStartTimestampInSeconds:[self.timeFetcher currentTimestampInSeconds]];
     self.impressionRecorded = YES;
     [self.messageCache removeMessageWithId:messageID];
     // Log an impression analytics event as well.


### PR DESCRIPTION
 Fix for issue #8907 InApp message is shown every new session (timestamp of the impression record is always 0 seconds).