### PR TITLE
CMakeLists.txt: add -DPB_NO_PACKED_STRUCTS=1 to the nanopb compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ add_external_subdirectory(nanopb)
 
 target_compile_definitions(
   protobuf-nanopb-static PUBLIC
-  -DPB_FIELD_32BIT -DPB_ENABLE_MALLOC
+  -DPB_FIELD_32BIT -DPB_ENABLE_MALLOC -DPB_NO_PACKED_STRUCTS=1
 )
 
 # Enable #include <nanopb/pb.h>


### PR DESCRIPTION
This fixes a flurry of "ld: warning: pointer not aligned at address" warnings that reportedly fail the build of the C++ SDK.

Here are some customer reports of these warnings affecting builds:
- https://github.com/firebase/firebase-cpp-sdk/issues/712
- https://github.com/firebase/firebase-unity-sdk/issues/83