### PR TITLE
Perf return session length return type

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 * Fix a crash related to FPRSessionDetails. (#8691)
 
-# Version 8.8.0 
+# Version 8.8.0
 * Create a random number of delay for remote config fetch during app starts.
 * Fix log spamming when Firebase Performance is disabled. (#8423, #8577)
 * Fix heap-heap-buffer overflow when decoding strings. (#8628)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Create a random number of delay for remote config fetch during app starts.
 * Fix log spamming when Firebase Performance is disabled. (#8423, #8577)
 * Fix heap-heap-buffer overflow when decoding strings. (#8628)
+* Fix a crash related to FPRSessionDetails. (#8691)
 
 # Version 8.6.1
 * Fix the case where the event were dropped for missing a critical field in the event.

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,8 +1,10 @@
-# Pending
+# Unreleased
+* Fix a crash related to FPRSessionDetails. (#8691)
+
+# Version 8.8.0 
 * Create a random number of delay for remote config fetch during app starts.
 * Fix log spamming when Firebase Performance is disabled. (#8423, #8577)
 * Fix heap-heap-buffer overflow when decoding strings. (#8628)
-* Fix a crash related to FPRSessionDetails. (#8691)
 
 # Version 8.6.1
 * Fix the case where the event were dropped for missing a critical field in the event.

--- a/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRSessionDetails.m
@@ -36,12 +36,13 @@
 - (FPRSessionDetails *)copyWithZone:(NSZone *)zone {
   FPRSessionDetails *detailsCopy = [[[self class] allocWithZone:zone] initWithSessionId:_sessionId
                                                                                 options:_options];
+  detailsCopy.sessionCreationTime = _sessionCreationTime;
   return detailsCopy;
 }
 
 - (NSUInteger)sessionLengthInMinutes {
   NSTimeInterval sessionLengthInSeconds = ABS([self.sessionCreationTime timeIntervalSinceNow]);
-  return (sessionLengthInSeconds / 60);
+  return (NSUInteger)(sessionLengthInSeconds / 60);
 }
 
 - (BOOL)isEqual:(FPRSessionDetails *)detailsObject {

--- a/FirebasePerformance/Tests/Unit/FPRSessionDetailsTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRSessionDetailsTest.m
@@ -29,6 +29,17 @@
   XCTAssertNotNil(details);
 }
 
+/** Validates object copy contains same details as the source. */
+- (void)testInstanceCopy {
+  FPRSessionDetails *details = [[FPRSessionDetails alloc] initWithSessionId:@"random"
+                                                                    options:FPRSessionOptionsNone];
+  FPRSessionDetails *detailsCopy = [details copy];
+  XCTAssertEqual(details.sessionId, detailsCopy.sessionId);
+  XCTAssertEqual(details.options, detailsCopy.options);
+  XCTAssertEqual(details.sessionLengthInMinutes, detailsCopy.sessionLengthInMinutes);
+  XCTAssertNotNil(details);
+}
+
 /** Validated that the details are valid. */
 - (void)testDetailsData {
   FPRSessionDetails *details = [[FPRSessionDetails alloc] initWithSessionId:@"random"


### PR DESCRIPTION
Fixes #8691

FPRSessionDetails contains the details about the current session. Whenever a trace is created, they take a copy of the session. But the session copy was not taking in the sessionStartTime which could lead to a situation where a check on the session expiration duration could cause a crash. The fix is to make sure the copy contains the same sessionStart time as the original session details object.