### PR TITLE
log_stdio.cc: add missing switch block for kLogLevelNotice

### DIFF
--- a/Firestore/core/src/util/log_stdio.cc
+++ b/Firestore/core/src/util/log_stdio.cc
@@ -56,6 +56,9 @@ void LogMessage(LogLevel log_level, const std::string& message) {
     case kLogLevelError:
       level_word = "ERROR";
       break;
+    case kLogLevelNotice:
+      level_word = "INFO";
+      break;
     default:
       UNREACHABLE();
       break;


### PR DESCRIPTION
I guess nobody tried logging messages at "info" level before 🤷 

#no-changelog