### PR TITLE
Refactor library and add WIP controller tests

### DIFF
--- a/HeartbeatLogging/Sources/AnyEncoder+AnyDecoder.swift
+++ b/HeartbeatLogging/Sources/AnyEncoder+AnyDecoder.swift
@@ -14,33 +14,31 @@
 
 import Foundation
 
-protocol Encoding {
+/// A type that can encode an `Encodable` object into `Data`.
+protocol AnyEncoder {
   func encode<T>(_ value: T) throws -> Data where T: Encodable
 }
 
-protocol Decoding {
-  func decode<T>(_ type: T.Type,
-                 from data: Data) throws -> T where T: Decodable
+/// A type that can decode `Data` into a `Decodable` object.
+protocol AnyDecoder {
+  func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable
 }
 
-typealias Coder = Encoding & Decoding
+extension JSONEncoder: AnyEncoder {}
+extension JSONDecoder: AnyDecoder {}
 
-class JSONCoder: Coder {
-  private let encoder: JSONEncoder
-  private let decoder: JSONDecoder
+// MARK: - Encodable
 
-  init(encoder: JSONEncoder = .init(),
-       decoder: JSONDecoder = .init()) {
-    self.encoder = encoder
-    self.decoder = decoder
+extension Encodable {
+  func encoded(using encoder: AnyEncoder = JSONEncoder()) throws -> Data {
+    try encoder.encode(self)
   }
+}
 
-  func encode<T>(_ value: T) throws -> Data where T: Encodable {
-    try encoder.encode(value)
-  }
+// MARK: - Data
 
-  func decode<T>(_ type: T.Type,
-                 from data: Data) throws -> T where T: Decodable {
-    try decoder.decode(type, from: data)
+extension Data {
+  func decoded<T>(using decoder: AnyDecoder = JSONDecoder()) throws -> T where T: Decodable {
+    try decoder.decode(T.self, from: self)
   }
 }

--- a/HeartbeatLogging/Sources/Heartbeat.swift
+++ b/HeartbeatLogging/Sources/Heartbeat.swift
@@ -18,7 +18,7 @@ import Foundation
 enum TimePeriod: Int, CaseIterable, Codable {
   /// The raw value is the number of calendar days within each time period.
   // TODO: Enable disabled types in future iterations.
-  case daily = 1 // , case weekly = 7, monthly = 28
+  case daily = 1 // , weekly = 7, monthly = 28
 
   /// The number of seconds in a given time period.
   var timeInterval: TimeInterval { Double(rawValue) * 86400 /* seconds in day */ }
@@ -33,9 +33,11 @@ struct Heartbeat: Codable, Equatable {
   private static let version: Int = 0
 
   /// An anonymous piece of information (i.e. user agent) to associate the heartbeat with.
-  let info: String
+  let agent: String
+
   /// The date when the heartbeat was recorded (standardized to be the start of a calendar day).
   let date: Date
+
   /// The heartbeat's model version.
   let version: Int
 
@@ -45,20 +47,20 @@ struct Heartbeat: Codable, Equatable {
   /// various time periods. Because a single heartbeat can help calculate moving averages for multiple
   /// time periods, this property serves to capture all the time periods that the heartbeat can represent in
   /// a moving average.
-  var timePeriods: [TimePeriod] = []
+  let timePeriods: [TimePeriod]
 
   /// Intializes a `Heartbeat` with given `info` and, optionally, a `date` and `version`.
   /// - Parameters:
-  ///   - info: An anonymous piece of information to associate the heartbeat with.
+  ///   - agent: An anonymous piece of information to associate the heartbeat with.
   ///   - date: The date when the heartbeat was recorded. Defaults to the current date.
   ///   - version: The heartbeat's model version. Defaults to the current model version.
-  init(info: String,
+  init(agent: String,
        date: Date = .init(),
-       version: Int = Self.version) {
-    self.info = info
-    // A heartbeat's date is a calendar day standardized at the start of day.
-    // TODO: Verify backend is using same calendar.
-    self.date = Calendar(identifier: .gregorian).startOfDay(for: date)
+       timePeriods: [TimePeriod],
+       version: Int = version) {
+    self.agent = agent
+    self.date = date
+    self.timePeriods = timePeriods
     self.version = version
   }
 }

--- a/HeartbeatLogging/Sources/HeartbeatController.swift
+++ b/HeartbeatLogging/Sources/HeartbeatController.swift
@@ -20,10 +20,10 @@ public final class HeartbeatController {
   private let storage: HeartbeatStorageProtocol
   // TODO: Document.
   private let limit: Int = 30 // TODO: Decide on default value.
-  // TODO: Document.
+  /// Current date provider. It is used instead of `Date.init` for testability.
   private let dateProvider: () -> Date
   // TODO: Verify that this standardization aligns with backend.
-  // TODO: Document.
+  /// Used for standardizing dates for calendar-day comparision.
   static let dateStandardizer = Calendar(identifier: .gregorian).startOfDay(for:)
 
   /// Public initializer.
@@ -50,11 +50,12 @@ public final class HeartbeatController {
   ///
   /// - Note: This API is thread-safe.
   ///
-  /// - Parameter info: A `String` identifier to associate a new heartbeat with.
-  public func log(_ info: String) {
-    let (agent, date, capacity) = (info, dateProvider(), limit)
+  /// - Parameter agent: A `String` identifier to associate a new heartbeat with.
+  public func log(_ agent: String) {
+    let date = dateProvider()
+    let capacity = limit
 
-    storage.async { heartbeatInfo in
+    storage.readAndWriteAsync { heartbeatInfo in
       var heartbeatInfo = heartbeatInfo ?? HeartbeatInfo(capacity: capacity)
 
       let timePeriods = heartbeatInfo.cache.filter { timePeriod, lastDate in

--- a/HeartbeatLogging/Sources/HeartbeatController.swift
+++ b/HeartbeatLogging/Sources/HeartbeatController.swift
@@ -75,7 +75,7 @@ public final class HeartbeatController {
   ///
   /// - Note: This API is thread-safe.
   ///
-  /// - Returns: The flushed heartbeats in the form of `HeartbeatInfo`.
+  /// - Returns: The flushed heartbeats in the form of `HeartbeatsPayload`.
   @discardableResult
   public func flush() -> HeartbeatsPayload {
     let capacity = limit

--- a/HeartbeatLogging/Sources/HeartbeatController.swift
+++ b/HeartbeatLogging/Sources/HeartbeatController.swift
@@ -89,6 +89,9 @@ public final class HeartbeatController {
       return HeartbeatInfo(capacity: capacity, cache: oldHeartbeatInfo.cache)
     }
 
+    // Synchronously gets and returns the stored heartbeats and resets storage
+    // using the given transform. If the operation threw an error, assume no
+    // heartbeats were retrieved/reset.
     let heartbeatInfo = try? storage.getAndReset(using: resetTransform)
 
     return HeartbeatsPayload.makePayload(heartbeatInfo: heartbeatInfo)

--- a/HeartbeatLogging/Sources/HeartbeatController.swift
+++ b/HeartbeatLogging/Sources/HeartbeatController.swift
@@ -22,6 +22,7 @@ public final class HeartbeatController {
   private let limit: Int = 30 // TODO: Decide on default value.
   // TODO: Document.
   private let dateProvider: () -> Date
+  // TODO: Verify that this standardization aligns with backend.
   // TODO: Document.
   static let dateStandardizer = Calendar(identifier: .gregorian).startOfDay(for:)
 
@@ -30,7 +31,7 @@ public final class HeartbeatController {
   /// - Parameter id: The `id` to associate this logger's internal storage with.
   public convenience init(id: String) {
     // TODO: Sanitize id.
-    let storage = HeartbeatStorage.storage(with: id)
+    let storage = HeartbeatStorage.getInstance(id: id)
     self.init(storage: storage)
   }
 

--- a/HeartbeatLogging/Sources/HeartbeatInfo.swift
+++ b/HeartbeatLogging/Sources/HeartbeatInfo.swift
@@ -53,14 +53,16 @@ struct HeartbeatInfo: Codable {
   /// <#Description#>
   /// - Parameter heartbeat: <#heartbeat description#>
   mutating func append(_ heartbeat: Heartbeat) {
-    // 1. Update buffer.
-    if let replaced = buffer.push(heartbeat) {
+    // 1. Push the heartbeat to the back of the buffer.
+    if let overwrittenHeartbeat = buffer.push(heartbeat) {
+      // If a heartbeat was overwritten, update the cache to ensure it's date
+      // is removed (if it was stored).
       cache = cache.mapValues { date in
         replaced.date == date ? .distantPast : date
       }
     }
 
-    // 2. Update cache.
+    // 2. Update cache with the new heartbeat's date.
     heartbeat.timePeriods.forEach {
       cache[$0] = heartbeat.date
     }

--- a/HeartbeatLogging/Sources/HeartbeatInfo.swift
+++ b/HeartbeatLogging/Sources/HeartbeatInfo.swift
@@ -58,7 +58,7 @@ struct HeartbeatInfo: Codable {
       // If a heartbeat was overwritten, update the cache to ensure it's date
       // is removed (if it was stored).
       cache = cache.mapValues { date in
-        replaced.date == date ? .distantPast : date
+        overwrittenHeartbeat.date == date ? .distantPast : date
       }
     }
 

--- a/HeartbeatLogging/Sources/HeartbeatPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatPayload.swift
@@ -1,0 +1,78 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A type that can be represented as an HTTP header.
+public protocol HTTPHeaderRepresentable {
+  func headerValue() -> String
+}
+
+// TODO: Add documentation.
+public struct HeartbeatsPayload: Codable, HTTPHeaderRepresentable {
+  struct UserAgentPayload: Codable {
+    let agent: String
+    let dates: [String]
+  }
+
+  let payload: [UserAgentPayload]
+  let version: Int
+
+  static let version: Int = 0
+
+  static let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "YYYY-MM-dd"
+    return formatter
+  }()
+
+  static func makePayload(heartbeatInfo: HeartbeatInfo?) -> HeartbeatsPayload {
+    guard let heartbeatInfo = heartbeatInfo else {
+      // TODO: Revisit `version` handling.
+      return HeartbeatsPayload(payload: [], version: version)
+    }
+
+    let agentsAndDates = heartbeatInfo.buffer.map { heartbeat in
+      (heartbeat.agent, [heartbeat.date])
+    }
+
+    let payload: [UserAgentPayload] = [String: [Date]]
+      .init(agentsAndDates, uniquingKeysWith: +)
+      .map { agent, dates in
+        UserAgentPayload(
+          agent: agent,
+          dates: dates.map(dateFormatter.string(from:))
+        )
+      }
+
+    // TODO: Revisit `version` handling.
+    return HeartbeatsPayload(payload: payload, version: version)
+  }
+
+  // MARK: - HTTPHeaderRepresentable
+
+  public func headerValue() -> String {
+    // TODO: Evaluate if it makes sense to return empty string when payload is empty.
+    guard !payload.isEmpty else {
+      return "" // Return empty string if `payload` value is empty.
+    }
+
+    let encodeResult = Result { try JSONCoder().encode(self) }
+
+    switch encodeResult {
+    case let .success(data): return data.base64EncodedString()
+    case .failure: return "" // Return empty string if encoding failed.
+    }
+  }
+}

--- a/HeartbeatLogging/Sources/HeartbeatPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatPayload.swift
@@ -68,7 +68,7 @@ public struct HeartbeatsPayload: Codable, HTTPHeaderRepresentable {
       return "" // Return empty string if `payload` value is empty.
     }
 
-    let encodeResult = Result { try JSONCoder().encode(self) }
+    let encodeResult = Result { try self.encoded() }
 
     switch encodeResult {
     case let .success(data): return data.base64EncodedString()

--- a/HeartbeatLogging/Sources/HeartbeatStorage.swift
+++ b/HeartbeatLogging/Sources/HeartbeatStorage.swift
@@ -17,7 +17,7 @@ import Foundation
 protocol HeartbeatStorageProtocol {
   typealias HeartbeatInfoTransform = (HeartbeatInfo?) -> HeartbeatInfo?
 
-  func async(_ transform: @escaping HeartbeatInfoTransform)
+  func readAndWriteAsync(using transform: @escaping HeartbeatInfoTransform)
   // TODO: Evaluate if async variant of below API is needed.
   func getAndReset(using transform: HeartbeatInfoTransform?) throws -> HeartbeatInfo?
 }
@@ -46,7 +46,7 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
   // MARK: - Instance Management
 
   /// <#Description#>
-  private(set) static var cachedInstances: [String: Weak<HeartbeatStorage>] = [:]
+  private(set) static var cachedInstances: [String: WeakContainer<HeartbeatStorage>] = [:]
 
   /// <#Description#>
   /// - Parameter id: <#id description#>
@@ -56,7 +56,7 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
       return cachedInstance
     } else {
       let newInstance = HeartbeatStorage.makeStorage(id: id)
-      cachedInstances[id] = Weak(object: newInstance)
+      cachedInstances[id] = WeakContainer(object: newInstance)
       return newInstance
     }
   }
@@ -68,7 +68,7 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
 
   // MARK: - HeartbeatStorageProtocol
 
-  func async(_ transform: @escaping HeartbeatInfoTransform) {
+  func readAndWriteAsync(using transform: @escaping HeartbeatInfoTransform) {
     queue.async { [self] in
       let oldHeartbeatInfo = try? load(from: storage)
       let newHeartbeatInfo = transform(oldHeartbeatInfo)

--- a/HeartbeatLogging/Sources/HeartbeatStorage.swift
+++ b/HeartbeatLogging/Sources/HeartbeatStorage.swift
@@ -28,17 +28,21 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
   private let id: String
   // The underlying storage container to read from and write to.
   private let storage: Storage
-  // An object used to encode and decode Codable heartbeat data.
-  private let coder: Coder
+  /// <#Description#>
+  private let encoder: AnyEncoder
+  /// <#Description#>
+  private let decoder: AnyDecoder
   // The queue for synchronizing storage operations.
   private let queue: DispatchQueue
 
   init(id: String,
        storage: Storage,
-       coder: Coder = JSONCoder()) {
+       encoder: AnyEncoder = JSONEncoder(),
+       decoder: AnyDecoder = JSONDecoder()) {
     self.id = id
     self.storage = storage
-    self.coder = coder
+    self.encoder = encoder
+    self.decoder = decoder
     queue = DispatchQueue(label: "com.heartbeat.storage.\(id)")
   }
 
@@ -88,13 +92,13 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
 
   private func load(from storage: Storage) throws -> HeartbeatInfo {
     let data = try storage.read()
-    let heartbeatData = try coder.decode(HeartbeatInfo.self, from: data)
+    let heartbeatData = try data.decoded(using: decoder) as HeartbeatInfo
     return heartbeatData
   }
 
   private func save(_ value: HeartbeatInfo?, to storage: Storage) throws {
     if let value = value {
-      let data = try coder.encode(value)
+      let data = try value.encoded(using: encoder)
       try storage.write(data)
     } else {
       try storage.write(nil)

--- a/HeartbeatLogging/Sources/HeartbeatStorage.swift
+++ b/HeartbeatLogging/Sources/HeartbeatStorage.swift
@@ -24,13 +24,13 @@ protocol HeartbeatStorageProtocol {
 
 /// Thread-safe storage object designed for storing heartbeat data.
 final class HeartbeatStorage: HeartbeatStorageProtocol {
-  // TODO: Document.
+  // The identifier used to differentiate instances.
   private let id: String
-  // TODO: Document.
+  // The underlying storage container to read from and write to.
   private let storage: Storage
-  // TODO: Add documentation.
+  // An object used to encode and decode Codable heartbeat data.
   private let coder: Coder
-  // TODO: Document.
+  // The queue for synchronizing storage operations.
   private let queue: DispatchQueue
 
   init(id: String,
@@ -43,15 +43,17 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
     self.queue = queue ?? DispatchQueue(label: "com.heartbeat.storage.\(id)")
   }
 
-  // TODO: Document.
-  static var cachedInstances: [String: Weak<HeartbeatStorage>] = [:]
+  // MARK: - Instance Management
 
-  // TODO: Add tests for insatnce management.
+  // TODO: Add tests for instance management.
+
+  /// <#Description#>
+  static var cachedInstances: [String: Weak<HeartbeatStorage>] = [:]
 
   /// <#Description#>
   /// - Parameter id: <#id description#>
   /// - Returns: <#description#>
-  static func storage(with id: String) -> HeartbeatStorage {
+  static func getInstance(id: String) -> HeartbeatStorage {
     if let cachedInstance = cachedInstances[id]?.object {
       return cachedInstance
     } else {

--- a/HeartbeatLogging/Sources/HeartbeatStorage.swift
+++ b/HeartbeatLogging/Sources/HeartbeatStorage.swift
@@ -45,10 +45,8 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
 
   // MARK: - Instance Management
 
-  // TODO: Add tests for instance management.
-
   /// <#Description#>
-  static var cachedInstances: [String: Weak<HeartbeatStorage>] = [:]
+  private(set) static var cachedInstances: [String: Weak<HeartbeatStorage>] = [:]
 
   /// <#Description#>
   /// - Parameter id: <#id description#>
@@ -57,7 +55,9 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
     if let cachedInstance = cachedInstances[id]?.object {
       return cachedInstance
     } else {
-      return HeartbeatStorage.makeStorage(id: id)
+      let newInstance = HeartbeatStorage.makeStorage(id: id)
+      cachedInstances[id] = Weak(object: newInstance)
+      return newInstance
     }
   }
 

--- a/HeartbeatLogging/Sources/HeartbeatStorage.swift
+++ b/HeartbeatLogging/Sources/HeartbeatStorage.swift
@@ -14,9 +14,9 @@
 
 import Foundation
 
-protocol HeartbeatStorageProtocol {
-  typealias HeartbeatInfoTransform = (HeartbeatInfo?) -> HeartbeatInfo?
+typealias HeartbeatInfoTransform = (HeartbeatInfo?) -> HeartbeatInfo?
 
+protocol HeartbeatStorageProtocol {
   func readAndWriteAsync(using transform: @escaping HeartbeatInfoTransform)
   // TODO: Evaluate if async variant of below API is needed.
   func getAndReset(using transform: HeartbeatInfoTransform?) throws -> HeartbeatInfo?
@@ -35,18 +35,17 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
 
   init(id: String,
        storage: Storage,
-       coder: Coder = JSONCoder(),
-       queue: DispatchQueue? = nil) {
+       coder: Coder = JSONCoder()) {
     self.id = id
     self.storage = storage
     self.coder = coder
-    self.queue = queue ?? DispatchQueue(label: "com.heartbeat.storage.\(id)")
+    queue = DispatchQueue(label: "com.heartbeat.storage.\(id)")
   }
 
   // MARK: - Instance Management
 
   /// <#Description#>
-  private(set) static var cachedInstances: [String: WeakContainer<HeartbeatStorage>] = [:]
+  private static var cachedInstances: [String: WeakContainer<HeartbeatStorage>] = [:]
 
   /// <#Description#>
   /// - Parameter id: <#id description#>

--- a/HeartbeatLogging/Sources/Storage.swift
+++ b/HeartbeatLogging/Sources/Storage.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-protocol PersistentStorage {
+protocol Storage {
   func read() throws -> Data
   func write(_ value: Data?) throws
 }
@@ -26,7 +26,7 @@ enum StorageError: Error {
 
 // MARK: - FileStorage
 
-class FileStorage {
+final class FileStorage: Storage {
   private let url: URL
   private let fileManager: FileManager
 
@@ -36,20 +36,6 @@ class FileStorage {
     self.fileManager = fileManager
   }
 
-  private func createDirectories(in url: URL) throws {
-    do {
-      try fileManager.createDirectory(
-        at: url,
-        withIntermediateDirectories: true,
-        attributes: nil
-      )
-    } catch CocoaError.fileWriteFileExists {
-      // Directory already exists.
-    } catch { throw error }
-  }
-}
-
-extension FileStorage: PersistentStorage {
   func read() throws -> Data {
     do {
       return try Data(contentsOf: url)
@@ -70,11 +56,23 @@ extension FileStorage: PersistentStorage {
       throw StorageError.writeError
     }
   }
+
+  private func createDirectories(in url: URL) throws {
+    do {
+      try fileManager.createDirectory(
+        at: url,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+    } catch CocoaError.fileWriteFileExists {
+      // Directory already exists.
+    } catch { throw error }
+  }
 }
 
 // MARK: - UserDefaultsStorage
 
-class UserDefaultsStorage {
+final class UserDefaultsStorage: Storage {
   private let defaults: UserDefaults
   private let key: String
 
@@ -83,9 +81,7 @@ class UserDefaultsStorage {
     self.defaults = defaults ?? .standard
     self.key = key
   }
-}
 
-extension UserDefaultsStorage: PersistentStorage {
   func read() throws -> Data {
     if let data = defaults.data(forKey: key) {
       return data

--- a/HeartbeatLogging/Sources/StorageFactory.swift
+++ b/HeartbeatLogging/Sources/StorageFactory.swift
@@ -14,36 +14,15 @@
 
 import Foundation
 
-/// A factory type for `PersistentStorage`.
-protocol PersistentStorageFactory {
-  static func makeStorage(id: String) -> PersistentStorage
+/// A factory type for `Storage`.
+protocol StorageFactory {
+  static func makeStorage(id: String) -> Self
 }
 
-// TODO: - Implement synchronization strategy for storage with same ID.
+// MARK: - FileStorage + StorageFactory
 
-/// A `PersistentStorage` factory.
-enum StorageFactory: PersistentStorageFactory {
-  /// Makes a `PersistentStorage` instance using a given `String` identifier.
-  ///
-  /// The created persistent storage object is platform dependent. For tvOS, user defaults
-  /// is used as the underlying storage container due to system storage limits. For all other platforms,
-  /// the file system is used.
-  ///
-  /// - Parameter id: A `String` identifier used to create the `PersistentStorage`.
-  /// - Returns: A `PersistentStorage` instance.
-  static func makeStorage(id: String) -> PersistentStorage {
-    #if os(tvOS)
-      UserDefaultsStorage.makeStorage(id: id)
-    #else
-      FileStorage.makeStorage(id: id)
-    #endif // os(tvOS)
-  }
-}
-
-// MARK: - FileStorage + PersistentStorageFactory
-
-extension FileStorage: PersistentStorageFactory {
-  static func makeStorage(id: String) -> PersistentStorage {
+extension FileStorage: StorageFactory {
+  static func makeStorage(id: String) -> FileStorage {
     let rootDirectory = FileManager.default.applicationSupportDirectory
     let storagePath = "google-heartbeat-storage/heartbeats-\(id)"
     let storageURL = rootDirectory
@@ -53,10 +32,10 @@ extension FileStorage: PersistentStorageFactory {
   }
 }
 
-// MARK: - UserDefaultsStorage + PersistentStorageFactory
+// MARK: - UserDefaultsStorage + StorageFactory
 
-extension UserDefaultsStorage: PersistentStorageFactory {
-  static func makeStorage(id: String) -> PersistentStorage {
+extension UserDefaultsStorage: StorageFactory {
+  static func makeStorage(id: String) -> UserDefaultsStorage {
     let suiteName = "com.google.heartbeat.storage"
     let defaults = UserDefaults(suiteName: suiteName)
     return UserDefaultsStorage(defaults: defaults, key: "heartbeats-\(id)")

--- a/HeartbeatLogging/Sources/Weak.swift
+++ b/HeartbeatLogging/Sources/Weak.swift
@@ -17,6 +17,6 @@ import Foundation
 // TODO: Document.
 
 /// <#Description#>
-struct Weak<Object: AnyObject> {
+struct WeakContainer<Object: AnyObject> {
   weak var object: Object?
 }

--- a/HeartbeatLogging/Sources/Weak.swift
+++ b/HeartbeatLogging/Sources/Weak.swift
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// TODO: Document.
+
+/// <#Description#>
+struct Weak<Object: AnyObject> {
+  weak var object: Object?
+}

--- a/HeartbeatLogging/Sources/WeakContainer.swift
+++ b/HeartbeatLogging/Sources/WeakContainer.swift
@@ -14,9 +14,7 @@
 
 import Foundation
 
-// TODO: Document.
-
-/// <#Description#>
+/// Used to weakly box reference types.
 struct WeakContainer<Object: AnyObject> {
   weak var object: Object?
 }

--- a/HeartbeatLogging/Tests/Unit/HeartbeatControllerTests.swift
+++ b/HeartbeatLogging/Tests/Unit/HeartbeatControllerTests.swift
@@ -15,45 +15,269 @@
 import XCTest
 @testable import HeartbeatLogging
 
-// TODO: Add additional validation (#8896 comments).
-
 class HeartbeatControllerTests: XCTestCase {
+  // 2021-11-01 @ 00:00:00 (EST)
+  let date = Date(timeIntervalSince1970: 1_635_739_200)
+
   func testFlushWhenEmpty() throws {
     // Given
     let controller = HeartbeatController(storage: HeartbeatStorageFake())
-    // When
-    let flushed = controller.flush()
     // Then
-    XCTAssertNil(flushed)
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
   }
 
-  func testLogThenFlush() throws {
+  func testLogAndFlush() throws {
     // Given
-    let controller = HeartbeatController(storage: HeartbeatStorageFake())
-    XCTAssertNil(controller.flush())
+    let clock = SystemClock(date: date)
+
+    let controller = HeartbeatController(
+      storage: HeartbeatStorageFake(),
+      dateProvider: { clock.date }
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+
     // When
-    controller.log(#function)
+    controller.log("dummy_agent")
+    let heartbeatPayload = controller.flush()
+
     // Then
-    XCTAssertNotNil(controller.flush())
-    XCTAssertNil(controller.flush())
+    assertEqualPayloadStrings(
+      heartbeatPayload.headerValue(),
+      """
+      {
+        "version": 0,
+        "payload": [
+          {
+            "agent": "dummy_agent",
+            "dates": ["2021-11-01"]
+          }
+        ]
+      }
+      """
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
   }
+
+  func testLoggingDifferentAgentsInSameTimePeriodOnlyStoresTheFirst() throws {
+    // Given
+    let clock = SystemClock(date: date)
+
+    let controller = HeartbeatController(
+      storage: HeartbeatStorageFake(),
+      dateProvider: { clock.date }
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+
+    // When
+    controller.log("dummy_agent")
+    controller.log("some_other_dummy_agent")
+    let heartbeatPayload = controller.flush()
+
+    // Then
+    assertEqualPayloadStrings(
+      heartbeatPayload.headerValue(),
+      """
+      {
+        "version": 0,
+        "payload": [
+          {
+            "agent": "dummy_agent",
+            "dates": ["2021-11-01"]
+          }
+        ]
+      }
+      """
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+  }
+
+  func testLogAtEndOfTimePeriodAndAcceptAtStartOfNextOne() throws {
+    // Given
+    let clock = SystemClock(date: date)
+
+    let controller = HeartbeatController(
+      storage: HeartbeatStorageFake(),
+      dateProvider: { clock.date }
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+
+    // When
+    // - Clock time 2021-11-01 @ 00:00:00 (EST)
+    controller.log("dummy_agent")
+
+    // - Advance to 2021-11-01 @ 23:59:59 (EST)
+    do { clock.advance(by: 60 * 60 * 24 - 1) }
+
+    controller.log("dummy_agent")
+
+    // - Advance to 2021-11-02 @ 00:00:00 (EST)
+    do { clock.advance(by: 1) }
+
+    controller.log("dummy_agent")
+
+    // Then
+    let heartbeatPayload = controller.flush()
+
+    assertEqualPayloadStrings(
+      heartbeatPayload.headerValue(),
+      """
+      {
+        "version": 0,
+        "payload": [
+          {
+            "agent": "dummy_agent",
+            "dates": ["2021-11-01", "2021-11-02"]
+          }
+        ]
+      }
+      """
+    )
+
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+  }
+
+  func testDoNotLogDuplicate() throws {
+    // Given
+    let clock = SystemClock(date: date)
+
+    let controller = HeartbeatController(
+      storage: HeartbeatStorageFake(),
+      dateProvider: { clock.date }
+    )
+
+    // When
+    controller.log("dummy_agent")
+    controller.log("dummy_agent")
+
+    // Then
+    let heartbeatPayload = controller.flush()
+
+    assertEqualPayloadStrings(
+      heartbeatPayload.headerValue(),
+      """
+      {
+        "version": 0,
+        "payload": [
+          {
+            "agent": "dummy_agent",
+            "dates": ["2021-11-01"]
+          }
+        ]
+      }
+      """
+    )
+  }
+
+  func testDoNotLogDuplicateAfterFlushing() throws {
+    // Given
+    let clock = SystemClock(date: date)
+
+    let controller = HeartbeatController(
+      storage: HeartbeatStorageFake(),
+      dateProvider: { clock.date }
+    )
+
+    // When
+    controller.log("dummy_agent")
+    let heartbeatPayload = controller.flush()
+    controller.log("dummy_agent")
+
+    // Then
+    assertEqualPayloadStrings(
+      heartbeatPayload.headerValue(),
+      """
+      {
+        "version": 0,
+        "payload": [
+          {
+            "agent": "dummy_agent",
+            "dates": ["2021-11-01"]
+          }
+        ]
+      }
+      """
+    )
+
+    // Below assertion asserts that duplicate was not logged again.
+    assertHeartbeatControllerFlushesEmptyPayload(controller)
+  }
+}
+
+func assertHeartbeatControllerFlushesEmptyPayload(_ controller: HeartbeatController) {
+  XCTAssertEqual(controller.flush().headerValue(), "")
 }
 
 // MARK: - Fakes
 
-private extension HeartbeatControllerTests {
+extension HeartbeatControllerTests {
   class HeartbeatStorageFake: HeartbeatStorageProtocol {
     private var heartbeatInfo: HeartbeatInfo?
 
-    func offer(_ heartbeat: Heartbeat) {
-      heartbeatInfo = HeartbeatInfo(capacity: 1)
-      heartbeatInfo!.offer(heartbeat)
+    func async(_ transform: @escaping HeartbeatInfoTransform) {
+      heartbeatInfo = transform(heartbeatInfo)
     }
 
-    func flush() -> HeartbeatInfo? {
-      let flushed = heartbeatInfo
-      heartbeatInfo = nil
-      return flushed
+    func getAndReset(using transform: HeartbeatInfoTransform?) throws -> HeartbeatInfo? {
+      let oldHeartbeatInfo = heartbeatInfo
+      heartbeatInfo = transform?(heartbeatInfo)
+      return oldHeartbeatInfo
     }
+  }
+
+  /// Simulates the device system time.
+  class SystemClock {
+    private(set) var date: Date
+
+    init(date: Date = .init()) {
+      self.date = date
+    }
+
+    func advance(by timeInterval: TimeInterval) {
+      date = date.advanced(by: timeInterval)
+    }
+
+    var formattedDate: String {
+      HeartbeatsPayload.dateFormatter.string(from: date)
+    }
+  }
+
+  // TODO: - Revisit below assertion implementation.
+  // This can be simplified further by making HeartbeatsPayload conform to Equatable...
+  func assertEqualPayloadStrings(_ encoded: String, _ literal: String) {
+    let encodedData = Data(base64Encoded: encoded)!
+    let literalData = literal.data(using: .utf8)!
+
+    let payloadFromEncoded = try! JSONDecoder().decode(HeartbeatsPayload.self, from: encodedData)
+    let payloadFromLiteral = try! JSONDecoder().decode(HeartbeatsPayload.self, from: literalData)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+
+    let payloadDataFromEncoded = try! encoder.encode(payloadFromEncoded)
+    let payloadDataFromLiteral = try! encoder.encode(payloadFromLiteral)
+
+    let jsonObjectFromEncoded = try! JSONSerialization
+      .jsonObject(with: payloadDataFromEncoded) as? [String: Any] ?? [:]
+    let jsonObjectFromLiteral = try! JSONSerialization
+      .jsonObject(with: payloadDataFromLiteral) as? [String: Any] ?? [:]
+
+    XCTAssert(
+      NSDictionary(dictionary: jsonObjectFromEncoded).isEqual(to: jsonObjectFromLiteral),
+      """
+      Mismatched payloads!
+
+      Payload 1:
+      \(String(data: payloadDataFromEncoded, encoding: .utf8) ?? "")
+
+      Payload 2:
+      \(String(data: payloadDataFromLiteral, encoding: .utf8) ?? "")
+
+      """
+    )
   }
 }

--- a/HeartbeatLogging/Tests/Unit/HeartbeatStorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/HeartbeatStorageTests.swift
@@ -39,7 +39,8 @@ class HeartbeatStorageTests: XCTestCase {
     )
 
     addTeardownBlock {
-      // Ass
+      // Assert that deallocated `HeartbeatStorage` is removed
+      // from cached instances.
       XCTAssertEqual(HeartbeatStorage.cachedInstances, [:])
     }
   }


### PR DESCRIPTION
Refactored library to improve testability and clarity.

Key Changes:
- All of the heartbeat logging logic (whether or not to log) is now in `HeartbeatController`
- Moved `HeartbeatInfo`'s visibility to internal and decoupled it's internal dependencies.
    -  Motivation: `HeartbeatInfo` represents stored heartbeats. Its structure is optimized for storage requirements (limit on write) and differs significantly from the structure the heartbeats will be in when they are sent.
- Added a new public model called `HeartbeatsPayload` 
   - Allows type safe encoding into header string.
- Added instance management system to `HeartbeatStorage` (tests for `HeartbeatStorage` are a WIP)
  -  Motivation: Multiple instances of `HeartbeatStorage` with the same identifier should share the same instance.