### PR TITLE
Port Functions integration tests to Swift

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -47,6 +47,12 @@ jobs:
       run: scripts/setup_spm_tests.sh
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFunctions iOS spmbuildonly
+    - name: Integration Test Server
+      run: FirebaseFunctions/Backend/start.sh synchronous
+    - name: iOS Swift Integration Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FunctionsSwiftIntegration iOS spm
+    - name: iOS Objective C Integration Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FunctionsIntegration iOS spm
     - name: Combine Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FunctionsCombineUnit iOS spm
 

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -25,6 +25,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
+    - name: Functions Integration Test Server
+      run: FirebaseFunctions/Backend/start.sh synchronous
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 

--- a/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
@@ -19,24 +19,29 @@ import FirebaseFunctionsTestingSupport
 import XCTest
 
 class IntegrationTests: XCTestCase {
-  let functions = FunctionsFake.init(projectID: "functions-integration-test", region: "us-central1", customDomain: nil, withToken: nil)
+  let functions = FunctionsFake(
+    projectID: "functions-integration-test",
+    region: "us-central1",
+    customDomain: nil,
+    withToken: nil
+  )
   let projectID = "functions-swift-integration-test"
-  
+
   override func setUp() {
     super.setUp()
     functions.useLocalhost()
   }
-  
+
   func testData() {
     let expectation = self.expectation(description: #function)
     let data = [
-      "bool" : true,
-      "int" : 2 as Int32,
-      "long" : 9876543210,
-      "string" : "four",
-      "array" : [5 as Int32, 6 as Int32],
-      "null" : nil
-    ] as [String : Any?]
+      "bool": true,
+      "int": 2 as Int32,
+      "long": 9_876_543_210,
+      "string": "four",
+      "array": [5 as Int32, 6 as Int32],
+      "null": nil,
+    ] as [String: Any?]
     let function = functions.httpsCallable("dataTest")
     XCTAssertNotNil(function)
     function.call(data) { result, error in
@@ -56,7 +61,7 @@ class IntegrationTests: XCTestCase {
     }
     waitForExpectations(timeout: 1)
   }
-  
+
   func testScalar() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("scalarTest")
@@ -73,12 +78,17 @@ class IntegrationTests: XCTestCase {
     }
     waitForExpectations(timeout: 1)
   }
-  
+
   func testToken() {
     // Recreate _functions with a token.
-    let functions = FunctionsFake.init(projectID: "functions-integration-test", region: "us-central1", customDomain: nil, withToken: "token")
+    let functions = FunctionsFake(
+      projectID: "functions-integration-test",
+      region: "us-central1",
+      customDomain: nil,
+      withToken: "token"
+    )
     functions.useLocalhost()
-    
+
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("FCMTokenTest")
     XCTAssertNotNil(function)
@@ -94,7 +104,7 @@ class IntegrationTests: XCTestCase {
     }
     waitForExpectations(timeout: 1)
   }
-  
+
   func testFCMToken() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("FCMTokenTest")
@@ -111,7 +121,7 @@ class IntegrationTests: XCTestCase {
     }
     waitForExpectations(timeout: 1)
   }
-  
+
   func testNull() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("nullTest")
@@ -120,7 +130,7 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNil(error)
         let data = try XCTUnwrap(result?.data) as? NSNull
-        XCTAssertEqual(data, NSNull.init())
+        XCTAssertEqual(data, NSNull())
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -128,7 +138,7 @@ class IntegrationTests: XCTestCase {
     }
     waitForExpectations(timeout: 1)
   }
-  
+
   func testMissingResult() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("missingResultTest")
@@ -137,8 +147,8 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
-        XCTAssertEqual("Response is missing data field.", error.localizedDescription);
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("Response is missing data field.", error.localizedDescription)
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -156,8 +166,8 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
-        XCTAssertEqual("INTERNAL", error.localizedDescription);
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("INTERNAL", error.localizedDescription)
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -166,7 +176,7 @@ class IntegrationTests: XCTestCase {
     XCTAssert(true)
     waitForExpectations(timeout: 1)
   }
-  
+
   func testUnknownError() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("unknownErrorTest")
@@ -175,8 +185,8 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
-        XCTAssertEqual("INTERNAL", error.localizedDescription);
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("INTERNAL", error.localizedDescription)
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -185,7 +195,7 @@ class IntegrationTests: XCTestCase {
     XCTAssert(true)
     waitForExpectations(timeout: 1)
   }
-  
+
   func testExplicitError() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("explicitErrorTest")
@@ -194,10 +204,10 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code);
-        XCTAssertEqual("explicit nope", error.localizedDescription);
-        XCTAssertEqual(["start": 10 as Int32, "end":20 as Int32, "long": 30],
-                       error.userInfo[FunctionsErrorDetailsKey] as! [String : Int32])
+        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
+        XCTAssertEqual("explicit nope", error.localizedDescription)
+        XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
+                       error.userInfo[FunctionsErrorDetailsKey] as! [String: Int32])
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -206,7 +216,7 @@ class IntegrationTests: XCTestCase {
     XCTAssert(true)
     waitForExpectations(timeout: 1)
   }
-  
+
   func testHttpError() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("httpErrorTest")
@@ -215,7 +225,7 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code);
+        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
         expectation.fulfill()
       } catch {
         XCTAssert(false, "Failed to unwrap the function result")
@@ -224,7 +234,7 @@ class IntegrationTests: XCTestCase {
     XCTAssert(true)
     waitForExpectations(timeout: 1)
   }
-  
+
   func testTimeout() {
     let expectation = self.expectation(description: #function)
     let function = functions.httpsCallable("timeoutTest")
@@ -234,8 +244,8 @@ class IntegrationTests: XCTestCase {
       do {
         XCTAssertNotNil(error)
         let error = try XCTUnwrap(error! as NSError)
-        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code);
-        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription);
+        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
+        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
         XCTAssertNil(error.userInfo[FunctionsErrorDetailsKey])
         expectation.fulfill()
       } catch {

--- a/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
@@ -18,6 +18,12 @@ import FirebaseFunctions
 import FirebaseFunctionsTestingSupport
 import XCTest
 
+/// This file was intitialized as a direct port of the Objective C
+/// FirebaseFunctions/Tests/Integration/FIRIntegrationTests.m
+///
+/// The tests require the emulator to be running with `FirebaseFunctions/Backend/start.sh synchronous`
+/// The Firebase Functions called in the tests are implemented in `FirebaseFunctions/Backend/index.js`.
+
 class IntegrationTests: XCTestCase {
   let functions = FunctionsFake(
     projectID: "functions-integration-test",
@@ -33,7 +39,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testData() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let data = [
       "bool": true,
       "int": 2 as Int32,
@@ -56,14 +62,14 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(code, 42)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     waitForExpectations(timeout: 1)
   }
 
   func testScalar() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("scalarTest")
     XCTAssertNotNil(function)
     function.call(17 as Int16) { result, error in
@@ -73,7 +79,7 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, 76)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     waitForExpectations(timeout: 1)
@@ -89,7 +95,7 @@ class IntegrationTests: XCTestCase {
     )
     functions.useLocalhost()
 
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("FCMTokenTest")
     XCTAssertNotNil(function)
     function.call([:]) { result, error in
@@ -99,14 +105,14 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, [:])
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     waitForExpectations(timeout: 1)
   }
 
   func testFCMToken() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("FCMTokenTest")
     XCTAssertNotNil(function)
     function.call([:]) { result, error in
@@ -116,14 +122,14 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, [:])
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     waitForExpectations(timeout: 1)
   }
 
   func testNull() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("nullTest")
     XCTAssertNotNil(function)
     function.call(nil) { result, error in
@@ -133,25 +139,25 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, NSNull())
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     waitForExpectations(timeout: 1)
   }
 
   func testMissingResult() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("missingResultTest")
     XCTAssertNotNil(function)
     function.call(nil) { result, error in
       do {
         XCTAssertNotNil(error)
-        let error = try XCTUnwrap(error! as NSError)
+        let error = try XCTUnwrap(error) as NSError
         XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
         XCTAssertEqual("Response is missing data field.", error.localizedDescription)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)
@@ -159,7 +165,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testUnhandledError() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("unhandledErrorTest")
     XCTAssertNotNil(function)
     function.call([]) { result, error in
@@ -170,7 +176,7 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual("INTERNAL", error.localizedDescription)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)
@@ -178,7 +184,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testUnknownError() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("unknownErrorTest")
     XCTAssertNotNil(function)
     function.call([]) { result, error in
@@ -189,7 +195,7 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual("INTERNAL", error.localizedDescription)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)
@@ -197,7 +203,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testExplicitError() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("explicitErrorTest")
     XCTAssertNotNil(function)
     function.call([]) { result, error in
@@ -210,7 +216,7 @@ class IntegrationTests: XCTestCase {
                        error.userInfo[FunctionsErrorDetailsKey] as! [String: Int32])
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)
@@ -218,7 +224,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testHttpError() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("httpErrorTest")
     XCTAssertNotNil(function)
     function.call([]) { result, error in
@@ -228,7 +234,7 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)
@@ -236,7 +242,7 @@ class IntegrationTests: XCTestCase {
   }
 
   func testTimeout() {
-    let expectation = self.expectation(description: #function)
+    let expectation = expectation(description: #function)
     let function = functions.httpsCallable("timeoutTest")
     XCTAssertNotNil(function)
     function.timeoutInterval = 0.05
@@ -249,7 +255,7 @@ class IntegrationTests: XCTestCase {
         XCTAssertNil(error.userInfo[FunctionsErrorDetailsKey])
         expectation.fulfill()
       } catch {
-        XCTAssert(false, "Failed to unwrap the function result")
+        XCTAssert(false, "Failed to unwrap the function result: \(error)")
       }
     }
     XCTAssert(true)

--- a/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/SwiftIntegration/IntegrationTests.swift
@@ -1,0 +1,248 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import FirebaseFunctions
+import FirebaseFunctionsTestingSupport
+import XCTest
+
+class IntegrationTests: XCTestCase {
+  let functions = FunctionsFake.init(projectID: "functions-integration-test", region: "us-central1", customDomain: nil, withToken: nil)
+  let projectID = "functions-swift-integration-test"
+  
+  override func setUp() {
+    super.setUp()
+    functions.useLocalhost()
+  }
+  
+  func testData() {
+    let expectation = self.expectation(description: #function)
+    let data = [
+      "bool" : true,
+      "int" : 2 as Int32,
+      "long" : 9876543210,
+      "string" : "four",
+      "array" : [5 as Int32, 6 as Int32],
+      "null" : nil
+    ] as [String : Any?]
+    let function = functions.httpsCallable("dataTest")
+    XCTAssertNotNil(function)
+    function.call(data) { result, error in
+      do {
+        XCTAssertNil(error)
+        let data = try XCTUnwrap(result?.data as? [String: Any])
+        let message = try XCTUnwrap(data["message"] as? String)
+        let long = try XCTUnwrap(data["long"] as? Int64)
+        let code = try XCTUnwrap(data["code"] as? Int32)
+        XCTAssertEqual(message, "stub response")
+        XCTAssertEqual(long, 420)
+        XCTAssertEqual(code, 42)
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testScalar() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("scalarTest")
+    XCTAssertNotNil(function)
+    function.call(17 as Int16) { result, error in
+      do {
+        XCTAssertNil(error)
+        let data = try XCTUnwrap(result?.data as? Int)
+        XCTAssertEqual(data, 76)
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testToken() {
+    // Recreate _functions with a token.
+    let functions = FunctionsFake.init(projectID: "functions-integration-test", region: "us-central1", customDomain: nil, withToken: "token")
+    functions.useLocalhost()
+    
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("FCMTokenTest")
+    XCTAssertNotNil(function)
+    function.call([:]) { result, error in
+      do {
+        XCTAssertNil(error)
+        let data = try XCTUnwrap(result?.data) as? [String: Int]
+        XCTAssertEqual(data, [:])
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testFCMToken() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("FCMTokenTest")
+    XCTAssertNotNil(function)
+    function.call([:]) { result, error in
+      do {
+        XCTAssertNil(error)
+        let data = try XCTUnwrap(result?.data) as? [String: Int]
+        XCTAssertEqual(data, [:])
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testNull() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("nullTest")
+    XCTAssertNotNil(function)
+    function.call(nil) { result, error in
+      do {
+        XCTAssertNil(error)
+        let data = try XCTUnwrap(result?.data) as? NSNull
+        XCTAssertEqual(data, NSNull.init())
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testMissingResult() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("missingResultTest")
+    XCTAssertNotNil(function)
+    function.call(nil) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
+        XCTAssertEqual("Response is missing data field.", error.localizedDescription);
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+
+  func testUnhandledError() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("unhandledErrorTest")
+    XCTAssertNotNil(function)
+    function.call([]) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
+        XCTAssertEqual("INTERNAL", error.localizedDescription);
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testUnknownError() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("unknownErrorTest")
+    XCTAssertNotNil(function)
+    function.call([]) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code);
+        XCTAssertEqual("INTERNAL", error.localizedDescription);
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testExplicitError() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("explicitErrorTest")
+    XCTAssertNotNil(function)
+    function.call([]) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code);
+        XCTAssertEqual("explicit nope", error.localizedDescription);
+        XCTAssertEqual(["start": 10 as Int32, "end":20 as Int32, "long": 30],
+                       error.userInfo[FunctionsErrorDetailsKey] as! [String : Int32])
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testHttpError() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("httpErrorTest")
+    XCTAssertNotNil(function)
+    function.call([]) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code);
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+  
+  func testTimeout() {
+    let expectation = self.expectation(description: #function)
+    let function = functions.httpsCallable("timeoutTest")
+    XCTAssertNotNil(function)
+    function.timeoutInterval = 0.05
+    function.call([]) { result, error in
+      do {
+        XCTAssertNotNil(error)
+        let error = try XCTUnwrap(error! as NSError)
+        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code);
+        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription);
+        XCTAssertNil(error.userInfo[FunctionsErrorDetailsKey])
+        expectation.fulfill()
+      } catch {
+        XCTAssert(false, "Failed to unwrap the function result")
+      }
+    }
+    XCTAssert(true)
+    waitForExpectations(timeout: 1)
+  }
+}

--- a/FirebaseTestingSupport/Functions/Sources/FIRFunctionsFake.m
+++ b/FirebaseTestingSupport/Functions/Sources/FIRFunctionsFake.m
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebaseTestingSupport/Functions/Sources/Public/FirebaseFunctionsTestingSupport/FIRFunctionsFake.h"
+#import "FirebaseTestingSupport/Functions/Sources/Public/FirebaseFunctionsTestingSupport/FIRFunctions+Testing.h"
+#import "SharedTestUtilities/FIRAuthInteropFake.h"
+#import "SharedTestUtilities/FIRMessagingInteropFake.h"
+
+@implementation FIRFunctionsFake
+
+- (instancetype)initWithProjectID:(NSString *)projectID
+                           region:(NSString *)region
+                     customDomain:(nullable NSString *)customDomain
+                        withToken:(nullable NSString *)token {
+  return [super initWithProjectID:projectID
+                           region:region
+                     customDomain:customDomain
+                             auth:[[FIRAuthInteropFake alloc] initWithToken:token userID:nil error:nil]
+                        messaging:[[FIRMessagingInteropFake alloc] init]
+                         appCheck:nil];
+}
+
+@end

--- a/FirebaseTestingSupport/Functions/Sources/FIRFunctionsFake.m
+++ b/FirebaseTestingSupport/Functions/Sources/FIRFunctionsFake.m
@@ -26,7 +26,9 @@
   return [super initWithProjectID:projectID
                            region:region
                      customDomain:customDomain
-                             auth:[[FIRAuthInteropFake alloc] initWithToken:token userID:nil error:nil]
+                             auth:[[FIRAuthInteropFake alloc] initWithToken:token
+                                                                     userID:nil
+                                                                      error:nil]
                         messaging:[[FIRMessagingInteropFake alloc] init]
                          appCheck:nil];
 }

--- a/FirebaseTestingSupport/Functions/Sources/Public/FirebaseFunctionsTestingSupport/FIRFunctionsFake.h
+++ b/FirebaseTestingSupport/Functions/Sources/Public/FirebaseFunctionsTestingSupport/FIRFunctionsFake.h
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import <FirebaseFunctions/FIRFunctions.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A functions object with fake tokens.
+NS_SWIFT_NAME(FunctionsFake)
+@interface FIRFunctionsFake : FIRFunctions
+
+/**
+ * Internal initializer for testing a Cloud Functions client with fakes.
+ * @param projectID The project ID for the Firebase project.
+ * @param region The region for the http trigger, such as "us-central1".
+ * @param customDomain A custom domain for the http trigger, such as "https://mydomain.com".
+ * @param token A token to use for validation (optional).
+ */
+- (instancetype)initWithProjectID:(NSString *)projectID
+                           region:(NSString *)region
+                     customDomain:(nullable NSString *)customDomain
+                        withToken:(nullable NSString *)token;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Package.swift
+++ b/Package.swift
@@ -694,6 +694,22 @@ let package = Package(
       dependencies: ["FirebaseFunctions"],
       path: "FirebaseFunctions/Tests/SwiftUnit"
     ),
+    .testTarget(
+      name: "FunctionsIntegration",
+      dependencies: ["FirebaseFunctions",
+                     "SharedTestUtilities"],
+      path: "FirebaseFunctions/Tests/Integration",
+      cSettings: [
+        .headerSearchPath("../../../"),
+      ]
+    ),
+    .testTarget(
+      name: "FunctionsSwiftIntegration",
+      dependencies: ["FirebaseFunctions",
+                     "FirebaseFunctionsTestingSupport",
+                     "SharedTestUtilities"],
+      path: "FirebaseFunctions/Tests/SwiftIntegration"
+    ),
     .target(
       name: "FirebaseFunctionsTestingSupport",
       dependencies: ["FirebaseFunctions"],
@@ -703,6 +719,8 @@ let package = Package(
         .headerSearchPath("../../.."),
       ]
     ),
+
+    // MARK: - Firebase In App Messaging
 
     .target(
       name: "FirebaseInAppMessagingTarget",

--- a/scripts/spm_test_schemes/FunctionsIntegration.xcscheme
+++ b/scripts/spm_test_schemes/FunctionsIntegration.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FunctionsIntegration"
+               BuildableName = "FunctionsIntegration"
+               BlueprintName = "FunctionsIntegration"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/spm_test_schemes/FunctionsSwiftIntegration.xcscheme
+++ b/scripts/spm_test_schemes/FunctionsSwiftIntegration.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FunctionsSwiftIntegration"
+               BuildableName = "FunctionsSwiftIntegration"
+               BlueprintName = "FunctionsSwiftIntegration"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
- Translate https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseFunctions/Tests/Integration/FIRIntegrationTests.m to Swift
- Add SPM targets for the integration tests
- Add FIRFunctionsFake.m to workaround the `init` function not bridging to Swift because of its parameters using forward declarations and to use the existing Objective C fake implementations

Future PRs will:
- Add a CocoaPods test_spec for the Swift integration tests
- Add async/await variations of the tests
- Review API coverage
- Prepare for Codable PR integration - See #8854