### PR TITLE
Public Functions Swift API build test coverage

### DIFF
--- a/FirebaseFunctions/Sources/Public/FirebaseFunctions/FIRHTTPSCallable.h
+++ b/FirebaseFunctions/Sources/Public/FirebaseFunctions/FIRHTTPSCallable.h
@@ -81,13 +81,10 @@ NS_SWIFT_NAME(HTTPSCallable)
  * @param data Parameters to pass to the trigger.
  * @param completion The block to call when the HTTPS request has completed.
  */
-// clang-format off
-// because it incorrectly breaks this NS_SWIFT_NAME.
 - (void)callWithObject:(nullable id)data
             completion:(void (^)(FIRHTTPSCallableResult *_Nullable result,
                                  NSError *_Nullable error))completion
     NS_SWIFT_NAME(call(_:completion:));
-// clang-format on
 
 /**
  * The timeout to use when calling the function. Defaults to 60 seconds.

--- a/FirebaseFunctions/Tests/SwiftIntegration/APITests.swift
+++ b/FirebaseFunctions/Tests/SwiftIntegration/APITests.swift
@@ -1,0 +1,33 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import FirebaseCore
+import FirebaseFunctions
+
+// This file is a build-only test for the public Functions Swift APIs not
+// exercised in IntegrationTests.swift.
+
+func apis() {
+  Functions.functions()
+  Functions.functions(region: "my-region")
+  Functions.functions(customDomain: "abc")
+  let myApp = FirebaseApp.app()!
+  Functions.functions(app: myApp)
+  Functions.functions(app: myApp, region: "my-region")
+  Functions.functions(app: myApp, customDomain: "my-domain")
+  Functions.functions().useLocalhost()
+  Functions.functions().useEmulator(withHost: "my-host", port: 1234)
+}


### PR DESCRIPTION
- Add build test coverage for Functions Public API surface not included in integration tests
- Remove no longer necessary clang-format directive