### PR TITLE
Crashlytics show logs in xcode

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -553,6 +553,10 @@ void FIRCLSLogInternalWrite(FIRCLSFile *file, NSString *message, uint64_t time) 
   FIRCLSFileWriteSectionEnd(file);
 }
 
+void FIRCLSLogConsoleWrite(NSString *message) {
+    NSLog(@"%@", message);
+}
+
 void FIRCLSLogInternal(FIRCLSUserLoggingABStorage *storage,
                        const char **activePath,
                        NSString *message) {
@@ -588,5 +592,6 @@ void FIRCLSLogInternal(FIRCLSUserLoggingABStorage *storage,
 
   FIRCLSUserLoggingWriteAndCheckABFiles(storage, activePath, ^(FIRCLSFile *file) {
     FIRCLSLogInternalWrite(file, message, time);
+    FIRCLSLogConsoleWrite(message);
   });
 }

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -37,6 +37,7 @@ NSString *const FIRCLSDevelopmentPlatformVersionKey =
 NSString *const FIRCLSSynchronizedPathKey = @"";
 
 const uint32_t FIRCLSUserLoggingMaxKVEntries = 64;
+const NSNumber *FIRCLSIsDebugMode;
 
 #pragma mark - Prototypes
 static void FIRCLSUserLoggingWriteKeysAndValues(NSDictionary *keysAndValues,
@@ -553,7 +554,18 @@ void FIRCLSLogInternalWrite(FIRCLSFile *file, NSString *message, uint64_t time) 
   FIRCLSFileWriteSectionEnd(file);
 }
 
+BOOL FIRCLSIsInDebugMode(void) {
+    if (FIRCLSIsDebugMode == nil) {
+        NSArray *arguments = [NSProcessInfo processInfo].arguments;
+        FIRCLSIsDebugMode = @([arguments containsObject:@"-FIRDebugEnabled"]);
+    }
+    return [FIRCLSIsDebugMode boolValue];
+}
+
 void FIRCLSLogConsoleWrite(NSString *message) {
+    if (!FIRCLSIsInDebugMode()) {
+        return;
+    }
     NSLog(@"%@", message);
 }
 


### PR DESCRIPTION
Fix for issue (https://github.com/firebase/firebase-ios-sdk/issues/8531) Show Crashlytics logs in Xcode
