### PR TITLE
[Doc Only] Update installation subsection anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ monetize your app. More information about Firebase can be found on the
 ## Installation
 
 See the subsections below for details about the different installation methods.
-1. [Standard pod install](README.md#standard-pod-install)
-1. [Swift Package Manager](SwiftPackageManager.md)
-1. [Installing from the GitHub repo](README.md#installing-from-github)
-1. [Experimental Carthage](README.md#carthage-ios-only)
+1. [Standard pod install](#standard-pod-install)
+1. [Swift Package Manager](#swift-package-manager)
+1. [Installing from the GitHub repo](#installing-from-github)
+1. [Experimental Carthage](#carthage-ios-only)
 
 ### Standard pod install
 


### PR DESCRIPTION
* Update the anchors to navigate to the sections below, in the same page, instead of going to a different page.

Currently, the anchors to the installation subsections in the main README in the entry page (https://github.com/firebase/firebase-ios-sdk) is using a wrong syntax, that opens the README file on the `master` branch (https://github.com/firebase/firebase-ios-sdk/blob/master/README.md#standard-pod-install), instead of jumping in the same page (https://github.com/firebase/firebase-ios-sdk#standard-pod-install)

Below is a video that shows the after and before fix behaviors.

https://user-images.githubusercontent.com/9660181/141672246-f7c7dbf8-e55e-4bcc-97b7-bb334dbe711d.mp4

* Relink the `Swift Package Manager` anchor to the section below, instead of the file.

Because the file link is given in the section, there is no need to use the anchor to go directly to the file.