### PR TITLE
[Heartbeat Logging] - Add underlying storage tests

### DIFF
--- a/HeartbeatLogging/Sources/HeartbeatInfo.swift
+++ b/HeartbeatLogging/Sources/HeartbeatInfo.swift
@@ -39,7 +39,8 @@ struct HeartbeatInfo: Codable, HeartbeatsPayloadConvertible {
   /// - Parameters:
   ///   - capacity: <#capacity description#>
   ///   - cacheProvider: <#cacheProvider description#>
-  init(capacity: Int, cache: [TimePeriod: Date] = cacheProvider()) {
+  init(capacity: Int,
+       cache: [TimePeriod: Date] = cacheProvider()) {
     buffer = RingBuffer(capacity: capacity)
     self.capacity = capacity
     self.cache = cache

--- a/HeartbeatLogging/Sources/Storage.swift
+++ b/HeartbeatLogging/Sources/Storage.swift
@@ -46,11 +46,12 @@ final class FileStorage: Storage {
 
   func write(_ value: Data?) throws {
     do {
+      try createDirectories(in: url.deletingLastPathComponent())
       if let value = value {
-        try createDirectories(in: url.deletingLastPathComponent())
         try value.write(to: url, options: .atomic)
       } else {
-        try? fileManager.removeItem(at: url)
+        let emptyData = Data()
+        try emptyData.write(to: url, options: .atomic)
       }
     } catch {
       throw StorageError.writeError
@@ -94,7 +95,8 @@ final class UserDefaultsStorage: Storage {
     if let value = value {
       defaults.set(value, forKey: key)
     } else {
-      defaults.removeObject(forKey: key)
+      let emptyData = Data()
+      defaults.set(emptyData, forKey: key)
     }
   }
 }

--- a/HeartbeatLogging/Sources/Storage.swift
+++ b/HeartbeatLogging/Sources/Storage.swift
@@ -50,7 +50,7 @@ final class FileStorage: Storage {
         try createDirectories(in: url.deletingLastPathComponent())
         try value.write(to: url, options: .atomic)
       } else {
-        try fileManager.removeItem(at: url)
+        try? fileManager.removeItem(at: url)
       }
     } catch {
       throw StorageError.writeError

--- a/HeartbeatLogging/Tests/Unit/StorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/StorageTests.swift
@@ -18,7 +18,7 @@ import XCTest
 private let data = "test_data".data(using: .utf8)!
 
 class FileStorageTests: XCTestCase {
-  func testRead_WhenFileDoesNotExist_ThrowsError() {
+  func testRead_WhenFileDoesNotExist_ThrowsError() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
     // Then
@@ -61,7 +61,7 @@ class FileStorageTests: XCTestCase {
     XCTAssertEqual(storedData, modifiedData)
   }
 
-  func testWriteNil_WhenFileDoesNotExist_DoesNothing() {
+  func testWriteNil_WhenFileDoesNotExist_DoesNothing() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
     XCTAssertThrowsError(try fileStorage.read())
@@ -71,7 +71,7 @@ class FileStorageTests: XCTestCase {
     XCTAssertThrowsError(try fileStorage.read())
   }
 
-  func testWriteNil_WhenFileExists_RemovesFile() {
+  func testWriteNil_WhenFileExists_RemovesFile() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
 

--- a/HeartbeatLogging/Tests/Unit/StorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/StorageTests.swift
@@ -16,17 +16,80 @@ import XCTest
 @testable import HeartbeatLogging
 
 class FileStorageTests: XCTestCase {
-  func testRead_WhenFileDoesNotExist_ThrowsError() {}
+  func testRead_WhenFileDoesNotExist_ThrowsError() {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
+    // Then
+    XCTAssertThrowsError(try fileStorage.read())
+  }
 
-  func testRead_WhenFileExists_ReturnsFilesData() {}
+  func testRead_WhenFileExists_ReturnsFileContents() throws {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
-  func testWriteData_WhenFileDoesNotExist_CreatesFile() {}
+    let data = "data".data(using: .utf8)
+    XCTAssertNoThrow(try fileStorage.write(data))
+    // When
+    let storedData = try fileStorage.read()
+    // Then
+    XCTAssertEqual(storedData, data)
+  }
 
-  func testWriteData_WhenFileExists_ModifiesFile() {}
+  func testWriteData_WhenFileDoesNotExist_CreatesFile() throws {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
+    XCTAssertThrowsError(try fileStorage.read())
+    // When
+    let data = Data()
+    XCTAssertNoThrow(try fileStorage.write(data))
+    // Then
+    let storedData = try fileStorage.read()
+    XCTAssertEqual(storedData, data)
+  }
 
-  func testWriteNil_WhenFileDoesNotExist_DoesNothing() {}
+  func testWriteData_WhenFileExists_ModifiesFile() throws {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
-  func testWriteNil_WhenFileExists_RemovesFile() {}
+    let data = "data".data(using: .utf8)
+    XCTAssertNoThrow(try fileStorage.write(data))
+    // When
+    let modifiedData = #function.data(using: .utf8)
+    XCTAssertNoThrow(try fileStorage.write(modifiedData))
+
+    // Then
+    let storedData = try fileStorage.read()
+    XCTAssertEqual(storedData, modifiedData)
+  }
+
+  func testWriteNil_WhenFileDoesNotExist_DoesNothing() {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
+    XCTAssertThrowsError(try fileStorage.read())
+    // When
+    XCTAssertNoThrow(try fileStorage.write(nil))
+    // Then
+    XCTAssertThrowsError(try fileStorage.read())
+  }
+
+  func testWriteNil_WhenFileExists_RemovesFile() {
+    // Given
+    let fileStorage = FileStorage(url: makeTemporaryFileURL())
+
+    let data = "data".data(using: .utf8)
+    XCTAssertNoThrow(try fileStorage.write(data))
+    // When
+    XCTAssertNoThrow(try fileStorage.write(nil))
+    // Then
+    XCTAssertThrowsError(try fileStorage.read())
+  }
+
+  func makeTemporaryFileURL(testName: String = #function, suffix: String = "") -> URL {
+    let temporaryPath = NSTemporaryDirectory() + testName + suffix
+    let temporaryURL = URL(fileURLWithPath: temporaryPath)
+    try? FileManager.default.removeItem(at: temporaryURL)
+    return temporaryURL
+  }
 }
 
 class UserDefaultsStorageTests: XCTestCase {
@@ -47,10 +110,12 @@ class UserDefaultsStorageTests: XCTestCase {
   }
 
   func testRead_WhenDefaultDoesNotExist_ThrowsError() throws {
+    // Given
     let defaultsStorage = UserDefaultsStorage(
       defaults: defaults,
       key: #function
     )
+    // Then
     XCTAssertThrowsError(try defaultsStorage.read())
   }
 
@@ -73,6 +138,7 @@ class UserDefaultsStorageTests: XCTestCase {
       defaults: defaults,
       key: #function
     )
+    XCTAssertThrowsError(try defaultsStorage.read())
     // When
     XCTAssertNoThrow(try defaultsStorage.write(data))
     // Then

--- a/HeartbeatLogging/Tests/Unit/StorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/StorageTests.swift
@@ -1,0 +1,124 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import HeartbeatLogging
+
+class FileStorageTests: XCTestCase {
+  func testRead_WhenFileDoesNotExist_ThrowsError() {}
+
+  func testRead_WhenFileExists_ReturnsFilesData() {}
+
+  func testWriteData_WhenFileDoesNotExist_CreatesFile() {}
+
+  func testWriteData_WhenFileExists_ModifiesFile() {}
+
+  func testWriteNil_WhenFileDoesNotExist_DoesNothing() {}
+
+  func testWriteNil_WhenFileExists_RemovesFile() {}
+}
+
+class UserDefaultsStorageTests: XCTestCase {
+  var defaults: UserDefaults!
+  var data: Data!
+  let suiteName = #file
+
+  override func setUpWithError() throws {
+    // Clean up suite in case prior test case did not complete.
+    UserDefaults.standard.removePersistentDomain(forName: suiteName)
+
+    defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    data = try XCTUnwrap("data".data(using: .utf8))
+  }
+
+  override func tearDownWithError() throws {
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  func testRead_WhenDefaultDoesNotExist_ThrowsError() throws {
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    XCTAssertThrowsError(try defaultsStorage.read())
+  }
+
+  func testRead_WhenDefaultExists_ReturnsDefault() throws {
+    // Given
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    XCTAssertNoThrow(try defaultsStorage.write(data))
+    // When
+    let storedData = try defaultsStorage.read()
+    // Then
+    XCTAssertEqual(storedData, data)
+  }
+
+  func testWriteData_WhenDefaultDoesNotExist_CreatesDefault() throws {
+    // Given
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    // When
+    XCTAssertNoThrow(try defaultsStorage.write(data))
+    // Then
+    let storedData = try defaultsStorage.read()
+    XCTAssertEqual(storedData, data)
+  }
+
+  func testWriteData_WhenDefaultExists_ModifiesDefault() throws {
+    // Given
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    XCTAssertNoThrow(try defaultsStorage.write(data))
+    // When
+    let modifiedData = #function.data(using: .utf8)
+    XCTAssertNoThrow(try defaultsStorage.write(modifiedData))
+
+    // Then
+    let storedData = try defaultsStorage.read()
+    XCTAssertEqual(storedData, modifiedData)
+  }
+
+  func testWriteNil_WhenDefaultDoesNotExist_DoesNothing() throws {
+    // Given
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    XCTAssertThrowsError(try defaultsStorage.read())
+    // When
+    XCTAssertNoThrow(try defaultsStorage.write(nil))
+    // Then
+    XCTAssertThrowsError(try defaultsStorage.read())
+  }
+
+  func testWriteNil_WhenDefaultExists_RemovesDefault() throws {
+    // Given
+    let defaultsStorage = UserDefaultsStorage(
+      defaults: defaults,
+      key: #function
+    )
+    XCTAssertNoThrow(try defaultsStorage.write(data))
+    // When
+    XCTAssertNoThrow(try defaultsStorage.write(nil))
+    // Then
+    XCTAssertThrowsError(try defaultsStorage.read())
+  }
+}

--- a/HeartbeatLogging/Tests/Unit/StorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/StorageTests.swift
@@ -15,6 +15,8 @@
 import XCTest
 @testable import HeartbeatLogging
 
+private let data = "test_data".data(using: .utf8)!
+
 class FileStorageTests: XCTestCase {
   func testRead_WhenFileDoesNotExist_ThrowsError() {
     // Given
@@ -27,7 +29,6 @@ class FileStorageTests: XCTestCase {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
-    let data = "data".data(using: .utf8)
     XCTAssertNoThrow(try fileStorage.write(data))
     // When
     let storedData = try fileStorage.read()
@@ -40,7 +41,6 @@ class FileStorageTests: XCTestCase {
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
     XCTAssertThrowsError(try fileStorage.read())
     // When
-    let data = Data()
     XCTAssertNoThrow(try fileStorage.write(data))
     // Then
     let storedData = try fileStorage.read()
@@ -51,10 +51,9 @@ class FileStorageTests: XCTestCase {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
-    let data = "data".data(using: .utf8)
     XCTAssertNoThrow(try fileStorage.write(data))
     // When
-    let modifiedData = #function.data(using: .utf8)
+    let modifiedData = "modified_data".data(using: .utf8)
     XCTAssertNoThrow(try fileStorage.write(modifiedData))
 
     // Then
@@ -76,7 +75,6 @@ class FileStorageTests: XCTestCase {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
-    let data = "data".data(using: .utf8)
     XCTAssertNoThrow(try fileStorage.write(data))
     // When
     XCTAssertNoThrow(try fileStorage.write(nil))
@@ -94,7 +92,6 @@ class FileStorageTests: XCTestCase {
 
 class UserDefaultsStorageTests: XCTestCase {
   var defaults: UserDefaults!
-  var data: Data!
   let suiteName = #file
 
   override func setUpWithError() throws {
@@ -102,7 +99,6 @@ class UserDefaultsStorageTests: XCTestCase {
     UserDefaults.standard.removePersistentDomain(forName: suiteName)
 
     defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-    data = try XCTUnwrap("data".data(using: .utf8))
   }
 
   override func tearDownWithError() throws {

--- a/HeartbeatLogging/Tests/Unit/StorageTests.swift
+++ b/HeartbeatLogging/Tests/Unit/StorageTests.swift
@@ -28,7 +28,6 @@ class FileStorageTests: XCTestCase {
   func testRead_WhenFileExists_ReturnsFileContents() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
-
     XCTAssertNoThrow(try fileStorage.write(data))
     // When
     let storedData = try fileStorage.read()
@@ -61,17 +60,18 @@ class FileStorageTests: XCTestCase {
     XCTAssertEqual(storedData, modifiedData)
   }
 
-  func testWriteNil_WhenFileDoesNotExist_DoesNothing() throws {
+  func testWriteNil_WhenFileDoesNotExist_CreatesEmptyFile() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
     XCTAssertThrowsError(try fileStorage.read())
     // When
     XCTAssertNoThrow(try fileStorage.write(nil))
     // Then
-    XCTAssertThrowsError(try fileStorage.read())
+    let emptyData = try fileStorage.read()
+    XCTAssertTrue(emptyData.isEmpty)
   }
 
-  func testWriteNil_WhenFileExists_RemovesFile() throws {
+  func testWriteNil_WhenFileExists_EmptiesFile() throws {
     // Given
     let fileStorage = FileStorage(url: makeTemporaryFileURL())
 
@@ -79,7 +79,8 @@ class FileStorageTests: XCTestCase {
     // When
     XCTAssertNoThrow(try fileStorage.write(nil))
     // Then
-    XCTAssertThrowsError(try fileStorage.read())
+    let emptyData = try fileStorage.read()
+    XCTAssertTrue(emptyData.isEmpty)
   }
 
   func makeTemporaryFileURL(testName: String = #function, suffix: String = "") -> URL {
@@ -158,7 +159,7 @@ class UserDefaultsStorageTests: XCTestCase {
     XCTAssertEqual(storedData, modifiedData)
   }
 
-  func testWriteNil_WhenDefaultDoesNotExist_DoesNothing() throws {
+  func testWriteNil_WhenDefaultDoesNotExist_CreatesEmptyDefault() throws {
     // Given
     let defaultsStorage = UserDefaultsStorage(
       defaults: defaults,
@@ -168,10 +169,11 @@ class UserDefaultsStorageTests: XCTestCase {
     // When
     XCTAssertNoThrow(try defaultsStorage.write(nil))
     // Then
-    XCTAssertThrowsError(try defaultsStorage.read())
+    let emptyData = try defaultsStorage.read()
+    XCTAssertTrue(emptyData.isEmpty)
   }
 
-  func testWriteNil_WhenDefaultExists_RemovesDefault() throws {
+  func testWriteNil_WhenDefaultExists_EmptiesDefault() throws {
     // Given
     let defaultsStorage = UserDefaultsStorage(
       defaults: defaults,
@@ -181,6 +183,7 @@ class UserDefaultsStorageTests: XCTestCase {
     // When
     XCTAssertNoThrow(try defaultsStorage.write(nil))
     // Then
-    XCTAssertThrowsError(try defaultsStorage.read())
+    let emptyData = try defaultsStorage.read()
+    XCTAssertTrue(emptyData.isEmpty)
   }
 }


### PR DESCRIPTION
This PR adds tests for the wrapper classes used to read and write from file system and user defaults.

#no-changelog