### PR TITLE
Swift Error Enum for Storage

### DIFF
--- a/FirebaseStorageSwift/Sources/Result.swift
+++ b/FirebaseStorageSwift/Sources/Result.swift
@@ -14,10 +14,6 @@
 
 import FirebaseStorage
 
-private enum DataError: Error {
-  case internalInconsistency // Thrown when both value and error are nil.
-}
-
 /// Generates a closure that returns a `Result` type from a closure that returns an optional type
 /// and `Error`.
 ///
@@ -33,9 +29,9 @@ private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Vo
     if let value = value {
       completion(.success(value))
     } else if let error = error {
-      completion(.failure(error))
+      completion(.failure(StorageError.swiftConvert(objcError: (error as NSError).code)))
     } else {
-      completion(.failure(DataError.internalInconsistency))
+      completion(.failure(StorageError.internalError))
     }
   }
 }

--- a/FirebaseStorageSwift/Sources/Result.swift
+++ b/FirebaseStorageSwift/Sources/Result.swift
@@ -29,9 +29,9 @@ private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Vo
     if let value = value {
       completion(.success(value))
     } else if let error = error {
-      completion(.failure(StorageError.swiftConvert(objcError: (error as NSError).code)))
+      completion(.failure(StorageError.swiftConvert(objcError: error as NSError)))
     } else {
-      completion(.failure(StorageError.internalError))
+      completion(.failure(StorageError.internalError("Internal failure in getResultCallback")))
     }
   }
 }

--- a/FirebaseStorageSwift/Sources/StorageError.swift
+++ b/FirebaseStorageSwift/Sources/StorageError.swift
@@ -1,0 +1,49 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseStorage
+
+public enum StorageError: Error {
+  case unknown
+  case objectNotFound
+  case bucketNotFound
+  case projectNotFound
+  case quotaExceeded
+  case unauthenticated
+  case unauthorized
+  case retryLimitExceeded
+  case nonMatchingChecksum
+  case downloadSizeExceeded
+  case cancelled
+  case invalidArgument
+  case internalError
+
+  static func swiftConvert(objcError: Int) -> StorageError {
+    switch objcError {
+    case StorageErrorCode.unknown.rawValue: return StorageError.unknown
+    case StorageErrorCode.objectNotFound.rawValue: return StorageError.objectNotFound
+    case StorageErrorCode.bucketNotFound.rawValue: return StorageError.bucketNotFound
+    case StorageErrorCode.projectNotFound.rawValue: return StorageError.projectNotFound
+    case StorageErrorCode.quotaExceeded.rawValue: return StorageError.quotaExceeded
+    case StorageErrorCode.unauthenticated.rawValue: return StorageError.unauthenticated
+    case StorageErrorCode.unauthorized.rawValue: return StorageError.unauthorized
+    case StorageErrorCode.retryLimitExceeded.rawValue: return StorageError.retryLimitExceeded
+    case StorageErrorCode.nonMatchingChecksum.rawValue: return StorageError.nonMatchingChecksum
+    case StorageErrorCode.downloadSizeExceeded.rawValue: return StorageError.downloadSizeExceeded
+    case StorageErrorCode.cancelled.rawValue: return StorageError.cancelled
+    case StorageErrorCode.invalidArgument.rawValue: return StorageError.invalidArgument
+    default: return StorageError.internalError
+    }
+  }
+}

--- a/FirebaseStorageSwift/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageAsyncAwait.swift
@@ -111,7 +111,7 @@ import XCTest
         _ = try await ref.putDataAsync(data)
         XCTFail("Unexpected success from unauthorized putData")
       } catch {
-        XCTAssertEqual((error as NSError).code, StorageErrorCode.unauthorized.rawValue)
+        XCTAssertEqual(error as! StorageError, StorageError.unauthorized)
       }
     }
 
@@ -130,8 +130,7 @@ import XCTest
         XCTFail("Unexpected success from putFile of a directory")
       } catch {
         // TODO: Investigate generating a more descriptive error code than unknown.
-        let e = error as NSError
-        XCTAssertEqual(e.code, StorageErrorCode.unknown.rawValue)
+        XCTAssertEqual(error as! StorageError, StorageError.unknown)
       }
     }
 
@@ -196,7 +195,7 @@ import XCTest
         _ = try await ref.data(maxSize: 1024)
         XCTFail("Unexpected success from getData too small")
       } catch {
-        XCTAssertEqual((error as NSError).code, StorageErrorCode.downloadSizeExceeded.rawValue)
+        XCTAssertEqual(error as! StorageError, StorageError.downloadSizeExceeded)
       }
     }
 

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -135,9 +135,11 @@ class StorageResultTests: StorageIntegrationCommon {
       switch result {
       case .success:
         XCTFail("Unexpected success from unauthorized putData")
-      case let .failure(error as NSError):
-        XCTAssertEqual(error.code, StorageErrorCode.unauthorized.rawValue)
+      case let .failure(error as StorageError):
+        XCTAssertEqual(error, StorageError.unauthorized)
         expectation.fulfill()
+      case let .failure(error):
+        XCTFail("Failed with unexpected error: \(error)")
       }
     }
     waitForExpectations()
@@ -317,8 +319,10 @@ class StorageResultTests: StorageIntegrationCommon {
       switch result {
       case .success:
         XCTFail("Unexpected success from getData too small")
-      case let .failure(error as NSError):
-        XCTAssertEqual(error.code, StorageErrorCode.downloadSizeExceeded.rawValue)
+      case let .failure(error as StorageError):
+        XCTAssertEqual(error, StorageError.downloadSizeExceeded)
+      case let .failure(error):
+        XCTFail("Failed with unexpected error: \(error)")
       }
       expectation.fulfill()
     }


### PR DESCRIPTION
Initial thoughts about a Swift Error enum for Firebase Storage.

Thoughts about this approach and recommendations for next steps appreciated.

This implementation takes advantage that most of the APIs that return error codes also have a Result API so that the Result implementation can map the Objective C error to a Swift error.

When implementing the tests, I realized that the auto-generated async APIs hide the Result version so the strategy does not work for both supporting async/await and Swift error codes.

Swift error codes may need to wait until we can do a breaking release and fully wrap and hide all of the Objective C APIs in favor of a purely Swift API.