### PR TITLE
Add Error Handling to Swift initiative

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@ improvements:
 * async/await API evaluation, tests, and augmentation
 * Fix non-Swifty APIs
 * Fill API gaps
+* Better Swift Error Handling
 * Property Wrappers (Not necessarily low hanging, but can be high value)
 * Identify larger projects for future phases
 


### PR DESCRIPTION
Based on #7723, #9000, and #9006, let's be explicit about including Error Handling in the scope of phase 1 of the Swift initiative.