### PR TITLE
Update for GoogleUtilitiesComponents 1.1.0 release

### DIFF
--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilitiesComponents'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Google Utilities Component Container for Apple platforms.'
 
   s.description      = <<-DESC
@@ -24,6 +24,7 @@ Not intended for direct public usage.
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
+  s.static_framework = true
 
   s.source_files = 'GoogleUtilitiesComponents/Sources/**/*.[mh]'
   s.public_header_files = 'GoogleUtilitiesComponents/Sources/Public/*.h', 'GoogleUtilitiesComponents/Sources/Private/*.h'


### PR DESCRIPTION
Fix #9021 

Bump version to 1.1.0 to update published minimum iOS version from 8.0 to 10.0.

Restore s.static_framework = true, so that the library is an exact match to 1.0.0 except for minimum iOS version.

This should technically be a major version update, but doing a minor version since the only CocoaPods dependent, MLKitCommon, which has always required iOS 10.0 and the minor update will get the fix with publishing only this pod and only a `pod update` from users.

Checks:
`git diff UtilitiesComponents-1.0.0 -- GoogleUtilitiesComponents`
` git diff UtilitiesComponents-1.0.0 -- GoogleUtilitiesComponents.podspec`
`~/.cocoapods/repos/cocoapods (master) $ git grep GoogleUtilitiesComponents`