### PR TITLE
Fix analytics warnings building for macOS/tvOS with SPM

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -8,6 +8,7 @@ on:
     - '.swiftpm/*'
     - 'scripts/build.sh'
     - 'SwiftPMTests/*'
+    - 'SwiftPM-PlatformExclude'
     - 'Gemfile*'
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWithoutAdIdSupportWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWithoutAdIdSupportWrap/dummy.m
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 #import <TargetConditionals.h>
-#if !TARGET_OS_IOS
-#warning "Firebase Analytics only supports the iOS platform"
+#if TARGET_OS_WATCH
+#warning "Firebase Analytics does not support the watchOS platform"
 #endif

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 #import <TargetConditionals.h>
-#if !TARGET_OS_IOS
-#warning "Firebase Analytics only supports the iOS platform"
+#if TARGET_OS_WATCH
+#warning "Firebase Analytics does not support the watchOS platform"
 #endif


### PR DESCRIPTION
Fix #9029

We missed updating two warnings when enabling Analytics multi-platform support in 8.9.0.  In the meantime, these warnings can be safely disregarded.