### PR TITLE
Fix Analytics SwiftPM platform availability.

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         target: [tvOS, macOS, catalyst]
-        # Full set of Firebase-Package tests only run on iOS because of Analytics.
+        # Include non iOS tests in this section.
     steps:
     - uses: actions/checkout@v2
     - name: Initialize xcodebuild

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         target: [tvOS, macOS, catalyst]
-        # Include non iOS tests in this section.
+        # Full set of Firebase-Package tests only run on iOS.
     steps:
     - uses: actions/checkout@v2
     - name: Initialize xcodebuild

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 8.10.1
+- [fixed] Fixed platform availability checks in Swift Package Manager that may prevent code
+  completion for Analytics APIs  macOS and tvOS. (#9032)
+
 # Firebase 8.10.0
 - [added] Firebase now includes community supported Combine publishers. More details can be found
   [here](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseCombineSwift/README.md). (#7295)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 8.10.1
 - [fixed] Fixed platform availability checks in Swift Package Manager that may prevent code
-  completion for Analytics APIs  macOS and tvOS. (#9032)
+  completion for Analytics APIs macOS and tvOS. (#9032)
 
 # Firebase 8.10.0
 - [added] Firebase now includes community supported Combine publishers. More details can be found

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 8.10.1
 - [fixed] Fixed platform availability checks in Swift Package Manager that may prevent code
-  completion for Analytics APIs macOS and tvOS. (#9032)
+  completion for Analytics APIs on macOS and tvOS. (#9032)
 
 # Firebase 8.10.0
 - [added] Firebase now includes community supported Combine publishers. More details can be found

--- a/Package.swift
+++ b/Package.swift
@@ -268,7 +268,7 @@ let package = Package(
     .target(
       name: "FirebaseAnalyticsTarget",
       dependencies: [.target(name: "FirebaseAnalyticsWrapper",
-                             condition: .when(platforms: [.iOS]))],
+                             condition: .when(platforms: [.iOS, .macOS, .tvOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseAnalyticsWrap"
     ),
 

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -15,8 +15,8 @@ Prior to version 8.0.0 (starting with version 6.31.0) support was in Beta.
 
 ## Limitations
 
-- Not all products are available on each platform. See [the chart on this page](https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform)
-  for information on product availabilty by platform.
+- Product availability varies by platform. See [the chart on this page](https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform)
+  for information on product availabilty for each platform.
 
 ## Installation
 

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -15,9 +15,8 @@ Prior to version 8.0.0 (starting with version 6.31.0) support was in Beta.
 
 ## Limitations
 
-- Analytics is only supported for iOS and cannot be used in apps that support other platforms.
-- watchOS support is available for ABTesting, Auth, Crashlytics, Messaging, Realtime Database,
-  RemoteConfig, and Storage.
+- Not all products are available on each platform. See [the chart on this page](https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform)
+  for information on product availabilty by platform.
 
 ## Installation
 
@@ -36,7 +35,7 @@ Search for the Firebase Apple SDK using the repo's URL:
 https://github.com/firebase/firebase-ios-sdk.git
 ```
 
-Next, set the **Dependency Rule** to be `Up to Next Major Version` and specify `8.0.0` as the lower bound.
+Next, set the **Dependency Rule** to be `Up to Next Major Version` and specify `8.10.0` as the lower bound.
 
 Then, select **Add Package**.
 
@@ -81,7 +80,7 @@ dependencies: [
   .package(
     name: "Firebase",
     url: "https://github.com/firebase/firebase-ios-sdk.git",
-    .upToNextMajor(from: "8.0.0")
+    .upToNextMajor(from: "8.10.0")
   ),
 
   // Any other dependencies you have...


### PR DESCRIPTION
For some reason this still works in a project, but Xcode gets confused
and doesn't autocomplete the module appropriately. This should fix it
for tvOS and macOS.

Also cleaned up a few references to Analytics only being available on
iOS.
