### PR TITLE
Set up specs testing

### DIFF
--- a/ReleaseTooling/Package.swift
+++ b/ReleaseTooling/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
   products: [
     .executable(name: "firebase-releaser", targets: ["FirebaseReleaser"]),
     .executable(name: "zip-builder", targets: ["ZipBuilder"]),
+    .executable(name: "podspecs-tester", targets: ["ZipBuilder"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.1.0")),
@@ -38,6 +39,10 @@ let package = Package(
     ),
     .target(
       name: "FirebaseReleaser",
+      dependencies: ["ArgumentParser", "FirebaseManifest", "Utils"]
+    ),
+    .target(
+      name: "PodspecsTester",
       dependencies: ["ArgumentParser", "FirebaseManifest", "Utils"]
     ),
     .target(

--- a/ReleaseTooling/Package.swift
+++ b/ReleaseTooling/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
   products: [
     .executable(name: "firebase-releaser", targets: ["FirebaseReleaser"]),
     .executable(name: "zip-builder", targets: ["ZipBuilder"]),
-    .executable(name: "podspecs-tester", targets: ["ZipBuilder"]),
+    .executable(name: "podspecs-tester", targets: ["PodspecsTester"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.1.0")),

--- a/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import FirebaseManifest
+import Utils
+
+private enum Constants {}
+
+extension Constants {
+  static let localSpecRepoName = "specstesting"
+  static let specRepo = "https://github.com/firebase/SpecsTesting"
+  static let sdkRepo = "https://github.com/firebase/firebase-ios-sdk"
+  static let testingTagPrefix = "testing-"
+}
+
+struct InitializeSpecTesting{
+  static func setupRepo(sdkRepoURL: URL) {
+    let manifest = FirebaseManifest.shared
+    addSpecRepo(repoURL: Constants.specRepo)
+    addTestingTag(path: sdkRepoURL, manifest: manifest)
+    updatePodspecs(path: sdkRepoURL, manifest: manifest)
+  }
+
+  // The SpecsTesting repo will be added to `${HOME}/.cocoapods/`, and all
+  // podspecs under this dir will be the source of the specs testing.
+  private static func addSpecRepo(repoURL: String, podRepoName: String = Constants.localSpecRepoName){
+    let result = Shell.executeCommandFromScript("pod repo remove \(podRepoName)")
+    switch result {
+    case let .error(code, output):
+      print("\(podRepoName) was not properly removed. \(podRepoName) probably" +
+            "does not exist in local.\n \(output)")
+    case let .success(output):
+      print("\(podRepoName) was removed.")
+    }
+    Shell.executeCommand("pod repo add \(podRepoName) \(repoURL)")
+  }
+
+  // Add a testing tag to the head of the branch.
+  private static func addTestingTag(path sdkRepoPath: URL, manifest: FirebaseManifest.Manifest) {
+    let manifest = FirebaseManifest.shared
+    let testingTag = Constants.testingTagPrefix+manifest.version
+    // Add or update the testing tag to the local sdk repo.
+    Shell.executeCommand("git tag -af \(testingTag) -m 'spectesting'", workingDir: sdkRepoPath)
+  }
+
+  // Update the podspec source.
+  private static func updatePodspecs(path: URL, manifest: FirebaseManifest.Manifest) {
+    for pod in manifest.pods {
+      let version = manifest.versionString(pod)
+      if !pod.isClosedSource {
+          // Replace git and tag in the source of a podspec.
+          Shell.executeCommand("sed -i.bak -e \"s|\\(.*\\:git =>[[:space:]]*\\).*|\\1'\(path.path)',| ; " +
+                               "s|\\(.*\\:tag =>[[:space:]]*\\).*|\\1'\(Constants.testingTagPrefix+manifest.version)',|\" \(pod.name).podspec",
+                               workingDir: path) 
+      }
+    }
+  }
+}

--- a/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
@@ -65,6 +65,16 @@ struct InitializeSpecTesting {
       let version = manifest.versionString(pod)
       if !pod.isClosedSource {
         // Replace git and tag in the source of a podspec.
+        // Before:
+        //  s.source           = {
+        //    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+        //    :tag => 'CocoaPods-' + s.version.to_s
+        //  }
+        // After `sed`:
+        //  s.source           = {
+        //    :git => '\(path.path)',
+        //    :tag => 'testing-\(manifest.version)',
+        //  }
         Shell.executeCommand(
           "sed -i.bak -e \"s|\\(.*\\:git =>[[:space:]]*\\).*|\\1'\(path.path)',| ; " +
             "s|\\(.*\\:tag =>[[:space:]]*\\).*|\\1'\(Constants.testingTagPrefix + manifest.version)',|\" \(pod.name).podspec",

--- a/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/InitializeSource.swift
@@ -28,7 +28,7 @@ extension Constants {
   static let testingTagPrefix = "testing-"
 }
 
-struct InitializeSpecTesting{
+struct InitializeSpecTesting {
   static func setupRepo(sdkRepoURL: URL) {
     let manifest = FirebaseManifest.shared
     addSpecRepo(repoURL: Constants.specRepo)
@@ -38,12 +38,13 @@ struct InitializeSpecTesting{
 
   // The SpecsTesting repo will be added to `${HOME}/.cocoapods/`, and all
   // podspecs under this dir will be the source of the specs testing.
-  private static func addSpecRepo(repoURL: String, podRepoName: String = Constants.localSpecRepoName){
+  private static func addSpecRepo(repoURL: String,
+                                  podRepoName: String = Constants.localSpecRepoName) {
     let result = Shell.executeCommandFromScript("pod repo remove \(podRepoName)")
     switch result {
     case let .error(code, output):
       print("\(podRepoName) was not properly removed. \(podRepoName) probably" +
-            "does not exist in local.\n \(output)")
+        "does not exist in local.\n \(output)")
     case let .success(output):
       print("\(podRepoName) was removed.")
     }
@@ -53,7 +54,7 @@ struct InitializeSpecTesting{
   // Add a testing tag to the head of the branch.
   private static func addTestingTag(path sdkRepoPath: URL, manifest: FirebaseManifest.Manifest) {
     let manifest = FirebaseManifest.shared
-    let testingTag = Constants.testingTagPrefix+manifest.version
+    let testingTag = Constants.testingTagPrefix + manifest.version
     // Add or update the testing tag to the local sdk repo.
     Shell.executeCommand("git tag -af \(testingTag) -m 'spectesting'", workingDir: sdkRepoPath)
   }
@@ -63,10 +64,12 @@ struct InitializeSpecTesting{
     for pod in manifest.pods {
       let version = manifest.versionString(pod)
       if !pod.isClosedSource {
-          // Replace git and tag in the source of a podspec.
-          Shell.executeCommand("sed -i.bak -e \"s|\\(.*\\:git =>[[:space:]]*\\).*|\\1'\(path.path)',| ; " +
-                               "s|\\(.*\\:tag =>[[:space:]]*\\).*|\\1'\(Constants.testingTagPrefix+manifest.version)',|\" \(pod.name).podspec",
-                               workingDir: path) 
+        // Replace git and tag in the source of a podspec.
+        Shell.executeCommand(
+          "sed -i.bak -e \"s|\\(.*\\:git =>[[:space:]]*\\).*|\\1'\(path.path)',| ; " +
+            "s|\\(.*\\:tag =>[[:space:]]*\\).*|\\1'\(Constants.testingTagPrefix + manifest.version)',|\" \(pod.name).podspec",
+          workingDir: path
+        )
       }
     }
   }

--- a/ReleaseTooling/Sources/PodspecsTester/main.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/main.swift
@@ -34,12 +34,11 @@ struct PodspecsTester: ParsableCommand {
   func run() throws {
     let startDate = Date()
     print("Started at: \(startDate.dateTimeString())")
-    InitializeSpecTesting.setupRepo(sdkRepoURL:gitRoot)
+    InitializeSpecTesting.setupRepo(sdkRepoURL: gitRoot)
     let finishDate = Date()
     print("Finished at: \(finishDate.dateTimeString()). " +
       "Duration: \(startDate.formattedDurationSince(finishDate))")
   }
-
 }
 
 // Start the parsing and run the tool.

--- a/ReleaseTooling/Sources/PodspecsTester/main.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/main.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import ArgumentParser
+import Utils
+
+struct PodspecsTester: ParsableCommand {
+  /// The root of the Firebase git repo.
+  @Option(help: "The root of the firebase-ios-sdk checked out git repo.",
+          transform: URL.init(fileURLWithPath:))
+  var gitRoot: URL
+
+  mutating func validate() throws {
+    guard FileManager.default.fileExists(atPath: gitRoot.path) else {
+      throw ValidationError("git-root does not exist: \(gitRoot.path)")
+    }
+  }
+
+  func run() throws {
+    let startDate = Date()
+    print("Started at: \(startDate.dateTimeString())")
+    InitializeSpecTesting.setupRepo(sdkRepoURL:gitRoot)
+    let finishDate = Date()
+    print("Finished at: \(finishDate.dateTimeString()). " +
+      "Duration: \(startDate.formattedDurationSince(finishDate))")
+  }
+
+}
+
+// Start the parsing and run the tool.
+PodspecsTester.main()


### PR DESCRIPTION
This is to set up spec testing before running. 

The [SpecsTesting repo](https://github.com/firebase/SpecsTesting) and [SDK repo](https://github.com/firebase/firebase-ios-sdk) to the head of a PR will be added to local through [checkout](https://github.com/actions/checkout).
A testing tag will be added to the local sdk repo.
All podspecs in the local sdk repo will be updated with a new git to the local sdk repo and a testing tag pointing to the head of head of a PR.

TODO for setup:
These updated podspecs will be copied to the local spec repo located in `${HOME}/.cocoapods`.
