### PR TITLE
Add app ID header to Firebase Auth

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Added a `X-Firebase-GMPID` header to network requests.
+
 # 8.9.0
 - [changed] Improved error logging. (#8704)
 - [added] Added MFA support for email link sign-in. (#8705)

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -453,7 +453,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 - (instancetype)initWithApp:(FIRApp *)app {
   [FIRAuth setKeychainServiceNameForApp:app];
-  self = [self initWithAPIKey:app.options.APIKey appName:app.name];
+  self = [self initWithAPIKey:app.options.APIKey appName:app.name appID:app.options.googleAppID];
   if (self) {
     _app = app;
 #if TARGET_OS_IOS
@@ -463,11 +463,13 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   return self;
 }
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appName:(NSString *)appName {
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                appName:(NSString *)appName
+                                  appID:(NSString *)appID {
   self = [super init];
   if (self) {
     _listenerHandles = [NSMutableArray array];
-    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey];
+    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey appID:appID];
     _firebaseAppName = [appName copy];
 #if TARGET_OS_IOS
     _settings = [[FIRAuthSettings alloc] init];

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -66,9 +66,11 @@ NS_ASSUME_NONNULL_BEGIN
     @brief Designated initializer.
     @param APIKey The Google Developers Console API key for making requests from your app.
     @param appName The name property of the previously created @c FIRApp instance.
+    @param appID The app ID of the Firebase application.
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
-                                appName:(NSString *)appName NS_DESIGNATED_INITIALIZER;
+                                appName:(NSString *)appName
+                                  appID:(NSString *)appID NS_DESIGNATED_INITIALIZER;
 
 /** @fn getUserID
     @brief Gets the identifier of the current user, if any.

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -88,6 +88,26 @@ static NSString *const kIosBundleIdentifierHeader = @"X-Ios-Bundle-Identifier";
  */
 static NSString *const kFirebaseLocalHeader = @"X-Firebase-Locale";
 
+/** @var kFirebaseAppIDHeader
+    @brief HTTP header name for the Firebase app ID.
+ */
+static NSString *const kFirebaseAppIDHeader = @"X-Firebase-GMPID";
+
+/** @var kFirebaseUserAgentHeader
+    @brief HTTP header name for the Firebase user agent.
+ */
+static NSString *const kFirebaseUserAgentHeader = @"X-Firebase-Client";
+
+/** @var kFirebaseHeartbeatHeader
+    @brief HTTP header name for the Firebase heartbeat.
+ */
+static NSString *const kFirebaseHeartbeatHeader = @"X-Firebase-Client-Log-Type";
+
+/** @var kHeartbeatStorageTag
+    @brief Storage tag for the Firebase Auth heartbeat.
+ */
+static NSString *const kHeartbeatStorageTag = @"fire-auth";
+
 /** @var kFirebaseAuthCoreFrameworkMarker
     @brief The marker in the HTTP header that indicates the request comes from Firebase Auth Core.
  */
@@ -640,6 +660,10 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [request setValue:clientVersion forHTTPHeaderField:kClientVersionHeader];
   NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
   [request setValue:bundleID forHTTPHeaderField:kIosBundleIdentifierHeader];
+  NSString *userAgent = [FIRApp firebaseUserAgent];
+  [request setValue:userAgent forKey:kFirebaseUserAgentHeader];
+  NSString *heartbeat = @([FIRHeartbeatInfo heartbeatCodeForTag:kHeartbeatStorageTag]).stringValue;
+  [request setValue:heartbeat forKey:kFirebaseHeartbeatHeader];
 
   NSArray<NSString *> *preferredLocalizations = [NSBundle mainBundle].preferredLocalizations;
   if (preferredLocalizations.count) {

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -660,6 +660,8 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [request setValue:clientVersion forHTTPHeaderField:kClientVersionHeader];
   NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
   [request setValue:bundleID forHTTPHeaderField:kIosBundleIdentifierHeader];
+  NSString *appID = requestConfiguration.appID;
+  [request setValue:appID forKey:kFirebaseAppIDHeader];
   NSString *userAgent = [FIRApp firebaseUserAgent];
   [request setValue:userAgent forKey:kFirebaseUserAgentHeader];
   NSString *heartbeat = @([FIRHeartbeatInfo heartbeatCodeForTag:kHeartbeatStorageTag]).stringValue;

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -646,7 +646,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
   [request setValue:bundleID forHTTPHeaderField:kIosBundleIdentifierHeader];
   NSString *appID = requestConfiguration.appID;
-  [request setValue:appID forKey:kFirebaseAppIDHeader];
+  [request setValue:appID forHTTPHeaderField:kFirebaseAppIDHeader];
 
   NSArray<NSString *> *preferredLocalizations = [NSBundle mainBundle].preferredLocalizations;
   if (preferredLocalizations.count) {

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -93,21 +93,6 @@ static NSString *const kFirebaseLocalHeader = @"X-Firebase-Locale";
  */
 static NSString *const kFirebaseAppIDHeader = @"X-Firebase-GMPID";
 
-/** @var kFirebaseUserAgentHeader
-    @brief HTTP header name for the Firebase user agent.
- */
-static NSString *const kFirebaseUserAgentHeader = @"X-Firebase-Client";
-
-/** @var kFirebaseHeartbeatHeader
-    @brief HTTP header name for the Firebase heartbeat.
- */
-static NSString *const kFirebaseHeartbeatHeader = @"X-Firebase-Client-Log-Type";
-
-/** @var kHeartbeatStorageTag
-    @brief Storage tag for the Firebase Auth heartbeat.
- */
-static NSString *const kHeartbeatStorageTag = @"fire-auth";
-
 /** @var kFirebaseAuthCoreFrameworkMarker
     @brief The marker in the HTTP header that indicates the request comes from Firebase Auth Core.
  */
@@ -662,10 +647,6 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [request setValue:bundleID forHTTPHeaderField:kIosBundleIdentifierHeader];
   NSString *appID = requestConfiguration.appID;
   [request setValue:appID forKey:kFirebaseAppIDHeader];
-  NSString *userAgent = [FIRApp firebaseUserAgent];
-  [request setValue:userAgent forKey:kFirebaseUserAgentHeader];
-  NSString *heartbeat = @([FIRHeartbeatInfo heartbeatCodeForTag:kHeartbeatStorageTag]).stringValue;
-  [request setValue:heartbeat forKey:kFirebaseHeartbeatHeader];
 
   NSArray<NSString *> *preferredLocalizations = [NSBundle mainBundle].preferredLocalizations;
   if (preferredLocalizations.count) {

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, readonly) NSString *APIKey;
 
+/** @property appID
+    @brief The Firebase appID used in the request.
+ */
+@property(nonatomic, copy, readonly) NSString *appID;
+
 /** @property LanguageCode
     @brief The language code used in the request.
  */
@@ -47,11 +52,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/** @fn initWithRequestClass:APIKey:authLanguage:
+/** @fn initWithAPIKey:appID:
     @brief Designated initializer.
     @param APIKey The API key to be used in the request.
+    @param appID The Firebase app ID to be passed in the request header.
  */
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID NS_DESIGNATED_INITIALIZER;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -22,10 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAuthRequestConfiguration
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey {
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID {
   self = [super init];
   if (self) {
     _APIKey = [APIKey copy];
+    _appID = [appID copy];
   }
   return self;
 }

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -118,6 +118,11 @@ static NSString *const kProviderDataKey = @"providerData";
  */
 static NSString *const kAPIKeyCodingKey = @"APIKey";
 
+/** @var kFirebaseAppIDCodingKey
+    @brief The key used to encode the appID instance variable for NSSecureCoding.
+ */
+static NSString *const kFirebaseAppIDCodingKey = @"firebaseAppID";
+
 /** @var kTokenServiceCodingKey
     @brief The key used to encode the tokenService instance variable for NSSecureCoding.
  */
@@ -345,6 +350,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                                      forKey:kMetadataCodingKey];
   NSString *tenantID = [aDecoder decodeObjectOfClass:[NSString class] forKey:kTenantIDCodingKey];
   NSString *APIKey = [aDecoder decodeObjectOfClass:[NSString class] forKey:kAPIKeyCodingKey];
+  NSString *appID = [aDecoder decodeObjectOfClass:[NSString class] forKey:kFirebaseAppIDCodingKey];
 #if TARGET_OS_IOS
   FIRMultiFactor *multiFactor = [aDecoder decodeObjectOfClass:[FIRMultiFactor class]
                                                        forKey:kMultiFactorCodingKey];
@@ -368,7 +374,7 @@ static void callInMainThreadWithAuthDataResultAndError(
     _phoneNumber = phoneNumber;
     _metadata = metadata ?: [[FIRUserMetadata alloc] initWithCreationDate:nil lastSignInDate:nil];
     _tenantID = tenantID;
-    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey];
+    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey appID:appID];
 #if TARGET_OS_IOS
     _multiFactor = multiFactor ?: [[FIRMultiFactor alloc] init];
 #endif
@@ -389,6 +395,7 @@ static void callInMainThreadWithAuthDataResultAndError(
   [aCoder encodeObject:_metadata forKey:kMetadataCodingKey];
   [aCoder encodeObject:_tenantID forKey:kTenantIDCodingKey];
   [aCoder encodeObject:_auth.requestConfiguration.APIKey forKey:kAPIKeyCodingKey];
+  [aCoder encodeObject:_auth.requestConfiguration.appID forKey:kFirebaseAppIDCodingKey];
   [aCoder encodeObject:_tokenService forKey:kTokenServiceCodingKey];
 #if TARGET_OS_IOS
   [aCoder encodeObject:_multiFactor forKey:kMultiFactorCodingKey];

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendCreateAuthURITests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendCreateAuthURITests.m
@@ -37,6 +37,11 @@ static NSString *const kTestContinueURI = @"https://www.example.com/";
  */
 static NSString *const kTestAPIKey = @"apikey_value";
 
+/** @var kTestFirebaseAppID
+    @brief A test value for the Firebase app ID
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestExpectedRequestURL
     @brief The URL we are expecting should be requested by valid requests.
  */
@@ -69,7 +74,7 @@ static NSString *const kTestProviderID2 = @"facebook.com";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRCreateAuthURIRequest *request =
       [[FIRCreateAuthURIRequest alloc] initWithIdentifier:kTestIdentifier
                                               continueURI:kTestContinueURI

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
@@ -35,6 +35,11 @@ static NSString *const kFakeRequestURL = @"https://www.google.com/";
  */
 static NSString *const kFakeAPIkey = @"FAKE_API_KEY";
 
+/** @var kFakeFirebaseAppID
+    @brief Used as a fake Firebase app ID for a fake RPC request. We don't test this here.
+ */
+static NSString *const kFakeFirebaseAppID = @"FAKE_APP_ID";
+
 /** @var kFakeErrorDomain
     @brief A value to use for fake @c NSErrors.
  */
@@ -226,7 +231,7 @@ static NSString *const kTestValue = @"TestValue";
 
 - (FIRAuthRequestConfiguration *)requestConfiguration {
   FIRAuthRequestConfiguration *fakeConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey appID:kFakeFirebaseAppID];
   return fakeConfiguration;
 }
 

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -80,6 +80,11 @@
  */
 static NSString *const kAPIKey = @"FAKE_API_KEY";
 
+/** @var kFirebaseAppID
+    @brief The fake Firebase app ID.
+ */
+static NSString *const kFirebaseAppID = @"FAKE_APP_ID";
+
 /** @var kAccessToken
     @brief The fake access token.
  */
@@ -1860,7 +1865,8 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForSignInWithAccessToken:kTestAccessToken APIKey:kTestAPIKey completion:nil];
   NSString *kTestAPIKey2 = @"fakeAPIKey2";
   FIRUser *user2 = [FIRAuth auth].currentUser;
-  user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey2];
+  user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey2
+                                                                             appID:kFirebaseAppID];
   OCMExpect([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]])
       .andDispatchError2([FIRAuthErrorUtils invalidAPIKeyError]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
@@ -1883,7 +1889,8 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForSignInWithAccessToken:kTestAccessToken APIKey:kTestAPIKey completion:nil];
   NSString *kTestAPIKey2 = @"fakeAPIKey2";
   FIRUser *user2 = [FIRAuth auth].currentUser;
-  user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey2];
+  user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey2
+                                                                             appID:kFirebaseAppID];
   NSError *underlyingError = [NSError errorWithDomain:@"Test Error" code:1 userInfo:nil];
   OCMExpect([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]])
       .andDispatchError2([FIRAuthErrorUtils networkErrorWithUnderlyingError:underlyingError]);
@@ -1973,7 +1980,8 @@ static const NSTimeInterval kWaitInterval = .5;
 
   FIRUser *user1 = [FIRAuth auth].currentUser;
   NSString *kTestAPIKey = @"fakeAPIKey";
-  user1.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  user1.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                             appID:kFirebaseAppID];
   [[FIRAuth auth] signOut:nil];
 
   NSString *kTestAccessToken2 = @"fakeAccessToken2";
@@ -2641,7 +2649,8 @@ static const NSTimeInterval kWaitInterval = .5;
                          password:kFakePassword
                        completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
                          result.user.requestConfiguration =
-                             [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey];
+                             [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
+                                                                           appID:kFirebaseAppID];
                          [expectation fulfill];
                          if (completion) {
                            completion(result.user, error);

--- a/FirebaseAuth/Tests/Unit/FIRCreateAuthURIRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRCreateAuthURIRequestTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestAuthUri
     @brief The test value of the "authURI" property in the json response.
  */
@@ -85,7 +90,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testEmailVerificationRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRCreateAuthURIRequest *request =
       [[FIRCreateAuthURIRequest alloc] initWithIdentifier:kTestIdentifier
                                               continueURI:kTestContinueURI

--- a/FirebaseAuth/Tests/Unit/FIRCreateAuthURIResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRCreateAuthURIResponseTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kAuthUriKey
     @brief The name of the "authURI" property in the json response.
  */
@@ -86,7 +91,8 @@ static NSString *const kInvalidEmailErrorMessage = @"INVALID_EMAIL:";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRDeleteAccountRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRDeleteAccountRequestTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kLocalID
     @brief Fake LocalID used for testing.
  */
@@ -80,7 +85,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testDeleteAccountRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRDeleteAccountRequest *request =
       [[FIRDeleteAccountRequest alloc] initWitLocalID:kLocalID
                                           accessToken:kAccessToken

--- a/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kLocalID
     @brief Fake LocalID used for testing.
  */
@@ -78,7 +83,8 @@ static NSString *const kCredentialTooOldErrorMessage = @"CREDENTIAL_TOO_OLD_LOGI
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIREmailLinkRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIREmailLinkRequestTests.m
@@ -31,6 +31,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestEmail
     @brief The key for the "email" value in the request.
  */
@@ -91,7 +96,8 @@ static NSString *const kExpectedAPIURL =
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
@@ -32,6 +32,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestEmail
     @brief The key for the "email" value in the request.
  */
@@ -122,7 +127,8 @@ static const BOOL kFakeIsNewUSerFlag = YES;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 /** @fn testFailedEmailLinkSignInResponse

--- a/FirebaseAuth/Tests/Unit/FIRGetAccountInfoRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetAccountInfoRequestTests.m
@@ -27,6 +27,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kIDTokenKey
     @brief The key for the "idToken" value in the request. This is actually the STS Access Token,
         despite it's confusing (backwards compatiable) parameter name.
@@ -72,7 +77,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testGetAccountInfoRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetAccountInfoRequest *request =
       [[FIRGetAccountInfoRequest alloc] initWithAccessToken:kTestAccessToken
                                        requestConfiguration:requestConfiguration];

--- a/FirebaseAuth/Tests/Unit/FIRGetAccountInfoResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetAccountInfoResponseTests.m
@@ -30,6 +30,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kUsersKey
     @brief the name of the "users" property in the response.
  */
@@ -152,7 +157,7 @@ static NSString *const kEmailVerifiedKey = @"emailVerified";
  */
 - (void)testGetAccountInfoUnexpectedResponseError {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetAccountInfoRequest *request =
       [[FIRGetAccountInfoRequest alloc] initWithAccessToken:kTestAccessToken
                                        requestConfiguration:requestConfiguration];
@@ -187,7 +192,7 @@ static NSString *const kEmailVerifiedKey = @"emailVerified";
  */
 - (void)testSuccessfulGetAccountInfoResponse {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetAccountInfoRequest *request =
       [[FIRGetAccountInfoRequest alloc] initWithAccessToken:kTestAccessToken
                                        requestConfiguration:requestConfiguration];

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
@@ -29,6 +29,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kExpectedAPIURL
     @brief The expected URL for the test calls.
  */
@@ -161,7 +166,8 @@ static NSString *const kDynamicLinkDomain = @"test.page.link";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeResponseTests.m
@@ -39,6 +39,11 @@ static NSString *const kTestAccessToken = @"ACCESS_TOKEN";
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kOOBCodeKey
     @brief The name of the field in the response JSON for the OOB code.
  */
@@ -140,7 +145,8 @@ static NSString *const kIosBundleID = @"testBundleID";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRGetProjectConfigRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetProjectConfigRequestTests.m
@@ -31,6 +31,11 @@ static NSString *const kGetProjectConfigEndPoint = @"getProjectConfig";
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kAPIURLFormat
     @brief URL format for server API calls.
  */
@@ -70,7 +75,7 @@ static NSString *gAPIHost = @"www.googleapis.com";
  */
 - (void)testGetProjectConfigRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetProjectConfigRequest *request =
       [[FIRGetProjectConfigRequest alloc] initWithRequestConfiguration:requestConfiguration];
 

--- a/FirebaseAuth/Tests/Unit/FIRGetProjectConfigResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetProjectConfigResponseTests.m
@@ -29,6 +29,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestProjectID
     @brief Fake project ID used for testing.
  */
@@ -79,7 +84,7 @@ static NSString *const kMissingAPIKeyErrorMessage = @"MISSING_API_KEY";
  */
 - (void)testMissingAPIKeyError {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetProjectConfigRequest *request =
       [[FIRGetProjectConfigRequest alloc] initWithRequestConfiguration:requestConfiguration];
 
@@ -108,7 +113,7 @@ static NSString *const kMissingAPIKeyErrorMessage = @"MISSING_API_KEY";
  */
 - (void)testSuccessFulGetProjectConfigRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetProjectConfigRequest *request =
       [[FIRGetProjectConfigRequest alloc] initWithRequestConfiguration:requestConfiguration];
 

--- a/FirebaseAuth/Tests/Unit/FIRGitHubAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGitHubAuthProviderTests.m
@@ -31,6 +31,11 @@ static NSString *const kGitHubToken = @"Token";
  */
 static NSString *const kAPIKey = @"APIKey";
 
+/** @var kFirebaseAppID
+    @brief A testing Firebase app ID.
+ */
+static NSString *const kFirebaseAppID = @"appID";
+
 /** @class FIRGitHubAuthProviderTests
     @brief Tests for @c FIRGitHubAuthProvider
  */
@@ -44,7 +49,7 @@ static NSString *const kAPIKey = @"APIKey";
  */
 - (void)testCredentialWithToken {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRAuthCredential *credential = [FIRGitHubAuthProvider credentialWithToken:kGitHubToken];
   FIRVerifyAssertionRequest *request =
       [[FIRVerifyAssertionRequest alloc] initWithProviderID:FIRGitHubAuthProviderID

--- a/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
@@ -28,6 +28,11 @@ static NSString *const kEndpoint = @"endpoint";
  */
 static NSString *const kAPIKey = @"APIKey";
 
+/** @var kFirebaseAppID
+    @brief A testing Firebase app ID.
+ */
+static NSString *const kFirebaseAppID = @"appID";
+
 /** @var kEmulatorHostAndPort
     @brief A testing emulator host and port.
  */
@@ -47,7 +52,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
                                      requestConfiguration:requestConfiguration];
@@ -64,7 +69,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointUseStagingExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
                                      requestConfiguration:requestConfiguration
@@ -84,7 +89,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointUseIdentityPlatformExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
                                      requestConfiguration:requestConfiguration
@@ -102,7 +107,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointUseIdentityPlatformUseStagingExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
                                      requestConfiguration:requestConfiguration
@@ -121,7 +126,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointUseEmulatorExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
@@ -139,7 +144,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testInitWithEndpointUseIdentityPlatformUseEmulatorExpectedRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint

--- a/FirebaseAuth/Tests/Unit/FIRResetPasswordRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRResetPasswordRequestTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestOOBCode
     @brief Fake OOBCode used for testing.
  */
@@ -86,7 +91,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testResetPasswordRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRResetPasswordRequest *request =
       [[FIRResetPasswordRequest alloc] initWithOobCode:kTestOOBCode
                                            newPassword:kTestNewPassword

--- a/FirebaseAuth/Tests/Unit/FIRResetPasswordResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRResetPasswordResponseTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kUserDisabledErrorMessage
     @brief This is the error message the server will respond with if the user's account has been
         disabled.
@@ -110,7 +115,8 @@ static NSString *const kExpectedResetPasswordRequestType = @"PASSWORD_RESET";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSecureTokenRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSecureTokenRequestTests.m
@@ -25,6 +25,11 @@
  */
 static NSString *const kAPIKey = @"APIKey";
 
+/** @var kFirebaseAppID
+    @brief A testing Firebase app ID.
+ */
+static NSString *const kFirebaseAppID = @"appID";
+
 /** @var kCode
     @brief A testing authorization code.
  */
@@ -49,7 +54,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testRequestURL {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRSecureTokenRequest *request =
       [FIRSecureTokenRequest authCodeRequestWithCode:kCode
                                 requestConfiguration:requestConfiguration];
@@ -66,7 +71,7 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
  */
 - (void)testRequestURLUseEmulator {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRSecureTokenRequest *request =
       [FIRSecureTokenRequest authCodeRequestWithCode:kCode

--- a/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeRequestTests.m
@@ -30,6 +30,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestPhoneNumber
     @brief Fake phone number used for testing.
  */
@@ -103,7 +108,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testSendVerificationCodeRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRAuthAppCredential *credential = [[FIRAuthAppCredential alloc] initWithReceipt:kTestReceipt
                                                                             secret:kTestSecret];
   FIRSendVerificationCodeRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
@@ -33,6 +33,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestPhoneNumber
     @brief Fake phone number used for testing.
  */
@@ -116,7 +121,8 @@ static NSString *const kCaptchaCheckFailedErrorMessage = @"CAPTCHA_CHECK_FAILED"
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kIDTokenKey
     @brief The key for the "idToken" value in the request. This is actually the STS Access Token,
         despite it's confusing (backwards compatiable) parameter name.
@@ -203,7 +208,8 @@ static NSString *const kExpectedAPIURL =
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSetAccountInfoResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSetAccountInfoResponseTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kEmailExistsErrorMessage
     @brief This is the error message the server will respond with if the user entered an invalid
         email address.
@@ -185,7 +190,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m
@@ -27,6 +27,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKEY";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"APPID";
+
 /** @var kExpectedAPIURL
     @brief The expected URL for the test calls.
  */
@@ -176,7 +181,8 @@ static NSString *const kAccessToken = @"ACCESSTOKEN";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   self.RPCIssuer = RPCIssuer;
-  self.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  self.requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
@@ -35,6 +35,11 @@ static NSString *const kExpectedAPIURL =
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kEmailKey
     @brief The name of the "email" property in the request.
  */
@@ -92,7 +97,8 @@ static NSString *const kReturnSecureTokenKey = @"returnSecureToken";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserResponseTests.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kIDTokenKey
     @brief The name of the "IDToken" property in the response.
  */
@@ -135,7 +140,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRTwitterAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRTwitterAuthProviderTests.m
@@ -36,6 +36,11 @@ static NSString *const kTwitterSecret = @"Secret";
  */
 static NSString *const kAPIKey = @"APIKey";
 
+/** @var kFirebaseAppID
+    @brief A testing Firebase app ID.
+ */
+static NSString *const kFirebaseAppID = @"appID";
+
 /** @class FIRTwitterAuthProviderTests
     @brief Tests for @c FIRTwitterAuthProvider
  */
@@ -51,7 +56,7 @@ static NSString *const kAPIKey = @"APIKey";
   FIRAuthCredential *credential = [FIRTwitterAuthProvider credentialWithToken:kTwitterToken
                                                                        secret:kTwitterSecret];
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRVerifyAssertionRequest *request =
       [[FIRVerifyAssertionRequest alloc] initWithProviderID:FIRTwitterAuthProviderID
                                        requestConfiguration:requestConfiguration];

--- a/FirebaseAuth/Tests/Unit/FIRVerifyAssertionRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyAssertionRequestTests.m
@@ -29,6 +29,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestPostBodyKey
     @brief The name of the "postBody" property in the response.
  */
@@ -143,7 +148,8 @@ static NSString *const kAutoCreateKey = @"autoCreate";
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyAssertionResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyAssertionResponseTests.m
@@ -29,6 +29,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kProviderIDKey
     @brief The name of the "providerId" property in the response.
  */
@@ -189,7 +194,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyClientRequestTest.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyClientRequestTest.m
@@ -34,6 +34,11 @@ static NSString *const kFakeAppToken = @"appToken";
  */
 static NSString *const kFakeAPIKey = @"APIKey";
 
+/** @var kFakeFirebaseAppID
+    @brief The fake Firebase app ID to use in the test request.
+ */
+static NSString *const kFakeFirebaseAppID = @"appID";
+
 /** @var kAppTokenKey
     @brief The key for the appToken request paramenter.
  */
@@ -82,7 +87,7 @@ static NSString *const kExpectedAPIURL =
  */
 - (void)testVerifyClientRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIKey];
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIKey appID:kFakeFirebaseAppID];
   FIRVerifyClientRequest *request =
       [[FIRVerifyClientRequest alloc] initWithAppToken:kFakeAppToken
                                              isSandbox:YES

--- a/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
@@ -36,6 +36,11 @@ static NSString *const kFakeAppToken = @"appToken";
  */
 static NSString *const kFakeAPIKey = @"APIKey";
 
+/** @var kFakeFirebaseAppID
+    @brief The fake Firebase app ID to use in the test request.
+ */
+static NSString *const kFakeFirebaseAppID = @"appID";
+
 /** @var kAppTokenKey
     @brief The key for the appToken request paramenter.
  */
@@ -105,7 +110,8 @@ static NSString *const kInvalidAppCredentialErrorMessage = @"INVALID_APP_CREDENT
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIKey
+                                                                        appID:kFakeFirebaseAppID];
 }
 
 /** @fn testMissingAppCredentialError

--- a/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenRequestTests.m
@@ -29,6 +29,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kTestTokenKey
     @brief The name of the "token" property in the response.
  */
@@ -70,7 +75,8 @@ static NSString *const kExpectedAPIURL =
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenResponseTests.m
@@ -33,6 +33,11 @@ static NSString *const kTestToken = @"test token";
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kIDTokenKey
     @brief The name of the "IDToken" property in the response.
  */
@@ -132,7 +137,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
@@ -28,6 +28,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kEmailKey
     @brief The key for the "email" value in the request.
  */
@@ -112,7 +117,8 @@ static NSString *const kExpectedAPIURL =
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
@@ -33,6 +33,11 @@ static NSString *const kTestPassword = @"testpassword";
  */
 static NSString *const kTestAPIKey = @"_test_API_key_";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kLocalIDKey
     @brief The name of the 'localID' property in the response.
  */
@@ -189,7 +194,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 /** @fn testUserDisabledError

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberRequestTests.m
@@ -30,6 +30,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kVerificationCode
     @brief Fake verification code used for testing.
  */
@@ -131,7 +136,8 @@ NSString *const FIRAuthOperationString(FIRAuthOperationType operationType);
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
@@ -33,6 +33,11 @@
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
 /** @var kVerificationCode
     @brief Fake verification code used for testing.
  */
@@ -122,7 +127,8 @@ static const double kAllowedTimeDifference = 0.1;
   FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
   _RPCIssuer = RPCIssuer;
-  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey];
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Add the `X-Firebase-GMPID` header to requests made from Firebase Auth.