### PR TITLE
Fix flaky messaging test

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -83,7 +83,8 @@ static NSString *const kValidImageURL =
     [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
     OCMVerify([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
                                        completionHandler:[OCMArg any]]);
-    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    // Wait longer to accomodate increased network latency when running on CI.
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
   }
 }
 #endif  // COCOAPODS


### PR DESCRIPTION
The flaky test requires internet access. I think it's easiest to increase the expectation timeout time by a few seconds but would like to verify this works.

**Update** I was not able to repro the flaky behavior seen in the nightlies. I still think it may be worth it to extend expectation wait time and see if this test flakes again in nightlies.

#no-changelog