### PR TITLE
[draft] This fixes the issue that APNS token is not set to FM properly

### DIFF
--- a/FirebaseMessaging/Apps/Shared/AppDelegate.swift
+++ b/FirebaseMessaging/Apps/Shared/AppDelegate.swift
@@ -62,4 +62,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     Messaging.serviceExtension().exportDeliveryMetricsToBigQuery(withMessageInfo: userInfo)
     completionHandler(.newData)
   }
+  
+  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    
+  }
 }


### PR DESCRIPTION
Issue: b/209693808

Looks like swizzling is not the issue, Messaging not able to set APNS token properly during app start