### PR TITLE
Fix build errors in `FirebaseCombineSwift`

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -30,6 +30,14 @@ on:
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile'
 
+    # Dependencies
+    - 'FirebaseCore/**'
+    - 'FirebaseAuth/**'
+    - 'FirebaseFunctions/**'
+    - 'Firestore/**'
+    - 'FirebaseStorage/**'
+    - 'FirebaseStorageSwift/**'
+
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/FirebaseCombineSwift/Tests/Unit/Auth/OAuthProviderTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/OAuthProviderTests.swift
@@ -55,7 +55,11 @@ class OAuthProviderTests: XCTestCase {
     private var _authURLPresenter: FIRAuthURLPresenter!
 
     override class func auth() -> Auth {
-      let auth = MockAuth(apiKey: Credentials.apiKey, appName: "app1")!
+      let auth = MockAuth(
+        apiKey: Credentials.apiKey,
+        appName: "app1",
+        appID: Credentials.googleAppID
+      )!
       auth._authURLPresenter = MockAuthURLPresenter()
       return auth
     }
@@ -67,7 +71,7 @@ class OAuthProviderTests: XCTestCase {
     override var authURLPresenter: FIRAuthURLPresenter { _authURLPresenter }
 
     override var requestConfiguration: FIRAuthRequestConfiguration {
-      MockRequestConfiguration(apiKey: Credentials.apiKey)!
+      MockRequestConfiguration(apiKey: Credentials.apiKey, appID: Credentials.googleAppID)!
     }
   }
 

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithGameCenterTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithGameCenterTests.swift
@@ -106,7 +106,7 @@ class SignInWithGameCenterTests: XCTestCase {
 
     let signature = Data(base64Encoded: Self.signature)!
     let salt = Data(base64Encoded: Self.salt)!
-    let requestConfiguration = FIRAuthRequestConfiguration(apiKey: Self.testAPI)!
+    let requestConfiguration = FIRAuthRequestConfiguration(apiKey: Self.testAPI, appID: "appID")!
 
     let request = FIRSignInWithGameCenterRequest(
       playerID: Self.playerID,


### PR DESCRIPTION
- Fix `combine` regression from #9069
- Run `combine` on dependency source changes
#no-changelog