### PR TITLE
Control async/await testing from source instead of podspec

### DIFF
--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -82,11 +82,11 @@ app update.
   # Run Swift API tests on a real backend.
   s.test_spec 'swift-api-tests' do |swift_api|
     swift_api.scheme = { :code_coverage => true }
-
-    # Use recent platform versions to enable async await testing
-    swift_api.ios.deployment_target = "15.0"
-    swift_api.osx.deployment_target = "12.0"
-    swift_api.tvos.deployment_target = "15.0"
+    swift_api.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     swift_api.source_files = 'FirebaseRemoteConfig/Tests/SwiftAPI/*.swift',
                              'FirebaseRemoteConfig/Tests/FakeUtils/*.[hm]',
                              'FirebaseRemoteConfig/Tests/FakeUtils/*.swift'
@@ -100,11 +100,11 @@ app update.
   # Run Swift API tests and tests requiring console changes on a Fake Console.
   s.test_spec 'fake-console-tests' do |fake_console|
     fake_console.scheme = { :code_coverage => true }
-
-    # Use recent platform versions to enable async await testing
-    fake_console.ios.deployment_target = "15.0"
-    fake_console.osx.deployment_target = "12.0"
-    fake_console.tvos.deployment_target = "15.0"
+    fake_console.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
     fake_console.source_files = 'FirebaseRemoteConfig/Tests/SwiftAPI/*.swift',
                                       'FirebaseRemoteConfig/Tests/FakeUtils/*.[hm]',
                                       'FirebaseRemoteConfig/Tests/FakeUtils/*.swift',

--- a/FirebaseRemoteConfig/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -28,131 +28,134 @@ private enum Constants {
   static let darthSidious = "Darth Sidious"
 }
 
-class AsyncAwaitTests: APITestBase {
-  var console: RemoteConfigConsole!
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  class AsyncAwaitTests: APITestBase {
+    var console: RemoteConfigConsole!
 
-  override func setUp() {
-    super.setUp()
-    if APITests.useFakeConfig {
-      fakeConsole.config = [Constants.key1: Constants.value1]
-    } else {
-      console = RemoteConfigConsole()
-      console.updateRemoteConfigValue(Constants.obiwan, forKey: Constants.jedi)
+    override func setUp() {
+      super.setUp()
+      if APITests.useFakeConfig {
+        fakeConsole.config = [Constants.key1: Constants.value1]
+      } else {
+        console = RemoteConfigConsole()
+        console.updateRemoteConfigValue(Constants.obiwan, forKey: Constants.jedi)
+      }
     }
-  }
 
-  override func tearDown() {
-    super.tearDown()
+    override func tearDown() {
+      super.tearDown()
 
-    // If using RemoteConfigConsole, reset remote config values.
-    if !APITests.useFakeConfig {
-      console.removeRemoteConfigValue(forKey: Constants.sith)
+      // If using RemoteConfigConsole, reset remote config values.
+      if !APITests.useFakeConfig {
+        console.removeRemoteConfigValue(forKey: Constants.sith)
+        console.removeRemoteConfigValue(forKey: Constants.jedi)
+      }
+    }
+
+    func testFetchThenActivate() async throws {
+      let status = try await config.fetch()
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      let success = try await config.activate()
+      XCTAssertTrue(success)
+    }
+
+    func testFetchWithExpirationThenActivate() async throws {
+      let status = try await config.fetch(withExpirationDuration: 0)
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      _ = try await config.activate()
+      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+    }
+
+    func testFetchAndActivate() async throws {
+      let status = try await config.fetchAndActivate()
+      XCTAssertEqual(status, .successFetchedFromRemote)
+      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+    }
+
+    // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
+    func testUnchangedActivateWillFlag() async throws {
+      let status = try await config.fetch()
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      let changed = try await config.activate()
+      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+      XCTAssertTrue(!APITests.useFakeConfig || changed)
+      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+    }
+
+    func testFetchAndActivateUnchangedConfig() async throws {
+      guard APITests.useFakeConfig == false else { return }
+
+      XCTAssertEqual(config.settings.minimumFetchInterval, 0)
+
+      // Represents pre-fetch occurring sometime in past.
+      let status = try await config.fetch()
+      XCTAssertEqual(status, .success)
+
+      // Represents a `fetchAndActivate` being made to pull latest changes from Remote Config.
+      let status2 = try await config.fetchAndActivate()
+      // Since no updates to remote config have occurred we use the `.successUsingPreFetchedData`.
+      // The behavior of the next test changed in Firebase 7.0.0.
+      // It's an open question which is correct, but it should only
+      // be changed in a major release.
+      // See https://github.com/firebase/firebase-ios-sdk/pull/8788
+      // XCTAssertEqual(status, .successUsingPreFetchedData)
+      XCTAssertEqual(status2, .successFetchedFromRemote)
+      // The `lastETagUpdateTime` should either be older or the same time as `lastFetchTime`.
+      if let lastFetchTime = try? XCTUnwrap(config.lastFetchTime) {
+        XCTAssertLessThanOrEqual(Double(config.settings.lastETagUpdateTime),
+                                 Double(lastFetchTime.timeIntervalSince1970))
+      } else {
+        XCTFail("Could not unwrap lastFetchTime.")
+      }
+    }
+
+    // MARK: - RemoteConfigConsole Tests
+
+    func testFetchConfigThenUpdateConsoleThenFetchAgain() async throws {
+      guard APITests.useFakeConfig == false else { return }
+
+      _ = try await config.fetchAndActivate()
+      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+      XCTAssertEqual(configValue, Constants.obiwan)
+
+      // Synchronously update the console.
+      console.updateRemoteConfigValue(Constants.yoda, forKey: Constants.jedi)
+
+      _ = try await config.fetchAndActivate()
+      let configValue2 = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+      XCTAssertEqual(configValue2, Constants.yoda)
+    }
+
+    func testFetchConfigThenAddValueOnConsoleThenFetchAgain() async throws {
+      guard APITests.useFakeConfig == false else { return }
+
+      // Ensure no Sith Lord has been written to Remote Config yet.
+      _ = try await config.fetchAndActivate()
+      XCTAssertTrue(config.configValue(forKey: Constants.sith).dataValue.isEmpty)
+
+      // Synchronously update the console
+      console.updateRemoteConfigValue(Constants.darthSidious, forKey: Constants.sith)
+
+      // Verify the Sith Lord can now be fetched from Remote Config
+      _ = try await config.fetchAndActivate()
+      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.sith).stringValue)
+      XCTAssertEqual(configValue, Constants.darthSidious)
+    }
+
+    func testFetchConfigThenDeleteValueOnConsoleThenFetchAgain() async throws {
+      guard APITests.useFakeConfig == false else { return }
+
+      _ = try await config.fetchAndActivate()
+      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+      XCTAssertEqual(configValue, Constants.obiwan)
+
+      // Synchronously delete value on the console.
       console.removeRemoteConfigValue(forKey: Constants.jedi)
+
+      _ = try await config.fetchAndActivate()
+      XCTAssertTrue(config.configValue(forKey: Constants.jedi).dataValue.isEmpty,
+                    "Remote config should have been deleted.")
     }
   }
-
-  func testFetchThenActivate() async throws {
-    let status = try await config.fetch()
-    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-    let success = try await config.activate()
-    XCTAssertTrue(success)
-  }
-
-  func testFetchWithExpirationThenActivate() async throws {
-    let status = try await config.fetch(withExpirationDuration: 0)
-    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-    _ = try await config.activate()
-    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-  }
-
-  func testFetchAndActivate() async throws {
-    let status = try await config.fetchAndActivate()
-    XCTAssertEqual(status, .successFetchedFromRemote)
-    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-  }
-
-  // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
-  func testUnchangedActivateWillFlag() async throws {
-    let status = try await config.fetch()
-    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-    let changed = try await config.activate()
-    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-    XCTAssertTrue(!APITests.useFakeConfig || changed)
-    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-  }
-
-  func testFetchAndActivateUnchangedConfig() async throws {
-    guard APITests.useFakeConfig == false else { return }
-
-    XCTAssertEqual(config.settings.minimumFetchInterval, 0)
-
-    // Represents pre-fetch occurring sometime in past.
-    let status = try await config.fetch()
-    XCTAssertEqual(status, .success)
-
-    // Represents a `fetchAndActivate` being made to pull latest changes from Remote Config.
-    let status2 = try await config.fetchAndActivate()
-    // Since no updates to remote config have occurred we use the `.successUsingPreFetchedData`.
-    // The behavior of the next test changed in Firebase 7.0.0.
-    // It's an open question which is correct, but it should only
-    // be changed in a major release.
-    // See https://github.com/firebase/firebase-ios-sdk/pull/8788
-    // XCTAssertEqual(status, .successUsingPreFetchedData)
-    XCTAssertEqual(status2, .successFetchedFromRemote)
-    // The `lastETagUpdateTime` should either be older or the same time as `lastFetchTime`.
-    if let lastFetchTime = try? XCTUnwrap(config.lastFetchTime) {
-      XCTAssertLessThanOrEqual(Double(config.settings.lastETagUpdateTime),
-                               Double(lastFetchTime.timeIntervalSince1970))
-    } else {
-      XCTFail("Could not unwrap lastFetchTime.")
-    }
-  }
-
-  // MARK: - RemoteConfigConsole Tests
-
-  func testFetchConfigThenUpdateConsoleThenFetchAgain() async throws {
-    guard APITests.useFakeConfig == false else { return }
-
-    _ = try await config.fetchAndActivate()
-    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-    XCTAssertEqual(configValue, Constants.obiwan)
-
-    // Synchronously update the console.
-    console.updateRemoteConfigValue(Constants.yoda, forKey: Constants.jedi)
-
-    _ = try await config.fetchAndActivate()
-    let configValue2 = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-    XCTAssertEqual(configValue2, Constants.yoda)
-  }
-
-  func testFetchConfigThenAddValueOnConsoleThenFetchAgain() async throws {
-    guard APITests.useFakeConfig == false else { return }
-
-    // Ensure no Sith Lord has been written to Remote Config yet.
-    _ = try await config.fetchAndActivate()
-    XCTAssertTrue(config.configValue(forKey: Constants.sith).dataValue.isEmpty)
-
-    // Synchronously update the console
-    console.updateRemoteConfigValue(Constants.darthSidious, forKey: Constants.sith)
-
-    // Verify the Sith Lord can now be fetched from Remote Config
-    _ = try await config.fetchAndActivate()
-    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.sith).stringValue)
-    XCTAssertEqual(configValue, Constants.darthSidious)
-  }
-
-  func testFetchConfigThenDeleteValueOnConsoleThenFetchAgain() async throws {
-    guard APITests.useFakeConfig == false else { return }
-
-    _ = try await config.fetchAndActivate()
-    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-    XCTAssertEqual(configValue, Constants.obiwan)
-
-    // Synchronously delete value on the console.
-    console.removeRemoteConfigValue(forKey: Constants.jedi)
-
-    _ = try await config.fetchAndActivate()
-    XCTAssertTrue(config.configValue(forKey: Constants.jedi).dataValue.isEmpty,
-                  "Remote config should have been deleted.")
-  }
-}
+#endif


### PR DESCRIPTION
The minimum versions in the podspec cause `pod install` and build warnings.  Also using `@available` is consistent with the rest of Firebase.