### PR TITLE
Make `CoreUnit` scheme buildable

### DIFF
--- a/scripts/spm_test_schemes/CoreUnit.xcscheme
+++ b/scripts/spm_test_schemes/CoreUnit.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "NO"
+            buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">
@@ -57,6 +57,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CoreUnit"
+            BuildableName = "CoreUnit"
+            BlueprintName = "CoreUnit"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
When developing `FirebaseCore` with SPM, I commonly try to build `FirebaseCore` in Xcode and get: 
<img width="250" alt="Screen Shot 2021-12-11 at 7 01 31 PM" src="https://user-images.githubusercontent.com/36927374/145695620-47c2c3ce-4c2f-45b1-addb-3c26209d10da.png">

So I tweaked the scheme to allow for running (building) the library.

#no-changelog