### PR TITLE
[Security] Change APIKey documentation

### DIFF
--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -32,7 +32,8 @@ NS_SWIFT_NAME(FirebaseOptions)
 
 /**
  * An iOS API key used for authenticating requests from your app, e.g.
- * The key must begin with "A" and contain exactly 39 alphanumeric characters, used to identify your app to Google servers.
+ * The key must begin with "A" and contain exactly 39 alphanumeric characters, used to identify your
+ * app to Google servers.
  */
 @property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
 

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -32,7 +32,7 @@ NS_SWIFT_NAME(FirebaseOptions)
 
 /**
  * An iOS API key used for authenticating requests from your app, e.g.
- * @"AIzaSyDdVgKwhZl0sTTTLZ7iTmt1r3N2cJLnaDk", used to identify your app to Google servers.
+ * The key contains about 39 alphanumeric digits, used to identify your app to Google servers.
  */
 @property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
 

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -32,7 +32,7 @@ NS_SWIFT_NAME(FirebaseOptions)
 
 /**
  * An iOS API key used for authenticating requests from your app, e.g.
- * The key contains about 39 alphanumeric digits, used to identify your app to Google servers.
+ * The key must begin with "A" and contain exactly 39 alphanumeric characters, used to identify your app to Google servers.
  */
 @property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
 


### PR DESCRIPTION
### Discussion

Fix #9087

Currently, the file `FIROptions.h` includes an example key that triggers security systems. A better solution can be to describe the key and not include one.

```
/**
 * An iOS API key used for authenticating requests from your app, e.g.
 * @"AIzaSyDdVgKwhZl0sTTTLZ7iTmt1r3N2cJLnaDk", used to identify your app to Google servers.
 */
@property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
```