### PR TITLE
Add Swift Doc Scrub to dashboard

### DIFF
--- a/SwiftDashboard.md
+++ b/SwiftDashboard.md
@@ -16,7 +16,8 @@ tasks for additional Swift improvements.
 | **Codable**           | n/a  | n/a     | n/a   |n/a    | n/a     | n/a    |n/a     |  ✔     |  ✔     | 1      | n/a     | n/a   | ❌     | n/a    | n/a    |  ❌  |n/a   |
 | **SwiftUI Lifecycle** | n/a  |  ❌    | n/a    |❌     | ❌     | n/a    |n/a     | n/a    | n/a    | n/a     | n/a    | n/a   | ❌     | n/a    | n/a    | n/a   |n/a  |
 | **SwiftUI Interop**   | ❌   |  ✔     | ❌     |❌    | ❌     | ❌     |❌      | ❌     | ❌    | ❌     | ✔      | ❌    | ❌     | ❌    | ❌     | ❌    |n/a  |
-| **Property Wrappers** |  ❌  |  ❌    | ❌    |❌     | ❌     | ❌     | ❌     | ❌     | 6     | ❌     | ❌     | ❌    | ❌     | ❌    | ❌     | ❌   |❌     |
+| **Property Wrappers** |  ❌  |  ❌    | ❌    |❌     | ❌     | ❌     | ❌     | ❌     | 6     | ❌     | ❌     | ❌    | ❌     | ❌    | ❌     | ❌   |❌    |
+| **Swift Doc Scrub**   |  ❌  |  ❌    | ❌    |❌     | ❌     | ❌     | ❌     | ❌     |  ❌   | ❌     | ❌     | ❌    | ❌     | ❌    | ❌     | ❌   |❌    |
 
 ### Other Projects
 - Tooling to surface full list of automatically generated Swift API from Objective C and validate.
@@ -45,6 +46,7 @@ for Storage.
 Property Wrappers and likely the SwiftUI lifecycle bits, but an audit and improvements could likely be made. The existing FIAM and Analytics View modifier
 APIs would fit into this category.
 * **Property Wrappers**: Property wrappers are used to improve the API.
+* **Swift Doc Scrub**: Review and update to change Objective C types and call examples to Swift.
 
 ## Columns (Firebase Products)
 * AB - AB Testing

--- a/SwiftDashboard.md
+++ b/SwiftDashboard.md
@@ -46,7 +46,8 @@ for Storage.
 Property Wrappers and likely the SwiftUI lifecycle bits, but an audit and improvements could likely be made. The existing FIAM and Analytics View modifier
 APIs would fit into this category.
 * **Property Wrappers**: Property wrappers are used to improve the API.
-* **Swift Doc Scrub**: Review and update to change Objective C types and call examples to Swift.
+* **Swift Doc Scrub**: Review and update to change Objective C types and call examples to Swift. In addition to updating the documentation content, we
+should also investigate using DocC to format the docs.
 
 ## Columns (Firebase Products)
 * AB - AB Testing


### PR DESCRIPTION
See https://firebase.google.com/docs/reference/swift/firebaseremoteconfig/api/reference/Classes/RemoteConfig?authuser=0 for an example where almost every API references an Objective C type or call even though the APIs themselves are Swift