### PR TITLE
Remove unused STS auth code flow.

### DIFF
--- a/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.h
@@ -20,65 +20,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** @enum FIRSecureTokenRequestGrantType
-    @brief Represents the possible grant types for a token request.
- */
-typedef NS_ENUM(NSUInteger, FIRSecureTokenRequestGrantType) {
-  /** @var FIRSecureTokenRequestGrantTypeAuthorizationCode
-      @brief Indicates an authorization code request.
-      @remarks Exchanges a Gitkit "ID Token" for an STS Access Token and Refresh Token.
-   */
-  FIRSecureTokenRequestGrantTypeAuthorizationCode,
-
-  /** @var FIRSecureTokenRequestGrantTypeRefreshToken
-      @brief Indicates an refresh token request.
-      @remarks Uses an existing Refresh Token to create a new Access Token.
-   */
-  FIRSecureTokenRequestGrantTypeRefreshToken,
-};
-
 /** @class FIRSecureTokenRequest
     @brief Represents the parameters for the token endpoint.
  */
 @interface FIRSecureTokenRequest : NSObject <FIRAuthRPCRequest>
-
-/** @property grantType
-    @brief The type of grant requested.
-    @see FIRSecureTokenRequestGrantType
- */
-@property(nonatomic, assign, readonly) FIRSecureTokenRequestGrantType grantType;
-
-/** @property scope
-    @brief The scopes requested (a comma-delimited list of scope strings.)
- */
-@property(nonatomic, copy, readonly, nullable) NSString *scope;
 
 /** @property refreshToken
     @brief The client's refresh token.
  */
 @property(nonatomic, copy, readonly, nullable) NSString *refreshToken;
 
-/** @property code
-    @brief The client's authorization code (legacy Gitkit "ID Token").
- */
-@property(nonatomic, copy, readonly, nullable) NSString *code;
-
 /** @property APIKey
     @brief The client's API Key.
  */
 @property(nonatomic, copy, readonly) NSString *APIKey;
 
-/** @fn authCodeRequestWithCode:
-    @brief Creates an authorization code request with the given code (legacy Gitkit "ID Token").
-    @param code The authorization code (legacy Gitkit "ID Token").
-    @param requestConfiguration An object containing configurations to be added to the request.
-    @return An authorization request.
- */
-+ (FIRSecureTokenRequest *)authCodeRequestWithCode:(NSString *)code
-                              requestConfiguration:
-                                  (FIRAuthRequestConfiguration *)requestConfiguration;
-
-/** @fn refreshRequestWithCode:
+/** @fn refreshRequestWithRefreshToken:requestConfiguration:
     @brief Creates a refresh request with the given refresh token.
     @param refreshToken The refresh token.
     @param requestConfiguration An object containing configurations to be added to the request.
@@ -89,23 +46,17 @@ typedef NS_ENUM(NSUInteger, FIRSecureTokenRequestGrantType) {
                                          (FIRAuthRequestConfiguration *)requestConfiguration;
 
 /** @fn init
-    @brief Please use initWithGrantType:scope:refreshToken:code:
+    @brief Please use initWithRefreshToken:requestConfiguration:
  */
 - (instancetype)init NS_UNAVAILABLE;
 
-/** @fn initWithGrantType:scope:refreshToken:code:APIKey:
+/** @fn initWithRefreshToken:requestConfiguration:
     @brief Designated initializer.
-    @param grantType The type of request.
-    @param scope The scopes requested.
     @param refreshToken The client's refresh token (for refresh requests.)
-    @param code The client's authorization code (Gitkit ID Token) (for authorization code requests.)
     @param requestConfiguration An object containing configurations to be added to the request.
  */
-- (nullable instancetype)initWithGrantType:(FIRSecureTokenRequestGrantType)grantType
-                                     scope:(nullable NSString *)scope
-                              refreshToken:(nullable NSString *)refreshToken
-                                      code:(nullable NSString *)code
-                      requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+- (nullable instancetype)initWithRefreshToken:(NSString *)refreshToken
+                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.m
@@ -37,30 +37,15 @@ static NSString *const kFIREmulatorURLFormat = @"http://%@/%@/v1/token?key=%@";
  */
 static NSString *const kFIRSecureTokenServiceGrantTypeRefreshToken = @"refresh_token";
 
-/** @var kFIRSecureTokenServiceGrantTypeAuthorizationCode
-    @brief The string value of the @c FIRSecureTokenRequestGrantTypeAuthorizationCode request type.
- */
-static NSString *const kFIRSecureTokenServiceGrantTypeAuthorizationCode = @"authorization_code";
-
 /** @var kGrantTypeKey
     @brief The key for the "grantType" parameter in the request.
  */
 static NSString *const kGrantTypeKey = @"grantType";
 
-/** @var kScopeKey
-    @brief The key for the "scope" parameter in the request.
- */
-static NSString *const kScopeKey = @"scope";
-
 /** @var kRefreshTokenKey
     @brief The key for the "refreshToken" parameter in the request.
  */
 static NSString *const kRefreshTokenKey = @"refreshToken";
-
-/** @var kCodeKey
-    @brief The key for the "code" parameter in the request.
- */
-static NSString *const kCodeKey = @"code";
 
 /** @var gAPIHost
  @brief Host for server API calls.
@@ -74,50 +59,17 @@ static NSString *gAPIHost = @"securetoken.googleapis.com";
   FIRAuthRequestConfiguration *_requestConfiguration;
 }
 
-+ (FIRSecureTokenRequest *)authCodeRequestWithCode:(NSString *)code
-                              requestConfiguration:
-                                  (FIRAuthRequestConfiguration *)requestConfiguration {
-  return [[self alloc] initWithGrantType:FIRSecureTokenRequestGrantTypeAuthorizationCode
-                                   scope:nil
-                            refreshToken:nil
-                                    code:code
-                    requestConfiguration:requestConfiguration];
-}
-
 + (FIRSecureTokenRequest *)refreshRequestWithRefreshToken:(NSString *)refreshToken
                                      requestConfiguration:
                                          (FIRAuthRequestConfiguration *)requestConfiguration {
-  return [[self alloc] initWithGrantType:FIRSecureTokenRequestGrantTypeRefreshToken
-                                   scope:nil
-                            refreshToken:refreshToken
-                                    code:nil
-                    requestConfiguration:requestConfiguration];
+  return [[self alloc] initWithRefreshToken:refreshToken requestConfiguration:requestConfiguration];
 }
 
-/** @fn grantTypeStringWithGrantType:
-    @brief Converts a @c FIRSecureTokenRequestGrantType to it's @c NSString equivilent.
- */
-+ (NSString *)grantTypeStringWithGrantType:(FIRSecureTokenRequestGrantType)grantType {
-  switch (grantType) {
-    case FIRSecureTokenRequestGrantTypeAuthorizationCode:
-      return kFIRSecureTokenServiceGrantTypeAuthorizationCode;
-    case FIRSecureTokenRequestGrantTypeRefreshToken:
-      return kFIRSecureTokenServiceGrantTypeRefreshToken;
-      // No Default case so we will notice if new grant types are added to the enum.
-  }
-}
-
-- (nullable instancetype)initWithGrantType:(FIRSecureTokenRequestGrantType)grantType
-                                     scope:(nullable NSString *)scope
-                              refreshToken:(nullable NSString *)refreshToken
-                                      code:(nullable NSString *)code
-                      requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
+- (nullable instancetype)initWithRefreshToken:(NSString *)refreshToken
+                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super init];
   if (self) {
-    _grantType = grantType;
-    _scope = [scope copy];
     _refreshToken = [refreshToken copy];
-    _code = [code copy];
     _APIKey = [requestConfiguration.APIKey copy];
     _requestConfiguration = requestConfiguration;
   }
@@ -148,17 +100,10 @@ static NSString *gAPIHost = @"securetoken.googleapis.com";
 }
 
 - (nullable id)unencodedHTTPRequestBodyWithError:(NSError *_Nullable *_Nullable)error {
-  NSMutableDictionary *postBody =
-      [@{kGrantTypeKey : [[self class] grantTypeStringWithGrantType:_grantType]} mutableCopy];
-  if (_scope) {
-    postBody[kScopeKey] = _scope;
-  }
-  if (_refreshToken) {
-    postBody[kRefreshTokenKey] = _refreshToken;
-  }
-  if (_code) {
-    postBody[kCodeKey] = _code;
-  }
+  NSMutableDictionary *postBody = [@{
+    kGrantTypeKey : kFIRSecureTokenServiceGrantTypeRefreshToken,
+    kRefreshTokenKey : _refreshToken
+  } mutableCopy];
   return [postBody copy];
 }
 

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.h
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.h
@@ -64,14 +64,6 @@ typedef void (^FIRFetchAccessTokenCallback)(NSString *_Nullable token,
  */
 @property(nonatomic, copy, readonly, nullable) NSDate *accessTokenExpirationDate;
 
-/** @fn initWithRequestConfiguration:authorizationCode:
-    @brief Creates a @c FIRSecureTokenService with an authroization code.
-    @param requestConfiguration The configuration for making requests to server.
-    @param authorizationCode An authorization code which needs to be exchanged for STS tokens.
- */
-- (instancetype)initWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
-                           authorizationCode:(NSString *)authorizationCode;
-
 /** @fn initWithRequestConfiguration:accessToken:accessTokenExpirationDate:refreshToken
     @brief Creates a @c FIRSecureTokenService with access and refresh tokens.
     @param requestConfiguration The configuration for making requests to server.

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -64,11 +64,6 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
    */
   FIRAuthSerialTaskQueue *_taskQueue;
 
-  /** @var _authorizationCode
-      @brief An authorization code which needs to be exchanged for Secure Token Service tokens.
-   */
-  NSString *_Nullable _authorizationCode;
-
   /** @var _accessToken
       @brief The currently cached access token. Or |nil| if no token is currently cached.
    */
@@ -79,16 +74,6 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
   self = [super init];
   if (self) {
     _taskQueue = [[FIRAuthSerialTaskQueue alloc] init];
-  }
-  return self;
-}
-
-- (instancetype)initWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
-                           authorizationCode:(NSString *)authorizationCode {
-  self = [self init];
-  if (self) {
-    _requestConfiguration = requestConfiguration;
-    _authorizationCode = [authorizationCode copy];
   }
   return self;
 }
@@ -176,14 +161,9 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
         access to and mutation of these instance variables.
  */
 - (void)requestAccessToken:(FIRFetchAccessTokenCallback)callback {
-  FIRSecureTokenRequest *request;
-  if (_refreshToken.length) {
-    request = [FIRSecureTokenRequest refreshRequestWithRefreshToken:_refreshToken
-                                               requestConfiguration:_requestConfiguration];
-  } else {
-    request = [FIRSecureTokenRequest authCodeRequestWithCode:_authorizationCode
-                                        requestConfiguration:_requestConfiguration];
-  }
+  FIRSecureTokenRequest *request =
+      [FIRSecureTokenRequest refreshRequestWithRefreshToken:_refreshToken
+                                       requestConfiguration:_requestConfiguration];
   [FIRAuthBackend
       secureToken:request
          callback:^(FIRSecureTokenResponse *_Nullable response, NSError *_Nullable error) {

--- a/FirebaseAuth/Tests/Unit/FIRSecureTokenRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSecureTokenRequestTests.m
@@ -30,10 +30,10 @@ static NSString *const kAPIKey = @"APIKey";
  */
 static NSString *const kFirebaseAppID = @"appID";
 
-/** @var kCode
-    @brief A testing authorization code.
+/** @var kRefreshToken
+    @brief A testing refresh token.
  */
-static NSString *const kCode = @"code";
+static NSString *const kRefreshToken = @"refreshToken";
 
 /** @var kEmulatorHostAndPort
     @brief A testing emulator host and port.
@@ -56,8 +56,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
   FIRAuthRequestConfiguration *requestConfiguration =
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRSecureTokenRequest *request =
-      [FIRSecureTokenRequest authCodeRequestWithCode:kCode
-                                requestConfiguration:requestConfiguration];
+      [FIRSecureTokenRequest refreshRequestWithRefreshToken:kRefreshToken
+                                       requestConfiguration:requestConfiguration];
 
   NSString *expectedURL =
       [NSString stringWithFormat:@"https://securetoken.googleapis.com/v1/token?key=%@", kAPIKey];
@@ -74,8 +74,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRSecureTokenRequest *request =
-      [FIRSecureTokenRequest authCodeRequestWithCode:kCode
-                                requestConfiguration:requestConfiguration];
+      [FIRSecureTokenRequest refreshRequestWithRefreshToken:kRefreshToken
+                                       requestConfiguration:requestConfiguration];
 
   NSString *expectedURL =
       [NSString stringWithFormat:@"http://%@/securetoken.googleapis.com/v1/token?key=%@",


### PR DESCRIPTION
Removing the unused Secure Token Service authorization code flow, as it is never invoked anywhere and is just dead code. In addition, the authorization code flow is deprecated on the backend.

#no-changelog non-user-visible refactoring