### PR TITLE
Remove reference to non-existent protocol.

### DIFF
--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -27,7 +27,6 @@
 @class FIRAuthDataResult;
 @class FIRAuthSettings;
 @class FIRUser;
-@protocol FIRAuthStateListener;
 @protocol FIRAuthUIDelegate;
 @protocol FIRFederatedAuthProvider;
 


### PR DESCRIPTION
`FIRAuthStateListener` has no definition nor other references, so is safe to remove.

#no-changelog non-user-visible refactoring