### PR TITLE
Update setup_bundler.sh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "9cebcde577f56aa26f27d8aa501b51fdd4d6abdb"
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
-# This line will trip CI.
 
 gem 'cocoapods', '1.11.2'
 gem 'cocoapods-generate', '2.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.11.2'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '6.1.0'
+ 

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ source 'https://rubygems.org'
 # gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "9cebcde577f56aa26f27d8aa501b51fdd4d6abdb"
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
+# This line will trip CI.
 
 gem 'cocoapods', '1.11.2'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '6.1.0'
- 

--- a/scripts/setup_bundler.sh
+++ b/scripts/setup_bundler.sh
@@ -20,10 +20,6 @@
 # - Uncomment the following line and choose the alternative Xcode version.
 #sudo xcode-select -s /Applications/Xcode_13.0.app/Contents/Developer
 
-# TODO(paulb777): Remove once Xcode 13 becomes the default version in macOS 11.
-# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-sudo xcode-select -s /Applications/Xcode_13.0.app/Contents/Developer
-
 bundle update --bundler # ensure bundler version is high enough for Gemfile.lock
 bundle install
 bundle --version


### PR DESCRIPTION
Resolve TODO because [Xcode 13 is now the default version in macOS 11](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode). Specifically, it is defaulting to Xcode **13.1**

#no-changelog