### PR TITLE
[Auth] Fixed macOS extension keychain access by adding recommended kS…

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [changed] Added a `X-Firebase-GMPID` header to network requests. (#9046)
 - [fixed] Added multi-tenancy support to generic OAuth providers. (#7990)
+- [fixed] macOS Extension access to Shared Keychain by adding kSecUseDataProtectionKeychain recommended key (#6876)
 
 # 8.9.0
 - [changed] Improved error logging. (#8704)

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -81,6 +81,9 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
   query[(__bridge id)kSecAttrService] = projectIdentifier;
   query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
+  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
+    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
+  }
   if (shareAuthStateAcrossDevices) {
     query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
   }
@@ -125,6 +128,9 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
   query[(__bridge id)kSecAttrService] = projectIdentifier;
   query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
+  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
+    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
+  }
   if (shareAuthStateAcrossDevices) {
     query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
   }
@@ -168,6 +174,9 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
   query[(__bridge id)kSecAttrService] = projectIdentifier;
   query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
+  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
+    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
+  }
 
   return [self.keychainServices removeItemWithQuery:query error:outError];
 }

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -75,19 +75,9 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
              shareAuthStateAcrossDevices:(BOOL)shareAuthStateAcrossDevices
                        projectIdentifier:(NSString *)projectIdentifier
                                    error:(NSError *_Nullable *_Nullable)outError {
-  NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
-  query[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
-
-  query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
-  query[(__bridge id)kSecAttrService] = projectIdentifier;
-  query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
-  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
-    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
-  }
-  if (shareAuthStateAcrossDevices) {
-    query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
-  }
-
+  NSMutableDictionary *query = [self keychainQueryForAccessGroup:accessGroup
+                                     shareAuthStateAcrossDevices:shareAuthStateAcrossDevices
+                                               projectIdentifier:projectIdentifier];
   NSData *data = [self.keychainServices getItemWithQuery:query error:outError];
   // If there's an outError parameter and it's populated, or there's no data, return.
   if ((outError && *outError) || !data) {
@@ -116,25 +106,15 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
     shareAuthStateAcrossDevices:(BOOL)shareAuthStateAcrossDevices
               projectIdentifier:(NSString *)projectIdentifier
                           error:(NSError *_Nullable *_Nullable)outError {
-  NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
-  query[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
+  NSMutableDictionary *query = [self keychainQueryForAccessGroup:accessGroup
+                                     shareAuthStateAcrossDevices:shareAuthStateAcrossDevices
+                                               projectIdentifier:projectIdentifier];
   if (shareAuthStateAcrossDevices) {
     query[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
   } else {
     query[(__bridge id)kSecAttrAccessible] =
         (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   }
-
-  query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
-  query[(__bridge id)kSecAttrService] = projectIdentifier;
-  query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
-  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
-    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
-  }
-  if (shareAuthStateAcrossDevices) {
-    query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
-  }
-
 #if TARGET_OS_WATCH
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:false];
 #else
@@ -159,26 +139,44 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
            shareAuthStateAcrossDevices:(BOOL)shareAuthStateAcrossDevices
                      projectIdentifier:(NSString *)projectIdentifier
                                  error:(NSError *_Nullable *_Nullable)outError {
-  NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
-  query[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
+  NSMutableDictionary *query = [self keychainQueryForAccessGroup:accessGroup
+                                     shareAuthStateAcrossDevices:shareAuthStateAcrossDevices
+                                               projectIdentifier:projectIdentifier];
   if (shareAuthStateAcrossDevices) {
     query[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
   } else {
     query[(__bridge id)kSecAttrAccessible] =
         (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   }
+  return [self.keychainServices removeItemWithQuery:query error:outError];
+}
+
+#pragma mark - Internal Methods
+
+- (NSMutableDictionary *)keychainQueryForAccessGroup:(NSString *)accessGroup
+                         shareAuthStateAcrossDevices:(BOOL)shareAuthStateAcrossDevices
+                                   projectIdentifier:(NSString *)projectIdentifier {
+  NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
+  query[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
+  query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
+  query[(__bridge id)kSecAttrService] = projectIdentifier;
+  query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
+
+  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
+    /*
+      "The data protection key affects operations only in macOS.
+      Other platforms automatically behave as if the key is set to true,
+      and ignore the key in the query dictionary. You can safely use the key on all platforms."
+      [kSecUseDataProtectionKeychain](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain)
+    */
+    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
+  }
+
   if (shareAuthStateAcrossDevices) {
     query[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanTrue;
   }
 
-  query[(__bridge id)kSecAttrAccessGroup] = accessGroup;
-  query[(__bridge id)kSecAttrService] = projectIdentifier;
-  query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
-  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
-    query[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
-  }
-
-  return [self.keychainServices removeItemWithQuery:query error:outError];
+  return query;
 }
 
 @end


### PR DESCRIPTION
Fixes #8950, #6876

I'm working on the app that used Firebase Auth for authentication. I have an iOS app with iOS Share Extension and macOS app with macOS Share Extension.
By adding Keychain Access Group, I can use authenticated accounts between the main iOS app and iOS Share Extension. But the same code doesn't work on macOS.
When the app is installed on macOS or when I'm trying to access it from macOS Share Extension, I always get a prompt to keychain access. I started to dig, and I found the keychain parameter https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain
from its documentation, we can find

> use the data protection key when adding, searching for, or deleting an item to which the kSecAttrAccessible or **kSecAttrAccessGroup** attributes apply.

> It's highly recommended that you set the value of this key to true for all keychain operations. This key helps to improve the portability of your code across platforms.

It can be added to all platforms:

> The data protection key affects operations only in macOS. Other platforms automatically behave as if the key is set to true, and ignore the key in the query dictionary. You can safely use the key on all platforms.

`kSecUseDataProtectionKeychain` key is also mentioned in https://developer.apple.com/documentation/security/ksecattraccessgroup documentation

> This attribute applies to macOS keychain items only if you also set a value of true for the kSecUseDataProtectionKeychain key, the kSecAttrSynchronizable key, or both.

But I have to limit it a bit with `@available` parameter.

I took screenshot from keychain without that key (only main app listed)
<img width="646" alt="Screen Shot 2021-12-15 at 13 15 43" src="https://user-images.githubusercontent.com/83073/146187676-2574b046-9153-46d8-9405-417fc25c1281.png">

and a screenshot from keychain after key added (KeychainGroup access instead is listed)
<img width="646" alt="Screen Shot 2021-12-15 at 13 15 36" src="https://user-images.githubusercontent.com/83073/146187808-cbd462b4-e5c0-4a8d-9127-9c726f168063.png">

