### PR TITLE
[Heartbeat Logging] Add compression for heartbeats payloads

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'FirebaseCore**'
     - 'Interop/CoreDiagnostics/Public/*.h'
+    - 'HeartbeatLogging**'
     - '.github/workflows/core.yml'
     - 'Gemfile*'
   schedule:

--- a/.github/workflows/heartbeat_logging.yml
+++ b/.github/workflows/heartbeat_logging.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'HeartbeatLogging**'
     - '.github/workflows/heartbeat_logging.yml'
+    - 'Gemfile*'
 
   # TODO(nickcooke): Schedule cron job.
 

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -53,6 +53,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   # Remember to also update version in `cmake/external/GoogleUtilities.cmake`
   s.dependency 'GoogleUtilities/Environment', '~> 7.6'
   s.dependency 'GoogleUtilities/Logger', '~> 7.6'
+  s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.6'
   s.dependency 'FirebaseCoreDiagnostics', '~> 8.0'
 
   s.pod_target_xcconfig = {

--- a/HeartbeatLogging/Sources/HeartbeatsPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatsPayload.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-import GoogleUtilities_NSData
+import GoogleUtilities
 
 /// A type that provides a string representation for use in an HTTP header.
 public protocol HTTPHeaderRepresentable {

--- a/HeartbeatLogging/Sources/HeartbeatsPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatsPayload.swift
@@ -89,7 +89,6 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
     do {
       let data = try encoder.encode(self)
       let gzippedData = try data.zipped()
-      return gzippedData.base64EncodedString()
       return gzippedData.base64URLEncodedString()
     } catch {
       return "" // Return empty string if processing failed.

--- a/HeartbeatLogging/Sources/HeartbeatsPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatsPayload.swift
@@ -89,6 +89,7 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
     do {
       let data = try encoder.encode(self)
       let gzippedData = try data.zipped()
+      return gzippedData.base64EncodedString()
       return gzippedData.base64URLEncodedString()
     } catch {
       return "" // Return empty string if processing failed.
@@ -153,25 +154,13 @@ public extension Data {
   /// - Returns: The compressed data.
   /// - Throws: An error if compression failed.
   func zipped() throws -> Data {
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
-      // Use standard library's zlib implementation.
-      return try (self as NSData).compressed(using: .zlib) as Data
-    } else {
-      // Fall back to Google Utilities gzip implementation.
-      return try NSData.gul_data(byGzippingData: self)
-    }
+    try NSData.gul_data(byGzippingData: self)
   }
 
   /// Returns the uncompressed data.
   /// - Returns: The decompressed data.
   /// - Throws: An error if decompression failed.
   func unzipped() throws -> Data {
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
-      // Use standard library's zlib implementation.
-      return try (self as NSData).decompressed(using: .zlib) as Data
-    } else {
-      // Fall back to Google Utilities gzip implementation.
-      return try NSData.gul_data(byInflatingGzippedData: self)
-    }
+    try NSData.gul_data(byInflatingGzippedData: self)
   }
 }

--- a/HeartbeatLogging/Sources/HeartbeatsPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatsPayload.swift
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import Foundation
-import GoogleUtilities
+
+#if SWIFT_PACKAGE
+  import GoogleUtilities_NSData
+#else
+  import GoogleUtilities
+#endif // SWIFT_PACKAGE
 
 /// A type that provides a string representation for use in an HTTP header.
 public protocol HTTPHeaderRepresentable {

--- a/HeartbeatLoggingTestUtils/Sources/HeartbeatLoggingTestUtils.swift
+++ b/HeartbeatLoggingTestUtils/Sources/HeartbeatLoggingTestUtils.swift
@@ -39,7 +39,11 @@ public class HeartbeatLoggingTestUtils: NSObject {
 
   @objc(assertEncodedPayloadString:isEqualToLiteralString:withError:)
   public static func assertEqualPayloadStrings(_ encoded: String, _ literal: String) throws {
-    let encodedData = try XCTUnwrap(Data(base64Encoded: encoded))
+    var encodedData = try XCTUnwrap(Data(base64URLEncoded: encoded))
+    if encodedData.count > 0 {
+      encodedData = try! encodedData.unzipped()
+    }
+
     let literalData = try XCTUnwrap(literal.data(using: .utf8))
 
     let decoder = JSONDecoder()

--- a/Package.swift
+++ b/Package.swift
@@ -244,6 +244,9 @@ let package = Package(
 
     .target(
       name: "HeartbeatLogging",
+      dependencies: [
+        .product(name: "GULNSData", package: "GoogleUtilities"),
+      ],
       path: "HeartbeatLogging/Sources/"
     ),
     .target(


### PR DESCRIPTION
**Context**
Compressing heartbeats payloads reduces size and should help reduce bandwidth when sending in requests

- [x] Do a manual backend test to ensure the backend can decode data from this implementation

**Experiments**
| payload type | not gzipped  (bytes) | gzipped (bytes) |
| --- | --- | --- |
| small | 75 | 85 |
| large | 490 | 171 |

#no-changelog