### PR TITLE
Update FirebaseStorage.podspec's swift_version

### DIFF
--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -26,6 +26,8 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
+  
+  s.swift_version = '5.3'
 
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false


### PR DESCRIPTION
I'm trying to figure out why storage qs workflow in #9117 is failing. I don't think changing the swift_version would break things but am using this PR's CI to validate that idea.

#no-changelog