### PR TITLE
pass appData for In-App Messaging's test message

### DIFF
--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -356,6 +356,7 @@
     }
     if (isTestMessage) {
       return [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:renderData
+                                                                    appData:dataBundle
                                                           experimentPayload:experimentPayload];
     } else {
       return [[FIRIAMMessageDefinition alloc] initWithRenderData:renderData

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -70,12 +70,13 @@
 }
 
 - (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData
+                                      appData:(nullable NSDictionary *)appData
                             experimentPayload:(nullable ABTExperimentPayload *)experimentPayload {
   return [self initWithRenderData:renderData
                         startTime:0
                           endTime:0
                 triggerDefinition:@[]
-                          appData:nil
+                          appData:appData
                 experimentPayload:experimentPayload
                     isTestMessage:YES];
 }

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -65,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Create a test message definition.
  */
 - (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData
+                                      appData:(nullable NSDictionary *)appData
                             experimentPayload:(nullable ABTExperimentPayload *)experimentPayload;
 
 - (BOOL)messageHasExpired;

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -519,6 +519,7 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   FIRInAppMessagingAction *testAction = [[FIRInAppMessagingAction alloc]
@@ -548,6 +549,7 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(10);
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ self.m2, testMessage, self.m4 ]];
@@ -756,6 +758,7 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ testMessage ]];
@@ -790,6 +793,7 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ testMessage ]];
@@ -865,6 +869,7 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   // not expecting triggering analytics recording

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
@@ -315,6 +315,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   OCMStub([self.mockMessageFetcher
@@ -338,6 +339,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   OCMStub([self.mockMessageFetcher

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -193,7 +193,6 @@
   XCTAssertFalse(results[1].isTestMessage);
   XCTAssertFalse(results[1].renderData.renderingEffectSettings.isTestMessage);
 
-
   XCTAssertTrue(results[2].isTestMessage);
   XCTAssertTrue(results[2].renderData.renderingEffectSettings.isTestMessage);
   XCTAssertEqual(results[2].appData.count, 2);

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -182,15 +182,23 @@
   // In our fixture file used in this test, there is no fetch expiration time
   XCTAssertNil(fetchWaitTime);
 
-  XCTAssertEqual(2, [results count]);
+  XCTAssertEqual(3, [results count]);
   XCTAssertEqual(0, discardCount);
 
   // First is a test message and the second one is not.
   XCTAssertTrue(results[0].isTestMessage);
   XCTAssertTrue(results[0].renderData.renderingEffectSettings.isTestMessage);
+  XCTAssertNil(results[0].appData);
 
   XCTAssertFalse(results[1].isTestMessage);
   XCTAssertFalse(results[1].renderData.renderingEffectSettings.isTestMessage);
+
+
+  XCTAssertTrue(results[2].isTestMessage);
+  XCTAssertTrue(results[2].renderData.renderingEffectSettings.isTestMessage);
+  XCTAssertEqual(results[2].appData.count, 2);
+  XCTAssertEqualObjects(results[2].appData[@"a"], @"b");
+  XCTAssertEqualObjects(results[2].appData[@"c"], @"d");
 }
 
 - (void)testParsingInvalidTestMessageNodes {

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMMessageClientCacheTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMMessageClientCacheTests.m
@@ -370,6 +370,7 @@
 
   FIRIAMMessageDefinition *testMessage =
       [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:m2.renderData
+                                                             appData:nil
                                                    experimentPayload:nil];
 
   // m1 and m3 are messages rendered on app open

--- a/FirebaseInAppMessaging/Tests/Unit/TestJsonDataWithTestMessageFromFetch.txt
+++ b/FirebaseInAppMessaging/Tests/Unit/TestJsonDataWithTestMessageFromFetch.txt
@@ -66,6 +66,33 @@
           }
         }
       ]
+    },
+    {
+      "vanillaPayload": {
+        "campaignId": "2108810525516234752"
+      },
+      "content": {
+        "modal": {
+          "title": {
+            "text": "FAST",
+            "hexColor": "#000000"
+          },
+          "body": {
+            "hexColor": "#000000"
+          },
+          "backgroundHexColor": "#ffffff"
+        }
+      },
+      "triggeringConditions": [
+        {
+          "fiamTrigger": "ON_FOREGROUND"
+        }
+      ],
+      "dataBundle": {
+        "a":"b",
+        "c":"d"
+      },
+      "isTestCampaign": true
     }
   ]
 }


### PR DESCRIPTION
refs: #9126 

`FIRIAMFetchResponseParser` is better not to ignore appData for test message. This PR fixes #9126 problems particaly but not completely. 