### PR TITLE
Enable functions test specs and pod spec lint

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -26,7 +26,8 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        # TODO: The --skip-tests might be removable with Xcode 13.2+
+        target: [ios, tvos, macos --skip-tests, watchos]
         podspec: [ 'FirebaseFunctions.podspec', 'FirebaseFunctionsSwift.podspec']
     env:
       POD_LIB_LINT_ONLY: 1

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -28,6 +28,8 @@ jobs:
       matrix:
         target: [ios, tvos, macos, watchos]
         podspec: [ 'FirebaseFunctions.podspec', 'FirebaseFunctionsSwift.podspec']
+    env:
+      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
@@ -143,14 +145,16 @@ jobs:
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
           FirebaseFunctions.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
 
-  #TODO - reenable once there's a tag with the new directory structure. See #8918 and #8299
-  # podspec-presubmit:
-    # Don't run on private repo unless it is a PR.
-    # if: github.repository == 'Firebase/firebase-ios-sdk' && github.event.pull_request.merged != true && github.event.action != 'closed'
-    # runs-on: macos-11
-    # steps:
-    # - uses: actions/checkout@v2
-    # - name: Setup Bundler
-    #   run: scripts/setup_bundler.sh
-    # - name: Build and test
-    #   run: scripts/third_party/travis/retry.sh pod spec lint FirebaseFunctions.podspec --skip-tests --sources='https://github.com/firebase/SpecsTesting','https://github.com/firebase/SpecsDev.git','https://github.com/firebase/SpecsStaging.git','https://cdn.cocoapods.org/'
+  podspec-presubmit:
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event.pull_request.merged != true && github.event.action != 'closed'
+    runs-on: macos-11
+    strategy:
+      matrix:
+        target: [ios, tvos, macos, watchos]
+        podspec: [ 'FirebaseFunctions.podspec', 'FirebaseFunctionsSwift.podspec']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Build and test
+      run: scripts/third_party/travis/retry.sh pod spec lint ${{ matrix.podspec }} --skip-tests --sources='https://github.com/firebase/SpecsTesting','https://github.com/firebase/SpecsDev.git','https://github.com/firebase/SpecsStaging.git','https://cdn.cocoapods.org/'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -58,15 +58,15 @@ Cloud Functions for Firebase.
                              'SharedTestUtilities/FIRMessagingInteropFake*'
   end
 
-  #  Uncomment to use pod gen to run the Swift Integration tests. This can't be
-  #  committed because of the dependency on the unpublished FirebaseFunctionsTestingSupport.
-  #  Alternatively, use Swift Package Manager to run the swift integration tests locally.
-  #
-  #   s.test_spec 'swift-integration' do |swift_int|
-  #   swift_int.platforms = {:ios => '15.0', :osx => '12.0', :tvos => '15.0', :watchos => '8.0'}
-  #   swift_int.scheme = { :code_coverage => true }
-  #   swift_int.dependency 'FirebaseFunctionsTestingSupport'
-  #   swift_int.source_files = 'FirebaseFunctions/Tests/SwiftIntegration/*',
-  #                            'FirebaseTestingSupport/Functions/Sources/*'
-  # end
+  # Using environment variable because of the dependency on the unpublished
+  # FirebaseFunctionsTestingSupport.
+  if ENV['POD_LIB_LINT_ONLY'] && ENV['POD_LIB_LINT_ONLY'] == '1' then
+    s.test_spec 'swift-integration' do |swift_int|
+      swift_int.platforms = {:ios => '15.0', :osx => '12.0', :tvos => '15.0', :watchos => '8.0'}
+      swift_int.scheme = { :code_coverage => true }
+      swift_int.dependency 'FirebaseFunctionsTestingSupport'
+      swift_int.source_files = 'FirebaseFunctions/Tests/SwiftIntegration/*',
+                               'FirebaseTestingSupport/Functions/Sources/*'
+    end
+  end
 end

--- a/FirebaseFunctionsSwift.podspec
+++ b/FirebaseFunctionsSwift.podspec
@@ -38,16 +38,16 @@ Swift SDK Extensions for Cloud Functions for Firebase.
   s.dependency 'FirebaseFunctions', '~> 8.11'
   s.dependency 'FirebaseSharedSwift', '~> 8.11'
 
-  # Uncomment to run via `pod gen`. It can't be saved because of the
-  # FirebaseFunctionsTestingSupport dependency.
-  #
-  # s.test_spec 'integration' do |int_tests|
-  #   int_tests.platforms = {
-  #     :ios => ios_deployment_target,
-  #     :osx => osx_deployment_target,
-  #     :tvos => tvos_deployment_target
-  #   }
-  #   int_tests.source_files = 'FirebaseFunctionsSwift/Tests/*.swift'
-  #   int_tests.dependency 'FirebaseFunctionsTestingSupport'
-  # end
-end
+  # Using environment variable because of the dependency on the unpublished
+  # FirebaseFunctionsTestingSupport.
+  if ENV['POD_LIB_LINT_ONLY'] && ENV['POD_LIB_LINT_ONLY'] == '1' then
+    s.test_spec 'integration' do |int_tests|
+      int_tests.platforms = {
+        :ios => ios_deployment_target,
+        :osx => osx_deployment_target,
+        :tvos => tvos_deployment_target
+      }
+      int_tests.source_files = 'FirebaseFunctionsSwift/Tests/*.swift'
+      int_tests.dependency 'FirebaseFunctionsTestingSupport'
+    end
+  end

--- a/FirebaseFunctionsSwift.podspec
+++ b/FirebaseFunctionsSwift.podspec
@@ -51,3 +51,4 @@ Swift SDK Extensions for Cloud Functions for Firebase.
       int_tests.dependency 'FirebaseFunctionsTestingSupport'
     end
   end
+end


### PR DESCRIPTION
- Use environment variable to enable Functions test_specs. 
- Disable macOS tests with TODO which fail on CI but run locally
- Reenable `pod spec lint` test now that 8.11.0 is staged

#no-changelog