### PR TITLE
Bump `swift_version` to 5.3 for all podspecs

### DIFF
--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -17,7 +17,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
   }
 
   s.static_framework        = true
-  s.swift_version           = '5.0'
+  s.swift_version           = '5.3'
   s.ios.deployment_target   = '13.0'
   s.osx.deployment_target   = '10.15'
   s.tvos.deployment_target  = '13.0'

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -19,7 +19,7 @@ for internal testing only. It should not be published.
 
   s.social_media_url = 'https://twitter.com/Firebase'
 
-  s.swift_version         = '5.0'
+  s.swift_version         = '5.3'
 
   ios_deployment_target = '13.0'
   osx_deployment_target = '10.15'

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -16,7 +16,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.swift_version           = '5.1'
+  s.swift_version           = '5.3'
   s.ios.deployment_target   = '10.0'
   s.osx.deployment_target   = '10.12'
   s.tvos.deployment_target  = '10.0'

--- a/FirebaseFunctionsSwift.podspec
+++ b/FirebaseFunctionsSwift.podspec
@@ -16,7 +16,7 @@ Swift SDK Extensions for Cloud Functions for Firebase.
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.swift_version           = '5.1'
+  s.swift_version           = '5.3'
 
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.swift_version = '5.0'
+  s.swift_version = '5.3'
 
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -16,7 +16,7 @@ This pod is for Firebase internal use and not supported for independent use.
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.swift_version           = '5.1'
+  s.swift_version           = '5.3'
 
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'

--- a/FirebaseStorageSwift.podspec
+++ b/FirebaseStorageSwift.podspec
@@ -17,7 +17,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.swift_version           = '5.0'
+  s.swift_version           = '5.3'
 
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'


### PR DESCRIPTION
Bump the `swift_version` spec property to `5.3` (the Swift version associated with Firebase's minimum supported Xcode– 12.2).


#no-changelog