### PR TITLE
Fix : Duplicate messages can occur when two campaigns are triggered by different events

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2021-12 -- v8.12.0
+# 2022-01 -- v8.12.0
 - [fixed] Duplicate messages can occur when two campaigns are triggered by different events in In-App Messaging (#9070).
 
 # 2021-12 -- v8.11.0

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2021-12 -- v8.12.0
+- [fixed] Duplicate messages can occur when two campaigns are triggered by different events in In-App Messaging (#9070).
+
 # 2021-12 -- v8.11.0
 - [fixed] InApp message is shown every new session (#8907).
 

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,8 +1,6 @@
-# 2022-01 -- v8.12.0
-- [fixed] Duplicate messages can occur when two campaigns are triggered by different events in In-App Messaging (#9070).
-
 # 2021-12 -- v8.11.0
 - [fixed] InApp message is shown every new session (#8907).
+- [fixed] Duplicate messages can occur when two campaigns are triggered by different events in In-App Messaging (#9070).
 
 # 2021-8 -- v8.6.0
 - [changed] Replaced conditionally-compiled APIs with `API_UNAVAILABLE` annotations on unsupported platforms (#8480).

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -616,6 +616,8 @@
 - (void)displayForMessage:(FIRIAMMessageDefinition *)message
               triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
   _currentMsgBeingDisplayed = message;
+  self.isMsgBeingDisplayed = YES;
+  
   [message.renderData.contentData
       loadImageDataWithBlock:^(NSData *_Nullable standardImageRawData,
                                NSData *_Nullable landscapeImageRawData, NSError *_Nullable error) {
@@ -633,6 +635,7 @@
                                             triggerType:triggerType];
           // short-circuit to display error handling
           [self displayErrorForMessage:erroredMessage error:error];
+          self.isMsgBeingDisplayed = NO;
           return;
         } else {
           if (standardImageRawData) {
@@ -658,11 +661,11 @@
         if (self.suppressMessageDisplay) {
           FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400042",
                       @"Message display suppressed by developer at message display time.");
+          self.isMsgBeingDisplayed = NO;
           return;
         }
 
         self.impressionRecorded = NO;
-        self.isMsgBeingDisplayed = YES;
 
         FIRInAppMessagingDisplayMessage *displayMessage =
             [self displayMessageWithMessageDefinition:message

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -617,7 +617,7 @@
               triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
   _currentMsgBeingDisplayed = message;
   self.isMsgBeingDisplayed = YES;
-  
+
   [message.renderData.contentData
       loadImageDataWithBlock:^(NSData *_Nullable standardImageRawData,
                                NSData *_Nullable landscapeImageRawData, NSError *_Nullable error) {


### PR DESCRIPTION
Fix: Duplicate messages can occur when two campaigns are triggered by different events in In-App Messaging #9070

The flags to prevent multiple calling of inapp message was set after image downloading and so if two events are fired simultaneously, the second message display will be called prior to flag set. So adjusted the flag.