### PR TITLE
Fix an issue that apns token is not sent during app fresh install

### DIFF
--- a/FirebaseMessaging/Apps/SwiftUISample/Podfile
+++ b/FirebaseMessaging/Apps/SwiftUISample/Podfile
@@ -1,0 +1,15 @@
+use_frameworks!
+
+source 'https://github.com/firebase/SpecsDev.git'
+source 'https://github.com/firebase/SpecsStaging.git'
+source 'https://cdn.cocoapods.org/'
+
+target 'SwiftUISample' do
+  platform :ios, '15.0'
+
+  pod 'FirebaseCore', :path => '../../../'
+  pod 'FirebaseMessaging', :path => '../../../'
+  pod 'FirebaseCoreDiagnostics', :path => '../../../'
+  pod 'FirebaseInstallations', :path => '../../../'
+
+end

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
@@ -1,0 +1,435 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2FBAECDD4E9E475C58A03807 /* Pods_SwiftUISample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */; };
+		5134F860277EAEC600AEE915 /* SwiftUISampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134F85F277EAEC600AEE915 /* SwiftUISampleApp.swift */; };
+		5134F862277EAEC600AEE915 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134F861277EAEC600AEE915 /* ContentView.swift */; };
+		5134F864277EAEC900AEE915 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5134F863277EAEC900AEE915 /* Assets.xcassets */; };
+		5134F867277EAEC900AEE915 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5134F866277EAEC900AEE915 /* Preview Assets.xcassets */; };
+		5134F86E277EAEF800AEE915 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5134F86D277EAEF800AEE915 /* GoogleService-Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUISample.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample.debug.xcconfig"; sourceTree = "<group>"; };
+		5134F85C277EAEC600AEE915 /* SwiftUISample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUISample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5134F85F277EAEC600AEE915 /* SwiftUISampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISampleApp.swift; sourceTree = "<group>"; };
+		5134F861277EAEC600AEE915 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		5134F863277EAEC900AEE915 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5134F866277EAEC900AEE915 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		5134F86D277EAEF800AEE915 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../Shared/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		5134F86F277EAF0A00AEE915 /* SwiftUISample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftUISample.entitlements; sourceTree = "<group>"; };
+		5134F870277EAF1600AEE915 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUISample.release.xcconfig"; path = "Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample.release.xcconfig"; sourceTree = "<group>"; };
+		E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUISample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5134F859277EAEC600AEE915 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2FBAECDD4E9E475C58A03807 /* Pods_SwiftUISample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5134F853277EAEC600AEE915 = {
+			isa = PBXGroup;
+			children = (
+				5134F85E277EAEC600AEE915 /* SwiftUISample */,
+				5134F85D277EAEC600AEE915 /* Products */,
+				DB0987F03946432268D7BD14 /* Pods */,
+				ECE30FFAD1AA90BF6484D060 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		5134F85D277EAEC600AEE915 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5134F85C277EAEC600AEE915 /* SwiftUISample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5134F85E277EAEC600AEE915 /* SwiftUISample */ = {
+			isa = PBXGroup;
+			children = (
+				5134F870277EAF1600AEE915 /* Info.plist */,
+				5134F86F277EAF0A00AEE915 /* SwiftUISample.entitlements */,
+				5134F85F277EAEC600AEE915 /* SwiftUISampleApp.swift */,
+				5134F86D277EAEF800AEE915 /* GoogleService-Info.plist */,
+				5134F861277EAEC600AEE915 /* ContentView.swift */,
+				5134F863277EAEC900AEE915 /* Assets.xcassets */,
+				5134F865277EAEC900AEE915 /* Preview Content */,
+			);
+			path = SwiftUISample;
+			sourceTree = "<group>";
+		};
+		5134F865277EAEC900AEE915 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				5134F866277EAEC900AEE915 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		DB0987F03946432268D7BD14 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */,
+				B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		ECE30FFAD1AA90BF6484D060 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		5134F85B277EAEC600AEE915 /* SwiftUISample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5134F86A277EAEC900AEE915 /* Build configuration list for PBXNativeTarget "SwiftUISample" */;
+			buildPhases = (
+				FE14701886717C21AE420839 /* [CP] Check Pods Manifest.lock */,
+				5134F858277EAEC600AEE915 /* Sources */,
+				5134F859277EAEC600AEE915 /* Frameworks */,
+				5134F85A277EAEC600AEE915 /* Resources */,
+				62C8405E4A3C387B27CF7F06 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftUISample;
+			productName = SwiftUISample;
+			productReference = 5134F85C277EAEC600AEE915 /* SwiftUISample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5134F854277EAEC600AEE915 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1300;
+				TargetAttributes = {
+					5134F85B277EAEC600AEE915 = {
+						CreatedOnToolsVersion = 13.0;
+					};
+				};
+			};
+			buildConfigurationList = 5134F857277EAEC600AEE915 /* Build configuration list for PBXProject "SwiftUISample" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 5134F853277EAEC600AEE915;
+			productRefGroup = 5134F85D277EAEC600AEE915 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5134F85B277EAEC600AEE915 /* SwiftUISample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5134F85A277EAEC600AEE915 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5134F867277EAEC900AEE915 /* Preview Assets.xcassets in Resources */,
+				5134F864277EAEC900AEE915 /* Assets.xcassets in Resources */,
+				5134F86E277EAEF800AEE915 /* GoogleService-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		62C8405E4A3C387B27CF7F06 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FE14701886717C21AE420839 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SwiftUISample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5134F858277EAEC600AEE915 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5134F862277EAEC600AEE915 /* ContentView.swift in Sources */,
+				5134F860277EAEC600AEE915 /* SwiftUISampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5134F868277EAEC900AEE915 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		5134F869277EAEC900AEE915 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5134F86B277EAEC900AEE915 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SwiftUISample/SwiftUISample.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUISample/Preview Content\"";
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SwiftUISample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Firebase iOS App Extensions Dev";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		5134F86C277EAEC900AEE915 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SwiftUISample/SwiftUISample.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUISample/Preview Content\"";
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SwiftUISample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Firebase iOS App Extensions Dev";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5134F857277EAEC600AEE915 /* Build configuration list for PBXProject "SwiftUISample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5134F868277EAEC900AEE915 /* Debug */,
+				5134F869277EAEC900AEE915 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5134F86A277EAEC900AEE915 /* Build configuration list for PBXNativeTarget "SwiftUISample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5134F86B277EAEC900AEE915 /* Debug */,
+				5134F86C277EAEC900AEE915 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5134F854277EAEC600AEE915 /* Project object */;
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 			children = (
 				5134F85E277EAEC600AEE915 /* SwiftUISample */,
 				5134F85D277EAEC600AEE915 /* Products */,
+				A18B84A7C0849ACD661DA216 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -72,6 +73,13 @@
 				5134F866277EAEC900AEE915 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		A18B84A7C0849ACD661DA216 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -275,11 +283,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SwiftUISample/SwiftUISample.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftUISample/Preview Content\"";
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SwiftUISample/Info.plist;
@@ -296,7 +304,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Firebase iOS App Extensions Dev";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -309,11 +317,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = SwiftUISample/SwiftUISample.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftUISample/Preview Content\"";
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SwiftUISample/Info.plist;
@@ -330,7 +338,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Firebase iOS App Extensions Dev";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2FBAECDD4E9E475C58A03807 /* Pods_SwiftUISample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */; };
 		5134F860277EAEC600AEE915 /* SwiftUISampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134F85F277EAEC600AEE915 /* SwiftUISampleApp.swift */; };
 		5134F862277EAEC600AEE915 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5134F861277EAEC600AEE915 /* ContentView.swift */; };
 		5134F864277EAEC900AEE915 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5134F863277EAEC900AEE915 /* Assets.xcassets */; };
@@ -16,7 +15,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUISample.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample.debug.xcconfig"; sourceTree = "<group>"; };
 		5134F85C277EAEC600AEE915 /* SwiftUISample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUISample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5134F85F277EAEC600AEE915 /* SwiftUISampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISampleApp.swift; sourceTree = "<group>"; };
 		5134F861277EAEC600AEE915 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -25,8 +23,6 @@
 		5134F86D277EAEF800AEE915 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../Shared/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5134F86F277EAF0A00AEE915 /* SwiftUISample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftUISample.entitlements; sourceTree = "<group>"; };
 		5134F870277EAF1600AEE915 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUISample.release.xcconfig"; path = "Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample.release.xcconfig"; sourceTree = "<group>"; };
-		E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUISample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,7 +30,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2FBAECDD4E9E475C58A03807 /* Pods_SwiftUISample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -46,8 +41,6 @@
 			children = (
 				5134F85E277EAEC600AEE915 /* SwiftUISample */,
 				5134F85D277EAEC600AEE915 /* Products */,
-				DB0987F03946432268D7BD14 /* Pods */,
-				ECE30FFAD1AA90BF6484D060 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -81,24 +74,6 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		DB0987F03946432268D7BD14 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */,
-				B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
-		ECE30FFAD1AA90BF6484D060 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				E25B56E875FD5BAFD1803D36 /* Pods_SwiftUISample.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -106,11 +81,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5134F86A277EAEC900AEE915 /* Build configuration list for PBXNativeTarget "SwiftUISample" */;
 			buildPhases = (
-				FE14701886717C21AE420839 /* [CP] Check Pods Manifest.lock */,
 				5134F858277EAEC600AEE915 /* Sources */,
 				5134F859277EAEC600AEE915 /* Frameworks */,
 				5134F85A277EAEC600AEE915 /* Resources */,
-				62C8405E4A3C387B27CF7F06 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -166,48 +139,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		62C8405E4A3C387B27CF7F06 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUISample/Pods-SwiftUISample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FE14701886717C21AE420839 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-SwiftUISample-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		5134F858277EAEC600AEE915 /* Sources */ = {
@@ -340,7 +271,6 @@
 		};
 		5134F86B277EAEC900AEE915 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 257B8750A38D7F97FBECCB24 /* Pods-SwiftUISample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -375,7 +305,6 @@
 		};
 		5134F86C277EAEC900AEE915 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B4FB44DA2D6E0B639E422D02 /* Pods-SwiftUISample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/xcshareddata/xcschemes/SwiftUISample.xcscheme
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample.xcodeproj/xcshareddata/xcschemes/SwiftUISample.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5134F85B277EAEC600AEE915"
+               BuildableName = "SwiftUISample.app"
+               BlueprintName = "SwiftUISample"
+               ReferencedContainer = "container:SwiftUISample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5134F85B277EAEC600AEE915"
+            BuildableName = "SwiftUISample.app"
+            BlueprintName = "SwiftUISample"
+            ReferencedContainer = "container:SwiftUISample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5134F85B277EAEC600AEE915"
+            BuildableName = "SwiftUISample.app"
+            BlueprintName = "SwiftUISample"
+            ReferencedContainer = "container:SwiftUISample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/Contents.json
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        Text("Hello, world!")
-            .padding()
-    }
+  var body: some View {
+    Text("Hello, world!")
+      .padding()
+  }
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
+  static var previews: some View {
+    ContentView()
+  }
 }

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  SwiftUISample
+//
+//  Created by Charlotte Liang on 12/30/21.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/ContentView.swift
@@ -1,9 +1,16 @@
+// Copyright 2022 Google LLC
 //
-//  ContentView.swift
-//  SwiftUISample
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Charlotte Liang on 12/30/21.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import SwiftUI
 

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Info.plist
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+</dict>
+</plist>

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISample.entitlements
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISample.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
@@ -20,29 +20,31 @@ import FirebaseMessaging
 @main
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-          FirebaseApp.configure()
-          application.delegate = self
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions launchOptions: [UIApplication
+                     .LaunchOptionsKey: Any]? = nil) -> Bool {
+    FirebaseApp.configure()
+    application.delegate = self
 
-          let center = UNUserNotificationCenter.current()
-          center.delegate = self
+    let center = UNUserNotificationCenter.current()
+    center.delegate = self
 
-          center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if error != nil {
-              print("Failed requesting notification permission: ", error ?? "")
-            }
-          }
-          application.registerForRemoteNotifications()
-        return true
+    center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+      if error != nil {
+        print("Failed requesting notification permission: ", error ?? "")
+      }
     }
+    application.registerForRemoteNotifications()
+    return true
+  }
 }
 
 struct SwiftUISampleApp: App {
   @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-   
+
   var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+    WindowGroup {
+      ContentView()
     }
+  }
 }

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
@@ -26,9 +26,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     FirebaseApp.configure()
     application.delegate = self
 
+    // Request permissions for push notifications
     let center = UNUserNotificationCenter.current()
     center.delegate = self
-
     center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
       if error != nil {
         print("Failed requesting notification permission: ", error ?? "")
@@ -40,6 +40,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 }
 
 struct SwiftUISampleApp: App {
+  // Add the adapter to access notifications APIs in AppDelegate
   @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
   var body: some Scene {

--- a/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
+++ b/FirebaseMessaging/Apps/SwiftUISample/SwiftUISample/SwiftUISampleApp.swift
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+import SwiftUI
+import FirebaseCore
+import FirebaseMessaging
+
+@main
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+          FirebaseApp.configure()
+          application.delegate = self
+
+          let center = UNUserNotificationCenter.current()
+          center.delegate = self
+
+          center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if error != nil {
+              print("Failed requesting notification permission: ", error ?? "")
+            }
+          }
+          application.registerForRemoteNotifications()
+        return true
+    }
+}
+
+struct SwiftUISampleApp: App {
+  @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+   
+  var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2021-08 -- v8.11.0
+- [fixed] Fixed an issue that token is not associated with APNS token during app start. (#8738)
+
 # 2021-08 -- v8.6.0
 - [changed] Removed iOS version check from `FIRMessagingExtensionHelper.h` (#8492).
 - [added] Added new API `FIRMessagingExtensionHelper exportDeliveryMetricsToBigQuery` that allows developers to enable notification delivery metrics that exports to BigQuery. (#6181)

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -48,7 +48,6 @@
 
 static NSString *const kFIRMessagingMessageViaAPNSRootKey = @"aps";
 static NSString *const kFIRMessagingReachabilityHostname = @"www.google.com";
-static NSString *const kFIRMessagingFCMTokenFetchAPNSOption = @"apns_token";
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification =
@@ -568,7 +567,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   }
   NSDictionary *options = nil;
   if (self.APNSToken) {
-    options = @{kFIRMessagingFCMTokenFetchAPNSOption : self.APNSToken};
+    options = @{kFIRMessagingTokenOptionsAPNSKey : self.APNSToken};
   } else {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeAPNSTokenNotAvailableDuringTokenFetch,
                            @"APNS device token not set before retrieving FCM Token for Sender ID "

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -232,17 +232,15 @@
           } else {
             FIRMessagingTokenInfo *cachedTokenInfo =
                 [self cachedTokenInfoWithAuthorizedEntity:authorizedEntity scope:scope];
-            if (cachedTokenInfo) {
-              FIRMessagingAPNSInfo *optionsAPNSInfo =
-                  [[FIRMessagingAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
-              // Check if APNS Info is changed
-              if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
-                  [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
-                // check if token is fresh
-                if ([cachedTokenInfo isFreshWithIID:identifier]) {
-                  newHandler(cachedTokenInfo.token, nil);
-                  return;
-                }
+            FIRMessagingAPNSInfo *optionsAPNSInfo =
+                [[FIRMessagingAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+            // Check if APNS Info is changed
+            if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
+                [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
+              // check if token is fresh
+              if ([cachedTokenInfo isFreshWithIID:identifier]) {
+                newHandler(cachedTokenInfo.token, nil);
+                return;
               }
             }
             [self fetchNewTokenWithAuthorizedEntity:[authorizedEntity copy]
@@ -659,48 +657,47 @@
   if (invalidatedTokens.count > 0 || [_tokenStore cachedTokenInfos].count == 0) {
     FIRMessaging_WEAKIFY(self);
 
-    [self.installations
-        installationIDWithCompletion:^(NSString *_Nullable identifier, NSError *_Nullable error) {
-          FIRMessaging_STRONGIFY(self);
-          if (self == nil) {
-            FIRMessagingLoggerError(kFIRMessagingMessageCodeInstanceID017,
-                                    @"Instance ID shut down during token reset. Aborting");
-            return;
-          }
-          if (self.currentAPNSInfo == nil) {
-            FIRMessagingLoggerError(kFIRMessagingMessageCodeInstanceID018,
-                                    @"apnsTokenData was set to nil during token reset. Aborting");
-            return;
-          }
+    [self.installations installationIDWithCompletion:^(NSString *_Nullable identifier,
+                                                       NSError *_Nullable error) {
+      FIRMessaging_STRONGIFY(self);
+      if (self == nil) {
+        FIRMessagingLoggerError(kFIRMessagingMessageCodeInstanceID017,
+                                @"Instance ID shut down during token reset. Aborting");
+        return;
+      }
+      if (self.currentAPNSInfo == nil) {
+        FIRMessagingLoggerError(kFIRMessagingMessageCodeInstanceID018,
+                                @"apnsTokenData was set to nil during token reset. Aborting");
+        return;
+      }
 
-          NSMutableDictionary *tokenOptions = [@{
-            kFIRMessagingTokenOptionsAPNSKey : self.currentAPNSInfo.deviceToken,
-            kFIRMessagingTokenOptionsAPNSIsSandboxKey : @(isSandboxApp)
-          } mutableCopy];
-          if (self.firebaseAppID) {
-            tokenOptions[kFIRMessagingTokenOptionsFirebaseAppIDKey] = self.firebaseAppID;
-          }
+      NSMutableDictionary *tokenOptions = [@{
+        kFIRMessagingTokenOptionsAPNSKey : self.currentAPNSInfo.deviceToken,
+        kFIRMessagingTokenOptionsAPNSIsSandboxKey : @(isSandboxApp)
+      } mutableCopy];
+      if (self.firebaseAppID) {
+        tokenOptions[kFIRMessagingTokenOptionsFirebaseAppIDKey] = self.firebaseAppID;
+      }
 
-          for (FIRMessagingTokenInfo *tokenInfo in invalidatedTokens) {
-            [self fetchNewTokenWithAuthorizedEntity:tokenInfo.authorizedEntity
-                                              scope:tokenInfo.scope
-                                         instanceID:identifier
-                                            options:tokenOptions
-                                            handler:^(NSString *_Nullable token,
-                                                      NSError *_Nullable error){
+      for (FIRMessagingTokenInfo *tokenInfo in invalidatedTokens) {
+        [self fetchNewTokenWithAuthorizedEntity:tokenInfo.authorizedEntity
+                                          scope:tokenInfo.scope
+                                     instanceID:identifier
+                                        options:tokenOptions
+                                        handler:^(NSString *_Nullable token,
+                                                  NSError *_Nullable error){
 
-                                            }];
-          }
-          if ([self->_tokenStore cachedTokenInfos].count == 0) {
-            [self fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
-                                              scope:kFIRMessagingDefaultTokenScope
-                                         instanceID:identifier
-                                            options:tokenOptions
-                                            handler:^(NSString *_Nullable FCMToken,
-                                                      NSError *_Nullable error){
-                                            }];
-          }
-        }];
+                                        }];
+      }
+      if ([self->_tokenStore cachedTokenInfos].count == 0) {
+        [self tokenWithAuthorizedEntity:self.fcmSenderID
+                                  scope:kFIRMessagingDefaultTokenScope
+                                options:tokenOptions
+                                handler:^(NSString *_Nullable FCMToken, NSError *_Nullable error){
+
+                                }];
+      }
+    }];
   }
 }
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -685,8 +685,8 @@
                                         options:tokenOptions
                                         handler:^(NSString *_Nullable token,
                                                   NSError *_Nullable error){
-          // Do nothing as callback is not needed and the sub-funciton already
-          // handle errors.
+                                            // Do nothing as callback is not needed and the
+                                            // sub-funciton already handle errors.
                                         }];
       }
       if ([self->_tokenStore cachedTokenInfos].count == 0) {
@@ -694,8 +694,8 @@
                                   scope:kFIRMessagingDefaultTokenScope
                                 options:tokenOptions
                                 handler:^(NSString *_Nullable FCMToken, NSError *_Nullable error){
-          // Do nothing as callback is not needed and the sub-funciton already
-          // handle errors.
+                                    // Do nothing as callback is not needed and the sub-funciton
+                                    // already handle errors.
                                 }];
       }
     }];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -652,8 +652,7 @@
                                                                  isSandbox:isSandboxApp];
 
   // Re-fetch any invalidated tokens automatically, this time with the current APNs token, so that
-  // they are up-to-date.
-  // Or this is a fresh install and no apns token stored yet.
+  // they are up-to-date. Or this is a fresh install and no apns token stored yet.
   if (invalidatedTokens.count > 0 || [_tokenStore cachedTokenInfos].count == 0) {
     FIRMessaging_WEAKIFY(self);
 
@@ -686,7 +685,8 @@
                                         options:tokenOptions
                                         handler:^(NSString *_Nullable token,
                                                   NSError *_Nullable error){
-
+          // Do nothing as callback is not needed and the sub-funciton already
+          // handle errors.
                                         }];
       }
       if ([self->_tokenStore cachedTokenInfos].count == 0) {
@@ -694,7 +694,8 @@
                                   scope:kFIRMessagingDefaultTokenScope
                                 options:tokenOptions
                                 handler:^(NSString *_Nullable FCMToken, NSError *_Nullable error){
-
+          // Do nothing as callback is not needed and the sub-funciton already
+          // handle errors.
                                 }];
       }
     }];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -655,7 +655,8 @@
 
   // Re-fetch any invalidated tokens automatically, this time with the current APNs token, so that
   // they are up-to-date.
-  if (invalidatedTokens.count > 0) {
+  // Or this is a fresh install and no apns token stored yet.
+  if (invalidatedTokens.count > 0 || [_tokenStore cachedTokenInfos].count == 0) {
     FIRMessaging_WEAKIFY(self);
 
     [self.installations
@@ -688,6 +689,15 @@
                                             handler:^(NSString *_Nullable token,
                                                       NSError *_Nullable error){
 
+                                            }];
+          }
+          if ([self->_tokenStore cachedTokenInfos].count == 0) {
+            [self fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
+                                              scope:kFIRMessagingDefaultTokenScope
+                                         instanceID:identifier
+                                            options:tokenOptions
+                                            handler:^(NSString *_Nullable FCMToken,
+                                                      NSError *_Nullable error){
                                             }];
           }
         }];


### PR DESCRIPTION
This fixes #8738.

The current implementation assumes APNS token is returned from apple system always after a new FCM token is fetched and stored during app install.
Seems like APNS token can be returned faster than that and currently the client only sends out request updating APNS token with FCM token when a cached FCM token exists.
Now update the logic to if no cached token exists and a new APNS token is set, always send a request to backend to update the FCM token with the apns token.

- Added a SwiftUI test app that uses the latest SwiftUI lifecycle
- Removed a redundant apns token key