### PR TITLE
`schedule` integration tests to run on prewarm feature branch

### DIFF
--- a/.github/performance-integration-tests-prewarm.yml
+++ b/.github/performance-integration-tests-prewarm.yml
@@ -35,4 +35,4 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Performance/GoogleService-Info_e2e_prod.plist.gpg \
             FirebasePerformance/Tests/FIRPerfE2E/FIRPerfE2EProd/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance iOS-device integration
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance all integration

--- a/.github/performance-integration-tests-prewarm.yml
+++ b/.github/performance-integration-tests-prewarm.yml
@@ -1,0 +1,38 @@
+# Merge the yml file to master branch for the cron job schedule to be effective.
+# Reference: https://github.community/t/on-schedule-per-branch/17525
+name: performance-integration-tests-prewarm
+
+on:
+  # See cron syntax references:
+  #   - https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+  #   - https://crontab.guru/
+  schedule:
+    # Runs every 2 hours.
+    # TODO: Validate when the timer starts after job is triggered.
+    - cron:  '0 */2 * * *'
+
+jobs:
+
+  # Public repository: Build and run the Integration Tests for the Firebase performance E2E Test App.
+  performance-integration-tests-prewarm:
+    if: github.repository == 'Firebase/firebase-ios-sdk'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-11
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: perfIdentifyPrewarming.customTrace
+    - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Performance/GoogleService-Info_e2e_autopush.plist.gpg \
+            FirebasePerformance/Tests/FIRPerfE2E/FIRPerfE2EAutopush/GoogleService-Info.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Performance/GoogleService-Info_e2e_prod.plist.gpg \
+            FirebasePerformance/Tests/FIRPerfE2E/FIRPerfE2EProd/GoogleService-Info.plist "$plist_secret"
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance all integration

--- a/.github/performance-integration-tests-prewarm.yml
+++ b/.github/performance-integration-tests-prewarm.yml
@@ -35,4 +35,4 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Performance/GoogleService-Info_e2e_prod.plist.gpg \
             FirebasePerformance/Tests/FIRPerfE2E/FIRPerfE2EProd/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance all integration
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance iOS-device integration


### PR DESCRIPTION
b/211905617

## Reason for PR to master
According to https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule, 

> Scheduled workflows run on the latest commit on the default or base branch. 

Thus a PR to master branch is required to have the E2E pipeline automatically test the prototype for us.

## Interval
Currently set to every 2 hours. Alternatively could keep the 4 hours interval and use the old `performance-integration-tests.yml` file instead of making a new one. 