### PR TITLE
Define new error codes for passthrough errors

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -359,6 +359,13 @@ static NSString *const kSessionExpiredErrorMessage = @"SESSION_EXPIRED";
  */
 static NSString *const kMissingOrInvalidNonceErrorMessage = @"MISSING_OR_INVALID_NONCE";
 
+/** @var kUnsupportedPassthroughOperationErrorMessage
+    @brief This is the error message the server will respond with if the operation is not supported
+        in passthrough mode.
+ */
+static NSString *const kUnsupportedPassthroughOperationErrorMessage =
+    @"UNSUPPORTED_PASSTHROUGH_OPERATION";
+
 /** @var kMissingAppTokenErrorMessage
     @brief This is the error message the server will respond with if the APNS token is missing in a
         verifyClient request.
@@ -1371,6 +1378,11 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
   if ([shortErrorMessage isEqualToString:kMissingOrInvalidNonceErrorMessage]) {
     return [FIRAuthErrorUtils missingOrInvalidNonceErrorWithMessage:serverDetailErrorMessage];
+  }
+
+  if ([shortErrorMessage isEqualToString:kUnsupportedPassthroughOperationErrorMessage]) {
+    return [FIRAuthErrorUtils
+        unsupportedPassthroughOperationErrorWithMessage:serverDetailErrorMessage];
   }
 
   if ([shortErrorMessage isEqualToString:kMissingMFAPendingCredentialErrorMessage]) {

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -413,6 +413,14 @@ typedef NS_ENUM(NSInteger, FIRAuthErrorCode) {
    */
   FIRAuthErrorCodeMissingOrInvalidNonce = 17094,
 
+  /** Indicates that the operation is not supported in passthrough mode.
+   */
+  FIRAuthErrorCodeUnsupportedPassthroughOperation = 17095,
+
+  /** Indicates that neither a refresh token nor a custom token provider is available.
+   */
+  FIRAuthErrorCodeTokenRefreshUnavailable = 17096,
+
   /** Indicates an error for when the client identifier is missing.
    */
   FIRAuthErrorCodeMissingClientIdentifier = 17993,

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -48,11 +48,6 @@ static NSString *const kRefreshTokenKey = @"refreshToken";
  */
 static NSString *const kAccessTokenKey = @"accessToken";
 
-/** @var kRefreshTokenError
-    @brief Missing refresh token error message.
- */
-static NSString *const kRefreshTokenError = @"No refresh token is available.";
-
 /** @var kAccessTokenExpirationDateKey
     @brief The key used to encode the access token expiration date for NSSecureCoding.
  */
@@ -209,10 +204,8 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
                                }];
     }];
   } else {
-    NSError *error = [FIRAuthErrorUtils errorWithCode:FIRAuthInternalErrorCodeInternalError
-                                              message:kRefreshTokenError];
+    NSError *error = [FIRAuthErrorUtils tokenRefreshUnavailableError];
     callback(nil, error, NO);
-    return;
   }
 }
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
@@ -592,6 +592,20 @@ NS_ASSUME_NONNULL_BEGIN
 */
 + (NSError *)missingOrInvalidNonceErrorWithMessage:(nullable NSString *)message;
 
+/** @fn unsupportedPassthroughOperationErrorWithMessage:
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeUnsupportedPassthroughOperation and
+        message provided.
+    @param message Error message from the backend, if any.
+    @return The nullable NSError instance associated with the given error message, if one is found.
+*/
++ (NSError *)unsupportedPassthroughOperationErrorWithMessage:(nullable NSString *)message;
+
+/** @fn tokenRefreshUnavailableError:
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeTokenRefreshUnavailable code.
+    @return The nullable NSError instance associated with the given FIRAuthError.
+*/
++ (NSError *)tokenRefreshUnavailableError;
+
 /** @fn tenantIDMismatchError
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeTenantIDMismatch code.
     @remarks This error is used when an attempt is made to update the current user with a

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -577,6 +577,18 @@ static NSString *const kFIRAuthErrorMessageRejectedCredential =
 static NSString *const kFIRAuthErrorMessageMissingOrInvalidNonce =
     @"The request contains malformed or mismatched credentials.";
 
+/** @var kFIRAuthErrorMessageUnsupportedPassthroughOperation
+    @brief Error message for @c FIRAuthErrorCodeUnsupportedPassthroughOperation errors.
+ */
+static NSString *const kFIRAuthErrorMessageUnsupportedPassthroughOperation =
+    @"This operation is not supported while in passthrough mode.";
+
+/** @var kFIRAuthErrorMessageTokenRefreshUnavailable
+    @brief Error message for @c FIRAuthErrorCodeTokenRefreshUnavailable errors.
+ */
+static NSString *const kFIRAuthErrorMessageTokenRefreshUnavailable =
+    @"No refresh token is available.";
+
 /** @var kFIRAuthErrorMessageTenantIDMismatch.
     @brief Message for @c FIRAuthErrorCodeTenantIDMismatch error code.
  */
@@ -751,6 +763,10 @@ static NSString *FIRAuthErrorDescription(FIRAuthErrorCode code) {
       return kFIRAuthErrorMessageRejectedCredential;
     case FIRAuthErrorCodeMissingOrInvalidNonce:
       return kFIRAuthErrorMessageMissingOrInvalidNonce;
+    case FIRAuthErrorCodeUnsupportedPassthroughOperation:
+      return kFIRAuthErrorMessageUnsupportedPassthroughOperation;
+    case FIRAuthErrorCodeTokenRefreshUnavailable:
+      return kFIRAuthErrorMessageTokenRefreshUnavailable;
     case FIRAuthErrorCodeTenantIDMismatch:
       return kFIRAuthErrorMessageTenantIDMismatch;
     case FIRAuthErrorCodeUnsupportedTenantOperation:
@@ -918,6 +934,10 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
       return @"ERROR_REJECTED_CREDENTIAL";
     case FIRAuthErrorCodeMissingOrInvalidNonce:
       return @"ERROR_MISSING_OR_INVALID_NONCE";
+    case FIRAuthErrorCodeUnsupportedPassthroughOperation:
+      return @"ERROR_UNSUPPORTED_PASSTHROUGH_OPERATION";
+    case FIRAuthErrorCodeTokenRefreshUnavailable:
+      return @"ERROR_TOKEN_REFRESH_UNAVAILABLE";
     case FIRAuthErrorCodeTenantIDMismatch:
       return @"ERROR_TENANT_ID_MISMATCH";
     case FIRAuthErrorCodeUnsupportedTenantOperation:
@@ -1387,6 +1407,15 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
 
 + (NSError *)missingOrInvalidNonceErrorWithMessage:(nullable NSString *)message {
   return [self errorWithCode:FIRAuthInternalErrorCodeMissingOrInvalidNonce message:message];
+}
+
++ (NSError *)unsupportedPassthroughOperationErrorWithMessage:(nullable NSString *)message {
+  return [self errorWithCode:FIRAuthInternalErrorCodeUnsupportedPassthroughOperation
+                     message:message];
+}
+
++ (NSError *)tokenRefreshUnavailableErrorWithMessage:(nullable NSString *)message {
+  return [self errorWithCode:FIRAuthInternalErrorCodeTokenRefreshUnavailable message:message];
 }
 
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status {

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -1414,8 +1414,8 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
                      message:message];
 }
 
-+ (NSError *)tokenRefreshUnavailableErrorWithMessage:(nullable NSString *)message {
-  return [self errorWithCode:FIRAuthInternalErrorCodeTokenRefreshUnavailable message:message];
++ (NSError *)tokenRefreshUnavailableError {
+  return [self errorWithCode:FIRAuthInternalErrorCodeTokenRefreshUnavailable];
 }
 
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status {

--- a/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
@@ -446,6 +446,16 @@ typedef NS_ENUM(NSInteger, FIRAuthInternalErrorCode) {
   FIRAuthInternalErrorCodeMissingOrInvalidNonce = FIRAuthPublicErrorCodeFlag |
                                                   FIRAuthErrorCodeMissingOrInvalidNonce,
 
+  /** Indicates that the operation is not supported in passthrough mode.
+   */
+  FIRAuthInternalErrorCodeUnsupportedPassthroughOperation =
+      FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeUnsupportedPassthroughOperation,
+
+  /** Indicates that neither a refresh token nor a custom token provider is available.
+   */
+  FIRAuthInternalErrorCodeTokenRefreshUnavailable = FIRAuthPublicErrorCodeFlag |
+                                                    FIRAuthErrorCodeTokenRefreshUnavailable,
+
   /** Indicates that a non-null user was expected as an argmument to the operation but a null
         user was provided.
    */

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1373,7 +1373,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
                                            NSError *_Nullable error) {
                                 XCTAssertTrue([NSThread isMainThread]);
                                 XCTAssertNil(tokenResult);
-                                XCTAssertEqual(error.code, FIRAuthErrorCodeInternalError);
+                                XCTAssertEqual(error.code, FIRAuthErrorCodeTokenRefreshUnavailable);
                                 XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey],
                                                       @"No refresh token is available.");
                                 [expectation fulfill];


### PR DESCRIPTION
Add `FIRAuthErrorCodeUnsupportedPassthroughOperation` and `FIRAuthErrorCodeTokenRefreshUnavailable` as part of passthrough support.

API Proposal: go/firebase-auth-passthrough-sdk-api

#no-changelog