### PR TITLE
Enable checking diff on fork.

### DIFF
--- a/scripts/health_metrics/get_updated_files.sh
+++ b/scripts/health_metrics/get_updated_files.sh
@@ -25,10 +25,7 @@ done
 
 dir=$(pwd)
 
-# Get most rescent ancestor commit.
-common_commit=$(git merge-base remotes/origin/${pr_branch} remotes/origin/${GITHUB_BASE_REF})
 target_branch_head=$(git rev-parse remotes/origin/${GITHUB_BASE_REF})
-echo "The common commit is ${common_commit}."
 echo "The target branch head commit is ${target_branch_head}."
 # Set target branch head and this will be used to compare diffs of coverage to the current commit.
 echo "::set-output name=target_branch_head::${target_branch_head}"


### PR DESCRIPTION
`common_commit` was the common ancestor of a target branch and base branch. This cannot be applied to fork. This variable block the workflow of spec testing on fork. This variable is not used in any workflows, and will be removed to unblock the workflow.
```
git diff --name-only remotes/origin/${GITHUB_BASE_REF} ${GITHUB_SHA} 
```
should be sufficient for spec testing on fork, where `remotes/origin/${GITHUB_BASE_REF}` is generally the `master` branch while `GITHUB_SHA` is a merge commit from a fork repo.