### PR TITLE
fix: `Firebase` podspec missing ML Model Downloader for macOS

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -171,7 +171,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'MLModelDownloader' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseMLModelDownloader', '~> 8.11.0-beta'
+    ss.dependency 'FirebaseMLModelDownloader', '~> 8.11.0-beta'
   end
 
   s.subspec 'Performance' do |ss|


### PR DESCRIPTION
### Discussion

[FirebaseMLModelDownloader.podspec](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseMLModelDownloader.podspec) supports osx as a target however the subspec in `Firebase.podspec` does not, this leads to build errors when adding the following as a dependency in podspecs:

```ruby
s.dependency 'Firebase/MLModelDownloader'
```

A work around for now is do just depend on an exact version of the ML pod directly e.g.:

```ruby
s.dependency 'FirebaseMLModelDownloader', '~> 8.10.0-beta'
```

### Testing

I've tested ML Model Downloader pod does work on macOS, via a Flutter macOS app that downloads/deletes models:

![image](https://user-images.githubusercontent.com/5347038/148728380-24ab3baa-49b9-404c-9065-dc394f747fda.png)

 - it builds without issues and downloading our test model works fine

### API Changes

  * None
