### PR TITLE
fix: issue where deployment targets for subspec `AppCheck` in `Firebase` podspec does not match `FirebaseAppCheck` podspec

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -99,9 +99,10 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.subspec 'AppCheck' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.dependency 'FirebaseAppCheck', '~> 8.11.0-beta'
-    ss.ios.deployment_target = '11.0'
-    ss.osx.deployment_target = '10.15'
-    ss.tvos.deployment_target = '11.0'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.12'
+    ss.tvos.deployment_target = '10.0'
+    ss.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'Auth' do |ss|


### PR DESCRIPTION
### Discussion

The deployment targets defined in https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseAppCheck.podspec#L20-L23 are not reflected in the [`AppCheck` subspec](https://github.com/firebase/firebase-ios-sdk/blob/master/Firebase.podspec#L102-L104) in the main `Firebase` podspec. This PR updates them to match.

### Testing

  * N/A

### API Changes

  * N/A
