### PR TITLE
Fix 32bit Firebase Distro build regression

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -22,9 +22,6 @@ struct FrameworkBuilder {
   /// Platforms to be included in the built frameworks.
   private let targetPlatforms: [TargetPlatform]
 
-  /// Minimum Version
-  private let minimumVersion: Float
-
   /// The directory containing the Xcode project and Pods folder.
   private let projectDir: URL
 
@@ -37,13 +34,9 @@ struct FrameworkBuilder {
   }
 
   /// Default initializer.
-  init(projectDir: URL, platform: Platform, dynamicFrameworks: Bool) {
+  init(projectDir: URL, targetPlatforms: [TargetPlatform], dynamicFrameworks: Bool) {
     self.projectDir = projectDir
-    targetPlatforms = platform.platformTargets
-    guard let minVersion = Float(platform.minimumVersion) else {
-      fatalError("Invalid minimum version: \(platform.minimumVersion)")
-    }
-    minimumVersion = minVersion
+    self.targetPlatforms = targetPlatforms
     self.dynamicFrameworks = dynamicFrameworks
   }
 
@@ -196,7 +189,7 @@ struct FrameworkBuilder {
 
     var archs = targetPlatform.archs.map { $0.rawValue }.joined(separator: " ")
     // The 32 bit archs do not build for iOS 11.
-    if framework == "FirebaseAppCheck" || minimumVersion >= 11.0 {
+    if framework == "FirebaseAppCheck" {
       if targetPlatform == .iOSDevice {
         archs = "arm64"
       } else if targetPlatform == .iOSSimulator {

--- a/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
@@ -34,9 +34,10 @@ enum TargetPlatform: CaseIterable {
   /// Valid architectures to be built for the platform.
   var archs: [Architecture] {
     switch self {
-    case .iOSDevice: return [.armv7, .arm64]
+    case .iOSDevice: return Included32BitIOS.include32 ? [.armv7, .arm64] : [.arm64]
     // Include arm64 slices in the simulator for Apple silicon Macs.
-    case .iOSSimulator: return [.i386, .x86_64, .arm64]
+    case .iOSSimulator: return Included32BitIOS
+      .include32 ? [.i386, .x86_64, .arm64] : [.x86_64, .arm64]
     // TODO: Evaluate x86_64h slice. Previous builds were limited to x86_64.
     case .catalyst: return [.x86_64, .arm64]
     case .macOS: return [.x86_64, .arm64]
@@ -96,4 +97,11 @@ enum Architecture: String, CaseIterable {
   case i386
   case x86_64
   case x86_64h // x86_64h, Haswell, used for Mac Catalyst
+}
+
+class Included32BitIOS {
+  fileprivate static var include32 = false
+  static func set() {
+    include32 = true
+  }
 }

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -129,7 +129,7 @@ struct ZipBuilder {
   /// Paths needed throughout the process of packaging the Zip file.
   public let paths: FilesystemPaths
 
-  /// The targetPlatforms to target for the builds.
+  /// The platforms to target for the builds.
   public let platforms: [Platform]
 
   /// Specifies if the builder is building dynamic frameworks instead of static frameworks.
@@ -231,7 +231,7 @@ struct ZipBuilder {
           // Don't build the Firebase pod.
         } else if podInfo.isSourcePod {
           let builder = FrameworkBuilder(projectDir: projectDir,
-                                         platform: platform,
+                                         targetPlatforms: platform.platformTargets,
                                          dynamicFrameworks: dynamicFrameworks)
           let (frameworks, resourceContents) =
             builder.compileFrameworkAndResources(withName: podName,

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -229,6 +229,14 @@ struct ZipBuilderTool: ParsableCommand {
       SkipCatalyst.set()
     }
 
+    // 32 bit iOS slices should only be built if the minimum iOS version is less than 11.
+    guard let minVersion = Float(minimumIOSVersion) else {
+      fatalError("Invalid minimum iOS version: \(minimumIOSVersion)")
+    }
+    if minVersion < 11.0 {
+      Included32BitIOS.set()
+    }
+
     let paths = ZipBuilder.FilesystemPaths(repoDir: repoDir,
                                            buildRoot: buildRoot,
                                            outputDir: outputDir,


### PR DESCRIPTION
#9142 broke the Firebase zip distribution build because the Firebase build changed the minimum iOS version to 14 just for building.

This PR fixes that regression while still fixing the issue #9142 resolved. It also makes the 32 bit build management a bit more robust.