### PR TITLE
FirebaseOptions docs: Swift and Analytics exception

### DIFF
--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -104,11 +104,12 @@ NS_SWIFT_NAME(FirebaseOptions)
  * For example:
  * ```swift
  *   if let path = Bundle.main.path(forResource:"GoogleServices-Info", ofType:"plist") {
- *       let options = FirebaseOptions.init(contentsOfFile: path)
+ *       let options = FirebaseOptions(contentsOfFile: path)
  *   }
  * ```
  * Note that it is not possible to customize FirebaseOptions for Firebase Analytics which expects a
- * static file named `GoogleServices-Info.plist`.
+ * static file named `GoogleServices-Info.plist` -
+ * https://github.com/firebase/firebase-ios-sdk/issues/230.
  * Returns nil if the plist file does not exist or is invalid.
  */
 - (nullable instancetype)initWithContentsOfFile:(NSString *)plistPath NS_DESIGNATED_INITIALIZER;
@@ -117,7 +118,7 @@ NS_SWIFT_NAME(FirebaseOptions)
  * Initializes a customized instance of FirebaseOptions with required fields. Use the mutable
  * properties to modify fields for configuring specific services. Note that it is not possible to
  * customize FirebaseOptions for Firebase Analytics which expects a static file named
- * `GoogleServices-Info.plist`.
+ * `GoogleServices-Info.plist` - https://github.com/firebase/firebase-ios-sdk/issues/230.
  */
 - (instancetype)initWithGoogleAppID:(NSString *)googleAppID
                         GCMSenderID:(NSString *)GCMSenderID

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -99,25 +99,29 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *appGroupID;
 
 /**
- * Initializes a customized instance of FIROptions from the file at the given plist file path. This
- * will read the file synchronously from disk.
- * For example,
- * NSString *filePath =
- *     [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
- * FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
+ * Initializes a customized instance of FirebaseOptions from the file at the given plist file path.
+ * This will read the file synchronously from disk.
+ * For example:
+ * ```swift
+ *   if let path = Bundle.main.path(forResource:"GoogleServices-Info", ofType:"plist") {
+ *       let options = FirebaseOptions.init(contentsOfFile: path)
+ *   }
+ * ```
+ * Note that it is not possible to customize FirebaseOptions for Firebase Analytics which expects a
+ * static file named `GoogleServices-Info.plist`.
  * Returns nil if the plist file does not exist or is invalid.
  */
 - (nullable instancetype)initWithContentsOfFile:(NSString *)plistPath NS_DESIGNATED_INITIALIZER;
 
 /**
- * Initializes a customized instance of FIROptions with required fields. Use the mutable properties
- * to modify fields for configuring specific services.
+ * Initializes a customized instance of FirebaseOptions with required fields. Use the mutable
+ * properties to modify fields for configuring specific services. Note that it is not possible to
+ * customize FirebaseOptions for Firebase Analytics which expects a static file named
+ * `GoogleServices-Info.plist`.
  */
-// clang-format off
 - (instancetype)initWithGoogleAppID:(NSString *)googleAppID
                         GCMSenderID:(NSString *)GCMSenderID
-    NS_SWIFT_NAME(init(googleAppID:gcmSenderID:)) NS_DESIGNATED_INITIALIZER;
-// clang-format on
+    NS_SWIFT_NAME(init(googleAppID:gcmSenderID:))NS_DESIGNATED_INITIALIZER;
 
 /** Unavailable. Please use `init(contentsOfFile:)` or `init(googleAppID:gcmSenderID:)` instead. */
 - (instancetype)init NS_UNAVAILABLE;


### PR DESCRIPTION
Fix #9201 

Clarify that FirebaseOptions APIs do not work for Analytics. Update rest of file to be Swifty.

#no-changelog