### PR TITLE
Add async/await variations for Auth Swift API tests

### DIFF
--- a/FirebaseAuth/Tests/Sample/ApiTests/FacebookAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/FacebookAuthTests.m
@@ -155,8 +155,6 @@ static NSString *const kFacebookTestAccountName = KFACEBOOK_USER_NAME;
                                            error.localizedDescription);
                                  }
                                }];
-  NSString *userInfo = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  NSLog(@"The info of created Facebook testing account is: %@", userInfo);
   // Parses the access token from the JSON data.
   NSDictionary *userInfoDict = [NSJSONSerialization JSONObjectWithData:data
                                                                options:kNilOptions

--- a/FirebaseAuth/Tests/Sample/ApiTests/GoogleAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/GoogleAuthTests.m
@@ -104,8 +104,6 @@ NSString *kGoogleTestAccountRefreshToken = KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN;
                                            error.localizedDescription);
                                  }
                                }];
-  NSString *userInfo = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  NSLog(@"The info of exchanged result is: %@", userInfo);
   NSDictionary *userInfoDict = [NSJSONSerialization JSONObjectWithData:data
                                                                options:kNilOptions
                                                                  error:nil];

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -48,7 +48,7 @@ class AccountInfoTests: TestsBase {
                      AuthErrorCode.emailAlreadyInUse.rawValue,
                      "Created a user despite it already exiting.")
       } else {
-        XCTAssertTrue(false, "Did not get error for recreating a user")
+        XCTFail("Did not get error for recreating a user")
       }
       expectation1.fulfill()
     }
@@ -74,4 +74,30 @@ class AccountInfoTests: TestsBase {
     }
     waitForExpectations(timeout:TestsBase.kExpectationsTimeout)
   }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testUpdatingUsersEmailAsync() async throws {
+    let auth = Auth.auth()
+    do {
+      let _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
+      XCTFail("Did not get error for recreating a user")
+    } catch {
+        XCTAssertEqual((error as NSError).code,
+                     AuthErrorCode.emailAlreadyInUse.rawValue,
+                     "Created a user despite it already exiting.")
+    }
+
+    let user = try await auth.signIn(withEmail: kOldUserEmail, password: "password")
+    XCTAssertEqual(auth.currentUser?.email,
+                   self.kOldUserEmail,
+                   "Signed user does not match request.")
+    XCTAssertEqual(user.user.email, kOldUserEmail)
+
+    try await auth.currentUser?.updateEmail(to: kNewUserEmail)
+    XCTAssertEqual(auth.currentUser?.email,
+                   self.kNewUserEmail,
+                   "Signed user does not match change.")
+  }
+  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -89,10 +89,10 @@ class AccountInfoTests: TestsBase {
     }
 
     let user = try await auth.signIn(withEmail: kOldUserEmail, password: "password")
+    XCTAssertEqual(user.user.email, kOldUserEmail)
     XCTAssertEqual(auth.currentUser?.email,
                    self.kOldUserEmail,
                    "Signed user does not match request.")
-    XCTAssertEqual(user.user.email, kOldUserEmail)
 
     try await auth.currentUser?.updateEmail(to: kNewUserEmail)
     XCTAssertEqual(auth.currentUser?.email,

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -24,8 +24,21 @@ class AnonymousTests: TestsBase {
     if let isAnonymous = Auth.auth().currentUser?.isAnonymous {
       XCTAssertTrue(isAnonymous)
     } else {
-      XCTAssertTrue(false, "Missing currentUser after anonymous sign in")
+      XCTFail("Missing currentUser after anonymous sign in")
     }
     self.deleteCurrentUser()
   }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testUpdatingUsersEmailAsync() async throws {
+    try await self.signInAnonymouslyAsync()
+    if let isAnonymous = Auth.auth().currentUser?.isAnonymous {
+      XCTAssertTrue(isAnonymous)
+    } else {
+      XCTFail("Missing currentUser after anonymous sign in")
+    }
+    try await self.deleteCurrentUserAsync()
+  }
+  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -68,9 +68,9 @@ class EmailPasswordTests: TestsBase {
   func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
     let auth = Auth.auth()
     try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")
-      XCTAssertEqual(auth.currentUser?.email,
-                     self.kExistingEmailToSignIn,
-                     "Signed user does not match request.")
+    XCTAssertEqual(auth.currentUser?.email,
+                   self.kExistingEmailToSignIn,
+                   "Signed user does not match request.")
   }
   #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -40,6 +40,16 @@ class EmailPasswordTests: TestsBase {
     self.deleteCurrentUser()
   }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testCreateAccountWithEmailAndPasswordAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
+    XCTAssertEqual(auth.currentUser?.email, kNewEmailToCreateUser, "Expected email doesn't match")
+    try await self.deleteCurrentUserAsync()
+  }
+  #endif
+
   func testSignInExistingUserWithEmailAndPassword() {
     let auth = Auth.auth()
     let expectation = self.expectation(description: "Signed in existing account with email and password.")
@@ -52,4 +62,15 @@ class EmailPasswordTests: TestsBase {
     }
     waitForExpectations(timeout:TestsBase.kExpectationsTimeout)
   }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")
+      XCTAssertEqual(auth.currentUser?.email,
+                     self.kExistingEmailToSignIn,
+                     "Signed user does not match request.")
+  }
+  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -20,17 +20,11 @@ import GTMSessionFetcher
 import XCTest
 
 class FacebookTests: TestsBase {
-  func testSignInWithFacebook() {
+  func testSignInWithFacebook() throws {
     let auth = Auth.auth()
     let userInfoDict = self.createFacebookTestingAccount()
-    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTFail("Failed to get facebookAccessToken")
-      return
-    }
-    guard let facebookAccountID = userInfoDict["id"] as! String? else {
-      XCTFail("Failed to get facebookAccountID")
-      return
-    }
+    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]  as? String)
+    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"] as? String)
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
     let expectation = self.expectation(description: "Signing in with Facebook finished.")
     auth.signIn(with: credential) { (result, error) in
@@ -53,8 +47,8 @@ class FacebookTests: TestsBase {
   func testSignInWithFacebookAsync() async throws {
     let auth = Auth.auth()
     let userInfoDict = try await self.createFacebookTestingAccountAsync()
-    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]) as! String
-    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"]) as! String
+    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]  as? String)
+    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"] as? String)
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
 
     try await auth.signIn(with: credential)
@@ -66,18 +60,12 @@ class FacebookTests: TestsBase {
   }
   #endif
 
-  func testLinkAnonymousAccountToFacebookAccount() {
+  func testLinkAnonymousAccountToFacebookAccount() throws {
     let auth = Auth.auth()
     self.signInAnonymously()
     let userInfoDict = self.createFacebookTestingAccount()
-    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTFail("Failed to get facebookAccessToken")
-      return
-    }
-    guard let facebookAccountID = userInfoDict["id"] as! String? else {
-      XCTFail("Failed to get facebookAccountID")
-      return
-    }
+    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]  as? String)
+    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"] as? String)
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
     let expectation = self.expectation(description: "Facebook linking finished.")
     auth.currentUser?.link(with: credential, completion: { (result, error) in
@@ -106,14 +94,8 @@ class FacebookTests: TestsBase {
     let auth = Auth.auth()
     try await self.signInAnonymouslyAsync()
     let userInfoDict = try await self.createFacebookTestingAccountAsync()
-    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTFail("Failed to get facebookAccessToken")
-      return
-    }
-    guard let facebookAccountID = userInfoDict["id"] as! String? else {
-      XCTFail("Failed to get facebookAccountID")
-      return
-    }
+    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]  as? String)
+    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"] as? String)
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
     try await auth.currentUser?.link(with: credential)
         guard let providers = (auth.currentUser?.providerData) else {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -53,18 +53,12 @@ class FacebookTests: TestsBase {
   func testSignInWithFacebookAsync() async throws {
     let auth = Auth.auth()
     let userInfoDict = try await self.createFacebookTestingAccountAsync()
-    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-        XCTFail("Failed to get facebookAccessToken")
-        return
-      }
-      guard let facebookAccountID = userInfoDict["id"] as! String? else {
-        XCTFail("Failed to get facebookAccountID")
-        return
-      }
-      let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
+    let facebookAccessToken: String = try XCTUnwrap(userInfoDict["access_token"]) as! String
+    let facebookAccountID: String = try XCTUnwrap(userInfoDict["id"]) as! String
+    let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
 
-      try await auth.signIn(with: credential)
-          XCTAssertEqual(auth.currentUser?.displayName, Credentials.kFacebookUserName)
+    try await auth.signIn(with: credential)
+    XCTAssertEqual(auth.currentUser?.displayName, Credentials.kFacebookUserName)
 
     // Clean up the created Firebase/Facebook user for future runs.
     try await self.deleteCurrentUserAsync()
@@ -162,11 +156,6 @@ class FacebookTests: TestsBase {
       } else {
         do {
           let data = try XCTUnwrap(data)
-          guard let userInfo = String.init(data: data, encoding: .utf8) else {
-            XCTAssertTrue(false, "Failed to convert data to string")
-            return
-          }
-          print("The created Facebook testing account info is: \(String(describing: userInfo))")
           returnValue = try JSONSerialization.jsonObject(with: data, options: [])
             as! Dictionary<String, Any>
         } catch (let error) {
@@ -195,11 +184,6 @@ class FacebookTests: TestsBase {
     fetcher.bodyData = postData
     fetcher.setRequestValue("text/plain", forHTTPHeaderField: "Content-Type")
     let data = try await fetcher.beginFetch()
-    guard let userInfo = String.init(data: data, encoding: .utf8) else {
-      XCTFail("Failed to convert data to string")
-      fatalError()
-    }
-    print("The created Facebook testing account info is: \(String(describing: userInfo))")
     guard let returnValue = try JSONSerialization.jsonObject(with: data, options: [])
             as? Dictionary<String, Any> else {
               XCTFail("Failed to serialize userInfo as a Dictionary")

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -24,18 +24,18 @@ class FacebookTests: TestsBase {
     let auth = Auth.auth()
     let userInfoDict = self.createFacebookTestingAccount()
     guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTAssertTrue(false, "Failed to get facebookAccessToken")
+      XCTFail("Failed to get facebookAccessToken")
       return
     }
     guard let facebookAccountID = userInfoDict["id"] as! String? else {
-      XCTAssertTrue(false, "Failed to get facebookAccountID")
+      XCTFail("Failed to get facebookAccountID")
       return
     }
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
     let expectation = self.expectation(description: "Signing in with Facebook finished.")
     auth.signIn(with: credential) { (result, error) in
       if let error = error {
-        XCTAssertTrue(false, "Signing in with Facebook had error: \(error)")
+        XCTFail("Signing in with Facebook had error: \(error)")
       } else {
         XCTAssertEqual(auth.currentUser?.displayName, Credentials.kFacebookUserName)
       }
@@ -48,26 +48,50 @@ class FacebookTests: TestsBase {
     self.deleteFacebookTestingAccountbyID(facebookAccountID)
   }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testSignInWithFacebookAsync() async throws {
+    let auth = Auth.auth()
+    let userInfoDict = try await self.createFacebookTestingAccountAsync()
+    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
+        XCTFail("Failed to get facebookAccessToken")
+        return
+      }
+      guard let facebookAccountID = userInfoDict["id"] as! String? else {
+        XCTFail("Failed to get facebookAccountID")
+        return
+      }
+      let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
+
+      try await auth.signIn(with: credential)
+          XCTAssertEqual(auth.currentUser?.displayName, Credentials.kFacebookUserName)
+
+    // Clean up the created Firebase/Facebook user for future runs.
+    try await self.deleteCurrentUserAsync()
+    try await self.deleteFacebookTestingAccountbyIDAsync(facebookAccountID)
+  }
+  #endif
+
   func testLinkAnonymousAccountToFacebookAccount() {
     let auth = Auth.auth()
     self.signInAnonymously()
     let userInfoDict = self.createFacebookTestingAccount()
     guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTAssertTrue(false, "Failed to get facebookAccessToken")
+      XCTFail("Failed to get facebookAccessToken")
       return
     }
     guard let facebookAccountID = userInfoDict["id"] as! String? else {
-      XCTAssertTrue(false, "Failed to get facebookAccountID")
+      XCTFail("Failed to get facebookAccountID")
       return
     }
     let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
     let expectation = self.expectation(description: "Facebook linking finished.")
     auth.currentUser?.link(with: credential, completion: { (result, error) in
       if let error = error {
-        XCTAssertTrue(false, "Link to Firebase error: \(error)")
+        XCTFail("Link to Firebase error: \(error)")
       } else {
         guard let providers = (auth.currentUser?.providerData) else {
-          XCTAssertTrue(false, "Failed to get providers")
+          XCTFail("Failed to get providers")
           return
         }
         XCTAssertEqual(providers.count, 1)
@@ -81,6 +105,35 @@ class FacebookTests: TestsBase {
     self.deleteCurrentUser()
     self.deleteFacebookTestingAccountbyID(facebookAccountID)
   }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func testLinkAnonymousAccountToFacebookAccountAsync() async throws {
+    let auth = Auth.auth()
+    try await self.signInAnonymouslyAsync()
+    let userInfoDict = try await self.createFacebookTestingAccountAsync()
+    guard let facebookAccessToken = userInfoDict["access_token"] as! String? else {
+      XCTFail("Failed to get facebookAccessToken")
+      return
+    }
+    guard let facebookAccountID = userInfoDict["id"] as! String? else {
+      XCTFail("Failed to get facebookAccountID")
+      return
+    }
+    let credential = FacebookAuthProvider.credential(withAccessToken: facebookAccessToken)
+    try await auth.currentUser?.link(with: credential)
+        guard let providers = (auth.currentUser?.providerData) else {
+          XCTFail("Failed to get providers")
+          return
+        }
+        XCTAssertEqual(providers.count, 1)
+        XCTAssertEqual(providers[0].providerID, "facebook.com")
+
+    // Clean up the created Firebase/Facebook user for future runs.
+    try await self.deleteCurrentUserAsync()
+    try await self.deleteFacebookTestingAccountbyIDAsync(facebookAccountID)
+  }
+  #endif
 
   ///** Creates a Facebook testing account using Facebook Graph API and return a dictionary that
   // * constains "id", "access_token", "login_url", "email" and "password" of the created account.
@@ -102,9 +155,9 @@ class FacebookTests: TestsBase {
         let error = error as NSError
         if let message = String.init(data: error.userInfo["data"] as! Data, encoding: .utf8) {
           // May get transient errors here for too many api calls when tests run frequently.
-          XCTAssertTrue(false, "Creating Facebook account failed with error: \(message)")
+          XCTFail("Creating Facebook account failed with error: \(message)")
         } else {
-          XCTAssertTrue(false, "Creating Facebook account failed with error: \(error)")
+          XCTFail("Creating Facebook account failed with error: \(error)")
         }
       } else {
         do {
@@ -117,7 +170,7 @@ class FacebookTests: TestsBase {
           returnValue = try JSONSerialization.jsonObject(with: data, options: [])
             as! Dictionary<String, Any>
         } catch (let error) {
-          XCTAssertTrue(false, "Failed to unwrap data \(error)")
+          XCTFail("Failed to unwrap data \(error)")
         }
       }
       expectation.fulfill()
@@ -125,6 +178,36 @@ class FacebookTests: TestsBase {
     waitForExpectations(timeout:TestsBase.kExpectationsTimeout)
     return returnValue
   }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  ///** Creates a Facebook testing account using Facebook Graph API and return a dictionary that
+  // * constains "id", "access_token", "login_url", "email" and "password" of the created account.
+  // */
+  func createFacebookTestingAccountAsync() async throws -> Dictionary<String, Any> {
+    let urltoCreateTestUser = "https://graph.facebook.com/\(Credentials.kFacebookAppID)" +
+      "/accounts/test-users"
+    let bodyString = "installed=true&name=\(Credentials.kFacebookUserName)" +
+      "&permissions=read_stream&access_token=\(Credentials.kFacebookAppAccessToken)"
+    let postData = bodyString.data(using: .utf8)
+    let service = GTMSessionFetcherService.init()
+    let fetcher = service.fetcher(withURLString: urltoCreateTestUser)
+    fetcher.bodyData = postData
+    fetcher.setRequestValue("text/plain", forHTTPHeaderField: "Content-Type")
+    let data = try await fetcher.beginFetch()
+    guard let userInfo = String.init(data: data, encoding: .utf8) else {
+      XCTFail("Failed to convert data to string")
+      fatalError()
+    }
+    print("The created Facebook testing account info is: \(String(describing: userInfo))")
+    guard let returnValue = try JSONSerialization.jsonObject(with: data, options: [])
+            as? Dictionary<String, Any> else {
+              XCTFail("Failed to serialize userInfo as a Dictionary")
+              fatalError()
+            }
+    return returnValue
+  }
+  #endif
 
   //** Delete a Facebook testing account by account Id using Facebook Graph API. */
   func deleteFacebookTestingAccountbyID(_ accountID: String) {
@@ -138,10 +221,24 @@ class FacebookTests: TestsBase {
     let expectation = self.expectation(description: "Deleting Facebook account finished.")
     fetcher.beginFetch { (data, error) in
       if let error = error {
-        XCTAssertTrue(false, "Deleting Facebook account failed with error: \(error)")
+        XCTFail("Deleting Facebook account failed with error: \(error)")
       }
       expectation.fulfill()
     }
     waitForExpectations(timeout:TestsBase.kExpectationsTimeout)
   }
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  //** Delete a Facebook testing account by account Id using Facebook Graph API. */
+  func deleteFacebookTestingAccountbyIDAsync(_ accountID: String) async throws{
+    let urltoDeleteTestUser = "https://graph.facebook.com/\(accountID)"
+    let bodyString = "method=delete&access_token=\(Credentials.kFacebookAppAccessToken)"
+    let postData = bodyString.data(using: .utf8)
+    let service = GTMSessionFetcherService.init()
+    let fetcher = service.fetcher(withURLString: urltoDeleteTestUser)
+    fetcher.bodyData = postData
+    fetcher.setRequestValue("text/plain", forHTTPHeaderField: "Content-Type")
+    try await fetcher.beginFetch()
+  }
+  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -84,8 +84,6 @@ class GoogleTests: TestsBase {
       } else {
         do {
           let data = try XCTUnwrap(data)
-          let userInfo = String.init(data: data, encoding: .utf8)
-          print("The info of exchanged result is: \(String(describing: userInfo))")
           returnValue = try JSONSerialization.jsonObject(with: data, options: [])
             as! Dictionary<String, Any>
         } catch (let error) {
@@ -115,8 +113,6 @@ class GoogleTests: TestsBase {
     fetcher.bodyData = postData
     fetcher.setRequestValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
     let data = try await fetcher.beginFetch()
-    let userInfo = String.init(data: data, encoding: .utf8)
-    print("The info of exchanged result is: \(String(describing: userInfo))")
     guard let returnValue = try JSONSerialization.jsonObject(with: data, options: [])
             as? Dictionary<String, Any> else {
               XCTFail("Failed to serialize userInfo as a Dictionary")

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -21,17 +21,11 @@ import XCTest
 
 class GoogleTests: TestsBase {
 
-  func testSignInWithGoogle() {
+  func testSignInWithGoogle() throws {
     let auth = Auth.auth()
     let userInfoDict = self.getGoogleAccessToken()
-    guard let googleAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTFail("Failed to get googleAccessToken")
-      return
-    }
-    guard let googleIDToken = userInfoDict["id_token"] as! String? else {
-      XCTFail("Failed to get googleIDToken")
-      return
-    }
+    let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
+    let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
     let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
                                                    accessToken: googleAccessToken)
     let expectation = self.expectation(description: "Signing in with Google finished.")
@@ -48,14 +42,8 @@ class GoogleTests: TestsBase {
   func testSignInWithGoogleAsync() async throws {
     let auth = Auth.auth()
     let userInfoDict = try await self.getGoogleAccessTokenAsync()
-    guard let googleAccessToken = userInfoDict["access_token"] as! String? else {
-      XCTFail("Failed to get googleAccessToken")
-      return
-    }
-    guard let googleIDToken = userInfoDict["id_token"] as! String? else {
-      XCTFail("Failed to get googleIDToken")
-      return
-    }
+    let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
+    let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
     let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
                                                    accessToken: googleAccessToken)
     let _ = try await auth.signIn(with: credential)

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -21,6 +21,20 @@ import XCTest
 class TestsBase : XCTestCase {
   static let kExpectationsTimeout = 10.0
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func signInAnonymouslyAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.signInAnonymously()
+  }
+
+  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  func deleteCurrentUserAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.currentUser?.delete()
+  }
+#endif
+
   func signInAnonymously() {
     let auth = Auth.auth()
 


### PR DESCRIPTION
New tests succeed here: https://github.com/firebase/firebase-ios-sdk/runs/4823864218?check_suite_focus=true#step:7:749

#no-changelog