### PR TITLE
Restore SharedTestUtilities after breakage

### DIFF
--- a/SharedTestUtilities/FIROptionsMock.m
+++ b/SharedTestUtilities/FIROptionsMock.m
@@ -18,8 +18,7 @@
 #import "SharedTestUtilities/FIROptionsMock.h"
 
 NSString *const kAndroidClientID = @"correct_android_client_id";
-// FIS requires 39 characters starting with A.
-NSString *const kAPIKey = @"A23456789012345678901234567890123456789";
+NSString *const kAPIKey = @"correct_api_key";
 NSString *const kCustomizedAPIKey = @"customized_api_key";
 NSString *const kClientID = @"correct_client_id";
 NSString *const kTrackingID = @"correct_tracking_id";
@@ -32,7 +31,7 @@ NSString *const kDeepLinkURLScheme = @"comgoogledeeplinkurl";
 NSString *const kNewDeepLinkURLScheme = @"newdeeplinkurlfortest";
 
 NSString *const kBundleID = @"com.google.FirebaseSDKTests";
-NSString *const kProjectID = @"Mocked Project ID";
+NSString *const kProjectID = @"abc-xyz-123";
 
 @interface FIROptionsMock ()
 


### PR DESCRIPTION
While experimenting, I changed this file in #9084 but ended up faking instead of mocking for RC.

The FirebaseCore unit tests depend on the old values.