### PR TITLE
Remove pull request trigger in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: release
 
 on:
-  pull_request:
-    paths:
-    - 'scripts/release_testing_setup.sh'
-    - '.github/workflows/release.yml'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times


### PR DESCRIPTION
Based on #9215, release and prerelease workflow will refresh the testing specrepos, [release specrepo](https://github.com/FirebasePrivate/SpecsTesting) and [prerelease sepcrepo](https://github.com/firebase/SpecsTesting). These two workflows are not for presubmits. Presubmits will refresh the specrepo and running in presubmits multiple times within a short time(like within ~4 hours) will cause concurrency issues.