### PR TITLE
Partial fix for expired ID token issue

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,47 +1,50 @@
+# Unreleased
+- [fixed] Partial fix for expired ID token issue. (#6521)
+
 # v8.11.0
 - [changed] Added a `X-Firebase-GMPID` header to network requests. (#9046)
 - [fixed] Added multi-tenancy support to generic OAuth providers. (#7990)
-- [fixed] macOS Extension access to Shared Keychain by adding kSecUseDataProtectionKeychain recommended key (#6876)
+- [fixed] macOS Extension access to Shared Keychain by adding `kSecUseDataProtectionKeychain` recommended key. (#6876)
 
-# 8.9.0
+# v8.9.0
 - [changed] Improved error logging. (#8704)
 - [added] Added MFA support for email link sign-in. (#8705)
 
-# 8.8.0
+# v8.8.0
 - [fixed] Fall back to reCAPTCHA for phone auth app verification if the push notification is not received before the timeout. (#8653)
 
-# 8.6.0
+# v8.6.0
 - [fixed] Annotated platform-level availability using `API_UNAVAILABLE` instead of conditionally compiling certain methods with `#if` directives. (#8451)
 
-# 8.5.0
+# v8.5.0
 - [fixed] Fixed an analyze issue introduced in Xcode 12.5. (#8411)
 
-# 8.2.0
+# v8.2.0
 - [fixed] Fixed analyze issues introduced in Xcode 12.5. (#8210)
 - [fixed] Fixed a bug in the link with email link, Game Center, and phone auth flows. (#8196)
 
-# 8.0.0
+# v8.0.0
 - [fixed] Fixed a crash that occurred when assigning auth settings. (#7670)
 
-# 7.8.0
+# v7.8.0
 - [fixed] Fixed auth state sharing during first app launch. (#7472)
 
-# 7.6.0
+# v7.6.0
 - [fixed] Auth emulator now works across the local network. (#7350)
 - [fixed] Fixed incorrect import for watchOS (#7425)
 
-# 7.4.0
+# v7.4.0
 - [fixed] Check if the reverse client ID is configured as a custom URL scheme before setting it as the callback scheme. (#7211)
 - [added] Add ability to sync auth state across devices. (#6924)
 - [fixed] Add multi-tenancy support for email link sign-in. (#7246)
 
-# 7.3.0
+# v7.3.0
 - [fixed] Catalyst browser issue with `verifyPhoneNumber` API. (#7049)
 
-# 7.1.0
+# v7.1.0
 - [fixed] Fixed completion handler issue in `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` method. (#6863)
 
-# 7.0.0
+# v7.0.0
 - [removed] Remove deprecated APIs `dataForKey`,`fetchProvidersForEmail:completion`, `signInAndRetrieveDataWithCredential:completion`, `reauthenticateAndRetrieveDataWithCredential:completion`, `linkAndRetrieveDataWithCredential:completion`. (#6607)
 - [added] Add support for the auth emulator. (#6624)
 - [changed] The global variables `FirebaseAuthVersionNum` and `FirebaseAuthVersionStr` are deleted.

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -180,7 +180,8 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
              // callback is invoked less than an hour after the request is made, a token is not
              // re-requested here but the approximateExpirationDate will still be off since that is
              // computed at the time the token is received.
-             if (retryIfExpired && [tokenResult.expirationDate timeIntervalSinceNow] <= 0) {
+             if (retryIfExpired &&
+                 [tokenResult.expirationDate timeIntervalSinceNow] <= kFiveMinutes) {
                // We only retry once, to avoid an infinite loop in the case that an end-user has
                // their local time skewed by over an hour.
                [self requestAccessToken:NO callback:callback];

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -101,11 +101,12 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
       callback(self->_accessToken, nil, NO);
     } else {
       FIRLogDebug(kFIRLoggerAuth, @"I-AUT000017", @"Fetching new token from backend.");
-      [self requestAccessToken:^(NSString *_Nullable token, NSError *_Nullable error,
+      [self requestAccessToken:YES
+                      callback:^(NSString *_Nullable token, NSError *_Nullable error,
                                  BOOL tokenUpdated) {
-        complete();
-        callback(token, error, tokenUpdated);
-      }];
+                        complete();
+                        callback(token, error, tokenUpdated);
+                      }];
     }
   }];
 }
@@ -161,7 +162,7 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
         since only one of those tasks is ever running at a time, and those tasks are the only
         access to and mutation of these instance variables.
  */
-- (void)requestAccessToken:(FIRFetchAccessTokenCallback)callback {
+- (void)requestAccessToken:(BOOL)retryIfExpired callback:(FIRFetchAccessTokenCallback)callback {
   FIRSecureTokenRequest *request =
       [FIRSecureTokenRequest refreshRequestWithRefreshToken:_refreshToken
                                        requestConfiguration:_requestConfiguration];
@@ -173,14 +174,16 @@ static const NSTimeInterval kFiveMinutes = 5 * 60;
            if (newAccessToken.length && ![newAccessToken isEqualToString:self->_accessToken]) {
              FIRAuthTokenResult *tokenResult =
                  [FIRAuthTokenResult tokenResultWithToken:newAccessToken];
-             if ([tokenResult.expirationDate timeIntervalSinceNow] < 0) {
-               // There is an edge case where the request for a new access token may be made right
-               // before the app goes inactive, resulting in the callback being invoked much later
-               // with an expired access token. This does not fully solve the issue, as if the
-               // callback is invoked less than an hour after the request is made, a token is not
-               // re-requested here but the approximateExpirationDate will still be off since that
-               // is computed at the time the token is received.
-               [self requestAccessToken:callback];
+             // There is an edge case where the request for a new access token may be made right
+             // before the app goes inactive, resulting in the callback being invoked much later
+             // with an expired access token. This does not fully solve the issue, as if the
+             // callback is invoked less than an hour after the request is made, a token is not
+             // re-requested here but the approximateExpirationDate will still be off since that is
+             // computed at the time the token is received.
+             if (retryIfExpired && [tokenResult.expirationDate timeIntervalSinceNow] <= 0) {
+               // We only retry once, to avoid an infinite loop in the case that an end-user has
+               // their local time skewed by over an hour.
+               [self requestAccessToken:NO callback:callback];
                return;
              }
              self->_accessToken = [newAccessToken copy];

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -2180,7 +2180,9 @@ static const NSTimeInterval kWaitInterval = .5;
   // Sign in a user.
   [self waitForSignIn];
 
-  // Set up expectation for secureToken RPC made by token refresh task.
+  // Set up expectation for secureToken RPC made by token refresh task. We call this twice, because
+  // we retry once if the access token is already expired.
+  [self mockSecureTokenResponseWithError:nil];
   [self mockSecureTokenResponseWithError:nil];
 
   // Verify that the current user's access token is the "old" access token before automatic token
@@ -2266,7 +2268,9 @@ static const NSTimeInterval kWaitInterval = .5;
   // token (kNewAccessToken).
   XCTAssertEqualObjects(kAccessToken, [FIRAuth auth].currentUser.rawAccessToken);
 
-  // Set up expectation for secureToken RPC made by a successful attempt to refresh tokens.
+  // Set up expectation for secureToken RPC made by a successful attempt to refresh tokens. We call
+  // this twice, because we retry once if the access token is already expired.
+  [self mockSecureTokenResponseWithError:nil];
   [self mockSecureTokenResponseWithError:nil];
 
   // Execute saved token refresh task.
@@ -2306,7 +2310,9 @@ static const NSTimeInterval kWaitInterval = .5;
   // Verify that current user is still valid with old access token.
   XCTAssertEqualObjects(kAccessToken, [FIRAuth auth].currentUser.rawAccessToken);
 
-  // Set up expectation for secureToken RPC made by a successful attempt to refresh tokens.
+  // Set up expectation for secureToken RPC made by a successful attempt to refresh tokens. We call
+  // this twice, because we retry once if the access token is already expired.
+  [self mockSecureTokenResponseWithError:nil];
   [self mockSecureTokenResponseWithError:nil];
 
   // Execute saved token refresh task.


### PR DESCRIPTION
Partial fix for #6521, where the callback for `getIDToken` appears to sometimes be invoked hours after the method is called if the app goes into the background.

Not sure if this is the best fix, but this should at least alleviate some cases of this happening. For the remainder, developers can catch the token expiration error from the backend and request a new token.