### PR TITLE
Fireperf: prewarm counters

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* [Fixed] Potentially drop pre-warmed app start traces on iOS 15 and above (#9026). App start measurements are made only for cold app starts (without pre-warming).
+
 # Version 8.10.0
 * Fix a crash related to FPRSessionDetails. (#8691)
 * Fix heap-buffer overflow when encoding sessions. (#8849)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [Fixed] Potentially drop pre-warmed app start traces on iOS 15 and above (#9026). App start measurements are made only for cold app starts (without pre-warming).
+* [fixed] Potentially drop pre-warmed app start traces on iOS 15 and above (#9026). App start measurements are made only for cold app starts (without pre-warming).
 
 # Version 8.10.0
 * Fix a crash related to FPRSessionDetails. (#8691)


### PR DESCRIPTION
Adding 2 hidden metrics to `_fs`, regardless of RC flag `fpr_prewarm_detection`:
* `_fsapc`: ActivePrewarm counter. if ActivePrewarm identifies an app start as prewarmed, `_fsapc` of 1 will be added, otherwise a `_fsapc` of 0 will b added.
* `_fsddc`: Double dispatch counter. If double dispatch identifies an app as prewarmed, `_fsddc` of 1 will be added; if double dispatch identifies as not-prewarmed, 0 will be added; if double dispatch is disabled by developers through plist, then no custom metric will be added. 