### PR TITLE
Fixes a bug in custom key and user ID logging

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed an issue where passing nil as a value for a custom key or user ID did not clear the stored value as expected.
+
 # v8.9.0
 - [fixed] Fixed an issue where exceptions with `nil` reasons weren't properly recorded (#8671).
 

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -294,13 +294,13 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 #pragma mark - API: setUserID
-- (void)setUserID:(NSString *)userID {
+- (void)setUserID:(nullable NSString *)userID {
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSUserIdentifierKey, userID);
 }
 
 #pragma mark - API: setCustomValue
 
-- (void)setCustomValue:(id)value forKey:(NSString *)key {
+- (void)setCustomValue:(nullable id)value forKey:(NSString *)key {
   FIRCLSUserLoggingRecordUserKeyValue(key, value);
 }
 

--- a/Crashlytics/Crashlytics/FIRCrashlyticsReport.m
+++ b/Crashlytics/Crashlytics/FIRCrashlyticsReport.m
@@ -167,7 +167,7 @@
 
 #pragma mark - API: setUserID
 
-- (void)setUserID:(NSString *)userID {
+- (void)setUserID:(nullable NSString *)userID {
   if (![self checkContextForMethod:@"setUserID:"]) {
     return;
   }
@@ -178,7 +178,7 @@
 
 #pragma mark - API: setCustomValue
 
-- (void)setCustomValue:(id)value forKey:(NSString *)key {
+- (void)setCustomValue:(nullable id)value forKey:(NSString *)key {
   if (![self checkContextForMethod:@"setCustomValue:forKey:"]) {
     return;
   }

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -82,7 +82,7 @@ NS_SWIFT_NAME(Crashlytics)
  * @param value The value to be associated with the key
  * @param key A unique key
  */
-- (void)setCustomValue:(id)value forKey:(NSString *)key;
+- (void)setCustomValue:(nullable id)value forKey:(NSString *)key;
 
 /**
  * Sets custom keys and values to be associated with subsequent fatal and non-fatal reports.
@@ -104,7 +104,7 @@ NS_SWIFT_NAME(Crashlytics)
  * @param userID An arbitrary user identifier string that associates a user to a record in your
  * system.
  */
-- (void)setUserID:(NSString *)userID;
+- (void)setUserID:(nullable NSString *)userID;
 
 /**
  * Records a non-fatal event described by an NSError object. The events are

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
@@ -79,7 +79,7 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param value The value to be associated with the key
  * @param key A unique key
  */
-- (void)setCustomValue:(id)value forKey:(NSString *)key;
+- (void)setCustomValue:(nullable id)value forKey:(NSString *)key;
 
 /**
  * Sets custom keys and values to be associated with subsequent fatal and non-fatal reports.
@@ -101,7 +101,7 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param userID An arbitrary user identifier string that associates a user to a record in your
  * system.
  */
-- (void)setUserID:(NSString *)userID;
+- (void)setUserID:(nullable NSString *)userID;
 
 @end
 

--- a/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
+++ b/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
@@ -104,13 +104,6 @@
   XCTAssertEqualObjects(entries[0][@"kv"][@"key"],
                         FIRCLSFileHexEncodeString([FIRCLSUserIdentifierKey UTF8String]), @"");
   XCTAssertEqualObjects(entries[0][@"kv"][@"value"], FIRCLSFileHexEncodeString("12345-6"), @"");
-  
-  [report setUserID:nil];
-  entries = FIRCLSFileReadSections(
-      [[report.internalReport pathForContentFile:FIRCLSReportInternalIncrementalKVFile]
-          fileSystemRepresentation],
-      false, nil);
-  XCTAssertEqualObjects(entries[0][@"kv"][@"value"], @"", @"");
 }
 
 - (void)testCustomKeysNoExisting {

--- a/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
+++ b/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
@@ -104,6 +104,13 @@
   XCTAssertEqualObjects(entries[0][@"kv"][@"key"],
                         FIRCLSFileHexEncodeString([FIRCLSUserIdentifierKey UTF8String]), @"");
   XCTAssertEqualObjects(entries[0][@"kv"][@"value"], FIRCLSFileHexEncodeString("12345-6"), @"");
+  
+  [report setUserID:nil];
+  entries = FIRCLSFileReadSections(
+      [[report.internalReport pathForContentFile:FIRCLSReportInternalIncrementalKVFile]
+          fileSystemRepresentation],
+      false, nil);
+  XCTAssertEqualObjects(entries[0][@"kv"][@"value"], @"", @"");
 }
 
 - (void)testCustomKeysNoExisting {


### PR DESCRIPTION
Fixes a bug where setting a custom key's value to nil or passing nil as a user ID did not clear the value as expected.

Resolves #9241, #9212