### PR TITLE
Functions Interop + CoreInternal

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -193,6 +193,12 @@ static FIRApp *sDefaultApp;
     FIRLogDebug(kFIRLoggerCore, @"I-COR000002", @"Configuring app named %@", name);
   }
 
+  // Default instantiation, make sure we populate with Swift SDKs that can't register in time.
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self registerSwiftComponents];
+  });
+
   @synchronized(self) {
     FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
     if (app.isDefaultApp) {
@@ -822,6 +828,20 @@ static FIRApp *sDefaultApp;
   });
 
   return collectionEnabledPlistObject;
+}
+
+#pragma mark - Swift Components.
+
++ (void)registerSwiftComponents {
+  SEL componentsToRegisterSEL = @selector(componentsToRegister:);
+  // Dictionary of class names and their user agents.
+  NSDictionary<NSString *, NSString *> *swiftLibs = @{@"FIRFunctions": @"fire-fun"};
+  for (NSString *className in swiftLibs.allKeys) {
+    Class klass = NSClassFromString(className);
+    if (klass && [klass respondsToSelector:componentsToRegisterSEL]) {
+      [FIRApp registerInternalLibrary:klass withName:swiftLibs[className]];
+    }
+  }
 }
 
 #pragma mark - App Life Cycle

--- a/FirebaseCoreInternal/Sources/Public/FIRAppInternal.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRAppInternal.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#endif
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#import "FIRComponentContainer.h"
+#import "FIRLibrary.h"
+
+/**
+ * The internal interface to FIRApp. This is meant for first-party integrators, who need to receive
+ * FIRApp notifications, log info about the success or failure of their configuration, and access
+ * other internal functionality of FIRApp.
+ *
+ * TODO(b/28296561): Restructure this header.
+ */
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kFIRDefaultAppName;
+extern NSString *const kFIRAppReadyToConfigureSDKNotification;
+extern NSString *const kFIRAppDeleteNotification;
+extern NSString *const kFIRAppIsDefaultAppKey;
+extern NSString *const kFIRAppNameKey;
+extern NSString *const kFIRGoogleAppIDKey;
+extern NSString *const kFirebaseCoreErrorDomain;
+
+/** The NSUserDefaults suite name for FirebaseCore, for those storage locations that use it. */
+extern NSString *const kFirebaseCoreDefaultsSuiteName;
+
+/**
+ * The format string for the User Defaults key used for storing the data collection enabled flag.
+ * This includes formatting to append the Firebase App's name.
+ */
+extern NSString *const kFIRGlobalAppDataCollectionEnabledDefaultsKeyFormat;
+
+/**
+ * The plist key used for storing the data collection enabled flag.
+ */
+extern NSString *const kFIRGlobalAppDataCollectionEnabledPlistKey;
+
+/** @var FIRAuthStateDidChangeInternalNotification
+ @brief The name of the @c NSNotificationCenter notification which is posted when the auth state
+ changes (e.g. a new token has been produced, a user logs in or out). The object parameter of
+ the notification is a dictionary possibly containing the key:
+ @c FIRAuthStateDidChangeInternalNotificationTokenKey (the new access token.) If it does not
+ contain this key it indicates a sign-out event took place.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotification;
+
+/** @var FIRAuthStateDidChangeInternalNotificationTokenKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the new access token.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey;
+
+/** @var FIRAuthStateDidChangeInternalNotificationAppKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the FIRApp associated with the auth instance.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationAppKey;
+
+/** @var FIRAuthStateDidChangeInternalNotificationUIDKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the new user's UID (or nil if there is no longer a user signed in).
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
+
+@interface FIRApp ()
+
+/**
+ * A flag indicating if this is the default app (has the default app name).
+ */
+@property(nonatomic, readonly) BOOL isDefaultApp;
+
+/*
+ * The container of interop SDKs for this app.
+ */
+@property(nonatomic) FIRComponentContainer *container;
+
+/**
+ * Checks if the default app is configured without trying to configure it.
+ */
++ (BOOL)isDefaultAppConfigured;
+
+/**
+ * Registers a given third-party library with the given version number to be reported for
+ * analytics.
+ *
+ * @param name Name of the library.
+ * @param version Version of the library.
+ */
++ (void)registerLibrary:(nonnull NSString *)name withVersion:(nonnull NSString *)version;
+
+/**
+ * Registers a given internal library to be reported for analytics.
+ *
+ * @param library Optional parameter for component registration.
+ * @param name Name of the library.
+ */
++ (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
+                       withName:(nonnull NSString *)name;
+
+/**
+ * Registers a given internal library with the given version number to be reported for
+ * analytics. This should only be used for non-Firebase libraries that have their own versioning
+ * scheme.
+ *
+ * @param library Optional parameter for component registration.
+ * @param name Name of the library.
+ * @param version Version of the library.
+ */
++ (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
+                       withName:(nonnull NSString *)name
+                    withVersion:(nonnull NSString *)version;
+
+/**
+ * A concatenated string representing all the third-party libraries and version numbers.
+ */
++ (NSString *)firebaseUserAgent;
+
+/**
+ * Can be used by the unit tests in eack SDK to reset FIRApp. This method is thread unsafe.
+ */
++ (void)resetApps;
+
+/**
+ * Can be used by the unit tests in each SDK to set customized options.
+ */
+- (instancetype)initInstanceWithName:(NSString *)name options:(FIROptions *)options;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRComponent.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRComponent.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#endif
+
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#import "FIRComponentContainer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Provides a system to clean up cached instances returned from the component system.
+NS_SWIFT_NAME(ComponentLifecycleMaintainer)
+@protocol FIRComponentLifecycleMaintainer
+/// The associated app will be deleted, clean up any resources as they are about to be deallocated.
+- (void)appWillBeDeleted:(FIRApp *)app;
+@end
+
+typedef _Nullable id (^FIRComponentCreationBlock)(FIRComponentContainer *container,
+                                                  BOOL *isCacheable)
+    NS_SWIFT_NAME(ComponentCreationBlock);
+
+@class FIRDependency;
+
+/// Describes the timing of instantiation. Note: new components should default to lazy unless there
+/// is a strong reason to be eager.
+typedef NS_ENUM(NSInteger, FIRInstantiationTiming) {
+  FIRInstantiationTimingLazy,
+  FIRInstantiationTimingAlwaysEager,
+  FIRInstantiationTimingEagerInDefaultApp
+} NS_SWIFT_NAME(InstantiationTiming);
+
+/// A component that can be used from other Firebase SDKs.
+NS_SWIFT_NAME(Component)
+@interface FIRComponent : NSObject
+
+/// The protocol describing functionality provided from the Component.
+@property(nonatomic, strong, readonly) Protocol *protocol;
+
+/// The timing of instantiation.
+@property(nonatomic, readonly) FIRInstantiationTiming instantiationTiming;
+
+/// An array of dependencies for the component.
+@property(nonatomic, copy, readonly) NSArray<FIRDependency *> *dependencies;
+
+/// A block to instantiate an instance of the component with the appropriate dependencies.
+@property(nonatomic, copy, readonly) FIRComponentCreationBlock creationBlock;
+
+// There's an issue with long NS_SWIFT_NAMES that causes compilation to fail, disable clang-format
+// for the next two methods.
+// clang-format off
+
+/// Creates a component with no dependencies that will be lazily initialized.
++ (instancetype)componentWithProtocol:(Protocol *)protocol
+                        creationBlock:(FIRComponentCreationBlock)creationBlock
+NS_SWIFT_NAME(init(_:creationBlock:));
+
+/// Creates a component to be registered with the component container.
+///
+/// @param protocol - The protocol describing functionality provided by the component.
+/// @param instantiationTiming - When the component should be initialized. Use .lazy unless there's
+///                              a good reason to be instantiated earlier.
+/// @param dependencies - Any dependencies the `implementingClass` has, optional or required.
+/// @param creationBlock - A block to instantiate the component with a container, and if
+/// @return A component that can be registered with the component container.
++ (instancetype)componentWithProtocol:(Protocol *)protocol
+                  instantiationTiming:(FIRInstantiationTiming)instantiationTiming
+                         dependencies:(NSArray<FIRDependency *> *)dependencies
+                        creationBlock:(FIRComponentCreationBlock)creationBlock
+NS_SWIFT_NAME(init(_:instantiationTiming:dependencies:creationBlock:));
+
+// clang-format on
+
+/// Unavailable.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRComponentContainer.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRComponentContainer.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#import <Foundation/Foundation.h>
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#endif
+
+/// A type-safe macro to retrieve a component from a container. This should be used to retrieve
+/// components instead of using the container directly.
+#define FIR_COMPONENT(type, container) \
+  [FIRComponentType<id<type>> instanceForProtocol:@protocol(type) inContainer:container]
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A container that holds different components that are registered via the
+/// `registerAsComponentRegistrant:` call. These classes should conform to `FIRComponentRegistrant`
+/// in order to properly register components for Core.
+NS_SWIFT_NAME(FirebaseComponentContainer)
+@interface FIRComponentContainer : NSObject
+
+/// A weak reference to the app that an instance of the container belongs to.
+@property(nonatomic, weak, readonly) FIRApp *app;
+
+/// Unavailable. Use the `container` property on `FIRApp`.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRComponentType.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRComponentType.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#import "FIRComponentContainer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Do not use directly. A placeholder type in order to provide a macro that will warn users of
+/// mis-matched protocols.
+NS_SWIFT_NAME(ComponentType)
+@interface FIRComponentType<__covariant T> : NSObject
+
+/// Do not use directly. A factory method to retrieve an instance that provides a specific
+/// functionality.
++ (T)instanceForProtocol:(Protocol *)protocol inContainer:(FIRComponentContainer *)container;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRDependency.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRDependency.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A dependency on a specific protocol's functionality.
+NS_SWIFT_NAME(Dependency)
+@interface FIRDependency : NSObject
+
+/// The protocol describing functionality being depended on.
+@property(nonatomic, strong, readonly) Protocol *protocol;
+
+/// A flag to specify if the dependency is required or not.
+@property(nonatomic, readonly) BOOL isRequired;
+
+/// Initializes a dependency that is required. Calls `initWithProtocol:isRequired` with `YES` for
+/// the required parameter.
+/// Creates a required dependency on the specified protocol's functionality.
++ (instancetype)dependencyWithProtocol:(Protocol *)protocol;
+
+/// Creates a dependency on the specified protocol's functionality and specify if it's required for
+/// the class's functionality.
++ (instancetype)dependencyWithProtocol:(Protocol *)protocol isRequired:(BOOL)required;
+
+/// Use `dependencyWithProtocol:isRequired:` instead.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRHeartbeatInfo.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRHeartbeatInfo.h
@@ -1,0 +1,39 @@
+// Copyright 2019 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRHeartbeatInfo : NSObject
+
+// Enum representing the different heartbeat codes.
+typedef NS_ENUM(NSInteger, FIRHeartbeatInfoCode) {
+  FIRHeartbeatInfoCodeNone = 0,
+  FIRHeartbeatInfoCodeSDK = 1,
+  FIRHeartbeatInfoCodeGlobal = 2,
+  FIRHeartbeatInfoCodeCombined = 3,
+};
+
+/**
+ * Get heartbeat code required for the sdk.
+ * @param heartbeatTag String representing the sdk heartbeat tag.
+ * @return Heartbeat code indicating whether or not an sdk/global heartbeat
+ * needs to be sent
+ */
++ (FIRHeartbeatInfoCode)heartbeatCodeForTag:(NSString *)heartbeatTag;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIRLibrary.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRLibrary.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: This breaks things. hmm.
+//#ifndef FIRLibrary_h
+//#define FIRLibrary_h
+
+#import <Foundation/Foundation.h>
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#endif
+
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#import "FIRComponent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Provide an interface to register a library for userAgent logging and availability to others.
+NS_SWIFT_NAME(Library)
+@protocol FIRLibrary
+
+/// Returns one or more FIRComponents that will be registered in
+/// FIRApp and participate in dependency resolution and injection.
++ (NSArray<FIRComponent *> *)componentsToRegister;
+
+@optional
+/// Implement this method if the library needs notifications for lifecycle events. This method is
+/// called when the developer calls `FirebaseApp.configure()`.
++ (void)configureWithApp:(FIRApp *)app;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+//#endif /* FIRLibrary_h */

--- a/FirebaseCoreInternal/Sources/Public/FIRLogger.h
+++ b/FirebaseCoreInternal/Sources/Public/FIRLogger.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FirebaseCore/FIRLoggerLevel.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The Firebase services used in Firebase logger.
+ */
+typedef NSString *const FIRLoggerService;
+
+extern FIRLoggerService kFIRLoggerAnalytics;
+extern FIRLoggerService kFIRLoggerCrash;
+extern FIRLoggerService kFIRLoggerCore;
+extern FIRLoggerService kFIRLoggerRemoteConfig;
+
+/**
+ * The key used to store the logger's error count.
+ */
+extern NSString *const kFIRLoggerErrorCountKey;
+
+/**
+ * The key used to store the logger's warning count.
+ */
+extern NSString *const kFIRLoggerWarningCountKey;
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Enables or disables Analytics debug mode.
+ * If set to YES, the logging level for Analytics will be set to FIRLoggerLevelDebug.
+ * Enabling the debug mode has no effect if the app is running from App Store.
+ * (required) analytics debug mode flag.
+ */
+void FIRSetAnalyticsDebugMode(BOOL analyticsDebugMode);
+
+/**
+ * Changes the default logging level of FIRLoggerLevelNotice to a user-specified level.
+ * The default level cannot be set above FIRLoggerLevelNotice if the app is running from App Store.
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ */
+void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
+
+/**
+ * Checks if the specified logger level is loggable given the current settings.
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ * (required) whether or not this function is called from the Analytics component.
+ */
+BOOL FIRIsLoggableLevel(FIRLoggerLevel loggerLevel, BOOL analyticsComponent);
+
+/**
+ * Logs a message to the Xcode console and the device log. If running from AppStore, will
+ * not log any messages with a level higher than FIRLoggerLevelNotice to avoid log spamming.
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ * (required) service name of type FIRLoggerService.
+ * (required) message code starting with "I-" which means iOS, followed by a capitalized
+ *            three-character service identifier and a six digit integer message ID that is unique
+ *            within the service.
+ *            An example of the message code is @"I-COR000001".
+ * (required) message string which can be a format string.
+ * (optional) variable arguments list obtained from calling va_start, used when message is a format
+ *            string.
+ */
+extern void FIRLogBasic(FIRLoggerLevel level,
+                        FIRLoggerService service,
+                        NSString *messageCode,
+                        NSString *message,
+// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
+// See: http://stackoverflow.com/q/29095469
+#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
+                        va_list args_ptr
+#else
+                        va_list _Nullable args_ptr
+#endif
+);
+
+/**
+ * The following functions accept the following parameters in order:
+ * (required) service name of type FIRLoggerService.
+ * (required) message code starting from "I-" which means iOS, followed by a capitalized
+ *            three-character service identifier and a six digit integer message ID that is unique
+ *            within the service.
+ *            An example of the message code is @"I-COR000001".
+ *            See go/firebase-log-proposal for details.
+ * (required) message string which can be a format string.
+ * (optional) the list of arguments to substitute into the format string.
+ * Example usage:
+ * FIRLogError(kFIRLoggerCore, @"I-COR000001", @"Configuration of %@ failed.", app.name);
+ */
+extern void FIRLogError(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
+    NS_FORMAT_FUNCTION(3, 4);
+extern void FIRLogWarning(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
+    NS_FORMAT_FUNCTION(3, 4);
+extern void FIRLogNotice(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
+    NS_FORMAT_FUNCTION(3, 4);
+extern void FIRLogInfo(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
+    NS_FORMAT_FUNCTION(3, 4);
+extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
+    NS_FORMAT_FUNCTION(3, 4);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+@interface FIRLoggerWrapper : NSObject
+
+/**
+ * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ * (required) service name of type FIRLoggerService.
+ * (required) message code starting with "I-" which means iOS, followed by a capitalized
+ *            three-character service identifier and a six digit integer message ID that is unique
+ *            within the service.
+ *            An example of the message code is @"I-COR000001".
+ * (required) message string which can be a format string.
+ * (optional) variable arguments list obtained from calling va_start, used when message is a format
+ *            string.
+ */
+
++ (void)logWithLevel:(FIRLoggerLevel)level
+         withService:(FIRLoggerService)service
+            withCode:(NSString *)messageCode
+         withMessage:(NSString *)message
+            withArgs:(va_list)args;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseCoreInternal/Sources/Public/FIROptionsInternal.h
+++ b/FirebaseCoreInternal/Sources/Public/FIROptionsInternal.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Don't forward declare since Swift will ignore any methods that use the forward declared types.
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIROptions.h>
+#endif
+
+/**
+ * Keys for the strings in the plist file.
+ */
+extern NSString *const kFIRAPIKey;
+extern NSString *const kFIRTrackingID;
+extern NSString *const kFIRGoogleAppID;
+extern NSString *const kFIRClientID;
+extern NSString *const kFIRGCMSenderID;
+extern NSString *const kFIRAndroidClientID;
+extern NSString *const kFIRDatabaseURL;
+extern NSString *const kFIRStorageBucket;
+extern NSString *const kFIRBundleID;
+extern NSString *const kFIRProjectID;
+
+/**
+ * Keys for the plist file name
+ */
+extern NSString *const kServiceInfoFileName;
+
+extern NSString *const kServiceInfoFileType;
+
+/**
+ * This header file exposes the initialization of FIROptions to internal use.
+ */
+@interface FIROptions ()
+
+/**
+ * resetDefaultOptions and initInternalWithOptionsDictionary: are exposed only for unit tests.
+ */
++ (void)resetDefaultOptions;
+
+/**
+ * Initializes the options with dictionary. The above strings are the keys of the dictionary.
+ * This is the designated initializer.
+ */
+- (instancetype)initInternalWithOptionsDictionary:(NSDictionary *)serviceInfoDictionary
+    NS_DESIGNATED_INITIALIZER;
+
+/**
+ * defaultOptions and defaultOptionsDictionary are exposed in order to be used in FIRApp and
+ * other first party services.
+ */
++ (FIROptions *)defaultOptions;
+
++ (NSDictionary *)defaultOptionsDictionary;
+
+/**
+ * Indicates whether or not Analytics collection was explicitly enabled via a plist flag or at
+ * runtime.
+ */
+@property(nonatomic, readonly) BOOL isAnalyticsCollectionExplicitlySet;
+
+/**
+ * Whether or not Analytics Collection was enabled. Analytics Collection is enabled unless
+ * explicitly disabled in GoogleService-Info.plist.
+ */
+@property(nonatomic, readonly) BOOL isAnalyticsCollectionEnabled;
+
+/**
+ * Whether or not Analytics Collection was completely disabled. If YES, then
+ * isAnalyticsCollectionEnabled will be NO.
+ */
+@property(nonatomic, readonly) BOOL isAnalyticsCollectionDeactivated;
+
+/**
+ * The version ID of the client library, e.g. @"1100000".
+ */
+@property(nonatomic, readonly, copy) NSString *libraryVersionID;
+
+/**
+ * The flag indicating whether this object was constructed with the values in the default plist
+ * file.
+ */
+@property(nonatomic) BOOL usingOptionsFromDefaultPlist;
+
+/**
+ * Whether or not Measurement was enabled. Measurement is enabled unless explicitly disabled in
+ * GoogleService-Info.plist.
+ */
+@property(nonatomic, readonly) BOOL isMeasurementEnabled;
+
+/**
+ * Whether or not Analytics was enabled in the developer console.
+ */
+@property(nonatomic, readonly) BOOL isAnalyticsEnabled;
+
+/**
+ * Whether or not SignIn was enabled in the developer console.
+ */
+@property(nonatomic, readonly) BOOL isSignInEnabled;
+
+/**
+ * Whether or not editing is locked. This should occur after FIROptions has been set on a FIRApp.
+ */
+@property(nonatomic, getter=isEditingLocked) BOOL editingLocked;
+
+@end

--- a/FirebaseCoreInternal/Sources/Public/FirebaseCoreInternal.h
+++ b/FirebaseCoreInternal/Sources/Public/FirebaseCoreInternal.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An umbrella header, for any other libraries in this repo to access Firebase Public and Private
+// headers. Any package manager complexity should be handled here.
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FirebaseCore.h>
+#endif
+
+#import "FIRAppInternal.h"
+#import "FIRComponent.h"
+#import "FIRComponentContainer.h"
+#import "FIRComponentType.h"
+#import "FIRDependency.h"
+#import "FIRHeartbeatInfo.h"
+#import "FIRLibrary.h"
+#import "FIRLogger.h"
+#import "FIROptionsInternal.h"

--- a/FirebaseCoreInternal/Sources/dummy.m
+++ b/FirebaseCoreInternal/Sources/dummy.m
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
-@objc protocol FunctionsProvider {}
+// Placeholder file, since SwiftPM requires a source file to create a module.

--- a/FirebaseCoreInternal/Tests/FIRObjCAPITest.m
+++ b/FirebaseCoreInternal/Tests/FIRObjCAPITest.m
@@ -1,0 +1,37 @@
+//
+//  FIRObjCAPITest.m
+//  
+//
+//  Created by Ryan Wilson on 2022-01-31.
+//
+
+#import <XCTest/XCTest.h>
+@import FirebaseCoreInternal;
+
+@interface FIRObjCAPITest : XCTestCase
+
+@end
+
+@implementation FIRObjCAPITest
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/FirebaseFunctionsSwift/Sources/Functions.swift
+++ b/FirebaseFunctionsSwift/Sources/Functions.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import FirebaseCore
+import FirebaseCoreInternal
 import FirebaseSharedSwift
 #if COCOAPODS
   import GTMSessionFetcher

--- a/FirebaseFunctionsSwift/Sources/Functions.swift
+++ b/FirebaseFunctionsSwift/Sources/Functions.swift
@@ -37,9 +37,15 @@ import FirebaseSharedSwift
 
 // END PLACEHOLDERS
 
+/// File specific constants.
 private enum Constants {
   static let appCheckTokenHeader = "X-Firebase-AppCheck"
   static let fcmTokenHeader = "Firebase-Instance-ID-Token"
+}
+
+/// Cross SDK constants.
+internal enum FunctionsConstants {
+  static let defaultRegion = "us-central1"
 }
 
 /**
@@ -52,14 +58,16 @@ private enum Constants {
   private let fetcherService: GTMSessionFetcherService
   // The projectID to use for all function references.
   private let projectID: String
-  // The region to use for all function references.
-  private let region: String
-  // The custom domain to use for all functions references (optional).
-  private let customDomain: String?
   // A serializer to encode/decode data and return values.
   private let serializer = FUNSerializer()
   // A factory for getting the metadata to include with function calls.
   private let contextProvider: FunctionsContextProvider
+
+  // The custom domain to use for all functions references (optional).
+  internal let customDomain: String?
+
+  // The region to use for all function references.
+  internal let region: String
 
   /**
    * The current emulator origin, or nil if it is not set.
@@ -73,36 +81,47 @@ private enum Constants {
    * @param region The region for the http trigger, such as "us-central1".
    */
   public class func functions(app: FirebaseApp = FirebaseApp.app()!,
-                              region: String = "us-central1") -> Functions {
-    return Functions(app: app, region: region, customDomain: nil)
+                              region: String) -> Functions {
+    let provider = ComponentType<FunctionsProvider>.instance(for: FunctionsProvider.self,
+                                                                in: app.container)
+    return provider.functions(for: app,
+                                 region: region,
+                                 customDomain: nil,
+                                 type: self)
   }
 
   /**
    * Creates a Cloud Functions client with the given app and region, or returns a pre-existing
    * instance if one already exists.
    * @param app The app for the Firebase project.
-   * @param customDomain A custom domain for the http trigger, such as "https://mydomain.com".
+   * @param region The region for the http trigger, such as "us-central1".
    */
   public class func functions(app: FirebaseApp = FirebaseApp.app()!,
-                              customDomain: String) -> Functions {
-    return Functions(app: app, region: "us-central1", customDomain: customDomain)
+                              customDomain: String? = nil) -> Functions {
+    let provider = ComponentType<FunctionsProvider>.instance(for: FunctionsProvider.self,
+                                                                in: app.container)
+    return provider.functions(for: app,
+                                 region: FunctionsConstants.defaultRegion,
+                                 customDomain: customDomain,
+                                 type: self)
   }
 
   internal convenience init(app: FirebaseApp,
                             region: String,
                             customDomain: String?) {
-    // TODO: "Should be fetched from the App's component container instead.
-    /*
-     id<FIRFunctionsProvider> provider = FIR_COMPONENT(FIRFunctionsProvider, app.container);
-     return [provider functionsForApp:app region:region customDomain:customDomain type:[self class]];
-     */
+    // TODO: These are not optionals, but they should be.
+    let auth = ComponentType<AuthInterop>.instance(for: AuthInterop.self, in: app.container)
+    let messaging = ComponentType<MessagingInterop>.instance(for: MessagingInterop.self,
+                                                                in: app.container)
+    let appCheck = ComponentType<AppCheckInterop>.instance(for: AppCheckInterop.self,
+                                                              in: app.container)
+
     self.init(projectID: app.options.projectID!,
               region: region,
               customDomain: customDomain,
-              // TODO: Get this out of the app.
-              auth: nil,
-              messaging: nil,
-              appCheck: nil)
+              auth: auth,
+              messaging: messaging,
+              appCheck: appCheck)
   }
 
   @objc internal init(projectID: String,

--- a/FirebaseFunctionsSwift/Sources/FunctionsComponent.swift
+++ b/FirebaseFunctionsSwift/Sources/FunctionsComponent.swift
@@ -1,0 +1,84 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import FirebaseCore
+import FirebaseCoreInternal
+
+@objc(FIRFunctionsProvider)
+protocol FunctionsProvider {
+  @objc func functions(for app: FirebaseApp,
+                       region: String?,
+                       customDomain: String?,
+                       type: AnyClass) -> Functions
+  // TODO: See if we can avoid the `type` parameter by either making it a `Functions` argument to
+  // allow subclasses, or avoid it entirely and fix tests. This was done for FunctionsCombineUnit,
+  // although we may be able to now port to using `@testable` instead of using the mock.
+}
+
+@objc class FunctionsComponent: NSObject, Library, FunctionsProvider {
+  // MARK: - Private Variables
+
+  /// The app associated with all functions instances in this container.
+  private let app: FirebaseApp
+
+  /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are arrays
+  /// containing all instances of Functions associated with the given app.
+  private let instances: [String: [Functions]] = [:]
+
+  /// Lock to manage access to the instances array to avoid race conditions.
+  private let instancesLock: os_unfair_lock = os_unfair_lock()
+
+  // MARK: - Initializers
+  required init(app: FirebaseApp) {
+    self.app = app
+  }
+
+  // MARK: - Library conformance
+
+  static func componentsToRegister() -> [Component] {
+    // TODO: We don't actually add a dependency on FCM or AppCheck here even though it's used.. is
+    // that okay?
+    // TODO: Get Auth Interop Working, we need the type.
+//    let authInterop = Dependency(with: AuthProvider.self, isRequired: false)
+    return [Component(FunctionsProvider.self,
+              instantiationTiming: .lazy,
+              dependencies: [/*authInterop*/]) { container, isCacheable in
+      guard let app = container.app else { return nil }
+      isCacheable.pointee = true
+      return self.init(app: app)
+    }]
+  }
+
+  // MARK: - FunctionsProvider conformance
+
+  func functions(for app: FirebaseApp,
+                 region: String?,
+                 customDomain: String?,
+                 type: AnyClass) -> Functions {
+    // TODO: Check local dictionary of instances first.
+
+    // TODO: Slightly awkward usage now because of default arguments, we can't pass in an optional
+    // region and it select the default for us. This if statement is fine though for the time being
+    // to ensure they always stay up to date.
+    if let region = region {
+      return Functions(app: app, region: region, customDomain: customDomain)
+    } else {
+      // TODO: Fix this
+      fatalError()
+//      return Functions(app: app, customDomain: customDomain)
+    }
+
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -237,6 +237,16 @@ let package = Package(
         .headerSearchPath("../../.."),
       ]
     ),
+
+    // Interal headers only for consuming from Swift.
+    .target(
+      name: "FirebaseCoreInternal",
+      path: "FirebaseCoreInternal/Sources",
+      publicHeadersPath: "Public",
+      cSettings: [
+//        .headerSearchPath("../../"),
+      ]
+    ),
     .target(
       name: "FirebaseCoreDiagnostics",
       dependencies: [
@@ -1185,34 +1195,6 @@ let package = Package(
         .headerSearchPath("../.."),
       ]
     ),
-
-    // MARK: GoogleUtilitiesComponents
-
-      .target(
-        name: "GoogleUtilitiesComponents",
-        dependencies: [
-//          .product(name: "GULEnvironment", package: "GoogleUtilities"),
-          .product(name: "GULLogger", package: "GoogleUtilities"),
-        ],
-        path: "GoogleUtilitiesComponents/Sources",
-        publicHeadersPath: "Public",
-        cSettings: [
-          .headerSearchPath("../.."),
-        ],
-        linkerSettings: [
-//          .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
-//          .linkedFramework("AppKit", .when(platforms: [.macOS])),
-        ]
-      ),
-      .testTarget(
-        name: "GoogleUtilitiesComponentsUnit",
-        dependencies: ["GoogleUtilitiesComponents", "OCMock"],
-        path: "GoogleUtilitiesComponents/Tests",
-        cSettings: [
-          .headerSearchPath("../.."),
-        ]
-      ),
-
 
     // MARK: Testing support
 

--- a/Package.swift
+++ b/Package.swift
@@ -691,6 +691,7 @@ let package = Package(
       name: "FirebaseFunctionsSwift",
       dependencies: [
         "FirebaseCore",
+        "FirebaseCoreInternal",
         "FirebaseSharedSwift",
         .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
       ],
@@ -1184,6 +1185,34 @@ let package = Package(
         .headerSearchPath("../.."),
       ]
     ),
+
+    // MARK: GoogleUtilitiesComponents
+
+      .target(
+        name: "GoogleUtilitiesComponents",
+        dependencies: [
+//          .product(name: "GULEnvironment", package: "GoogleUtilities"),
+          .product(name: "GULLogger", package: "GoogleUtilities"),
+        ],
+        path: "GoogleUtilitiesComponents/Sources",
+        publicHeadersPath: "Public",
+        cSettings: [
+          .headerSearchPath("../.."),
+        ],
+        linkerSettings: [
+//          .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+//          .linkedFramework("AppKit", .when(platforms: [.macOS])),
+        ]
+      ),
+      .testTarget(
+        name: "GoogleUtilitiesComponentsUnit",
+        dependencies: ["GoogleUtilitiesComponents", "OCMock"],
+        path: "GoogleUtilitiesComponents/Tests",
+        cSettings: [
+          .headerSearchPath("../.."),
+        ]
+      ),
+
 
     // MARK: Testing support
 


### PR DESCRIPTION
- Created the CoreInternal library (needs API audit, has more APIs than needed)
- Introduced component system to Functions
- UNTESTED: register functions Swift library in FIRApp instead of at `+load`.

TODO: 
- [ ] Test the Core registration of Functions
- [ ] Create an interop SwiftPM package to get the Auth, Messaging, and AppCheck headers
- [ ] Migrate to use the above interop library

#no-changelog