### PR TITLE
Firestore: Add more details to the assertion failure in OrderBy::Compare()

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Add more details to the assertion failure in OrderBy::Compare() to
+  help with future debugging (#9258).
+
 # v8.12.0
 - [fixed] Fixed an AppCheck issue that caused Firestore listeners to stop
 working and receive a "Permission Denied" error. This issue only occurred for

--- a/Firestore/core/src/core/order_by.cc
+++ b/Firestore/core/src/core/order_by.cc
@@ -34,15 +34,17 @@ using util::ComparisonResult;
 
 namespace {
 
-void AssertBothOptionalsHaveValues(const absl::optional<google_firestore_v1_Value>& value1, const absl::optional<google_firestore_v1_Value>& value2) {
+void AssertBothOptionalsHaveValues(
+    const absl::optional<google_firestore_v1_Value>& value1,
+    const absl::optional<google_firestore_v1_Value>& value2) {
   if (value1.has_value() && value2.has_value()) {
     return;
   }
 
   std::ostringstream ss;
   ss << "Trying to compare documents on fields that don't exist;"
-      << " value1.has_value()=" << (value1.has_value() ? "true" : "false")
-      << ", value2.has_value()=" << (value2.has_value() ? "true" : "false");
+     << " value1.has_value()=" << (value1.has_value() ? "true" : "false")
+     << ", value2.has_value()=" << (value2.has_value() ? "true" : "false");
 
   if (value1.has_value()) {
     ss << ", value1=" << value1->ToString();

--- a/Firestore/core/src/core/order_by.cc
+++ b/Firestore/core/src/core/order_by.cc
@@ -35,15 +35,20 @@ using util::ComparisonResult;
 namespace {
 
 void AssertBothOptionalsHaveValues(
+    const model::FieldPath& field_path,
     const absl::optional<google_firestore_v1_Value>& value1,
-    const absl::optional<google_firestore_v1_Value>& value2) {
+    const absl::optional<google_firestore_v1_Value>& value2,
+    const Document& lhs,
+    const Document& rhs) {
   if (value1.has_value() && value2.has_value()) {
     return;
   }
 
   std::ostringstream ss;
   ss << "Trying to compare documents on fields that don't exist;"
-     << " value1.has_value()=" << (value1.has_value() ? "true" : "false")
+     << " field_path=" << field_path.CanonicalString()
+     << ", lhs=" << lhs->key().ToString() << ", rhs=" << rhs->key().ToString()
+     << ", value1.has_value()=" << (value1.has_value() ? "true" : "false")
      << ", value2.has_value()=" << (value2.has_value() ? "true" : "false");
 
   if (value1.has_value()) {
@@ -67,7 +72,7 @@ ComparisonResult OrderBy::Compare(const Document& lhs,
   } else {
     absl::optional<google_firestore_v1_Value> value1 = lhs->field(field_);
     absl::optional<google_firestore_v1_Value> value2 = rhs->field(field_);
-    AssertBothOptionalsHaveValues(value1, value2);
+    AssertBothOptionalsHaveValues(field_, value1, value2, lhs, rhs);
     result = model::Compare(*value1, *value2);
   }
 

--- a/Firestore/core/src/core/order_by.cc
+++ b/Firestore/core/src/core/order_by.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/core/order_by.h"
 
 #include <ostream>
+#include <sstream>
 
 #include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/model/value_util.h"
@@ -31,6 +32,31 @@ using model::Document;
 using model::FieldPath;
 using util::ComparisonResult;
 
+namespace {
+
+void AssertBothOptionalsHaveValues(const absl::optional<google_firestore_v1_Value>& value1, const absl::optional<google_firestore_v1_Value>& value2) {
+  if (value1.has_value() && value2.has_value()) {
+    return;
+  }
+
+  std::ostringstream ss;
+  ss << "Trying to compare documents on fields that don't exist;"
+      << " value1.has_value()=" << (value1.has_value() ? "true" : "false")
+      << ", value2.has_value()=" << (value2.has_value() ? "true" : "false");
+
+  if (value1.has_value()) {
+    ss << ", value1=" << value1->ToString();
+  }
+  if (value2.has_value()) {
+    ss << ", value2=" << value2->ToString();
+  }
+
+  std::string message = ss.str();
+  HARD_FAIL(message.c_str());
+}
+
+}  // namespace
+
 ComparisonResult OrderBy::Compare(const Document& lhs,
                                   const Document& rhs) const {
   ComparisonResult result;
@@ -39,8 +65,7 @@ ComparisonResult OrderBy::Compare(const Document& lhs,
   } else {
     absl::optional<google_firestore_v1_Value> value1 = lhs->field(field_);
     absl::optional<google_firestore_v1_Value> value2 = rhs->field(field_);
-    HARD_ASSERT(value1.has_value() && value2.has_value(),
-                "Trying to compare documents on fields that don't exist.");
+    AssertBothOptionalsHaveValues(value1, value2);
     result = model::Compare(*value1, *value2);
   }
 


### PR DESCRIPTION
There have been multiple reports of crashes with the message "Trying to compare documents on fields that don't exist". However, debugging these crashes has been fruitless. This PR updates the assertion message to contain additional information to help with future debugging.

Some of the issue reports of this crash include #9258, #8661, #7082, and #5238.