### PR TITLE
Combine tests ported to depend on Swift Functions

### DIFF
--- a/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
@@ -15,7 +15,7 @@
 #if canImport(Combine) && swift(>=5.0)
 
   import Combine
-  import FirebaseFunctions
+  import FirebaseFunctionsSwift
 
   @available(swift 5.0)
   @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)

--- a/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/HTTPSCallable+Combine.swift
@@ -15,7 +15,7 @@
 #if canImport(Combine) && swift(>=5.0)
 
   import Combine
-  import FirebaseFunctionsSwift
+  import FirebaseFunctions
 
   @available(swift 5.0)
   @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)

--- a/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
+++ b/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
@@ -28,7 +28,7 @@ import XCTest
 private let timeoutInterval: TimeInterval = 70.0
 private let expectationTimeout: TimeInterval = 2
 
-@objc class MockFunctions: Functions {
+class MockFunctions: Functions {
   let mockCallFunction: () throws -> HTTPSCallableResult
   var verifyParameters: ((_ name: String, _ data: Any?, _ timeout: TimeInterval) throws -> Void)?
   override func callFunction(name: String,

--- a/FirebaseFunctionsSwift/Sources/Functions.swift
+++ b/FirebaseFunctionsSwift/Sources/Functions.swift
@@ -115,7 +115,7 @@ internal enum FunctionsConstants {
               appCheck: appCheck)
   }
 
-  public init(projectID: String,
+  @objc internal init(projectID: String,
                       region: String,
                       customDomain: String?,
                       auth: AuthInterop?,

--- a/FirebaseFunctionsSwift/Sources/Functions.swift
+++ b/FirebaseFunctionsSwift/Sources/Functions.swift
@@ -115,7 +115,7 @@ internal enum FunctionsConstants {
               appCheck: appCheck)
   }
 
-  @objc internal init(projectID: String,
+  public init(projectID: String,
                       region: String,
                       customDomain: String?,
                       auth: AuthInterop?,

--- a/Package.swift
+++ b/Package.swift
@@ -745,13 +745,12 @@ let package = Package(
     ),
     .target(
       name: "FirebaseFunctionsCombineSwift",
-      dependencies: ["FirebaseFunctions"],
+      dependencies: ["FirebaseFunctionsSwift"],
       path: "FirebaseCombineSwift/Sources/Functions"
     ),
     .testTarget(
       name: "FunctionsCombineUnit",
       dependencies: ["FirebaseFunctionsCombineSwift",
-                     "FirebaseFunctionsTestingSupport",
                      "SharedTestUtilities"],
       path: "FirebaseFunctions/Tests/CombineUnit"
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1110,7 +1110,7 @@ let package = Package(
         "FirebaseDynamicLinks",
         "FirebaseFirestore",
         "FirebaseFirestoreSwift",
-        "FirebaseFunctions",
+        "FirebaseFunctionsSwift",
         "FirebaseInAppMessaging",
         .target(name: "FirebaseInAppMessagingSwift",
                 condition: .when(platforms: [.iOS, .tvOS])),

--- a/SwiftPMTests/swift-test/main.swift
+++ b/SwiftPMTests/swift-test/main.swift
@@ -26,7 +26,7 @@ import FirebaseDatabase
 import FirebaseDynamicLinks
 import FirebaseFirestore
 import FirebaseFirestoreSwift
-import FirebaseFunctions
+import FirebaseFunctionsSwift
 #if (os(iOS) || os(tvOS)) && !targetEnvironment(macCatalyst)
   import FirebaseInAppMessaging
   @testable import FirebaseInAppMessagingSwift


### PR DESCRIPTION
Port the Functions combine tests to depend on the FirebaseFunctionsSwift instead of FirebaseFunctions

cc: @peterfriese 