### PR TITLE
Fix occurrences of inconsistent parameter names between declaration and definition

### DIFF
--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1201,14 +1201,14 @@ std::string LevelDbIndexEntryKey::KeyPrefix() {
 std::string LevelDbIndexEntryKey::Key(int32_t index_id,
                                       absl::string_view user_id,
                                       absl::string_view array_value,
-                                      absl::string_view dicrectional_value,
+                                      absl::string_view directional_value,
                                       absl::string_view document_key) {
   Writer writer;
   writer.WriteTableName(kIndexEntriesTable);
   writer.WriteIndexId(index_id);
   writer.WriteUserId(user_id);
   writer.WriteIndexArrayValue(array_value);
-  writer.WriteIndexDirectionalValue(dicrectional_value);
+  writer.WriteIndexDirectionalValue(directional_value);
   writer.WriteDocumentId(document_key);
   writer.WriteTerminator();
   return writer.result();

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1202,14 +1202,14 @@ std::string LevelDbIndexEntryKey::Key(int32_t index_id,
                                       absl::string_view user_id,
                                       absl::string_view array_value,
                                       absl::string_view directional_value,
-                                      absl::string_view document_key) {
+                                      absl::string_view document_name) {
   Writer writer;
   writer.WriteTableName(kIndexEntriesTable);
   writer.WriteIndexId(index_id);
   writer.WriteUserId(user_id);
   writer.WriteIndexArrayValue(array_value);
   writer.WriteIndexDirectionalValue(directional_value);
-  writer.WriteDocumentId(document_key);
+  writer.WriteDocumentId(document_name);
   writer.WriteTerminator();
   return writer.result();
 }

--- a/Firestore/core/src/model/field_index.h
+++ b/Firestore/core/src/model/field_index.h
@@ -95,8 +95,8 @@ class IndexOffset : public util::Comparable<IndexOffset> {
   /** Creates a new offset based on the provided document. */
   static IndexOffset FromDocument(const Document& document);
 
-  static util::ComparisonResult DocumentCompare(const Document& a,
-                                                const Document& b);
+  static util::ComparisonResult DocumentCompare(const Document& lhs,
+                                                const Document& rhs);
 
   /**
    * Returns the latest read time version that has been indexed by Firestore for


### PR DESCRIPTION
This inconsistency was found during a copybara of this code into google3. Googlers can see cl/428004925 for details.

No code or functionality is changed by this PR; merely the names of some function/method parameters.

#no-changelog