### PR TITLE
Fireperf: fix ActivePrewarm

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
-* [fixed] Potentially drop pre-warmed app start traces on iOS 15 and above (#9026). App start measurements are made only for cold app starts (without pre-warming).
+* [fixed] Make pre-warming identification more reliable by moving the pre-warm check to the earliest phase of app start.
+
+# Version 8.12.0
+* [fixed] Attempted to fix an issue where app start trace durations are not reliable on iOS 15. App start measurements are now made only for cold app starts (without pre-warming) (#9026).
 
 # Version 8.10.0
 * Fix a crash related to FPRSessionDetails. (#8691)

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -165,7 +165,8 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  */
 - (BOOL)isPrewarmAvailable {
   BOOL canPrewarm = NO;
-  // Guarding for double dispatch which does not work below iOS 13
+  // Guarding for double dispatch which does not work below iOS 13, and 0.1% of app start also show
+  // signs of prewarming on iOS 14 go/paste/5533761933410304
   if (@available(iOS 13, *)) {
     canPrewarm = YES;
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -158,13 +158,13 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
 }
 
 /**
- * Checks if prewarming is available for the platform on current device.
- * It is available when running iOS 15 and above.
+ * Checks if prewarming is available for the platform and OS version on the current device.
  *
  * @return true if the platform could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
   BOOL canPrewarm = NO;
+  // Guarding for double dispatch which is only accurate in iOS 13+
   if (@available(iOS 13, *)) {
     canPrewarm = YES;
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -166,19 +166,13 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  * @return true if the platform could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
-  NSString *platform = [[GULAppEnvironmentUtil applePlatform] lowercaseString];
-  BOOL iOS = [platform isEqualToString:@"ios"];
-  BOOL catalyst = [platform isEqualToString:@"maccatalyst"];
-  BOOL tvos = [platform isEqualToString:@"tvos"];
-  if (![GULAppEnvironmentUtil isSimulator] && (iOS || catalyst || tvos)) {
-    NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
-    if ([systemVersion length] > 0) {
-      return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
-    } else {
-      [self.activeTrace incrementMetric:kFPRAppCounterNameActivePrewarm byInt:2];
-    }
+  NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
+  if ([systemVersion length] > 0) {
+    return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
+  } else {
+    [self.activeTrace incrementMetric:kFPRAppCounterNameActivePrewarm byInt:2];
+    return NO;
   }
-  return NO;
 }
 
 /**

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -159,9 +159,9 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
 }
 
 /**
- * Checks if prewarming is available for the platform and OS version on the current device.
+ * Checks if the prewarming feature is available on the current device.
  *
- * @return true if the platform could prewarm apps on the current device
+ * @return true if the OS could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
   BOOL canPrewarm = NO;

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -166,7 +166,7 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  * @return true if the platform could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
-  if (@available(iOS 15.0, macCatalyst 15.0, tvOS 15.0, *)) {
+  if (@available(iOS 13, *)) {
     NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
     return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -86,8 +86,9 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
       });
     });
   }
-  
-  // ActivePrewarm is an env var set by Apple when an app is prewarmed, then cleared after didFinishLaunching
+
+  // When an app is prewarmed, Apple sets env variable ActivePrewarm to 1, then the env variable is
+  // deleted after didFinishLaunching
   isActivePrewarm = [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];
 
   gAppStartCPUGaugeData = fprCollectCPUMetric();
@@ -166,8 +167,7 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  */
 + (BOOL)isPrewarmAvailable {
   NSString *platform = [[GULAppEnvironmentUtil applePlatform] lowercaseString];
-  if (![platform isEqualToString:@"ios"] &&
-      ![platform isEqualToString:@"maccatalyst"] &&
+  if (![platform isEqualToString:@"ios"] && ![platform isEqualToString:@"maccatalyst"] &&
       ![platform isEqualToString:@"tvos"]) {
     return NO;
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -24,8 +24,6 @@
 #import "FirebasePerformance/Sources/Timer/FIRTrace+Internal.h"
 #import "FirebasePerformance/Sources/Timer/FIRTrace+Private.h"
 
-#import <GoogleUtilities/GULAppEnvironmentUtil.h>
-
 static NSDate *appStartTime = nil;
 static NSDate *doubleDispatchTime = nil;
 static NSDate *applicationDidFinishLaunchTime = nil;
@@ -166,11 +164,11 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  * @return true if the platform could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
+  BOOL canPrewarm = NO;
   if (@available(iOS 13, *)) {
-    NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
-    return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
+    canPrewarm = YES;
   }
-  return NO;
+  return canPrewarm;
 }
 
 /**

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -165,17 +165,20 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  *
  * @return true if the platform could prewarm apps on the current device
  */
-+ (BOOL)isPrewarmAvailable {
+- (BOOL)isPrewarmAvailable {
   NSString *platform = [[GULAppEnvironmentUtil applePlatform] lowercaseString];
-  if (![platform isEqualToString:@"ios"] && ![platform isEqualToString:@"maccatalyst"] &&
-      ![platform isEqualToString:@"tvos"]) {
-    return NO;
+  BOOL iOS = [platform isEqualToString:@"ios"];
+  BOOL catalyst = [platform isEqualToString:@"maccatalyst"];
+  BOOL tvos = [platform isEqualToString:@"tvos"];
+  if (![GULAppEnvironmentUtil isSimulator] && (iOS || catalyst || tvos)) {
+    NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
+    if ([systemVersion length] > 0) {
+      return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
+    } else {
+      [self.activeTrace incrementMetric:kFPRAppCounterNameActivePrewarm byInt:2];
+    }
   }
-  NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
-  if ([systemVersion length] == 0) {
-    return NO;
-  }
-  return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
+  return NO;
 }
 
 /**
@@ -207,7 +210,7 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  Checks if the current app start is a prewarmed app start
  */
 - (BOOL)isApplicationPreWarmed {
-  if (![FPRAppActivityTracker isPrewarmAvailable]) {
+  if (![self isPrewarmAvailable]) {
     return NO;
   }
 

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -166,13 +166,11 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  * @return true if the platform could prewarm apps on the current device
  */
 - (BOOL)isPrewarmAvailable {
-  NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
-  if ([systemVersion length] > 0) {
+  if (@available(iOS 15.0, macCatalyst 15.0, tvOS 15.0, *)) {
+    NSString *systemVersion = [GULAppEnvironmentUtil systemVersion];
     return [systemVersion compare:@"15" options:NSNumericSearch] != NSOrderedAscending;
-  } else {
-    [self.activeTrace incrementMetric:kFPRAppCounterNameActivePrewarm byInt:2];
-    return NO;
   }
+  return NO;
 }
 
 /**

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -18,6 +18,7 @@
 #import <UIKit/UIKit.h>
 
 #import "FirebasePerformance/Sources/AppActivity/FPRSessionManager.h"
+#import "FirebasePerformance/Sources/Configurations/FPRConfigurations.h"
 #import "FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeCollector+Private.h"
 #import "FirebasePerformance/Sources/Gauges/FPRGaugeManager.h"
 #import "FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeCollector+Private.h"

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -165,7 +165,7 @@ NSString *const kFPRAppCounterNameDoubleDispatch = @"_fsddc";
  */
 - (BOOL)isPrewarmAvailable {
   BOOL canPrewarm = NO;
-  // Guarding for double dispatch which is only accurate in iOS 13+
+  // Guarding for double dispatch which does not work below iOS 13
   if (@available(iOS 13, *)) {
     canPrewarm = YES;
   }

--- a/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
@@ -31,7 +31,7 @@
 @interface FPRAppActivityTracker (Tests)
 
 @property(nonatomic) FPRConfigurations *configurations;
-+ (BOOL)isPrewarmAvailable;
+- (BOOL)isPrewarmAvailable;
 - (BOOL)isAppStartEnabled;
 - (BOOL)isActivePrewarmEnabled;
 - (BOOL)isDoubleDispatchEnabled;

--- a/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
@@ -230,6 +230,7 @@
   OCMStub([mockAppTracker isActivePrewarmEnabled]).andReturn(YES);
 
   setenv("ActivePrewarm", "1", 1);
+  [FPRAppActivityTracker load];
   XCTAssertTrue([mockAppTracker isApplicationPreWarmed]);
 }
 


### PR DESCRIPTION
b/220342323
# Bug
Reading `ActivePrewarm` in `appDidBecomeActiveNotification` always results in `null`. Presumably Apple deletes the `ActivePrewarm` env variable some time after `didFinishLaunching`, which is the latest callback I have confirmed where reading `ActivePrewarm` works. 

# Fix
Move reading `ActivePrewarm` to `+load()`.

Additionally switch to using `@avaiable(iOS 13, *)` for version and platform checks. This aligns Hub, and is similar to Firebase App Monitoring (cl/424623478).

# Todo
* Perhaps remove `didFinishLaunching` callback and the code for double dispatch as we learned it did not work well. 

 