### PR TITLE
Fix bugs in LevelDbDocumentOverlayCache where it failed to check for equality of the DocumentKey

### DIFF
--- a/Firestore/core/test/unit/local/document_overlay_cache_test.cc
+++ b/Firestore/core/test/unit/local/document_overlay_cache_test.cc
@@ -152,8 +152,6 @@ TEST_P(DocumentOverlayCacheTest, CanReadSavedOverlays) {
   });
 }
 
-// Ensure that the fix in https://github.com/firebase/firebase-ios-sdk/pull/9381
-// doesn't regress.
 TEST_P(DocumentOverlayCacheTest, GetOverlayExactlyMatchesTheGivenDocumentKey) {
   this->persistence_->Run("Test", [&] {
     this->SaveOverlaysWithSetMutations(1, {"coll/doc1/sub/doc2"});
@@ -309,8 +307,6 @@ TEST_P(DocumentOverlayCacheTest, UpdateDocumentOverlay) {
   });
 }
 
-// Ensure that the fix in https://github.com/firebase/firebase-ios-sdk/pull/9381
-// doesn't regress.
 TEST_P(DocumentOverlayCacheTest, SaveDoesntAffectSubCollections) {
   this->persistence_->Run("Test", [&] {
     Mutation mutation1 =

--- a/Firestore/core/test/unit/local/document_overlay_cache_test.cc
+++ b/Firestore/core/test/unit/local/document_overlay_cache_test.cc
@@ -152,6 +152,8 @@ TEST_P(DocumentOverlayCacheTest, CanReadSavedOverlays) {
   });
 }
 
+// Ensure that the fix in https://github.com/firebase/firebase-ios-sdk/pull/9381
+// doesn't regress.
 TEST_P(DocumentOverlayCacheTest, GetOverlayExactlyMatchesTheGivenDocumentKey) {
   this->persistence_->Run("Test", [&] {
     this->SaveOverlaysWithSetMutations(1, {"coll/doc1/sub/doc2"});
@@ -307,6 +309,8 @@ TEST_P(DocumentOverlayCacheTest, UpdateDocumentOverlay) {
   });
 }
 
+// Ensure that the fix in https://github.com/firebase/firebase-ios-sdk/pull/9381
+// doesn't regress.
 TEST_P(DocumentOverlayCacheTest, SaveDoesntAffectSubCollections) {
   this->persistence_->Run("Test", [&] {
     Mutation mutation1 =


### PR DESCRIPTION
There were several latent bugs in `LevelDbDocumentOverlayCache` where it first searched the LevelDb database for an entry with a given key prefix, but then failed to ensure that the document key encoded in the LevelDb key was exactly equal to the requested key.

This resulted in at least two bugs:

1. `GetOverlay()` would incorrectly return the overlay for some document in a subcollection if the requested document did not have an overlay.
2. `SaveOverlays()` would delete the overlay for some document in a subcollection if the document with the given DocumentKey did not have an overlay.

Googlers see b/210002758 for details.

#no-changelog