### PR TITLE
[#2933] Removed `[FIRLibrary configureWithApp:]`

### DIFF
--- a/FirebaseCore/Internal/FIRLibrary.h
+++ b/FirebaseCore/Internal/FIRLibrary.h
@@ -32,11 +32,6 @@ NS_SWIFT_NAME(Library)
 /// FirebaseApp and participate in dependency resolution and injection.
 + (NSArray<FIRComponent *> *)componentsToRegister;
 
-@optional
-/// Implement this method if the library needs notifications for lifecycle events. This method is
-/// called when the developer calls `FirebaseApp.configure()`.
-+ (void)configureWithApp:(FIRApp *)app;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -103,12 +103,6 @@ NSString *const kFirebaseCoreDefaultsSuiteName = @"com.firebase.core";
  */
 static NSString *const kPlistURL = @"https://console.firebase.google.com/";
 
-/**
- * An array of all classes that registered as `FIRCoreConfigurable` in order to receive lifecycle
- * events from Core.
- */
-static NSMutableArray<Class<FIRLibrary>> *sRegisteredAsConfigurable;
-
 @interface FIRApp ()
 
 #ifdef DEBUG
@@ -465,14 +459,6 @@ static FIRApp *sDefaultApp;
   [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                       object:self
                                                     userInfo:appInfoDict];
-
-  // This is the new way of sending information to SDKs.
-  // TODO: Do we want this on a background thread, maybe?
-  @synchronized(self) {
-    for (Class<FIRLibrary> library in sRegisteredAsConfigurable) {
-      [library configureWithApp:app];
-    }
-  }
 }
 
 + (NSError *)errorForMissingOptions {
@@ -537,15 +523,6 @@ static FIRApp *sDefaultApp;
   }
 
   [FIRComponentContainer registerAsComponentRegistrant:library];
-  if ([(Class)library respondsToSelector:@selector(configureWithApp:)]) {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      sRegisteredAsConfigurable = [[NSMutableArray alloc] init];
-    });
-    @synchronized(self) {
-      [sRegisteredAsConfigurable addObject:library];
-    }
-  }
   [self registerLibrary:name withVersion:version];
 }
 


### PR DESCRIPTION
[Closes #2933]

* Removed all calls to `[FIRLibrary configureWithApp:]`
* Removed the `configureWithApp:` method from the `FIRLibrary` protocol

⚠️ Breaking Changes: Based on the [issue](https://github.com/firebase/firebase-ios-sdk/issues/2933), this PR should land in Firebase v9.