### PR TITLE
[#9275] Added Swift Name to `kFirebaseInstallationsErrorDomain`

### DIFF
--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
@@ -24,7 +24,8 @@
 #import "FBLPromises.h"
 #endif
 
-NSString *const kFirebaseInstallationsErrorDomain = @"com.firebase.installations";
+NSString *const kFirebaseInstallationsErrorDomain NS_SWIFT_NAME(InstallationsErrorDomain) =
+                                                                    @"com.firebase.installations";
 
 void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
   if (pointer != NULL) {


### PR DESCRIPTION
[Closes #9275]

* Specified `InstallationsErrorDomain` as the `NS_SWIFT_NAME` of FirebaseInstallations’s `kFirebaseInstallationsErrorDomain`

⚠️ Breaking Changes: Based on the [issue](https://github.com/firebase/firebase-ios-sdk/issues/9275), this PR should land in Firebase v9.