### PR TITLE
Improve performance of LevelDbDocumentOverlayCache::GetOverlays(ResourcePath, ...)

### DIFF
--- a/Firestore/core/src/local/leveldb_document_overlay_cache.cc
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.cc
@@ -60,7 +60,7 @@ absl::optional<Overlay> LevelDbDocumentOverlayCache::GetOverlay(
   auto it = db_->current_transaction()->NewIterator();
   it->Seek(key_prefix);
 
-  if (!(it->Valid() && absl::StartsWith(it->key(), key_prefix))) {
+  if (!it->Valid() || !absl::StartsWith(it->key(), key_prefix)) {
     return absl::nullopt;
   }
 
@@ -202,7 +202,7 @@ void LevelDbDocumentOverlayCache::DeleteOverlay(
   auto it = db_->current_transaction()->NewIterator();
   it->Seek(key_prefix);
 
-  if (!(it->Valid() && absl::StartsWith(it->key(), key_prefix))) {
+  if (!it->Valid() || !absl::StartsWith(it->key(), key_prefix)) {
     return;
   }
 
@@ -278,7 +278,7 @@ absl::optional<Overlay> LevelDbDocumentOverlayCache::GetOverlay(
   auto it = db_->current_transaction()->NewIterator();
   const std::string encoded_key = key.Encode();
   it->Seek(encoded_key);
-  if (!(it->Valid() && it->key() == encoded_key)) {
+  if (!it->Valid() || it->key() != encoded_key) {
     return absl::nullopt;
   }
   return ParseOverlay(key, it->value());

--- a/Firestore/core/src/local/leveldb_document_overlay_cache.h
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.h
@@ -70,9 +70,10 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
  private:
   friend class LevelDbDocumentOverlayCacheTestHelper;
 
-  // Returns the number of index entries for the largest batch ID.
-  // This method exists for unit testing only.
+  // Returns the number of index entries of the various types.
+  // These methods exist for unit testing only.
   int GetLargestBatchIdIndexEntryCount() const;
+  int GetCollectionIndexEntryCount() const;
 
   int GetOverlayCount() const override;
   int CountEntriesWithKeyPrefix(const std::string& key_prefix) const;
@@ -96,6 +97,14 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
   void ForEachKeyWithLargestBatchId(
       int largest_batch_id,
       std::function<void(LevelDbDocumentOverlayKey&&)>) const;
+
+  void ForEachKeyInCollection(
+      const model::ResourcePath& collection,
+      int since_batch_id,
+      std::function<void(LevelDbDocumentOverlayKey&&)>) const;
+
+  absl::optional<model::mutation::Overlay> GetOverlay(
+      const LevelDbDocumentOverlayKey& decoded_key) const;
 
   // The LevelDbDocumentOverlayCache instance is owned by LevelDbPersistence.
   LevelDbPersistence* db_;

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1264,12 +1264,6 @@ bool LevelDbIndexEntryKey::Decode(absl::string_view key) {
   return reader.ok();
 }
 
-std::string LevelDbDocumentOverlayKey::KeyPrefix() {
-  Writer writer;
-  writer.WriteTableName(kDocumentOverlaysTable);
-  return writer.result();
-}
-
 std::string LevelDbDocumentOverlayKey::KeyPrefix(absl::string_view user_id) {
   Writer writer;
   writer.WriteTableName(kDocumentOverlaysTable);
@@ -1306,12 +1300,6 @@ bool LevelDbDocumentOverlayKey::Decode(absl::string_view key) {
   largest_batch_id_ = reader.ReadBatchId();
   reader.ReadTerminator();
   return reader.ok();
-}
-
-std::string LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix() {
-  Writer writer;
-  writer.WriteTableName(kDocumentOverlaysLargestBatchIdIndexTable);
-  return writer.result();
 }
 
 std::string LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix(
@@ -1355,12 +1343,6 @@ bool LevelDbDocumentOverlayLargestBatchIdIndexKey::Decode(
   Reset(std::move(user_id), std::move(largest_batch_id),
         std::move(document_key));
   return reader.ok();
-}
-
-std::string LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix() {
-  Writer writer;
-  writer.WriteTableName(kDocumentOverlaysCollectionIndexTable);
-  return writer.result();
 }
 
 std::string LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1340,8 +1340,7 @@ bool LevelDbDocumentOverlayLargestBatchIdIndexKey::Decode(
   auto largest_batch_id = reader.ReadBatchId();
   auto document_key = reader.ReadDocumentKey();
   reader.ReadTerminator();
-  Reset(std::move(user_id), std::move(largest_batch_id),
-        std::move(document_key));
+  Reset(std::move(user_id), largest_batch_id, std::move(document_key));
   return reader.ok();
 }
 

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1396,7 +1396,7 @@ bool LevelDbDocumentOverlayCollectionIndexKey::Decode(absl::string_view key) {
   auto largest_batch_id = reader.ReadBatchId();
   const std::string document_id = reader.ReadDocumentId();
   reader.ReadTerminator();
-  Reset(std::move(user_id), std::move(largest_batch_id),
+  Reset(std::move(user_id), largest_batch_id,
         DocumentKey(collection.Append(document_id)));
   return reader.ok();
 }

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -1377,13 +1377,13 @@ std::string LevelDbDocumentOverlayCollectionIndexKey::Key(
     absl::string_view user_id,
     const model::ResourcePath& collection,
     model::BatchId largest_batch_id,
-    const model::DocumentKey& document_key) {
+    absl::string_view document_id) {
   Writer writer;
   writer.WriteTableName(kDocumentOverlaysCollectionIndexTable);
   writer.WriteUserId(user_id);
   writer.WriteResourcePath(collection);
   writer.WriteBatchId(largest_batch_id);
-  writer.WriteResourcePath(document_key.path());
+  writer.WriteDocumentId(document_id);
   writer.WriteTerminator();
   return writer.result();
 }
@@ -1392,12 +1392,12 @@ bool LevelDbDocumentOverlayCollectionIndexKey::Decode(absl::string_view key) {
   Reader reader{key};
   reader.ReadTableNameMatching(kDocumentOverlaysCollectionIndexTable);
   auto user_id = reader.ReadUserId();
-  collection_ = reader.ReadResourcePath();
+  const ResourcePath collection = reader.ReadResourcePath();
   auto largest_batch_id = reader.ReadBatchId();
-  auto document_key = reader.ReadDocumentKey();
+  const std::string document_id = reader.ReadDocumentId();
   reader.ReadTerminator();
   Reset(std::move(user_id), std::move(largest_batch_id),
-        std::move(document_key));
+        DocumentKey(collection.Append(document_id)));
   return reader.ok();
 }
 

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -1029,10 +1029,10 @@ class LevelDbDocumentOverlayIndexKey {
 
   /** Sets the values of this object's instance variables. */
   void Reset(std::string&& user_id,
-             model::BatchId&& largest_batch_id,
+             model::BatchId largest_batch_id,
              model::DocumentKey&& document_key) {
     user_id_ = std::move(user_id);
-    largest_batch_id_ = std::move(largest_batch_id);
+    largest_batch_id_ = largest_batch_id;
     document_key_ = std::move(document_key);
   }
 

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -925,11 +925,6 @@ class LevelDbDocumentOverlayKey {
   }
 
   /**
-   * Creates a key prefix that points just before the first key in the table.
-   */
-  static std::string KeyPrefix();
-
-  /**
    * Creates a key prefix that points just before the first key for the given
    * user_id.
    */
@@ -1052,11 +1047,6 @@ class LevelDbDocumentOverlayLargestBatchIdIndexKey
     : public LevelDbDocumentOverlayIndexKey {
  public:
   /**
-   * Creates a key prefix that points just before the first key in the table.
-   */
-  static std::string KeyPrefix();
-
-  /**
    * Creates a key prefix that points just before the first key for the given
    * user_id.
    */
@@ -1100,11 +1090,6 @@ class LevelDbDocumentOverlayLargestBatchIdIndexKey
 class LevelDbDocumentOverlayCollectionIndexKey
     : public LevelDbDocumentOverlayIndexKey {
  public:
-  /**
-   * Creates a key prefix that points just before the first key in the table.
-   */
-  static std::string KeyPrefix();
-
   /**
    * Creates a key prefix that points just before the first key for the given
    * user_id.

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -133,7 +133,7 @@ namespace local {
 //   - user_id: string
 //   - collection: ResourcePath
 //   - largest_batch_id: model::BatchId
-//   - document_key: ResourcePath
+//   - document_id: string
 
 /**
  * Parses the given key and returns a human readable description of its
@@ -1118,14 +1118,15 @@ class LevelDbDocumentOverlayCollectionIndexKey
   static std::string Key(absl::string_view user_id,
                          const model::ResourcePath& collection,
                          model::BatchId largest_batch_id,
-                         const model::DocumentKey& document_key);
+                         absl::string_view document_id);
 
   /**
    * Creates a complete key that points to a specific key in the overlays table.
    */
   static std::string Key(const LevelDbDocumentOverlayKey& key) {
     return Key(key.user_id(), key.document_key().path().PopLast(),
-               key.largest_batch_id(), key.document_key());
+               key.largest_batch_id(),
+               key.document_key().path().last_segment());
   }
 
   /**
@@ -1139,13 +1140,10 @@ class LevelDbDocumentOverlayCollectionIndexKey
   ABSL_MUST_USE_RESULT
   bool Decode(absl::string_view key);
 
-  /** The collection_, as encoded in the key. */
-  const model::ResourcePath& collection() const {
-    return collection_;
+  /** The collection, as encoded in the key. */
+  model::ResourcePath collection() const {
+    return document_key().path().PopLast();
   }
-
- private:
-  model::ResourcePath collection_;
 };
 
 }  // namespace local

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -921,7 +921,7 @@ class LevelDbDocumentOverlayKey {
                             model::BatchId largest_batch_id)
       : user_id_(std::move(user_id)),
         document_key_(std::move(document_key)),
-        largest_batch_id_(std::move(largest_batch_id)) {
+        largest_batch_id_(largest_batch_id) {
   }
 
   /**
@@ -1004,9 +1004,8 @@ class LevelDbDocumentOverlayIndexKey {
   // Overload `ToLevelDbDocumentOverlayKey()` to avoid copies if invoked on
   // an rvalue reference.
   LevelDbDocumentOverlayKey ToLevelDbDocumentOverlayKey() && {
-    return LevelDbDocumentOverlayKey(std::move(user_id_),
-                                     std::move(document_key_),
-                                     std::move(largest_batch_id_));
+    return LevelDbDocumentOverlayKey(
+        std::move(user_id_), std::move(document_key_), largest_batch_id_);
   }
 
   /** The user ID, as encoded in the key. */

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -127,6 +127,13 @@ namespace local {
 //   - user_id: string
 //   - largest_batch_id: model::BatchId
 //   - document_key: ResourcePath
+//
+// document_overlays_collection_index:
+//   - table_name: "document_overlays_collection_index"
+//   - user_id: string
+//   - collection: ResourcePath
+//   - largest_batch_id: model::BatchId
+//   - document_key: ResourcePath
 
 /**
  * Parses the given key and returns a human readable description of its
@@ -965,8 +972,13 @@ class LevelDbDocumentOverlayKey {
   }
 
   /** The path to the document, as encoded in the key. */
-  const model::DocumentKey& document_key() const {
+  const model::DocumentKey& document_key() const& {
     return document_key_;
+  }
+
+  // Overload document_key() to avoid copies if invoked on an rvalue reference.
+  model::DocumentKey&& document_key() && {
+    return std::move(document_key_);
   }
 
   /** The largest batch ID, as encoded in the key. */
@@ -980,8 +992,64 @@ class LevelDbDocumentOverlayKey {
   model::BatchId largest_batch_id_ = -1;
 };
 
+/** A base class for an index key in the document_overlays table. */
+class LevelDbDocumentOverlayIndexKey {
+ public:
+  virtual ~LevelDbDocumentOverlayIndexKey() = default;
+
+  /**
+   * Creates and returns the `LevelDbDocumentOverlayKey` to which this index
+   * entry refers.
+   */
+  LevelDbDocumentOverlayKey ToLevelDbDocumentOverlayKey() const& {
+    return LevelDbDocumentOverlayKey(user_id_, document_key_,
+                                     largest_batch_id_);
+  }
+
+  // Overload `ToLevelDbDocumentOverlayKey()` to avoid copies if invoked on
+  // an rvalue reference.
+  LevelDbDocumentOverlayKey ToLevelDbDocumentOverlayKey() && {
+    return LevelDbDocumentOverlayKey(std::move(user_id_),
+                                     std::move(document_key_),
+                                     std::move(largest_batch_id_));
+  }
+
+  /** The user ID, as encoded in the key. */
+  const std::string& user_id() const {
+    return user_id_;
+  }
+
+  /** The largest_batch_id_, as encoded in the key. */
+  model::BatchId largest_batch_id() const {
+    return largest_batch_id_;
+  }
+
+  /**
+   * The key in the document_overlays table to which this index entry points,
+   * as encoded in the key.
+   */
+  const model::DocumentKey& document_key() const {
+    return document_key_;
+  }
+
+  /** Sets the values of this object's instance variables. */
+  void Reset(std::string&& user_id,
+             model::BatchId&& largest_batch_id,
+             model::DocumentKey&& document_key) {
+    user_id_ = std::move(user_id);
+    largest_batch_id_ = std::move(largest_batch_id);
+    document_key_ = std::move(document_key);
+  }
+
+ private:
+  std::string user_id_;
+  model::BatchId largest_batch_id_ = -1;
+  model::DocumentKey document_key_;
+};
+
 /** A key in the "largest_batch_id" index of the document_overlays table. */
-class LevelDbDocumentOverlayLargestBatchIdIndexKey {
+class LevelDbDocumentOverlayLargestBatchIdIndexKey
+    : public LevelDbDocumentOverlayIndexKey {
  public:
   /**
    * Creates a key prefix that points just before the first key in the table.
@@ -1026,46 +1094,73 @@ class LevelDbDocumentOverlayLargestBatchIdIndexKey {
    */
   ABSL_MUST_USE_RESULT
   bool Decode(absl::string_view key);
+};
+
+/** A key in the "collection" index of the document_overlays table. */
+class LevelDbDocumentOverlayCollectionIndexKey
+    : public LevelDbDocumentOverlayIndexKey {
+ public:
+  /**
+   * Creates a key prefix that points just before the first key in the table.
+   */
+  static std::string KeyPrefix();
 
   /**
-   * Creates and returns the `LevelDbDocumentOverlayKey` to which this index
-   * entry refers.
+   * Creates a key prefix that points just before the first key for the given
+   * user_id.
    */
-  LevelDbDocumentOverlayKey ToLevelDbDocumentOverlayKey() const& {
-    return LevelDbDocumentOverlayKey(user_id_, document_key_,
-                                     largest_batch_id_);
-  }
+  static std::string KeyPrefix(absl::string_view user_id);
 
-  // Overload `ToLevelDbDocumentOverlayKey()` to avoid copies if invoked on
-  // an rvalue reference.
-  LevelDbDocumentOverlayKey ToLevelDbDocumentOverlayKey() && {
-    return LevelDbDocumentOverlayKey(std::move(user_id_),
-                                     std::move(document_key_),
-                                     std::move(largest_batch_id_));
-  }
+  /**
+   * Creates a key prefix that points just before the first key for the given
+   * user_id, collection.
+   */
+  static std::string KeyPrefix(absl::string_view user_id,
+                               const model::ResourcePath& collection);
 
-  /** The user ID, as encoded in the key. */
-  const std::string& user_id() const {
-    return user_id_;
-  }
+  /**
+   * Creates a key prefix that points just before the first key for the given
+   * user_id, collection, and largest_batch_id.
+   */
+  static std::string KeyPrefix(absl::string_view user_id,
+                               const model::ResourcePath& collection,
+                               model::BatchId largest_batch_id);
 
-  /** The largest_batch_id_, as encoded in the key. */
-  model::BatchId largest_batch_id() const {
-    return largest_batch_id_;
+  /**
+   * Creates a complete key that points to a specific user_id, collection, and
+   * largest_batch_id for a given key in the document_overlays table.
+   */
+  static std::string Key(absl::string_view user_id,
+                         const model::ResourcePath& collection,
+                         model::BatchId largest_batch_id,
+                         const model::DocumentKey& document_key);
+
+  /**
+   * Creates a complete key that points to a specific key in the overlays table.
+   */
+  static std::string Key(const LevelDbDocumentOverlayKey& key) {
+    return Key(key.user_id(), key.document_key().path().PopLast(),
+               key.largest_batch_id(), key.document_key());
   }
 
   /**
-   * The key in the document_overlays table to which this index entry points,
-   * as encoded in the key.
+   * Decodes the given complete key, storing the decoded values in this
+   * instance.
+   *
+   * @return true if the key successfully decoded, false otherwise. If false is
+   * returned, this instance is in an undefined state until the next call to
+   * `Decode()`.
    */
-  const model::DocumentKey& document_key() const {
-    return document_key_;
+  ABSL_MUST_USE_RESULT
+  bool Decode(absl::string_view key);
+
+  /** The collection_, as encoded in the key. */
+  const model::ResourcePath& collection() const {
+    return collection_;
   }
 
  private:
-  std::string user_id_;
-  model::BatchId largest_batch_id_ = -1;
-  model::DocumentKey document_key_;
+  model::ResourcePath collection_;
 };
 
 }  // namespace local

--- a/Firestore/core/test/unit/local/leveldb_document_overlay_cache_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_document_overlay_cache_test.cc
@@ -42,6 +42,11 @@ class LevelDbDocumentOverlayCacheTestHelper final {
       const LevelDbDocumentOverlayCache& instance) {
     return instance.GetLargestBatchIdIndexEntryCount();
   }
+
+  static int GetCollectionIndexEntryCount(
+      const LevelDbDocumentOverlayCache& instance) {
+    return instance.GetCollectionIndexEntryCount();
+  }
 };
 
 namespace {
@@ -76,6 +81,13 @@ class LevelDbDocumentOverlayCacheTest : public DocumentOverlayCacheTestBase {
       EXPECT_EQ(LevelDbDocumentOverlayCacheTestHelper::
                     GetLargestBatchIdIndexEntryCount(cache),
                 expected_count);
+    }
+    {
+      SCOPED_TRACE("GetCollectionIndexEntryCount");
+      EXPECT_EQ(
+          LevelDbDocumentOverlayCacheTestHelper::GetCollectionIndexEntryCount(
+              cache),
+          expected_count);
     }
   }
 };

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/local/leveldb_key.h"
 
+#include <type_traits>
+
 #include "Firestore/core/src/util/autoid.h"
 #include "Firestore/core/src/util/string_util.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
@@ -749,6 +751,40 @@ TEST(LevelDbDocumentOverlayKeyTest, Description) {
       LevelDbDocumentOverlayKey::Key("foo-bar?baz!quux",
                                      testutil::Key("coll/doc"), 123));
 }
+
+TEST(LevelDbDocumentOverlayIndexKeyTest, TypeTraits) {
+  static_assert(
+      std::has_virtual_destructor<LevelDbDocumentOverlayIndexKey>::value,
+      "LevelDbDocumentOverlayIndexKey should have a virtual destructor");
+}
+
+TEST(LevelDbDocumentOverlayIndexKeyTest, ToLevelDbDocumentOverlayKey) {
+  LevelDbDocumentOverlayIndexKey index_key;
+  index_key.Reset("test_user", 123, testutil::Key("coll/doc1"));
+  LevelDbDocumentOverlayKey key = index_key.ToLevelDbDocumentOverlayKey();
+  EXPECT_EQ(key.user_id(), "test_user");
+  EXPECT_EQ(key.largest_batch_id(), 123);
+  EXPECT_EQ(key.document_key(), testutil::Key("coll/doc1"));
+}
+
+TEST(LevelDbDocumentOverlayIndexKeyTest, ToLevelDbDocumentOverlayKeyRvalue) {
+  LevelDbDocumentOverlayIndexKey index_key;
+  index_key.Reset("test_user", 123, testutil::Key("coll/doc1"));
+  LevelDbDocumentOverlayKey key =
+      std::move(index_key).ToLevelDbDocumentOverlayKey();
+  EXPECT_EQ(key.user_id(), "test_user");
+  EXPECT_EQ(key.largest_batch_id(), 123);
+  EXPECT_EQ(key.document_key(), testutil::Key("coll/doc1"));
+}
+
+TEST(LevelDbDocumentOverlayIndexKeyTest, Getters) {
+  LevelDbDocumentOverlayIndexKey key;
+  key.Reset("test_user", 123, testutil::Key("coll/doc1"));
+  EXPECT_EQ(key.user_id(), "test_user");
+  EXPECT_EQ(key.largest_batch_id(), 123);
+  EXPECT_EQ(key.document_key(), testutil::Key("coll/doc1"));
+}
+
 TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest, Prefixing) {
   const std::string table_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix();
@@ -852,8 +888,10 @@ TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest, Description) {
 TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest,
      FromLevelDbDocumentOverlayKey) {
   LevelDbDocumentOverlayKey key("test_user", testutil::Key("coll/doc"), 123);
+
   const std::string encoded_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::Key(key);
+
   LevelDbDocumentOverlayLargestBatchIdIndexKey decoded_key;
   ASSERT_TRUE(decoded_key.Decode(encoded_key));
   EXPECT_EQ(decoded_key.user_id(), "test_user");
@@ -861,36 +899,148 @@ TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest,
   EXPECT_EQ(decoded_key.document_key(), testutil::Key("coll/doc"));
 }
 
-TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest,
-     ToLevelDbDocumentOverlayKey) {
-  const std::string encoded_key =
-      LevelDbDocumentOverlayLargestBatchIdIndexKey::Key(
-          "test_user", 123, testutil::Key("coll/doc"));
-  LevelDbDocumentOverlayLargestBatchIdIndexKey decoded_key;
-  ASSERT_TRUE(decoded_key.Decode(encoded_key));
+TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
+  const std::string table_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix();
+  const std::string user1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix("test_user1");
+  const std::string user2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix("test_user2");
+  const std::string user1_coll1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user1", model::ResourcePath::FromString("coll1"));
+  const std::string user1_coll2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user1", model::ResourcePath::FromString("coll2"));
+  const std::string user2_coll2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user2", model::ResourcePath::FromString("coll2"));
+  const std::string user1_coll1_batch1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user1", model::ResourcePath::FromString("coll1"), 1);
+  const std::string user1_coll1_batch2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user1", model::ResourcePath::FromString("coll1"), 2);
+  const std::string user2_coll2_batch2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user2", model::ResourcePath::FromString("coll2"), 2);
 
-  const LevelDbDocumentOverlayKey key =
-      decoded_key.ToLevelDbDocumentOverlayKey();
+  ASSERT_TRUE(absl::StartsWith(user1_key, table_key));
+  ASSERT_TRUE(absl::StartsWith(user2_key, table_key));
+  ASSERT_TRUE(absl::StartsWith(user1_coll1_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user1_coll2_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_key, user1_coll1_key));
+  ASSERT_TRUE(absl::StartsWith(user1_coll1_batch2_key, user1_coll1_key));
+  ASSERT_FALSE(absl::StartsWith(user1_key, user2_key));
+  ASSERT_FALSE(absl::StartsWith(user2_key, user1_key));
+  ASSERT_FALSE(absl::StartsWith(user1_coll1_key, user1_coll2_key));
+  ASSERT_FALSE(absl::StartsWith(user1_coll2_key, user1_coll1_key));
+  ASSERT_FALSE(
+      absl::StartsWith(user1_coll1_batch1_key, user1_coll1_batch2_key));
+  ASSERT_FALSE(
+      absl::StartsWith(user1_coll1_batch2_key, user1_coll1_batch1_key));
 
-  EXPECT_EQ(key.user_id(), "test_user");
-  EXPECT_EQ(key.document_key(), testutil::Key("coll/doc"));
-  EXPECT_EQ(key.largest_batch_id(), 123);
+  const std::string user1_coll1_batch1_doc1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "test_user1", model::ResourcePath::FromString("coll1"), 1,
+          testutil::Key("coll/doc1"));
+  const std::string user2_coll2_batch2_doc2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "test_user2", model::ResourcePath::FromString("coll2"), 2,
+          testutil::Key("coll/doc2"));
+  ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_doc1_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user2_coll2_batch2_doc2_key, user2_key));
+  ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_doc1_key, user1_coll1_key));
+  ASSERT_TRUE(absl::StartsWith(user2_coll2_batch2_doc2_key, user2_coll2_key));
+  ASSERT_TRUE(
+      absl::StartsWith(user1_coll1_batch1_doc1_key, user1_coll1_batch1_key));
+  ASSERT_TRUE(
+      absl::StartsWith(user2_coll2_batch2_doc2_key, user2_coll2_batch2_key));
 }
 
-TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest,
-     ToLevelDbDocumentOverlayKeyOnRvalueRef) {
+TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Ordering) {
+  const std::string user1_coll1_batch1_doc1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "user1", model::ResourcePath::FromString("coll1"), 1,
+          testutil::Key("coll/doc1"));
+  const std::string user2_coll1_batch1_doc1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "user2", model::ResourcePath::FromString("coll1"), 1,
+          testutil::Key("coll/doc1"));
+  const std::string user2_coll2_batch1_doc1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "user2", model::ResourcePath::FromString("coll2"), 1,
+          testutil::Key("coll/doc1"));
+  const std::string user2_coll2_batch2_doc1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "user2", model::ResourcePath::FromString("coll2"), 2,
+          testutil::Key("coll/doc1"));
+  const std::string user2_coll2_batch2_doc2_key =
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "user2", model::ResourcePath::FromString("coll2"), 2,
+          testutil::Key("coll/doc2"));
+
+  ASSERT_LT(user1_coll1_batch1_doc1_key, user2_coll1_batch1_doc1_key);
+  ASSERT_LT(user2_coll1_batch1_doc1_key, user2_coll2_batch1_doc1_key);
+  ASSERT_LT(user2_coll2_batch1_doc1_key, user2_coll2_batch2_doc1_key);
+  ASSERT_LT(user2_coll2_batch2_doc1_key, user2_coll2_batch2_doc2_key);
+}
+
+TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, EncodeDecodeCycle) {
+  const std::vector<std::string> user_ids{"test_user", "foo/bar2",
+                                          "foo-bar?baz!quux"};
+  const std::vector<model::ResourcePath> collections{
+      model::ResourcePath::FromString("coll1"),
+      model::ResourcePath::FromString("coll2"),
+      model::ResourcePath::FromString("coll3/docX/coll4")};
+  const std::vector<model::BatchId> batch_ids{1, 2, 3};
+  const std::vector<model::DocumentKey> document_keys{
+      testutil::Key("coll/doc1"), testutil::Key("coll/doc2"),
+      testutil::Key("coll/doc3")};
+  for (const std::string& user_id : user_ids) {
+    for (const model::ResourcePath& collection : collections) {
+      for (const model::BatchId batch_id : batch_ids) {
+        for (const model::DocumentKey& document_key : document_keys) {
+          SCOPED_TRACE(absl::StrCat("user_name=", user_id, " collection=",
+                                    collection.CanonicalString(),
+                                    " path=", document_key.ToString()));
+          const std::string encoded =
+              LevelDbDocumentOverlayCollectionIndexKey::Key(
+                  user_id, collection, batch_id, document_key);
+          LevelDbDocumentOverlayCollectionIndexKey key;
+          EXPECT_TRUE(key.Decode(encoded));
+          EXPECT_EQ(key.user_id(), user_id);
+          EXPECT_EQ(key.collection(), collection);
+          EXPECT_EQ(key.largest_batch_id(), batch_id);
+          EXPECT_EQ(key.document_key(), document_key);
+        }
+      }
+    }
+  }
+}
+
+TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Description) {
+  AssertExpectedKeyDescription(
+      "[document_overlays_collection_index: user_id=foo-bar?baz!quux "
+      "path=coll1 batch_id=123 path=coll/docX]",
+      LevelDbDocumentOverlayCollectionIndexKey::Key(
+          "foo-bar?baz!quux", model::ResourcePath::FromString("coll1"), 123,
+          testutil::Key("coll/docX")));
+}
+
+TEST(LevelDbDocumentOverlayCollectionIndexKeyTest,
+     FromLevelDbDocumentOverlayKey) {
+  LevelDbDocumentOverlayKey key("test_user", testutil::Key("coll/doc"), 123);
+
   const std::string encoded_key =
-      LevelDbDocumentOverlayLargestBatchIdIndexKey::Key(
-          "test_user", 123, testutil::Key("coll/doc"));
-  LevelDbDocumentOverlayLargestBatchIdIndexKey decoded_key;
+      LevelDbDocumentOverlayCollectionIndexKey::Key(key);
+
+  LevelDbDocumentOverlayCollectionIndexKey decoded_key;
   ASSERT_TRUE(decoded_key.Decode(encoded_key));
-
-  LevelDbDocumentOverlayKey key =
-      std::move(decoded_key).ToLevelDbDocumentOverlayKey();
-
-  EXPECT_EQ(key.user_id(), "test_user");
-  EXPECT_EQ(key.document_key(), testutil::Key("coll/doc"));
-  EXPECT_EQ(key.largest_batch_id(), 123);
+  EXPECT_EQ(decoded_key.user_id(), "test_user");
+  EXPECT_EQ(decoded_key.collection(), model::ResourcePath::FromString("coll"));
+  EXPECT_EQ(decoded_key.largest_batch_id(), 123);
+  EXPECT_EQ(decoded_key.document_key(), testutil::Key("coll/doc"));
 }
 
 #undef AssertExpectedKeyDescription

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -26,6 +26,7 @@
 
 using firebase::firestore::model::BatchId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
@@ -905,25 +906,25 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix("test_user2");
   const std::string user1_coll1_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user1", model::ResourcePath::FromString("coll1"));
+          "test_user1", ResourcePath{"coll1"});
   const std::string user1_coll2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user1", model::ResourcePath::FromString("coll2"));
+          "test_user1", ResourcePath{"coll2"});
   const std::string user2_coll1_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user2", model::ResourcePath::FromString("coll1"));
+          "test_user2", ResourcePath{"coll1"});
   const std::string user2_coll2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user2", model::ResourcePath::FromString("coll2"));
+          "test_user2", ResourcePath{"coll2"});
   const std::string user1_coll1_batch1_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user1", model::ResourcePath::FromString("coll1"), 1);
+          "test_user1", ResourcePath{"coll1"}, 1);
   const std::string user1_coll1_batch2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user1", model::ResourcePath::FromString("coll1"), 2);
+          "test_user1", ResourcePath{"coll1"}, 2);
   const std::string user2_coll2_batch2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
-          "test_user2", model::ResourcePath::FromString("coll2"), 2);
+          "test_user2", ResourcePath{"coll2"}, 2);
 
   ASSERT_TRUE(absl::StartsWith(user1_coll1_key, user1_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll2_key, user1_key));
@@ -942,10 +943,10 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
 
   const std::string user1_coll1_batch1_doc1_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "test_user1", model::ResourcePath::FromString("coll1"), 1, "doc1");
+          "test_user1", ResourcePath{"coll1"}, 1, "doc1");
   const std::string user2_coll2_batch2_doc2_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "test_user2", model::ResourcePath::FromString("coll2"), 2, "doc2");
+          "test_user2", ResourcePath{"coll2"}, 2, "doc2");
   ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_doc1_key, user1_key));
   ASSERT_TRUE(absl::StartsWith(user2_coll2_batch2_doc2_key, user2_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_doc1_key, user1_coll1_key));
@@ -959,19 +960,19 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
 TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Ordering) {
   const std::string user1_coll1_batch1_doc1_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "user1", model::ResourcePath::FromString("coll1"), 1, "doc1");
+          "user1", ResourcePath{"coll1"}, 1, "doc1");
   const std::string user2_coll1_batch1_doc1_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "user2", model::ResourcePath::FromString("coll1"), 1, "doc1");
+          "user2", ResourcePath{"coll1"}, 1, "doc1");
   const std::string user2_coll2_batch1_doc1_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "user2", model::ResourcePath::FromString("coll2"), 1, "doc1");
+          "user2", ResourcePath{"coll2"}, 1, "doc1");
   const std::string user2_coll2_batch2_doc1_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "user2", model::ResourcePath::FromString("coll2"), 2, "doc1");
+          "user2", ResourcePath{"coll2"}, 2, "doc1");
   const std::string user2_coll2_batch2_doc2_key =
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "user2", model::ResourcePath::FromString("coll2"), 2, "doc2");
+          "user2", ResourcePath{"coll2"}, 2, "doc2");
 
   ASSERT_LT(user1_coll1_batch1_doc1_key, user2_coll1_batch1_doc1_key);
   ASSERT_LT(user2_coll1_batch1_doc1_key, user2_coll2_batch1_doc1_key);
@@ -982,14 +983,13 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Ordering) {
 TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, EncodeDecodeCycle) {
   const std::vector<std::string> user_ids{"test_user", "foo/bar2",
                                           "foo-bar?baz!quux"};
-  const std::vector<model::ResourcePath> collections{
-      model::ResourcePath::FromString("coll1"),
-      model::ResourcePath::FromString("coll2"),
-      model::ResourcePath::FromString("coll3/docX/coll4")};
+  const std::vector<ResourcePath> collections{
+      ResourcePath{"coll1"}, ResourcePath{"coll2"},
+      ResourcePath{"coll3", "docX", "coll4"}};
   const std::vector<model::BatchId> batch_ids{1, 2, 3};
   const std::vector<std::string> document_ids{"doc1", "doc2", "doc3"};
   for (const std::string& user_id : user_ids) {
-    for (const model::ResourcePath& collection : collections) {
+    for (const ResourcePath& collection : collections) {
       for (const model::BatchId batch_id : batch_ids) {
         for (const std::string& document_id : document_ids) {
           SCOPED_TRACE(absl::StrCat("user_name=", user_id, " collection=",
@@ -1016,8 +1016,7 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Description) {
       "[document_overlays_collection_index: user_id=foo-bar?baz!quux "
       "path=coll1 batch_id=123 document_id=docX]",
       LevelDbDocumentOverlayCollectionIndexKey::Key(
-          "foo-bar?baz!quux", model::ResourcePath::FromString("coll1"), 123,
-          "docX"));
+          "foo-bar?baz!quux", ResourcePath{"coll1"}, 123, "docX"));
 }
 
 TEST(LevelDbDocumentOverlayCollectionIndexKeyTest,
@@ -1030,7 +1029,7 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest,
   LevelDbDocumentOverlayCollectionIndexKey decoded_key;
   ASSERT_TRUE(decoded_key.Decode(encoded_key));
   EXPECT_EQ(decoded_key.user_id(), "test_user");
-  EXPECT_EQ(decoded_key.collection(), model::ResourcePath::FromString("coll"));
+  EXPECT_EQ(decoded_key.collection(), ResourcePath{"coll"});
   EXPECT_EQ(decoded_key.largest_batch_id(), 123);
   EXPECT_EQ(decoded_key.document_key(), testutil::Key("coll/doc"));
 }

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -46,7 +46,7 @@ std::string RemoteDocKeyPrefix(absl::string_view path_string) {
 
 std::string DocMutationKey(absl::string_view user_id,
                            absl::string_view key,
-                           model::BatchId batch_id) {
+                           BatchId batch_id) {
   return LevelDbDocumentMutationKey::Key(user_id, testutil::Key(key), batch_id);
 }
 
@@ -726,10 +726,10 @@ TEST(LevelDbDocumentOverlayKeyTest, EncodeDecodeCycle) {
                                           "foo-bar?baz!quux"};
   const std::vector<std::string> document_keys{"col1/doc1",
                                                "col2/doc2/col3/doc3"};
-  const std::vector<model::BatchId> batch_ids{1, 2, 3};
+  const std::vector<BatchId> batch_ids{1, 2, 3};
   for (const std::string& user_id : user_ids) {
     for (const std::string& document_key : document_keys) {
-      for (model::BatchId batch_id : batch_ids) {
+      for (BatchId batch_id : batch_ids) {
         SCOPED_TRACE(absl::StrCat("user_name=", user_id,
                                   " document_key=", document_key,
                                   " largest_batch_id=", batch_id));
@@ -855,13 +855,13 @@ TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest, Ordering) {
 TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest, EncodeDecodeCycle) {
   const std::vector<std::string> user_ids{"test_user", "foo/bar2",
                                           "foo-bar?baz!quux"};
-  const std::vector<model::BatchId> batch_ids{1, 2, 3};
-  const std::vector<model::DocumentKey> document_keys{
-      testutil::Key("coll/doc1"), testutil::Key("coll/doc2"),
-      testutil::Key("coll/doc3")};
+  const std::vector<BatchId> batch_ids{1, 2, 3};
+  const std::vector<DocumentKey> document_keys{testutil::Key("coll/doc1"),
+                                               testutil::Key("coll/doc2"),
+                                               testutil::Key("coll/doc3")};
   for (const std::string& user_id : user_ids) {
-    for (model::BatchId batch_id : batch_ids) {
-      for (const model::DocumentKey& document_key : document_keys) {
+    for (BatchId batch_id : batch_ids) {
+      for (const DocumentKey& document_key : document_keys) {
         SCOPED_TRACE(absl::StrCat("user_name=", user_id, " batch_id=", batch_id,
                                   " path=", document_key.ToString()));
         const std::string encoded =
@@ -986,11 +986,11 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, EncodeDecodeCycle) {
   const std::vector<ResourcePath> collections{
       ResourcePath{"coll1"}, ResourcePath{"coll2"},
       ResourcePath{"coll3", "docX", "coll4"}};
-  const std::vector<model::BatchId> batch_ids{1, 2, 3};
+  const std::vector<BatchId> batch_ids{1, 2, 3};
   const std::vector<std::string> document_ids{"doc1", "doc2", "doc3"};
   for (const std::string& user_id : user_ids) {
     for (const ResourcePath& collection : collections) {
-      for (const model::BatchId batch_id : batch_ids) {
+      for (const BatchId batch_id : batch_ids) {
         for (const std::string& document_id : document_ids) {
           SCOPED_TRACE(absl::StrCat("user_name=", user_id, " collection=",
                                     collection.CanonicalString(),

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -680,18 +680,18 @@ TEST(LevelDbDocumentOverlayKeyTest, Encode) {
 }
 
 TEST(LevelDbDocumentOverlayKeyTest, Prefixing) {
-  const std::string table_key = LevelDbDocumentOverlayKey::KeyPrefix();
   const std::string user1_key =
       LevelDbDocumentOverlayKey::KeyPrefix("test_user1");
   const std::string user2_key =
       LevelDbDocumentOverlayKey::KeyPrefix("test_user2");
   const std::string user1_doc1_key = LevelDbDocumentOverlayKey::KeyPrefix(
       "test_user1", testutil::Key("coll/doc1"));
+  const std::string user2_doc2_key = LevelDbDocumentOverlayKey::KeyPrefix(
+      "test_user2", testutil::Key("coll/doc2"));
   const std::string user1_doc2_key = LevelDbDocumentOverlayKey::KeyPrefix(
       "test_user1", testutil::Key("coll/doc2"));
-  ASSERT_TRUE(absl::StartsWith(user1_key, table_key));
-  ASSERT_TRUE(absl::StartsWith(user2_key, table_key));
   ASSERT_TRUE(absl::StartsWith(user1_doc1_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user2_doc2_key, user2_key));
   ASSERT_FALSE(absl::StartsWith(user1_key, user2_key));
   ASSERT_FALSE(absl::StartsWith(user2_key, user1_key));
   ASSERT_FALSE(absl::StartsWith(user1_doc1_key, user1_doc2_key));
@@ -786,19 +786,18 @@ TEST(LevelDbDocumentOverlayIndexKeyTest, Getters) {
 }
 
 TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest, Prefixing) {
-  const std::string table_key =
-      LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix();
   const std::string user1_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix("test_user1");
   const std::string user2_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix("test_user2");
   const std::string user1_batch1_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix("test_user1", 1);
+  const std::string user2_batch2_key =
+      LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix("test_user2", 2);
   const std::string user1_batch2_key =
       LevelDbDocumentOverlayLargestBatchIdIndexKey::KeyPrefix("test_user1", 2);
-  ASSERT_TRUE(absl::StartsWith(user1_key, table_key));
-  ASSERT_TRUE(absl::StartsWith(user2_key, table_key));
   ASSERT_TRUE(absl::StartsWith(user1_batch1_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user2_batch2_key, user2_key));
   ASSERT_FALSE(absl::StartsWith(user1_key, user2_key));
   ASSERT_FALSE(absl::StartsWith(user2_key, user1_key));
   ASSERT_FALSE(absl::StartsWith(user1_batch1_key, user1_batch2_key));
@@ -900,8 +899,6 @@ TEST(LevelDbDocumentOverlayLargestBatchIdIndexKeyTest,
 }
 
 TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
-  const std::string table_key =
-      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix();
   const std::string user1_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix("test_user1");
   const std::string user2_key =
@@ -912,6 +909,9 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
   const std::string user1_coll2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
           "test_user1", model::ResourcePath::FromString("coll2"));
+  const std::string user2_coll1_key =
+      LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
+          "test_user2", model::ResourcePath::FromString("coll1"));
   const std::string user2_coll2_key =
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
           "test_user2", model::ResourcePath::FromString("coll2"));
@@ -925,10 +925,10 @@ TEST(LevelDbDocumentOverlayCollectionIndexKeyTest, Prefixing) {
       LevelDbDocumentOverlayCollectionIndexKey::KeyPrefix(
           "test_user2", model::ResourcePath::FromString("coll2"), 2);
 
-  ASSERT_TRUE(absl::StartsWith(user1_key, table_key));
-  ASSERT_TRUE(absl::StartsWith(user2_key, table_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll1_key, user1_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll2_key, user1_key));
+  ASSERT_TRUE(absl::StartsWith(user2_coll1_key, user2_key));
+  ASSERT_TRUE(absl::StartsWith(user2_coll2_key, user2_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll1_batch1_key, user1_coll1_key));
   ASSERT_TRUE(absl::StartsWith(user1_coll1_batch2_key, user1_coll1_key));
   ASSERT_FALSE(absl::StartsWith(user1_key, user2_key));


### PR DESCRIPTION
The `LevelDbDocumentOverlayCache` class was added in In #9345, but with recognized performance issues. This PR improves the performance of `GetOverlays(ResourcePath, ...)` from θ(N), where `N` is the total size of the table, to θ(m(log(m)), where `m` is the number of overlays returned. 

This index implementation is directly based on the implementation for the `RemoveOverlaysForBatchId()` method, as implemented in #9386. See that PR for a deeper explanation of the implementation details.

This PR introduces the class `LevelDbDocumentOverlayIndexKey`, which is used as the base class for all index keys in the `document_overlays` table. As of this PR, it has two subclasses: `LevelDbDocumentOverlayLargestBatchIdIndexKey` (modified in this PR to subclass it) and `LevelDbDocumentOverlayCollectionIndexKey` (added in this PR).

Googlers see b/210002758 for details.

#no-changelog
