### PR TITLE
[Heartbeat Logging] Refinements to how `HeartbeatsPayload`s are converted into header strings

### DIFF
--- a/HeartbeatLogging/Sources/HeartbeatsPayload.swift
+++ b/HeartbeatLogging/Sources/HeartbeatsPayload.swift
@@ -84,21 +84,20 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
   /// Returns a processed payload string intended for use in a HTTP header.
   /// - Returns: A string value from the heartbeats payload.
   public func headerValue() -> String {
-    // TODO(ncooke3): Return a empty payload instead of empty string.
-    if userAgentPayloads.isEmpty {
-      return ""
-    }
-
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .formatted(Self.dateFormatter)
 
-    // TODO(ncooke3): Fall back to base64URL-only if gzipping fails.
+    guard let data = try? encoder.encode(self) else {
+      // Because `HeartbeatsPayload` conforms to Codal
+      return Self.emptyPayload.headerValue()
+    }
+
     do {
-      let data = try encoder.encode(self)
       let gzippedData = try data.zipped()
       return gzippedData.base64URLEncodedString()
     } catch {
-      return "" // Return empty string if processing failed.
+      // If gzipping fails, fall back to encoding with base64URL.
+      return data.base64URLEncodedString()
     }
   }
 }

--- a/HeartbeatLogging/Tests/Integration/HeartbeatLoggingIntegrationTests.swift
+++ b/HeartbeatLogging/Tests/Integration/HeartbeatLoggingIntegrationTests.swift
@@ -133,7 +133,8 @@ class HeartbeatLoggingIntegrationTests: XCTestCase {
 
     // Then
     let nonEmptyPayloads = payloads.filter { payload in
-      payload.headerValue().count > 0
+      // Filter out non-empty payloads.
+      !payload.userAgentPayloads.isEmpty
     }
 
     XCTAssertEqual(nonEmptyPayloads.count, 1)
@@ -173,7 +174,8 @@ class HeartbeatLoggingIntegrationTests: XCTestCase {
 
     // Then
     let nonEmptyPayloads = payloads.filter { payload in
-      payload.headerValue().count > 0
+      // Filter out non-empty payloads.
+      !payload.userAgentPayloads.isEmpty
     }
 
     XCTAssertEqual(nonEmptyPayloads.count, 1)

--- a/HeartbeatLogging/Tests/Unit/HeartbeatControllerTests.swift
+++ b/HeartbeatLogging/Tests/Unit/HeartbeatControllerTests.swift
@@ -410,6 +410,12 @@ private class HeartbeatStorageFake: HeartbeatStorageProtocol {
 // MARK: - Assertions
 
 func assertHeartbeatControllerFlushesEmptyPayload(_ controller: HeartbeatController) {
-  XCTAssertEqual(controller.flushHeartbeatFromToday().headerValue(), "")
-  XCTAssertEqual(controller.flush().headerValue(), "")
+  XCTAssertEqual(
+    controller.flushHeartbeatFromToday().headerValue(),
+    HeartbeatsPayload.emptyPayload.headerValue()
+  )
+  XCTAssertEqual(
+    controller.flush().headerValue(),
+    HeartbeatsPayload.emptyPayload.headerValue()
+  )
 }

--- a/HeartbeatLogging/Tests/Unit/HeartbeatsBundleTests.swift
+++ b/HeartbeatLogging/Tests/Unit/HeartbeatsBundleTests.swift
@@ -77,7 +77,15 @@ class HeartbeatsBundleTests: XCTestCase {
       .makeHeartbeatsPayload()
       .headerValue()
 
-    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(heartbeatsBundleString, "")
+    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(
+      heartbeatsBundleString,
+      """
+      {
+        "version": 2,
+        "heartbeats": []
+      }
+      """
+    )
 
     XCTAssertEqual(heartbeatsBundle.lastAddedHeartbeatDates, preAppendCacheSnapshot)
   }
@@ -147,7 +155,15 @@ class HeartbeatsBundleTests: XCTestCase {
       .makeHeartbeatsPayload()
       .headerValue()
 
-    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(heartbeatsBundleString, "")
+    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(
+      heartbeatsBundleString,
+      """
+      {
+        "version": 2,
+        "heartbeats": []
+      }
+      """
+    )
 
     XCTAssertEqual(heartbeatsBundle.lastAddedHeartbeatDates, preRemoveCacheSnapshot)
   }
@@ -166,7 +182,15 @@ class HeartbeatsBundleTests: XCTestCase {
       .makeHeartbeatsPayload()
       .headerValue()
 
-    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(heartbeatsBundleString, "")
+    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(
+      heartbeatsBundleString,
+      """
+      {
+        "version": 2,
+        "heartbeats": []
+      }
+      """
+    )
   }
 
   func testRemovingHeartbeatFromDate_WhenHeartbeatFromDateNotInBundle_RemovesNothingAndReturnsNil() throws {

--- a/HeartbeatLogging/Tests/Unit/HeartbeatsPayloadTests.swift
+++ b/HeartbeatLogging/Tests/Unit/HeartbeatsPayloadTests.swift
@@ -103,6 +103,14 @@ class HeartbeatsPayloadTests: XCTestCase {
     // When
     let headerValue = heartbeatsPayload.headerValue()
     // Then
-    XCTAssertEqual(headerValue, "")
+    try HeartbeatLoggingTestUtils.assertEqualPayloadStrings(
+      headerValue,
+      """
+      {
+        "version": 2,
+        "heartbeats": []
+      }
+      """
+    )
   }
 }


### PR DESCRIPTION
This PR