### PR TITLE
Improve performance of LevelDbDocumentOverlayCache::GetOverlays(absl::string_view)

### DIFF
--- a/Firestore/core/src/local/document_overlay_cache.h
+++ b/Firestore/core/src/local/document_overlay_cache.h
@@ -18,7 +18,6 @@
 #define FIRESTORE_CORE_SRC_LOCAL_DOCUMENT_OVERLAY_CACHE_H_
 
 #include <cstdlib>
-#include <string>
 #include <unordered_map>
 
 #include "Firestore/core/src/model/document_key.h"
@@ -101,7 +100,7 @@ class DocumentOverlayCache {
    * overlay.
    */
   virtual OverlayByDocumentKeyMap GetOverlays(
-      const std::string& collection_group,
+      absl::string_view collection_group,
       int since_batch_id,
       std::size_t count) const = 0;
 

--- a/Firestore/core/src/local/leveldb_document_overlay_cache.h
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.h
@@ -63,7 +63,7 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
   OverlayByDocumentKeyMap GetOverlays(const model::ResourcePath& collection,
                                       int since_batch_id) const override;
 
-  OverlayByDocumentKeyMap GetOverlays(const std::string& collection_group,
+  OverlayByDocumentKeyMap GetOverlays(absl::string_view collection_group,
                                       int since_batch_id,
                                       std::size_t count) const override;
 
@@ -74,9 +74,15 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
   // These methods exist for unit testing only.
   int GetLargestBatchIdIndexEntryCount() const;
   int GetCollectionIndexEntryCount() const;
+  int GetCollectionGroupIndexEntryCount() const;
 
   int GetOverlayCount() const override;
   int CountEntriesWithKeyPrefix(const std::string& key_prefix) const;
+
+  enum class ForEachKeyAction {
+    kKeepGoing,
+    kStop,
+  };
 
   model::mutation::Overlay ParseOverlay(
       const LevelDbDocumentOverlayKey& key,
@@ -90,10 +96,6 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
 
   void DeleteOverlay(const LevelDbDocumentOverlayKey&);
 
-  void ForEachOverlay(
-      std::function<void(LevelDbDocumentOverlayKey&&,
-                         absl::string_view encoded_mutation)>) const;
-
   void ForEachKeyWithLargestBatchId(
       int largest_batch_id,
       std::function<void(LevelDbDocumentOverlayKey&&)>) const;
@@ -102,6 +104,11 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
       const model::ResourcePath& collection,
       int since_batch_id,
       std::function<void(LevelDbDocumentOverlayKey&&)>) const;
+
+  void ForEachKeyInCollectionGroup(
+      absl::string_view collection_group,
+      int since_batch_id,
+      std::function<ForEachKeyAction(LevelDbDocumentOverlayKey&&)>) const;
 
   absl::optional<model::mutation::Overlay> GetOverlay(
       const LevelDbDocumentOverlayKey& decoded_key) const;

--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -21,10 +21,12 @@
 
 #include "Firestore/core/src/local/leveldb_util.h"
 #include "Firestore/core/src/model/mutation_batch.h"
+#include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/ordered_code.h"
 #include "absl/base/attributes.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
+#include "absl/types/optional.h"
 
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ResourcePath;
@@ -1445,6 +1447,15 @@ std::string LevelDbDocumentOverlayCollectionGroupIndexKey::Key(
   writer.WriteResourcePath(document_key.path());
   writer.WriteTerminator();
   return writer.result();
+}
+
+std::string LevelDbDocumentOverlayCollectionGroupIndexKey::Key(
+    const LevelDbDocumentOverlayKey& key) {
+  const absl::optional<std::string> collection_group =
+      key.document_key().GetCollectionId();
+  HARD_ASSERT(collection_group.has_value());
+  return Key(key.user_id(), collection_group.value(), key.largest_batch_id(),
+             key.document_key());
 }
 
 bool LevelDbDocumentOverlayCollectionGroupIndexKey::Decode(

--- a/Firestore/core/src/local/leveldb_key.h
+++ b/Firestore/core/src/local/leveldb_key.h
@@ -25,7 +25,6 @@
 #include "Firestore/core/src/model/resource_path.h"
 #include "Firestore/core/src/model/types.h"
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 #include "leveldb/slice.h"
 
 namespace firebase {
@@ -1190,15 +1189,7 @@ class LevelDbDocumentOverlayCollectionGroupIndexKey
   /**
    * Creates a complete key that points to a specific key in the overlays table.
    */
-  static absl::optional<std::string> Key(const LevelDbDocumentOverlayKey& key) {
-    const absl::optional<std::string> collection_group =
-        key.document_key().GetCollectionId();
-    if (!collection_group.has_value()) {
-      return absl::nullopt;
-    }
-    return Key(key.user_id(), collection_group.value(), key.largest_batch_id(),
-               key.document_key());
-  }
+  static std::string Key(const LevelDbDocumentOverlayKey& key);
 
   /**
    * Decodes the given complete key, storing the decoded values in this

--- a/Firestore/core/src/local/memory_document_overlay_cache.cc
+++ b/Firestore/core/src/local/memory_document_overlay_cache.cc
@@ -18,7 +18,6 @@
 
 #include <cstdlib>
 #include <map>
-#include <string>
 
 #include "Firestore/core/src/util/hard_assert.h"
 
@@ -91,7 +90,7 @@ MemoryDocumentOverlayCache::GetOverlays(const ResourcePath& collection,
 }
 
 DocumentOverlayCache::OverlayByDocumentKeyMap
-MemoryDocumentOverlayCache::GetOverlays(const std::string& collection_group,
+MemoryDocumentOverlayCache::GetOverlays(absl::string_view collection_group,
                                         int since_batch_id,
                                         std::size_t count) const {
   // NOTE: This method is only used by the backfiller, which will not run for

--- a/Firestore/core/src/local/memory_document_overlay_cache.h
+++ b/Firestore/core/src/local/memory_document_overlay_cache.h
@@ -17,7 +17,6 @@
 #ifndef FIRESTORE_CORE_SRC_LOCAL_MEMORY_DOCUMENT_OVERLAY_CACHE_H_
 #define FIRESTORE_CORE_SRC_LOCAL_MEMORY_DOCUMENT_OVERLAY_CACHE_H_
 
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -50,7 +49,7 @@ class MemoryDocumentOverlayCache final : public DocumentOverlayCache {
   OverlayByDocumentKeyMap GetOverlays(const model::ResourcePath& collection,
                                       int since_batch_id) const override;
 
-  OverlayByDocumentKeyMap GetOverlays(const std::string& collection_group,
+  OverlayByDocumentKeyMap GetOverlays(absl::string_view collection_group,
                                       int since_batch_id,
                                       std::size_t count) const override;
 

--- a/Firestore/core/src/model/document_key.cc
+++ b/Firestore/core/src/model/document_key.cc
@@ -107,9 +107,18 @@ const ResourcePath& DocumentKey::path() const {
 }
 
 /** Returns true if the document is in the specified collection_id. */
-bool DocumentKey::HasCollectionId(const std::string& collection_id) const {
-  size_t size = path().size();
-  return size >= 2 && path()[size - 2] == collection_id;
+bool DocumentKey::HasCollectionId(absl::string_view collection_id) const {
+  const auto collection_id_opt = GetCollectionId();
+  return collection_id_opt.has_value() &&
+         collection_id_opt.value() == collection_id;
+}
+
+absl::optional<std::string> DocumentKey::GetCollectionId() const {
+  const size_t size = path().size();
+  if (size < 2) {
+    return absl::nullopt;
+  }
+  return path()[size - 2];
 }
 
 size_t DocumentKeyHash::operator()(const DocumentKey& key) const {

--- a/Firestore/core/src/model/document_key.h
+++ b/Firestore/core/src/model/document_key.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 
 namespace firebase {
 namespace firestore {
@@ -82,7 +83,10 @@ class DocumentKey {
   const ResourcePath& path() const;
 
   /** Returns true if the document is in the specified collection_id. */
-  bool HasCollectionId(const std::string& collection_id) const;
+  bool HasCollectionId(absl::string_view collection_id) const;
+
+  /** Returns the collection_id, if this document key has one. */
+  absl::optional<std::string> GetCollectionId() const;
 
  private:
   // This is an optimization to make passing DocumentKey around cheaper (it's

--- a/Firestore/core/test/unit/local/leveldb_document_overlay_cache_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_document_overlay_cache_test.cc
@@ -47,6 +47,11 @@ class LevelDbDocumentOverlayCacheTestHelper final {
       const LevelDbDocumentOverlayCache& instance) {
     return instance.GetCollectionIndexEntryCount();
   }
+
+  static int GetCollectionGroupIndexEntryCount(
+      const LevelDbDocumentOverlayCache& instance) {
+    return instance.GetCollectionGroupIndexEntryCount();
+  }
 };
 
 namespace {
@@ -88,6 +93,12 @@ class LevelDbDocumentOverlayCacheTest : public DocumentOverlayCacheTestBase {
           LevelDbDocumentOverlayCacheTestHelper::GetCollectionIndexEntryCount(
               cache),
           expected_count);
+    }
+    {
+      SCOPED_TRACE("GetCollectionGroupIndexEntryCount");
+      EXPECT_EQ(LevelDbDocumentOverlayCacheTestHelper::
+                    GetCollectionGroupIndexEntryCount(cache),
+                expected_count);
     }
   }
 };

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -1171,16 +1171,6 @@ TEST(LevelDbDocumentOverlayCollectionGroupIndexKeyTest,
   EXPECT_EQ(decoded_key.document_key(), testutil::Key("coll/doc"));
 }
 
-TEST(LevelDbDocumentOverlayCollectionGroupIndexKeyTest,
-     FromLevelDbDocumentOverlayKey_KeyHasNoCollectionGroup) {
-  LevelDbDocumentOverlayKey key("test_user", DocumentKey(ResourcePath{}), 123);
-
-  const absl::optional<std::string> encoded_key =
-      LevelDbDocumentOverlayCollectionGroupIndexKey::Key(key);
-
-  ASSERT_FALSE(encoded_key.has_value());
-}
-
 #undef AssertExpectedKeyDescription
 
 }  // namespace local

--- a/Firestore/core/test/unit/local/leveldb_key_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_key_test.cc
@@ -1120,6 +1120,9 @@ TEST(LevelDbDocumentOverlayCollectionGroupIndexKeyTest, Ordering) {
 TEST(LevelDbDocumentOverlayCollectionGroupIndexKeyTest, EncodeDecodeCycle) {
   const std::vector<std::string> user_ids{"test_user", "foo/bar2",
                                           "foo-bar?baz!quux"};
+  // NOTE: These collection groups do not actually match the document keys used;
+  // however, that's okay here in this unit test because the LevelDb key itself
+  // doesn't care if they match.
   const std::vector<std::string> collection_groups{"group1", "group2"};
   const std::vector<model::BatchId> batch_ids{1, 2, 3};
   const std::vector<model::DocumentKey> document_keys{


### PR DESCRIPTION
The `LevelDbDocumentOverlayCache` class was added in In #9345, but with recognized performance issues. This PR improves the performance of `GetOverlays(absl::string_view)` from θ(N), where `N` is the total size of the table, to θ(m(log(m)), where `m` is the number of overlays returned.

A similar optimization was implemented for `GetOverlays(ResourcePath)` in #9401 and for `RemoveOverlaysForBatchId()` in #9386.

Googlers see b/210002758 for details.

#no-changelog