### PR TITLE
Move firestore::model::mutation::Overlay into its parent namespace

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -57,15 +57,14 @@
 		08E3D48B3651E4908D75B23A /* async_testing.cc in Sources */ = {isa = PBXBuildFile; fileRef = 872C92ABD71B12784A1C5520 /* async_testing.cc */; };
 		08F44F7DF9A3EF0D35C8FB57 /* FIRNumericTransformTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D5B25E7E7D6873CBA4571841 /* FIRNumericTransformTests.mm */; };
 		08FA4102AD14452E9587A1F2 /* leveldb_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */; };
-		095A878BB33211AB52BFAD9F /* leveldb_document_overlay_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AE89CFF09C6804573841397F /* leveldb_document_overlay_cache_test.cc */; };
 		0929C73B3F3BFC331E9E9D2F /* resource.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1C3F7302BF4AE6CBC00ECDD0 /* resource.pb.cc */; };
+		095A878BB33211AB52BFAD9F /* leveldb_document_overlay_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AE89CFF09C6804573841397F /* leveldb_document_overlay_cache_test.cc */; };
 		0963F6D7B0F9AE1E24B82866 /* path_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 403DBF6EFB541DFD01582AA3 /* path_test.cc */; };
 		096BA3A3703AC1491F281618 /* index.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 395E8B07639E69290A929695 /* index.pb.cc */; };
 		098191405BA24F9A7E4F80C6 /* append_only_list_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5477CDE922EE71C8000FCC1E /* append_only_list_test.cc */; };
 		0A4E1B5E3E853763AE6ED7AE /* grpc_stream_tester.cc in Sources */ = {isa = PBXBuildFile; fileRef = 87553338E42B8ECA05BA987E /* grpc_stream_tester.cc */; };
 		0A52B47C43B7602EE64F53A7 /* cc_compilation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B342370EAE3AA02393E33EB /* cc_compilation_test.cc */; };
 		0A6FBE65A7FE048BAD562A15 /* FSTGoogleTestTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 54764FAE1FAA21B90085E60A /* FSTGoogleTestTests.mm */; };
-		0AAC19331BDCCDAA02D22CCB /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		0ABCE06A0D96EA3899B3A259 /* query_engine_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B8A853940305237AFDA8050B /* query_engine_test.cc */; };
 		0AE084A7886BC11B8C305122 /* string_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380CFC201A2EE200D97691 /* string_util_test.cc */; };
 		0B002E2E2012B32EB801C6D5 /* bundle_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 79EAA9F7B1B9592B5F053923 /* bundle_spec_test.json */; };
@@ -171,6 +170,7 @@
 		1F4930A8366F74288121F627 /* create_noop_connectivity_monitor.cc in Sources */ = {isa = PBXBuildFile; fileRef = CF39535F2C41AB0006FA6C0E /* create_noop_connectivity_monitor.cc */; };
 		1F56F51EB6DF0951B1F4F85B /* lru_garbage_collector_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277EAACC4DD7C21332E8496A /* lru_garbage_collector_test.cc */; };
 		1F998DDECB54A66222CC66AA /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
+		2045517602D767BD01EA71D9 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		20814A477D00EA11D0E76631 /* FIRDocumentSnapshotTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E04B202154AA00B64F25 /* FIRDocumentSnapshotTests.mm */; };
 		20A26E9D0336F7F32A098D05 /* Pods_Firestore_IntegrationTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2220F583583EFC28DE792ABE /* Pods_Firestore_IntegrationTests_tvOS.framework */; };
 		21836C4D9D48F962E7A3A244 /* ordered_code_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380D03201BC6E400D97691 /* ordered_code_test.cc */; };
@@ -231,7 +231,6 @@
 		2D220B9ABFA36CD7AC43D0A7 /* time_testing.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5497CB76229DECDE000FB92F /* time_testing.cc */; };
 		2D65D31D71A75B046C47B0EB /* view_testing.cc in Sources */ = {isa = PBXBuildFile; fileRef = A5466E7809AD2871FFDE6C76 /* view_testing.cc */; };
 		2DB56B6DED2C93014AE5C51A /* write_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA12A51F315EE100DD57A1 /* write_spec_test.json */; };
-		2DCF3D3E60CE87C72683FD4F /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		2E0BBA7E627EB240BA11B0D0 /* exponential_backoff_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6D1B68420E2AB1A00B35856 /* exponential_backoff_test.cc */; };
 		2E169CF1E9E499F054BB873A /* FSTEventAccumulator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E0392021401F00B64F25 /* FSTEventAccumulator.mm */; };
 		2E373EA9D5FF8C6DE2507675 /* field_index_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = BF76A8DA34B5B67B4DD74666 /* field_index_test.cc */; };
@@ -329,7 +328,6 @@
 		44EAF3E6EAC0CC4EB2147D16 /* transform_operation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 33607A3AE91548BD219EC9C6 /* transform_operation_test.cc */; };
 		4562CDD90F5FF0491F07C5DA /* leveldb_opener_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 75860CD13AF47EB1EA39EC2F /* leveldb_opener_test.cc */; };
 		457171CE2510EEA46F7D8A30 /* FIRFirestoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5467FAFF203E56F8009C9584 /* FIRFirestoreTests.mm */; };
-		45927566F465117A79C5BB34 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		45939AFF906155EA27D281AB /* annotations.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9520B89AAC00B5BCE7 /* annotations.pb.cc */; };
 		45A5504D33D39C6F80302450 /* async_queue_libdispatch_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4680208EA0BE00554BA2 /* async_queue_libdispatch_test.mm */; };
 		45CECACC11031B4FA6A2F4E8 /* bundle_loader_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = A853C81A6A5A51C9D0389EDA /* bundle_loader_test.cc */; };
@@ -371,9 +369,11 @@
 		4CC78CA0E9E03F5DCF13FEBD /* Pods_Firestore_Tests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7DF4A6F740086A2D8C0E28E /* Pods_Firestore_Tests_tvOS.framework */; };
 		4CDFF1AE3D639AA89C5C4411 /* query_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 731541602214AFFA0037F4DC /* query_spec_test.json */; };
 		4D1775B7916D4CDAD1BF1876 /* bundle.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = A366F6AE1A5A77548485C091 /* bundle.pb.cc */; };
+		4D20563D846FA0F3BEBFDE9D /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		4D2655C5675D83205C3749DC /* fake_target_metadata_provider.cc in Sources */ = {isa = PBXBuildFile; fileRef = 71140E5D09C6E76F7C71B2FC /* fake_target_metadata_provider.cc */; };
 		4D42E5C756229C08560DD731 /* XCTestCase+Await.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E0372021401E00B64F25 /* XCTestCase+Await.mm */; };
 		4D6761FB02F4D915E466A985 /* datastore_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3167BD972EFF8EC636530E59 /* datastore_test.cc */; };
+		4D7900401B1BF3D3C24DDC7E /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		4D8367018652104A8803E8DB /* memory_index_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DB5A1E760451189DA36028B3 /* memory_index_manager_test.cc */; };
 		4D903ED7B7E4D38F988CD3F8 /* create_noop_connectivity_monitor.cc in Sources */ = {isa = PBXBuildFile; fileRef = CF39535F2C41AB0006FA6C0E /* create_noop_connectivity_monitor.cc */; };
 		4D98894EB5B3D778F5628456 /* grpc_stream_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6BBE42F21262CF400C6A53E /* grpc_stream_test.cc */; };
@@ -620,7 +620,6 @@
 		6369DE4E258556FE3382DD78 /* field_filter_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E8551D6C6FB0B1BACE9E5BAD /* field_filter_test.cc */; };
 		6380CACCF96A9B26900983DC /* leveldb_target_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E76F0CDF28E5FA62D21DE648 /* leveldb_target_cache_test.cc */; };
 		63B91FC476F3915A44F00796 /* query.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D621C2DDC800EFB9CC /* query.pb.cc */; };
-		64CA849415318C8B54DB8FD0 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		650B31A5EC6F8D2AEA79C350 /* index_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AE4A9E38D65688EE000EE2A1 /* index_manager_test.cc */; };
 		65537B22A73E3909666FB5BC /* remote_document_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 7EB299CF85034F09CFD6F3FD /* remote_document_cache_test.cc */; };
 		65D54B964A2021E5A36AB21F /* bundle_loader_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = A853C81A6A5A51C9D0389EDA /* bundle_loader_test.cc */; };
@@ -888,6 +887,7 @@
 		A4ECA8335000CBDF94586C94 /* FSTDatastoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E07E202154EC00B64F25 /* FSTDatastoreTests.mm */; };
 		A5175CA2E677E13CC5F23D72 /* document_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB6B908320322E4D00CC290A /* document_test.cc */; };
 		A55266E6C986251D283CE948 /* FIRCursorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E070202154D600B64F25 /* FIRCursorTests.mm */; };
+		A5583822218F9D5B1E86FCAC /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		A57EC303CD2D6AA4F4745551 /* FIRFieldValueTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E04A202154AA00B64F25 /* FIRFieldValueTests.mm */; };
 		A585BD0F31E90980B5F5FBCA /* local_serializer_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = F8043813A5D16963EC02B182 /* local_serializer_test.cc */; };
 		A5AB1815C45FFC762981E481 /* write.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D921C2DDC800EFB9CC /* write.pb.cc */; };
@@ -1029,6 +1029,7 @@
 		BDD2D1812BAD962E3C81A53F /* hashing_test_apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = B69CF3F02227386500B281C8 /* hashing_test_apple.mm */; };
 		BDDAE67000DBF10E9EA7FED0 /* nanopb_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6F5B6C1399F92FD60F2C582B /* nanopb_util_test.cc */; };
 		BDF3A6C121F2773BB3A347A7 /* counting_query_engine.cc in Sources */ = {isa = PBXBuildFile; fileRef = 99434327614FEFF7F7DC88EC /* counting_query_engine.cc */; };
+		BE1D7C7E413449AFFBA21BCB /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		BE767D2312D2BE84484309A0 /* event_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6F57521E161450FAF89075ED /* event_manager_test.cc */; };
 		BE92E16A9B9B7AD5EB072919 /* string_format_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */; };
 		BEE0294A23AB993E5DE0E946 /* leveldb_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */; };
@@ -1100,6 +1101,7 @@
 		D143FBD057481C1A59B27E5E /* persistence_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA12A31F315EE100DD57A1 /* persistence_spec_test.json */; };
 		D1690214781198276492442D /* event_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 6F57521E161450FAF89075ED /* event_manager_test.cc */; };
 		D18DBCE3FE34BF5F14CF8ABD /* mutation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = C8522DE226C467C54E6788D8 /* mutation_test.cc */; };
+		D1BCDAEACF6408200DFB9870 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */; };
 		D21060F8115A5F48FC3BF335 /* local_store_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 307FF03D0297024D59348EBD /* local_store_test.cc */; };
 		D22B96C19A0F3DE998D4320C /* delayed_constructor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */; };
 		D377FA653FB976FB474D748C /* remote_event_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 584AE2C37A55B408541A6FF3 /* remote_event_test.cc */; };
@@ -1136,7 +1138,6 @@
 		DA1D665B12AA1062DCDEA6BD /* async_queue_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB467B208E9A8200554BA2 /* async_queue_test.cc */; };
 		DA4303684707606318E1914D /* target_id_generator_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380CF82019382300D97691 /* target_id_generator_test.cc */; };
 		DABB9FB61B1733F985CBF713 /* executor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4688208F9B9100554BA2 /* executor_test.cc */; };
-		DAF19F9F1144CFFBBCB5C938 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		DAFF0CF921E64AC30062958F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DAFF0CF821E64AC30062958F /* AppDelegate.m */; };
 		DAFF0CFB21E64AC40062958F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DAFF0CFA21E64AC40062958F /* Assets.xcassets */; };
 		DAFF0CFE21E64AC40062958F /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DAFF0CFC21E64AC40062958F /* MainMenu.xib */; };
@@ -1281,7 +1282,6 @@
 		FABE084FA7DA6E216A41EE80 /* status_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352C20A3B3D7003E0143 /* status_test.cc */; };
 		FAD97B82766AEC29B7B5A1B7 /* index_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AE4A9E38D65688EE000EE2A1 /* index_manager_test.cc */; };
 		FAE5DA6ED3E1842DC21453EE /* fake_target_metadata_provider.cc in Sources */ = {isa = PBXBuildFile; fileRef = 71140E5D09C6E76F7C71B2FC /* fake_target_metadata_provider.cc */; };
-		FAF094D65A12935BEDED81C9 /* overlay_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DEB1D304BB728BB798719D98 /* overlay_test.cc */; };
 		FB2111D9205822CC8E7368C2 /* FIRDocumentReferenceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E049202154AA00B64F25 /* FIRDocumentReferenceTests.mm */; };
 		FB2D5208A6B5816A7244D77A /* query_engine_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B8A853940305237AFDA8050B /* query_engine_test.cc */; };
 		FB3D9E01547436163C456A3C /* message_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = CE37875365497FFA8687B745 /* message_test.cc */; };
@@ -1703,9 +1703,9 @@
 		DE51B1981F0D48AC0013853F /* FSTSpecTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FSTSpecTests.h; sourceTree = "<group>"; };
 		DE51B19A1F0D48AC0013853F /* FSTSyncEngineTestDriver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FSTSyncEngineTestDriver.h; sourceTree = "<group>"; };
 		DE51B1A71F0D48AC0013853F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		DEB1D304BB728BB798719D98 /* overlay_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = overlay_test.cc; path = mutation/overlay_test.cc; sourceTree = "<group>"; };
 		DF148C0D5EEC4A2CD9FA484C /* Pods-Firestore_Example_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_macOS/Pods-Firestore_Example_macOS.release.xcconfig"; sourceTree = "<group>"; };
 		DF445D5201750281F1817387 /* document_overlay_cache_test.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = document_overlay_cache_test.h; sourceTree = "<group>"; };
+		E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = overlay_test.cc; sourceTree = "<group>"; };
 		E3228F51DCDC2E90D5C58F97 /* ConditionalConformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConditionalConformanceTests.swift; sourceTree = "<group>"; };
 		E42355285B9EF55ABD785792 /* Pods_Firestore_Example_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E592181BFD7C53C305123739 /* Pods-Firestore_Tests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_iOS/Pods-Firestore_Tests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2379,7 +2379,6 @@
 		A673E8876DA382A08A72E007 /* mutation */ = {
 			isa = PBXGroup;
 			children = (
-				DEB1D304BB728BB798719D98 /* overlay_test.cc */,
 			);
 			name = mutation;
 			sourceTree = "<group>";
@@ -2429,6 +2428,7 @@
 				7515B47C92ABEEC66864B55C /* field_transform_test.cc */,
 				C8522DE226C467C54E6788D8 /* mutation_test.cc */,
 				214877F52A705012D6720CA0 /* object_value_test.cc */,
+				E1459FA70B8FC18DE4B80D0D /* overlay_test.cc */,
 				549CCA5520A36E1F00BCEB75 /* precondition_test.cc */,
 				B686F2B02024FFD70028D6BE /* resource_path_test.cc */,
 				ABA495B9202B7E79008A7851 /* snapshot_version_test.cc */,
@@ -3622,7 +3622,7 @@
 				87B5972F1C67CB8D53ADA024 /* object_value_test.cc in Sources */,
 				E08297B35E12106105F448EB /* ordered_code_benchmark.cc in Sources */,
 				72AD91671629697074F2545B /* ordered_code_test.cc in Sources */,
-				64CA849415318C8B54DB8FD0 /* overlay_test.cc in Sources */,
+				BE1D7C7E413449AFFBA21BCB /* overlay_test.cc in Sources */,
 				DB7E9C5A59CCCDDB7F0C238A /* path_test.cc in Sources */,
 				E30BF9E316316446371C956C /* persistence_testing.cc in Sources */,
 				0455FC6E2A281BD755FD933A /* precondition_test.cc in Sources */,
@@ -3819,7 +3819,7 @@
 				F0C8EB1F4FB56401CFA4F374 /* object_value_test.cc in Sources */,
 				B3C87C635527A2E57944B789 /* ordered_code_benchmark.cc in Sources */,
 				FD8EA96A604E837092ACA51D /* ordered_code_test.cc in Sources */,
-				DAF19F9F1144CFFBBCB5C938 /* overlay_test.cc in Sources */,
+				2045517602D767BD01EA71D9 /* overlay_test.cc in Sources */,
 				0963F6D7B0F9AE1E24B82866 /* path_test.cc in Sources */,
 				92D7081085679497DC112EDB /* persistence_testing.cc in Sources */,
 				152543FD706D5E8851C8DA92 /* precondition_test.cc in Sources */,
@@ -4030,7 +4030,7 @@
 				AFB2455806D7C4100C16713B /* object_value_test.cc in Sources */,
 				28691225046DF9DF181B3350 /* ordered_code_benchmark.cc in Sources */,
 				E4A573B7C9227C3C24661B5B /* ordered_code_test.cc in Sources */,
-				FAF094D65A12935BEDED81C9 /* overlay_test.cc in Sources */,
+				A5583822218F9D5B1E86FCAC /* overlay_test.cc in Sources */,
 				70A171FC43BE328767D1B243 /* path_test.cc in Sources */,
 				EECC1EC64CA963A8376FA55C /* persistence_testing.cc in Sources */,
 				34D69886DAD4A2029BFC5C63 /* precondition_test.cc in Sources */,
@@ -4241,7 +4241,7 @@
 				D711B3F495923680B6FC2FC6 /* object_value_test.cc in Sources */,
 				71702588BFBF5D3A670508E7 /* ordered_code_benchmark.cc in Sources */,
 				B4C675BE9030D5C7D19C4D19 /* ordered_code_test.cc in Sources */,
-				2DCF3D3E60CE87C72683FD4F /* overlay_test.cc in Sources */,
+				D1BCDAEACF6408200DFB9870 /* overlay_test.cc in Sources */,
 				B3A309CCF5D75A555C7196E1 /* path_test.cc in Sources */,
 				46EAC2828CD942F27834F497 /* persistence_testing.cc in Sources */,
 				9EE1447AA8E68DF98D0590FF /* precondition_test.cc in Sources */,
@@ -4448,7 +4448,7 @@
 				1EE2B61B15AAA7C864188A59 /* object_value_test.cc in Sources */,
 				3040FD156E1B7C92B0F2A70C /* ordered_code_benchmark.cc in Sources */,
 				AB380D04201BC6E400D97691 /* ordered_code_test.cc in Sources */,
-				45927566F465117A79C5BB34 /* overlay_test.cc in Sources */,
+				4D20563D846FA0F3BEBFDE9D /* overlay_test.cc in Sources */,
 				5A080105CCBFDB6BF3F3772D /* path_test.cc in Sources */,
 				21C17F15579341289AD01051 /* persistence_testing.cc in Sources */,
 				549CCA5920A36E1F00BCEB75 /* precondition_test.cc in Sources */,
@@ -4678,7 +4678,7 @@
 				DF7ABEB48A650117CBEBCD26 /* object_value_test.cc in Sources */,
 				4FAB27F13EA5D3D79E770EA2 /* ordered_code_benchmark.cc in Sources */,
 				21836C4D9D48F962E7A3A244 /* ordered_code_test.cc in Sources */,
-				0AAC19331BDCCDAA02D22CCB /* overlay_test.cc in Sources */,
+				4D7900401B1BF3D3C24DDC7E /* overlay_test.cc in Sources */,
 				6105A1365831B79A7DEEA4F3 /* path_test.cc in Sources */,
 				CB8BEF34CC4A996C7BE85119 /* persistence_testing.cc in Sources */,
 				4194B7BB8B0352E1AC5D69B9 /* precondition_test.cc in Sources */,

--- a/Firestore/core/src/local/document_overlay_cache.h
+++ b/Firestore/core/src/local/document_overlay_cache.h
@@ -23,7 +23,7 @@
 
 #include "Firestore/core/src/model/document_key.h"
 #include "Firestore/core/src/model/mutation.h"
-#include "Firestore/core/src/model/mutation/overlay.h"
+#include "Firestore/core/src/model/overlay.h"
 #include "Firestore/core/src/model/resource_path.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -46,9 +46,8 @@ class DocumentOverlayCacheTestHelper;
  */
 class DocumentOverlayCache {
  public:
-  using OverlayByDocumentKeyMap = std::unordered_map<model::DocumentKey,
-                                                     model::mutation::Overlay,
-                                                     model::DocumentKeyHash>;
+  using OverlayByDocumentKeyMap = std::
+      unordered_map<model::DocumentKey, model::Overlay, model::DocumentKeyHash>;
   using MutationByDocumentKeyMap = std::unordered_map<model::DocumentKey,
                                                       model::Mutation,
                                                       model::DocumentKeyHash>;
@@ -60,7 +59,7 @@ class DocumentOverlayCache {
    *
    * Returns an empty optional if there is no overlay for that key.
    */
-  virtual absl::optional<model::mutation::Overlay> GetOverlay(
+  virtual absl::optional<model::Overlay> GetOverlay(
       const model::DocumentKey& key) const = 0;
 
   /**

--- a/Firestore/core/src/local/leveldb_document_overlay_cache.cc
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.cc
@@ -39,9 +39,9 @@ namespace local {
 using credentials::User;
 using model::DocumentKey;
 using model::Mutation;
+using model::Overlay;
+using model::OverlayHash;
 using model::ResourcePath;
-using model::mutation::Overlay;
-using model::mutation::OverlayHash;
 using nanopb::Message;
 using nanopb::StringReader;
 

--- a/Firestore/core/src/local/leveldb_document_overlay_cache.h
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.h
@@ -84,9 +84,8 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
     kStop,
   };
 
-  model::Overlay ParseOverlay(
-      const LevelDbDocumentOverlayKey& key,
-      absl::string_view encoded_mutation) const;
+  model::Overlay ParseOverlay(const LevelDbDocumentOverlayKey& key,
+                              absl::string_view encoded_mutation) const;
 
   void SaveOverlay(int largest_batch_id,
                    const model::DocumentKey& document_key,

--- a/Firestore/core/src/local/leveldb_document_overlay_cache.h
+++ b/Firestore/core/src/local/leveldb_document_overlay_cache.h
@@ -52,7 +52,7 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
   LevelDbDocumentOverlayCache& operator=(LevelDbDocumentOverlayCache&&) =
       delete;
 
-  absl::optional<model::mutation::Overlay> GetOverlay(
+  absl::optional<model::Overlay> GetOverlay(
       const model::DocumentKey&) const override;
 
   void SaveOverlays(int largest_batch_id,
@@ -78,9 +78,8 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
   int GetOverlayCount() const override;
   int CountEntriesWithKeyPrefix(const std::string& key_prefix) const;
 
-  model::mutation::Overlay ParseOverlay(
-      const LevelDbDocumentOverlayKey& key,
-      absl::string_view encoded_mutation) const;
+  model::Overlay ParseOverlay(const LevelDbDocumentOverlayKey& key,
+                              absl::string_view encoded_mutation) const;
 
   void SaveOverlay(int largest_batch_id,
                    const model::DocumentKey& document_key,
@@ -103,7 +102,7 @@ class LevelDbDocumentOverlayCache final : public DocumentOverlayCache {
       int since_batch_id,
       std::function<void(LevelDbDocumentOverlayKey&&)>) const;
 
-  absl::optional<model::mutation::Overlay> GetOverlay(
+  absl::optional<model::Overlay> GetOverlay(
       const LevelDbDocumentOverlayKey& decoded_key) const;
 
   // The LevelDbDocumentOverlayCache instance is owned by LevelDbPersistence.

--- a/Firestore/core/src/local/local_serializer.cc
+++ b/Firestore/core/src/local/local_serializer.cc
@@ -35,7 +35,6 @@
 #include "Firestore/core/src/local/target_data.h"
 #include "Firestore/core/src/model/field_path.h"
 #include "Firestore/core/src/model/mutable_document.h"
-#include "Firestore/core/src/model/mutation/overlay.h"
 #include "Firestore/core/src/model/mutation_batch.h"
 #include "Firestore/core/src/model/snapshot_version.h"
 #include "Firestore/core/src/nanopb/byte_string.h"
@@ -64,7 +63,6 @@ using model::MutationBatch;
 using model::ObjectValue;
 using model::Segment;
 using model::SnapshotVersion;
-using model::mutation::Overlay;
 using nanopb::ByteString;
 using nanopb::CheckedSize;
 using nanopb::CopyBytesArray;

--- a/Firestore/core/src/local/memory_document_overlay_cache.cc
+++ b/Firestore/core/src/local/memory_document_overlay_cache.cc
@@ -29,8 +29,8 @@ namespace local {
 using model::DocumentKey;
 using model::DocumentKeyHash;
 using model::Mutation;
+using model::Overlay;
 using model::ResourcePath;
-using model::mutation::Overlay;
 
 absl::optional<Overlay> MemoryDocumentOverlayCache::GetOverlay(
     const DocumentKey& key) const {

--- a/Firestore/core/src/local/memory_document_overlay_cache.h
+++ b/Firestore/core/src/local/memory_document_overlay_cache.h
@@ -39,7 +39,7 @@ class MemoryDocumentOverlayCache final : public DocumentOverlayCache {
   MemoryDocumentOverlayCache(MemoryDocumentOverlayCache&&) = delete;
   MemoryDocumentOverlayCache& operator=(MemoryDocumentOverlayCache&&) = delete;
 
-  absl::optional<model::mutation::Overlay> GetOverlay(
+  absl::optional<model::Overlay> GetOverlay(
       const model::DocumentKey& key) const override;
 
   void SaveOverlays(int largest_batch_id,
@@ -56,7 +56,7 @@ class MemoryDocumentOverlayCache final : public DocumentOverlayCache {
 
  private:
   using OverlayByDocumentKeySortedMap =
-      immutable::SortedMap<model::DocumentKey, model::mutation::Overlay>;
+      immutable::SortedMap<model::DocumentKey, model::Overlay>;
   using DocumentKeySet =
       std::unordered_set<model::DocumentKey, model::DocumentKeyHash>;
   using DocumentKeysByBatchIdMap = std::unordered_map<int, DocumentKeySet>;

--- a/Firestore/core/src/model/model_fwd.h
+++ b/Firestore/core/src/model/model_fwd.h
@@ -58,12 +58,6 @@ class Message;
 
 namespace model {
 
-namespace mutation {
-
-class Overlay;
-
-}  // namespace mutation
-
 class DatabaseId;
 class DeleteMutation;
 class Document;
@@ -80,6 +74,7 @@ class MutationBatch;
 class MutationBatchResult;
 class MutationResult;
 class ObjectValue;
+class Overlay;
 class PatchMutation;
 class Precondition;
 class SetMutation;

--- a/Firestore/core/src/model/overlay.cc
+++ b/Firestore/core/src/model/overlay.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "Firestore/core/src/model/mutation/overlay.h"
+#include "Firestore/core/src/model/overlay.h"
 
 #include <iostream>
 
@@ -25,7 +25,6 @@
 namespace firebase {
 namespace firestore {
 namespace model {
-namespace mutation {
 
 bool operator==(const Overlay& lhs, const Overlay& rhs) {
   return lhs.largest_batch_id_ == rhs.largest_batch_id_ &&
@@ -53,7 +52,6 @@ std::size_t OverlayHash::operator()(const Overlay& overlay) const {
   return overlay.Hash();
 }
 
-}  // namespace mutation
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/model/overlay.h
+++ b/Firestore/core/src/model/overlay.h
@@ -28,7 +28,6 @@
 namespace firebase {
 namespace firestore {
 namespace model {
-namespace mutation {
 
 /**
  * Representation of an overlay computed by Firestore.
@@ -80,7 +79,6 @@ struct OverlayHash {
   std::size_t operator()(const Overlay&) const;
 };
 
-}  // namespace mutation
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/model/overlay.h
+++ b/Firestore/core/src/model/overlay.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef FIRESTORE_CORE_SRC_MODEL_MUTATION_OVERLAY_H_
-#define FIRESTORE_CORE_SRC_MODEL_MUTATION_OVERLAY_H_
+#ifndef FIRESTORE_CORE_SRC_MODEL_OVERLAY_H_
+#define FIRESTORE_CORE_SRC_MODEL_OVERLAY_H_
 
 #include <cstdlib>
 #include <iosfwd>
@@ -83,4 +83,4 @@ struct OverlayHash {
 }  // namespace firestore
 }  // namespace firebase
 
-#endif  // FIRESTORE_CORE_SRC_MODEL_MUTATION_OVERLAY_H_
+#endif  // FIRESTORE_CORE_SRC_MODEL_OVERLAY_H_

--- a/Firestore/core/test/unit/local/document_overlay_cache_test.cc
+++ b/Firestore/core/test/unit/local/document_overlay_cache_test.cc
@@ -42,8 +42,8 @@ namespace local {
 using credentials::User;
 using model::DocumentKey;
 using model::Mutation;
+using model::Overlay;
 using model::ResourcePath;
-using model::mutation::Overlay;
 using ::testing::UnorderedElementsAreArray;
 using testutil::DeleteMutation;
 using testutil::Map;

--- a/Firestore/core/test/unit/model/overlay_test.cc
+++ b/Firestore/core/test/unit/model/overlay_test.cc
@@ -19,7 +19,7 @@
 #include <utility>
 
 #include "Firestore/core/src/model/mutation.h"
-#include "Firestore/core/src/model/mutation/overlay.h"
+#include "Firestore/core/src/model/overlay.h"
 #include "Firestore/core/src/model/patch_mutation.h"
 #include "Firestore/core/src/model/resource_path.h"
 #include "Firestore/core/test/unit/testutil/equals_tester.h"
@@ -30,7 +30,6 @@
 namespace firebase {
 namespace firestore {
 namespace model {
-namespace mutation {
 namespace {
 
 using testing::EndsWith;
@@ -234,7 +233,6 @@ TEST(OverlayHashTest, OverlayHashTest) {
 }
 
 }  // namespace
-}  // namespace mutation
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase


### PR DESCRIPTION
The `Overlay` class was added in #9301, creating a new namespace `firestore::model::mutation`. This was done because the [`Overlay` class in the Android SDK](https://github.com/firebase/firebase-android-sdk/blob/d6df524d4ba800a5a3bd42162ce711093290053b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/Overlay.java) (from which it was ported) is in a similarly-named Java package. It turns out, however, that these two SDKs merely use different file/package/namespace layouts and the `Overlay` class should have been added into the existing namespace `firestore::model`. This PR moves the `Overlay` class into that correct location.

Googlers see b/210002758 for details.

#no-changelog