### PR TITLE
local_serializer.cc: fix lossy implicit conversion compiler warning

### DIFF
--- a/Firestore/core/src/local/local_serializer.cc
+++ b/Firestore/core/src/local/local_serializer.cc
@@ -499,9 +499,12 @@ LocalSerializer::EncodeFieldIndexSegments(
   result->query_scope =
       google_firestore_admin_v1_Index_QueryScope_COLLECTION_GROUP;
 
-  result->fields_count = segments.size();
+  // Explicitly cast the result of segments.size() to suppress compiler warnings
+  // about implicit conversion resulting in potential loss of precision.
+  const auto segments_size = static_cast<pb_size_t>(segments.size());
+  result->fields_count = segments_size;
   result->fields =
-      MakeArray<google_firestore_admin_v1_Index_IndexField>(segments.size());
+      MakeArray<google_firestore_admin_v1_Index_IndexField>(segments_size);
   int i = 0;
   for (const auto& segment : segments) {
     google_firestore_admin_v1_Index_IndexField field;


### PR DESCRIPTION
Fix the following warning in `local_serializer.cc`:

```
Implicit conversion loses integer precision: 'std::vector<firebase::firestore::model::Segment>::size_type' (aka 'unsigned long') to 'pb_size_t' (aka 'unsigned int')
```

The fix is to explicitly cast to suppress the compiler warning. There should NEVER be a case where the size of the vector is greater than 2**32, so, in practice, this will never be a lossy conversion.

Fixes #9430

#no-changelog