### PR TITLE
[Heartbeat Logging] Update FirebaseCore dependents for heartbeat logging changes

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -28,6 +28,8 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.cocoapods_version = '>= 1.4.0'
 
+  s.swift_version = '5.3'
+
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |ss|

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -35,6 +35,8 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 
+  s.swift_version = '5.3'
+
   base_dir = "FirebaseABTesting/Sources/"
   s.source_files = [
     base_dir + '**/*.[mh]',

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -17,6 +17,8 @@ iOS SDK for App Distribution for Firebase.
 
   s.ios.deployment_target = '10.0'
 
+  s.swift_version = '5.3'
+
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -24,6 +24,8 @@ supports email and password accounts, as well as several 3rd party authenticatio
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseAuthTestingSupport.podspec
+++ b/FirebaseAuthTestingSupport.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseCore/CMakeLists.txt
+++ b/FirebaseCore/CMakeLists.txt
@@ -21,6 +21,9 @@ include(GoogleUtilities)
 
 file(GLOB headers Sources/Private/*.h Sources/Public/FirebaseCore/*.h)
 file(GLOB sources Sources/*.m)
+# Exclude the `FIRHeartbeatLogger.m` since it depends on the Swift Heartbeat logging
+# library that is not configured to build for Cmake builds.
+list(FILTER sources EXCLUDE REGEX "FIRHeartbeatLogger.m")
 
 podspec_version(version ${PROJECT_SOURCE_DIR}/FirebaseCore.podspec)
 firebase_version(firebase_version ${PROJECT_SOURCE_DIR}/FirebaseCore.podspec)

--- a/FirebaseCore/CMakeLists.txt
+++ b/FirebaseCore/CMakeLists.txt
@@ -22,7 +22,7 @@ include(GoogleUtilities)
 file(GLOB headers Sources/Private/*.h Sources/Public/FirebaseCore/*.h)
 file(GLOB sources Sources/*.m)
 # Exclude the `FIRHeartbeatLogger.m` since it depends on the Swift Heartbeat logging
-# library that is not configured to build for Cmake builds.
+# library that is not configured to build for CMake builds.
 list(FILTER sources EXCLUDE REGEX "FIRHeartbeatLogger.m")
 
 podspec_version(version ${PROJECT_SOURCE_DIR}/FirebaseCore.podspec)

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -22,6 +22,8 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '7.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -18,6 +18,8 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.social_media_url = 'https://twitter.com/Firebase'
   s.ios.deployment_target = '10.0'
 
+  s.swift_version = '5.3'
+
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -20,6 +20,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
+  s.swift_version = '5.3'
+
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 

--- a/FirebaseFirestoreTestingSupport.podspec
+++ b/FirebaseFirestoreTestingSupport.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -23,6 +23,8 @@ Cloud Functions for Firebase.
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 
+  s.swift_version = '5.3'
+
   s.source_files = [
     'FirebaseFunctions/Sources/**/*',
     'Interop/Auth/Public/*.h',

--- a/FirebaseFunctionsTestingSupport.podspec
+++ b/FirebaseFunctionsTestingSupport.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -20,6 +20,8 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.deployment_target = '10.0'
   s.tvos.deployment_target = '10.0'
 
+  s.swift_version = '5.3'
+
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -25,6 +25,8 @@ device, and it is completely free.
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -20,6 +20,8 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   ios_deployment_target = '10.0'
   tvos_deployment_target = '10.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.tvos.deployment_target = tvos_deployment_target
 

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -23,6 +23,8 @@ app update.
   tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
+  s.swift_version = '5.3'
+
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -19,7 +19,7 @@ app update.
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.swift_version           = '5.0'
+  s.swift_version           = '5.3'
 
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'


### PR DESCRIPTION
I tripped CI in https://github.com/firebase/firebase-ios-sdk/pull/9373 to see what work needed to be done to get this ready for merging into `v9`.  

Here is some context:
1. Add a `swift_version` to all pods that depend on `FirebaseCore`. The FirebaseCore's podspec was changed to include the swift heartbeat code. Because of the presence of Swift in the spec source, CocoaPods will consider FirebaseCore to be a Swift pod. Swift pods should specify a `swift_version` to avoid a linting warning. [Example failure](https://github.com/firebase/firebase-ios-sdk/runs/5279145928?check_suite_focus=true#step:4:369) from #9373. 

   I've set the `swift_version` to `5.3`.
3. Firestore CI will build all of FirebaseCore via CMake. Currently, the Swift heartbeat code has not been configured to build via CMake.  We deemed this to be OK since customers won't use CMake to build Firestore and other Firebase SDKs (i.e. Games SDK) that use Firestore will build via CocoaPods on Apple platforms (see [Games SDK's CMake config for Firestore](https://github.com/firebase/firebase-unity-sdk/blob/main/firestore/CMakeLists.txt#L105-L117), and [C++ SDK's CMake config for Firestore](https://github.com/firebase/firebase-cpp-sdk/blob/main/firestore/CMakeLists.txt#L301-L318)).

#no-changelog