### PR TITLE
Renamed variable to avoid symbol resolution ambiguity with Xcode 12.4

### DIFF
--- a/Firestore/Swift/Source/Codable/DocumentSnapshot+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentSnapshot+ReadDecodable.swift
@@ -36,7 +36,7 @@ public extension DocumentSnapshot {
   func data<T: Decodable>(as type: T.Type,
                           with serverTimestampBehavior: ServerTimestampBehavior = .none,
                           decoder: Firestore.Decoder = .init()) throws -> T {
-    let data: Any = data(with: serverTimestampBehavior) ?? NSNull()
-    return try decoder.decode(T.self, from: data, in: reference)
+    let d: Any = data(with: serverTimestampBehavior) ?? NSNull()
+    return try decoder.decode(T.self, from: d, in: reference)
   }
 }


### PR DESCRIPTION
Fix #9437 by renaming a variable to avoid symbol resolution ambiguity on Xcode 12.4 (and perhaps other versions too).
