### PR TITLE
Record the size of the request bytes for POST/PUT URL Requests

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Pending
+* [fixed] Record the request payload size for POST/PUT requests.
+
 # Version 8.13.0
 * [fixed] Make pre-warming identification more reliable by moving the pre-warm check to the earliest phase of app start.
 

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -199,6 +199,10 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
     self.backgroundActivityTracker = [[FPRTraceBackgroundActivityTracker alloc] init];
     [self checkpointState:FPRNetworkTraceCheckpointStateInitiated];
 
+    if ([self.URLRequest.HTTPMethod isEqualToString:@"POST"] ||
+        [self.URLRequest.HTTPMethod isEqualToString:@"PUT"]) {
+      self.requestSize = self.URLRequest.HTTPBody.length;
+    }
     FPRSessionManager *sessionManager = [FPRSessionManager sharedInstance];
     [self updateTraceWithCurrentSession:[sessionManager.sessionDetails copy]];
     [sessionManager.sessionNotificationCenter addObserver:self

--- a/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
@@ -584,6 +584,31 @@
   [instrument deregisterInstrumentors];
 }
 
+/** Tests that dataTaskWithRequest:completionHandler: for a POST request returns a non-nil object and collects request size. */
+- (void)testDataTaskWithPostRequestAndCompletionHandler {
+  FPRNSURLSessionInstrument *instrument = [[FPRNSURLSessionInstrument alloc] init];
+  [instrument registerInstrumentors];
+  NSURLSession *session = [NSURLSession sharedSession];
+  NSURL *URL = [self.testServer.serverURL URLByAppendingPathComponent:@"test"];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
+  request.HTTPMethod = @"POST";
+  request.HTTPBody = [@"sampleData" dataUsingEncoding:NSUTF8StringEncoding];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completionHandler called"];
+  
+  void (^completionHandler)(NSData *_Nullable, NSURLResponse *_Nullable, NSError *_Nullable) =
+      ^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
+        [expectation fulfill];
+      };
+  NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                              completionHandler:completionHandler];
+  XCTAssertNotNil(dataTask);
+  [dataTask resume];
+  FPRNetworkTrace *trace = [FPRNetworkTrace networkTraceFromObject:dataTask];
+  XCTAssertEqual(trace.requestSize, 10);
+  [self waitForExpectationsWithTimeout:10.0 handler:nil];
+  [instrument deregisterInstrumentors];
+}
+
 /** Tests that dataTaskWithUrl:completionHandler: returns a non-nil object. */
 - (void)testDataTaskWithUrlAndCompletionHandler {
   FPRNSURLSessionInstrument *instrument = [[FPRNSURLSessionInstrument alloc] init];


### PR DESCRIPTION
Currently we record only the request bytes only for upload requests. But there could be request bytes even for non-upload requests (POST/PUT). This change would start recording the request payload bytes for POST and PUT requests for dataTask requests.