### PR TITLE
Updated to the Swift dashboard

### DIFF
--- a/SwiftDashboard.md
+++ b/SwiftDashboard.md
@@ -9,15 +9,15 @@ tasks for additional Swift improvements.
 
 |                       | An     | ApC    | ApD    | Aut    | Cor    | Crs    | DB     | DL     | Fst    | Fn     | IAM    | Ins    | Msg    | MLM    | Prf    | RC     |    Str |
 |   :---                | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: |
-| **Swift Library**     |   ✔    | ❌     |❌     | ❌     | n/a     | ❌      |  ✔     | ❌     |  ✔    | ✔      |  ✔     | ❌    | ❌     | ✔      | ❌        |  ✔        | ✔     |
-| **API Tests**         |  ❌    |  ✔     |❌     | ✔      | ✔       | ❌     | 3      | ❌      | 2     |  ✔     | 2      | ✔      | ✔     | 2      | ❌        |  ✔      | ✔    |
-| **async/await**       |  ✔    |  ✔      |✔     | ✔      |  ✔      | ✔      | 3     | ❌      |  ✔     |  ✔     | ✔      | ✔     | ✔        | ❌      | ✔      |  ✔     | ✔    |
-| **Swift Errors**      |  ✔    | ❌     |❌     | 4      | ✔       | ❌      | ❌      | ❌     | ❌    | ❌     | ❌     | ❌      | ❌     | ✔      | ✔     |  ❌   | 5   |
-| **Codable**           |  n/a   | n/a   |n/a    | n/a     | n/a    |n/a     |  ✔     | n/a    |  ✔     | ✔      | n/a    | n/a   | n/a     | n/a    | n/a    |   ✔  |n/a   |
-| **SwiftUI Lifecycle** |  ❌    | n/a    | n/a   | ❌     | n/a    |n/a     | n/a     | ❌    | n/a    | n/a     | n/a    | n/a    | ❌     | n/a    | ❌     | n/a   |n/a  |
-| **SwiftUI Interop**   |   ✔    | n/a    | ❌    | ❌     | n/a     |❌      | ❌      | n/a    | ✔     | n/a     | ✔      | n/a   | n/a     | n/a    | ❌     | n/a   |n/a  |
-| **Property Wrappers** |  ❌    | ❌     |❌     | ❌     | ❌     | ❌     | ❌      | ❌     | 6     | ❌     | ❌     | ❌    | ❌     | ❌    | ❌     | ❌   |❌    |
-| **Swift Doc Scrub**   |  ❌    | ❌     |❌     | ❌     | ✔      | ✔     | ❌      | ❌     |  ❌   | ❌     | ❌     | ❌    | ❌     | ❌    | ❌     | ❌   |❌    |
+| **Swift Library**     |   ✔    | ❌     |❌      | ❌     | n/a   | ❌     |  ✔     | ❌     |  ✔     | ✔      |  ✔     | ❌    | ❌     | ✔      | ❌     |  ✔     | ✔      |
+| **API Tests**         |  ❌    |  ✔     |❌      | ✔      | ✔     | ❌     | 3      | ❌     | 2      |  ✔     | 2      | ✔      | ✔      | 2      | ❌     |  ✔     | ✔      |
+| **async/await**       |  ✔     |  ✔     |✔       | ✔       |  ✔    | ✔      | 3      | ❌     |  ✔     |  ✔     | ✔      | ✔      | ✔      | ❌     | ✔      |  ✔     | ✔      |
+| **Swift Errors**      |  ✔     | ❌     |❌      | 4      | ✔     | ❌     | ❌     | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ✔      | ✔      |  ❌    | 5     |
+| **Codable**           |  n/a   | n/a    | n/a    | n/a    | n/a    | n/a    |  ✔     | n/a    |  ✔     | ✔      | n/a    | n/a    | n/a    | n/a    | n/a    |   ✔    | n/a    |
+| **SwiftUI Lifecycle** |  ❌    | n/a    | n/a    | ❌    | n/a    | n/a    | n/a    | ❌     | n/a    | n/a    | n/a    | n/a    | ❌     | n/a    | ❌     | n/a    | n/a    |
+| **SwiftUI Interop**   |   ✔    | n/a    | ❌     | ❌    | n/a    | ❌     | ❌     | n/a    | ✔      | n/a    | ✔      | n/a    | n/a    | n/a    | ❌     | n/a    | n/a    |
+| **Property Wrappers** |  ❌    | ❌     |❌     | ❌     | ❌    | ❌     | ❌     | ❌     | 6      | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ❌    | ❌     |
+| **Swift Doc Scrub**   |  ❌    | ❌     |❌     | ❌     | ✔     | ✔      | ❌      | ❌    |  ❌    | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ❌    | ❌     |
 
 ### Other Projects
 - Tooling to surface full list of automatically generated Swift API from Objective C and validate.

--- a/SwiftDashboard.md
+++ b/SwiftDashboard.md
@@ -7,17 +7,17 @@ to help prioritize any particular cell(s).
 This dashboard is intended to track an initial full Swift review of Firebase along with addressing low-hanging fruit. We would expect it to identify additional follow up
 tasks for additional Swift improvements.
 
-|                       | An     | ApC    | ApD    | Aut    | Cor    | Crs    | DB     | DL     | Fst    | Fn     | IAM    | Ins    | Msg    | MLM    | Prf    | RC     |    Str |
-|   :---                | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: |
-| **Swift Library**     |   ✔    | ❌     |❌      | ❌     | n/a   | ❌     |  ✔     | ❌     |  ✔     | ✔      |  ✔     | ❌    | ❌     | ✔      | ❌     |  ✔     | ✔      |
-| **API Tests**         |  ❌    |  ✔     |❌      | ✔      | ✔     | ❌     | 3      | ❌     | 2      |  ✔     | 2      | ✔      | ✔      | 2      | ❌     |  ✔     | ✔      |
-| **async/await**       |  ✔     |  ✔     |✔       | ✔       |  ✔    | ✔      | 3      | ❌     |  ✔     |  ✔     | ✔      | ✔      | ✔      | ❌     | ✔      |  ✔     | ✔      |
-| **Swift Errors**      |  ✔     | ❌     |❌      | 4      | ✔     | ❌     | ❌     | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ✔      | ✔      |  ❌    | 5     |
-| **Codable**           |  n/a   | n/a    | n/a    | n/a    | n/a    | n/a    |  ✔     | n/a    |  ✔     | ✔      | n/a    | n/a    | n/a    | n/a    | n/a    |   ✔    | n/a    |
-| **SwiftUI Lifecycle** |  ❌    | n/a    | n/a    | ❌    | n/a    | n/a    | n/a    | ❌     | n/a    | n/a    | n/a    | n/a    | ❌     | n/a    | ❌     | n/a    | n/a    |
-| **SwiftUI Interop**   |   ✔    | n/a    | ❌     | ❌    | n/a    | ❌     | ❌     | n/a    | ✔      | n/a    | ✔      | n/a    | n/a    | n/a    | ❌     | n/a    | n/a    |
-| **Property Wrappers** |  ❌    | ❌     |❌     | ❌     | ❌    | ❌     | ❌     | ❌     | 6      | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ❌    | ❌     |
-| **Swift Doc Scrub**   |  ❌    | ❌     |❌     | ❌     | ✔     | ✔      | ❌      | ❌    |  ❌    | ❌     | ❌     | ❌    | ❌     | ❌     | ❌     | ❌    | ❌     |
+|                       | An    | ApC   | ApD   | Aut   | Cor   | Crs   | DB    | DL    | Fst   | Fn    | IAM   | Ins   | Msg   | MLM   | Prf   | RC    | Str   |
+|   :---                | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Swift Library**     |   ✔   | ❌    |❌     | ❌   | n/a   | ❌    |  ✔    | ❌    |  ✔    | ✔     |  ✔    | ❌   | ❌    | ✔     | ❌    |  ✔    | ✔     |
+| **API Tests**         |  ❌   |  ✔    |❌     | ✔     | ✔    | ❌    | 3     | ❌    | 2     |  ✔    | 2     | ✔     | ✔     | 2     | ❌    |  ✔    | ✔     |
+| **async/await**       |  ✔    |  ✔    | ✔     | ✔     |  ✔    | ✔     | 3     | ❌    |  ✔    |  ✔    | ✔     | ✔     | ✔     | ❌    | ✔     |  ✔    | ✔    |
+| **Swift Errors**      |  ✔    | ❌    |❌     | 4     | ✔    | ❌    | ❌    | ❌    | ❌    | ❌   | ❌    | ❌    | ❌    | ✔     | ✔     |  ❌   | 5    |
+| **Codable**           |  n/a  | n/a   | n/a   | n/a   | n/a   | n/a   |  ✔    | n/a   |  ✔    | ✔     | n/a   | n/a   | n/a   | n/a   | n/a   |   ✔   | n/a   |
+| **SwiftUI Lifecycle** |  ❌   | n/a   | n/a   | ❌   | n/a   | n/a   | n/a   | ❌    | n/a   | n/a   | n/a   | n/a   | ❌    | n/a   | ❌    | n/a   | n/a   |
+| **SwiftUI Interop**   |   ✔   | n/a   | ❌    | ❌   | n/a   | ❌    | ❌    | n/a   | ✔     | n/a   | ✔     | n/a   | n/a   | n/a   | ❌    | n/a   | n/a   |
+| **Property Wrappers** |  n/a  | n/a   | n/a   | ❌    | n/a  | n/a   | ❌    | n/a   | 6     | n/a   | n/a   | n/a   | n/a   | n/a   | n/a    | ❌   | n/a   |
+| **Swift Doc Scrub**   |  ❌   | ❌    |❌    | ❌    | ✔     | ✔     | ❌    | ❌   |  ❌   | ❌    | ❌    | ❌   | ❌    | ✔     | ❌    | ❌   | ❌    |
 
 ### Other Projects
 - Tooling to surface full list of automatically generated Swift API from Objective C and validate.


### PR DESCRIPTION
Reduced the amount of whitespace and tried better alignment for
plaintext editing.

Moved the following products property wrappers to n/a:
- Analytics
- AppCheck
- AppDistro
- Core
- Crashlytics
- FDL
- Functions
- FIAM
- Installations
- Mssaging
- MLModelDownloader
- Perf
- Storage

Docs scrub marked as complete for MLModelDownloader (that's it
unfortunately)