### PR TITLE
Add white background to drawings for improved dark mode readability

### DIFF
--- a/docs/resources/firebase_from_dynamic_framework.svg
+++ b/docs/resources/firebase_from_dynamic_framework.svg
@@ -50,6 +50,7 @@
      inkscape:document-rotation="0"
      bordercolor="#666666"
      pagecolor="#ffffff" />
+  <rect width="100%" height="100%" fill="white" />
   <clipPath
      id="p.0">
     <path

--- a/docs/resources/firebase_from_static_framework.svg
+++ b/docs/resources/firebase_from_static_framework.svg
@@ -50,6 +50,7 @@
      inkscape:document-rotation="0"
      bordercolor="#666666"
      pagecolor="#ffffff" />
+  <rect width="100%" height="100%" fill="white" />
   <clipPath
      id="p.0">
     <path


### PR DESCRIPTION
Use the ![Display Rich Diff](https://user-images.githubusercontent.com/1097316/159016089-1ebf22a3-b97a-49d0-9c2d-1dd4519e7736.png) button for a visual difference.

## The existing dark mode view:
![Existing dark mode view](https://user-images.githubusercontent.com/1097316/159016209-be23c228-bec7-436f-b02f-dad4e7c29d8f.png)

## The new dark mode view:
![New dark mode view](https://user-images.githubusercontent.com/1097316/159016512-940253bc-38f2-4192-b470-6bd9043c4b8d.png)

Light mode is unaffected.
