### PR TITLE
Fix cmake build for macOS 12.3 where `python` no longer exists.

### DIFF
--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(FindPythonInterp)
+
 # Generate output in-place. So long as the build is idempotent this helps
 # verify that the protoc-generated output isn't changing.
 set(OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -197,7 +199,7 @@ if(FIREBASE_IOS_PROTOC_GENERATE_SOURCES)
     COMMENT "Generating nanopb sources"
     OUTPUT ${NANOPB_GENERATED_SOURCES}
     COMMAND
-      python
+      ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/build_protos.py
         --nanopb
         --protoc=$<TARGET_FILE:protoc>
@@ -229,7 +231,7 @@ if(FIREBASE_IOS_PROTOC_GENERATE_SOURCES)
     COMMENT "Generating C++ protobuf sources"
     OUTPUT ${PROTOBUF_CPP_GENERATED_SOURCES}
     COMMAND
-      python
+      ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/build_protos.py
         --cpp
         --protoc=$<TARGET_FILE:protoc>

--- a/Firestore/Protos/build_protos.py
+++ b/Firestore/Protos/build_protos.py
@@ -120,7 +120,7 @@ def CppGeneratorScriptTweaked(path):
   would possibly break some builds too.
   """
   # Read the script into memory.
-  with io.open(path, "rt", encoding="utf8") as f:
+  with io.open(path, 'rt', encoding='utf8') as f:
     lines = [line for line in f]
 
   # Verify that the read file looks like the right one.
@@ -136,7 +136,7 @@ def CppGeneratorScriptTweaked(path):
 
   try:
     # Write the lines of the tweaked script to the temporary file.
-    with io.open(temp_path, "wt", encoding="utf8") as f:
+    with io.open(temp_path, 'wt', encoding='utf8') as f:
       f.writelines(lines)
 
     # Make sure that the temporary file is executable.

--- a/Firestore/Protos/build_protos.py
+++ b/Firestore/Protos/build_protos.py
@@ -124,11 +124,11 @@ def CppGeneratorScriptTweaked(path):
     lines = [line for line in f]
 
   # Verify that the read file looks like the right one.
-  if lines[0] != '#!/usr/bin/env python\n':
+  if lines[0] != u'#!/usr/bin/env python\n':
     raise RuntimeError('unexpected first line of ' + path + ': ' + lines[0])
 
   # Replace the shebang line with a custom one.
-  lines[0] = '#!' + sys.executable + '\n'
+  lines[0] = u'#!' + sys.executable + u'\n'
 
   # Create a temporary file to which to write the tweaked script.
   (handle, temp_path) = tempfile.mkstemp('.py', dir=os.path.dirname(path))

--- a/Firestore/core/CMakeLists.txt
+++ b/Firestore/core/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 include(CheckSymbolExists)
 include(CheckIncludeFiles)
+include(FindPythonInterp)
 
 
 ## firestore_util
@@ -285,7 +286,7 @@ add_custom_command(
   OUTPUT
   ${GRPC_ROOT_CERTIFICATE_SOURCES}
   COMMAND
-  python ${FIREBASE_SOURCE_DIR}/scripts/binary_to_array.py
+  ${PYTHON_EXECUTABLE} ${FIREBASE_SOURCE_DIR}/scripts/binary_to_array.py
   --output_header=${OUTPUT_DIR}/grpc_root_certificates_generated.h
   --output_source=${OUTPUT_DIR}/grpc_root_certificates_generated.cc
   --cpp_namespace=firebase::firestore::remote


### PR DESCRIPTION
#no-changelog