### PR TITLE
Swiftify symbol name for Swift

### DIFF
--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v9.0.0 -- M115
+- [fixed] Swift-only: Updated symbol name kFirebaseInstallationsErrorDomain to
+  InstallationsErrorDomain. (#9275)
+
 # v8.4.0 -- M100
 - [fixed] Bump Promises dependency. (#8365)
 

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
@@ -24,8 +24,7 @@
 #import "FBLPromises.h"
 #endif
 
-NSString *const kFirebaseInstallationsErrorDomain NS_SWIFT_NAME(InstallationsErrorDomain) =
-                                                                    @"com.firebase.installations";
+NSString *const kFirebaseInstallationsErrorDomain = @"com.firebase.installations";
 
 void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
   if (pointer != NULL) {

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const kFirebaseInstallationsErrorDomain;
+extern NSString *const kFirebaseInstallationsErrorDomain NS_SWIFT_NAME(InstallationsErrorDomain);
 
 typedef NS_ENUM(NSUInteger, FIRInstallationsErrorCode) {
   /** Unknown error. See `userInfo` for details. */

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -155,5 +155,9 @@ final class InstallationsAPITests {
         }
       }
     }
+    func globalStringSymbols() {
+      let _ : String = InstallationIDDidChangeAppNameKey
+      let _ : String = InstallationsErrorDomain
+    }
   }
 }

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -156,8 +156,8 @@ final class InstallationsAPITests {
       }
     }
     func globalStringSymbols() {
-      let _ : String = InstallationIDDidChangeAppNameKey
-      let _ : String = InstallationsErrorDomain
+      let _: String = InstallationIDDidChangeAppNameKey
+      let _: String = InstallationsErrorDomain
     }
   }
 }


### PR DESCRIPTION
Followup to #9395 to fix #9275.  

- NS_SWIFT_NAME in header instead of .m
- Add a test
- Release note 