### PR TITLE
Include ToString() in Firestore's Query::Comparator() assertion failure message

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Add more details to the assertion failure in Query::Comparator() to
+  help with future debugging (#9258).
+
 # v8.14.0
 - [fixed] Fixed compiler warnings in `local_serializer.cc` about "implicit
   conversion loses integer precision" that were introduced in 8.13.0 (#9430).

--- a/Firestore/core/src/core/query.cc
+++ b/Firestore/core/src/core/query.cc
@@ -279,8 +279,10 @@ model::DocumentComparator Query::Comparator() const {
       break;
     }
   }
-  HARD_ASSERT(has_key_ordering,
-              "QueryComparator needs to have a key ordering.");
+
+  if (!has_key_ordering) {
+    HARD_FAIL("QueryComparator needs to have a key ordering: %s", ToString());
+  }
 
   return DocumentComparator(
       [ordering](const Document& doc1, const Document& doc2) {


### PR DESCRIPTION
Improve the assertion failure message in `Query::Comparator()` to also include the result of calling `ToString()`. This may help find the root cause of https://github.com/firebase/firebase-ios-sdk/issues/9258.