### PR TITLE
CI fixes for Firestore shared Codable

### DIFF
--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -33,6 +33,7 @@ target 'FirebasePodTest' do
 
   # Get dependent pods from the repo also
   pod 'FirebaseCoreDiagnostics', :path => '../../../'
+  pod 'FirebaseSharedSwift', :path => '../../../'
 
   pod 'FirebaseAnalytics' # Analytics is not open source
 end

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -115,6 +115,7 @@ if is_platform(:ios)
     target 'Firestore_IntegrationTests_iOS' do
       inherit! :search_paths
 
+      pod 'FirebaseSharedSwift', :path => '../../'
       pod 'FirebaseFirestoreSwift', :path => '../../'
       pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
       pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
@@ -151,6 +152,7 @@ if is_platform(:osx)
     target 'Firestore_IntegrationTests_macOS' do
       inherit! :search_paths
 
+      pod 'FirebaseSharedSwift', :path => '../../'
       pod 'FirebaseFirestoreSwift', :path => '../../'
       pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
       pod 'GoogleTest', :podspec => 'GoogleTest.podspec'


### PR DESCRIPTION
Fix the CI issues in #9465 

Without these changes, Xcode tries to use the master version of FirebaseSharedSwift to build FirebaseFirestoreSwift.