### PR TITLE
[Infra] Add GHA behavior where old workflows are cancelled when new commit is pushed to a PR

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -16,7 +16,6 @@ concurrency:
     cancel-in-progress: ${{ !contains(github.event.head_commit.message, 'keep ci') }}
 
 jobs:
-
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -11,6 +11,10 @@ on:
     # Run every day at 1am(PST) - cron uses UTC times
     - cron: '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: ${{ !contains(github.event.head_commit.message, 'keep ci') }}
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: ${{ !contains(github.event.head_commit.message, '[keep ci]') }}
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: ${{ !contains(github.event.head_commit.message, '[keep ci]') }}
+    cancel-in-progress: ${{ !contains(github.event.head_commit.message, 'keep ci') }}
 
 jobs:
 

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -16,6 +16,7 @@ concurrency:
     cancel-in-progress: ${{ !contains(github.event.head_commit.message, '[keep ci]') }}
 
 jobs:
+
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -12,6 +12,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron: '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/app_check.yml
+++ b/.github/workflows/app_check.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod_lib_lint:

--- a/.github/workflows/app_check.yml
+++ b/.github/workflows/app_check.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod_lib_lint:

--- a/.github/workflows/app_check.yml
+++ b/.github/workflows/app_check.yml
@@ -9,6 +9,10 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod_lib_lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron: '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   # Archive tests for pods that support iOS only.

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   # Archive tests for pods that support iOS only.

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -9,6 +9,10 @@ on:
     # This is set to 3 hours after zip workflow finishes so zip testing can run after.
     - cron:  '0 10 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   # Archive tests for pods that support iOS only.
   pods-ios-only-cron:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -11,6 +11,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron:  '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pod-lib-lint:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: master
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   check:
     # Don't run on private repo.

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   tests:

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 2am (PST) - cron uses UTC times
     - cron:  '0 10 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   tests:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   tests:

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -44,7 +44,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   xcodebuild:

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -44,7 +44,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   xcodebuild:

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -42,6 +42,10 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   xcodebuild:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/core-diagnostics.yml
+++ b/.github/workflows/core-diagnostics.yml
@@ -12,6 +12,10 @@ on:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/core-diagnostics.yml
+++ b/.github/workflows/core-diagnostics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/core-diagnostics.yml
+++ b/.github/workflows/core-diagnostics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -11,6 +11,10 @@ on:
     # Run every day at 2am (PST) - cron uses UTC times
     - cron:  '0 10 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -12,6 +12,10 @@ on:
     # Run every day at 10am (PST) - cron uses UTC times
     - cron:  '0 2 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pod-lib-lint:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,6 +3,10 @@ name: danger
 on:
   pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   danger:
     runs-on: macos-11

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   danger:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   danger:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -15,6 +15,10 @@ on:
     # Run every day at 2am (PST) - cron uses UTC times
     - cron:  '0 10 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   unit:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   unit:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   unit:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod_lib_lint:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod_lib_lint:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -11,6 +11,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron:  '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod_lib_lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   installation-test:

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -13,6 +13,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron:  '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   installation-test:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   installation-test:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -59,6 +59,10 @@ on:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   check:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -61,7 +61,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   check:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -61,7 +61,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -17,6 +17,10 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron:  '0 9 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pod-lib-lint:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -8,11 +8,6 @@ on:
   schedule:
     # Run every day at 5am (PST) - cron uses UTC times
     - cron:  '0 13 * * *'
-
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
-
 jobs:
   generate_an_issue:
     # Don't run on private repo.

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   generate_an_issue:

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     # Run every day at 5am (PST) - cron uses UTC times
     - cron:  '0 13 * * *'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   generate_an_issue:
     # Don't run on private repo.

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   generate_an_issue:

--- a/.github/workflows/google-utilities-components.yml
+++ b/.github/workflows/google-utilities-components.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/google-utilities-components.yml
+++ b/.github/workflows/google-utilities-components.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/google-utilities-components.yml
+++ b/.github/workflows/google-utilities-components.yml
@@ -10,6 +10,11 @@ on:
     # Run every day at 10pm (PST) - cron uses UTC times
     - cron:  '0 6 * * *'
 
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -10,6 +10,11 @@ on:
 env:
   METRICS_SERVICE_SECRET: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   # Check all the modified SDKs, the flags will be true if changed files match patterns in the file
   # scripts/health_metrics/file_patterns.json

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -12,7 +12,7 @@ env:
 
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -20,9 +20,6 @@ jobs:
   # scripts/health_metrics/file_patterns.json
   check:
     if: github.repository == 'Firebase/firebase-ios-sdk' && (github.event.action == 'opened' || github.event.action == 'synchronize')
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     name: Check changed files
     outputs:
       abtesting_run_job: ${{ steps.check_files.outputs.abtesting_run_job }}
@@ -66,9 +63,6 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - name: Access to Metrics Service
@@ -116,9 +110,6 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
@@ -141,9 +132,6 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
@@ -163,9 +151,6 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
@@ -188,9 +173,6 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -12,7 +12,7 @@ env:
 
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -20,6 +20,9 @@ jobs:
   # scripts/health_metrics/file_patterns.json
   check:
     if: github.repository == 'Firebase/firebase-ios-sdk' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     name: Check changed files
     outputs:
       abtesting_run_job: ${{ steps.check_files.outputs.abtesting_run_job }}
@@ -63,6 +66,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - name: Access to Metrics Service
@@ -110,6 +116,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
@@ -132,6 +141,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
@@ -151,6 +163,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
@@ -173,6 +188,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
     steps:
     - uses: actions/checkout@v2
     - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -13,7 +13,7 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   # Check all the modified SDKs, the flags will be true if changed files match patterns in the file

--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -13,7 +13,7 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   # Check all the modified SDKs, the flags will be true if changed files match patterns in the file

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -7,6 +7,11 @@ on:
 env:
   gpg_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   release-diffing:
     runs-on: ubuntu-latest

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -10,7 +10,7 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   release-diffing:

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -10,7 +10,7 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   release-diffing:

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -11,6 +11,10 @@ on:
     # Run every day at 10pm (PST) - cron uses UTC times
     - cron:  '0 6 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pod_lib_lint:

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 10pm (PST) - cron uses UTC times
     - cron:  '0 6 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -17,6 +17,10 @@ on:
     # Run every day at 10pm (PST) - cron uses UTC times
     - cron:  '0 6 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   messaging:

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   pod-lib-lint:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   pod-lib-lint:

--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -11,6 +11,10 @@ on:
     # TODO: Validate when the timer starts after job is triggered.
     - cron:  '0 */4 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   # Public repository: Build and run the Integration Tests for the Firebase performance E2E Test App.

--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -18,6 +18,10 @@ on:
     # Specified in format 'minutes hours day month dayofweek'
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   # Build and run the unit tests for Firebase performance SDK.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   buildup_SpecsTesting_repo:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,6 +9,10 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   buildup_SpecsTesting_repo:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   buildup_SpecsTesting_repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   buildup_SpecsTesting_repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   buildup_SpecsTesting_repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   buildup_SpecsTesting_repo:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -12,6 +12,10 @@ on:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   remoteconfig:

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -10,6 +10,10 @@ on:
     # Run every day at 3am (PST) - cron uses UTC times
     - cron:  '0 11 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pod-lib-lint:

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   specs_checking:

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   specs_checking:

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -3,6 +3,10 @@ name: spectesting
 on:
   pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   swift-build-run:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   swift-build-run:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -17,6 +17,10 @@ on:
 # This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
 # because each platform takes 15-20 minutes after adding Firestore.
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   swift-build-run:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   storage:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -13,6 +13,10 @@ on:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   storage:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   storage:

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -12,6 +12,10 @@ on:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   installation-test:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   installation-test:

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   installation-test:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   trigger_cpp_sdk_update:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   trigger_cpp_sdk_update:

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   trigger_cpp_sdk_update:
     # Only when a new release (not just the CocoaPods-* tag) is published.

--- a/.github/workflows/watchos-sample.yml
+++ b/.github/workflows/watchos-sample.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
 

--- a/.github/workflows/watchos-sample.yml
+++ b/.github/workflows/watchos-sample.yml
@@ -20,6 +20,10 @@ on:
     # Run every day at 10pm (PST) - cron uses UTC times
     - cron:  '0 6 * * *'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   tv-sample-build-test:

--- a/.github/workflows/watchos-sample.yml
+++ b/.github/workflows/watchos-sample.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+    cancel-in-progress: true 
 
 jobs:
   package-release:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -20,6 +20,10 @@ on:
         required: true
         default: 'https://github.com/firebase/SpecsStaging.git'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
   package-release:
     # Don't run on private repo.

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true 
+    cancel-in-progress: true
 
 jobs:
   package-release:


### PR DESCRIPTION
With this change, a new commit to a PR will kill the workflows of the previous commit.

Fixes #9450

#no-changelog