### PR TITLE
Swift Error Improvements

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -178,8 +178,11 @@ final class AppCheckAPITests {
               Task {
                 do {
                   _ = try await deviceCheckProvider.getToken()
-                } catch {
+                } catch AppCheckErrorCode.unsupported {
                   // ...
+                } catch {
+
+
                 }
               }
             }

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -180,10 +180,7 @@ final class AppCheckAPITests {
                   _ = try await deviceCheckProvider.getToken()
                 } catch AppCheckErrorCode.unsupported {
                   // ...
-                } catch {
-
-
-                }
+                } catch {}
               }
             }
           #endif // compiler(>=5.5) && canImport(_Concurrency)

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -180,7 +180,9 @@ final class AppCheckAPITests {
                   _ = try await deviceCheckProvider.getToken()
                 } catch AppCheckErrorCode.unsupported {
                   // ...
-                } catch {}
+                } catch {
+                  // ...
+                }
               }
             }
           #endif // compiler(>=5.5) && canImport(_Concurrency)

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -78,19 +78,19 @@ FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
 /**
  * Error codes representing sign in or version check failure reasons.
  */
-typedef NS_ERROR_ENUM(FIRAppDistributionErrorDomain, FIRAppDistributionError) {
-  /// Returned when an unknown error occurred.
-  FIRAppDistributionErrorUnknown = 0,
+typedef NS_ERROR_ENUM(FIRAppDistributionErrorDomain, FIRAppDistributionError){
+    /// Returned when an unknown error occurred.
+    FIRAppDistributionErrorUnknown = 0,
 
-  /// Returned when App Distribution failed to authenticate the user.
-  FIRAppDistributionErrorAuthenticationFailure = 1,
+    /// Returned when App Distribution failed to authenticate the user.
+    FIRAppDistributionErrorAuthenticationFailure = 1,
 
-  /// Returned when sign-in was cancelled.
-  FIRAppDistributionErrorAuthenticationCancelled = 2,
+    /// Returned when sign-in was cancelled.
+    FIRAppDistributionErrorAuthenticationCancelled = 2,
 
-  /// Returned when the network was unavailable to make requests or
-  /// the request timed out.
-  FIRAppDistributionErrorNetworkFailure = 3,
+    /// Returned when the network was unavailable to make requests or
+    /// the request timed out.
+    FIRAppDistributionErrorNetworkFailure = 3,
 
 } NS_SWIFT_NAME(AppDistributionError);
 

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -72,13 +72,13 @@ FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDomain
 
 /// The key for finding error details in the `NSError`'s `userInfo`.
 FOUNDATION_EXPORT NSString *const FIRAppDistributionErrorDetailsKey
-    NS_SWIFT_NAME(FunctionsErrorDetailsKey);
+    NS_SWIFT_NAME(AppDistributionErrorDetailsKey);
 // clang-format on
 
 /**
  * Error codes representing sign in or version check failure reasons.
  */
-typedef NS_ENUM(NSUInteger, FIRAppDistributionError) {
+typedef NS_ERROR_ENUM(FIRAppDistributionErrorDomain, FIRAppDistributionError) {
   /// Returned when an unknown error occurred.
   FIRAppDistributionErrorUnknown = 0,
 

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
@@ -18,17 +18,18 @@
 
 extern NSString *const kFirebaseInstallationsErrorDomain NS_SWIFT_NAME(InstallationsErrorDomain);
 
-typedef NS_ERROR_ENUM(kFirebaseInstallationsErrorDomain, FIRInstallationsErrorCode) {
-  /** Unknown error. See `userInfo` for details. */
-  FIRInstallationsErrorCodeUnknown = 0,
+typedef NS_ERROR_ENUM(kFirebaseInstallationsErrorDomain, FIRInstallationsErrorCode){
+    /** Unknown error. See `userInfo` for details. */
+    FIRInstallationsErrorCodeUnknown = 0,
 
-  /** Keychain error. See `userInfo` for details. */
-  FIRInstallationsErrorCodeKeychain = 1,
+    /** Keychain error. See `userInfo` for details. */
+    FIRInstallationsErrorCodeKeychain = 1,
 
-  /** Server unreachable. A network error or server is unavailable. See `userInfo` for details. */
-  FIRInstallationsErrorCodeServerUnreachable = 2,
+    /** Server unreachable. A network error or server is unavailable. See `userInfo` for details. */
+    FIRInstallationsErrorCodeServerUnreachable = 2,
 
-  /** FirebaseApp configuration issues e.g. invalid GMP-App-ID, etc. See `userInfo` for details. */
-  FIRInstallationsErrorCodeInvalidConfiguration = 3,
+    /** FirebaseApp configuration issues e.g. invalid GMP-App-ID, etc. See `userInfo` for details.
+     */
+    FIRInstallationsErrorCodeInvalidConfiguration = 3,
 
 } NS_SWIFT_NAME(InstallationsErrorCode);

--- a/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FirebaseInstallations/FIRInstallationsErrors.h
@@ -18,7 +18,7 @@
 
 extern NSString *const kFirebaseInstallationsErrorDomain NS_SWIFT_NAME(InstallationsErrorDomain);
 
-typedef NS_ENUM(NSUInteger, FIRInstallationsErrorCode) {
+typedef NS_ERROR_ENUM(kFirebaseInstallationsErrorDomain, FIRInstallationsErrorCode) {
   /** Unknown error. See `userInfo` for details. */
   FIRInstallationsErrorCodeUnknown = 0,
 

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -121,7 +121,9 @@ final class InstallationsAPITests {
         Task {
           do {
             _ = try await Installations.installations().delete()
-          } catch let error as NSError where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode.unknown.rawValue {
+          } catch let error as NSError
+            where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode
+            .unknown.rawValue {
             // Above is the old way to handle errors.
           } catch InstallationsErrorCode.unknown {
             // Above is the new way to handle errors.

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -121,6 +121,10 @@ final class InstallationsAPITests {
         Task {
           do {
             _ = try await Installations.installations().delete()
+          } catch let error as NSError where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode.unknown.rawValue {
+            // Above is the old way to handle errors.
+          } catch InstallationsErrorCode.unknown {
+            // Above is the new way to handle errors.
           } catch {
             // ...
           }
@@ -141,6 +145,7 @@ final class InstallationsAPITests {
 
     Installations.installations().authToken { _, error in
       if let error = error {
+        // Old error handling.
         switch (error as NSError).code {
         case Int(InstallationsErrorCode.unknown.rawValue):
           break
@@ -150,6 +155,21 @@ final class InstallationsAPITests {
           break
         case Int(InstallationsErrorCode.invalidConfiguration.rawValue):
           break
+        default:
+          break
+        }
+
+        // New error handling.
+        switch error {
+        case InstallationsErrorCode.unknown:
+          break
+        case InstallationsErrorCode.keychain:
+          break
+        case InstallationsErrorCode.serverUnreachable:
+          break
+        case InstallationsErrorCode.invalidConfiguration:
+          break
+
         default:
           break
         }

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -63,6 +63,8 @@ NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled =
 NSString *const kFIRMessagingPlistAutoInitEnabled =
     @"FirebaseMessagingAutoInitEnabled";  // Auto Init Enabled key stored in Info.plist
 
+NSString *const FIRMessagingErrorDomain = @"com.google.fcm";
+
 const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   if ([message[kFIRMessagingMessageViaAPNSRootKey] isKindOfClass:[NSDictionary class]]) {
     NSDictionary *aps = message[kFIRMessagingMessageViaAPNSRootKey];
@@ -208,7 +210,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   if (!GCMSenderID.length) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeFIRApp000,
                             @"Firebase not set up correctly, nil or empty senderID.");
-    [NSException raise:kFIRMessagingDomain
+    [NSException raise:FIRMessagingErrorDomain
                 format:@"Could not configure Firebase Messaging. GCMSenderID must not be nil or "
                        @"empty."];
   }

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -18,8 +18,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT NSString *const kFIRMessagingDomain;
-
 // FIRMessaging Internal Error Code
 typedef NS_ENUM(NSUInteger, FIRMessagingErrorCode) {
   kFIRMessagingErrorCodeUnknown = 0,

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import "FirebaseMessaging.h"
 #import "FirebaseMessaging/Sources/NSError+FIRMessaging.h"
+#import "FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h"
 
 @implementation NSError (FIRMessaging)
 

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -15,8 +15,7 @@
  */
 
 #import "FirebaseMessaging/Sources/NSError+FIRMessaging.h"
-
-NSString *const kFIRMessagingDomain = @"com.google.fcm";
+#import "FirebaseMessaging.h"
 
 @implementation NSError (FIRMessaging)
 
@@ -24,7 +23,7 @@ NSString *const kFIRMessagingDomain = @"com.google.fcm";
                       failureReason:(NSString *)failureReason {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
-  return [NSError errorWithDomain:kFIRMessagingDomain code:errorCode userInfo:userInfo];
+  return [NSError errorWithDomain:FIRMessagingErrorDomain code:errorCode userInfo:userInfo];
 }
 
 @end

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import "FirebaseMessaging/Sources/NSError+FIRMessaging.h"
 #import "FirebaseMessaging.h"
+#import "FirebaseMessaging/Sources/NSError+FIRMessaging.h"
 
 @implementation NSError (FIRMessaging)
 

--- a/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
+++ b/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
@@ -75,30 +75,30 @@ FOUNDATION_EXPORT NSString *const FIRMessagingErrorDomain NS_SWIFT_NAME(Messagin
 /**
  *  @enum FIRMessagingError
  */
-typedef NS_ERROR_ENUM(FIRMessagingErrorDomain, FIRMessagingError) {
-  /// Unknown error.
-  FIRMessagingErrorUnknown = 0,
+typedef NS_ERROR_ENUM(FIRMessagingErrorDomain, FIRMessagingError){
+    /// Unknown error.
+    FIRMessagingErrorUnknown = 0,
 
-  /// FIRMessaging couldn't validate request from this client.
-  FIRMessagingErrorAuthentication = 1,
+    /// FIRMessaging couldn't validate request from this client.
+    FIRMessagingErrorAuthentication = 1,
 
-  /// InstanceID service cannot be accessed.
-  FIRMessagingErrorNoAccess = 2,
+    /// InstanceID service cannot be accessed.
+    FIRMessagingErrorNoAccess = 2,
 
-  /// Request to InstanceID backend timed out.
-  FIRMessagingErrorTimeout = 3,
+    /// Request to InstanceID backend timed out.
+    FIRMessagingErrorTimeout = 3,
 
-  /// No network available to reach the servers.
-  FIRMessagingErrorNetwork = 4,
+    /// No network available to reach the servers.
+    FIRMessagingErrorNetwork = 4,
 
-  /// Another similar operation in progress, bailing this one.
-  FIRMessagingErrorOperationInProgress = 5,
+    /// Another similar operation in progress, bailing this one.
+    FIRMessagingErrorOperationInProgress = 5,
 
-  /// Some parameters of the request were invalid.
-  FIRMessagingErrorInvalidRequest = 7,
+    /// Some parameters of the request were invalid.
+    FIRMessagingErrorInvalidRequest = 7,
 
-  /// Topic name is invalid for subscription/unsubscription.
-  FIRMessagingErrorInvalidTopicName = 8,
+    /// Topic name is invalid for subscription/unsubscription.
+    FIRMessagingErrorInvalidTopicName = 8,
 
 } NS_SWIFT_NAME(MessagingError);
 

--- a/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
+++ b/FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h
@@ -69,9 +69,13 @@ FOUNDATION_EXPORT const NSNotificationName FIRMessagingRegistrationTokenRefreshe
 // clang-format on
 
 /**
+ * The domain used for all errors in Messaging.
+ */
+FOUNDATION_EXPORT NSString *const FIRMessagingErrorDomain NS_SWIFT_NAME(MessagingErrorDomain);
+/**
  *  @enum FIRMessagingError
  */
-typedef NS_ENUM(NSUInteger, FIRMessagingError) {
+typedef NS_ERROR_ENUM(FIRMessagingErrorDomain, FIRMessagingError) {
   /// Unknown error.
   FIRMessagingErrorUnknown = 0,
 

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -55,7 +55,8 @@ func apis() {
   }
 
   // Use random to eliminate the warning that we're evaluating to a constant.
-  let messagingError: MessagingError = Bool.random() ? MessagingError(.unknown) : MessagingError(.authentication)
+  let messagingError: MessagingError = Bool
+    .random() ? MessagingError(.unknown) : MessagingError(.authentication)
   switch messagingError.code {
   case .unknown: ()
   case .authentication: ()
@@ -145,7 +146,6 @@ func apiAsync() async throws {
     do {
       try await messaging.unsubscribe(fromTopic: topic)
     } catch MessagingError.timeout {
-    } catch {
-    }
+    } catch {}
   #endif
 }

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -55,8 +55,8 @@ func apis() {
   }
 
   // Use random to eliminate the warning that we're evaluating to a constant.
-  let messagingError: MessagingError = Bool.random() ? .unknown : .authentication
-  switch messagingError {
+  let messagingError: MessagingError = Bool.random() ? MessagingError(.unknown) : MessagingError(.authentication)
+  switch messagingError.code {
   case .unknown: ()
   case .authentication: ()
   case .noAccess: ()
@@ -92,6 +92,18 @@ func apis() {
   let topic = "cat_video"
   messaging.subscribe(toTopic: topic)
   messaging.unsubscribe(fromTopic: topic)
+  messaging.unsubscribe(fromTopic: topic, completion: { error in
+    if let error = error {
+      switch error {
+      // Handle errors in the new format.
+      case MessagingError.timeout:
+        ()
+      default:
+        ()
+      }
+    }
+  })
+
   messaging.unsubscribe(fromTopic: topic) { _ in
   }
 
@@ -128,5 +140,12 @@ func apiAsync() async throws {
     try await messaging.deleteFCMToken(forSenderID: "fakeSenderID")
 
     try await messaging.deleteData()
+
+    // Test new handling of errors
+    do {
+      try await messaging.unsubscribe(fromTopic: topic)
+    } catch MessagingError.timeout {
+    } catch {
+    }
   #endif
 }

--- a/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, FIRRemoteConfigFetchAndActivateStatus) {
 /// Remote Config error domain that handles errors when fetching data from the service.
 extern NSString *const _Nonnull FIRRemoteConfigErrorDomain NS_SWIFT_NAME(RemoteConfigErrorDomain);
 /// Firebase Remote Config service fetch error.
-typedef NS_ENUM(NSInteger, FIRRemoteConfigError) {
+typedef NS_ERROR_ENUM(FIRRemoteConfigErrorDomain, FIRRemoteConfigError) {
   /// Unknown or no error.
   FIRRemoteConfigErrorUnknown = 8001,
   /// Frequency of fetch requests exceeds throttled limit.

--- a/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
@@ -56,13 +56,13 @@ typedef NS_ENUM(NSInteger, FIRRemoteConfigFetchAndActivateStatus) {
 /// Remote Config error domain that handles errors when fetching data from the service.
 extern NSString *const _Nonnull FIRRemoteConfigErrorDomain NS_SWIFT_NAME(RemoteConfigErrorDomain);
 /// Firebase Remote Config service fetch error.
-typedef NS_ERROR_ENUM(FIRRemoteConfigErrorDomain, FIRRemoteConfigError) {
-  /// Unknown or no error.
-  FIRRemoteConfigErrorUnknown = 8001,
-  /// Frequency of fetch requests exceeds throttled limit.
-  FIRRemoteConfigErrorThrottled = 8002,
-  /// Internal error that covers all internal HTTP errors.
-  FIRRemoteConfigErrorInternalError = 8003,
+typedef NS_ERROR_ENUM(FIRRemoteConfigErrorDomain, FIRRemoteConfigError){
+    /// Unknown or no error.
+    FIRRemoteConfigErrorUnknown = 8001,
+    /// Frequency of fetch requests exceeds throttled limit.
+    FIRRemoteConfigErrorThrottled = 8002,
+    /// Internal error that covers all internal HTTP errors.
+    FIRRemoteConfigErrorInternalError = 8003,
 } NS_SWIFT_NAME(RemoteConfigError);
 
 /// Enumerated value that indicates the source of Remote Config data. Data can come from

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
@@ -24,7 +24,7 @@ FOUNDATION_EXPORT NSString *const FIRFirestoreErrorDomain NS_SWIFT_NAME(Firestor
 /** Error codes used by Cloud Firestore. */
 typedef NS_ERROR_ENUM(FIRFirestoreErrorDomain, FIRFirestoreErrorCode){
     /**
-     * The operation completed successfully. NSError wobjects will never have a code with this
+     * The operation completed successfully. NSError objects will never have a code with this
      * value.
      */
     FIRFirestoreErrorCodeOK = 0,

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
@@ -22,9 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const FIRFirestoreErrorDomain NS_SWIFT_NAME(FirestoreErrorDomain);
 
 /** Error codes used by Cloud Firestore. */
-typedef NS_ENUM(NSInteger, FIRFirestoreErrorCode) {
+typedef NS_ERROR_ENUM(FIRFirestoreErrorDomain, FIRFirestoreErrorCode) {
   /**
-   * The operation completed successfully. NSError objects will never have a code with this value.
+   * The operation completed successfully. NSError wobjects will never have a code with this value.
    */
   FIRFirestoreErrorCodeOK = 0,
 

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreErrors.h
@@ -22,82 +22,82 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const FIRFirestoreErrorDomain NS_SWIFT_NAME(FirestoreErrorDomain);
 
 /** Error codes used by Cloud Firestore. */
-typedef NS_ERROR_ENUM(FIRFirestoreErrorDomain, FIRFirestoreErrorCode) {
-  /**
-   * The operation completed successfully. NSError wobjects will never have a code with this value.
-   */
-  FIRFirestoreErrorCodeOK = 0,
+typedef NS_ERROR_ENUM(FIRFirestoreErrorDomain, FIRFirestoreErrorCode){
+    /**
+     * The operation completed successfully. NSError wobjects will never have a code with this
+     * value.
+     */
+    FIRFirestoreErrorCodeOK = 0,
 
-  /** The operation was cancelled (typically by the caller). */
-  FIRFirestoreErrorCodeCancelled = 1,
+    /** The operation was cancelled (typically by the caller). */
+    FIRFirestoreErrorCodeCancelled = 1,
 
-  /** Unknown error or an error from a different error domain. */
-  FIRFirestoreErrorCodeUnknown = 2,
+    /** Unknown error or an error from a different error domain. */
+    FIRFirestoreErrorCodeUnknown = 2,
 
-  /**
-   * Client specified an invalid argument. Note that this differs from FailedPrecondition.
-   * InvalidArgument indicates arguments that are problematic regardless of the state of the
-   * system (e.g., an invalid field name).
-   */
-  FIRFirestoreErrorCodeInvalidArgument = 3,
+    /**
+     * Client specified an invalid argument. Note that this differs from FailedPrecondition.
+     * InvalidArgument indicates arguments that are problematic regardless of the state of the
+     * system (e.g., an invalid field name).
+     */
+    FIRFirestoreErrorCodeInvalidArgument = 3,
 
-  /**
-   * Deadline expired before operation could complete. For operations that change the state of the
-   * system, this error may be returned even if the operation has completed successfully. For
-   * example, a successful response from a server could have been delayed long enough for the
-   * deadline to expire.
-   */
-  FIRFirestoreErrorCodeDeadlineExceeded = 4,
+    /**
+     * Deadline expired before operation could complete. For operations that change the state of the
+     * system, this error may be returned even if the operation has completed successfully. For
+     * example, a successful response from a server could have been delayed long enough for the
+     * deadline to expire.
+     */
+    FIRFirestoreErrorCodeDeadlineExceeded = 4,
 
-  /** Some requested document was not found. */
-  FIRFirestoreErrorCodeNotFound = 5,
+    /** Some requested document was not found. */
+    FIRFirestoreErrorCodeNotFound = 5,
 
-  /** Some document that we attempted to create already exists. */
-  FIRFirestoreErrorCodeAlreadyExists = 6,
+    /** Some document that we attempted to create already exists. */
+    FIRFirestoreErrorCodeAlreadyExists = 6,
 
-  /** The caller does not have permission to execute the specified operation. */
-  FIRFirestoreErrorCodePermissionDenied = 7,
+    /** The caller does not have permission to execute the specified operation. */
+    FIRFirestoreErrorCodePermissionDenied = 7,
 
-  /**
-   * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
-   * is out of space.
-   */
-  FIRFirestoreErrorCodeResourceExhausted = 8,
+    /**
+     * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
+     * is out of space.
+     */
+    FIRFirestoreErrorCodeResourceExhausted = 8,
 
-  /**
-   * Operation was rejected because the system is not in a state required for the operation's
-   * execution.
-   */
-  FIRFirestoreErrorCodeFailedPrecondition = 9,
+    /**
+     * Operation was rejected because the system is not in a state required for the operation's
+     * execution.
+     */
+    FIRFirestoreErrorCodeFailedPrecondition = 9,
 
-  /**
-   * The operation was aborted, typically due to a concurrency issue like transaction aborts, etc.
-   */
-  FIRFirestoreErrorCodeAborted = 10,
+    /**
+     * The operation was aborted, typically due to a concurrency issue like transaction aborts, etc.
+     */
+    FIRFirestoreErrorCodeAborted = 10,
 
-  /** Operation was attempted past the valid range. */
-  FIRFirestoreErrorCodeOutOfRange = 11,
+    /** Operation was attempted past the valid range. */
+    FIRFirestoreErrorCodeOutOfRange = 11,
 
-  /** Operation is not implemented or not supported/enabled. */
-  FIRFirestoreErrorCodeUnimplemented = 12,
+    /** Operation is not implemented or not supported/enabled. */
+    FIRFirestoreErrorCodeUnimplemented = 12,
 
-  /**
-   * Internal errors. Means some invariants expected by underlying system has been broken. If you
-   * see one of these errors, something is very broken.
-   */
-  FIRFirestoreErrorCodeInternal = 13,
+    /**
+     * Internal errors. Means some invariants expected by underlying system has been broken. If you
+     * see one of these errors, something is very broken.
+     */
+    FIRFirestoreErrorCodeInternal = 13,
 
-  /**
-   * The service is currently unavailable. This is a most likely a transient condition and may be
-   * corrected by retrying with a backoff.
-   */
-  FIRFirestoreErrorCodeUnavailable = 14,
+    /**
+     * The service is currently unavailable. This is a most likely a transient condition and may be
+     * corrected by retrying with a backoff.
+     */
+    FIRFirestoreErrorCodeUnavailable = 14,
 
-  /** Unrecoverable data loss or corruption. */
-  FIRFirestoreErrorCodeDataLoss = 15,
+    /** Unrecoverable data loss or corruption. */
+    FIRFirestoreErrorCodeDataLoss = 15,
 
-  /** The request does not have valid authentication credentials for the operation. */
-  FIRFirestoreErrorCodeUnauthenticated = 16
-} NS_SWIFT_NAME(FirestoreErrorCode);
+    /** The request does not have valid authentication credentials for the operation. */
+    FIRFirestoreErrorCodeUnauthenticated = 16} NS_SWIFT_NAME(FirestoreErrorCode);
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -253,21 +253,41 @@ func readDocument(at docRef: DocumentReference) {
       if let foo = document["foo"] {
         print("Field: \(foo)")
       }
-    } else {
-      // TODO(mikelehen): There may be a better way to do this, but it at least demonstrates
-      // the swift error domain / enum codes are renamed appropriately.
-      if let errorCode = error.flatMap({
-        ($0._domain == FirestoreErrorDomain) ? FirestoreErrorCode(rawValue: $0._code) : nil
-      }) {
+    } else if let error = error {
+      // New way to handle errors.
+      switch error {
+      case FirestoreErrorCode.unavailable:
+        print("Can't read document due to being offline!")
+      default:
+        print("Failed to read.")
+      }
+
+      // Old way to handle errors.
+      let nsError = error as NSError
+      guard nsError.domain == FirestoreErrorDomain else {
+        print("Unknown error!")
+        return
+      }
+
+      // Option 1: try to initialize the error code enum.
+      if let errorCode = FirestoreErrorCode.Code(rawValue: nsError.code) {
         switch errorCode {
         case .unavailable:
           print("Can't read document due to being offline!")
-        case _:
+        default:
           print("Failed to read.")
         }
-      } else {
-        print("Unknown error!")
       }
+
+      // Option 2: switch on the code and compare agianst raw values.
+      switch nsError.code {
+      case FirestoreErrorCode.unavailable.rawValue:
+        print("Can't read document due to being offline!")
+      default:
+        print("Failed to read.")
+      }
+    } else {
+      print("No error or document. Thanks, ObjC.")
     }
   }
 }


### PR DESCRIPTION
Use NS_ERROR_ENUM where possible for Firebase SDKs. This is a breaking change for Swift users that greatly improves error handling:

## Before
```swift
// Completion Handlers
messaging.unsubscribe(fromTopic: topic) { error in
  if let error = error {
    // Missing: domain check. Need to publicize the domain.
    switch UInt((error as NSError).code) {    // old
    case MessagingError.timeout.rawValue:     // old
      tryAgain()
    default:
      print("Couldn't unsubscribe.")
    }
    return
  }

  // no error
}

// async/await
do {
  try await messaging.unsubscribe(fromTopic: topic)
  // Missing: domain check. Need to publicize the domain.
} catch let error as NSError where MessagingError(rawValue: UInt(error.code)) == .timeout {  // old
  // timeout
} catch {
  print("Couldn't unsubscribe.")
}

// Installations
do {
  _ = try await Installations.installations().delete()
} catch let error as NSError where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode.unknown.rawValue { // old
  // ...
} catch {
  // ...
}
```

## After
```swift
// Completion Handlers
messaging.unsubscribe(fromTopic: topic) { error in
  if let error = error {
    switch error {
    case MessagingError.timeout:  // new
      tryAgain()
    default:
      print("Couldn't unsubscribe.")
    }
  }

    // No error
}

// async/await
do {
  try await messaging.unsubscribe(fromTopic: topic)
} catch MessagingError.timeout {  // new
  tryAgain()
} catch {
  print("Couldn't unsubscribe.")
}

// Installations
do {
  _ = try await Installations.installations().delete()
} catch InstallationsErrorCode.unknown { // new
  // Above is the new way to handle errors.
} catch {
  // ...
}
```

[skip ci]  (will run CI later)