### PR TITLE
Fix inconsistent argument names in .h/.cc files

### DIFF
--- a/Firestore/core/src/index/index_entry.h
+++ b/Firestore/core/src/index/index_entry.h
@@ -62,8 +62,7 @@ class IndexEntry : public util::Comparable<IndexEntry> {
   size_t Hash() const;
 
   std::string ToString() const;
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const IndexEntry& database_id);
+  friend std::ostream& operator<<(std::ostream& out, const IndexEntry& entry);
 
  private:
   int32_t index_id_;

--- a/Firestore/core/src/local/leveldb_index_manager.h
+++ b/Firestore/core/src/local/leveldb_index_manager.h
@@ -65,7 +65,7 @@ class LevelDbIndexManager : public IndexManager {
   absl::optional<model::FieldIndex> GetFieldIndex(core::Target target) override;
 
   absl::optional<std::vector<model::DocumentKey>> GetDocumentsMatchingTarget(
-      model::FieldIndex fieldIndex, core::Target target) override;
+      model::FieldIndex field_index, core::Target target) override;
 
   absl::optional<std::string> GetNextCollectionGroupToUpdate() override;
 


### PR DESCRIPTION
These inconsistencies cause warnings when the code is copied into google3 via copybara.

#no-changelog