### PR TITLE
Remove the double dispatch code from the pre-warm detection.

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Pending
+* Remove the unused code for pre-warm detection.
+
 # Version 8.14.0
 * [fixed] Record the request payload size for POST/PUT requests.
 

--- a/FirebasePerformance/Sources/Configurations/FPRConfigurations.h
+++ b/FirebasePerformance/Sources/Configurations/FPRConfigurations.h
@@ -20,16 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
  * Different modes of prewarm-detection
  * KeepNone = No app start events are allowed
  * ActivePrewarm = Only detect prewarming using ActivePrewarm environment
- * DoubleDispatch = Only detect prewarming using double dispatch method
- * ActivePrewarmOrDoubleDispatch = Detect prewarming using both ActivePrewarm and double dispatch
  * KeepAll = All app start events are allowed
  */
 typedef NS_ENUM(NSInteger, PrewarmDetectionMode) {
   PrewarmDetectionModeKeepNone = 0,
   PrewarmDetectionModeActivePrewarm = 1,
-  PrewarmDetectionModeDoubleDispatch = 2,
-  PrewarmDetectionModeActivePrewarmOrDoubleDispatch = 3,
-  PrewarmDetectionModeKeepAll = 4
+  PrewarmDetectionModeKeepAll = 3
 };
 
 /** A typedef for ensuring that config names are one of the below specified strings. */

--- a/FirebasePerformance/Sources/Configurations/FPRConfigurations.h
+++ b/FirebasePerformance/Sources/Configurations/FPRConfigurations.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, PrewarmDetectionMode) {
   PrewarmDetectionModeKeepNone = 0,
   PrewarmDetectionModeActivePrewarm = 1,
-  PrewarmDetectionModeKeepAll = 3
+  PrewarmDetectionModeKeepAll = 2
 };
 
 /** A typedef for ensuring that config names are one of the below specified strings. */

--- a/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRAppActivityTrackerTest.m
@@ -205,28 +205,11 @@
   XCTAssertEqual(appTracker.applicationState, FPRApplicationStateBackground);
 }
 
-/** Validates double dispatch returns true when +load occurs before didFinishLaunching
- */
-- (void)test_isApplicationPrewarmed_doubleDispatch_returnsYes {
-  id mockAppTracker = OCMPartialMock([FPRAppActivityTracker sharedInstance]);
-  OCMStub([mockAppTracker isPrewarmAvailable]).andReturn(YES);
-  OCMStub([mockAppTracker isDoubleDispatchEnabled]).andReturn(YES);
-  OCMStub([mockAppTracker isActivePrewarmEnabled]).andReturn(NO);
-
-  [FPRAppActivityTracker load];
-  [[NSNotificationCenter defaultCenter]
-      postNotificationName:UIApplicationDidFinishLaunchingNotification
-                    object:[UIApplication sharedApplication]];
-
-  XCTAssertTrue([mockAppTracker isApplicationPreWarmed]);
-}
-
 /** Validates ActivePrewarm environment variable set to true is detected by prewarm-detection
  */
 - (void)test_isApplicationPrewarmed_activePrewarm_returnsYes {
   id mockAppTracker = OCMPartialMock([FPRAppActivityTracker sharedInstance]);
   OCMStub([mockAppTracker isPrewarmAvailable]).andReturn(YES);
-  OCMStub([mockAppTracker isDoubleDispatchEnabled]).andReturn(NO);
   OCMStub([mockAppTracker isActivePrewarmEnabled]).andReturn(YES);
 
   setenv("ActivePrewarm", "1", 1);
@@ -239,7 +222,6 @@
 - (void)test_isApplicationPrewarmed_activePrewarm_returnsNo {
   id mockAppTracker = OCMPartialMock([FPRAppActivityTracker sharedInstance]);
   OCMStub([mockAppTracker isPrewarmAvailable]).andReturn(YES);
-  OCMStub([mockAppTracker isDoubleDispatchEnabled]).andReturn(NO);
   OCMStub([mockAppTracker isActivePrewarmEnabled]).andReturn(YES);
 
   XCTAssertFalse([mockAppTracker isApplicationPreWarmed]);
@@ -279,68 +261,6 @@
 
   OCMStub([mockConfigurations prewarmDetectionMode]).andReturn(PrewarmDetectionModeActivePrewarm);
   XCTAssertTrue([appTracker isActivePrewarmEnabled]);
-}
-
-/** Validates ActivePrewarm filtering is disabled when RC flag fpr_prewarm_detection is
- * PrewarmDetectionModeDoubleDispatch
- */
-- (void)test_isActivePrewarmEnabled_PrewarmDetectionModeDoubleDispatch_returnsNo {
-  FPRAppActivityTracker *appTracker = [FPRAppActivityTracker sharedInstance];
-  id mockConfigurations = OCMClassMock([FPRConfigurations class]);
-  appTracker.configurations = mockConfigurations;
-
-  OCMStub([mockConfigurations prewarmDetectionMode]).andReturn(PrewarmDetectionModeDoubleDispatch);
-  XCTAssertFalse([appTracker isActivePrewarmEnabled]);
-}
-
-/** Validates double dispatch filtering is disabled when RC flag fpr_prewarm_detection is
- * PrewarmDetectionModeActivePrewarm
- */
-- (void)test_isDoubleDispatchEnabled_PrewarmDetectionModeActivePrewarm_returnsNo {
-  FPRAppActivityTracker *appTracker = [FPRAppActivityTracker sharedInstance];
-  id mockConfigurations = OCMClassMock([FPRConfigurations class]);
-  appTracker.configurations = mockConfigurations;
-
-  OCMStub([mockConfigurations prewarmDetectionMode]).andReturn(PrewarmDetectionModeActivePrewarm);
-  XCTAssertFalse([appTracker isDoubleDispatchEnabled]);
-}
-
-/** Validates double dispatch filtering is enabled when RC flag fpr_prewarm_detection is
- * PrewarmDetectionModeDoubleDispatch
- */
-- (void)test_isDoubleDispatchEnabled_PrewarmDetectionModeDoubleDispatch_returnsYes {
-  FPRAppActivityTracker *appTracker = [FPRAppActivityTracker sharedInstance];
-  id mockConfigurations = OCMClassMock([FPRConfigurations class]);
-  appTracker.configurations = mockConfigurations;
-
-  OCMStub([mockConfigurations prewarmDetectionMode]).andReturn(PrewarmDetectionModeDoubleDispatch);
-  XCTAssertTrue([appTracker isDoubleDispatchEnabled]);
-}
-
-/** Validates ActivePrewarm filtering is enabled when RC flag fpr_prewarm_detection is
- * PrewarmDetectionModeActivePrewarmOrDoubleDispatch
- */
-- (void)test_isActivePrewarmEnabled_PrewarmDetectionModeActivePrewarmOrDoubleDispatch_returnsYes {
-  FPRAppActivityTracker *appTracker = [FPRAppActivityTracker sharedInstance];
-  id mockConfigurations = OCMClassMock([FPRConfigurations class]);
-  appTracker.configurations = mockConfigurations;
-
-  OCMStub([mockConfigurations prewarmDetectionMode])
-      .andReturn(PrewarmDetectionModeActivePrewarmOrDoubleDispatch);
-  XCTAssertTrue([appTracker isActivePrewarmEnabled]);
-}
-
-/** Validates double dispatch filtering is enabled when RC flag fpr_prewarm_detection is
- * PrewarmDetectionModeActivePrewarmOrDoubleDispatch
- */
-- (void)test_isDoubleDispatchEnabled_PrewarmDetectionModeActivePrewarmOrDoubleDispatch_returnsYes {
-  FPRAppActivityTracker *appTracker = [FPRAppActivityTracker sharedInstance];
-  id mockConfigurations = OCMClassMock([FPRConfigurations class]);
-  appTracker.configurations = mockConfigurations;
-
-  OCMStub([mockConfigurations prewarmDetectionMode])
-      .andReturn(PrewarmDetectionModeActivePrewarmOrDoubleDispatch);
-  XCTAssertTrue([appTracker isDoubleDispatchEnabled]);
 }
 
 @end


### PR DESCRIPTION
Remove the double dispatch code from the pre-warm detection.

The remote config flag will now contain just 3 states:

1. Disable all app starts
2. Active prewarm enabled/Disabled
3. Send all app starts

