### PR TITLE
[v9, Infra] Fix `FirebaseCore` CMake build error for Firestore CI

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -31,7 +31,7 @@ on:
     - 'FirebaseFirestore.podspec'
 
     # CMake
-    - 'CMakeLists.txt'
+    - '**CMakeLists.txt'
     - 'cmake/**'
 
     # Build scripts to which Firestore is sensitive

--- a/FirebaseCore/CMakeLists.txt
+++ b/FirebaseCore/CMakeLists.txt
@@ -34,9 +34,9 @@ firebase_ios_framework_public_headers(FirebaseCore ${headers})
 target_compile_definitions(
   FirebaseCore PRIVATE
   Firebase_VERSION=${firebase_version}
-  # This macro is defined and used to exclude `FIRHeartbeatLogger` symbols.
-  # This avoids building the FirebaseCoreInternal Swift module which is not
-  # yet configured to build for CMake builds.
+  # This macro is defined and used to exclude symbols from the
+  # FirebaseCoreInternal Swift module, which is not yet configured to build
+  # for CMake builds.
   BUILD_WITH_CMAKE=1
 )
 

--- a/FirebaseCore/CMakeLists.txt
+++ b/FirebaseCore/CMakeLists.txt
@@ -37,7 +37,7 @@ target_compile_definitions(
   # This macro is defined and used to exclude symbols from the
   # FirebaseCoreInternal Swift module, which is not yet configured to build
   # for CMake builds.
-  BUILD_WITH_CMAKE=1
+  FIREBASE_BUILD_CMAKE=1
 )
 
 target_link_libraries(

--- a/FirebaseCore/CMakeLists.txt
+++ b/FirebaseCore/CMakeLists.txt
@@ -21,9 +21,6 @@ include(GoogleUtilities)
 
 file(GLOB headers Sources/Private/*.h Sources/Public/FirebaseCore/*.h)
 file(GLOB sources Sources/*.m)
-# Exclude the `FIRHeartbeatLogger.m` since it depends on the Swift Heartbeat logging
-# library that is not configured to build for CMake builds.
-list(FILTER sources EXCLUDE REGEX "FIRHeartbeatLogger.m")
 
 podspec_version(version ${PROJECT_SOURCE_DIR}/FirebaseCore.podspec)
 firebase_version(firebase_version ${PROJECT_SOURCE_DIR}/FirebaseCore.podspec)
@@ -37,6 +34,10 @@ firebase_ios_framework_public_headers(FirebaseCore ${headers})
 target_compile_definitions(
   FirebaseCore PRIVATE
   Firebase_VERSION=${firebase_version}
+  # This macro is defined and used to exclude `FIRHeartbeatLogger` symbols.
+  # This avoids building the FirebaseCoreInternal Swift module which is not
+  # yet configured to build for CMake builds.
+  BUILD_WITH_CMAKE=1
 )
 
 target_link_libraries(

--- a/FirebaseCore/Extension/FIRAppInternal.h
+++ b/FirebaseCore/Extension/FIRAppInternal.h
@@ -17,8 +17,8 @@
 #import <FirebaseCore/FIRApp.h>
 
 @class FIRComponentContainer;
-@protocol FIRLibrary;
 @class FIRHeartbeatLogger;
+@protocol FIRLibrary;
 
 /**
  * The internal interface to `FirebaseApp`. This is meant for first-party integrators, who need to

--- a/FirebaseCore/Extension/FIRHeartbeatLogger.h
+++ b/FirebaseCore/Extension/FIRHeartbeatLogger.h
@@ -19,6 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifndef BUILD_WITH_CMAKE
 @class FIRHeartbeatsPayload;
 
 /// Returns a nullable string header value from a given heartbeats payload.
@@ -27,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @param heartbeatsPayload The heartbeats payload.
 NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *heartbeatsPayload);
+#endif  // BUILD_WITH_CMAKE
 
 /// A thread safe, synchronized object that logs and flushes platform logging info.
 @interface FIRHeartbeatLogger : NSObject
@@ -38,6 +40,7 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 /// @note This API is thread-safe.
 - (void)log;
 
+#ifndef BUILD_WITH_CMAKE
 /// Flushes heartbeats from storage into a structured payload of heartbeats.
 ///
 /// This API is for clients using platform logging V2.
@@ -53,6 +56,7 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 /// @note This API is thread-safe.
 /// @return Heartbeat code indicating whether or not there is an unsent global heartbeat.
 - (FIRHeartbeatInfoCode)heartbeatCodeForToday;
+#endif  // BUILD_WITH_CMAKE
 
 @end
 

--- a/FirebaseCore/Extension/FIRHeartbeatLogger.h
+++ b/FirebaseCore/Extension/FIRHeartbeatLogger.h
@@ -19,7 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 @class FIRHeartbeatsPayload;
 
 /// Returns a nullable string header value from a given heartbeats payload.
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @param heartbeatsPayload The heartbeats payload.
 NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *heartbeatsPayload);
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 
 /// A thread safe, synchronized object that logs and flushes platform logging info.
 @interface FIRHeartbeatLogger : NSObject
@@ -40,7 +40,7 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 /// @note This API is thread-safe.
 - (void)log;
 
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 /// Flushes heartbeats from storage into a structured payload of heartbeats.
 ///
 /// This API is for clients using platform logging V2.
@@ -56,7 +56,7 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 /// @note This API is thread-safe.
 /// @return Heartbeat code indicating whether or not there is an unsent global heartbeat.
 - (FIRHeartbeatInfoCode)heartbeatCodeForToday;
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 
 @end
 

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -32,7 +32,9 @@
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 #import "FirebaseCore/Extension/FIRCoreDiagnosticsConnector.h"
+#ifndef BUILD_WITH_CMAKE
 #import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
+#endif  // BUILD_WITH_CMAKE
 #import "FirebaseCore/Extension/FIRLibrary.h"
 #import "FirebaseCore/Extension/FIRLogger.h"
 #import "FirebaseCore/Extension/FIROptionsInternal.h"
@@ -339,7 +341,9 @@ static FIRApp *sDefaultApp;
     _options.editingLocked = YES;
     _isDefaultApp = [name isEqualToString:kFIRDefaultAppName];
     _container = [[FIRComponentContainer alloc] initWithApp:self];
+#ifndef BUILD_WITH_CMAKE
     _heartbeatLogger = [[FIRHeartbeatLogger alloc] initWithAppID:self.options.googleAppID];
+#endif  // BUILD_WITH_CMAKE
   }
   return self;
 }

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -32,9 +32,9 @@
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 #import "FirebaseCore/Extension/FIRCoreDiagnosticsConnector.h"
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 #import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 #import "FirebaseCore/Extension/FIRLibrary.h"
 #import "FirebaseCore/Extension/FIRLogger.h"
 #import "FirebaseCore/Extension/FIROptionsInternal.h"
@@ -341,9 +341,9 @@ static FIRApp *sDefaultApp;
     _options.editingLocked = YES;
     _isDefaultApp = [name isEqualToString:kFIRDefaultAppName];
     _container = [[FIRComponentContainer alloc] initWithApp:self];
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
     _heartbeatLogger = [[FIRHeartbeatLogger alloc] initWithAppID:self.options.googleAppID];
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
   }
   return self;
 }

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -32,9 +32,7 @@
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 #import "FirebaseCore/Extension/FIRCoreDiagnosticsConnector.h"
-#ifndef FIREBASE_BUILD_CMAKE
 #import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
-#endif  // FIREBASE_BUILD_CMAKE
 #import "FirebaseCore/Extension/FIRLibrary.h"
 #import "FirebaseCore/Extension/FIRLogger.h"
 #import "FirebaseCore/Extension/FIROptionsInternal.h"
@@ -341,9 +339,7 @@ static FIRApp *sDefaultApp;
     _options.editingLocked = YES;
     _isDefaultApp = [name isEqualToString:kFIRDefaultAppName];
     _container = [[FIRComponentContainer alloc] initWithApp:self];
-#ifndef FIREBASE_BUILD_CMAKE
     _heartbeatLogger = [[FIRHeartbeatLogger alloc] initWithAppID:self.options.googleAppID];
-#endif  // FIREBASE_BUILD_CMAKE
   }
   return self;
 }

--- a/FirebaseCore/Sources/FIRHeartbeatLogger.m
+++ b/FirebaseCore/Sources/FIRHeartbeatLogger.m
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BUILD_WITH_CMAKE
-#endif  // BUILD_WITH_CMAKE
-
 #import <Foundation/Foundation.h>
 
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 @import FirebaseCoreInternal;
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 #import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
 
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *heartbeatsPayload) {
   if ([heartbeatsPayload isEmpty]) {
     return nil;
@@ -32,12 +29,12 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 
   return [heartbeatsPayload headerValue];
 }
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 
 @interface FIRHeartbeatLogger ()
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 @property(nonatomic, readonly) FIRHeartbeatController *heartbeatController;
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 @property(copy, readonly) NSString * (^userAgentProvider)(void);
 @end
 
@@ -51,9 +48,9 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
             userAgentProvider:(NSString * (^)(void))userAgentProvider {
   self = [super init];
   if (self) {
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
     _heartbeatController = [[FIRHeartbeatController alloc] initWithId:[appID copy]];
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
     _userAgentProvider = [userAgentProvider copy];
   }
   return self;
@@ -67,12 +64,12 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 
 - (void)log {
   NSString *userAgent = _userAgentProvider();
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
   [_heartbeatController log:userAgent];
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 }
 
-#ifndef BUILD_WITH_CMAKE
+#ifndef FIREBASE_BUILD_CMAKE
 - (FIRHeartbeatsPayload *)flushHeartbeatsIntoPayload {
   FIRHeartbeatsPayload *payload = [_heartbeatController flush];
   return payload;
@@ -87,6 +84,6 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
     return FIRHeartbeatInfoCodeGlobal;
   }
 }
-#endif  // BUILD_WITH_CMAKE
+#endif  // FIREBASE_BUILD_CMAKE
 
 @end

--- a/FirebaseCore/Sources/FIRHeartbeatLogger.m
+++ b/FirebaseCore/Sources/FIRHeartbeatLogger.m
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef BUILD_WITH_CMAKE
+#endif  // BUILD_WITH_CMAKE
+
 #import <Foundation/Foundation.h>
 
-#import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
-
+#ifndef BUILD_WITH_CMAKE
 @import FirebaseCoreInternal;
+#endif  // BUILD_WITH_CMAKE
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
+#import "FirebaseCore/Extension/FIRHeartbeatLogger.h"
 
+#ifndef BUILD_WITH_CMAKE
 NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *heartbeatsPayload) {
   if ([heartbeatsPayload isEmpty]) {
     return nil;
@@ -27,9 +32,12 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 
   return [heartbeatsPayload headerValue];
 }
+#endif  // BUILD_WITH_CMAKE
 
 @interface FIRHeartbeatLogger ()
+#ifndef BUILD_WITH_CMAKE
 @property(nonatomic, readonly) FIRHeartbeatController *heartbeatController;
+#endif  // BUILD_WITH_CMAKE
 @property(copy, readonly) NSString * (^userAgentProvider)(void);
 @end
 
@@ -43,7 +51,9 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
             userAgentProvider:(NSString * (^)(void))userAgentProvider {
   self = [super init];
   if (self) {
+#ifndef BUILD_WITH_CMAKE
     _heartbeatController = [[FIRHeartbeatController alloc] initWithId:[appID copy]];
+#endif  // BUILD_WITH_CMAKE
     _userAgentProvider = [userAgentProvider copy];
   }
   return self;
@@ -57,9 +67,12 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 
 - (void)log {
   NSString *userAgent = _userAgentProvider();
+#ifndef BUILD_WITH_CMAKE
   [_heartbeatController log:userAgent];
+#endif  // BUILD_WITH_CMAKE
 }
 
+#ifndef BUILD_WITH_CMAKE
 - (FIRHeartbeatsPayload *)flushHeartbeatsIntoPayload {
   FIRHeartbeatsPayload *payload = [_heartbeatController flush];
   return payload;
@@ -74,5 +87,6 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
     return FIRHeartbeatInfoCodeGlobal;
   }
 }
+#endif  // BUILD_WITH_CMAKE
 
 @end


### PR DESCRIPTION
Fixes Firestore CMake CI failues on `v9b`. 

Added a macro to avoid building symbols from new Swift `HeartbeatCoreInternal` module. See comment with context:
https://github.com/firebase/firebase-ios-sdk/blob/614e311d223e3c58bf329258bd86252e78bba8d5/FirebaseCore/CMakeLists.txt#L34-L41

I `ifdef`'d all symbols related to the Swift `FirebaseCoreInternal` module. This is a slightly better bandaid than what I had before.

- I believe this issue surfaced in #9531 when I cherry-picked the `clang-format14` update (which styled a Firestore file).
- This issue is causing Firestore CI failures in #9512.

#no-changelog