### PR TITLE
[Docs] Bump `clang-format` version from 13 to 14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@13
+    brew install clang-format@14
     brew install mint
     ```
 


### PR DESCRIPTION
I missed this in #9527.

#no-changelog