### PR TITLE
Fix abseil forward ref warning for StrSplit

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -88,7 +88,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseCore', '~> 8.0'
 
-  abseil_version = '0.20200225.0'
+  abseil_version = '~> 1.20211102.0'
   s.dependency 'abseil/algorithm', abseil_version
   s.dependency 'abseil/base', abseil_version
   s.dependency 'abseil/container/flat_hash_map', abseil_version
@@ -98,7 +98,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'abseil/time', abseil_version
   s.dependency 'abseil/types', abseil_version
 
-  s.dependency 'gRPC-C++', '~> 1.28.0'
+  s.dependency 'gRPC-C++', '~> 1.44.0'
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'nanopb', '~> 2.30908.0'
 

--- a/Firestore/core/src/model/field_path.cc
+++ b/Firestore/core/src/model/field_path.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 #include "Firestore/core/src/util/exception.h"
 #include "Firestore/core/src/util/hard_assert.h"
@@ -100,7 +101,7 @@ FieldPath FieldPath::FromDotSeparatedStringView(absl::string_view path) {
         path);
   }
 
-  SegmentsT segments =
+  std::vector<absl::string_view> segments =
       absl::StrSplit(path, '.', [path](absl::string_view segment) {
         if (segment.empty()) {
           ThrowInvalidArgument(
@@ -111,7 +112,10 @@ FieldPath FieldPath::FromDotSeparatedStringView(absl::string_view path) {
         return true;
       });
 
-  return FieldPath(std::move(segments));
+  std::vector<std::string> segment_strs =
+      std::vector<std::string>(segments.begin(), segments.end());
+
+  return FieldPath(std::move(segment_strs));
 }
 
 StatusOr<FieldPath> FieldPath::FromServerFormat(const std::string& path) {

--- a/Firestore/core/src/model/resource_path.cc
+++ b/Firestore/core/src/model/resource_path.cc
@@ -45,9 +45,12 @@ ResourcePath ResourcePath::FromStringView(absl::string_view path) {
 
   // SkipEmpty because we may still have an empty segment at the beginning or
   // end if they had a leading or trailing slash (which we allow).
-  std::vector<std::string> segments =
+  std::vector<absl::string_view> segments =
       absl::StrSplit(path, '/', absl::SkipEmpty());
-  return ResourcePath{std::move(segments)};
+  std::vector<std::string> segment_strs =
+      std::vector<std::string>(segments.begin(), segments.end());
+
+  return ResourcePath{std::move(segment_strs)};
 }
 
 std::string ResourcePath::CanonicalString() const {

--- a/Firestore/core/src/model/value_util.cc
+++ b/Firestore/core/src/model/value_util.cc
@@ -161,9 +161,9 @@ ComparisonResult CompareBlobs(const google_firestore_v1_Value& left,
 
 ComparisonResult CompareReferences(const google_firestore_v1_Value& left,
                                    const google_firestore_v1_Value& right) {
-  std::vector<std::string> left_segments = absl::StrSplit(
+  std::vector<absl::string_view> left_segments = absl::StrSplit(
       nanopb::MakeStringView(left.reference_value), '/', absl::SkipEmpty());
-  std::vector<std::string> right_segments = absl::StrSplit(
+  std::vector<absl::string_view> right_segments = absl::StrSplit(
       nanopb::MakeStringView(right.reference_value), '/', absl::SkipEmpty());
 
   size_t min_length = std::min(left_segments.size(), right_segments.size());
@@ -398,7 +398,7 @@ std::string CanonifyBlob(const google_firestore_v1_Value& value) {
 }
 
 std::string CanonifyReference(const google_firestore_v1_Value& value) {
-  std::vector<std::string> segments = absl::StrSplit(
+  std::vector<absl::string_view> segments = absl::StrSplit(
       nanopb::MakeStringView(value.reference_value), '/', absl::SkipEmpty());
   HARD_ASSERT(segments.size() >= 5,
               "Reference values should have at least 5 components");

--- a/Package.swift
+++ b/Package.swift
@@ -178,12 +178,12 @@ let package = Package(
     .package(
       name: "abseil",
       url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      "0.20200225.4" ..< "0.20200226.0"
+      "0.20220203.1" ..< "0.20220204.0"
     ),
     .package(
       name: "gRPC",
-      url: "https://github.com/firebase/grpc-SwiftPM.git",
-      "1.28.4" ..< "1.29.0"
+      url: "https://github.com/grpc/grpc-ios.git",
+      "1.44.0-grpc" ..< "1.45.0-grpc"
     ),
     .package(
       name: "OCMock",


### PR DESCRIPTION
Patching StrSplit usage for [bugprone-move-forwarding-reference](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html) warning as seem from https://github.com/firebase/firebase-ios-sdk/pull/9486.  StrSplit requires a forwarding reference (rvalue ref inferred from a template param) to be passed into its first parameter, and we are currently passing a lvalue ref instead. 