### PR TITLE
Enable async/await APIs for iOS 13, etc.

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -66,7 +66,7 @@ final class AppCheckAPITests {
 
     // Get token (async/await)
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -100,7 +100,7 @@ final class AppCheckAPITests {
 
       // Get token (async/await)
       #if compiler(>=5.5.2) && canImport(_Concurrency)
-        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             do {
@@ -173,7 +173,7 @@ final class AppCheckAPITests {
           }
           // Get token (async/await)
           #if compiler(>=5.5.2) && canImport(_Concurrency)
-            if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+            if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
               // async/await is a Swift 5.5+ feature available on iOS 15+
               Task {
                 do {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -66,7 +66,7 @@ final class AppCheckAPITests {
 
     // Get token (async/await)
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -100,7 +100,7 @@ final class AppCheckAPITests {
 
       // Get token (async/await)
       #if compiler(>=5.5.2) && canImport(_Concurrency)
-        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             do {
@@ -173,7 +173,7 @@ final class AppCheckAPITests {
           }
           // Get token (async/await)
           #if compiler(>=5.5.2) && canImport(_Concurrency)
-            if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+            if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
               // async/await is a Swift 5.5+ feature available on iOS 15+
               Task {
                 do {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -65,7 +65,7 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -76,7 +76,7 @@ final class AppCheckAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Set `AppCheckProviderFactory`
     AppCheck.setAppCheckProviderFactory(DummyAppCheckProviderFactory())
@@ -99,7 +99,7 @@ final class AppCheckAPITests {
       }
 
       // Get token (async/await)
-      #if compiler(>=5.5) && canImport(_Concurrency)
+      #if compiler(>=5.5.2) && canImport(_Concurrency)
         if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
@@ -110,7 +110,7 @@ final class AppCheckAPITests {
             }
           }
         }
-      #endif // compiler(>=5.5) && canImport(_Concurrency)
+      #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
       _ = debugProvider.localDebugToken()
       _ = debugProvider.currentDebugToken()
@@ -172,7 +172,7 @@ final class AppCheckAPITests {
             }
           }
           // Get token (async/await)
-          #if compiler(>=5.5) && canImport(_Concurrency)
+          #if compiler(>=5.5.2) && canImport(_Concurrency)
             if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
               // async/await is a Swift 5.5+ feature available on iOS 15+
               Task {
@@ -183,7 +183,7 @@ final class AppCheckAPITests {
                 }
               }
             }
-          #endif // compiler(>=5.5) && canImport(_Concurrency)
+          #endif // compiler(>=5.5.2) && canImport(_Concurrency)
         }
       }
     #endif // !os(watchOS)

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -76,7 +76,7 @@ class AccountInfoTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 7, *)
     func testUpdatingUsersEmailAsync() async throws {
       let auth = Auth.auth()
       do {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -75,8 +75,8 @@ class AccountInfoTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testUpdatingUsersEmailAsync() async throws {
       let auth = Auth.auth()
       do {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -30,7 +30,7 @@ class AnonymousTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUpdatingUsersEmailAsync() async throws {
       try await signInAnonymouslyAsync()
       if let isAnonymous = Auth.auth().currentUser?.isAnonymous {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -30,7 +30,7 @@ class AnonymousTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testUpdatingUsersEmailAsync() async throws {
       try await signInAnonymouslyAsync()
       if let isAnonymous = Auth.auth().currentUser?.isAnonymous {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -29,8 +29,8 @@ class AnonymousTests: TestsBase {
     deleteCurrentUser()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testUpdatingUsersEmailAsync() async throws {
       try await signInAnonymouslyAsync()
       if let isAnonymous = Auth.auth().currentUser?.isAnonymous {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -40,7 +40,7 @@ class EmailPasswordTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testCreateAccountWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
@@ -64,7 +64,7 @@ class EmailPasswordTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -39,8 +39,8 @@ class EmailPasswordTests: TestsBase {
     deleteCurrentUser()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testCreateAccountWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
@@ -63,8 +63,8 @@ class EmailPasswordTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -40,7 +40,7 @@ class EmailPasswordTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testCreateAccountWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
@@ -64,7 +64,7 @@ class EmailPasswordTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
       try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -42,8 +42,8 @@ class FacebookTests: TestsBase {
     deleteFacebookTestingAccountbyID(facebookAccountID)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testSignInWithFacebookAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await createFacebookTestingAccountAsync()
@@ -88,8 +88,8 @@ class FacebookTests: TestsBase {
     deleteFacebookTestingAccountbyID(facebookAccountID)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testLinkAnonymousAccountToFacebookAccountAsync() async throws {
       let auth = Auth.auth()
       try await signInAnonymouslyAsync()
@@ -150,8 +150,8 @@ class FacebookTests: TestsBase {
     return returnValue
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     /// ** Creates a Facebook testing account using Facebook Graph API and return a dictionary that
     // * constains "id", "access_token", "login_url", "email" and "password" of the created account.
     // */
@@ -194,8 +194,8 @@ class FacebookTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     // ** Delete a Facebook testing account by account Id using Facebook Graph API. */
     func deleteFacebookTestingAccountbyIDAsync(_ accountID: String) async throws {
       let urltoDeleteTestUser = "https://graph.facebook.com/\(accountID)"

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -43,7 +43,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testSignInWithFacebookAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await createFacebookTestingAccountAsync()
@@ -89,7 +89,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testLinkAnonymousAccountToFacebookAccountAsync() async throws {
       let auth = Auth.auth()
       try await signInAnonymouslyAsync()
@@ -151,7 +151,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     /// ** Creates a Facebook testing account using Facebook Graph API and return a dictionary that
     // * constains "id", "access_token", "login_url", "email" and "password" of the created account.
     // */
@@ -195,7 +195,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     // ** Delete a Facebook testing account by account Id using Facebook Graph API. */
     func deleteFacebookTestingAccountbyIDAsync(_ accountID: String) async throws {
       let urltoDeleteTestUser = "https://graph.facebook.com/\(accountID)"

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -43,7 +43,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testSignInWithFacebookAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await createFacebookTestingAccountAsync()
@@ -89,7 +89,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testLinkAnonymousAccountToFacebookAccountAsync() async throws {
       let auth = Auth.auth()
       try await signInAnonymouslyAsync()
@@ -151,7 +151,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     /// ** Creates a Facebook testing account using Facebook Graph API and return a dictionary that
     // * constains "id", "access_token", "login_url", "email" and "password" of the created account.
     // */
@@ -195,7 +195,7 @@ class FacebookTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     // ** Delete a Facebook testing account by account Id using Facebook Graph API. */
     func deleteFacebookTestingAccountbyIDAsync(_ accountID: String) async throws {
       let urltoDeleteTestUser = "https://graph.facebook.com/\(accountID)"

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -37,8 +37,8 @@ class GoogleTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testSignInWithGoogleAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await getGoogleAccessTokenAsync()
@@ -84,8 +84,8 @@ class GoogleTests: TestsBase {
     return returnValue
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     /// ** Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
     // * access token. Returns a dictionary that constains "access_token", "token_type", "expires_in" and
     // * sometimes the "id_token". (The id_token is not guaranteed to be returned during a refresh

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -38,7 +38,7 @@ class GoogleTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testSignInWithGoogleAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await getGoogleAccessTokenAsync()
@@ -85,7 +85,7 @@ class GoogleTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     /// ** Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
     // * access token. Returns a dictionary that constains "access_token", "token_type", "expires_in" and
     // * sometimes the "id_token". (The id_token is not guaranteed to be returned during a refresh

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -38,7 +38,7 @@ class GoogleTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testSignInWithGoogleAsync() async throws {
       let auth = Auth.auth()
       let userInfoDict = try await getGoogleAccessTokenAsync()
@@ -85,7 +85,7 @@ class GoogleTests: TestsBase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     /// ** Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
     // * access token. Returns a dictionary that constains "access_token", "token_type", "expires_in" and
     // * sometimes the "id_token". (The id_token is not guaranteed to be returned during a refresh

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
@@ -91,7 +91,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRAuth_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!
@@ -221,7 +221,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRAuthUIDelegate_hAsync() async {
       class AuthUIImpl: NSObject, AuthUIDelegate {
         func present(_ viewControllerToPresent: UIViewController, animated flag: Bool) async {}
@@ -254,7 +254,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRFedederatedAuthProvider_hAsync() async throws {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
@@ -272,7 +272,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRGameCenterAuthProvider_hAsync() async throws {
       _ = try await GameCenterAuthProvider.getCredential()
     }
@@ -299,7 +299,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRMultiFactor_hAsync() async throws {
       let obj = MultiFactor()
       try await obj.session()
@@ -316,7 +316,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRMultiFactorResolver_hAsync() async throws {
       let obj = MultiFactorResolver()
       try await obj.resolveSignIn(with: MultiFactorAssertion())
@@ -352,7 +352,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRPhoneAuthProvider_hAsync() async throws {
       _ = PhoneAuthProvider.provider()
       let provider = PhoneAuthProvider.provider(auth: FirebaseAuth.Auth.auth())
@@ -424,7 +424,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func FIRUser_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
@@ -90,8 +90,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     try auth.getStoredUser(forAccessGroup: "def")
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRAuth_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!
@@ -220,8 +220,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     obj.dismiss(animated: false) {}
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRAuthUIDelegate_hAsync() async {
       class AuthUIImpl: NSObject, AuthUIDelegate {
         func present(_ viewControllerToPresent: UIViewController, animated flag: Bool) async {}
@@ -253,8 +253,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRFedederatedAuthProvider_hAsync() async throws {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
@@ -271,8 +271,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRGameCenterAuthProvider_hAsync() async throws {
       _ = try await GameCenterAuthProvider.getCredential()
     }
@@ -298,8 +298,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRMultiFactor_hAsync() async throws {
       let obj = MultiFactor()
       try await obj.session()
@@ -315,8 +315,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRMultiFactorResolver_hAsync() async throws {
       let obj = MultiFactorResolver()
       try await obj.resolveSignIn(with: MultiFactorAssertion())
@@ -351,8 +351,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     provider.credential(withVerificationID: "id", verificationCode: "code")
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRPhoneAuthProvider_hAsync() async throws {
       _ = PhoneAuthProvider.provider()
       let provider = PhoneAuthProvider.provider(auth: FirebaseAuth.Auth.auth())
@@ -423,8 +423,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func FIRUser_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/SwiftAPI.swift
@@ -91,7 +91,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRAuth_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!
@@ -221,7 +221,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRAuthUIDelegate_hAsync() async {
       class AuthUIImpl: NSObject, AuthUIDelegate {
         func present(_ viewControllerToPresent: UIViewController, animated flag: Bool) async {}
@@ -254,7 +254,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRFedederatedAuthProvider_hAsync() async throws {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
@@ -272,7 +272,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRGameCenterAuthProvider_hAsync() async throws {
       _ = try await GameCenterAuthProvider.getCredential()
     }
@@ -299,7 +299,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRMultiFactor_hAsync() async throws {
       let obj = MultiFactor()
       try await obj.session()
@@ -316,7 +316,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRMultiFactorResolver_hAsync() async throws {
       let obj = MultiFactorResolver()
       try await obj.resolveSignIn(with: MultiFactorAssertion())
@@ -352,7 +352,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRPhoneAuthProvider_hAsync() async throws {
       _ = PhoneAuthProvider.provider()
       let provider = PhoneAuthProvider.provider(auth: FirebaseAuth.Auth.auth())
@@ -424,7 +424,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRUser_hAsync() async throws {
       let auth = FirebaseAuth.Auth.auth()
       let user = auth.currentUser!

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -22,13 +22,13 @@ class TestsBase: XCTestCase {
   static let kExpectationsTimeout = 10.0
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func signInAnonymouslyAsync() async throws {
       let auth = Auth.auth()
       try await auth.signInAnonymously()
     }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func deleteCurrentUserAsync() async throws {
       let auth = Auth.auth()
       try await auth.currentUser?.delete()

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -21,14 +21,14 @@ import XCTest
 class TestsBase: XCTestCase {
   static let kExpectationsTimeout = 10.0
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func signInAnonymouslyAsync() async throws {
       let auth = Auth.auth()
       try await auth.signInAnonymously()
     }
 
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func deleteCurrentUserAsync() async throws {
       let auth = Auth.auth()
       try await auth.currentUser?.delete()

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -22,13 +22,13 @@ class TestsBase: XCTestCase {
   static let kExpectationsTimeout = 10.0
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func signInAnonymouslyAsync() async throws {
       let auth = Auth.auth()
       try await auth.signInAnonymously()
     }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func deleteCurrentUserAsync() async throws {
       let auth = Auth.auth()
       try await auth.currentUser?.delete()

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -52,7 +52,7 @@ final class CoreAPITests {
       }
 
       #if compiler(>=5.5.2) && canImport(_Concurrency)
-        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             await app.delete()

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -51,14 +51,14 @@ final class CoreAPITests {
         // ...
       }
 
-      #if compiler(>=5.5) && canImport(_Concurrency)
+      #if compiler(>=5.5.2) && canImport(_Concurrency)
         if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             await app.delete()
           }
         }
-      #endif // compiler(>=5.5) && canImport(_Concurrency)
+      #endif // compiler(>=5.5.2) && canImport(_Concurrency)
     }
 
     // Properties

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -52,7 +52,7 @@ final class CoreAPITests {
       }
 
       #if compiler(>=5.5.2) && canImport(_Concurrency)
-        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             await app.delete()

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -112,7 +112,7 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot = dataSnapshot
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -123,7 +123,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Observe Single Event
 
@@ -138,7 +138,7 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -147,7 +147,7 @@ final class DatabaseAPITests {
             .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseQuery.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -210,7 +210,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -222,7 +222,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     databaseReference.setValue(value, andPriority: priority)
 
@@ -232,7 +232,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -245,7 +245,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Remove value
     databaseReference.removeValue()
@@ -256,7 +256,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -267,7 +267,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Set priority
     databaseReference.setPriority(priority)
@@ -278,7 +278,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -290,7 +290,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Update child values
     databaseReference.updateChildValues(values)
@@ -301,7 +301,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -314,7 +314,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Observe for data
 
@@ -357,7 +357,7 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -366,7 +366,7 @@ final class DatabaseAPITests {
             .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseReference.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -391,7 +391,7 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot = dataSnapshot
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -402,7 +402,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Remove Observers
     databaseReference.removeObserver(withHandle: databaseHandle)
@@ -435,7 +435,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -448,7 +448,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     databaseReference.onDisconnectSetValue(value, andPriority: priorityAny)
 
@@ -459,7 +459,7 @@ final class DatabaseAPITests {
         let /* databaseReference */ _: DatabaseReference = databaseReference
       }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -474,7 +474,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // onDisconnectRemoveValue
     databaseReference.onDisconnectRemoveValue()
@@ -485,7 +485,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -497,7 +497,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // onDisconnectUpdateChildValues
     databaseReference.onDisconnectUpdateChildValues(values)
@@ -508,7 +508,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -521,7 +521,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // cancelDisconnectOperations
     databaseReference.cancelDisconnectOperations()
@@ -532,7 +532,7 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -544,7 +544,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // runTransactionBlock
 
@@ -564,7 +564,7 @@ final class DatabaseAPITests {
       let /* optionalDataSnapshot */ _: DataSnapshot? = optionalDataSnapshot
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -580,7 +580,7 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // runTransactionBlock(_ block:andCompletionBlock completionBlock:withLocalEvents localEvents:)
     databaseReference.runTransactionBlock({ mutableData in

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -113,7 +113,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -139,7 +139,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           // observeSingleEvent(of eventType:)
@@ -211,7 +211,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -233,7 +233,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -257,7 +257,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -279,7 +279,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -302,7 +302,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -358,7 +358,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           // observeSingleEvent(of eventType:)
@@ -392,7 +392,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -436,7 +436,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -460,7 +460,7 @@ final class DatabaseAPITests {
       }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -486,7 +486,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -509,7 +509,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -533,7 +533,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -565,7 +565,7 @@ final class DatabaseAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {

--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.0.0
+- [changed] Backported Callable async/await APIs to iOS 13, etc. (#9483).
+
 # v8.9.0
 - [fixed] Add watchOS support for Swift Package Manager (#8864).
 

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -107,7 +107,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     call(data, completion: completion)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Executes this Callable HTTPS trigger asynchronously.
     ///
     /// The data passed into the trigger must be of the generic `Request` type:
@@ -128,7 +128,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Throws: An error if the callable fails to complete
     ///
     /// - Returns: The decoded `Response` value
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     public func call(_ data: Request,
                      encoder: FirebaseDataEncoder = FirebaseDataEncoder(),
                      decoder: FirebaseDataDecoder =
@@ -157,7 +157,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Parameters:
     ///   - data: Parameters to pass to the trigger.
     /// - Returns: The decoded `Response` value
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     public func callAsFunction(_ data: Request) async throws -> Response {
       return try await call(data)
     }

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -128,7 +128,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Throws: An error if the callable fails to complete
     ///
     /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     public func call(_ data: Request,
                      encoder: FirebaseDataEncoder = FirebaseDataEncoder(),
                      decoder: FirebaseDataDecoder =
@@ -157,7 +157,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Parameters:
     ///   - data: Parameters to pass to the trigger.
     /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     public func callAsFunction(_ data: Request) async throws -> Response {
       return try await call(data)
     }

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -128,7 +128,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Throws: An error if the callable fails to complete
     ///
     /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     public func call(_ data: Request,
                      encoder: FirebaseDataEncoder = FirebaseDataEncoder(),
                      decoder: FirebaseDataDecoder =
@@ -157,7 +157,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     /// - Parameters:
     ///   - data: Parameters to pass to the trigger.
     /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     public func callAsFunction(_ data: Request) async throws -> Response {
       return try await call(data)
     }

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -127,7 +127,7 @@ open class HTTPSCallable: NSObject {
      * @param data Parameters to pass to the trigger.
      * @returns The result of the call.
      */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
       return try await withCheckedThrowingContinuation { continuation in
         // TODO(bonus): Use task to handle and cancellation.

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -127,7 +127,7 @@ open class HTTPSCallable: NSObject {
      * @param data Parameters to pass to the trigger.
      * @returns The result of the call.
      */
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
       return try await withCheckedThrowingContinuation { continuation in
         // TODO(bonus): Use task to handle and cancellation.

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -112,7 +112,7 @@ open class HTTPSCallable: NSObject {
     call(nil, completion: completion)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      * Executes this Callable HTTPS trigger asynchronously.
      *
@@ -127,7 +127,7 @@ open class HTTPSCallable: NSObject {
      * @param data Parameters to pass to the trigger.
      * @returns The result of the call.
      */
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
       return try await withCheckedThrowingContinuation { continuation in
         // TODO(bonus): Use task to handle and cancellation.
@@ -140,5 +140,5 @@ open class HTTPSCallable: NSObject {
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
+  #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 }

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -105,8 +105,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testDataAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -150,8 +150,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testScalarAsync() async throws {
       let function = functions.httpsCallable(
         "scalarTest",
@@ -163,7 +163,7 @@ class IntegrationTests: XCTestCase {
       XCTAssertEqual(result, 76)
     }
 
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testScalarAsyncAlternateSignature() async throws {
       let function: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
       let result = try await function.call(17)
@@ -203,8 +203,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testTokenAsync() async throws {
       // Recreate functions with a token.
       let functions = Functions(
@@ -247,8 +247,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testFCMTokenAsync() async throws {
       let function = functions.httpsCallable(
         "FCMTokenTest",
@@ -280,8 +280,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testNullAsync() async throws {
       let function = functions.httpsCallable(
         "nullTest",
@@ -316,8 +316,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testMissingResultAsync() async {
       let function = functions.httpsCallable(
         "missingResultTest",
@@ -358,8 +358,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testUnhandledErrorAsync() async {
       let function = functions.httpsCallable(
         "unhandledErrorTest",
@@ -399,8 +399,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testUnknownErrorAsync() async {
       let function = functions.httpsCallable(
         "unknownErrorTest",
@@ -442,8 +442,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testExplicitErrorAsync() async {
       let function = functions.httpsCallable(
         "explicitErrorTest",
@@ -485,8 +485,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testHttpErrorAsync() async {
       let function = functions.httpsCallable(
         "httpErrorTest",
@@ -527,8 +527,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testTimeoutAsync() async {
       var function = functions.httpsCallable(
         "timeoutTest",
@@ -578,8 +578,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testCallAsFunctionAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -633,8 +633,8 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func testInferredTyesAsync() async throws {
       let data = DataTestRequest(
         bool: true,

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -106,7 +106,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testDataAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -151,7 +151,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testScalarAsync() async throws {
       let function = functions.httpsCallable(
         "scalarTest",
@@ -163,7 +163,7 @@ class IntegrationTests: XCTestCase {
       XCTAssertEqual(result, 76)
     }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testScalarAsyncAlternateSignature() async throws {
       let function: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
       let result = try await function.call(17)
@@ -204,7 +204,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testTokenAsync() async throws {
       // Recreate functions with a token.
       let functions = Functions(
@@ -248,7 +248,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testFCMTokenAsync() async throws {
       let function = functions.httpsCallable(
         "FCMTokenTest",
@@ -281,7 +281,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testNullAsync() async throws {
       let function = functions.httpsCallable(
         "nullTest",
@@ -317,7 +317,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testMissingResultAsync() async {
       let function = functions.httpsCallable(
         "missingResultTest",
@@ -359,7 +359,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnhandledErrorAsync() async {
       let function = functions.httpsCallable(
         "unhandledErrorTest",
@@ -400,7 +400,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnknownErrorAsync() async {
       let function = functions.httpsCallable(
         "unknownErrorTest",
@@ -443,7 +443,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testExplicitErrorAsync() async {
       let function = functions.httpsCallable(
         "explicitErrorTest",
@@ -486,7 +486,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testHttpErrorAsync() async {
       let function = functions.httpsCallable(
         "httpErrorTest",
@@ -528,7 +528,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testTimeoutAsync() async {
       var function = functions.httpsCallable(
         "timeoutTest",
@@ -579,7 +579,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testCallAsFunctionAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -634,7 +634,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testInferredTyesAsync() async throws {
       let data = DataTestRequest(
         bool: true,

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -106,7 +106,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testDataAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -151,7 +151,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testScalarAsync() async throws {
       let function = functions.httpsCallable(
         "scalarTest",
@@ -163,7 +163,7 @@ class IntegrationTests: XCTestCase {
       XCTAssertEqual(result, 76)
     }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testScalarAsyncAlternateSignature() async throws {
       let function: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
       let result = try await function.call(17)
@@ -204,7 +204,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testTokenAsync() async throws {
       // Recreate functions with a token.
       let functions = Functions(
@@ -248,7 +248,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testFCMTokenAsync() async throws {
       let function = functions.httpsCallable(
         "FCMTokenTest",
@@ -281,7 +281,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testNullAsync() async throws {
       let function = functions.httpsCallable(
         "nullTest",
@@ -317,7 +317,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testMissingResultAsync() async {
       let function = functions.httpsCallable(
         "missingResultTest",
@@ -359,7 +359,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testUnhandledErrorAsync() async {
       let function = functions.httpsCallable(
         "unhandledErrorTest",
@@ -400,7 +400,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testUnknownErrorAsync() async {
       let function = functions.httpsCallable(
         "unknownErrorTest",
@@ -443,7 +443,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testExplicitErrorAsync() async {
       let function = functions.httpsCallable(
         "explicitErrorTest",
@@ -486,7 +486,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testHttpErrorAsync() async {
       let function = functions.httpsCallable(
         "httpErrorTest",
@@ -528,7 +528,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testTimeoutAsync() async {
       var function = functions.httpsCallable(
         "timeoutTest",
@@ -579,7 +579,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testCallAsFunctionAsync() async throws {
       let data = DataTestRequest(
         bool: true,
@@ -634,7 +634,7 @@ class IntegrationTests: XCTestCase {
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func testInferredTyesAsync() async throws {
       let data = DataTestRequest(
         bool: true,

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -58,7 +58,7 @@ final class FunctionsAPITests {
       }
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -70,7 +70,7 @@ final class FunctionsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     callableRef.call { result, error in
       if let result = result {
@@ -80,7 +80,7 @@ final class FunctionsAPITests {
       }
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -92,7 +92,7 @@ final class FunctionsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // MARK: - FunctionsErrorCode
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -59,7 +59,7 @@ final class FunctionsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -81,7 +81,7 @@ final class FunctionsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -59,7 +59,7 @@ final class FunctionsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -81,7 +81,7 @@ final class FunctionsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -51,7 +51,7 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -62,7 +62,7 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Retrieves an installation auth token
     Installations.installations().authToken { result, error in
@@ -73,7 +73,7 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -84,7 +84,7 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Retrieves an installation auth token with forcing refresh parameter
     Installations.installations().authTokenForcingRefresh(true) { result, error in
@@ -95,7 +95,7 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -106,7 +106,7 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5) && canImport(_Concurrency)
+    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Delete installation data
     Installations.installations().delete { error in

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -52,7 +52,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -74,7 +74,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -96,7 +96,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -116,7 +116,7 @@ final class InstallationsAPITests {
     }
 
     #if swift(>=5.5)
-      if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -52,7 +52,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -74,7 +74,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -96,7 +96,7 @@ final class InstallationsAPITests {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {
@@ -116,7 +116,7 @@ final class InstallationsAPITests {
     }
 
     #if swift(>=5.5)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *) {
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
           do {

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -110,7 +110,7 @@ class CustomDelegate: NSObject, MessagingDelegate {
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {}
 }
 
-@available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
 func apiAsync() async throws {
   let messaging = Messaging.messaging()
   let topic = "cat_video"

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -110,7 +110,7 @@ class CustomDelegate: NSObject, MessagingDelegate {
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {}
 }
 
-@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 func apiAsync() async throws {
   let messaging = Messaging.messaging()
   let topic = "cat_video"

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -110,11 +110,11 @@ class CustomDelegate: NSObject, MessagingDelegate {
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {}
 }
 
-@available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+@available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
 func apiAsync() async throws {
   let messaging = Messaging.messaging()
   let topic = "cat_video"
-  #if compiler(>=5.5) && canImport(_Concurrency)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
     try await messaging.subscribe(toTopic: topic)
 
     try await messaging.unsubscribe(fromTopic: topic)

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -18,7 +18,7 @@ import FirebaseCore
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class AsyncAwaitTests: APITestBase {
     func testFetchThenActivate() async throws {
       let status = try await config.fetch()

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -18,7 +18,7 @@ import FirebaseCore
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   class AsyncAwaitTests: APITestBase {
     func testFetchThenActivate() async throws {
       let status = try await config.fetch()

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -17,8 +17,8 @@ import FirebaseCore
 
 import XCTest
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   class AsyncAwaitTests: APITestBase {
     func testFetchThenActivate() async throws {
       let status = try await config.fetch()

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -18,7 +18,7 @@ import FirebaseRemoteConfigSwift
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class CodableTests: APITestBase {
     // MARK: - Test decoding Remote Config JSON values
 

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -18,7 +18,7 @@ import FirebaseRemoteConfigSwift
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   class CodableTests: APITestBase {
     // MARK: - Test decoding Remote Config JSON values
 

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -17,8 +17,8 @@ import FirebaseRemoteConfigSwift
 
 import XCTest
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   class CodableTests: APITestBase {
     // MARK: - Test decoding Remote Config JSON values
 

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -18,7 +18,7 @@ import FirebaseRemoteConfigSwift
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class ValueTests: APITestBase {
     func testFetchAndActivateAllTypes() async throws {
       let status = try await config.fetchAndActivate()

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -17,8 +17,8 @@ import FirebaseRemoteConfigSwift
 
 import XCTest
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   class ValueTests: APITestBase {
     func testFetchAndActivateAllTypes() async throws {
       let status = try await config.fetchAndActivate()

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -18,7 +18,7 @@ import FirebaseRemoteConfigSwift
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   class ValueTests: APITestBase {
     func testFetchAndActivateAllTypes() async throws {
       let status = try await config.fetchAndActivate()

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.0.0
+- [changed] Backported `StorageReference` async/await APIs to iOS 13, etc. (#9483).
+
 # 8.5.0
 - [fixed] Fixed an issue where Storage could not connect to local emulators using
   http (#8389).

--- a/FirebaseStorageSwift/Sources/AsyncAwait.swift
+++ b/FirebaseStorageSwift/Sources/AsyncAwait.swift
@@ -14,8 +14,8 @@
 
 import FirebaseStorage
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   public extension StorageReference {
     /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
     /// A Data object of the provided max size will be allocated, so ensure that the device has

--- a/FirebaseStorageSwift/Sources/AsyncAwait.swift
+++ b/FirebaseStorageSwift/Sources/AsyncAwait.swift
@@ -15,7 +15,7 @@
 import FirebaseStorage
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension StorageReference {
     /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
     /// A Data object of the provided max size will be allocated, so ensure that the device has

--- a/FirebaseStorageSwift/Sources/AsyncAwait.swift
+++ b/FirebaseStorageSwift/Sources/AsyncAwait.swift
@@ -15,7 +15,7 @@
 import FirebaseStorage
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   public extension StorageReference {
     /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
     /// A Data object of the provided max size will be allocated, so ensure that the device has

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -17,8 +17,8 @@
 import FirebaseFirestore
 import Foundation
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   public extension CollectionReference {
     /// Adds a new document to this collection with the specified data, assigning it a document ID
     /// automatically.

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -18,7 +18,7 @@ import FirebaseFirestore
 import Foundation
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   public extension CollectionReference {
     /// Adds a new document to this collection with the specified data, assigning it a document ID
     /// automatically.

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -18,7 +18,7 @@ import FirebaseFirestore
 import Foundation
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension CollectionReference {
     /// Adds a new document to this collection with the specified data, assigning it a document ID
     /// automatically.

--- a/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
@@ -18,7 +18,7 @@ import FirebaseFirestore
 import Foundation
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension Firestore {
     /// Loads a Firestore bundle into the local cache.
     /// - Parameter bundleData: Data from the bundle to be loaded.

--- a/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
@@ -18,7 +18,7 @@ import FirebaseFirestore
 import Foundation
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   public extension Firestore {
     /// Loads a Firestore bundle into the local cache.
     /// - Parameter bundleData: Data from the bundle to be loaded.

--- a/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
@@ -17,8 +17,8 @@
 import FirebaseFirestore
 import Foundation
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   public extension Firestore {
     /// Loads a Firestore bundle into the local cache.
     /// - Parameter bundleData: Data from the bundle to be loaded.

--- a/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
@@ -99,7 +99,7 @@ public extension DocumentReference {
     ///   - decoder: The decoder to use to convert the document. Defaults to use
     ///     the default decoder.
     /// - Returns: This instance of the supplied `Decodable` type `T`.
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
     func getDocument<T: Decodable>(as type: T.Type,
                                    with serverTimestampBehavior: ServerTimestampBehavior =
                                      .none,

--- a/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
@@ -99,7 +99,7 @@ public extension DocumentReference {
     ///   - decoder: The decoder to use to convert the document. Defaults to use
     ///     the default decoder.
     /// - Returns: This instance of the supplied `Decodable` type `T`.
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func getDocument<T: Decodable>(as type: T.Type,
                                    with serverTimestampBehavior: ServerTimestampBehavior =
                                      .none,

--- a/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
@@ -72,7 +72,7 @@ public extension DocumentReference {
     }
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
+  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Fetches and decodes the document referenced by this `DocumentReference`.
     ///
     /// This allows users to retrieve a Firestore document and have it decoded
@@ -99,7 +99,7 @@ public extension DocumentReference {
     ///   - decoder: The decoder to use to convert the document. Defaults to use
     ///     the default decoder.
     /// - Returns: This instance of the supplied `Decodable` type `T`.
-    @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
     func getDocument<T: Decodable>(as type: T.Type,
                                    with serverTimestampBehavior: ServerTimestampBehavior =
                                      .none,

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -473,8 +473,8 @@ func terminateDb(database db: Firestore) {
   }
 }
 
-#if swift(>=5.5)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+#if swift(>=5.5.2)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testAsyncAwait(database db: Firestore) async throws {
     try await db.enableNetwork()
     try await db.disableNetwork()

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -474,7 +474,7 @@ func terminateDb(database db: Firestore) {
 }
 
 #if swift(>=5.5)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   func testAsyncAwait(database db: Firestore) async throws {
     try await db.enableNetwork()
     try await db.disableNetwork()

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -474,7 +474,7 @@ func terminateDb(database db: Firestore) {
 }
 
 #if swift(>=5.5)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   func testAsyncAwait(database db: Firestore) async throws {
     try await db.enableNetwork()
     try await db.disableNetwork()

--- a/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
@@ -33,8 +33,8 @@ let emptyBundle = """
 }
 """
 
-#if swift(>=5.5)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
+#if swift(>=5.5.2)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class AsyncAwaitIntegrationTests: FSTIntegrationTestCase {
     func testAddData() async throws {
       let collection = collectionRef()

--- a/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
@@ -34,7 +34,7 @@ let emptyBundle = """
 """
 
 #if swift(>=5.5)
-  @available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
   class AsyncAwaitIntegrationTests: FSTIntegrationTestCase {
     func testAddData() async throws {
       let collection = collectionRef()

--- a/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
@@ -34,7 +34,7 @@ let emptyBundle = """
 """
 
 #if swift(>=5.5)
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 6, *)
   class AsyncAwaitIntegrationTests: FSTIntegrationTestCase {
     func testAddData() async throws {
       let collection = collectionRef()


### PR DESCRIPTION
This bumps the required compiler version to 5.5.2 which was included in
Xcode 13.2, where backporting was first introduced.

This breaks less developers and enables developers who aren't using
these APIs to still compile using Xcode 13.0 and 13.1.

As far as I can tell, the only breakage this includes now is developers
who are using Xcode 13.0 or 13.1, targeting iOS 15 and using one of
these 7 APIs. It will result in a compiler error and they'll have to
either use the completion handler version or upgrade to Xcode 13.2+ to
fix the compilation error.

Fixes #9483. 