### PR TITLE
Storage Swift API tests and fixes

### DIFF
--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -63,6 +63,16 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     }
   end
 
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.scheme = { :code_coverage => true }
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
+    unit_tests.source_files = 'FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift'
+  end
+
   s.test_spec 'integration' do |int_tests|
     int_tests.scheme = { :code_coverage => true }
     int_tests.platforms = {

--- a/FirebaseStorageSwift/Sources/StorageObservableTask.swift
+++ b/FirebaseStorageSwift/Sources/StorageObservableTask.swift
@@ -46,7 +46,7 @@ import FirebaseStorageObjC
    * Removes the single observer with the provided handle.
    * @param handle The handle of the task to remove.
    */
-  @objc(removeObserverWithHandle:) open func removeObserver(handle: String) {
+  @objc(removeObserverWithHandle:) open func removeObserver(withHandle handle: String) {
     (impl as! FIRIMPLStorageObservableTask).removeObserver(withHandle: handle)
   }
 
@@ -55,7 +55,7 @@ import FirebaseStorageObjC
    * @param status A StorageTaskStatus to remove listeners for.
    */
   @objc(removeAllObserversForStatus:)
-  open func removeAllObservers(status: StorageTaskStatus) {
+  open func removeAllObservers(for status: StorageTaskStatus) {
     (impl as! FIRIMPLStorageObservableTask)
       .removeAllObservers(for: FIRIMPLStorageTaskStatus(rawValue: status.rawValue)!)
   }

--- a/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
+++ b/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
@@ -1,0 +1,210 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MARK: This file is used to evaluate the experience of using Firebase APIs in Swift.
+
+import Foundation
+
+import FirebaseCore
+import FirebaseStorage
+
+final class StorageAPITests {
+  func StorageAPIs() {
+    let app = FirebaseApp.app()
+    _ = Storage.storage()
+    _ = Storage.storage(app: app!)
+    _ = Storage.storage(url: "my-url")
+    let storage = Storage.storage(app: app!, url: "my-url")
+    _ = storage.app
+    storage.maxUploadRetryTime = storage.maxUploadRetryTime
+    storage.maxDownloadRetryTime = storage.maxDownloadRetryTime + 1
+    storage.maxOperationRetryTime = storage.maxOperationRetryTime + 1
+    storage.callbackQueue = storage.callbackQueue
+    _ = storage.reference()
+    _ = storage.reference(forURL: "my-url")
+    _ = storage.reference(withPath: "path")
+    storage.useEmulator(withHost: "host", port: 123)
+  }
+
+  func StorageReferenceApis() {
+    var ref = Storage.storage().reference()
+    _ = ref.storage
+    _ = ref.bucket
+    _ = ref.fullPath
+    _ = ref.name
+
+    ref = ref.root()
+    ref = ref.parent()!
+    ref = ref.child("path")
+
+    _ = ref.putData(Data())
+    _ = ref.putData(Data(), metadata: nil)
+    _ = ref.putData(Data(), metadata: nil) { result in
+    }
+    _ = ref.putData(Data(), metadata: nil) { metadata, error in
+    }
+
+    let file = URL(string: "my-url")!
+    _ = ref.putFile(from: file)
+    _ = ref.putFile(from: file, metadata: nil)
+    _ = ref.putFile(from: file, metadata: nil) { result in
+    }
+    _ = ref.putFile(from: file, metadata: nil) { metadata, error in
+    }
+
+    _ = ref.getData(maxSize: 122) { data, error in
+    }
+    _ = ref.getData(maxSize: 122) { result in
+    }
+
+    ref.downloadURL { url, error in
+    }
+    ref.downloadURL { result in
+    }
+
+    ref.write(toFile: file)
+    ref.write(toFile: file) { url, error in
+    }
+    ref.write(toFile: file) { result in
+    }
+
+    ref.listAll { listResult, error in
+    }
+    ref.listAll { result in
+    }
+
+    ref.list(maxResults: 123) { listResult, error in
+    }
+    ref.list(maxResults: 222) { result in
+    }
+    ref.list(maxResults: 123, pageToken: "pageToken") { listResult, error in
+    }
+    ref.list(maxResults: 222, pageToken: "pageToken") { result in
+    }
+
+    ref.getMetadata { result in
+    }
+    ref.getMetadata { metadata, error in
+    }
+
+    ref.delete { error in
+    }
+  }
+
+  #if Firebase9Breaking
+    func StorageConstantsTypedefs() {
+      var _: StorageHandle
+      var _: StorageVoidDataError
+      var _: StorageVoidError
+      var _: StorageVoidMetadata
+      var _: StorageVoidMetadataError
+      var _: StorageVoidSnapshot
+      var _: StorageVoidURLError
+    }
+
+    func StorageConstantsGlobal() -> String {
+      return StorageErrorDomain
+    }
+  #endif
+
+  func StorageListResultApis(result: StorageListResult) {
+    _ = result.prefixes
+    _ = result.items
+    _ = result.pageToken
+  }
+
+  func taskStatuses(status: StorageTaskStatus) -> StorageTaskStatus {
+    switch status {
+    case .unknown: return status
+    case .resume: return status
+    case .progress: return status
+    case .pause: return status
+    case .success: return status
+    case .failure: return status
+    @unknown default:
+      fatalError()
+    }
+  }
+
+  func errorCodes(code: StorageErrorCode) -> StorageErrorCode {
+    switch code {
+    case .unknown: return code
+    case .objectNotFound: return code
+    case .bucketNotFound: return code
+    case .projectNotFound: return code
+    case .quotaExceeded: return code
+    case .unauthenticated: return code
+    case .unauthorized: return code
+    case .retryLimitExceeded: return code
+    case .nonMatchingChecksum: return code
+    case .downloadSizeExceeded: return code
+    case .cancelled: return code
+    case .invalidArgument: return code
+    @unknown default:
+      fatalError()
+    }
+  }
+
+  func storageMetadataApis() {
+    let metadata = StorageMetadata()
+    _ = metadata.bucket
+    metadata.cacheControl = metadata.cacheControl
+    metadata.contentDisposition = metadata.contentDisposition
+    metadata.contentEncoding = metadata.contentEncoding
+    metadata.contentLanguage = metadata.contentLanguage
+    metadata.contentType = metadata.contentType
+    _ = metadata.md5Hash
+    _ = metadata.generation
+    metadata.customMetadata = metadata.customMetadata
+    _ = metadata.metageneration
+    _ = metadata.name
+    _ = metadata.path
+    _ = metadata.size
+    _ = metadata.timeCreated
+    _ = metadata.updated
+    _ = metadata.storageReference
+    _ = metadata.dictionaryRepresentation()
+    _ = metadata.isFile
+    _ = metadata.isFolder
+  }
+
+  func StorageObservableTaskApis(ref: StorageReference) throws {
+    let task = ref.write(toFile: URL(string: "url")!)
+    _ = task.observe(.pause) { snaphot in
+    }
+    task.removeObserver(withHandle: "handle")
+    task.removeAllObservers()
+    task.removeAllObservers(for: .progress)
+  }
+
+  func StorageTaskApis(task: StorageTask) {
+    _ = task.snapshot
+  }
+
+  func StorageTaskManagementApis(task: StorageTaskManagement) {
+    task.enqueue()
+    task.pause?()
+    task.cancel?()
+    task.resume?()
+  }
+
+  func StorageTaskSnapshotApis(snapshot: StorageTaskSnapshot) {
+    _ = snapshot.task
+    _ = snapshot.metadata
+    _ = snapshot.reference
+    _ = snapshot.progress
+    _ = snapshot.error
+    _ = snapshot.status
+  }
+}

--- a/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
+++ b/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
@@ -30,7 +30,7 @@ final class StorageAPITests {
     storage.maxUploadRetryTime = storage.maxUploadRetryTime
     storage.maxDownloadRetryTime = storage.maxDownloadRetryTime + 1
     storage.maxOperationRetryTime = storage.maxOperationRetryTime + 1
-    let queue : DispatchQueue = storage.callbackQueue
+    let queue: DispatchQueue = storage.callbackQueue
     storage.callbackQueue = queue
     _ = storage.reference()
     _ = storage.reference(forURL: "my-url")

--- a/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
+++ b/FirebaseStorageSwift/Tests/Unit/StorageAPITests.swift
@@ -30,7 +30,8 @@ final class StorageAPITests {
     storage.maxUploadRetryTime = storage.maxUploadRetryTime
     storage.maxDownloadRetryTime = storage.maxDownloadRetryTime + 1
     storage.maxOperationRetryTime = storage.maxOperationRetryTime + 1
-    storage.callbackQueue = storage.callbackQueue
+    let queue : DispatchQueue = storage.callbackQueue
+    storage.callbackQueue = queue
     _ = storage.reference()
     _ = storage.reference(forURL: "my-url")
     _ = storage.reference(withPath: "path")
@@ -48,19 +49,21 @@ final class StorageAPITests {
     ref = ref.parent()!
     ref = ref.child("path")
 
+    let metadata = StorageMetadata()
+
     _ = ref.putData(Data())
-    _ = ref.putData(Data(), metadata: nil)
-    _ = ref.putData(Data(), metadata: nil) { result in
+    _ = ref.putData(Data(), metadata: metadata)
+    _ = ref.putData(Data(), metadata: metadata) { result in
     }
-    _ = ref.putData(Data(), metadata: nil) { metadata, error in
+    _ = ref.putData(Data(), metadata: metadata) { metadata, error in
     }
 
     let file = URL(string: "my-url")!
     _ = ref.putFile(from: file)
-    _ = ref.putFile(from: file, metadata: nil)
-    _ = ref.putFile(from: file, metadata: nil) { result in
+    _ = ref.putFile(from: file, metadata: metadata)
+    _ = ref.putFile(from: file, metadata: metadata) { result in
     }
-    _ = ref.putFile(from: file, metadata: nil) { metadata, error in
+    _ = ref.putFile(from: file, metadata: metadata) { metadata, error in
     }
 
     _ = ref.getData(maxSize: 122) { data, error in


### PR DESCRIPTION
- After verifying in `master` branch, add build tests for Storage Swift APIs.
- Fix two StorageObservableTask signature issues
- Mark the v9 breaking changes
- Build new tests in both SPM and CocoaPods