### PR TITLE
order_by.cc: Use IsKeyFieldPath() instead of == FieldPath::KeyFieldPath()

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [changed] Potentially fix a use-after-free crash that can occur during program
+  exit in `OrderBy::Compare()` (#9258).
 - [changed] Add more details to the assertion failure in Query::Comparator() to
   help with future debugging (#9258).
 

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [changed] Potentially fix a use-after-free crash that can occur during program
-  exit in `OrderBy::Compare()` (#9258).
+- [changed] Potentially fixed a crash during application exit caused by an
+  assertion about ordering documents by missing fields (#9258).
 - [changed] Add more details to the assertion failure in Query::Comparator() to
   help with future debugging (#9258).
 

--- a/Firestore/core/src/core/order_by.cc
+++ b/Firestore/core/src/core/order_by.cc
@@ -67,7 +67,7 @@ void AssertBothOptionalsHaveValues(
 ComparisonResult OrderBy::Compare(const Document& lhs,
                                   const Document& rhs) const {
   ComparisonResult result;
-  if (field_ == FieldPath::KeyFieldPath()) {
+  if (field_.IsKeyFieldPath()) {
     result = lhs->key().CompareTo(rhs->key());
   } else {
     absl::optional<google_firestore_v1_Value> value1 = lhs->field(field_);


### PR DESCRIPTION
Modify `OrderBy::Compare()` to test for the key field path using `field_.IsKeyFieldPath()` instead of `field_ == FieldPath::KeyFieldPath()`.

This is an attempted fix for https://github.com/firebase/firebase-ios-sdk/issues/9258, which reports sporadic crashes with an assertion message like the following:

```
FIRESTORE INTERNAL ASSERTION FAILED: Trying to compare documents on fields that don't exist; field_path=__name__, lhs=users/16451, rhs=users/16451, value1.has_value()=false, value2.has_value()=false
```

This fix is based on the following code in `OrderBy::Compare()`:
https://github.com/firebase/firebase-ios-sdk/blob/82f163bd86566f83c5d7572a1c2c0024a04eb4dc/Firestore/core/src/core/order_by.cc#L70-L77

When `__name__` is the field being compared then `field_ == FieldPath::KeyFieldPath()` should evaluate to `true` and the first block should be executed; however, it appears to be evaluating to `false`, going into the "else" block, which is invalid since `__name__` is a synthetic field and not a real field.

My hypothesis is that this crash is happening during application shutdown. When a C++ program shuts down it runs all of the destructors of objects allocated with _static storage duration_. In this case, the `FieldPath` object returned from `FieldPath::KeyFieldPath()` has static storage duration:

https://github.com/firebase/firebase-ios-sdk/blob/82f163bd86566f83c5d7572a1c2c0024a04eb4dc/Firestore/core/src/model/field_path.cc#L205-L208

When the application exits it uses the main thread to run the destructors of objects allocated with static storage duration. But other threads can still be running. If one of these threads (such as Firestore's async queue thread) uses an object with static storage duration _after_ its destructor has been run then the behavior is undefined, just like any other instance of use-after-free. My hypothesis is that this is an occurrence of just such a race condition.

The fix in this PR changes the logic to use `FieldPath::IsKeyFieldPath()`, which doesn't use any objects with static storage duration:
https://github.com/firebase/firebase-ios-sdk/blob/82f163bd86566f83c5d7572a1c2c0024a04eb4dc/Firestore/core/src/model/field_path.cc#L210-L212
Well, technically it uses `FieldPath::kDocumentKeyPath` which has static storage duration but it is a `constexpr const char*` and doesn't have a destructor so there is no race condition.