### PR TITLE
Make AppDistro releaseNotes nullable.

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.0.0-beta
+- [fixed] Marked `releaseNotes` as `nullable` as they don't always exist. (#8602)
+
 # v8.3.0-beta
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error (#8270).
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionRelease.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionRelease.m
@@ -17,7 +17,7 @@
 @interface FIRAppDistributionRelease ()
 @property(nonatomic, copy) NSString *displayVersion;
 @property(nonatomic, copy) NSString *buildVersion;
-@property(nonatomic, copy) NSString *releaseNotes;
+@property(nonatomic, nullable, copy) NSString *releaseNotes;
 @property(nonatomic, strong) NSURL *downloadURL;
 @property(nonatomic) NSDate *expirationTime;
 @end

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistributionRelease.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistributionRelease.h
@@ -30,7 +30,7 @@ NS_SWIFT_NAME(AppDistributionRelease)
 @property(nonatomic, copy, readonly) NSString *buildVersion;
 
 /// The release notes for this build.
-@property(nonatomic, copy, readonly) NSString *releaseNotes;
+@property(nonatomic, nullable, copy, readonly) NSString *releaseNotes;
 
 /// The URL for the build.
 @property(nonatomic, strong, readonly) NSURL *downloadURL;

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -87,6 +87,12 @@
   _mockInstallationId = @"this-id-is-fake-ccccc";
   _mockReleases = @[
     @{
+      @"codeHash" : @"this-is-the-first-code-hash",
+      @"displayVersion" : @"1.0.0",
+      @"buildVersion" : @"110",
+      @"downloadUrl" : @"http://faketyfakefake.download"
+    },
+    @{
       @"codeHash" : @"this-is-another-code-hash",
       @"displayVersion" : @"1.0.0",
       @"buildVersion" : @"111",


### PR DESCRIPTION
These were unintentionally marked as non-null, but should be nullable.

Fixes #8602