### PR TITLE
Fix perf test regression from recent RC change

### DIFF
--- a/FirebasePerformance/Tests/Unit/Configurations/FPRRemoteConfigFlagsTest.m
+++ b/FirebasePerformance/Tests/Unit/Configurations/FPRRemoteConfigFlagsTest.m
@@ -33,8 +33,10 @@ static NSInteger const kLogSource = 462;  // LogRequest_LogSource_Fireperf
 - (void)testInstanceCreation {
   XCTAssertNotNil([FPRRemoteConfigFlags sharedInstance]);
 
-  FIRRemoteConfig *rConfig = [FIRRemoteConfig remoteConfig];
-  XCTAssertNotNil([[FPRRemoteConfigFlags alloc] initWithRemoteConfig:rConfig]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  XCTAssertNotNil([[FPRRemoteConfigFlags alloc] initWithRemoteConfig:nil]);
+#pragma clang diagnostic pop
 }
 
 /** Validate the singleton nature of the object. */


### PR DESCRIPTION
Fix a regression test failure introduced by the new exception introduced in #9552 

It preserves the previous (probably unintended behavior) of passing nil to `[[FPRRemoteConfigFlags alloc] initWithRemoteConfig:`

Now an unconfigured initWithRemoteConfig: is throwing instead of returning nil.