### PR TITLE
[Heartbeat Logging] Migrate Auth from using `FIRHeartbeatInfo` to `FIRHeartbeatLogger` 

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -96,7 +96,9 @@ jobs:
   catalyst:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
+    env:
+      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
+      POD_LIB_LINT_ONLY: 1
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -44,6 +44,8 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
+      POD_LIB_LINT_ONLY: 1
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -22,7 +22,9 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
     runs-on: macos-11
-
+    env:
+      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
+      POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -56,43 +56,48 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
 
-  s.test_spec 'unit' do |unit_tests|
-    unit_tests.scheme = { :code_coverage => true }
-    # Unit tests can't run on watchOS.
-    unit_tests.platforms = {
-      :ios => ios_deployment_target,
-      :osx => osx_deployment_target,
-      :tvos => tvos_deployment_target
-    }
-    unit_tests.source_files = 'FirebaseAuth/Tests/Unit/*.[mh]'
-    unit_tests.osx.exclude_files = [
-      'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m',
-      'FirebaseAuth/Tests/Unit/FIREmailLink*',
-      'FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m',
-      'FirebaseAuth/Tests/Unit/FIRSendVerificationCode*',
-      'FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m',
-      'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
-      'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
-      'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
-    ]
-    unit_tests.tvos.exclude_files = [
-      'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m',
-      'FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m',
-      'FirebaseAuth/Tests/Unit/FIREmailLink*',
-      'FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m',
-      'FirebaseAuth/Tests/Unit/FIRSendVerificationCode*',
-      'FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m',
-      'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
-      'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
-      'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
-    ]
-    # app_host is needed for tests with keychain
-    unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+  # Using environment variable because of the dependency on the unpublished
+  # HeartbeatLoggingTestUtils.
+  if ENV['POD_LIB_LINT_ONLY'] && ENV['POD_LIB_LINT_ONLY'] == '1' then
+    s.test_spec 'unit' do |unit_tests|
+      unit_tests.scheme = { :code_coverage => true }
+      # Unit tests can't run on watchOS.
+      unit_tests.platforms = {
+        :ios => ios_deployment_target,
+        :osx => osx_deployment_target,
+        :tvos => tvos_deployment_target
+      }
+      unit_tests.source_files = 'FirebaseAuth/Tests/Unit/*.[mh]'
+      unit_tests.osx.exclude_files = [
+        'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthAppCredentialManagerTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m',
+        'FirebaseAuth/Tests/Unit/FIREmailLink*',
+        'FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m',
+        'FirebaseAuth/Tests/Unit/FIRSendVerificationCode*',
+        'FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m',
+        'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
+        'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
+        'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
+      ]
+      unit_tests.tvos.exclude_files = [
+        'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m',
+        'FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m',
+        'FirebaseAuth/Tests/Unit/FIREmailLink*',
+        'FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m',
+        'FirebaseAuth/Tests/Unit/FIRSendVerificationCode*',
+        'FirebaseAuth/Tests/Unit/FIRSignInWithGameCenterTests.m',
+        'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
+        'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
+        'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
+      ]
+      # app_host is needed for tests with keychain
+      unit_tests.requires_app_host = true
+      unit_tests.dependency 'OCMock'
+      unit_tests.dependency 'HeartbeatLoggingTestUtils'
+    end
   end
 end

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -468,8 +468,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                 appName:(NSString *)appName
+                                  appID:(NSString *)appID {
+  return [self initWithAPIKey:APIKey appName:appName appID:appID heartbeatLogger:nil];
+}
+
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                appName:(NSString *)appName
                                   appID:(NSString *)appID
-                        heartbeatLogger:(FIRHeartbeatLogger *)heartbeatLogger {
+                        heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger {
   self = [super init];
   if (self) {
     _listenerHandles = [NSMutableArray array];

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -453,7 +453,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 - (instancetype)initWithApp:(FIRApp *)app {
   [FIRAuth setKeychainServiceNameForApp:app];
-  self = [self initWithAPIKey:app.options.APIKey appName:app.name appID:app.options.googleAppID];
+  self = [self initWithAPIKey:app.options.APIKey
+                      appName:app.name
+                        appID:app.options.googleAppID
+              heartbeatLogger:app.heartbeatLogger];
   if (self) {
     _app = app;
 #if TARGET_OS_IOS
@@ -465,11 +468,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                 appName:(NSString *)appName
-                                  appID:(NSString *)appID {
+                                  appID:(NSString *)appID
+                        heartbeatLogger:(FIRHeartbeatLogger *)heartbeatLogger {
   self = [super init];
   if (self) {
     _listenerHandles = [NSMutableArray array];
-    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey appID:appID];
+    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
+                                                                          appID:appID
+                                                                heartbeatLogger:heartbeatLogger];
     _firebaseAppName = [appName copy];
 #if TARGET_OS_IOS
     _settings = [[FIRAuthSettings alloc] init];

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -21,7 +21,6 @@
 
 @class FIRAuthRequestConfiguration;
 @class FIRAuthURLPresenter;
-@protocol FIRHeartbeatLoggerProtocol;
 
 #if TARGET_OS_IOS
 @class FIRAuthAPNSTokenManager;

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -21,6 +21,7 @@
 
 @class FIRAuthRequestConfiguration;
 @class FIRAuthURLPresenter;
+@protocol FIRHeartbeatLoggerProtocol;
 
 #if TARGET_OS_IOS
 @class FIRAuthAPNSTokenManager;
@@ -70,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                 appName:(NSString *)appName
-                                  appID:(NSString *)appID NS_DESIGNATED_INITIALIZER;
+                                  appID:(NSString *)appID;
 
 /** @fn getUserID
     @brief Gets the identifier of the current user, if any.

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -93,20 +93,10 @@ static NSString *const kFirebaseLocalHeader = @"X-Firebase-Locale";
  */
 static NSString *const kFirebaseAppIDHeader = @"X-Firebase-GMPID";
 
-/** @var kFirebaseUserAgentHeader
-    @brief HTTP header name for the Firebase user agent.
- */
-static NSString *const kFirebaseUserAgentHeader = @"X-Firebase-Client";
-
 /** @var kFirebaseHeartbeatHeader
-    @brief HTTP header name for the Firebase heartbeat.
+    @brief HTTP header name for a Firebase heartbeats payload.
  */
-static NSString *const kFirebaseHeartbeatHeader = @"X-Firebase-Client-Log-Type";
-
-/** @var kHeartbeatStorageTag
-    @brief Storage tag for the Firebase Auth heartbeat.
- */
-static NSString *const kHeartbeatStorageTag = @"fire-auth";
+static NSString *const kFirebaseHeartbeatHeader = @"X-Firebase-Client";
 
 /** @var kFirebaseAuthCoreFrameworkMarker
     @brief The marker in the HTTP header that indicates the request comes from Firebase Auth Core.
@@ -662,11 +652,9 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [request setValue:bundleID forHTTPHeaderField:kIosBundleIdentifierHeader];
   NSString *appID = requestConfiguration.appID;
   [request setValue:appID forHTTPHeaderField:kFirebaseAppIDHeader];
-  NSString *userAgent = [FIRApp firebaseUserAgent];
-  [request setValue:userAgent forHTTPHeaderField:kFirebaseUserAgentHeader];
-  NSString *heartbeat = @([FIRHeartbeatInfo heartbeatCodeForTag:kHeartbeatStorageTag]).stringValue;
-  [request setValue:heartbeat forHTTPHeaderField:kFirebaseHeartbeatHeader];
-
+  [request setValue:FIRHeaderValueFromHeartbeatsPayload(
+                        [requestConfiguration.heartbeatLogger flushHeartbeatsIntoPayload])
+      forHTTPHeaderField:kFirebaseHeartbeatHeader];
   NSArray<NSString *> *preferredLocalizations = [NSBundle mainBundle].preferredLocalizations;
   if (preferredLocalizations.count) {
     NSString *acceptLanguage = preferredLocalizations.firstObject;

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -18,6 +18,8 @@
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
 
+@class FIRHeartbeatLogger;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** @class FIRAuthRequestConfiguration
@@ -34,6 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
     @brief The Firebase appID used in the request.
  */
 @property(nonatomic, copy, readonly) NSString *appID;
+
+/** @property heartbeatLogger
+    @brief The heartbeat logger used to add heartbeats to the coresponding request's header.
+ */
+@property(nonatomic, copy, nullable) FIRHeartbeatLogger *heartbeatLogger;
 
 /** @property LanguageCode
     @brief The language code used in the request.
@@ -56,9 +63,13 @@ NS_ASSUME_NONNULL_BEGIN
     @brief Designated initializer.
     @param APIKey The API key to be used in the request.
     @param appID The Firebase app ID to be passed in the request header.
+    @param heartbeatLogger The heartbeat logger used to add heartbeats to the request header.
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
-                                  appID:(NSString *)appID NS_DESIGNATED_INITIALIZER;
+                                  appID:(NSString *)appID
+                        heartbeatLogger:(nullable FIRHeartbeatLogger *)heartbeatLogger
+    NS_DESIGNATED_INITIALIZER;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /** @fn initWithAPIKey:appID:
-    @brief Designated initializer.
+    @brief Convenience initializer.
     @param APIKey The API key to be used in the request.
     @param appID The Firebase app ID to be passed in the request header.
  */

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, readonly) NSString *appID;
 
 /** @property heartbeatLogger
-    @brief The heartbeat logger used to add heartbeats to the coresponding request's header.
+    @brief The heartbeat logger used to add heartbeats to the corresponding request's header.
  */
 @property(nonatomic, copy, nullable) id<FIRHeartbeatLoggerProtocol> heartbeatLogger;
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -18,7 +18,7 @@
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
 
-@class FIRHeartbeatLogger;
+@protocol FIRHeartbeatLoggerProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** @property heartbeatLogger
     @brief The heartbeat logger used to add heartbeats to the coresponding request's header.
  */
-@property(nonatomic, copy, nullable) FIRHeartbeatLogger *heartbeatLogger;
+@property(nonatomic, copy, nullable) id<FIRHeartbeatLoggerProtocol> heartbeatLogger;
 
 /** @property LanguageCode
     @brief The language code used in the request.
@@ -63,11 +63,18 @@ NS_ASSUME_NONNULL_BEGIN
     @brief Designated initializer.
     @param APIKey The API key to be used in the request.
     @param appID The Firebase app ID to be passed in the request header.
+ */
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID;
+
+/** @fn initWithAPIKey:appID:heartbeatLogger:
+    @brief Designated initializer.
+    @param APIKey The API key to be used in the request.
+    @param appID The Firebase app ID to be passed in the request header.
     @param heartbeatLogger The heartbeat logger used to add heartbeats to the request header.
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                        heartbeatLogger:(nullable FIRHeartbeatLogger *)heartbeatLogger
+                        heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger
     NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -22,9 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAuthRequestConfiguration
 
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID {
+  return [self initWithAPIKey:APIKey appID:appID heartbeatLogger:nil];
+}
+
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                        heartbeatLogger:(nullable FIRHeartbeatLogger *)heartbeatLogger {
+                        heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger {
   self = [super init];
   if (self) {
     _APIKey = [APIKey copy];

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -22,11 +22,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAuthRequestConfiguration
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID {
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID
+                        heartbeatLogger:(nullable FIRHeartbeatLogger *)heartbeatLogger {
   self = [super init];
   if (self) {
     _APIKey = [APIKey copy];
     _appID = [appID copy];
+    _heartbeatLogger = heartbeatLogger;
   }
   return self;
 }

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -374,7 +374,9 @@ static void callInMainThreadWithAuthDataResultAndError(
     _phoneNumber = phoneNumber;
     _metadata = metadata ?: [[FIRUserMetadata alloc] initWithCreationDate:nil lastSignInDate:nil];
     _tenantID = tenantID;
-    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey appID:appID];
+    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
+                                                                          appID:appID
+                                                                heartbeatLogger:nil];
 #if TARGET_OS_IOS
     _multiFactor = multiFactor ?: [[FIRMultiFactor alloc] init];
 #endif
@@ -407,6 +409,7 @@ static void callInMainThreadWithAuthDataResultAndError(
 - (void)setAuth:(nullable FIRAuth *)auth {
   _auth = auth;
   _tokenService.requestConfiguration = auth.requestConfiguration;
+  _requestConfiguration = auth.requestConfiguration;
 }
 
 - (NSString *)providerID {

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -374,6 +374,7 @@ static void callInMainThreadWithAuthDataResultAndError(
     _phoneNumber = phoneNumber;
     _metadata = metadata ?: [[FIRUserMetadata alloc] initWithCreationDate:nil lastSignInDate:nil];
     _tenantID = tenantID;
+    // The `heartbeatLogger` will be set later via a property update.
     _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
                                                                           appID:appID
                                                                 heartbeatLogger:nil];

--- a/FirebaseAuth/Tests/Sample/Podfile
+++ b/FirebaseAuth/Tests/Sample/Podfile
@@ -14,6 +14,8 @@ target 'AuthSample' do
   pod 'FirebaseCoreDiagnostics', :path => '../../../'
   pod 'FirebaseCoreInternal', :path => '../../../'
   pod 'FirebaseAuth', :path => '../../../', :testspecs => ['unit']
+  # `HeartbeatLoggingTestUtils` is unpublished.
+  pod 'HeartbeatLoggingTestUtils', :path => '../../../'
   pod 'FirebaseInstallations', :path => '../../..'
   pod 'FBSDKLoginKit'
   pod 'GoogleSignIn', '~> 5'

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+@import HeartbeatLoggingTestUtils;
+
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCResponse.h"
@@ -23,6 +25,8 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
 #import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+
+#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 /** @var kFakeRequestURL
     @brief Used as a fake URL for a fake RPC request. We don't test this here, since it's tested
@@ -110,6 +114,8 @@ static NSString *const kServerErrorDetailMarker = @" : ";
  */
 static NSString *const kTestValue = @"TestValue";
 
+#pragma mark - FIRAuthBackendRPCImplementation
+
 /** @class FIRAuthBackendRPCImplementation
     @brief Exposes an otherwise private class to these tests. See the real implementation for
         documentation.
@@ -134,6 +140,43 @@ static NSString *const kTestValue = @"TestValue";
                callback:(void (^)(NSError *error))callback;
 
 @end
+
+#pragma mark - FIRFakeHeartbeatLogger
+
+/// A fake heartbeat logger used for dependency injection during testing.
+@interface FIRFakeHeartbeatLogger : NSObject <FIRHeartbeatLoggerProtocol>
+@property(nonatomic, copy, nullable) FIRHeartbeatsPayload * (^onFlushHeartbeatsIntoPayloadHandler)
+    (void);
+@property(nonatomic, copy, nullable) FIRHeartbeatInfoCode (^onHeartbeatCodeForTodayHandler)(void);
+@end
+
+@implementation FIRFakeHeartbeatLogger
+
+- (nonnull FIRHeartbeatsPayload *)flushHeartbeatsIntoPayload {
+  if (self.onFlushHeartbeatsIntoPayloadHandler) {
+    return self.onFlushHeartbeatsIntoPayloadHandler();
+  } else {
+    return nil;
+  }
+}
+
+- (FIRHeartbeatInfoCode)heartbeatCodeForToday {
+  // This API should not be used by the below tests because the Auth
+  // SDK uses only the V2 heartbeat API (`flushHeartbeatsIntoPayload`) for
+  // getting heartbeats.
+  [self doesNotRecognizeSelector:_cmd];
+  return FIRHeartbeatInfoCodeNone;
+}
+
+- (void)log {
+  // This API should not be used by the below tests because the Auth
+  // SDK does not log heartbeats in it's networking context.
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+@end
+
+#pragma mark - FIRFakeRequest
 
 /** @class FIRFakeRequest
     @brief Allows us to fake a request with deterministic request bodies and encoding errors
@@ -174,9 +217,12 @@ static NSString *const kTestValue = @"TestValue";
         invoked.
     @param encodingError The fake error to return when @c unencodedHTTPRequestBodyWithError is
         invoked.
+    @param requestConfiguration The request configuration associated with the fake request.
  */
 - (nullable instancetype)initWithRequestBody:(nullable id)requestBody
                                encodingError:(nullable NSError *)encodingError
+                        requestConfiguration:
+                            (nullable FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -193,30 +239,47 @@ static NSString *const kTestValue = @"TestValue";
           is invoked.
    */
   NSError *_Nullable _requestEncodingError;
+
+  /** @var _requestConfiguration
+      @brief The request configuration to return.
+   */
+  FIRAuthRequestConfiguration *_Nullable _requestConfiguration;
 }
 
 + (nullable instancetype)fakeRequest {
-  return [[self alloc] initWithRequestBody:@{} encodingError:nil];
+  return [[self alloc] initWithRequestBody:@{} encodingError:nil requestConfiguration:nil];
+}
+
++ (nullable instancetype)fakeRequestWithRequestConfiguration:
+    (FIRAuthRequestConfiguration *)requestConfiguration {
+  return [[self alloc] initWithRequestBody:@{}
+                             encodingError:nil
+                      requestConfiguration:requestConfiguration];
 }
 
 + (nullable instancetype)fakeRequestWithEncodingError:(NSError *)error {
-  return [[self alloc] initWithRequestBody:nil encodingError:error];
+  return [[self alloc] initWithRequestBody:nil encodingError:error requestConfiguration:nil];
 }
 
 + (nullable instancetype)fakeRequestWithUnserializableRequestBody {
-  return [[self alloc] initWithRequestBody:@{@"unencodableValue" : self} encodingError:nil];
+  return [[self alloc] initWithRequestBody:@{@"unencodableValue" : self}
+                             encodingError:nil
+                      requestConfiguration:nil];
 }
 
 + (nullable instancetype)fakeRequestWithNoBody {
-  return [[self alloc] initWithRequestBody:nil encodingError:nil];
+  return [[self alloc] initWithRequestBody:nil encodingError:nil requestConfiguration:nil];
 }
 
 - (nullable instancetype)initWithRequestBody:(nullable id)requestBody
-                               encodingError:(nullable NSError *)encodingError {
+                               encodingError:(nullable NSError *)encodingError
+                        requestConfiguration:
+                            (nullable FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super init];
   if (self) {
     _requestBody = requestBody;
     _requestEncodingError = encodingError;
+    _requestConfiguration = requestConfiguration;
   }
   return self;
 }
@@ -230,9 +293,11 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 - (FIRAuthRequestConfiguration *)requestConfiguration {
-  FIRAuthRequestConfiguration *fakeConfiguration =
-      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey appID:kFakeFirebaseAppID];
-  return fakeConfiguration;
+  if (!_requestConfiguration) {
+    _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey
+                                                                          appID:kFakeFirebaseAppID];
+  }
+  return _requestConfiguration;
 }
 
 - (nullable id)unencodedHTTPRequestBodyWithError:(NSError *_Nullable *_Nullable)error {
@@ -243,6 +308,8 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 @end
+
+#pragma mark - FIRFakeResponse
 
 /** @class FIRFakeResponse
     @brief Allows us to inspect the dictionaries received by @c FIRAuthRPCResponse classes, and
@@ -314,6 +381,8 @@ static NSString *const kTestValue = @"TestValue";
 
 @end
 
+#pragma mark - FIRAuthBackendRPCImplementationTests
+
 /** @class FIRAuthBackendRPCImplementationTests
     @brief This set of unit tests is designed primarily to test the possible outcomes of the
         @c FIRAuthBackendRPCImplementation.postWithRequest:response:callback: method.
@@ -345,6 +414,82 @@ static NSString *const kTestValue = @"TestValue";
   [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
   _RPCIssuer = nil;
   _RPCImplementation = nil;
+}
+
+/** @fn testRequest_IncludesHeartbeatPayload_WhenHeartbeatsNeedSending
+    @brief This test checks the behavior of @c postWithRequest:response:callback:
+        to verify that a heartbeats payload is attached as a header to an
+        outgoing request when there are stored heartbeats that need sending.
+ */
+- (void)testRequest_IncludesHeartbeatPayload_WhenHeartbeatsNeedSending {
+  // Given
+  FIRFakeHeartbeatLogger *fakeHeartbeatLogger = [[FIRFakeHeartbeatLogger alloc] init];
+  FIRAuthRequestConfiguration *requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey
+                                                    appID:kFakeFirebaseAppID
+                                          heartbeatLogger:fakeHeartbeatLogger];
+  FIRFakeRequest *request =
+      [FIRFakeRequest fakeRequestWithRequestConfiguration:requestConfiguration];
+  FIRFakeResponse *response = [FIRFakeResponse fakeResponse];
+
+  // When
+  FIRHeartbeatsPayload *nonEmptyHeartbeatsPayload =
+      [FIRHeartbeatLoggingTestUtils nonEmptyHeartbeatsPayload];
+
+  fakeHeartbeatLogger.onFlushHeartbeatsIntoPayloadHandler = ^FIRHeartbeatsPayload * {
+    return nonEmptyHeartbeatsPayload;
+  };
+
+  __block NSError *callbackError;
+  __block BOOL callbackInvoked;
+  [_RPCImplementation postWithRequest:request
+                             response:response
+                             callback:^(NSError *error) {
+                               callbackInvoked = YES;
+                               callbackError = error;
+                             }];
+
+  // Then
+  NSString *expectedHeader = FIRHeaderValueFromHeartbeatsPayload(nonEmptyHeartbeatsPayload);
+  XCTAssertEqualObjects([_RPCIssuer.completeRequest valueForHTTPHeaderField:@"X-Firebase-Client"],
+                        expectedHeader);
+}
+
+/** @fn testRequest_DoesNotIncludeAHeartbeatPayload_WhenNoHeartbeatsNeedSending
+    @brief This test checks the behavior of @c postWithRequest:response:callback:
+        to verify that a request header does not heartbeat data in the case
+        that there are no stored heartbeats that need sending.
+ */
+- (void)testRequest_DoesNotIncludeAHeartbeatPayload_WhenNoHeartbeatsNeedSending {
+  // Given
+  FIRFakeHeartbeatLogger *fakeHeartbeatLogger = [[FIRFakeHeartbeatLogger alloc] init];
+  FIRAuthRequestConfiguration *requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kFakeAPIkey
+                                                    appID:kFakeFirebaseAppID
+                                          heartbeatLogger:fakeHeartbeatLogger];
+  FIRFakeRequest *request =
+      [FIRFakeRequest fakeRequestWithRequestConfiguration:requestConfiguration];
+  FIRFakeResponse *response = [FIRFakeResponse fakeResponse];
+
+  // When
+  FIRHeartbeatsPayload *emptyHeartbeatsPayload =
+      [FIRHeartbeatLoggingTestUtils emptyHeartbeatsPayload];
+
+  fakeHeartbeatLogger.onFlushHeartbeatsIntoPayloadHandler = ^FIRHeartbeatsPayload * {
+    return emptyHeartbeatsPayload;
+  };
+
+  __block NSError *callbackError;
+  __block BOOL callbackInvoked;
+  [_RPCImplementation postWithRequest:request
+                             response:response
+                             callback:^(NSError *error) {
+                               callbackInvoked = YES;
+                               callbackError = error;
+                             }];
+
+  // Then
+  XCTAssertNil([_RPCIssuer.completeRequest valueForHTTPHeaderField:@"X-Firebase-Client"]);
 }
 
 /** @fn testRequestEncodingError

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
@@ -457,8 +457,8 @@ static NSString *const kTestValue = @"TestValue";
 
 /** @fn testRequest_DoesNotIncludeAHeartbeatPayload_WhenNoHeartbeatsNeedSending
     @brief This test checks the behavior of @c postWithRequest:response:callback:
-        to verify that a request header does not heartbeat data in the case
-        that there are no stored heartbeats that need sending.
+        to verify that a request header does not contain heartbeat data in the
+        case that there are no stored heartbeats that need sending.
  */
 - (void)testRequest_DoesNotIncludeAHeartbeatPayload_WhenNoHeartbeatsNeedSending {
   // Given

--- a/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h
+++ b/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h
@@ -46,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) NSString *contentType;
 
+/** @property completeRequest
+    @brief The last request to be processed by the backend.
+ */
+@property(atomic, readonly) NSURLRequest *completeRequest;
+
 /** @fn respondWithData:error:
     @brief Responds to a pending RPC request with data and an error.
     @remarks This is useful for simulating an error response with bogus data or unexpected data

--- a/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
+++ b/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
@@ -15,6 +15,13 @@
  */
 
 #import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+#import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
+
+@interface FIRAuthBackend (Internal)
++ (NSMutableURLRequest *)requestWithURL:(NSURL *)URL
+                            contentType:(NSString *)contentType
+                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
+@end
 
 /** @var kFakeErrorDomain
     @brief Fake error domain used for testing.
@@ -36,6 +43,11 @@ static NSString *const kFakeErrorDomain = @"fake domain";
   _requestURL = [URL copy];
   if (body) {
     _requestData = body;
+    // Use the real implementation to verify that so the complete request can
+    // be verified during testing.
+    _completeRequest = [FIRAuthBackend requestWithURL:URL
+                                          contentType:contentType
+                                 requestConfiguration:requestConfiguration];
     NSDictionary *JSON = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
     _decodedRequest = JSON;
   }

--- a/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
+++ b/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
@@ -43,7 +43,7 @@ static NSString *const kFakeErrorDomain = @"fake domain";
   _requestURL = [URL copy];
   if (body) {
     _requestData = body;
-    // Use the real implementation to verify that so the complete request can
+    // Use the real implementation so that the complete request can
     // be verified during testing.
     _completeRequest = [FIRAuthBackend requestWithURL:URL
                                           contentType:contentType

--- a/Package.swift
+++ b/Package.swift
@@ -451,7 +451,7 @@ let package = Package(
     ),
     .testTarget(
       name: "AuthUnit",
-      dependencies: ["FirebaseAuth", "OCMock"],
+      dependencies: ["FirebaseAuth", "OCMock", "HeartbeatLoggingTestUtils"],
       path: "FirebaseAuth/Tests/Unit",
       exclude: [
         "FIRAuthKeychainServicesTests.m", // TODO: figure out SPM keychain testing


### PR DESCRIPTION
- Migrated Auth's use of v1 heartbeat API to v2 heartbeat API
- Added two unit tests to assert that the request contains expected heartbeat payload information

The `FIRAuthBackendRPCIssuerImplementation` class made it rather difficult to add tests so I tried to do so in the least invasive way possible to get some coverage. It might be worth investigating what a refactor could like there to more easily inject dependencies of the class.


#no-changelog