### PR TITLE
SDK support for logical termination in Firestore BatchGetDocuments

### DIFF
--- a/Firestore/core/src/remote/datastore.cc
+++ b/Firestore/core/src/remote/datastore.cc
@@ -233,8 +233,8 @@ void Datastore::LookupDocumentsWithCredentials(
   active_calls_.push_back(std::move(call_owning));
 
   // TODO(c++14): lambda captures using move.
-  auto docs_callback =
-      [this, user_callback](const std::vector<grpc::ByteBuffer> result) {
+  auto messages_callback =
+      [this, user_callback](const std::vector<grpc::ByteBuffer>& result) {
         user_callback(datastore_serializer_.MergeLookupResponses(result));
       };
 
@@ -251,7 +251,7 @@ void Datastore::LookupDocumentsWithCredentials(
     RemoveGrpcCall(call);
   };
 
-  call->Start(keys.size(), docs_callback, close_callback);
+  call->Start(keys.size(), messages_callback, close_callback);
 }
 
 void Datastore::ResumeRpcWithCredentials(const OnCredentials& on_credentials) {

--- a/Firestore/core/src/remote/datastore.cc
+++ b/Firestore/core/src/remote/datastore.cc
@@ -233,7 +233,7 @@ void Datastore::LookupDocumentsWithCredentials(
   active_calls_.push_back(std::move(call_owning));
 
   // TODO(c++14): lambda captures using move.
-  auto messages_callback =
+  auto responses_callback =
       [this, user_callback](const std::vector<grpc::ByteBuffer>& result) {
         user_callback(datastore_serializer_.MergeLookupResponses(result));
       };
@@ -251,7 +251,7 @@ void Datastore::LookupDocumentsWithCredentials(
     RemoveGrpcCall(call);
   };
 
-  call->Start(keys.size(), messages_callback, close_callback);
+  call->Start(keys.size(), responses_callback, close_callback);
 }
 
 void Datastore::ResumeRpcWithCredentials(const OnCredentials& on_credentials) {

--- a/Firestore/core/src/remote/datastore.h
+++ b/Firestore/core/src/remote/datastore.h
@@ -177,9 +177,6 @@ class Datastore : public std::enable_shared_from_this<Datastore> {
       const std::string& app_check_token,
       const std::vector<model::DocumentKey>& keys,
       LookupCallback&& callback);
-  void OnLookupDocumentsResponse(
-      const util::StatusOr<std::vector<grpc::ByteBuffer>>& result,
-      const LookupCallback& callback);
 
   using OnCredentials = std::function<void(
       const util::StatusOr<credentials::AuthToken>&, const std::string&)>;

--- a/Firestore/core/src/remote/datastore.h
+++ b/Firestore/core/src/remote/datastore.h
@@ -104,7 +104,7 @@ class Datastore : public std::enable_shared_from_this<Datastore> {
   void CommitMutations(const std::vector<model::Mutation>& mutations,
                        CommitCallback&& callback);
   void LookupDocuments(const std::vector<model::DocumentKey>& keys,
-                       LookupCallback&& callback);
+                       LookupCallback&& user_callback);
 
   /** Returns true if the given error is a gRPC ABORTED error. */
   static bool IsAbortedError(const util::Status& error);
@@ -176,7 +176,7 @@ class Datastore : public std::enable_shared_from_this<Datastore> {
       const credentials::AuthToken& auth_token,
       const std::string& app_check_token,
       const std::vector<model::DocumentKey>& keys,
-      LookupCallback&& callback);
+      LookupCallback&& user_callback);
 
   using OnCredentials = std::function<void(
       const util::StatusOr<credentials::AuthToken>&, const std::string&)>;

--- a/Firestore/core/src/remote/grpc_streaming_reader.cc
+++ b/Firestore/core/src/remote/grpc_streaming_reader.cc
@@ -42,14 +42,13 @@ GrpcStreamingReader::GrpcStreamingReader(
                                             worker_queue,
                                             grpc_connection,
                                             this)},
-      request_{request},
-      callback_fired_(false) {
+      request_{request} {
 }
 
-void GrpcStreamingReader::Start(size_t key_count,
-                                DocsCallback&& docs_callback,
+void GrpcStreamingReader::Start(size_t expected_response_count,
+                                MessagesCallback&& docs_callback,
                                 CloseCallback&& close_callback) {
-  key_count_ = key_count;
+  expected_response_count_ = expected_response_count;
   docs_callback_ = std::move(docs_callback);
   close_callback_ = std::move(close_callback);
   stream_->Start();
@@ -73,19 +72,19 @@ void GrpcStreamingReader::OnStreamRead(const grpc::ByteBuffer& message) {
   // Accumulate responses, docs_callback_ will be fired if GrpcStreamingReader
   // has received all the responses.
   responses_.push_back(message);
-  if (responses_.size() == key_count_) {
+  if (responses_.size() == expected_response_count_) {
     callback_fired_ = true;
-    docs_callback_(std::move(responses_));
+    docs_callback_(responses_);
   }
 }
 
 void GrpcStreamingReader::OnStreamFinish(const util::Status& status) {
   // Handle the case where 0 document reads required.
   // OnStreamRead will never be triggered,
-  // but we still need to return an empty vector of documents
+  // but we still need to return an empty vector of documents.
   if (status.ok() && !callback_fired_) {
     callback_fired_ = true;
-    docs_callback_({});
+    docs_callback_(responses_);
   }
 
   // Invoking the callback ends this reader's lifetime.

--- a/Firestore/core/src/remote/grpc_streaming_reader.h
+++ b/Firestore/core/src/remote/grpc_streaming_reader.h
@@ -47,7 +47,7 @@ class GrpcConnection;
 class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
  public:
   using ResponsesT = grpc::ByteBuffer;
-  using ReadCallback = std::function<void(std::vector<ResponsesT>)>;
+  using DocsCallback = std::function<void(const std::vector<ResponsesT>)>;
   using CloseCallback = std::function<void(const util::Status&, bool)>;
 
   GrpcStreamingReader(
@@ -63,7 +63,7 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
    * a non-ok status.
    */
   void Start(size_t key_count,
-             ReadCallback&& messageCallback,
+             DocsCallback&& messageCallback,
              CloseCallback&& closeCallback);
 
   /**
@@ -103,12 +103,11 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
   std::unique_ptr<GrpcStream> stream_;
   grpc::ByteBuffer request_;
 
-  ReadCallback message_callback_;
+  size_t key_count_;
+  bool callback_fired_;
+  DocsCallback docs_callback_;
   CloseCallback close_callback_;
   std::vector<ResponsesT> responses_;
-
-  size_t key_count_;
-  bool callback_fired;
 };
 
 }  // namespace remote

--- a/Firestore/core/src/remote/grpc_streaming_reader.h
+++ b/Firestore/core/src/remote/grpc_streaming_reader.h
@@ -47,7 +47,7 @@ class GrpcConnection;
 class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
  public:
   using ResponsesT = grpc::ByteBuffer;
-  using DocsCallback = std::function<void(const std::vector<ResponsesT>)>;
+  using MessagesCallback = std::function<void(const std::vector<ResponsesT>)>;
   using CloseCallback = std::function<void(const util::Status&, bool)>;
 
   GrpcStreamingReader(
@@ -63,7 +63,7 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
    * a non-ok status.
    */
   void Start(size_t key_count,
-             DocsCallback&& messageCallback,
+             MessagesCallback&& messageCallback,
              CloseCallback&& closeCallback);
 
   /**
@@ -103,9 +103,9 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
   std::unique_ptr<GrpcStream> stream_;
   grpc::ByteBuffer request_;
 
-  size_t key_count_;
-  bool callback_fired_;
-  DocsCallback docs_callback_;
+  size_t expected_response_count_;
+  bool callback_fired_ = false;
+  MessagesCallback docs_callback_;
   CloseCallback close_callback_;
   std::vector<ResponsesT> responses_;
 };

--- a/Firestore/core/src/remote/grpc_streaming_reader.h
+++ b/Firestore/core/src/remote/grpc_streaming_reader.h
@@ -24,6 +24,7 @@
 
 #include "Firestore/core/src/remote/grpc_stream.h"
 #include "Firestore/core/src/remote/grpc_stream_observer.h"
+#include "Firestore/core/src/util/status.h"
 #include "Firestore/core/src/util/status_fwd.h"
 #include "Firestore/core/src/util/warnings.h"
 #include "grpcpp/client_context.h"
@@ -45,8 +46,9 @@ class GrpcConnection;
  */
 class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
  public:
-  using ResponsesT = std::vector<grpc::ByteBuffer>;
-  using Callback = std::function<void(const util::StatusOr<ResponsesT>&)>;
+  using ResponsesT = grpc::ByteBuffer;
+  using ReadCallback = std::function<void(std::vector<ResponsesT>)>;
+  using CloseCallback = std::function<void(const util::Status&, bool)>;
 
   GrpcStreamingReader(
       std::unique_ptr<grpc::ClientContext> context,
@@ -60,7 +62,9 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
    * results of the call. If the call fails, the `callback` will be invoked with
    * a non-ok status.
    */
-  void Start(Callback&& callback);
+  void Start(size_t key_count,
+             ReadCallback&& messageCallback,
+             CloseCallback&& closeCallback);
 
   /**
    * If the call is in progress, attempts to cancel the call; otherwise, it's
@@ -99,8 +103,12 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
   std::unique_ptr<GrpcStream> stream_;
   grpc::ByteBuffer request_;
 
-  Callback callback_;
-  ResponsesT responses_;
+  ReadCallback message_callback_;
+  CloseCallback close_callback_;
+  std::vector<ResponsesT> responses_;
+
+  size_t key_count_;
+  bool callback_fired;
 };
 
 }  // namespace remote

--- a/Firestore/core/src/remote/grpc_streaming_reader.h
+++ b/Firestore/core/src/remote/grpc_streaming_reader.h
@@ -62,7 +62,7 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
    * results of the call. If the call fails, the `callback` will be invoked with
    * a non-ok status.
    */
-  void Start(size_t key_count,
+  void Start(size_t expected_response_count,
              MessagesCallback&& messageCallback,
              CloseCallback&& closeCallback);
 

--- a/Firestore/core/src/remote/grpc_streaming_reader.h
+++ b/Firestore/core/src/remote/grpc_streaming_reader.h
@@ -47,7 +47,7 @@ class GrpcConnection;
 class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
  public:
   using ResponsesT = grpc::ByteBuffer;
-  using MessagesCallback = std::function<void(const std::vector<ResponsesT>)>;
+  using ResponsesCallback = std::function<void(const std::vector<ResponsesT>)>;
   using CloseCallback = std::function<void(const util::Status&, bool)>;
 
   GrpcStreamingReader(
@@ -63,8 +63,8 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
    * a non-ok status.
    */
   void Start(size_t expected_response_count,
-             MessagesCallback&& messageCallback,
-             CloseCallback&& closeCallback);
+             ResponsesCallback&& responses_callback,
+             CloseCallback&& close_callback);
 
   /**
    * If the call is in progress, attempts to cancel the call; otherwise, it's
@@ -105,7 +105,7 @@ class GrpcStreamingReader : public GrpcCall, public GrpcStreamObserver {
 
   size_t expected_response_count_;
   bool callback_fired_ = false;
-  MessagesCallback docs_callback_;
+  ResponsesCallback responses_callback_;
   CloseCallback close_callback_;
   std::vector<ResponsesT> responses_;
 };

--- a/Firestore/core/test/unit/remote/datastore_test.cc
+++ b/Firestore/core/test/unit/remote/datastore_test.cc
@@ -254,7 +254,7 @@ TEST_F(DatastoreTest, LookupDocumentsOneSuccessfulRead) {
   std::vector<Document> resulting_docs;
   Status resulting_status;
   datastore->LookupDocuments(
-      {model::DocumentKey()},
+      {model::DocumentKey::FromPathString("foo/1")},
       [&](const StatusOr<std::vector<Document>>& documents) {
         done = true;
         if (documents.ok()) {
@@ -282,7 +282,8 @@ TEST_F(DatastoreTest, LookupDocumentsTwoSuccessfulReads) {
   std::vector<Document> resulting_docs;
   Status resulting_status;
   datastore->LookupDocuments(
-      {model::DocumentKey(), model::DocumentKey()},
+      {model::DocumentKey::FromPathString("foo/1"),
+       model::DocumentKey::FromPathString("foo/2")},
       [&](const StatusOr<std::vector<Document>>& documents) {
         done = true;
         if (documents.ok()) {
@@ -326,12 +327,13 @@ TEST_F(DatastoreTest, CommitMutationsError) {
   EXPECT_EQ(resulting_status.code(), Error::kErrorUnavailable);
 }
 
-TEST_F(DatastoreTest, LookupDocumentsTwoSuccessfulReadsButFailStatus) {
+TEST_F(DatastoreTest, LookupDocumentsTwoSuccessfulReadsButFailureStatus) {
   bool done = false;
   std::vector<Document> resulting_docs;
   Status resulting_status;
   datastore->LookupDocuments(
-      {model::DocumentKey(), model::DocumentKey()},
+      {model::DocumentKey::FromPathString("foo/1"),
+       model::DocumentKey::FromPathString("foo/2")},
       [&](const StatusOr<std::vector<Document>>& documents) {
         done = true;
         if (documents.ok()) {

--- a/Firestore/core/test/unit/remote/grpc_connection_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_connection_test.cc
@@ -167,24 +167,24 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
   foo->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        foo.reset();
         ++changes_count;
+        foo.reset();
       });
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        bar.reset();
         ++changes_count;
+        bar.reset();
       });
 
   std::unique_ptr<GrpcStreamingReader> baz = tester.CreateStreamingReader();
   baz->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        baz.reset();
         ++changes_count;
+        baz.reset();
       });
 
   tester.KeepPollingGrpcQueue();

--- a/Firestore/core/test/unit/remote/grpc_connection_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_connection_test.cc
@@ -126,7 +126,7 @@ TEST_F(GrpcConnectionTest, GrpcStreamingCallsNoticeChangeInConnectivity) {
   std::unique_ptr<GrpcStreamingReader> streaming_call =
       tester.CreateStreamingReader();
   streaming_call->Start(
-      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
+      0, [&](const std::vector<ResponsesT>) {},
       [&](const util::Status& st, bool) {
         if (IsConnectivityChange(st)) {
           ++change_count;
@@ -165,7 +165,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> foo = tester.CreateStreamingReader();
   foo->Start(
-      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
+      0, [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         foo.reset();
@@ -173,7 +173,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
-      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
+      0, [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         bar.reset();
@@ -181,7 +181,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> baz = tester.CreateStreamingReader();
   baz->Start(
-      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
+      0, [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         baz.reset();
@@ -212,7 +212,7 @@ TEST_F(GrpcConnectionTest, ShutdownFastFinishesActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
-      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
+      0, [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         FAIL() << "Callback shouldn't have been invoked";
       });

--- a/Firestore/core/test/unit/remote/grpc_connection_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_connection_test.cc
@@ -167,24 +167,24 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
   foo->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        ++changes_count;
         foo.reset();
+        ++changes_count;
       });
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        ++changes_count;
         bar.reset();
+        ++changes_count;
       });
 
   std::unique_ptr<GrpcStreamingReader> baz = tester.CreateStreamingReader();
   baz->Start(
       static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
-        ++changes_count;
         baz.reset();
+        ++changes_count;
       });
 
   tester.KeepPollingGrpcQueue();

--- a/Firestore/core/test/unit/remote/grpc_connection_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_connection_test.cc
@@ -126,7 +126,7 @@ TEST_F(GrpcConnectionTest, GrpcStreamingCallsNoticeChangeInConnectivity) {
   std::unique_ptr<GrpcStreamingReader> streaming_call =
       tester.CreateStreamingReader();
   streaming_call->Start(
-      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status& st, bool) {
         if (IsConnectivityChange(st)) {
           ++change_count;
@@ -165,7 +165,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> foo = tester.CreateStreamingReader();
   foo->Start(
-      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         foo.reset();
@@ -173,7 +173,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
-      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         bar.reset();
@@ -181,7 +181,7 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> baz = tester.CreateStreamingReader();
   baz->Start(
-      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         ++changes_count;
         baz.reset();
@@ -212,7 +212,7 @@ TEST_F(GrpcConnectionTest, ShutdownFastFinishesActiveCalls) {
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
   bar->Start(
-      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      static_cast<size_t>(0), [&](const std::vector<ResponsesT>) {},
       [&](const util::Status&, bool) {
         FAIL() << "Callback shouldn't have been invoked";
       });

--- a/Firestore/core/test/unit/remote/grpc_connection_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_connection_test.cc
@@ -43,6 +43,7 @@ using util::Status;
 using util::StatusOr;
 
 using NetworkStatus = ConnectivityMonitor::NetworkStatus;
+using ResponsesT = grpc::ByteBuffer;
 
 namespace {
 
@@ -125,8 +126,9 @@ TEST_F(GrpcConnectionTest, GrpcStreamingCallsNoticeChangeInConnectivity) {
   std::unique_ptr<GrpcStreamingReader> streaming_call =
       tester.CreateStreamingReader();
   streaming_call->Start(
-      [&](const StatusOr<std::vector<grpc::ByteBuffer>>& result) {
-        if (IsConnectivityChange(result.status())) {
+      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      [&](const util::Status& st, bool) {
+        if (IsConnectivityChange(st)) {
           ++change_count;
         }
       });
@@ -162,22 +164,28 @@ TEST_F(GrpcConnectionTest, ConnectivityChangeWithSeveralActiveCalls) {
   int changes_count = 0;
 
   std::unique_ptr<GrpcStreamingReader> foo = tester.CreateStreamingReader();
-  foo->Start([&](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-    foo.reset();
-    ++changes_count;
-  });
+  foo->Start(
+      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      [&](const util::Status&, bool) {
+        ++changes_count;
+        foo.reset();
+      });
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
-  bar->Start([&](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-    bar.reset();
-    ++changes_count;
-  });
+  bar->Start(
+      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      [&](const util::Status&, bool) {
+        ++changes_count;
+        bar.reset();
+      });
 
   std::unique_ptr<GrpcStreamingReader> baz = tester.CreateStreamingReader();
-  baz->Start([&](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-    baz.reset();
-    ++changes_count;
-  });
+  baz->Start(
+      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      [&](const util::Status&, bool) {
+        ++changes_count;
+        baz.reset();
+      });
 
   tester.KeepPollingGrpcQueue();
   // Calls will be unregistering themselves with `GrpcConnection` as it notifies
@@ -203,9 +211,11 @@ TEST_F(GrpcConnectionTest, ShutdownFastFinishesActiveCalls) {
   foo->Start();
 
   std::unique_ptr<GrpcStreamingReader> bar = tester.CreateStreamingReader();
-  bar->Start([](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-    FAIL() << "Callback shouldn't have been invoked";
-  });
+  bar->Start(
+      static_cast<size_t>(0), [&](std::vector<ResponsesT>) {},
+      [&](const util::Status&, bool) {
+        FAIL() << "Callback shouldn't have been invoked";
+      });
 
   std::unique_ptr<GrpcUnaryCall> baz = tester.CreateUnaryCall();
   baz->Start([](const StatusOr<grpc::ByteBuffer>&) {

--- a/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
@@ -74,10 +74,10 @@ class GrpcStreamingReaderTest : public testing::Test {
     tester.KeepPollingGrpcQueue();
   }
 
-  void StartReader(size_t key_count) {
+  void StartReader(size_t expected_response_count) {
     worker_queue->EnqueueBlocking([&] {
       reader->Start(
-          key_count,
+          expected_response_count,
           [&](std::vector<ResponsesT> result) {
             responses = std::move(result);
           },
@@ -101,7 +101,7 @@ TEST_F(GrpcStreamingReaderTest, FinishImmediatelyIsIdempotent) {
   worker_queue->EnqueueBlocking(
       [&] { EXPECT_NO_THROW(reader->FinishImmediately()); });
 
-  StartReader(static_cast<size_t>(0));
+  StartReader(0);
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -114,12 +114,12 @@ TEST_F(GrpcStreamingReaderTest, FinishImmediatelyIsIdempotent) {
 // Method prerequisites -- correct usage of `GetResponseHeaders`
 
 TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterStarting) {
-  StartReader(static_cast<size_t>(0));
+  StartReader(0);
   EXPECT_NO_THROW(reader->GetResponseHeaders());
 }
 
 TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterFinishing) {
-  StartReader(static_cast<size_t>(0));
+  StartReader(0);
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -139,7 +139,7 @@ TEST_F(GrpcStreamingReaderTest, CannotFinishAndNotifyBeforeStarting) {
 // Normal operation
 
 TEST_F(GrpcStreamingReaderTest, OneSuccessfulRead) {
-  StartReader(static_cast<size_t>(1));
+  StartReader(1);
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -158,7 +158,7 @@ TEST_F(GrpcStreamingReaderTest, OneSuccessfulRead) {
 }
 
 TEST_F(GrpcStreamingReaderTest, TwoSuccessfulReads) {
-  StartReader(static_cast<size_t>(2));
+  StartReader(2);
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -178,7 +178,7 @@ TEST_F(GrpcStreamingReaderTest, TwoSuccessfulReads) {
 }
 
 TEST_F(GrpcStreamingReaderTest, FinishWhileReading) {
-  StartReader(static_cast<size_t>(1));
+  StartReader(1);
 
   ForceFinishAnyTypeOrder({{Type::Write, CompletionResult::Ok},
                            {Type::Read, CompletionResult::Ok}});
@@ -194,7 +194,7 @@ TEST_F(GrpcStreamingReaderTest, FinishWhileReading) {
 // Errors
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
-  StartReader(static_cast<size_t>(1));
+  StartReader(1);
 
   bool failed_write = false;
   auto future = tester.ForceFinishAsync([&](GrpcCompletion* completion) {
@@ -230,7 +230,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
-  StartReader(static_cast<size_t>(1));
+  StartReader(1);
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -245,7 +245,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
-  StartReader(static_cast<size_t>(2));
+  StartReader(2);
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -264,7 +264,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
   worker_queue->EnqueueBlocking([&] {
     reader->Start(
-        static_cast<size_t>(1), [&](std::vector<ResponsesT>) {},
+        1, [&](std::vector<ResponsesT>) {},
         [&](const util::Status&, bool) { reader.reset(); });
   });
 
@@ -282,7 +282,7 @@ TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnError) {
   worker_queue->EnqueueBlocking([&] {
     reader->Start(
-        static_cast<size_t>(1), [&](std::vector<ResponsesT>) {},
+        1, [&](std::vector<ResponsesT>) {},
         [&](const util::Status&, bool) { reader.reset(); });
   });
 

--- a/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
@@ -101,7 +101,7 @@ TEST_F(GrpcStreamingReaderTest, FinishImmediatelyIsIdempotent) {
   worker_queue->EnqueueBlocking(
       [&] { EXPECT_NO_THROW(reader->FinishImmediately()); });
 
-  StartReader(static_cast<size_t>(3));
+  StartReader(static_cast<size_t>(0));
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -119,7 +119,7 @@ TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterStarting) {
 }
 
 TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterFinishing) {
-  StartReader(static_cast<size_t>(1));
+  StartReader(static_cast<size_t>(0));
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -194,7 +194,7 @@ TEST_F(GrpcStreamingReaderTest, FinishWhileReading) {
 // Errors
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
-  StartReader(static_cast<size_t>(2));
+  StartReader(static_cast<size_t>(1));
 
   bool failed_write = false;
   auto future = tester.ForceFinishAsync([&](GrpcCompletion* completion) {
@@ -230,7 +230,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
-  StartReader(static_cast<size_t>(2));
+  StartReader(static_cast<size_t>(1));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -245,7 +245,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
-  StartReader(static_cast<size_t>(3));
+  StartReader(static_cast<size_t>(2));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -264,7 +264,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
   worker_queue->EnqueueBlocking([&] {
     reader->Start(
-        static_cast<size_t>(2), [&](std::vector<ResponsesT>) {},
+        static_cast<size_t>(1), [&](std::vector<ResponsesT>) {},
         [&](const util::Status&, bool) { reader.reset(); });
   });
 
@@ -282,7 +282,7 @@ TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnError) {
   worker_queue->EnqueueBlocking([&] {
     reader->Start(
-        static_cast<size_t>(2), [&](std::vector<ResponsesT>) {},
+        static_cast<size_t>(1), [&](std::vector<ResponsesT>) {},
         [&](const util::Status&, bool) { reader.reset(); });
   });
 

--- a/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
+++ b/Firestore/core/test/unit/remote/grpc_streaming_reader_test.cc
@@ -39,6 +39,7 @@ using util::Status;
 using util::StatusOr;
 using util::StringFormat;
 using Type = GrpcCompletion::Type;
+using ResponsesT = grpc::ByteBuffer;
 
 class GrpcStreamingReaderTest : public testing::Test {
  public:
@@ -73,15 +74,14 @@ class GrpcStreamingReaderTest : public testing::Test {
     tester.KeepPollingGrpcQueue();
   }
 
-  void StartReader() {
+  void StartReader(size_t key_count) {
     worker_queue->EnqueueBlocking([&] {
       reader->Start(
-          [this](const StatusOr<std::vector<grpc::ByteBuffer>>& result) {
-            status = result.status();
-            if (status->ok()) {
-              responses = result.ValueOrDie();
-            }
-          });
+          key_count,
+          [&](std::vector<ResponsesT> result) {
+            responses = std::move(result);
+          },
+          [&](const util::Status& st, bool) { status = st; });
     });
   }
 
@@ -101,7 +101,7 @@ TEST_F(GrpcStreamingReaderTest, FinishImmediatelyIsIdempotent) {
   worker_queue->EnqueueBlocking(
       [&] { EXPECT_NO_THROW(reader->FinishImmediately()); });
 
-  StartReader();
+  StartReader(static_cast<size_t>(3));
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -114,12 +114,12 @@ TEST_F(GrpcStreamingReaderTest, FinishImmediatelyIsIdempotent) {
 // Method prerequisites -- correct usage of `GetResponseHeaders`
 
 TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterStarting) {
-  StartReader();
+  StartReader(static_cast<size_t>(0));
   EXPECT_NO_THROW(reader->GetResponseHeaders());
 }
 
 TEST_F(GrpcStreamingReaderTest, CanGetResponseHeadersAfterFinishing) {
-  StartReader();
+  StartReader(static_cast<size_t>(1));
 
   KeepPollingGrpcQueue();
   worker_queue->EnqueueBlocking([&] {
@@ -139,7 +139,7 @@ TEST_F(GrpcStreamingReaderTest, CannotFinishAndNotifyBeforeStarting) {
 // Normal operation
 
 TEST_F(GrpcStreamingReaderTest, OneSuccessfulRead) {
-  StartReader();
+  StartReader(static_cast<size_t>(1));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -158,7 +158,7 @@ TEST_F(GrpcStreamingReaderTest, OneSuccessfulRead) {
 }
 
 TEST_F(GrpcStreamingReaderTest, TwoSuccessfulReads) {
-  StartReader();
+  StartReader(static_cast<size_t>(2));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -178,7 +178,7 @@ TEST_F(GrpcStreamingReaderTest, TwoSuccessfulReads) {
 }
 
 TEST_F(GrpcStreamingReaderTest, FinishWhileReading) {
-  StartReader();
+  StartReader(static_cast<size_t>(1));
 
   ForceFinishAnyTypeOrder({{Type::Write, CompletionResult::Ok},
                            {Type::Read, CompletionResult::Ok}});
@@ -188,13 +188,13 @@ TEST_F(GrpcStreamingReaderTest, FinishWhileReading) {
   worker_queue->EnqueueBlocking([&] { reader->FinishImmediately(); });
 
   EXPECT_FALSE(status.has_value());
-  EXPECT_TRUE(responses.empty());
+  ASSERT_EQ(responses.size(), 1);
 }
 
 // Errors
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
-  StartReader();
+  StartReader(static_cast<size_t>(2));
 
   bool failed_write = false;
   auto future = tester.ForceFinishAsync([&](GrpcCompletion* completion) {
@@ -230,7 +230,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnWrite) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
-  StartReader();
+  StartReader(static_cast<size_t>(2));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -245,7 +245,7 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnFirstRead) {
 }
 
 TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
-  StartReader();
+  StartReader(static_cast<size_t>(3));
 
   ForceFinishAnyTypeOrder({
       {Type::Write, CompletionResult::Ok},
@@ -263,9 +263,9 @@ TEST_F(GrpcStreamingReaderTest, ErrorOnSecondRead) {
 
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
   worker_queue->EnqueueBlocking([&] {
-    reader->Start([this](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-      reader.reset();
-    });
+    reader->Start(
+        static_cast<size_t>(2), [&](std::vector<ResponsesT>) {},
+        [&](const util::Status&, bool) { reader.reset(); });
   });
 
   ForceFinishAnyTypeOrder({
@@ -281,9 +281,9 @@ TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnSuccess) {
 
 TEST_F(GrpcStreamingReaderTest, CallbackCanDestroyReaderOnError) {
   worker_queue->EnqueueBlocking([&] {
-    reader->Start([this](const StatusOr<std::vector<grpc::ByteBuffer>>&) {
-      reader.reset();
-    });
+    reader->Start(
+        static_cast<size_t>(2), [&](std::vector<ResponsesT>) {},
+        [&](const util::Status&, bool) { reader.reset(); });
   });
 
   ForceFinishAnyTypeOrder({


### PR DESCRIPTION
#no-changelog

For BatchGetDocuments, since the SDK knows the number of document paths in the requests, as soon as the SDK receives all the responses needed, it will fire user callback to save user's waiting time. 