### PR TITLE
Register Combine modules with Swift component system

### DIFF
--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -17,6 +17,8 @@
   import Combine
   import FirebaseAuth
 
+  @objc(FIRCombineAuthComponent) private class __CombineAuthComponent: NSObject {}
+
   @available(swift 5.0)
   @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
   public extension Auth {

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -17,7 +17,8 @@
   import Combine
   import FirebaseAuth
 
-  @objc(FIRCombineAuthComponent) private class __CombineAuthComponent: NSObject {}
+  // Make this class discoverable from Objective-C. Don't instantiate directly.
+  @objc(FIRCombineAuthLibrary) private class __CombineAuthLibrary: NSObject {}
 
   @available(swift 5.0)
   @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)

--- a/FirebaseCombineSwift/Sources/Firestore/Firestore+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/Firestore+Combine.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0)
+
+  import Foundation
+  @objc(FIRCombineFirestoreComponent) private class __CombineFirestoreComponent: NSObject {}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Firestore/Firestore+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Firestore/Firestore+Combine.swift
@@ -15,6 +15,8 @@
 #if canImport(Combine) && swift(>=5.0)
 
   import Foundation
-  @objc(FIRCombineFirestoreComponent) private class __CombineFirestoreComponent: NSObject {}
+
+  // Make this class discoverable from Objective-C. Don't instantiate directly.
+  @objc(FIRCombineFirestoreLibrary) private class __CombineFirestoreLibrary: NSObject {}
 
 #endif

--- a/FirebaseCombineSwift/Sources/Functions/Functions+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/Functions+Combine.swift
@@ -15,6 +15,8 @@
 #if canImport(Combine) && swift(>=5.0)
 
   import Foundation
-  @objc(FIRCombineFunctionsComponent) private class __CombineFunctionsComponent: NSObject {}
+
+  // Make this class discoverable from Objective-C. Don't instantiate directly.
+  @objc(FIRCombineFunctionsLibrary) private class __CombineFunctionsLibrary: NSObject {}
 
 #endif

--- a/FirebaseCombineSwift/Sources/Functions/Functions+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Functions/Functions+Combine.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0)
+
+  import Foundation
+  @objc(FIRCombineFunctionsComponent) private class __CombineFunctionsComponent: NSObject {}
+
+#endif

--- a/FirebaseCombineSwift/Sources/Storage/Storage+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/Storage+Combine.swift
@@ -15,6 +15,8 @@
 #if canImport(Combine) && swift(>=5.0)
 
   import Foundation
-  @objc(FIRCombineStorageComponent) private class __CombineStorageComponent: NSObject {}
+
+  // Make this class discoverable from Objective-C. Don't instantiate directly.
+  @objc(FIRCombineStorageLibrary) private class __CombineStorageLibrary: NSObject {}
 
 #endif

--- a/FirebaseCombineSwift/Sources/Storage/Storage+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Storage/Storage+Combine.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0)
+
+  import Foundation
+  @objc(FIRCombineStorageComponent) private class __CombineStorageComponent: NSObject {}
+
+#endif

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -848,10 +848,10 @@ static FIRApp *sDefaultApp;
 
   // Swift libraries that don't need component behaviour
   NSDictionary<NSString *, NSString *> *swiftLibraries = @{
-    @"FIRCombineAuthComponent" : @"comb-auth",
-    @"FIRCombineFirestoreComponent" : @"comb-firestore",
-    @"FIRCombineFunctionsComponent" : @"comb-functions",
-    @"FIRCombineStorageComponent" : @"comb-storage",
+    @"FIRCombineAuthLibrary" : @"comb-auth",
+    @"FIRCombineFirestoreLibrary" : @"comb-firestore",
+    @"FIRCombineFunctionsLibrary" : @"comb-functions",
+    @"FIRCombineStorageLibrary" : @"comb-storage",
   };
   for (NSString *className in swiftLibraries.allKeys) {
     Class klass = NSClassFromString(className);

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -838,11 +838,25 @@ static FIRApp *sDefaultApp;
   SEL componentsToRegisterSEL = @selector(componentsToRegister);
   // Dictionary of class names that conform to `FIRLibrary` and their user agents. These should only
   // be SDKs that are written in Swift but still visible to ObjC.
-  NSDictionary<NSString *, NSString *> *swiftLibs = @{@"FIRFunctionsComponent" : @"fire-fun"};
-  for (NSString *className in swiftLibs.allKeys) {
+  NSDictionary<NSString *, NSString *> *swiftComponents = @{@"FIRFunctionsComponent" : @"fire-fun"};
+  for (NSString *className in swiftComponents.allKeys) {
     Class klass = NSClassFromString(className);
     if (klass && [klass respondsToSelector:componentsToRegisterSEL]) {
-      [FIRApp registerInternalLibrary:klass withName:swiftLibs[className]];
+      [FIRApp registerInternalLibrary:klass withName:swiftComponents[className]];
+    }
+  }
+
+  // Swift libraries that don't need component behaviour
+  NSDictionary<NSString *, NSString *> *swiftLibraries = @{
+    @"FIRCombineAuthComponent" : @"comb-auth",
+    @"FIRCombineFirestoreComponent" : @"comb-firestore",
+    @"FIRCombineFunctionsComponent" : @"comb-functions",
+    @"FIRCombineStorageComponent" : @"comb-storage",
+  };
+  for (NSString *className in swiftLibraries.allKeys) {
+    Class klass = NSClassFromString(className);
+    if (klass) {
+      [FIRApp registerLibrary:swiftLibraries[className] withVersion:FIRFirebaseVersion()];
     }
   }
 }


### PR DESCRIPTION
This PR adds a Swift component for Firebase Combine, so that Combine will be included in the user agent.

This is a replacement for PR #9363 and contains all code already discussed there, and addresses the most recent comments/

#no-changelog 