### PR TITLE
[Minor] Fixed a typo in The InAppMessaging Swift test

### DIFF
--- a/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
+++ b/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
@@ -62,7 +62,7 @@ struct ModalInAppMessageView: View {
   @ViewBuilder
   func dismissButton(modalMessage: InAppMessagingModalDisplay,
                      delegate: InAppMessagingDisplayDelegate) -> some View {
-    if let _ = modalMessage.actionButton, modalMessage.actionURL != nil {
+    if let _ = modalMessage.actionButton, modalMessage.actionURL == nil {
       Button(action: {
         delegate.messageDismissed?(modalMessage, dismissType: .typeUserTapClose)
       }) {


### PR DESCRIPTION
Without this change the dismess button was never added, creating a
modal dialog that cannot be closed if the message have no action
