### PR TITLE
[Minor] Fixed a typo in The InAppMessaging Swift test

### DIFF
--- a/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
+++ b/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
@@ -62,7 +62,7 @@ struct ModalInAppMessageView: View {
   @ViewBuilder
   func dismissButton(modalMessage: InAppMessagingModalDisplay,
                      delegate: InAppMessagingDisplayDelegate) -> some View {
-    if let _ = modalMessage.actionButton, modalMessage.actionURL != nil {
+    if let _ = modalMessage.actionButton, modalMessage.actionURL == nil {
       Button(action: {
         delegate.messageDismissed?(modalMessage, dismissType: .typeUserTapClose)
       }) {

--- a/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
+++ b/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
@@ -58,7 +58,8 @@ struct ModalInAppMessageView: View {
   }
 
   // Need a dismiss button for the case where there's an action button with an action URL. Otherwise
-  // user would be forced into a clickthrough.
+  // user would be forced into a clickthrough. If there's No action button at all we also need a
+  // dismissButton, otherwise the user will not be able to close the modal!
   @ViewBuilder
   func dismissButton(modalMessage: InAppMessagingModalDisplay,
                      delegate: InAppMessagingDisplayDelegate) -> some View {

--- a/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
+++ b/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
@@ -62,7 +62,7 @@ struct ModalInAppMessageView: View {
   @ViewBuilder
   func dismissButton(modalMessage: InAppMessagingModalDisplay,
                      delegate: InAppMessagingDisplayDelegate) -> some View {
-    if let _ = modalMessage.actionButton, modalMessage.actionURL == nil {
+    if (modalMessage.actionButton != nil && modalMessage.actionURL != nil) || modelMesssage.actionButton == nil {
       Button(action: {
         delegate.messageDismissed?(modalMessage, dismissType: .typeUserTapClose)
       }) {

--- a/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
+++ b/FirebaseInAppMessaging/Swift/Tests/Integration/FIAMSwiftUI/Shared/ModalInAppMessageView.swift
@@ -58,12 +58,12 @@ struct ModalInAppMessageView: View {
   }
 
   // Need a dismiss button for the case where there's an action button with an action URL. Otherwise
-  // user would be forced into a clickthrough. If there's No action button at all we also need a
+  // user would be forced into a clickthrough. If there's no action button at all we also need a
   // dismissButton, otherwise the user will not be able to close the modal!
   @ViewBuilder
   func dismissButton(modalMessage: InAppMessagingModalDisplay,
                      delegate: InAppMessagingDisplayDelegate) -> some View {
-    if (modalMessage.actionButton != nil && modalMessage.actionURL != nil) || modelMesssage.actionButton == nil {
+    if (modalMessage.actionButton != nil && modalMessage.actionURL != nil) || modalMesssage.actionButton == nil {
       Button(action: {
         delegate.messageDismissed?(modalMessage, dismissType: .typeUserTapClose)
       }) {


### PR DESCRIPTION
Without this change the dismess button was never added, creating a
modal dialog that cannot be closed if the message have no action
