### PR TITLE
[Don't Merge] Run `messaging` CI

### DIFF
--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -10,6 +10,7 @@ on:
     # Podspec
     - 'FirebaseMessaging.podspec'
     # This file
+    # TODO(ncooke3): Remove this line.
     - '.github/workflows/messaging.yml'
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'


### PR DESCRIPTION
The messaging CI is broken in #9568 but I'm not convinced the changes in that PR are causing the workflow to fail.

I ran the workflow locally on `master` and `v9b` and it failed as well.

Opening this PR to run on GHA.

#no-changelog