### PR TITLE
Version 9.0

### DIFF
--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -102,6 +102,8 @@ jobs:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
+      POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
         target: [ios, tvos, macos]

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -36,14 +36,14 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
-    ss.ios.dependency 'FirebaseAnalytics', '~> 8.15.0'
-    ss.osx.dependency 'FirebaseAnalytics', '~> 8.15.0'
-    ss.tvos.dependency 'FirebaseAnalytics', '~> 8.15.0'
+    ss.ios.dependency 'FirebaseAnalytics', '~> 9.0.0'
+    ss.osx.dependency 'FirebaseAnalytics', '~> 9.0.0'
+    ss.tvos.dependency 'FirebaseAnalytics', '~> 9.0.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '8.15.0'
+    ss.dependency 'FirebaseCore', '9.0.0'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -79,13 +79,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
-    ss.ios.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '~> 8.15.0'
+    ss.ios.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '~> 9.0.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 
   s.subspec 'ABTesting' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseABTesting', '~> 8.15.0'
+    ss.dependency 'FirebaseABTesting', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
@@ -95,12 +95,12 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseAppDistribution', '~> 8.15.0-beta'
+    ss.ios.dependency 'FirebaseAppDistribution', '~> 9.0.0-beta'
   end
 
   s.subspec 'AppCheck' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAppCheck', '~> 8.15.0-beta'
+    ss.dependency 'FirebaseAppCheck', '~> 9.0.0-beta'
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
@@ -109,7 +109,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Auth' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAuth', '~> 8.15.0'
+    ss.dependency 'FirebaseAuth', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
@@ -119,7 +119,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseCrashlytics', '~> 8.15.0'
+    ss.dependency 'FirebaseCrashlytics', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
@@ -129,7 +129,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Database' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseDatabase', '~> 8.15.0'
+    ss.dependency 'FirebaseDatabase', '~> 9.0.0'
     # Standard platforms PLUS watchOS 7.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
@@ -139,32 +139,32 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'DynamicLinks' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseDynamicLinks', '~> 8.15.0'
+    ss.ios.dependency 'FirebaseDynamicLinks', '~> 9.0.0'
   end
 
   s.subspec 'Firestore' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFirestore', '~> 8.15.0'
+    ss.dependency 'FirebaseFirestore', '~> 9.0.0'
   end
 
   s.subspec 'Functions' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFunctions', '~> 8.15.0'
+    ss.dependency 'FirebaseFunctions', '~> 9.0.0'
   end
 
   s.subspec 'InAppMessaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseInAppMessaging', '~> 8.15.0-beta'
+    ss.ios.dependency 'FirebaseInAppMessaging', '~> 9.0.0-beta'
   end
 
   s.subspec 'Installations' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseInstallations', '~> 8.15.0'
+    ss.dependency 'FirebaseInstallations', '~> 9.0.0'
   end
 
   s.subspec 'Messaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMessaging', '~> 8.15.0'
+    ss.dependency 'FirebaseMessaging', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
@@ -174,18 +174,18 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'MLModelDownloader' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMLModelDownloader', '~> 8.15.0-beta'
+    ss.dependency 'FirebaseMLModelDownloader', '~> 9.0.0-beta'
   end
 
   s.subspec 'Performance' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebasePerformance', '~> 8.15.0'
-    ss.tvos.dependency 'FirebasePerformance', '~> 8.15.0'
+    ss.ios.dependency 'FirebasePerformance', '~> 9.0.0'
+    ss.tvos.dependency 'FirebasePerformance', '~> 9.0.0'
   end
 
   s.subspec 'RemoteConfig' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseRemoteConfig', '~> 8.15.0'
+    ss.dependency 'FirebaseRemoteConfig', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
@@ -195,7 +195,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Storage' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseStorage', '~> 8.15.0'
+    ss.dependency 'FirebaseStorage', '~> 9.0.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -41,7 +41,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   s.source_files = [
     base_dir + '**/*.[mh]',
    'Interop/Analytics/Public/*.h',
-   'FirebaseCore/Internal/*.h',
+   'FirebaseCore/Extension/*.h',
   ]
   s.requires_arc = base_dir + '*.m'
   s.public_header_files = base_dir + 'Public/FirebaseABTesting/*.h'
@@ -49,7 +49,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC

--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -3,8 +3,8 @@
     "cocoapods_version": ">= 1.10.0",
     "default_subspecs": "AdIdSupport",
     "dependencies": {
-        "FirebaseCore": "~> 8.0",
-        "FirebaseInstallations": "~> 8.0",
+        "FirebaseCore": "~> 9.0",
+        "FirebaseInstallations": "~> 9.0",
         "GoogleUtilities/AppDelegateSwizzler": "~> 7.7",
         "GoogleUtilities/MethodSwizzler": "~> 7.7",
         "GoogleUtilities/NSData+zlib": "~> 7.7",
@@ -55,5 +55,7 @@
         }
     ],
     "summary": "Firebase Analytics for iOS",
+
+    "swift_version" : "5.3",
     "version": "9.0.0"
 }

--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -38,7 +38,7 @@
         {
             "name": "AdIdSupport",
             "dependencies": {
-                "GoogleAppMeasurement": "8.15.0"
+                "GoogleAppMeasurement": "9.0.0"
             },
             "vendored_frameworks": [
                 "Frameworks/FirebaseAnalytics.xcframework"
@@ -47,7 +47,7 @@
         {
             "name": "WithoutAdIdSupport",
             "dependencies": {
-                "GoogleAppMeasurement/WithoutAdIdSupport": "8.15.0"
+                "GoogleAppMeasurement/WithoutAdIdSupport": "9.0.0"
             },
             "vendored_frameworks": [
                 "Frameworks/FirebaseAnalytics.xcframework"
@@ -55,5 +55,5 @@
         }
     ],
     "summary": "Firebase Analytics for iOS",
-    "version": "8.15.0"
+    "version": "9.0.0"
 }

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -29,5 +29,5 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     'FirebaseAnalyticsSwift/Sources/*.swift',
   ]
 
-  s.dependency 'FirebaseAnalytics', '~> 8.9'
+  s.dependency 'FirebaseAnalytics', '~> 9.0'
 end

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseAnalyticsSwift'
-  s.version                 = '8.15.0-beta'
+  s.version                 = '9.0.0-beta'
   s.summary                 = 'Swift Extensions for Firebase Analytics'
 
   s.description      = <<-DESC

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   s.source_files = [
     base_dir + 'Sources/**/*.[mh]',
     base_dir + 'Interop/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseAppCheck/*.h'
 
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'PromisesObjC', '~> 2.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
 

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheck'
-  s.version          = '8.15.0-beta'
+  s.version          = '9.0.0-beta'
   s.summary          = 'Firebase App Check SDK.'
 
   s.description      = <<-DESC

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheckInterop'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use AppCheck functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppDistribution'
-  s.version          = '8.15.0-beta'
+  s.version          = '9.0.0-beta'
   s.summary          = 'App Distribution for Firebase iOS SDK.'
 
   s.description      = <<-DESC

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -25,15 +25,15 @@ iOS SDK for App Distribution for Firebase.
   base_dir = "FirebaseAppDistribution/Sources/"
   s.source_files = [
     base_dir + '**/*.{c,h,m,mm}',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseAppDistribution/*.h'
 
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.7'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'GoogleDataTransport', '~> 9.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Apple platform client for Firebase Authentication'
 
   s.description      = <<-DESC

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -37,7 +37,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   source = 'FirebaseAuth/Sources/'
   s.source_files = [
     source + '**/*.[mh]',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseAuth/Interop/*.h',
   ]
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
@@ -51,7 +51,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.5'

--- a/FirebaseAuthInterop.podspec
+++ b/FirebaseAuthInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuthInterop'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Auth functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -51,11 +51,11 @@ for internal testing only. It should not be published.
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseFunctions', '~> 8.12'
-  s.dependency 'FirebaseFirestore', '~> 8.0'
-  s.dependency 'FirebaseStorage', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseAuth', '~> 9.0'
+  s.dependency 'FirebaseFunctions', '~> 9.0'
+  s.dependency 'FirebaseFirestore', '~> 9.0'
+  s.dependency 'FirebaseStorage', '~> 9.0'
 
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -53,8 +53,8 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   # Remember to also update version in `cmake/external/GoogleUtilities.cmake`
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'
-  s.dependency 'FirebaseCoreDiagnostics', '~> 8.0'
-  s.dependency 'FirebaseCoreInternal', '~> 8.12'
+  s.dependency 'FirebaseCoreDiagnostics', '~> 9.0'
+  s.dependency 'FirebaseCoreInternal', '~> 9.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreDiagnostics'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Core Diagnostics'
 
   s.description      = <<-DESC

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |s|
     s.source_files = 'FirebaseCore/Extension/*.[hm]'
     s.public_header_files = 'FirebaseCore/Extension/*.h'
 
-    s.dependency 'FirebaseCore', '~> 8.12'
+    s.dependency 'FirebaseCore', '~> 9.0'
   end

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseCoreExtension'
-    s.version          = '8.15.0'
+    s.version          = '9.0.0'
     s.summary          = 'Extended FirebaseCore APIs for Firebase product SDKs'
 
     s.description      = <<-DESC

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreInternal'
-  s.version          = '8.13.0'
+  s.version          = '9.0.0'
   s.summary          = 'APIs for internal FirebaseCore usage.'
 
   s.description      = <<-DESC

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCrashlytics'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Best and lightest-weight crash reporting for mobile, desktop and tvOS.'
   s.description      = 'Firebase Crashlytics helps you track, prioritize, and fix stability issues that erode app quality.'
   s.homepage         = 'https://firebase.google.com/'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     'Crashlytics/Protogen/**/*.{c,h,m,mm}',
     'Crashlytics/Shared/**/*.{c,h,m,mm}',
     'Crashlytics/third_party/**/*.{c,h,m,mm}',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
     'Interop/Analytics/Public/*.h',
   ]
@@ -53,8 +53,8 @@ Pod::Spec.new do |s|
     cp -f ./Crashlytics/upload-symbols ./upload-symbols
   PREPARE_COMMAND_END
 
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'PromisesObjC', '~> 2.0'
   s.dependency 'GoogleDataTransport', '~> 9.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDatabase'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Realtime Database'
 
   s.description      = <<-DESC

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -39,7 +39,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     base_dir + 'third_party/SocketRocket/fbase64.c',
     'FirebaseAuth/Interop/*.h',
     'FirebaseAppCheck/Interop/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseDatabase/*.h'
   s.libraries = ['c++', 'icucore']
@@ -48,7 +48,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.macos.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.watchos.frameworks = 'CFNetwork', 'Security', 'WatchKit'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -28,6 +28,6 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     'FirebaseDatabaseSwift/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseDatabase', '~> 8.0'
-  s.dependency 'FirebaseSharedSwift', '~> 8.11'
+  s.dependency 'FirebaseDatabase', '~> 9.0'
+  s.dependency 'FirebaseSharedSwift', '~> 9.0'
 end

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseDatabaseSwift'
-  s.version                 = '8.15.0-beta'
+  s.version                 = '9.0.0-beta'
   s.summary                 = 'Swift Extensions for Firebase Realtime Database'
 
   s.description      = <<-DESC

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDynamicLinks'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Dynamic Links'
 
   s.description      = <<-DESC

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -26,12 +26,12 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.source_files = [
     'FirebaseDynamicLinks/Sources/**/*.[mh]',
     'Interop/Analytics/Public/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = 'FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/*.h'
   s.frameworks = 'QuartzCore'
   s.weak_framework = 'WebKit'
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -45,7 +45,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   # that "quick open" by filename in Xcode will continue to work.
   s.source_files = [
     'FirebaseAppCheck/Interop/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'Firestore/Source/Public/FirebaseFirestore/*.h',
     'Firestore/Source/**/*.{m,mm}',
     'Firestore/Protos/nanopb/**/*.cc',
@@ -88,7 +88,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/core/src/util/secure_random_openssl.cc'
   ]
 
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
 
   abseil_version = '~> 1.20211102.0'
   s.dependency 'abseil/algorithm', abseil_version

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseFirestoreSwift'
-  s.version                 = '8.15.0-beta'
+  s.version                 = '9.0.0-beta'
   s.summary                 = 'Swift Extensions for Google Cloud Firestore'
 
   s.description      = <<-DESC

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -35,5 +35,5 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/third_party/FirestoreEncoder/*.swift',
   ]
 
-  s.dependency 'FirebaseFirestore', '~> 8.0'
+  s.dependency 'FirebaseFirestore', '~> 9.0'
 end

--- a/FirebaseFirestoreTestingSupport.podspec
+++ b/FirebaseFirestoreTestingSupport.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
 
   s.public_header_files = base_dir + '**/*.h'
 
-  s.dependency 'FirebaseFirestore', '~> 8.0'
+  s.dependency 'FirebaseFirestore', '~> 9.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Cloud Functions for Firebase'
 
   s.description      = <<-DESC

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -37,12 +37,12 @@ Cloud Functions for Firebase.
     'FirebaseFunctions/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseCore', '~> 8.12'
-  s.dependency 'FirebaseCoreExtension', '~> 8.12'
-  s.dependency 'FirebaseAppCheckInterop', '~> 8.12'
-  s.dependency 'FirebaseAuthInterop', '~> 8.12'
-  s.dependency 'FirebaseMessagingInterop', '~> 8.12'
-  s.dependency 'FirebaseSharedSwift', '~> 8.12'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseCoreExtension', '~> 9.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 9.0'
+  s.dependency 'FirebaseAuthInterop', '~> 9.0'
+  s.dependency 'FirebaseMessagingInterop', '~> 9.0'
+  s.dependency 'FirebaseSharedSwift', '~> 9.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
 
   s.test_spec 'integration' do |int_tests|

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -40,7 +40,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 	base_dir + "Sources/Util/**/*.[cmh]",
     'Interop/Analytics/Public/*.h',
     'FirebaseABTesting/Sources/Private/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
 
@@ -57,7 +57,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 	base_dir + "Sources/Util/**/*.[cmh]",
     'Interop/Analytics/Public/*.h',
     'FirebaseABTesting/Sources/Private/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
 
@@ -78,9 +78,9 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
-  s.dependency 'FirebaseABTesting', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
+  s.dependency 'FirebaseABTesting', '~> 9.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'nanopb', '~> 2.30908.0'
 

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '8.15.0-beta'
+  s.version          = '9.0.0-beta'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseInAppMessagingSwift'
-  s.version                 = '8.15.0-beta'
+  s.version                 = '9.0.0-beta'
   s.summary                 = 'Swift Extensions for Firebase In-App Messaging'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -35,5 +35,5 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.framework = 'UIKit'
 
-  s.dependency 'FirebaseInAppMessaging', '~> 8.0-beta'
+  s.dependency 'FirebaseInAppMessaging', '~> 9.0-beta'
 end

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -35,14 +35,14 @@ Pod::Spec.new do |s|
   base_dir = "FirebaseInstallations/Source/"
   s.source_files = [
     base_dir + 'Library/**/*.[mh]',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = [
     base_dir + 'Library/Public/FirebaseInstallations/*.h',
   ]
 
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'PromisesObjC', '~> 2.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.7'
@@ -76,21 +76,21 @@ Pod::Spec.new do |s|
         unit_tests.source_files += base_dir + 'Tests/Unit/IIDStoreTests/*.[mh]'
       end
     end
-  end
 
-  s.test_spec 'integration' do |int_tests|
-    int_tests.scheme = { :code_coverage => true }
-    int_tests.platforms = {:ios => '9.0', :osx => '10.15', :tvos => '10.0'}
-    int_tests.source_files = base_dir + 'Tests/Integration/**/*.[mh]'
-    int_tests.resources = base_dir + 'Tests/Resources/**/*'
-    if ENV['FIS_INTEGRATION_TESTS_REQUIRED'] && ENV['FIS_INTEGRATION_TESTS_REQUIRED'] == '1' then
-      int_tests.pod_target_xcconfig = {
-      'GCC_PREPROCESSOR_DEFINITIONS' =>
-        'FIR_INSTALLATIONS_INTEGRATION_TESTS_REQUIRED=1'
-      }
+    s.test_spec 'integration' do |int_tests|
+      int_tests.scheme = { :code_coverage => true }
+      int_tests.platforms = {:ios => '9.0', :osx => '10.15', :tvos => '10.0'}
+      int_tests.source_files = base_dir + 'Tests/Integration/**/*.[mh]'
+      int_tests.resources = base_dir + 'Tests/Resources/**/*'
+      if ENV['FIS_INTEGRATION_TESTS_REQUIRED'] && ENV['FIS_INTEGRATION_TESTS_REQUIRED'] == '1' then
+        int_tests.pod_target_xcconfig = {
+        'GCC_PREPROCESSOR_DEFINITIONS' =>
+          'FIR_INSTALLATIONS_INTEGRATION_TESTS_REQUIRED=1'
+        }
+      end
+      int_tests.requires_app_host = true
+      int_tests.dependency 'OCMock'
+      int_tests.dependency 'HeartbeatLoggingTestUtils'
     end
-    int_tests.requires_app_host = true
-    int_tests.dependency 'OCMock'
-    int_tests.dependency 'HeartbeatLoggingTestUtils'
   end
 end

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Installations'
 
   s.description      = <<-DESC

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMLModelDownloader'
-  s.version          = '8.15.0-beta'
+  s.version          = '9.0.0-beta'
   s.summary          = 'Firebase ML Model Downloader'
 
   s.description      = <<-DESC

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -36,8 +36,8 @@ Pod::Spec.new do |s|
   ]
 
   s.framework = 'Foundation'
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'GoogleDataTransport', '~> 9.1'
   # TODO: Revisit this dependency
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Messaging'
 
   s.description      = <<-DESC

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -41,7 +41,7 @@ device, and it is completely free.
     base_dir + 'Sources/Protogen/nanopb/*.h',
     base_dir + 'Interop/*.h',
     'Interop/Analytics/Public/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseMessaging/*.h'
@@ -58,8 +58,8 @@ device, and it is completely free.
   s.tvos.framework = 'SystemConfiguration'
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
-  s.dependency 'FirebaseCore', '~> 8.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/Reachability', '~> 7.7'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'

--- a/FirebaseMessagingInterop.podspec
+++ b/FirebaseMessagingInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessagingInterop'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Messaging functionality.'
 
   s.description      = <<-DESC

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebasePerformance'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Performance'
 
   s.description      = <<-DESC

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -31,7 +31,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   base_dir = "FirebasePerformance/"
   s.source_files = [
     base_dir + 'Sources/**/*.[cmh]',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
     'FirebaseRemoteConfig/Sources/Private/*.h',
   ]
@@ -59,9 +59,9 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.ios.framework = 'CoreTelephony'
   s.framework = 'QuartzCore'
   s.framework = 'SystemConfiguration'
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
-  s.dependency 'FirebaseRemoteConfig', '~> 8.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
+  s.dependency 'FirebaseRemoteConfig', '~> 9.0'
   s.dependency 'GoogleDataTransport', '~> 9.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/ISASwizzler', '~> 7.7'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Remote Config'
 
   s.description      = <<-DESC

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -38,7 +38,7 @@ app update.
     base_dir + '**/*.[mh]',
     'Interop/Analytics/Public/*.h',
     'FirebaseABTesting/Sources/Private/*.h',
-    'FirebaseCore/Internal/*.h',
+    'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseRemoteConfig/*.h'
@@ -46,9 +46,9 @@ app update.
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseABTesting', '~> 8.0'
-  s.dependency 'FirebaseCore', '~> 8.0'
-  s.dependency 'FirebaseInstallations', '~> 8.0'
+  s.dependency 'FirebaseABTesting', '~> 9.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.7'
 

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseRemoteConfigSwift'
-  s.version                 = '8.15.0-beta'
+  s.version                 = '9.0.0-beta'
   s.summary                 = 'Swift Extensions for Firebase Remote Config'
 
   s.description      = <<-DESC

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -38,8 +38,8 @@ app update.
     'FirebaseRemoteConfigSwift/Sources/*.swift',
   ]
 
-  s.dependency 'FirebaseRemoteConfig', '~> 8.11'
-  s.dependency 'FirebaseSharedSwift', '~> 8.11-beta'
+  s.dependency 'FirebaseRemoteConfig', '~> 9.0'
+  s.dependency 'FirebaseSharedSwift', '~> 9.0'
 
   # Run Swift API tests on a real backend.
   s.test_spec 'swift-api-tests' do |swift_api|

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseSharedSwift'
-  s.version                 = '8.15.0'
+  s.version                 = '9.0.0'
   s.summary                 = 'Shared Swift Extensions for Firebase'
 
   s.description      = <<-DESC

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -37,11 +37,11 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     'FirebaseStorageSwift/Typedefs/*.h',
   ]
 
-  s.dependency 'FirebaseStorageObjC', '~> 8.15'
-  s.dependency 'FirebaseAppCheckInterop', '~> 8.15'
-  s.dependency 'FirebaseAuthInterop', '~> 8.15'
-  s.dependency 'FirebaseCore', '~> 8.15'
-  s.dependency 'FirebaseCoreExtension', '~> 8.15'
+  s.dependency 'FirebaseStorageObjC', '~> 9.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 9.0'
+  s.dependency 'FirebaseAuthInterop', '~> 9.0'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseCoreExtension', '~> 9.0'
 
   s.test_spec 'ObjCIntegration' do |objc_tests|
     objc_tests.scheme = { :code_coverage => true }

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -57,7 +57,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     objc_tests.requires_app_host = true
     objc_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist'
-    objc_tests.dependency 'FirebaseAuth', '~> 8.13'
+    objc_tests.dependency 'FirebaseAuth', '~> 9.0'
     objc_tests.pod_target_xcconfig = {
       'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
     }
@@ -85,6 +85,6 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist',
                           'FirebaseStorage/Tests/Integration/Resources/HomeImprovement.numbers'
-    int_tests.dependency 'FirebaseAuth', '~> 8.13'
+    int_tests.dependency 'FirebaseAuth', '~> 9.0'
   end
 end

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorage'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC

--- a/FirebaseStorage/Sources/FIRStorage.m
+++ b/FirebaseStorage/Sources/FIRStorage.m
@@ -22,8 +22,9 @@
 #import "FirebaseStorage/Sources/FIRStorageUtils.h"
 #import "FirebaseStorage/Sources/FIRStorage_Private.h"
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAuth/Interop/FIRAuthInterop.h"
+#import <FirebaseAppCheckInterop/FIRAppCheckInterop.h>
+#import <FirebaseAuthInterop/FIRAuthInterop.h>
+
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 #if SWIFT_PACKAGE

--- a/FirebaseStorage/Sources/FIRStorageTokenAuthorizer.m
+++ b/FirebaseStorage/Sources/FIRStorageTokenAuthorizer.m
@@ -23,9 +23,10 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
-#import "FirebaseAuth/Interop/FIRAuthInterop.h"
+#import <FirebaseAppCheckInterop/FIRAppCheckInterop.h>
+#import <FirebaseAppCheckInterop/FIRAppCheckTokenResultInterop.h>
+
+#import <FirebaseAuthInterop/FIRAuthInterop.h>
 
 static NSString *const kAppCheckTokenHeader = @"X-Firebase-AppCheck";
 static NSString *const kAuthHeader = @"Authorization";

--- a/FirebaseStorage/Sources/FIRStorageTokenAuthorizer.m
+++ b/FirebaseStorage/Sources/FIRStorageTokenAuthorizer.m
@@ -25,7 +25,6 @@
 
 #import <FirebaseAppCheckInterop/FIRAppCheckInterop.h>
 #import <FirebaseAppCheckInterop/FIRAppCheckTokenResultInterop.h>
-
 #import <FirebaseAuthInterop/FIRAuthInterop.h>
 
 static NSString *const kAppCheckTokenHeader = @"X-Firebase-AppCheck";

--- a/FirebaseStorageObjC.podspec
+++ b/FirebaseStorageObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorageObjC'
-  s.version          = '8.15.0'
+  s.version          = '9.0.0'
   s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC

--- a/FirebaseStorageObjC.podspec
+++ b/FirebaseStorageObjC.podspec
@@ -35,14 +35,15 @@ Objective C Implementations for FirebaseStorage. This pod should not be directly
   s.source_files = [
     'FirebaseStorage/Sources/**/*.[mh]',
     'FirebaseCore/Sources/Private/*.h',
+    'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = 'FirebaseStorage/Sources/Public/FirebaseStorage/*.h'
 
   s.osx.framework = 'CoreServices'
 
-  s.dependency 'FirebaseCore', '~> 8.13'
-  s.dependency 'FirebaseAppCheckInterop', '~> 8.13'
-  s.dependency 'FirebaseAuthInterop', '~> 8.13'
+  s.dependency 'FirebaseCore', '~> 9.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 9.0'
+  s.dependency 'FirebaseAuthInterop', '~> 9.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -36,7 +36,7 @@
         {
             "name": "AdIdSupport",
             "dependencies": {
-                "GoogleAppMeasurement/WithoutAdIdSupport": "8.15.0"
+                "GoogleAppMeasurement/WithoutAdIdSupport": "9.0.0"
             },
             "vendored_frameworks": [
                 "Frameworks/GoogleAppMeasurementIdentitySupport.xcframework"
@@ -50,5 +50,5 @@
         }
     ],
     "summary": "Shared measurement methods for Google libraries. Not intended for direct use.",
-    "version": "8.15.0"
+    "version": "9.0.0"
 }

--- a/HeartbeatLoggingTestUtils.podspec
+++ b/HeartbeatLoggingTestUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'HeartbeatLoggingTestUtils'
-  s.version                 = '8.12.0'
+  s.version                 = '9.0.0'
   s.summary                 = 'Testing utilities for testing the HeartbeatLogging module'
 
   s.description             = <<-DESC
@@ -34,5 +34,5 @@ Pod::Spec.new do |s|
 
   s.framework = 'XCTest'
 
-  s.dependency 'FirebaseCoreInternal', '~> 8.11'
+  s.dependency 'FirebaseCoreInternal', '~> 9.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let firebaseVersion = "8.15.0"
+let firebaseVersion = "9.0.0"
 
 let package = Package(
   name: "Firebase",

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "8.15.0",
+  version: "9.0.0",
   pods: [
     Pod("FirebaseSharedSwift"),
     Pod("FirebaseCoreDiagnostics"),

--- a/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
@@ -33,7 +33,7 @@ enum Push {
   }
 
   private static func push(to destination: Destination, gitRoot: URL) {
-    let stagingRepo = "git@github.com:firebase/SpecsDev"
+    let stagingRepo = "git@github.com:firebase/SpecsStaging"
     let stagingLocation = findOrRegisterPrivateCocoaPodsRepo(
       repo: stagingRepo,
       gitRoot: gitRoot,

--- a/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
@@ -33,7 +33,7 @@ enum Push {
   }
 
   private static func push(to destination: Destination, gitRoot: URL) {
-    let stagingRepo = "git@github.com:firebase/SpecsStaging"
+    let stagingRepo = "git@github.com:firebase/SpecsDev"
     let stagingLocation = findOrRegisterPrivateCocoaPodsRepo(
       repo: stagingRepo,
       gitRoot: gitRoot,


### PR DESCRIPTION
podspecs are available at https://github.com/firebase/SpecsDev

Miscellaneous fixes were needed to successfully `pod spec lint` which hadn't been tested on the v9 branch.

#no-changelog