### PR TITLE
[Analytics] Bump Analytics minimum iOS version to `10.0`

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -62,21 +62,21 @@ Simplify your app development, grow your user base, and monetize more effectivel
   end
 
   s.subspec 'Analytics' do |ss|
-    ss.ios.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
     ss.dependency 'Firebase/Core'
   end
 
   s.subspec 'AnalyticsWithAdIdSupport' do |ss|
-    ss.ios.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
     ss.dependency 'Firebase/Core'
   end
 
   s.subspec 'AnalyticsWithoutAdIdSupport' do |ss|
-    ss.ios.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
     ss.ios.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '~> 9.0.0'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -33,7 +33,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |ss|
-    ss.ios.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '12.0'
     ss.ios.dependency 'FirebaseAnalytics', '~> 9.0.0'

--- a/FirebaseAnalytics.podspec.json
+++ b/FirebaseAnalytics.podspec.json
@@ -27,7 +27,7 @@
     },
     "name": "FirebaseAnalytics",
     "platforms": {
-        "ios": "9.0",
+        "ios": "10.0",
         "osx": "10.12",
         "tvos": "12.0"
     },

--- a/GoogleAppMeasurement.podspec.json
+++ b/GoogleAppMeasurement.podspec.json
@@ -25,7 +25,7 @@
     },
     "name": "GoogleAppMeasurement",
     "platforms": {
-        "ios": "9.0",
+        "ios": "10.0",
         "osx": "10.12",
         "tvos": "12.0"
     },


### PR DESCRIPTION
Fixes #9589

#no-changelog