### PR TITLE
Functions/Storage 9.0.0 release notes updates

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v9.0.0
+- [changed] The FirebaseFunctionsSwift library has been removed. All of its APIs are now included
+  in the FirebaseFunctions. Please remove references to FirebaseFunctionsSwift from Podfile's and
+  Swift Package Manager configurations.
 - [changed] Backported Callable async/await APIs to iOS 13, etc. (#9483).
+- [changed] The global variables `FunctionsErrorDomain` and `FunctionsErrorDetailsKey` are
+  restored for Swift only.
 
 # v8.15.0
 - [deprecated] The global variables `FIRFunctionsErrorDomain` and `FIRFunctionsErrorDetailsKey` are

--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v9.0.0
 - [changed] The FirebaseFunctionsSwift library has been removed. All of its APIs are now included
-  in the FirebaseFunctions. Please remove references to FirebaseFunctionsSwift from Podfile's and
-  Swift Package Manager configurations.
+  in the FirebaseFunctions library. Please remove references to FirebaseFunctionsSwift from Podfiles
+  and Swift Package Manager configurations. `import FirebaseFunctionsSwift` should be replaced with
+  `import FirebaseFunctions`.
 - [changed] Backported Callable async/await APIs to iOS 13, etc. (#9483).
 - [changed] The global variables `FunctionsErrorDomain` and `FunctionsErrorDetailsKey` are
   restored for Swift only.

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 9.0.0
 - [changed] The FirebaseStorageSwift library has been removed. All of its APIs are now included
-  in the FirebaseStorage. Please remove references to FirebaseStorageSwift from Podfile's and
-  Swift Package Manager configurations.
+  in the FirebaseStorage library. Please remove references to FirebaseStorageSwift from Podfiles and
+  Swift Package Manager configurations. `import FirebaseStorageSwift` should be replaced with
+  `import FirebaseStorage`.
 - [changed] Backported `StorageReference` async/await APIs to iOS 13, etc. (#9483).
 - [changed] The global variable `StorageErrorDomain` is restored for Swift only.
 

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 9.0.0
+- [changed] The FirebaseStorageSwift library has been removed. All of its APIs are now included
+  in the FirebaseStorage. Please remove references to FirebaseStorageSwift from Podfile's and
+  Swift Package Manager configurations.
 - [changed] Backported `StorageReference` async/await APIs to iOS 13, etc. (#9483).
+- [changed] The global variable `StorageErrorDomain` is restored for Swift only.
 
 # 8.15.0
 - [deprecated] The global variable `FIRStorageErrorDomain` is deprecated and will


### PR DESCRIPTION
Fix #9487 

The API proposal is approved. Internally, see go/storage-function-error-variable-deprecations

`StorageErrorDomain` still needs to be added.