### PR TITLE
Bump zip minimum versions

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Firebase 9.0.0
 - [changed] Firebase now requires at least Xcode 13.2.1.
 - [added] The zip and Carthage distibutions now include the Swift extension frameworks. (#7819)
+- [changed] Update the minimum supported versions for the zip and Carthage distributions to
+  iOS 11.0, tvOS 11.0 and macOS 10.13.
 
 # Firebase 8.10.0
 - [fixed] Fixed platform availability checks in Swift Package Manager that may prevent code

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -100,15 +100,15 @@ struct ZipBuilderTool: ParsableCommand {
   // MARK: - Platform Arguments
 
   /// The minimum iOS Version to build for.
-  @Option(default: "10.0", help: ArgumentHelp("The minimum supported iOS version."))
+  @Option(default: "11.0", help: ArgumentHelp("The minimum supported iOS version."))
   var minimumIOSVersion: String
 
   /// The minimum macOS Version to build for.
-  @Option(default: "10.12", help: ArgumentHelp("The minimum supported macOS version."))
+  @Option(default: "10.13", help: ArgumentHelp("The minimum supported macOS version."))
   var minimumMacOSVersion: String
 
   /// The minimum tvOS Version to build for.
-  @Option(default: "10.0", help: ArgumentHelp("The minimum supported tvOS version."))
+  @Option(default: "11.0", help: ArgumentHelp("The minimum supported tvOS version."))
   var minimumTVOSVersion: String
 
   /// The list of platforms to build for.


### PR DESCRIPTION
Bump minimum iOS versions and associated other versions to drop support for 32 bit arm IOS OS's.

With Xcode 13.2.1, when building for iOS 10, the FirebaseStorage-Swift.h bridging header gets created with architecture ifdef's that fail to trigger when testing an Objective C test app with libraries built from a Swift library.

The ifdefs are not generated when building for iOS 11 and the test app builds fine.

Fix #9631