### PR TITLE
App Distro: fix async/await issue

### DIFF
--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -43,7 +43,10 @@ iOS SDK for App Distribution for Firebase.
 
   s.test_spec 'unit' do |unit_tests|
    unit_tests.scheme = { :code_coverage => true }
-   unit_tests.source_files = 'FirebaseAppDistribution/Tests/Unit*/*.[mh]'
+   unit_tests.source_files = [
+     'FirebaseAppDistribution/Tests/Unit*/*.[mh]',
+     'FirebaseAppDistribution/Tests/Unit/Swift*/*.swift',
+   ]
    unit_tests.resources = 'FirebaseAppDistribution/Tests/Unit/Resources/*'
    unit_tests.dependency 'OCMock'
   end

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v9.0.0-beta
-- [fixed] Marked `releaseNotes` as `nullable` as they don't always exist. (#8602)
-- [fixed] Fixed `checkForUpdate()` to return an error when no release is marked as "latest". (#9604)
+- [fixed] Marked `releaseNotes` as `nullable` as they don't always exist (#8602).
+- [fixed] **Breaking change:** Fixed an ObjC-to-Swift API conversion error where`checkForUpdate()`
+  returned a non-optional type. This change is breaking for Swift users only (#9604).
 
 # v8.3.0-beta
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error (#8270).

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v9.0.0-beta
 - [fixed] Marked `releaseNotes` as `nullable` as they don't always exist. (#8602)
+- [fixed] Fixed `checkForUpdate()` to return an error when no release is marked as "latest". (#9604)
 
 # v8.3.0-beta
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthorized error (#8270).

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -286,10 +286,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
       }
     }
 
-    // At this point, no release matches the "latest release". An error should be returned.
-    NSError *notFound = [self NSErrorForErrorCodeAndMessage:FIRAppDistributionErrorUnknown
-                                                    message:@"Could not find the latest release."];
-    completion(nil, notFound);
+    completion(nil, nil);
   }];
 }
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -245,49 +245,49 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
 
 - (void)fetchNewLatestRelease:(void (^)(FIRAppDistributionRelease *_Nullable release,
                                         NSError *_Nullable error))completion {
-  [FIRFADApiService fetchReleasesWithCompletion:^(NSArray *_Nullable releases,
-                                                  NSError *_Nullable error) {
-    if (error) {
-      if ([error code] == FIRFADApiErrorUnauthenticated) {
-        FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need "
-                       @"to sign in again.");
-        [self signOutTester];
-      } else if ([error code] == FIRFADApiErrorUnauthorized) {
-        FIRFADErrorLog(@"Tester is not authorized to view releases for this app. Tester will "
-                       @"need to sign in again.");
-        [self signOutTester];
-      }
+  [FIRFADApiService
+      fetchReleasesWithCompletion:^(NSArray *_Nullable releases, NSError *_Nullable error) {
+        if (error) {
+          if ([error code] == FIRFADApiErrorUnauthenticated) {
+            FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need "
+                           @"to sign in again.");
+            [self signOutTester];
+          } else if ([error code] == FIRFADApiErrorUnauthorized) {
+            FIRFADErrorLog(@"Tester is not authorized to view releases for this app. Tester will "
+                           @"need to sign in again.");
+            [self signOutTester];
+          }
 
-      dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, [self mapFetchReleasesError:error]);
-      });
-      return;
-    }
-
-    for (NSDictionary *releaseDict in releases) {
-      if ([[releaseDict objectForKey:kLatestReleaseKey] boolValue]) {
-        FIRFADInfoLog(@"Tester API - found latest release in response.");
-        NSString *displayVersion = [releaseDict objectForKey:kDisplayVersionKey];
-        NSString *buildVersion = [releaseDict objectForKey:kBuildVersionKey];
-
-        NSString *codeHash = [releaseDict objectForKey:kCodeHashKey];
-
-        if (![self isCurrentVersion:displayVersion buildVersion:buildVersion] ||
-            ![self isCodeHashIdentical:codeHash]) {
-          FIRAppDistributionRelease *release =
-              [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
           dispatch_async(dispatch_get_main_queue(), ^{
-            FIRFADInfoLog(@"Found new release with version: %@ (%@)", [release displayVersion],
-                          [release buildVersion]);
-            completion(release, nil);
+            completion(nil, [self mapFetchReleasesError:error]);
           });
           return;
         }
-      }
-    }
 
-    completion(nil, nil);
-  }];
+        for (NSDictionary *releaseDict in releases) {
+          if ([[releaseDict objectForKey:kLatestReleaseKey] boolValue]) {
+            FIRFADInfoLog(@"Tester API - found latest release in response.");
+            NSString *displayVersion = [releaseDict objectForKey:kDisplayVersionKey];
+            NSString *buildVersion = [releaseDict objectForKey:kBuildVersionKey];
+
+            NSString *codeHash = [releaseDict objectForKey:kCodeHashKey];
+
+            if (![self isCurrentVersion:displayVersion buildVersion:buildVersion] ||
+                ![self isCodeHashIdentical:codeHash]) {
+              FIRAppDistributionRelease *release =
+                  [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
+              dispatch_async(dispatch_get_main_queue(), ^{
+                FIRFADInfoLog(@"Found new release with version: %@ (%@)", [release displayVersion],
+                              [release buildVersion]);
+                completion(release, nil);
+              });
+              return;
+            }
+          }
+        }
+
+        completion(nil, nil);
+      }];
 }
 
 - (void)checkForUpdateWithCompletion:(void (^)(FIRAppDistributionRelease *_Nullable release,

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -46,8 +46,8 @@ NS_SWIFT_NAME(AppDistribution)
 /**
  * Check to see whether a new distribution is available
  */
-- (void)checkForUpdateWithCompletion:
-    (void (^)(FIRAppDistributionRelease *_Nullable_result release, NSError *_Nullable error))completion
+- (void)checkForUpdateWithCompletion:(void (^)(FIRAppDistributionRelease *_Nullable_result release,
+                                               NSError *_Nullable error))completion
     NS_SWIFT_NAME(checkForUpdate(completion:));
 
 /**

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -48,7 +48,7 @@ NS_SWIFT_NAME(AppDistribution)
  */
 - (void)checkForUpdateWithCompletion:
     (void (^)(FIRAppDistributionRelease *_Nullable_result release, NSError *_Nullable error))completion
-    NS_SWIFT_NAME(checkForUpdate(completion:)) ;
+    NS_SWIFT_NAME(checkForUpdate(completion:));
 
 /**
  * Sign out App Distribution tester

--- a/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h
@@ -47,8 +47,8 @@ NS_SWIFT_NAME(AppDistribution)
  * Check to see whether a new distribution is available
  */
 - (void)checkForUpdateWithCompletion:
-    (void (^)(FIRAppDistributionRelease *_Nullable release, NSError *_Nullable error))completion
-    NS_SWIFT_NAME(checkForUpdate(completion:));
+    (void (^)(FIRAppDistributionRelease *_Nullable_result release, NSError *_Nullable error))completion
+    NS_SWIFT_NAME(checkForUpdate(completion:)) ;
 
 /**
  * Sign out App Distribution tester

--- a/FirebaseAppDistribution/Tests/Unit/Swift/AppDistributionAPITest.swift
+++ b/FirebaseAppDistribution/Tests/Unit/Swift/AppDistributionAPITest.swift
@@ -16,7 +16,6 @@ import XCTest
 @testable import FirebaseAppDistribution
 
 class AppDistributionAPITests: XCTestCase {
-
   @available(iOS 13.0.0, *)
   func asyncAPIs() async throws {
     let distro = AppDistribution.appDistribution()

--- a/FirebaseAppDistribution/Tests/Unit/Swift/AppDistributionAPITest.swift
+++ b/FirebaseAppDistribution/Tests/Unit/Swift/AppDistributionAPITest.swift
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import FirebaseAppDistribution
+
+class AppDistributionAPITests: XCTestCase {
+
+  @available(iOS 13.0.0, *)
+  func asyncAPIs() async throws {
+    let distro = AppDistribution.appDistribution()
+
+    // Release should be optional if there are no new releases.
+    let _: AppDistributionRelease? = try await distro.checkForUpdate()
+    try await distro.signInTester()
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,7 @@ let package = Package(
       url: "https://github.com/google/GoogleAppMeasurement.git",
       // Note that CI changes the version to the head of main for CI.
       // See scripts/setup_spm_tests.sh.
-      .exact("8.14.0")
+      .exact("8.15.0")
     ),
     .package(
       name: "GoogleDataTransport",

--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,7 @@ let package = Package(
       url: "https://github.com/google/GoogleAppMeasurement.git",
       // Note that CI changes the version to the head of main for CI.
       // See scripts/setup_spm_tests.sh.
-      .exact("8.15.0")
+      .exact("8.14.0")
     ),
     .package(
       name: "GoogleDataTransport",
@@ -410,9 +410,18 @@ let package = Package(
       name: "AppDistributionUnit",
       dependencies: ["FirebaseAppDistribution", "OCMock"],
       path: "FirebaseAppDistribution/Tests/Unit",
+      exclude: ["Swift/"],
       resources: [.process("Resources")],
       cSettings: [
         .headerSearchPath("../../.."),
+      ]
+    ),
+    .testTarget(
+      name: "AppDistributionUnitSwift",
+      dependencies: ["FirebaseAppDistribution"],
+      path: "FirebaseAppDistribution/Tests/Unit/Swift",
+      cSettings: [
+        .headerSearchPath("../../../.."),
       ]
     ),
 


### PR DESCRIPTION
Right now we're calling a completion handler with `nil, nil` when
releases are fetched but none are marked as "latest". This is an expected result - no new releases but no errors. When translated to async/await, the result is not an optional, which will crash. This turns the return type into an Optional.
