### PR TITLE
Revert "[AppCheck] Improve documentation for retrieving a debug token"

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,5 +1,4 @@
 # v9.0.0 -- M115
-- [fixed] Improved documentation for retrieving an existing debug token. (#9547)
 - [added] **Breaking change:** `FirebaseAppCheck` has exited beta and is now
   generally available for use.
 

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
@@ -45,13 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// '3BA09C8C-8A0D-4030-ACD5-B96D99DB73F9'".
 /// 4. Register the debug token in the Firebase console.
 ///
-/// NOTE: A local debug token is only logged to the console when it is first
-/// created. After its creation, it is cached in local storage and not logged
-/// in future application runs. To inspect the debug token after it has been
-/// created, inspect the result of `AppCheckDebugProvider`'s
-/// `localDebugToken` API, or re-install the app and look for a log with the
-/// debug token on the application's first run.
-///
 /// Once the debug token is registered the debug provider will be able to provide a valid Firebase
 /// App Check token.
 ///


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#9639

This is actually not totally accurate. Specifically, the notion that `A local debug token is only logged to the console when it is first created.` is not true. I had a custom breakpoint that I had added during the debug process that I confused with the SDK's actual behavior. :/

I think this feature could use a documentation update. But this is not it.