### PR TITLE
xcresult_logs.py: Fix potential UnicodeEncodeError

### DIFF
--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -64,7 +64,19 @@ def main():
     # but also makes it harder to deal with.
     log_id = find_log_id(xcresult_path)
     log = export_log(xcresult_path, log_id)
-    sys.stdout.write(log)
+
+    # Avoid UnicodeEncodeError by adapting the code example from
+    # https://docs.python.org/3/library/sys.html#sys.displayhook
+    try:
+      sys.stdout.write(log)
+    except UnicodeEncodeError:
+      log_encoded = log.encode(sys.stdout.encoding, errors='backslashreplace')
+      if hasattr(sys.stdout, 'buffer'):
+        sys.stdout.flush()
+        sys.stdout.buffer.write(log_encoded)
+      else:
+        log_decoded = log_encoded.decode(sys.stdout.encoding, errors='strict')
+        sys.stdout.write(log_decoded)
 
 
 # Most flags on the xcodebuild command-line are uninteresting, so only pull

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -66,10 +66,15 @@ def main():
     log = export_log(xcresult_path, log_id)
 
     # Avoid a potential UnicodeEncodeError raised by sys.stdout.write() by
-    # doing a relaxed encoding ourselves and writing the resulting bytes.
-    log_encoded = log.encode('utf8', errors='backslashreplace')
-    sys.stdout.flush()
-    sys.stdout.buffer.write(log_encoded)
+    # doing a relaxed encoding ourselves.
+    if hasattr(sys.stdout, 'buffer'):
+      log_encoded = log.encode('utf8', errors='backslashreplace')
+      sys.stdout.flush()
+      sys.stdout.buffer.write(log_encoded)
+    else:
+      log_encoded = log.encode('ascii', errors='backslashreplace')
+      log_decoded = log_encoded.decode('ascii', errors='strict')
+      sys.stdout.write(log_decoded)
 
 
 # Most flags on the xcodebuild command-line are uninteresting, so only pull

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -65,18 +65,11 @@ def main():
     log_id = find_log_id(xcresult_path)
     log = export_log(xcresult_path, log_id)
 
-    # Avoid UnicodeEncodeError by adapting the code example from
-    # https://docs.python.org/3/library/sys.html#sys.displayhook
-    try:
-      sys.stdout.write(log)
-    except UnicodeEncodeError:
-      log_encoded = log.encode(sys.stdout.encoding, errors='backslashreplace')
-      if hasattr(sys.stdout, 'buffer'):
-        sys.stdout.flush()
-        sys.stdout.buffer.write(log_encoded)
-      else:
-        log_decoded = log_encoded.decode(sys.stdout.encoding, errors='strict')
-        sys.stdout.write(log_decoded)
+    # Avoid a potential UnicodeEncodeError raised by sys.stdout.write() by
+    # doing a relaxed encoding ourselves and writing the resulting bytes.
+    log_encoded = log.encode('utf8', errors='backslashreplace')
+    sys.stdout.flush()
+    sys.stdout.buffer.write(log_encoded)
 
 
 # Most flags on the xcodebuild command-line are uninteresting, so only pull


### PR DESCRIPTION
This PR fixes the following `UnicodeDecodeError` that sometimes happens in GitHub actions:

```
Traceback (most recent call last):
  File "scripts/xcresult_logs.py", line 300, in <module>
    main()
  File "scripts/xcresult_logs.py", line 67, in main
    sys.stdout.write(log)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 421: ordinal not in range(128)
```

e.g. https://github.com/firebase/firebase-ios-sdk/runs/6000587971

#no-changelog