### PR TITLE
Firestore: Specify --verbose to ctest instead of --output-on-failure

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -356,7 +356,7 @@ case "$product-$platform-$method" in
 
       echo "Building cmake build ..."
       ninja -k 10 all
-      ctest --output-on-failure
+      ctest --verbose
     )
     ;;
 


### PR DESCRIPTION
When `--output-on-failure` is specified to `ctest` then it only prints the names of the test suites that are executed, not the individual tests. This makes it impossible to determine which tests actually ran (unless they happen to fail).

By instead specifying `--verbose` it prints the names of each test as they are executed. This is indeed more "verbose", but (1) it lets a reader determine which tests were run and (b) it is consistent with the other logs for GitHub Actions that run tests.

My specific use case was that I added a new test and wanted to make sure it actually got picked up by the GitHub Actions. 

#no-changelog