### PR TITLE
Revert "Adding Custom Time to FirebaseStorage (#9576)"

### DIFF
--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -92,18 +92,6 @@ import FirebaseStorageInternal
   }
 
   /**
-   * Custom-Time of the object data.
-   */
-  @objc public var customTime: Date? {
-    get {
-      return impl.customTime
-    }
-    set(newValue) {
-      impl.customTime = newValue
-    }
-  }
-
-  /**
    * MD5 hash of the data; encoded using base64.
    */
   @objc public let md5Hash: String?

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -276,14 +276,12 @@ import XCTest
 
     private func assertMetadata(actualMetadata: StorageMetadata,
                                 expectedContentType: String,
-                                expectedCustomTime: Date,
                                 expectedCustomMetadata: [String: String]) {
       XCTAssertEqual(actualMetadata.cacheControl, "cache-control")
       XCTAssertEqual(actualMetadata.contentDisposition, "content-disposition")
       XCTAssertEqual(actualMetadata.contentEncoding, "gzip")
       XCTAssertEqual(actualMetadata.contentLanguage, "de")
       XCTAssertEqual(actualMetadata.contentType, expectedContentType)
-      XCTAssertEqual(actualMetadata.customTime, expectedCustomTime)
       XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
       for (key, value) in expectedCustomMetadata {
         XCTAssertEqual(actualMetadata.customMetadata![key], value)
@@ -296,7 +294,6 @@ import XCTest
       XCTAssertEqual(actualMetadata.contentEncoding, "identity")
       XCTAssertNil(actualMetadata.contentLanguage)
       XCTAssertNil(actualMetadata.contentType)
-      XCTAssertNil(actualMetadata.customTime)
       XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
       XCTAssertNil(actualMetadata.customMetadata)
     }
@@ -310,31 +307,26 @@ import XCTest
       metadata.contentEncoding = "gzip"
       metadata.contentLanguage = "de"
       metadata.contentType = "content-type-a"
-      metadata.customTime = Date(timeIntervalSince1970: 0)
       metadata.customMetadata = ["a": "b"]
 
       let updatedMetadata = try await ref.updateMetadata(metadata)
       assertMetadata(actualMetadata: updatedMetadata,
                      expectedContentType: "content-type-a",
-                     expectedCustomTime: Date(timeIntervalSince1970: 0),
                      expectedCustomMetadata: ["a": "b"])
 
       let metadata2 = updatedMetadata
       metadata2.contentType = "content-type-b"
-      metadata.customTime = Date(timeIntervalSince1970: 100)
       metadata2.customMetadata = ["a": "b", "c": "d"]
 
       let metadata3 = try await ref.updateMetadata(metadata2)
       assertMetadata(actualMetadata: metadata3,
                      expectedContentType: "content-type-b",
-                     expectedCustomTime: Date(timeIntervalSince1970: 100),
                      expectedCustomMetadata: ["a": "b", "c": "d"])
       metadata.cacheControl = nil
       metadata.contentDisposition = nil
       metadata.contentEncoding = nil
       metadata.contentLanguage = nil
       metadata.contentType = nil
-      metadata.customTime = nil
       metadata.customMetadata = nil
       let metadata4 = try await ref.updateMetadata(metadata)
       XCTAssertNotNil(metadata4)

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -417,14 +417,12 @@ class StorageResultTests: StorageIntegrationCommon {
 
   private func assertMetadata(actualMetadata: StorageMetadata,
                               expectedContentType: String,
-                              expectedCustomTime: Date,
                               expectedCustomMetadata: [String: String]) {
     XCTAssertEqual(actualMetadata.cacheControl, "cache-control")
     XCTAssertEqual(actualMetadata.contentDisposition, "content-disposition")
     XCTAssertEqual(actualMetadata.contentEncoding, "gzip")
     XCTAssertEqual(actualMetadata.contentLanguage, "de")
     XCTAssertEqual(actualMetadata.contentType, expectedContentType)
-    XCTAssertEqual(actualMetadata.customTime, expectedCustomTime)
     XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
     for (key, value) in expectedCustomMetadata {
       XCTAssertEqual(actualMetadata.customMetadata![key], value)
@@ -437,7 +435,6 @@ class StorageResultTests: StorageIntegrationCommon {
     XCTAssertEqual(actualMetadata.contentEncoding, "identity")
     XCTAssertNil(actualMetadata.contentLanguage)
     XCTAssertNil(actualMetadata.contentType)
-    XCTAssertNil(actualMetadata.customTime)
     XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
     XCTAssertNil(actualMetadata.customMetadata)
   }
@@ -452,7 +449,6 @@ class StorageResultTests: StorageIntegrationCommon {
     metadata.contentEncoding = "gzip"
     metadata.contentLanguage = "de"
     metadata.contentType = "content-type-a"
-    metadata.customTime = Date(timeIntervalSince1970: 0)
     metadata.customMetadata = ["a": "b"]
 
     ref.updateMetadata(metadata) { updatedMetadata, error in
@@ -464,12 +460,10 @@ class StorageResultTests: StorageIntegrationCommon {
       }
       self.assertMetadata(actualMetadata: updatedMetadata,
                           expectedContentType: "content-type-a",
-                          expectedCustomTime: Date(timeIntervalSince1970: 0),
                           expectedCustomMetadata: ["a": "b"])
 
       let metadata = updatedMetadata
       metadata.contentType = "content-type-b"
-      metadata.customTime = Date(timeIntervalSince1970: 100)
       metadata.customMetadata = ["a": "b", "c": "d"]
 
       ref.updateMetadata(metadata) { result in
@@ -477,14 +471,12 @@ class StorageResultTests: StorageIntegrationCommon {
         case let .success(updatedMetadata):
           self.assertMetadata(actualMetadata: updatedMetadata,
                               expectedContentType: "content-type-b",
-                              expectedCustomTime: Date(timeIntervalSince1970: 100),
                               expectedCustomMetadata: ["a": "b", "c": "d"])
           metadata.cacheControl = nil
           metadata.contentDisposition = nil
           metadata.contentEncoding = nil
           metadata.contentLanguage = nil
           metadata.contentType = nil
-          metadata.customTime = nil
           metadata.customMetadata = nil
           ref.updateMetadata(metadata) { result in
             self.assertResultSuccess(result)

--- a/FirebaseStorageInternal/Sources/FIRStorageConstants.m
+++ b/FirebaseStorageInternal/Sources/FIRStorageConstants.m
@@ -64,7 +64,6 @@ NSString *const kFIRStorageMetadataContentDisposition = @"contentDisposition";
 NSString *const kFIRStorageMetadataContentEncoding = @"contentEncoding";
 NSString *const kFIRStorageMetadataContentLanguage = @"contentLanguage";
 NSString *const kFIRStorageMetadataContentType = @"contentType";
-NSString *const kFIRStorageMetadataCustomTime = @"customTime";
 NSString *const kFIRStorageMetadataCustomMetadata = @"metadata";
 NSString *const kFIRStorageMetadataSize = @"size";
 NSString *const kFIRStorageMetadataGeneration = @"generation";

--- a/FirebaseStorageInternal/Sources/FIRStorageConstants_Private.h
+++ b/FirebaseStorageInternal/Sources/FIRStorageConstants_Private.h
@@ -59,7 +59,6 @@ FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentDisposition;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentEncoding;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentLanguage;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentType;
-FOUNDATION_EXPORT NSString *const kFIRStorageMetadataCustomTime;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataCustomMetadata;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataSize;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataGeneration;

--- a/FirebaseStorageInternal/Sources/FIRStorageMetadata.m
+++ b/FirebaseStorageInternal/Sources/FIRStorageMetadata.m
@@ -40,7 +40,6 @@
     _contentEncoding = dictionary[kFIRStorageMetadataContentEncoding];
     _contentLanguage = dictionary[kFIRStorageMetadataContentLanguage];
     _contentType = dictionary[kFIRStorageMetadataContentType];
-    _customTime = [self dateFromRFC3339String:dictionary[kFIRStorageMetadataCustomTime]];
     _customMetadata = dictionary[kFIRStorageMetadataCustomMetadata];
     _size = [dictionary[kFIRStorageMetadataSize] longLongValue];
     _generation = [dictionary[kFIRStorageMetadataGeneration] longLongValue];
@@ -118,10 +117,6 @@
 
   if (_contentType) {
     metadataDictionary[kFIRStorageMetadataContentType] = _contentType;
-  }
-
-  if (_customTime) {
-    metadataDictionary[kFIRStorageMetadataCustomTime] = [self RFC3339StringFromDate:_customTime];
   }
 
   if (_md5Hash) {

--- a/FirebaseStorageInternal/Sources/Public/FirebaseStorageInternal/FIRStorageMetadata.h
+++ b/FirebaseStorageInternal/Sources/Public/FirebaseStorageInternal/FIRStorageMetadata.h
@@ -60,11 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(copy, nonatomic, nullable) NSString *contentType;
 
 /**
- * Custom-Time of the object data.
- */
-@property(copy, nonatomic, nullable) NSDate *customTime;
-
-/**
  * MD5 hash of the data; encoded using base64.
  */
 @property(copy, nonatomic, nullable, readonly) NSString *md5Hash;

--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -580,14 +580,12 @@ NSString *const kTestPassword = KPASSWORD;
 
 - (void)assertMetadata:(FIRStorageMetadata *)actualMetadata
            contentType:(NSString *)expectedContentType
-            customTime:(NSDate *)expectedCustomTime
         customMetadata:(NSDictionary *)expectedCustomMetadata {
   XCTAssertEqualObjects(actualMetadata.cacheControl, @"cache-control");
   XCTAssertEqualObjects(actualMetadata.contentDisposition, @"content-disposition");
   XCTAssertEqualObjects(actualMetadata.contentEncoding, @"gzip");
   XCTAssertEqualObjects(actualMetadata.contentLanguage, @"de");
   XCTAssertEqualObjects(actualMetadata.contentType, expectedContentType);
-  XCTAssertEqualObjects(actualMetadata.customTime, expectedCustomTime);
   XCTAssertTrue([actualMetadata.md5Hash length] == 24);
   for (NSString *key in expectedCustomMetadata) {
     XCTAssertEqualObjects([actualMetadata.customMetadata objectForKey:key],
@@ -601,7 +599,6 @@ NSString *const kTestPassword = KPASSWORD;
   XCTAssertEqualObjects(actualMetadata.contentEncoding, @"identity");
   XCTAssertNil(actualMetadata.contentLanguage);
   XCTAssertNil(actualMetadata.contentType);
-  XCTAssertNil(actualMetadata.customTime);
   XCTAssertTrue([actualMetadata.md5Hash length] == 24);
   XCTAssertNil(actualMetadata.customMetadata);
 }
@@ -618,7 +615,6 @@ NSString *const kTestPassword = KPASSWORD;
   metadata.contentEncoding = @"gzip";
   metadata.contentLanguage = @"de";
   metadata.contentType = @"content-type-a";
-  metadata.customTime = [NSDate dateWithTimeIntervalSince1970:0];
   metadata.customMetadata = @{@"a" : @"b"};
 
   [ref updateMetadata:metadata
@@ -626,13 +622,11 @@ NSString *const kTestPassword = KPASSWORD;
              XCTAssertNil(error);
              [self assertMetadata:updatedMetadata
                       contentType:@"content-type-a"
-                       customTime:[NSDate dateWithTimeIntervalSince1970:0]
                    customMetadata:@{@"a" : @"b"}];
 
              // Update a subset of the metadata using the existing object.
              FIRStorageMetadata *metadata = updatedMetadata;
              metadata.contentType = @"content-type-b";
-             metadata.customTime = [NSDate dateWithTimeIntervalSince1970:100];
              metadata.customMetadata = @{@"a" : @"b", @"c" : @"d"};
 
              [ref updateMetadata:metadata
@@ -640,7 +634,6 @@ NSString *const kTestPassword = KPASSWORD;
                         XCTAssertNil(error);
                         [self assertMetadata:updatedMetadata
                                  contentType:@"content-type-b"
-                                  customTime:[NSDate dateWithTimeIntervalSince1970:100]
                               customMetadata:@{@"a" : @"b", @"c" : @"d"}];
 
                         // Clear all metadata.
@@ -650,7 +643,6 @@ NSString *const kTestPassword = KPASSWORD;
                         metadata.contentEncoding = nil;
                         metadata.contentLanguage = nil;
                         metadata.contentType = nil;
-                        metadata.customTime = nil;
                         metadata.customMetadata = [NSDictionary dictionary];
 
                         [ref updateMetadata:metadata

--- a/FirebaseStorageInternal/Tests/Unit/FIRStorageMetadataTests.m
+++ b/FirebaseStorageInternal/Tests/Unit/FIRStorageMetadataTests.m
@@ -42,7 +42,6 @@
     kFIRStorageMetadataContentEncoding : @"gzip",
     kFIRStorageMetadataContentLanguage : @"en-us",
     kFIRStorageMetadataContentType : @"application/octet-stream",
-    kFIRStorageMetadataCustomTime : @"2016-03-01T20:16:01.673Z",
     kFIRStorageMetadataCustomMetadata : @{@"foo" : @{@"bar" : @"baz"}},
     kFIRStorageMetadataGeneration : @"12345",
     kFIRStorageMetadataMetageneration : @"67890",
@@ -60,8 +59,6 @@
                         metaDict[kFIRStorageMetadataContentDisposition]);
   XCTAssertEqualObjects(metadata.contentEncoding, metaDict[kFIRStorageMetadataContentEncoding], );
   XCTAssertEqualObjects(metadata.contentType, metaDict[kFIRStorageMetadataContentType]);
-  XCTAssertEqualObjects([metadata RFC3339StringFromDate:metadata.customTime],
-                        metaDict[kFIRStorageMetadataCustomTime]);
   XCTAssertEqualObjects(metadata.customMetadata, metaDict[kFIRStorageMetadataCustomMetadata]);
   XCTAssertEqualObjects(metadata.md5Hash, metaDict[kFIRStorageMetadataMd5Hash]);
   NSString *generation = [NSString stringWithFormat:@"%lld", metadata.generation];
@@ -85,7 +82,6 @@
     kFIRStorageMetadataContentEncoding : @"gzip",
     kFIRStorageMetadataContentLanguage : @"en-us",
     kFIRStorageMetadataContentType : @"application/octet-stream",
-    kFIRStorageMetadataCustomTime : @"2016-03-01T20:16:01.673Z",
     kFIRStorageMetadataCustomMetadata : @{@"foo" : @{@"bar" : @"baz"}},
     kFIRStorageMetadataGeneration : @"12345",
     kFIRStorageMetadataMetageneration : @"67890",
@@ -110,8 +106,6 @@
                         metaDict[kFIRStorageMetadataContentLanguage]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataContentType],
                         metaDict[kFIRStorageMetadataContentType]);
-  XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataCustomTime],
-                        metaDict[kFIRStorageMetadataCustomTime]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataCustomMetadata],
                         metaDict[kFIRStorageMetadataCustomMetadata]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataDownloadTokens],


### PR DESCRIPTION
#9576 breaks the integration and it looks like the backend does not write customTime into the metadata. Perhaps, because it's missing in `FirebaseStorageContextImpl.java`?

Also, https://cloud.google.com/storage/docs/metadata#custom-time says "You cannot remove Custom-Time once it's been set on an object", so should it be a read-only field?