### PR TITLE
Add FIRESTORE_INCLUDE_OBJC cmake cache variable

### DIFF
--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Provide a mechanism for firebase-cpp-sdk to avoid unnecessarily building
+# the Objective-C APIs and Tests, which it doesn't use.
+option(FIRESTORE_INCLUDE_OBJC "Build the Firestore Objective-C layer" ON)
+
 add_subdirectory(Protos)
 add_subdirectory(Source)
 add_subdirectory(core)

--- a/Firestore/Example/CMakeLists.txt
+++ b/Firestore/Example/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT FIRESTORE_INCLUDE_OBJC)
+  return()
+endif()
+
 add_subdirectory(Benchmarks)
 
 add_subdirectory(App)

--- a/Firestore/Source/CMakeLists.txt
+++ b/Firestore/Source/CMakeLists.txt
@@ -16,6 +16,10 @@ if(NOT APPLE)
   return()
 endif()
 
+if(NOT FIRESTORE_INCLUDE_OBJC)
+  return()
+endif()
+
 file(GLOB headers Public/FirebaseFirestore/*.h)
 file(GLOB sources API/*.h API/*.m API/*.mm)
 


### PR DESCRIPTION
If this new `FIRESTORE_INCLUDE_OBJC` cmake cache variable is set to a false value (e.g. "NO", "OFF") then the `Source` and `Example` subdirectories of Firestore will not be compiled. The default value is true.

This new cmake cache variable will be used by the firebase-cpp-sdk repository to avoid unnecessarily compiling the objective-c sources that it does not use. The immediate motivation is to work around the following compilation error in firebase-cpp-sdk:

```
FIRFirestore.h:147:20: error: unknown attribute 'swift_async' ignored [-Werror,-Wunknown-attributes]
    __attribute__((swift_async(none)));  // Disable async import due to #9426.
                   ^
1 error generated.
```

e.g. https://github.com/firebase/firebase-cpp-sdk/runs/6033445422

This problematic usage of `swift_async` was added in https://github.com/firebase/firebase-ios-sdk/pull/9502. Instead of trying to fix the build error when compiled by the firebase-cpp-sdk, it's easier to just disable compiling this code all together.

#no-changelog