### PR TITLE
Add callableWithURL

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [changed] Backported Callable async/await APIs to iOS 13, etc. (#9483).
 - [changed] The global variables `FunctionsErrorDomain` and `FunctionsErrorDetailsKey` are
   restored for Swift only.
+- [added] Added a new method httpsCallableWithURL to create callables with URLs other than cloudfunctions.net.
 
 # v8.15.0
 - [deprecated] The global variables `FIRFunctionsErrorDomain` and `FIRFunctionsErrorDetailsKey` are

--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [changed] Backported Callable async/await APIs to iOS 13, etc. (#9483).
 - [changed] The global variables `FunctionsErrorDomain` and `FunctionsErrorDetailsKey` are
   restored for Swift only.
-- [added] Added a new method httpsCallableWithURL to create callables with URLs other than cloudfunctions.net.
+- [added] Added a new method `httpsCallable(url:)` to create callables with URLs other than cloudfunctions.net.
 
 # v8.15.0
 - [deprecated] The global variables `FIRFunctionsErrorDomain` and `FIRFunctionsErrorDetailsKey` are

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -103,6 +103,10 @@ internal enum FunctionsConstants {
   @objc(HTTPSCallableWithName:) open func httpsCallable(_ name: String) -> HTTPSCallable {
     return HTTPSCallable(functions: self, name: name)
   }
+  
+  @objc(HTTPSCallableWithUrl:) open func httpsCallable(url: String) -> HTTPSCallable {
+    return HTTPSCallable(functions: self, url: url)
+  }
 
   /// Creates a reference to the Callable HTTPS trigger with the given name, the type of an `Encodable`
   /// request and the type of a `Decodable` response.

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -103,7 +103,7 @@ internal enum FunctionsConstants {
   @objc(HTTPSCallableWithName:) open func httpsCallable(_ name: String) -> HTTPSCallable {
     return HTTPSCallable(functions: self, name: name)
   }
-  
+
   @objc(HTTPSCallableWithUrl:) open func httpsCallable(url: String) -> HTTPSCallable {
     return HTTPSCallable(functions: self, url: url)
   }
@@ -253,7 +253,7 @@ internal enum FunctionsConstants {
       }
     }
   }
-  
+
   internal func callFunction(url: String,
                              withObject data: Any?,
                              timeout: TimeInterval,
@@ -273,7 +273,6 @@ internal enum FunctionsConstants {
       }
     }
   }
-
 
   private func callFunction(url: String,
                             withObject data: Any?,

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -104,7 +104,7 @@ internal enum FunctionsConstants {
     return HTTPSCallable(functions: self, name: name)
   }
 
-  @objc(HTTPSCallableWithUrl:) open func httpsCallable(url: String) -> HTTPSCallable {
+  @objc(HTTPSCallableWithURL:) open func httpsCallable(url: URL) -> HTTPSCallable {
     return HTTPSCallable(functions: self, url: url)
   }
 
@@ -126,7 +126,25 @@ internal enum FunctionsConstants {
     -> Callable<Request, Response> {
     return Callable(callable: httpsCallable(name), encoder: encoder, decoder: decoder)
   }
-
+  /// Creates a reference to the Callable HTTPS trigger with the given name, the type of an `Encodable`
+  /// request and the type of a `Decodable` response.
+  /// - Parameter url: The url of the Callable HTTPS trigger
+  /// - Parameter requestAs: The type of the `Encodable` entity to use for requests to this `Callable`
+  /// - Parameter responseAs: The type of the `Decodable` entity to use for responses from this `Callable`
+  /// - Parameter encoder: The encoder instance to use to run the encoding.
+  /// - Parameter decoder: The decoder instance to use to run the decoding.
+  open func httpsCallable<Request: Encodable,
+    Response: Decodable>(url: URL,
+                         requestAs: Request.Type = Request.self,
+                         responseAs: Response.Type = Response.self,
+                         encoder: FirebaseDataEncoder = FirebaseDataEncoder(
+                         ),
+                         decoder: FirebaseDataDecoder = FirebaseDataDecoder(
+                         ))
+    -> Callable<Request, Response> {
+    return Callable(callable: httpsCallable(url:url), encoder: encoder, decoder: decoder)
+  }
+  
   /**
    * Changes this instance to point to a Cloud Functions emulator running locally.
    * See https://firebase.google.com/docs/functions/local-emulator
@@ -245,7 +263,7 @@ internal enum FunctionsConstants {
         completion(.failure(error))
       } else {
         let url = self.urlWithName(name)
-        self.callFunction(url: url,
+        self.callFunction(url: URL(string:url)!,
                           withObject: data,
                           timeout: timeout,
                           context: context,
@@ -254,7 +272,7 @@ internal enum FunctionsConstants {
     }
   }
 
-  internal func callFunction(url: String,
+  internal func callFunction(url: URL,
                              withObject data: Any?,
                              timeout: TimeInterval,
                              completion: @escaping ((Result<HTTPSCallableResult, Error>) -> Void)) {
@@ -274,12 +292,12 @@ internal enum FunctionsConstants {
     }
   }
 
-  private func callFunction(url: String,
+  private func callFunction(url: URL,
                             withObject data: Any?,
                             timeout: TimeInterval,
                             context: FunctionsContext,
                             completion: @escaping ((Result<HTTPSCallableResult, Error>) -> Void)) {
-    let request = URLRequest(url: URL(string: url)!,
+    let request = URLRequest(url: url,
                              cachePolicy: .useProtocolCachePolicy,
                              timeoutInterval: timeout)
     let fetcher = fetcherService.fetcher(with: request)

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -240,7 +240,28 @@ internal enum FunctionsConstants {
       if let error = error {
         completion(.failure(error))
       } else {
-        self.callFunction(name: name,
+        let url = self.urlWithName(name)
+        self.callFunction(url: url,
+                          withObject: data,
+                          timeout: timeout,
+                          context: context,
+                          completion: completion)
+      }
+    }
+  }
+  
+  internal func callFunction(url: String,
+                             withObject data: Any?,
+                             timeout: TimeInterval,
+                             completion: @escaping ((Result<HTTPSCallableResult, Error>) -> Void)) {
+    // Get context first.
+    contextProvider.getContext { context, error in
+      // Note: context is always non-nil since some checks could succeed, we're only failing if
+      // there's an error.
+      if let error = error {
+        completion(.failure(error))
+      } else {
+        self.callFunction(url: url,
                           withObject: data,
                           timeout: timeout,
                           context: context,
@@ -249,13 +270,13 @@ internal enum FunctionsConstants {
     }
   }
 
-  private func callFunction(name: String,
+
+  private func callFunction(url: String,
                             withObject data: Any?,
                             timeout: TimeInterval,
                             context: FunctionsContext,
                             completion: @escaping ((Result<HTTPSCallableResult, Error>) -> Void)) {
-    let url = URL(string: urlWithName(name))!
-    let request = URLRequest(url: url,
+    let request = URLRequest(url: URL(string: url)!,
                              cachePolicy: .useProtocolCachePolicy,
                              timeoutInterval: timeout)
     let fetcher = fetcherService.fetcher(with: request)

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -126,6 +126,7 @@ internal enum FunctionsConstants {
     -> Callable<Request, Response> {
     return Callable(callable: httpsCallable(name), encoder: encoder, decoder: decoder)
   }
+
   /// Creates a reference to the Callable HTTPS trigger with the given name, the type of an `Encodable`
   /// request and the type of a `Decodable` response.
   /// - Parameter url: The url of the Callable HTTPS trigger
@@ -142,9 +143,9 @@ internal enum FunctionsConstants {
                          decoder: FirebaseDataDecoder = FirebaseDataDecoder(
                          ))
     -> Callable<Request, Response> {
-    return Callable(callable: httpsCallable(url:url), encoder: encoder, decoder: decoder)
+    return Callable(callable: httpsCallable(url: url), encoder: encoder, decoder: decoder)
   }
-  
+
   /**
    * Changes this instance to point to a Cloud Functions emulator running locally.
    * See https://firebase.google.com/docs/functions/local-emulator
@@ -263,7 +264,7 @@ internal enum FunctionsConstants {
         completion(.failure(error))
       } else {
         let url = self.urlWithName(name)
-        self.callFunction(url: URL(string:url)!,
+        self.callFunction(url: URL(string: url)!,
                           withObject: data,
                           timeout: timeout,
                           context: context,

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -46,7 +46,7 @@ open class HTTPSCallable: NSObject {
   // The name of the http endpoint this reference refers to.
   private let name: String?
 
-  private let url: String?
+  private let url: URL?
 
   // MARK: - Public Properties
 
@@ -61,7 +61,7 @@ open class HTTPSCallable: NSObject {
     url = nil
   }
 
-  internal init(functions: Functions, url: String) {
+  internal init(functions: Functions, url: URL) {
     self.functions = functions
     name = nil
     self.url = url
@@ -100,8 +100,8 @@ open class HTTPSCallable: NSObject {
       }
     }
 
-    if name != nil {
-      functions.callFunction(name: name!,
+    if let name = name {
+      functions.callFunction(name: name,
                              withObject: data,
                              timeout: timeoutInterval,
                              completion: callback)

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -45,7 +45,7 @@ open class HTTPSCallable: NSObject {
 
   // The name of the http endpoint this reference refers to.
   private let name: String?
-  
+
   private let url: String?
 
   // MARK: - Public Properties
@@ -58,14 +58,15 @@ open class HTTPSCallable: NSObject {
   internal init(functions: Functions, name: String) {
     self.functions = functions
     self.name = name
-    self.url = nil
+    url = nil
   }
 
   internal init(functions: Functions, url: String) {
     self.functions = functions
-    self.name = nil
+    name = nil
     self.url = url
   }
+
   /**
    * Executes this Callable HTTPS trigger asynchronously.
    *
@@ -98,17 +99,17 @@ open class HTTPSCallable: NSObject {
         completion(nil, error)
       }
     }
-    
-    if (name != nil) {
+
+    if name != nil {
       functions.callFunction(name: name!,
                              withObject: data,
                              timeout: timeoutInterval,
-                             completion:callback)
+                             completion: callback)
     } else {
       functions.callFunction(url: url!,
-                             withObject:data,
-                             timeout:timeoutInterval,
-                             completion:callback)
+                             withObject: data,
+                             timeout: timeoutInterval,
+                             completion: callback)
     }
   }
 

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -105,11 +105,13 @@ open class HTTPSCallable: NSObject {
                              withObject: data,
                              timeout: timeoutInterval,
                              completion: callback)
-    } else {
-      functions.callFunction(url: url!,
+    } else if let url = url {
+      functions.callFunction(url: url,
                              withObject: data,
                              timeout: timeoutInterval,
                              completion: callback)
+    } else {
+      preconditionFailure("name or url must be set via constructor")
     }
   }
 

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -43,10 +43,12 @@ open class HTTPSCallable: NSObject {
   // The functions client to use for making calls.
   private let functions: Functions
 
-  // The name of the http endpoint this reference refers to.
-  private let name: String?
+  private enum EndpointType {
+    case name(String)
+    case url(URL)
+  }
 
-  private let url: URL?
+  private let endpoint: EndpointType
 
   // MARK: - Public Properties
 
@@ -57,14 +59,12 @@ open class HTTPSCallable: NSObject {
 
   internal init(functions: Functions, name: String) {
     self.functions = functions
-    self.name = name
-    url = nil
+    endpoint = .name(name)
   }
 
   internal init(functions: Functions, url: URL) {
     self.functions = functions
-    name = nil
-    self.url = url
+    endpoint = .url(url)
   }
 
   /**
@@ -100,18 +100,17 @@ open class HTTPSCallable: NSObject {
       }
     }
 
-    if let name = name {
+    switch endpoint {
+    case let .name(name):
       functions.callFunction(name: name,
                              withObject: data,
                              timeout: timeoutInterval,
                              completion: callback)
-    } else if let url = url {
+    case let .url(url):
       functions.callFunction(url: url,
                              withObject: data,
                              timeout: timeoutInterval,
                              completion: callback)
-    } else {
-      preconditionFailure("name or url must be set via constructor")
     }
   }
 

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -62,7 +62,6 @@ struct DataTestResponse: Decodable, Equatable {
 }
 
 class IntegrationTests: XCTestCase {
-
   let functions = Functions(projectID: "functions-integration-test",
                             region: "us-central1",
                             customDomain: nil,
@@ -74,9 +73,9 @@ class IntegrationTests: XCTestCase {
     super.setUp()
     functions.useEmulator(withHost: "localhost", port: 5005)
   }
-  
+
   func emulatorURL(_ funcName: String) -> URL {
-    return URL(string:"http://localhost:5005/functions-integration-test/us-central1/\(funcName)")!
+    return URL(string: "http://localhost:5005/functions-integration-test/us-central1/\(funcName)")!
   }
 
   func testData() {
@@ -89,12 +88,12 @@ class IntegrationTests: XCTestCase {
       null: nil
     )
     let byName = functions.httpsCallable("dataTest",
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
-      let byURL = functions.httpsCallable(url:emulatorURL("dataTest"),
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
-    
+                                         requestAs: DataTestRequest.self,
+                                         responseAs: DataTestResponse.self)
+    let byURL = functions.httpsCallable(url: emulatorURL("dataTest"),
+                                        requestAs: DataTestRequest.self,
+                                        responseAs: DataTestResponse.self)
+
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call(data) { result in
@@ -153,22 +152,22 @@ class IntegrationTests: XCTestCase {
       responseAs: Int.self
     )
     let byURL = functions.httpsCallable(
-      url:emulatorURL("scalarTest"),
+      url: emulatorURL("scalarTest"),
       requestAs: Int16.self,
       responseAs: Int.self
     )
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
-    function.call(17) { result in
-      do {
-        let response = try result.get()
-        XCTAssertEqual(response, 76)
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+      function.call(17) { result in
+        do {
+          let response = try result.get()
+          XCTAssertEqual(response, 76)
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
+        expectation.fulfill()
       }
-      expectation.fulfill()
-    }
-    waitForExpectations(timeout: 5)
+      waitForExpectations(timeout: 5)
     }
   }
 
@@ -181,14 +180,14 @@ class IntegrationTests: XCTestCase {
         responseAs: Int.self
       )
       let byURL = functions.httpsCallable(
-        url:emulatorURL("scalarTest"),
+        url: emulatorURL("scalarTest"),
         requestAs: Int16.self,
         responseAs: Int.self
       )
 
       for function in [byName, byURL] {
-      let result = try await function.call(17)
-      XCTAssertEqual(result, 76)
+        let result = try await function.call(17)
+        XCTAssertEqual(result, 76)
       }
     }
 
@@ -197,8 +196,8 @@ class IntegrationTests: XCTestCase {
       let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
       let byURL: Callable<Int16, Int> = functions.httpsCallable(url: emulatorURL("scalarTest"))
       for function in [byName, byURL] {
-      let result = try await function.call(17)
-      XCTAssertEqual(result, 76)
+        let result = try await function.call(17)
+        XCTAssertEqual(result, 76)
       }
     }
 
@@ -221,25 +220,25 @@ class IntegrationTests: XCTestCase {
       requestAs: [String: Int].self,
       responseAs: [String: Int].self
     )
-      let byURL = functions.httpsCallable(
-        url: emulatorURL("tokenTest"),
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
-      for function in [byName, byURL] {
-        let expectation = expectation(description: #function)
-    XCTAssertNotNil(function)
-    function.call([:]) { result in
-      do {
-        let data = try result.get()
-        XCTAssertEqual(data, [:])
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+    let byURL = functions.httpsCallable(
+      url: emulatorURL("tokenTest"),
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      XCTAssertNotNil(function)
+      function.call([:]) { result in
+        do {
+          let data = try result.get()
+          XCTAssertEqual(data, [:])
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
+        expectation.fulfill()
       }
-      expectation.fulfill()
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
-      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -280,24 +279,24 @@ class IntegrationTests: XCTestCase {
       requestAs: [String: Int].self,
       responseAs: [String: Int].self
     )
-      let byURL = functions.httpsCallable(
-        url: emulatorURL("FCMTokenTest"),
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
-      for function in [byName, byURL] {
-        let expectation = expectation(description: #function)
-    function.call([:]) { result in
-      do {
-        let data = try result.get()
-        XCTAssertEqual(data, [:])
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+    let byURL = functions.httpsCallable(
+      url: emulatorURL("FCMTokenTest"),
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call([:]) { result in
+        do {
+          let data = try result.get()
+          XCTAssertEqual(data, [:])
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
+        expectation.fulfill()
       }
-      expectation.fulfill()
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
-      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -315,8 +314,8 @@ class IntegrationTests: XCTestCase {
       )
 
       for function in [byName, byURL] {
-      let data = try await function.call([:])
-      XCTAssertEqual(data, [:])
+        let data = try await function.call([:])
+        XCTAssertEqual(data, [:])
       }
     }
   #endif
@@ -327,24 +326,24 @@ class IntegrationTests: XCTestCase {
       requestAs: Int?.self,
       responseAs: Int?.self
     )
-      let byURL = functions.httpsCallable(
-        url: emulatorURL("nullTest"),
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
-      for function in [byName, byURL] {
-        let expectation = expectation(description: #function)
-    function.call(nil) { result in
-      do {
-        let data = try result.get()
-        XCTAssertEqual(data, nil)
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+    let byURL = functions.httpsCallable(
+      url: emulatorURL("nullTest"),
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call(nil) { result in
+        do {
+          let data = try result.get()
+          XCTAssertEqual(data, nil)
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
+        expectation.fulfill()
       }
-      expectation.fulfill()
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
-      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -356,14 +355,14 @@ class IntegrationTests: XCTestCase {
         responseAs: Int?.self
       )
       let byURL = functions.httpsCallable(
-        url:emulatorURL("nullTest"),
+        url: emulatorURL("nullTest"),
         requestAs: Int?.self,
         responseAs: Int?.self
       )
 
       for function in [byName, byURL] {
-      let data = try await function.call(nil)
-      XCTAssertEqual(data, nil)
+        let data = try await function.call(nil)
+        XCTAssertEqual(data, nil)
       }
     }
   #endif
@@ -374,28 +373,28 @@ class IntegrationTests: XCTestCase {
       requestAs: Int?.self,
       responseAs: Int?.self
     )
-      let byURL = functions.httpsCallable(
-        url:emulatorURL("missingResultTest"),
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
-      for function in [byName, byURL] {
-        let expectation = expectation(description: #function)
-    function.call(nil) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("Response is missing data field.", error.localizedDescription)
-        expectation.fulfill()
-        return
+    let byURL = functions.httpsCallable(
+      url: emulatorURL("missingResultTest"),
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call(nil) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("Response is missing data field.", error.localizedDescription)
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
+
+      waitForExpectations(timeout: 5)
     }
-      
-    waitForExpectations(timeout: 5)
-      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -407,19 +406,19 @@ class IntegrationTests: XCTestCase {
         responseAs: Int?.self
       )
       let byURL = functions.httpsCallable(
-        url:emulatorURL("missingResultTest"),
+        url: emulatorURL("missingResultTest"),
         requestAs: Int?.self,
         responseAs: Int?.self
       )
       for function in [byName, byURL] {
-      do {
-        _ = try await function.call(nil)
-        XCTFail("Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("Response is missing data field.", error.localizedDescription)
-      }
+        do {
+          _ = try await function.call(nil)
+          XCTFail("Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("Response is missing data field.", error.localizedDescription)
+        }
       }
     }
   #endif
@@ -431,26 +430,26 @@ class IntegrationTests: XCTestCase {
       responseAs: Int.self
     )
     let byURL = functions.httpsCallable(
-      url:emulatorURL("unhandledErrorTest"),
+      url: emulatorURL("unhandledErrorTest"),
       requestAs: [Int].self,
       responseAs: Int.self
     )
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
-    function.call([]) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("INTERNAL", error.localizedDescription)
-        expectation.fulfill()
-        return
+      function.call([]) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("INTERNAL", error.localizedDescription)
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
-    }
-    XCTAssert(true)
-    waitForExpectations(timeout: 5)
+      XCTAssert(true)
+      waitForExpectations(timeout: 5)
     }
   }
 
@@ -468,14 +467,14 @@ class IntegrationTests: XCTestCase {
         responseAs: Int.self
       )
       for function in [byName, byURL] {
-      do {
-        _ = try await function.call([])
-        XCTFail("Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("INTERNAL", error.localizedDescription)
-      }
+        do {
+          _ = try await function.call([])
+          XCTFail("Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("INTERNAL", error.localizedDescription)
+        }
       }
     }
   #endif
@@ -487,7 +486,7 @@ class IntegrationTests: XCTestCase {
       responseAs: Int.self
     )
     let byURL = functions.httpsCallable(
-      url:emulatorURL("unknownErrorTest"),
+      url: emulatorURL("unknownErrorTest"),
       requestAs: [Int].self,
       responseAs: Int.self
     )
@@ -575,7 +574,7 @@ class IntegrationTests: XCTestCase {
         responseAs: Int.self
       )
       let byURL = functions.httpsCallable(
-        url:emulatorURL("explicitErrorTest"),
+        url: emulatorURL("explicitErrorTest"),
         requestAs: [Int].self,
         responseAs: Int.self
       )
@@ -601,7 +600,7 @@ class IntegrationTests: XCTestCase {
       responseAs: Int.self
     )
     let byURL = functions.httpsCallable(
-      url:emulatorURL("httpErrorTest"),
+      url: emulatorURL("httpErrorTest"),
       requestAs: [Int].self,
       responseAs: Int.self
     )
@@ -632,7 +631,7 @@ class IntegrationTests: XCTestCase {
         responseAs: Int.self
       )
       let byURL = functions.httpsCallable(
-        url:emulatorURL("httpErrorTest"),
+        url: emulatorURL("httpErrorTest"),
         requestAs: [Int].self,
         responseAs: Int.self
       )
@@ -655,7 +654,7 @@ class IntegrationTests: XCTestCase {
       responseAs: Int.self
     )
     let byURL = functions.httpsCallable(
-      url:emulatorURL("timeoutTest"),
+      url: emulatorURL("timeoutTest"),
       requestAs: [Int].self,
       responseAs: Int.self
     )
@@ -718,11 +717,11 @@ class IntegrationTests: XCTestCase {
       null: nil
     )
     let byName = functions.httpsCallable("dataTest",
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
-    let byURL = functions.httpsCallable(url:emulatorURL("dataTest"),
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
+                                         requestAs: DataTestRequest.self,
+                                         responseAs: DataTestResponse.self)
+    let byURL = functions.httpsCallable(url: emulatorURL("dataTest"),
+                                        requestAs: DataTestRequest.self,
+                                        responseAs: DataTestResponse.self)
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function(data) { result in
@@ -756,12 +755,12 @@ class IntegrationTests: XCTestCase {
       )
 
       let byName = functions.httpsCallable("dataTest",
-                                             requestAs: DataTestRequest.self,
-                                             responseAs: DataTestResponse.self)
+                                           requestAs: DataTestRequest.self,
+                                           responseAs: DataTestResponse.self)
 
       let byURL = functions.httpsCallable(url: emulatorURL("dataTest"),
-                                             requestAs: DataTestRequest.self,
-                                             responseAs: DataTestResponse.self)
+                                          requestAs: DataTestRequest.self,
+                                          responseAs: DataTestResponse.self)
 
       for function in [byName, byURL] {
         let response = try await function(data)
@@ -785,7 +784,8 @@ class IntegrationTests: XCTestCase {
       null: nil
     )
     let byName: Callable<DataTestRequest, DataTestResponse> = functions.httpsCallable("dataTest")
-    let byURL:Callable<DataTestRequest, DataTestResponse> = functions.httpsCallable(url: emulatorURL("dataTest"))
+    let byURL: Callable<DataTestRequest, DataTestResponse> = functions
+      .httpsCallable(url: emulatorURL("dataTest"))
 
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
@@ -822,7 +822,7 @@ class IntegrationTests: XCTestCase {
       let byName: Callable<DataTestRequest, DataTestResponse> = functions
         .httpsCallable("dataTest")
       let byURL: Callable<DataTestRequest, DataTestResponse> = functions
-        .httpsCallable(url:emulatorURL("dataTest"))
+        .httpsCallable(url: emulatorURL("dataTest"))
 
       for function in [byName, byURL] {
         let response = try await function(data)

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -62,21 +62,24 @@ struct DataTestResponse: Decodable, Equatable {
 }
 
 class IntegrationTests: XCTestCase {
+
   let functions = Functions(projectID: "functions-integration-test",
                             region: "us-central1",
                             customDomain: nil,
                             auth: nil,
                             messaging: MessagingTokenProvider(),
                             appCheck: nil)
-  let projectID = "functions-swift-integration-test"
 
   override func setUp() {
     super.setUp()
     functions.useEmulator(withHost: "localhost", port: 5005)
   }
+  
+  func emulatorURL(_ funcName: String) -> URL {
+    return URL(string:"http://localhost:5005/functions-integration-test/us-central1/\(funcName)")!
+  }
 
   func testData() {
-    let expectation = expectation(description: #function)
     let data = DataTestRequest(
       bool: true,
       int: 2,
@@ -85,24 +88,31 @@ class IntegrationTests: XCTestCase {
       array: [5, 6],
       null: nil
     )
-    let function = functions.httpsCallable("dataTest",
+    let byName = functions.httpsCallable("dataTest",
                                            requestAs: DataTestRequest.self,
                                            responseAs: DataTestResponse.self)
-    function.call(data) { result in
-      do {
-        let response = try result.get()
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-      } catch {
-        XCTFail("Failed to unwrap the function result: \(error)")
+      let byURL = functions.httpsCallable(url:emulatorURL("dataTest"),
+                                           requestAs: DataTestRequest.self,
+                                           responseAs: DataTestResponse.self)
+    
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call(data) { result in
+        do {
+          let response = try result.get()
+          let expected = DataTestResponse(
+            message: "stub response",
+            long: 420,
+            code: 42
+          )
+          XCTAssertEqual(response, expected)
+        } catch {
+          XCTFail("Failed to unwrap the function result: \(error)")
+        }
+        expectation.fulfill()
       }
-      expectation.fulfill()
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -117,27 +127,38 @@ class IntegrationTests: XCTestCase {
         null: nil
       )
 
-      let function = functions.httpsCallable("dataTest",
-                                             requestAs: DataTestRequest.self,
-                                             responseAs: DataTestResponse.self)
+      let byName = functions.httpsCallable("dataTest",
+                                           requestAs: DataTestRequest.self,
+                                           responseAs: DataTestResponse.self)
+      let byUrl = functions.httpsCallable(url: emulatorURL("dataTest"),
+                                          requestAs: DataTestRequest.self,
+                                          responseAs: DataTestResponse.self)
 
-      let response = try await function.call(data)
-      let expected = DataTestResponse(
-        message: "stub response",
-        long: 420,
-        code: 42
-      )
-      XCTAssertEqual(response, expected)
+      for function in [byName, byUrl] {
+        let response = try await function.call(data)
+        let expected = DataTestResponse(
+          message: "stub response",
+          long: 420,
+          code: 42
+        )
+        XCTAssertEqual(response, expected)
+      }
     }
   #endif
 
   func testScalar() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "scalarTest",
       requestAs: Int16.self,
       responseAs: Int.self
     )
+    let byURL = functions.httpsCallable(
+      url:emulatorURL("scalarTest"),
+      requestAs: Int16.self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
     function.call(17) { result in
       do {
         let response = try result.get()
@@ -148,26 +169,37 @@ class IntegrationTests: XCTestCase {
       expectation.fulfill()
     }
     waitForExpectations(timeout: 5)
+    }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testScalarAsync() async throws {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "scalarTest",
         requestAs: Int16.self,
         responseAs: Int.self
       )
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("scalarTest"),
+        requestAs: Int16.self,
+        responseAs: Int.self
+      )
 
+      for function in [byName, byURL] {
       let result = try await function.call(17)
       XCTAssertEqual(result, 76)
+      }
     }
 
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testScalarAsyncAlternateSignature() async throws {
-      let function: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
+      let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
+      let byURL: Callable<Int16, Int> = functions.httpsCallable(url: emulatorURL("scalarTest"))
+      for function in [byName, byURL] {
       let result = try await function.call(17)
       XCTAssertEqual(result, 76)
+      }
     }
 
   #endif
@@ -184,12 +216,18 @@ class IntegrationTests: XCTestCase {
     )
     functions.useEmulator(withHost: "localhost", port: 5005)
 
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "tokenTest",
       requestAs: [String: Int].self,
       responseAs: [String: Int].self
     )
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("tokenTest"),
+        requestAs: [String: Int].self,
+        responseAs: [String: Int].self
+      )
+      for function in [byName, byURL] {
+        let expectation = expectation(description: #function)
     XCTAssertNotNil(function)
     function.call([:]) { result in
       do {
@@ -201,6 +239,7 @@ class IntegrationTests: XCTestCase {
       expectation.fulfill()
     }
     waitForExpectations(timeout: 5)
+      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -217,24 +256,37 @@ class IntegrationTests: XCTestCase {
       )
       functions.useEmulator(withHost: "localhost", port: 5005)
 
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "tokenTest",
         requestAs: [String: Int].self,
         responseAs: [String: Int].self
       )
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("tokenTest"),
+        requestAs: [String: Int].self,
+        responseAs: [String: Int].self
+      )
 
-      let data = try await function.call([:])
-      XCTAssertEqual(data, [:])
+      for function in [byName, byURL] {
+        let data = try await function.call([:])
+        XCTAssertEqual(data, [:])
+      }
     }
   #endif
 
   func testFCMToken() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "FCMTokenTest",
       requestAs: [String: Int].self,
       responseAs: [String: Int].self
     )
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("FCMTokenTest"),
+        requestAs: [String: Int].self,
+        responseAs: [String: Int].self
+      )
+      for function in [byName, byURL] {
+        let expectation = expectation(description: #function)
     function.call([:]) { result in
       do {
         let data = try result.get()
@@ -245,29 +297,43 @@ class IntegrationTests: XCTestCase {
       expectation.fulfill()
     }
     waitForExpectations(timeout: 5)
+      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testFCMTokenAsync() async throws {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "FCMTokenTest",
         requestAs: [String: Int].self,
         responseAs: [String: Int].self
       )
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("FCMTokenTest"),
+        requestAs: [String: Int].self,
+        responseAs: [String: Int].self
+      )
 
+      for function in [byName, byURL] {
       let data = try await function.call([:])
       XCTAssertEqual(data, [:])
+      }
     }
   #endif
 
   func testNull() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "nullTest",
       requestAs: Int?.self,
       responseAs: Int?.self
     )
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("nullTest"),
+        requestAs: Int?.self,
+        responseAs: Int?.self
+      )
+      for function in [byName, byURL] {
+        let expectation = expectation(description: #function)
     function.call(nil) { result in
       do {
         let data = try result.get()
@@ -278,29 +344,43 @@ class IntegrationTests: XCTestCase {
       expectation.fulfill()
     }
     waitForExpectations(timeout: 5)
+      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testNullAsync() async throws {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "nullTest",
         requestAs: Int?.self,
         responseAs: Int?.self
       )
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("nullTest"),
+        requestAs: Int?.self,
+        responseAs: Int?.self
+      )
 
+      for function in [byName, byURL] {
       let data = try await function.call(nil)
       XCTAssertEqual(data, nil)
+      }
     }
   #endif
 
   func testMissingResult() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "missingResultTest",
       requestAs: Int?.self,
       responseAs: Int?.self
     )
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("missingResultTest"),
+        requestAs: Int?.self,
+        responseAs: Int?.self
+      )
+      for function in [byName, byURL] {
+        let expectation = expectation(description: #function)
     function.call(nil) { result in
       do {
         _ = try result.get()
@@ -313,17 +393,25 @@ class IntegrationTests: XCTestCase {
       }
       XCTFail("Failed to throw error for missing result")
     }
+      
     waitForExpectations(timeout: 5)
+      }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testMissingResultAsync() async {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "missingResultTest",
         requestAs: Int?.self,
         responseAs: Int?.self
       )
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("missingResultTest"),
+        requestAs: Int?.self,
+        responseAs: Int?.self
+      )
+      for function in [byName, byURL] {
       do {
         _ = try await function.call(nil)
         XCTFail("Failed to throw error for missing result")
@@ -332,16 +420,23 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
         XCTAssertEqual("Response is missing data field.", error.localizedDescription)
       }
+      }
     }
   #endif
 
   func testUnhandledError() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "unhandledErrorTest",
       requestAs: [Int].self,
       responseAs: Int.self
     )
+    let byURL = functions.httpsCallable(
+      url:emulatorURL("unhandledErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
     function.call([]) { result in
       do {
         _ = try result.get()
@@ -356,16 +451,23 @@ class IntegrationTests: XCTestCase {
     }
     XCTAssert(true)
     waitForExpectations(timeout: 5)
+    }
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnhandledErrorAsync() async {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "unhandledErrorTest",
         requestAs: [Int].self,
         responseAs: Int.self
       )
+      let byURL = functions.httpsCallable(
+        "unhandledErrorTest",
+        requestAs: [Int].self,
+        responseAs: Int.self
+      )
+      for function in [byName, byURL] {
       do {
         _ = try await function.call([])
         XCTFail("Failed to throw error for missing result")
@@ -374,27 +476,35 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
         XCTAssertEqual("INTERNAL", error.localizedDescription)
       }
+      }
     }
   #endif
 
   func testUnknownError() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "unknownErrorTest",
       requestAs: [Int].self,
       responseAs: Int.self
     )
-    function.call([]) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("INTERNAL", error.localizedDescription)
-        expectation.fulfill()
-        return
+    let byURL = functions.httpsCallable(
+      url:emulatorURL("unknownErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call([]) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("INTERNAL", error.localizedDescription)
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
     }
     waitForExpectations(timeout: 5)
   }
@@ -402,154 +512,203 @@ class IntegrationTests: XCTestCase {
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnknownErrorAsync() async {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "unknownErrorTest",
         requestAs: [Int].self,
         responseAs: Int.self
       )
-      do {
-        _ = try await function.call([])
-        XCTAssertFalse(true, "Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-        XCTAssertEqual("INTERNAL", error.localizedDescription)
+      let byURL = functions.httpsCallable(
+        url: emulatorURL("unknownErrorTest"),
+        requestAs: [Int].self,
+        responseAs: Int.self
+      )
+      for function in [byName, byURL] {
+        do {
+          _ = try await function.call([])
+          XCTAssertFalse(true, "Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+          XCTAssertEqual("INTERNAL", error.localizedDescription)
+        }
       }
     }
   #endif
 
   func testExplicitError() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "explicitErrorTest",
       requestAs: [Int].self,
       responseAs: Int.self
     )
-    function.call([]) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
-        XCTAssertEqual("explicit nope", error.localizedDescription)
-        XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
-                       error.userInfo["details"] as! [String: Int32])
-        expectation.fulfill()
-        return
+    let byURL = functions.httpsCallable(
+      "explicitErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.call([]) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
+          XCTAssertEqual("explicit nope", error.localizedDescription)
+          XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
+                         error.userInfo["details"] as! [String: Int32])
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testExplicitErrorAsync() async {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "explicitErrorTest",
         requestAs: [Int].self,
         responseAs: Int.self
       )
-      do {
-        _ = try await function.call([])
-        XCTAssertFalse(true, "Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
-        XCTAssertEqual("explicit nope", error.localizedDescription)
-        XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
-                       error.userInfo["details"] as! [String: Int32])
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("explicitErrorTest"),
+        requestAs: [Int].self,
+        responseAs: Int.self
+      )
+      for function in [byName, byURL] {
+        do {
+          _ = try await function.call([])
+          XCTAssertFalse(true, "Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
+          XCTAssertEqual("explicit nope", error.localizedDescription)
+          XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
+                         error.userInfo["details"] as! [String: Int32])
+        }
       }
     }
   #endif
 
   func testHttpError() {
-    let expectation = expectation(description: #function)
-    let function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "httpErrorTest",
       requestAs: [Int].self,
       responseAs: Int.self
     )
-    XCTAssertNotNil(function)
-    function.call([]) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
-        expectation.fulfill()
-        return
+    let byURL = functions.httpsCallable(
+      url:emulatorURL("httpErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      XCTAssertNotNil(function)
+      function.call([]) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testHttpErrorAsync() async {
-      let function = functions.httpsCallable(
+      let byName = functions.httpsCallable(
         "httpErrorTest",
         requestAs: [Int].self,
         responseAs: Int.self
       )
-      do {
-        _ = try await function.call([])
-        XCTAssertFalse(true, "Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
+      let byURL = functions.httpsCallable(
+        url:emulatorURL("httpErrorTest"),
+        requestAs: [Int].self,
+        responseAs: Int.self
+      )
+      for function in [byName, byURL] {
+        do {
+          _ = try await function.call([])
+          XCTAssertFalse(true, "Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
+        }
       }
     }
   #endif
 
   func testTimeout() {
-    let expectation = expectation(description: #function)
-    var function = functions.httpsCallable(
+    let byName = functions.httpsCallable(
       "timeoutTest",
       requestAs: [Int].self,
       responseAs: Int.self
     )
-    function.timeoutInterval = 0.05
-    function.call([]) { result in
-      do {
-        _ = try result.get()
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
-        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
-        XCTAssertNil(error.userInfo["details"])
-        expectation.fulfill()
-        return
+    let byURL = functions.httpsCallable(
+      url:emulatorURL("timeoutTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for var function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function.timeoutInterval = 0.05
+      function.call([]) { result in
+        do {
+          _ = try result.get()
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
+          XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
+          XCTAssertNil(error.userInfo["details"])
+          expectation.fulfill()
+          return
+        }
+        XCTFail("Failed to throw error for missing result")
       }
-      XCTFail("Failed to throw error for missing result")
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testTimeoutAsync() async {
-      var function = functions.httpsCallable(
+      var byName = functions.httpsCallable(
         "timeoutTest",
         requestAs: [Int].self,
         responseAs: Int.self
       )
-      function.timeoutInterval = 0.05
-      do {
-        _ = try await function.call([])
-        XCTAssertFalse(true, "Failed to throw error for missing result")
-      } catch {
-        let error = error as NSError
-        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
-        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
-        XCTAssertNil(error.userInfo["details"])
+      byName.timeoutInterval = 0.05
+      var byURL = functions.httpsCallable(
+        url: emulatorURL("timeoutTest"),
+        requestAs: [Int].self,
+        responseAs: Int.self
+      )
+      byURL.timeoutInterval = 0.05
+      for function in [byName, byURL] {
+        do {
+          _ = try await function.call([])
+          XCTAssertFalse(true, "Failed to throw error for missing result")
+        } catch {
+          let error = error as NSError
+          XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
+          XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
+          XCTAssertNil(error.userInfo["details"])
+        }
       }
     }
   #endif
 
   func testCallAsFunction() {
-    let expectation = expectation(description: #function)
     let data = DataTestRequest(
       bool: true,
       int: 2,
@@ -558,24 +717,30 @@ class IntegrationTests: XCTestCase {
       array: [5, 6],
       null: nil
     )
-    let function = functions.httpsCallable("dataTest",
+    let byName = functions.httpsCallable("dataTest",
                                            requestAs: DataTestRequest.self,
                                            responseAs: DataTestResponse.self)
-    function(data) { result in
-      do {
-        let response = try result.get()
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-        expectation.fulfill()
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+    let byURL = functions.httpsCallable(url:emulatorURL("dataTest"),
+                                           requestAs: DataTestRequest.self,
+                                           responseAs: DataTestResponse.self)
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function(data) { result in
+        do {
+          let response = try result.get()
+          let expected = DataTestResponse(
+            message: "stub response",
+            long: 420,
+            code: 42
+          )
+          XCTAssertEqual(response, expected)
+          expectation.fulfill()
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
       }
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -590,22 +755,27 @@ class IntegrationTests: XCTestCase {
         null: nil
       )
 
-      let function = functions.httpsCallable("dataTest",
+      let byName = functions.httpsCallable("dataTest",
                                              requestAs: DataTestRequest.self,
                                              responseAs: DataTestResponse.self)
 
-      let response = try await function(data)
-      let expected = DataTestResponse(
-        message: "stub response",
-        long: 420,
-        code: 42
-      )
-      XCTAssertEqual(response, expected)
+      let byURL = functions.httpsCallable(url: emulatorURL("dataTest"),
+                                             requestAs: DataTestRequest.self,
+                                             responseAs: DataTestResponse.self)
+
+      for function in [byName, byURL] {
+        let response = try await function(data)
+        let expected = DataTestResponse(
+          message: "stub response",
+          long: 420,
+          code: 42
+        )
+        XCTAssertEqual(response, expected)
+      }
     }
   #endif
 
   func testInferredTypes() {
-    let expectation = expectation(description: #function)
     let data = DataTestRequest(
       bool: true,
       int: 2,
@@ -614,23 +784,27 @@ class IntegrationTests: XCTestCase {
       array: [5, 6],
       null: nil
     )
-    let function: Callable<DataTestRequest, DataTestResponse> = functions.httpsCallable("dataTest")
+    let byName: Callable<DataTestRequest, DataTestResponse> = functions.httpsCallable("dataTest")
+    let byURL:Callable<DataTestRequest, DataTestResponse> = functions.httpsCallable(url: emulatorURL("dataTest"))
 
-    function(data) { result in
-      do {
-        let response = try result.get()
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-        expectation.fulfill()
-      } catch {
-        XCTAssert(false, "Failed to unwrap the function result: \(error)")
+    for function in [byName, byURL] {
+      let expectation = expectation(description: #function)
+      function(data) { result in
+        do {
+          let response = try result.get()
+          let expected = DataTestResponse(
+            message: "stub response",
+            long: 420,
+            code: 42
+          )
+          XCTAssertEqual(response, expected)
+          expectation.fulfill()
+        } catch {
+          XCTAssert(false, "Failed to unwrap the function result: \(error)")
+        }
       }
+      waitForExpectations(timeout: 5)
     }
-    waitForExpectations(timeout: 5)
   }
 
   #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -645,16 +819,20 @@ class IntegrationTests: XCTestCase {
         null: nil
       )
 
-      let function: Callable<DataTestRequest, DataTestResponse> = functions
+      let byName: Callable<DataTestRequest, DataTestResponse> = functions
         .httpsCallable("dataTest")
+      let byURL: Callable<DataTestRequest, DataTestResponse> = functions
+        .httpsCallable(url:emulatorURL("dataTest"))
 
-      let response = try await function(data)
-      let expected = DataTestResponse(
-        message: "stub response",
-        long: 420,
-        code: 42
-      )
-      XCTAssertEqual(response, expected)
+      for function in [byName, byURL] {
+        let response = try await function(data)
+        let expected = DataTestResponse(
+          message: "stub response",
+          long: 420,
+          code: 42
+        )
+        XCTAssertEqual(response, expected)
+      }
     }
   #endif
 }

--- a/FirebaseFunctions/Tests/ObjCIntegration/ObjCAPITests.m
+++ b/FirebaseFunctions/Tests/ObjCIntegration/ObjCAPITests.m
@@ -33,7 +33,9 @@
   func = [FIRFunctions functionsForApp:app region:@"my-region"];
   func = [FIRFunctions functionsForApp:app customDomain:@"my-domain"];
 
-  FIRHTTPSCallable *callable = [func HTTPSCallableWithName:@"name"];
+  NSURL *url = [NSURL URLWithString:@"http://localhost:5050/project/location/name"];
+  FIRHTTPSCallable *callable = [func HTTPSCallableWithURL:url];
+  callable = [func HTTPSCallableWithName:@"name"];
 
   [func useEmulatorWithHost:@"host" port:123];
 

--- a/FirebaseFunctions/Tests/ObjCIntegration/ObjCPPAPITests.mm
+++ b/FirebaseFunctions/Tests/ObjCIntegration/ObjCPPAPITests.mm
@@ -34,6 +34,8 @@
   func = [FIRFunctions functionsForApp:app customDomain:@"my-domain"];
 
   FIRHTTPSCallable *callable = [func HTTPSCallableWithName:@"name"];
+  NSURL *url = [NSURL URLWithString:@"http://host:123/project/location/name"];
+  callable = [func HTTPSCallableWithURL:url];
 
   [func useEmulatorWithHost:@"host" port:123];
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -51,13 +51,13 @@ final class FunctionsAPITests: XCTestCase {
     let callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
     callableRef.timeoutInterval = 60
     let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
-    let callableRefByURL = Functions.functions().httpsCallable<String, String>(url: url)
+    let callableRefByURL = Functions.functions().httpsCallable(url: url)
     let codableByName = Functions.functions().httpsCallable<String, String>("woop",
                                                                             encoder: FirebaseDataEncoder(
                                                                             ),
                                                                             decoder: FirebaseDataDecoder(
                                                                             ))
-    let codableByUrl = Functions.functions().httpsCallable(
+    let codableByUrl = Functions.functions().httpsCallable<String, String>(
       url: url, encoder: FirebaseDataEncoder(), decoder: FirebaseDataDecoder()
     )
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -52,10 +52,11 @@ final class FunctionsAPITests: XCTestCase {
     callableRef.timeoutInterval = 60
     let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
     let callableRefByURL = Functions.functions().httpsCallable(url: url)
-    let codable = new Callable(
-      callable: callableRef,
-      encoder: new FirebaseDataDecoder(),
-      decoder: new FirebaseDataDecoder()
+    let codableByName = Functions.functions().httpsCallable("woop",
+                                                            encoder: FirebaseDataEncoder(),
+                                                            decoder: FirebaseDataDecoder())
+    let codableByUrl = Functions.functions().httpsCallable(
+      url: url, encoder: FirebaseDataEncoder(), decoder: FirebaseDataDecoder()
     )
 
     let data: Any? = nil

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -47,7 +47,9 @@ final class FunctionsAPITests: XCTestCase {
 
     // MARK: - HTTPSCallable
 
-    let callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
+    var callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
+    let url = new URL("https://localhost:8080/setCourseForAlderaan")
+    callableRef = Functions.functions().httpsCallable(url: url)
     callableRef.timeoutInterval = 60
 
     let data: Any? = nil

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -19,6 +19,7 @@ import XCTest
 
 import FirebaseCore
 import FirebaseFunctions
+import FirebaseSharedSwift
 
 final class FunctionsAPITests: XCTestCase {
   func usage() {
@@ -51,6 +52,11 @@ final class FunctionsAPITests: XCTestCase {
     callableRef.timeoutInterval = 60
     let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
     let callableRefByURL = Functions.functions().httpsCallable(url: url)
+    let codable = new Callable(
+      callable: callableRef,
+      encoder: new FirebaseDataDecoder(),
+      decoder: new FirebaseDataDecoder()
+    )
 
     let data: Any? = nil
     callableRef.call(data) { result, error in

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -51,10 +51,12 @@ final class FunctionsAPITests: XCTestCase {
     let callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
     callableRef.timeoutInterval = 60
     let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
-    let callableRefByURL = Functions.functions().httpsCallable(url: url)
-    let codableByName = Functions.functions().httpsCallable("woop",
-                                                            encoder: FirebaseDataEncoder(),
-                                                            decoder: FirebaseDataDecoder())
+    let callableRefByURL = Functions.functions().httpsCallable<String, String>(url: url)
+    let codableByName = Functions.functions().httpsCallable<String, String>("woop",
+                                                                            encoder: FirebaseDataEncoder(
+                                                                            ),
+                                                                            decoder: FirebaseDataDecoder(
+                                                                            ))
     let codableByUrl = Functions.functions().httpsCallable(
       url: url, encoder: FirebaseDataEncoder(), decoder: FirebaseDataDecoder()
     )

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -47,10 +47,10 @@ final class FunctionsAPITests: XCTestCase {
 
     // MARK: - HTTPSCallable
 
-    var callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
-    let url = URL(string:"https://localhost:8080/setCourseForAlderaan")!
-    callableRef = Functions.functions().httpsCallable(url: url)
+    let callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
     callableRef.timeoutInterval = 60
+    let url = URL(string:"https://localhost:8080/setCourseForAlderaan")!
+    let callableRefByURL = Functions.functions().httpsCallable(url: url)
 
     let data: Any? = nil
     callableRef.call(data) { result, error in

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -52,14 +52,20 @@ final class FunctionsAPITests: XCTestCase {
     callableRef.timeoutInterval = 60
     let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
     let callableRefByURL = Functions.functions().httpsCallable(url: url)
-    let codableByName = Functions.functions().httpsCallable<String, String>("woop",
-                                                                            encoder: FirebaseDataEncoder(
-                                                                            ),
-                                                                            decoder: FirebaseDataDecoder(
-                                                                            ))
-    let codableByUrl = Functions.functions().httpsCallable<String, String>(
-      url: url, encoder: FirebaseDataEncoder(), decoder: FirebaseDataDecoder()
-    )
+
+    struct Message: Codable {
+      let hello: String
+      let world: String
+    }
+
+    let message = Message(hello: "hello", world: "world")
+    callableRef.call(message) { result, error in
+      if let result = result {
+        _ = result.data
+      } else if let _ /* error */ = error {
+        // ...
+      }
+    }
 
     let data: Any? = nil
     callableRef.call(data) { result, error in

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -48,7 +48,7 @@ final class FunctionsAPITests: XCTestCase {
     // MARK: - HTTPSCallable
 
     var callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
-    let url = new URL("https://localhost:8080/setCourseForAlderaan")
+    let url = URL(string:"https://localhost:8080/setCourseForAlderaan")!
     callableRef = Functions.functions().httpsCallable(url: url)
     callableRef.timeoutInterval = 60
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -49,7 +49,7 @@ final class FunctionsAPITests: XCTestCase {
 
     let callableRef = Functions.functions().httpsCallable("setCourseForAlderaan")
     callableRef.timeoutInterval = 60
-    let url = URL(string:"https://localhost:8080/setCourseForAlderaan")!
+    let url = URL(string: "https://localhost:8080/setCourseForAlderaan")!
     let callableRefByURL = Functions.functions().httpsCallable(url: url)
 
     let data: Any? = nil


### PR DESCRIPTION
Sorry for a late-coming urgent change; AFAICT nobody on the SDK team could staff these changes, so I'm trying to write the change for the top 3 SDKs before I/O freeze.

For context, see [go/cf3v2-crash-landing](http://go/cf3v2-crash-landing).
For API approval, see [go/callable-functions-custom-urls](http://go/callable-functions-custom-urls)