### PR TITLE
[v9] Update  `FirebaseSharedSwift/CHANGELOG.md` for v9

### DIFF
--- a/FirebaseSharedSwift/CHANGELOG.md
+++ b/FirebaseSharedSwift/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 8.11.0-beta
+# 8.11.0
 - Introduced shared Codable implementation. Initially used by Firebase Functions
   and Firebase Database. (#9091)


### PR DESCRIPTION
Following offline discussion, it was decided that FirebaseSharedSwift should not have had `-beta` tagging in it's CHANGELOG.