### PR TITLE
[v9] Update pinned minor version of `GTMSessionFetcher` dependencies

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -54,7 +54,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
 
   # Using environment variable because of the dependency on the unpublished
   # HeartbeatLoggingTestUtils.

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -43,7 +43,7 @@ Cloud Functions for Firebase.
   s.dependency 'FirebaseAuthInterop', '~> 9.0'
   s.dependency 'FirebaseMessagingInterop', '~> 9.0'
   s.dependency 'FirebaseSharedSwift', '~> 9.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
 
   s.test_spec 'objc' do |objc_tests|
     objc_tests.platforms = {

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -44,7 +44,7 @@ Objective C Implementations for FirebaseStorage. This pod should not be directly
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 9.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.5'
+  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/Package.swift
+++ b/Package.swift
@@ -165,7 +165,7 @@ let package = Package(
     .package(
       name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "1.5.0" ..< "2.0.0"
+      "1.7.0" ..< "2.0.0"
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
`GTMSessionFetcher` was the only dependency that had a pinned minor version that needed updating.

All were updated: 
```console
➜  firebase-ios-sdk git:(nc/dependencies-v9) 
‣ git --no-pager grep "dependency 'GTMSessionFetcher"                                                                                                                                                                                                 (233ms) 
FirebaseAuth.podspec:  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
FirebaseFunctions.podspec:  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
FirebaseStorageInternal.podspec:  s.dependency 'GTMSessionFetcher/Core', '~> 1.7'
```