### PR TITLE
[FirebaseCoreInternal] Sanitize app ID used in file system resource

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
@@ -22,7 +22,6 @@ public final class HeartbeatController {
   private let heartbeatsStorageCapacity: Int = 30
   /// Current date provider. It is used for testability.
   private let dateProvider: () -> Date
-  // TODO: Maybe share config with HeartbeatsPayload's DateFormatter?
   /// Used for standardizing dates for calendar-day comparision.
   static let dateStandardizer: (Date) -> (Date) = {
     var calendar = Calendar(identifier: .iso8601)

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatStorage.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatStorage.swift
@@ -90,7 +90,9 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
 
   // MARK: - HeartbeatStorageProtocol
 
-  // TODO: Document.
+  /// Synchronously reads from and writes to storage using the given transform block.
+  /// - Parameter transform: A block to transform the currently stored heartbeats bundle to a new
+  /// heartbeats bundle value.
   func readAndWriteSync(using transform: (HeartbeatsBundle?) -> HeartbeatsBundle?) {
     queue.sync {
       let oldHeartbeatsBundle = try? load(from: storage)

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/StorageFactory.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/StorageFactory.swift
@@ -32,7 +32,10 @@ extension FileStorage: StorageFactory {
   static func makeStorage(id: String) -> Storage {
     let rootDirectory = FileManager.default.applicationSupportDirectory
     let heartbeatDirectoryPath = Constants.heartbeatFileStorageDirectoryPath
-    let heartbeatFilePath = "heartbeats-\(id)"
+
+    // Sanitize the `id` so the heartbeat file name does not include a ":".
+    let sanitizedID = id.replacingOccurrences(of: ":", with: "_")
+    let heartbeatFilePath = "heartbeats-\(sanitizedID)"
 
     let storageURL = rootDirectory
       .appendingPathComponent(heartbeatDirectoryPath, isDirectory: true)


### PR DESCRIPTION
### Context
- The name of an app's heartbeats storage file includes the Firebase app ID. Since the Firebase app ID includes the ":" character, the filename also contains a ":". 

  This works on Apple's latest filesystem but it's safer to replace each ":" with a "_"

- In practice, this code change will cause the below diff in an app's container:
  ```diff
  📂 Application Support/
  └── 📂 google-heartbeat-storage/
  -    └── 📄 heartbeats-1:123456789000:ios:abcdefghijklmnop
  +    └── 📄 heartbeats-1_123456789000_ios_abcdefghijklmnop
  ```
- Also, resolved outstanding `TODO`s in FirebaseCoreInternal.

#no-changelog