### PR TITLE
Make RTDB integration tests runnable on a real target

### DIFF
--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -78,6 +78,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.test_spec 'integration' do |int_tests|
     int_tests.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
     int_tests.scheme = { :code_coverage => true }
+    int_tests.requires_app_host = true
     int_tests.source_files = [
       'FirebaseDatabase/Tests/Integration/*.[mh]',
       'FirebaseDatabase/Tests/Helpers/*.[mh]',

--- a/FirebaseDatabase/Tests/Helpers/FTestBase.m
+++ b/FirebaseDatabase/Tests/Helpers/FTestBase.m
@@ -20,12 +20,22 @@
 #import "FirebaseDatabase/Tests/Helpers/FTestBase.h"
 #import "SharedTestUtilities/FIROptionsMock.h"
 
+@interface FIROptions (Testing)
++ (NSString *)plistFilePathWithName:(NSString *)fileName;
+@end
+
 @implementation FTestBase
 
 + (void)setUp {
   static dispatch_once_t once;
   dispatch_once(&once, ^{
-    [FIROptionsMock mockFIROptions];
+    if ([FIROptions plistFilePathWithName:@"GoogleService-Info"] == nil) {
+      // Mock options for unit tests and emulator runs.
+      // To run the integration tests with a real GoogleService-Info.plist, add the
+      // GoogleService-Info.plist file to the AppHost-FirebaseDatabase-Unit-Tests generated target
+      // in the Pods project created by `pod gen`.
+      [FIROptionsMock mockFIROptions];
+    }
     [FIRApp configure];
   });
 }


### PR DESCRIPTION
Reenable RTDB integration tests with a real GoogleService-Info.plist that were broken in #6557.

See the added comment for run instructions.

There are still 9 failures because of a race condition:

![Screen Shot 2022-04-22 at 8 36 18 AM](https://user-images.githubusercontent.com/73870/164747542-9e20d156-3a0c-4037-b694-7348dcff4404.png)


