### PR TITLE
[Crashlytics] Investigate Crashlytics nightly failures

### DIFF
--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -18,39 +18,39 @@ concurrency:
 
 jobs:
 
-  pod-lib-lint:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # pod-lib-lint:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    runs-on: macos-11
+  #   runs-on: macos-11
 
-    strategy:
-      matrix:
-        target: [ios, tvos, macos, watchos --skip-tests]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Build and test
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }}
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos, watchos --skip-tests]
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Build and test
+  #     run: |
+  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }}
 
-  spm:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-11
-    strategy:
-      matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-    steps:
-    - uses: actions/checkout@v2
-    - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseCrashlytics ${{ matrix.target }} spmbuildonly
+  # spm:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   runs-on: macos-11
+  #   strategy:
+  #     matrix:
+  #       target: [iOS, tvOS, macOS, catalyst, watchOS]
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: mikehardy/buildcache-action@50738c6c77de7f34e66b870e4f8ede333b69d077
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Initialize xcodebuild
+  #     run: scripts/setup_spm_tests.sh
+  #   - name: Unit Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseCrashlytics ${{ matrix.target }} spmbuildonly
 
 
   catalyst:
@@ -68,53 +68,53 @@ jobs:
     - name: Setup project and Build for Catalyst
       run: scripts/test_catalyst.sh FirebaseCrashlytics test FirebaseCrashlytics-Unit-unit
 
-  quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # quickstart:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-11
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh crashlytics
-      env:
-        LEGACY: true
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-          quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Test objc quickstart
-      run: |
-        mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
-        # Set the deployed pod location of run and upload-symbols with the development pod version.
-        cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-        ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics true)
-      env:
-        LEGACY: true
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics true swift)
-      env:
-        LEGACY: true
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-11
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh crashlytics
+  #     env:
+  #       LEGACY: true
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+  #         quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test objc quickstart
+  #     run: |
+  #       mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
+  #       # Set the deployed pod location of run and upload-symbols with the development pod version.
+  #       cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+  #       cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+  #       ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics true)
+  #     env:
+  #       LEGACY: true
+  #   - name: Test swift quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics true swift)
+  #     env:
+  #       LEGACY: true
 
-  crashlytics-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  # crashlytics-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-    runs-on: macos-11
-    strategy:
-      matrix:
-        # Disable watchos because it does not support XCTest.
-        target: [ios, tvos, macos, watchos --skip-tests]
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod-lib-lint
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint Auth Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #   runs-on: macos-11
+  #   strategy:
+  #     matrix:
+  #       # Disable watchos because it does not support XCTest.
+  #       target: [ios, tvos, macos, watchos --skip-tests]
+  #       flags: [
+  #         '--use-static-frameworks'
+  #       ]
+  #   needs: pod-lib-lint
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: PodLibLint Auth Cron
+  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -13,24 +13,24 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  release-diffing:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
-      - name: Authenticate Google Cloud SDK
-        run: |
-          scripts/decrypt_gha_secret.sh \
-            scripts/gha-encrypted/metrics_service_access.json.gpg \
-            service_account.json \
-            "${{ env.gpg_passphrase }}"
-          gcloud auth activate-service-account --key-file service_account.json
-      - name: Produce health metric diff reports
-        uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
-        with:
-          repo: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          commit: ${{ github.sha }}
-          releaseId: ${{ github.event.release.id }}
+  # release-diffing:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+  #     - name: Set up Google Cloud SDK
+  #       uses: google-github-actions/setup-gcloud@master
+  #     - name: Authenticate Google Cloud SDK
+  #       run: |
+  #         scripts/decrypt_gha_secret.sh \
+  #           scripts/gha-encrypted/metrics_service_access.json.gpg \
+  #           service_account.json \
+  #           "${{ env.gpg_passphrase }}"
+  #         gcloud auth activate-service-account --key-file service_account.json
+  #     - name: Produce health metric diff reports
+  #       uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
+  #       with:
+  #         repo: ${{ github.repository }}
+  #         ref: ${{ github.ref }}
+  #         commit: ${{ github.sha }}
+  #         releaseId: ${{ github.event.release.id }}

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -8,61 +8,61 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  specs_checking:
-    # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-11
-    outputs:
-      matrix: ${{ steps.check_files.outputs.matrix }}
-      podspecs: ${{ steps.check_files.outputs.podspecs }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: check files
-      id: check_files
-      env:
-        pr_branch: ${{ github.event.pull_request.head.ref }}
-      run: |
-        # The output.json will have podspecs that will be tested.
-        # ``` output.json
-        # [{"podspec":"FirebaseABTesting.podspec"},{"podspec":"FirebaseAnalytics.podspec.json"}]
-        # ```
-        # This array will help generate a matrix for jobs in GHA, taking
-        # advantage of `include`.
-        # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
-        # The final matrix will be set as an env var in the GHA workflow,
-        # This env var, matrix, will be passed as a matrix in the next job of
-        # the workflow.
-        # If multiple podspecs need to be excluded, escaping space is required
-        # to split podspecs, e.g. get_updated_files.sh ... -e Firebase.podspec\ FirebaseABTesting.podspec
-        ./scripts/health_metrics/get_updated_files.sh -p output.json -e Firebase.podspec\ FirebaseFunctions.podspec
-        echo "::set-output name=matrix::{\"include\":$( cat output.json )}"
-        # `podspecs` is to help determine if specs_testing job should be run.
-        echo "::set-output name=podspecs::$(cat output.json)"
-  specs_testing:
-    needs: specs_checking
-    if: ${{ needs.specs_checking.outputs.podspecs != '[]' }}
-    runs-on: macos-11
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}
-    env:
-      PODSPEC: ${{ matrix.podspec }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Init podspecs and source
-      run: |
-        mkdir specTestingLogs
-        cd ReleaseTooling
-        swift run podspecs-tester --git-root "${GITHUB_WORKSPACE}" --podspec ${PODSPEC} --skip-tests --temp-log-dir "${GITHUB_WORKSPACE}/specTestingLogs"
-    - name: Upload Failed Testing Logs
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: specTestingLogs
-        path: specTestingLogs/*.txt
+  # specs_checking:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk'
+  #   runs-on: macos-11
+  #   outputs:
+  #     matrix: ${{ steps.check_files.outputs.matrix }}
+  #     podspecs: ${{ steps.check_files.outputs.podspecs }}
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #   - name: check files
+  #     id: check_files
+  #     env:
+  #       pr_branch: ${{ github.event.pull_request.head.ref }}
+  #     run: |
+  #       # The output.json will have podspecs that will be tested.
+  #       # ``` output.json
+  #       # [{"podspec":"FirebaseABTesting.podspec"},{"podspec":"FirebaseAnalytics.podspec.json"}]
+  #       # ```
+  #       # This array will help generate a matrix for jobs in GHA, taking
+  #       # advantage of `include`.
+  #       # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
+  #       # The final matrix will be set as an env var in the GHA workflow,
+  #       # This env var, matrix, will be passed as a matrix in the next job of
+  #       # the workflow.
+  #       # If multiple podspecs need to be excluded, escaping space is required
+  #       # to split podspecs, e.g. get_updated_files.sh ... -e Firebase.podspec\ FirebaseABTesting.podspec
+  #       ./scripts/health_metrics/get_updated_files.sh -p output.json -e Firebase.podspec\ FirebaseFunctions.podspec
+  #       echo "::set-output name=matrix::{\"include\":$( cat output.json )}"
+  #       # `podspecs` is to help determine if specs_testing job should be run.
+  #       echo "::set-output name=podspecs::$(cat output.json)"
+  # specs_testing:
+  #   needs: specs_checking
+  #   if: ${{ needs.specs_checking.outputs.podspecs != '[]' }}
+  #   runs-on: macos-11
+  #   strategy:
+  #     fail-fast: false
+  #     matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}
+  #   env:
+  #     PODSPEC: ${{ matrix.podspec }}
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #   - name: Init podspecs and source
+  #     run: |
+  #       mkdir specTestingLogs
+  #       cd ReleaseTooling
+  #       swift run podspecs-tester --git-root "${GITHUB_WORKSPACE}" --podspec ${PODSPEC} --skip-tests --temp-log-dir "${GITHUB_WORKSPACE}/specTestingLogs"
+  #   - name: Upload Failed Testing Logs
+  #     if: failure()
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: specTestingLogs
+  #       path: specTestingLogs/*.txt

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -5,8 +5,8 @@ on:
     paths:
     - 'FirebaseStorage**'
     - 'FirebaseAuth/Interop/*.h'
-    - '.github/workflows/storage.yml'
-    - 'scripts/**'
+    # - '.github/workflows/storage.yml'
+    # - 'scripts/**'
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile*'
   schedule:

--- a/Crashlytics/UnitTests/FABOperation/FABNetworkOperationTests.m
+++ b/Crashlytics/UnitTests/FABOperation/FABNetworkOperationTests.m
@@ -26,7 +26,7 @@
 
 @implementation FABNetworkOperationTests
 
-- (void)testNetworkOperationHeaders {
+- (void)DISABLED_testNetworkOperationHeaders {
   FIRCLSDataCollectionToken *token = [FIRCLSDataCollectionToken validToken];
   NSString *googleAppID = @"someGoogleAppID";
 

--- a/Crashlytics/UnitTests/FABOperation/FABOperationInFlightCancellationTest.m
+++ b/Crashlytics/UnitTests/FABOperation/FABOperationInFlightCancellationTest.m
@@ -30,7 +30,7 @@
 
 @implementation FABInFlightCancellationTests
 
-- (void)testAsyncCancellationInFlight {
+- (void)DISABLED_testAsyncCancellationInFlight {
   FABTestAsyncOperation *cancelledOperation = [[FABTestAsyncOperation alloc] init];
   cancelledOperation.name = @"cancelledOperation";
 
@@ -71,7 +71,7 @@
 // its compoundQueue, the first should be checked using the in-flight cancellation checks, and the
 // ones awaiting execution should be checked using the pre-flight checks. The compound operation is
 // checked using the in-flight checks.
-- (void)testCompoundCancellationInFlight {
+- (void)DISABLED_testCompoundCancellationInFlight {
   FIRCLSCompoundOperation *cancelledCompoundOperation = [[FIRCLSCompoundOperation alloc] init];
   cancelledCompoundOperation.name = @"cancelled compound operation";
   cancelledCompoundOperation.compoundQueue.maxConcurrentOperationCount = 1;

--- a/Crashlytics/UnitTests/FABOperation/FABOperationPreFlightCancellationTest.m
+++ b/Crashlytics/UnitTests/FABOperation/FABOperationPreFlightCancellationTest.m
@@ -30,7 +30,7 @@
 
 @implementation FABOperationPreFlightCancellationTest
 
-- (void)testAsyncCancellationPreFlight {
+- (void)DISABLED_testAsyncCancellationPreFlight {
   FABTestAsyncOperation *cancelledOperation = [[FABTestAsyncOperation alloc] init];
   cancelledOperation.name = @"cancelledOperation";
 
@@ -65,7 +65,7 @@
 // This test case adds several async operations to a compound operation and cancels the compound
 // operation before it can execute. All suboperations and the compound operation are tested using
 // pre-flight cancellation checks.
-- (void)testCompoundCancellationPreFlight {
+- (void)DISABLED_testCompoundCancellationPreFlight {
   FIRCLSCompoundOperation *cancelledCompoundOperation = [[FIRCLSCompoundOperation alloc] init];
   cancelledCompoundOperation.name = @"cancelled compound operation";
   cancelledCompoundOperation.compoundQueue.maxConcurrentOperationCount = 1;

--- a/Crashlytics/UnitTests/FABOperation/FABTestExpectations.h
+++ b/Crashlytics/UnitTests/FABOperation/FABTestExpectations.h
@@ -37,11 +37,11 @@ typedef void (^FABPreFlightCancellationFailureAssertionBlock)(void);
  */
 + (void)
     addInFlightCancellationCompletionExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                    testCase:(XCTestCase *)testCase
+                                                    testCase:(XCTestCase *)DISABLED_testCase
                                               assertionBlock:
                                                   (FABAsyncCompletionAssertionBlock)assertionBlock;
 + (void)addInFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                 testCase:(XCTestCase *)testCase;
+                                                 testCase:(XCTestCase *)DISABLED_testCase;
 
 /*
  The two following methods add XCTestExpectations for async operations that will be cancelled before
@@ -49,11 +49,11 @@ typedef void (^FABPreFlightCancellationFailureAssertionBlock)(void);
  */
 + (void)
     addPreFlightCancellationCompletionExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                     testCase:(XCTestCase *)testCase
+                                                     testCase:(XCTestCase *)DISABLED_testCase
                                           asyncAssertionBlock:
                                               (FABAsyncCompletionAssertionBlock)asyncAssertionBlock;
 + (FABTestExpectationObserver *)
     addPreFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                              testCase:(XCTestCase *)testCase;
+                                              testCase:(XCTestCase *)DISABLED_testCase;
 
 @end

--- a/Crashlytics/UnitTests/FABOperation/FABTestExpectations.m
+++ b/Crashlytics/UnitTests/FABOperation/FABTestExpectations.m
@@ -64,7 +64,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (void)
     addInFlightCancellationCompletionExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                    testCase:(XCTestCase *)DISABLED_testCase
+                                                    testCase:(XCTestCase *)testCase
                                               assertionBlock:
                                                   (FABAsyncCompletionAssertionBlock)assertionBlock {
   XCTestExpectation *syncCompletionExpectation = [testCase
@@ -85,7 +85,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 }
 
 + (void)addInFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                 testCase:(XCTestCase *)DISABLED_testCase {
+                                                 testCase:(XCTestCase *)testCase {
   for (NSString *selector in @[
          NSStringFromSelector(@selector(isCancelled)), NSStringFromSelector(@selector(isFinished)),
          NSStringFromSelector(@selector(isExecuting))
@@ -117,7 +117,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (void)addPreFlightCancellationCompletionExpectationsToOperation:
             (FIRCLSFABAsyncOperation *)operation
-                                                         testCase:(XCTestCase *)DISABLED_testCase
+                                                         testCase:(XCTestCase *)testCase
                                               asyncAssertionBlock:(FABAsyncCompletionAssertionBlock)
                                                                       asyncAssertionBlock {
   // we expect the synchronous, standard completionBlock to execute. Per Apple's documentation, it
@@ -140,7 +140,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (FABTestExpectationObserver *)
     addPreFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                              testCase:(XCTestCase *)DISABLED_testCase {
+                                              testCase:(XCTestCase *)testCase {
   // add an expectation that isFinished is set to true, isCancelled is true and isExecuting is false
   BOOL (^handler)(NSOperation *observedOperation, NSDictionary *change) =
       ^(NSOperation *observedOperation, NSDictionary *change) {

--- a/Crashlytics/UnitTests/FABOperation/FABTestExpectations.m
+++ b/Crashlytics/UnitTests/FABOperation/FABTestExpectations.m
@@ -64,7 +64,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (void)
     addInFlightCancellationCompletionExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                    testCase:(XCTestCase *)testCase
+                                                    testCase:(XCTestCase *)DISABLED_testCase
                                               assertionBlock:
                                                   (FABAsyncCompletionAssertionBlock)assertionBlock {
   XCTestExpectation *syncCompletionExpectation = [testCase
@@ -85,7 +85,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 }
 
 + (void)addInFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                                 testCase:(XCTestCase *)testCase {
+                                                 testCase:(XCTestCase *)DISABLED_testCase {
   for (NSString *selector in @[
          NSStringFromSelector(@selector(isCancelled)), NSStringFromSelector(@selector(isFinished)),
          NSStringFromSelector(@selector(isExecuting))
@@ -117,7 +117,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (void)addPreFlightCancellationCompletionExpectationsToOperation:
             (FIRCLSFABAsyncOperation *)operation
-                                                         testCase:(XCTestCase *)testCase
+                                                         testCase:(XCTestCase *)DISABLED_testCase
                                               asyncAssertionBlock:(FABAsyncCompletionAssertionBlock)
                                                                       asyncAssertionBlock {
   // we expect the synchronous, standard completionBlock to execute. Per Apple's documentation, it
@@ -140,7 +140,7 @@ void *FABOperationPreFlightCancellationTestKVOContext =
 
 + (FABTestExpectationObserver *)
     addPreFlightCancellationKVOExpectationsToOperation:(FIRCLSFABAsyncOperation *)operation
-                                              testCase:(XCTestCase *)testCase {
+                                              testCase:(XCTestCase *)DISABLED_testCase {
   // add an expectation that isFinished is set to true, isCancelled is true and isExecuting is false
   BOOL (^handler)(NSOperation *observedOperation, NSDictionary *change) =
       ^(NSOperation *observedOperation, NSDictionary *change) {

--- a/Crashlytics/UnitTests/FABURLBuilderTests.m
+++ b/Crashlytics/UnitTests/FABURLBuilderTests.m
@@ -35,7 +35,7 @@
   [super tearDown];
 }
 
-- (void)testTheRightUrlEncodingIsUsed {
+- (void)DISABLED_testTheRightUrlEncodingIsUsed {
   NSString *actual =
       @"https://settings.crashlytics.com/spi/v2/platforms/ios/apps/"
       @"com.dogs.testingappforfunandprofit/"

--- a/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
+++ b/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
@@ -52,7 +52,7 @@
 #if CLS_COMPACT_UNWINDING_SUPPORTED
 
 #if !TARGET_OS_IPHONE
-- (void)testParseCompactUnwindInfoForthread_get_state_10_9_4 {
+- (void)DISABLED_testParseCompactUnwindInfoForthread_get_state_10_9_4 {
   NSString* dylibPath = [self pathForResource:@"10.9.4_libsystem_kernel.dylib"];
 
   struct FIRCLSMachOFile file;
@@ -83,7 +83,7 @@
   XCTAssertEqual(result.functionStart, loadAddress + 0x0000DCC1, @"");
 }
 
-- (void)testParseCompactUnwindInfoForFunctionInLastIndexEntry {
+- (void)DISABLED_testParseCompactUnwindInfoForFunctionInLastIndexEntry {
   NSString* dylibPath = [self pathForResource:@"10.9.4_libsystem_kernel.dylib"];
 
   struct FIRCLSMachOFile file;
@@ -113,7 +113,7 @@
   XCTAssertFalse(FIRCLSCompactUnwindLookup(&context, loadAddress + 0x00016FDE, &result), @"");
 }
 
-- (void)testParseCompactUnwindInfoForBoundaryBetween2ndLevelEntries {
+- (void)DISABLED_testParseCompactUnwindInfoForBoundaryBetween2ndLevelEntries {
   NSString* dylibPath = [self pathForResource:@"10.9.4_libsystem_kernel.dylib"];
 
   struct FIRCLSMachOFile file;
@@ -156,7 +156,7 @@
 #endif
 
 #if CLS_CPU_X86_64
-- (void)testComputeDirectStackSize {
+- (void)DISABLED_testComputeDirectStackSize {
   const compact_unwind_encoding_t encoding = 0x20a1860;
   const intptr_t functionStart = 0x0;
 

--- a/Crashlytics/UnitTests/FIRCLSConstantsTest.m
+++ b/Crashlytics/UnitTests/FIRCLSConstantsTest.m
@@ -26,13 +26,13 @@
 
 @implementation FIRCLSConstantsTest
 
-- (void)testGeneratorName {
+- (void)DISABLED_testGeneratorName {
   NSString *expectedGeneratorName =
       [NSString stringWithFormat:@"%s/%s", STR(CLS_SDK_NAME), FIRCLSSDKVersion().UTF8String];
   XCTAssertEqualObjects(expectedGeneratorName, FIRCLSSDKGeneratorName());
 }
 
-- (void)testSdkVersion {
+- (void)DISABLED_testSdkVersion {
   NSString *expectedSdkVersion = FIRFirebaseVersion();
   XCTAssertEqualObjects(expectedSdkVersion, FIRCLSSDKVersion());
 }

--- a/Crashlytics/UnitTests/FIRCLSDataCollectionArbiterTest.m
+++ b/Crashlytics/UnitTests/FIRCLSDataCollectionArbiterTest.m
@@ -49,31 +49,31 @@
   [super tearDown];
 }
 
-- (void)testNothingSet {
+- (void)DISABLED_testNothingSet {
   self.fakeApp.isDefaultCollectionEnabled = YES;
   FIRCLSDataCollectionArbiter *arbiter = [self arbiterWithDictionary:@{}];
   XCTAssertTrue([arbiter isCrashlyticsCollectionEnabled]);
 }
 
-- (void)testOnlyStickyOff {
+- (void)DISABLED_testOnlyStickyOff {
   FIRCLSDataCollectionArbiter *arbiter = [self arbiterWithDictionary:@{}];
   [arbiter setCrashlyticsCollectionEnabled:NO];
   XCTAssertFalse([arbiter isCrashlyticsCollectionEnabled]);
 }
 
-- (void)testOnlyFlagOff {
+- (void)DISABLED_testOnlyFlagOff {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithDataCollectionValue:NO]];
   XCTAssertFalse([arbiter isCrashlyticsCollectionEnabled]);
 }
 
-- (void)testOnlyFIRAppOff {
+- (void)DISABLED_testOnlyFIRAppOff {
   self.fakeApp.isDefaultCollectionEnabled = NO;
   FIRCLSDataCollectionArbiter *arbiter = [self arbiterWithDictionary:@{}];
   XCTAssertFalse([arbiter isCrashlyticsCollectionEnabled]);
 }
 
-- (void)testStickyPrecedent {
+- (void)DISABLED_testStickyPrecedent {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithDataCollectionValue:NO]];
   self.fakeApp.isDefaultCollectionEnabled = NO;
@@ -82,7 +82,7 @@
   XCTAssertFalse([arbiter isLegacyDataCollectionKeyInPlist]);
 }
 
-- (void)testPlistPrecedent {
+- (void)DISABLED_testPlistPrecedent {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithDataCollectionValue:YES]];
   self.fakeApp.isDefaultCollectionEnabled = NO;
@@ -90,13 +90,13 @@
   XCTAssertFalse([arbiter isLegacyDataCollectionKeyInPlist]);
 }
 
-- (void)testLegacyFlag {
+- (void)DISABLED_testLegacyFlag {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithLegacyDataCollectionValue:YES]];
   XCTAssertTrue([arbiter isLegacyDataCollectionKeyInPlist]);
 }
 
-- (void)testLegacyAndNewImplementationsAreIndependent {
+- (void)DISABLED_testLegacyAndNewImplementationsAreIndependent {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithLegacyDataCollectionValue:YES]];
   self.fakeApp.isDefaultCollectionEnabled = NO;
@@ -104,7 +104,7 @@
   XCTAssertTrue([arbiter isLegacyDataCollectionKeyInPlist]);
 }
 
-- (void)testLegacyAndNewFlagsAreIndependent {
+- (void)DISABLED_testLegacyAndNewFlagsAreIndependent {
   FIRCLSDataCollectionArbiter *arbiter =
       [self arbiterWithDictionary:[self fabricConfigWithDataCollectionValue:YES andLegacy:NO]];
   self.fakeApp.isDefaultCollectionEnabled = YES;
@@ -121,7 +121,7 @@
   return expectation;
 }
 
-- (void)testWaitForCrashlyticsCollectionEnabled {
+- (void)DISABLED_testWaitForCrashlyticsCollectionEnabled {
   // true, wait
   FIRCLSDataCollectionArbiter *arbiter = [self arbiterWithDictionary:@{}];
   [arbiter setCrashlyticsCollectionEnabled:YES];

--- a/Crashlytics/UnitTests/FIRCLSDemangleOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDemangleOperationTests.m
@@ -37,16 +37,16 @@
   return [FIRCLSDemangleOperation demangleSymbol:symbol];
 }
 
-- (void)testDemangleUnmangledSymbol {
+- (void)DISABLED_testDemangleUnmangledSymbol {
   XCTAssertNil([self demangle:"unmangledSymbol"], @"");
 }
 
-- (void)testDemangleCppSymbols {
+- (void)DISABLED_testDemangleCppSymbols {
   XCTAssertEqualObjects([self demangle:"_Z7monitorP8NSStringlS0_"],
                         @"monitor(NSString*, long, NSString*)", @"");
 }
 
-- (void)testDemangleCppSymbolsWithBlockInvoke {
+- (void)DISABLED_testDemangleCppSymbolsWithBlockInvoke {
   XCTAssertEqualObjects([self demangle:"__Z7monitorP8NSStringlS0__block_invoke"],
                         @"monitor(NSString*, long, NSString*)_block_invoke", @"");
   XCTAssertEqualObjects([self demangle:"__Z7monitorP8NSStringlS0__block_invoke_2"],
@@ -55,7 +55,7 @@
   XCTAssertNil([self demangle:"__Zinvalid_block_invoke"], @"Invalid Cpp symbol");
 }
 
-- (void)testOperation {
+- (void)DISABLED_testOperation {
   NSMutableArray *frameArray = [[NSMutableArray alloc] init];
   [frameArray addObject:[FIRStackFrame stackFrameWithSymbol:@"_Z7monitorP8NSStringlS0_"]];
   [frameArray addObject:[FIRStackFrame stackFrameWithSymbol:@"_ZN9wikipedia7article6formatEv"]];

--- a/Crashlytics/UnitTests/FIRCLSDwarfExpressionTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfExpressionTests.m
@@ -36,7 +36,7 @@
 
 #if CLS_DWARF_UNWINDING_SUPPORTED
 
-- (void)testDwarfStackPushAndPop {
+- (void)DISABLED_testDwarfStackPushAndPop {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -56,7 +56,7 @@
   XCTAssert(FIRCLSDwarfExpressionStackIsValid(&stack));
 }
 
-- (void)testDwarfStackPeek {
+- (void)DISABLED_testDwarfStackPeek {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -76,7 +76,7 @@
   XCTAssertEqual(FIRCLSDwarfExpressionStackPop(&stack), (intptr_t)1);
 }
 
-- (void)testDwarfStackPushMaxNumberOfValues {
+- (void)DISABLED_testDwarfStackPushMaxNumberOfValues {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -90,7 +90,7 @@
                  (intptr_t)(CLS_DWARF_EXPRESSION_STACK_SIZE - 1));
 }
 
-- (void)testDwarfStackOverflow {
+- (void)DISABLED_testDwarfStackOverflow {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -106,7 +106,7 @@
   XCTAssertFalse(FIRCLSDwarfExpressionStackIsValid(&stack));
 }
 
-- (void)testDwarfStackPopUnderflow {
+- (void)DISABLED_testDwarfStackPopUnderflow {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -116,7 +116,7 @@
   XCTAssertFalse(FIRCLSDwarfExpressionStackIsValid(&stack));
 }
 
-- (void)testDwarfStackPeekUnderflow {
+- (void)DISABLED_testDwarfStackPeekUnderflow {
   FIRCLSDwarfExpressionStack stack;
 
   FIRCLSDwarfExpressionStackInit(&stack);
@@ -126,7 +126,7 @@
   XCTAssertFalse(FIRCLSDwarfExpressionStackIsValid(&stack));
 }
 
-- (void)testDwarfExpressionMachineInit {
+- (void)DISABLED_testDwarfExpressionMachineInit {
   FIRCLSDwarfExpressionMachine machine;
   uint8_t fakeData;
   FIRCLSThreadContext registers;

--- a/Crashlytics/UnitTests/FIRCLSDwarfTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfTests.m
@@ -52,7 +52,7 @@
 #if CLS_DWARF_UNWINDING_SUPPORTED
 #if CLS_CPU_X86_64
 
-- (void)testParseDwarfUnwindInfoForobjc_msgSend_x86_64_1093 {
+- (void)DISABLED_testParseDwarfUnwindInfoForobjc_msgSend_x86_64_1093 {
   NSString* dylibPath = [self pathForResource:@"10.9.3_libobjc.A.dylib"];
 
   struct FIRCLSMachOFile file;
@@ -103,7 +103,7 @@
 
 #endif
 
-- (void)testGetSavedRegisterWithInvalidValues {
+- (void)DISABLED_testGetSavedRegisterWithInvalidValues {
   FIRCLSThreadContext registers;
   const FIRCLSDwarfRegister dRegister = {FIRCLSDwarfRegisterUnused, 0};
 
@@ -111,7 +111,7 @@
   XCTAssertEqual(FIRCLSDwarfGetSavedRegister(&registers, 0, dRegister), 0, @"");
 }
 
-- (void)testGetSavedRegisterWithInCFA {
+- (void)DISABLED_testGetSavedRegisterWithInCFA {
   uintptr_t memoryBuffer[2] = {45, 46};
   FIRCLSThreadContext registers;
   const FIRCLSDwarfRegister dRegister = {FIRCLSDwarfRegisterInCFA, sizeof(uintptr_t)};
@@ -121,7 +121,7 @@
                  @"");
 }
 
-- (void)testRegisterStructureSizingAndMaxValues {
+- (void)DISABLED_testRegisterStructureSizingAndMaxValues {
   FIRCLSDwarfState state;
 
   XCTAssertEqual(sizeof(state.registers) / sizeof(FIRCLSDwarfRegister),
@@ -133,7 +133,7 @@
   XCTAssertTrue(CLS_DWARF_INVALID_REGISTER_NUM > CLS_DWARF_MAX_REGISTER_NUM);
 }
 
-- (void)testAssignReturnRegisterNumber {
+- (void)DISABLED_testAssignReturnRegisterNumber {
   FIRCLSDwarfState state;
   FIRCLSThreadContext inputRegisters;
   FIRCLSThreadContext outputRegisters;

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -136,7 +136,7 @@
 
 #pragma mark - Tests
 
-- (void)testNoReports {
+- (void)DISABLED_testNoReports {
   [self.existingReportManager collectExistingReports];
 
   [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
@@ -148,7 +148,7 @@
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
 
-- (void)testReportNoEvents {
+- (void)DISABLED_testReportNoEvents {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:NO];
   [self createActiveReportWithID:@"report_B" time:12315 withEvents:NO];
 
@@ -163,7 +163,7 @@
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
 
-- (void)testUnsentReportsUnderLimit {
+- (void)DISABLED_testUnsentReportsUnderLimit {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];
   [self createActiveReportWithID:@"report_B" time:12315 withEvents:YES];
   [self createActiveReportWithID:@"report_C" time:31533 withEvents:YES];
@@ -188,7 +188,7 @@
  * ensure performant startup and prevent disk space from filling up. Delete starting with the oldest
  * first.
  */
-- (void)testUnsentReportsOverLimit {
+- (void)DISABLED_testUnsentReportsOverLimit {
   // Create a bunch of reports starting at different times
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];
   [self createActiveReportWithID:@"report_B" time:12315 withEvents:YES];

--- a/Crashlytics/UnitTests/FIRCLSFileManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSFileManagerTests.m
@@ -57,7 +57,7 @@
   return [[NSFileManager defaultManager] fileExistsAtPath:path];
 }
 
-- (void)testCreateV4DirectoryStructure {
+- (void)DISABLED_testCreateV4DirectoryStructure {
   NSString* path = [[self manager] rootPath];
 
   [[self manager] createReportDirectories];

--- a/Crashlytics/UnitTests/FIRCLSFileTests.m
+++ b/Crashlytics/UnitTests/FIRCLSFileTests.m
@@ -54,7 +54,7 @@
 
 #pragma mark -
 
-- (void)testEmptySection {
+- (void)DISABLED_testEmptySection {
   [self emptySectionWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self emptySectionWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -80,7 +80,7 @@
 
 #pragma mark -
 
-- (void)testSingleArrayCollection {
+- (void)DISABLED_testSingleArrayCollection {
   [self singleArrayCollectionWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self singleArrayCollectionWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -109,7 +109,7 @@
 
 #pragma mark -
 
-- (void)testEmptyCollectionFollowedByEntry {
+- (void)DISABLED_testEmptyCollectionFollowedByEntry {
   [self emptyCollectionFollowedByEntryWithFile:&_unbufferedFile
                                       filePath:self.unbufferedPath
                                       buffered:NO];
@@ -144,7 +144,7 @@
 
 #pragma mark -
 
-- (void)testHexEncodingString {
+- (void)DISABLED_testHexEncodingString {
   [self hexEncodingStringWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self hexEncodingStringWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -171,7 +171,7 @@
 
 #pragma mark -
 
-- (void)testHexEncodingLongString {
+- (void)DISABLED_testHexEncodingLongString {
   [self hexEncodingLongStringWithFile:&_unbufferedFile
                              filePath:self.unbufferedPath
                                length:CLS_FILE_HEX_BUFFER * 10
@@ -221,7 +221,7 @@
 
 #pragma mark -
 
-- (void)testSignedInteger {
+- (void)DISABLED_testSignedInteger {
   [self signedIntegerWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self signedIntegerWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -251,7 +251,7 @@
 
 #pragma mark -
 
-- (void)testBigInteger {
+- (void)DISABLED_testBigInteger {
   [self bigIntegerWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self bigIntegerWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -281,7 +281,7 @@
 
 #pragma mark -
 
-- (void)testMaxUInt64 {
+- (void)DISABLED_testMaxUInt64 {
   [self maxUInt64WithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self maxUInt64WithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -309,7 +309,7 @@
 
 #pragma mark -
 
-- (void)testSimpleHashPerformanceWithUnbufferedFile {
+- (void)DISABLED_testSimpleHashPerformanceWithUnbufferedFile {
   [self measureBlock:^{
     // just one run isn't sufficient
     for (NSUInteger i = 0; i < 2000; ++i) {
@@ -322,7 +322,7 @@
   }];
 }
 
-- (void)testSimpleHashPerformanceWithBufferedFile {
+- (void)DISABLED_testSimpleHashPerformanceWithBufferedFile {
   [self measureBlock:^{
     // just one run isn't sufficient
     for (NSUInteger i = 0; i < 2000; ++i) {
@@ -337,7 +337,7 @@
 
 #pragma mark -
 
-- (void)testOpenAndClose {
+- (void)DISABLED_testOpenAndClose {
   [self openAndCloseWithFile:&_unbufferedFile filePath:self.unbufferedPath buffered:NO];
   [self openAndCloseWithFile:&_bufferedFile filePath:self.bufferedPath buffered:YES];
 }
@@ -361,7 +361,7 @@
 
 #pragma mark -
 
-- (void)testCloseAndOpenAlternatingBufferedOption {
+- (void)DISABLED_testCloseAndOpenAlternatingBufferedOption {
   [self closeAndOpenAlternatingBufferedOptionWithFile:&_unbufferedFile
                                              filePath:self.unbufferedPath
                                              buffered:NO];
@@ -399,7 +399,7 @@
 
 #pragma mark -
 
-- (void)testLoggingInputLongerThanBuffer {
+- (void)DISABLED_testLoggingInputLongerThanBuffer {
   size_t inputLength = (FIRCLSWriteBufferLength + 2) * sizeof(char);
   char *input = malloc(inputLength);
   for (size_t i = 0; i < inputLength - 1; i++) {

--- a/Crashlytics/UnitTests/FIRCLSInstallIdentifierModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSInstallIdentifierModelTests.m
@@ -48,7 +48,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   [_defaults removeObjectForKey:FIRCLSInstallationIIDHashKey];
 }
 
-- (void)testCreateUUID {
+- (void)DISABLED_testCreateUUID {
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_instance_id"];
 
   FIRCLSInstallIdentifierModel *model =
@@ -59,7 +59,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertNil([_defaults objectForKey:FABInstallationADIDKey]);
 }
 
-- (void)testCreateUUIDAndRotate {
+- (void)DISABLED_testCreateUUIDAndRotate {
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_instance_id"];
 
   FIRCLSInstallIdentifierModel *model =
@@ -76,7 +76,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testCreateUUIDAndErrorGettingInstanceID {
+- (void)DISABLED_testCreateUUIDAndErrorGettingInstanceID {
   NSError *fakeError = [NSError errorWithDomain:NSCocoaErrorDomain code:-1 userInfo:@{}];
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithError:fakeError];
 
@@ -92,7 +92,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertEqualObjects(nil, [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testCreateUUIDNoIID {
+- (void)DISABLED_testCreateUUIDNoIID {
   FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:nil];
 
   FIRCLSInstallIdentifierModel *model =
@@ -104,7 +104,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertEqualObjects(nil, [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testIIDBecomesNil {
+- (void)DISABLED_testIIDBecomesNil {
   // Set up the initial state with a valid iid and uuid.
   [_defaults setObject:@"old_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"old_instance_id" forKey:FIRCLSInstallationIIDHashKey];
@@ -122,7 +122,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertNil([_defaults objectForKey:FABInstallationADIDKey]);
 }
 
-- (void)testIIDChanges {
+- (void)DISABLED_testIIDChanges {
   // Set up the initial state with a valid iid and uuid.
   [_defaults setObject:@"old_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"old_instance_id" forKey:FIRCLSInstallationIIDHashKey];
@@ -144,7 +144,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testIIDDoesntChange {
+- (void)DISABLED_testIIDDoesntChange {
   // Set up the initial state with a valid iid and uuid.
   [_defaults setObject:@"test_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:FIRCLSTestHashOfTestInstanceID forKey:FIRCLSInstallationIIDHashKey];
@@ -166,7 +166,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testUUIDSetButNeverIIDNilIID {
+- (void)DISABLED_testUUIDSetButNeverIIDNilIID {
   // Set up the initial state with a valid iid and uuid.
   [_defaults setObject:@"old_uuid" forKey:FABInstallationUUIDKey];
 
@@ -187,7 +187,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertEqualObjects([_defaults objectForKey:FIRCLSInstallationIIDHashKey], nil);
 }
 
-- (void)testUUIDSetButNeverIIDWithIID {
+- (void)DISABLED_testUUIDSetButNeverIIDWithIID {
   // Set up the initial state with a valid iid and uuid.
   [_defaults setObject:@"old_uuid" forKey:FABInstallationUUIDKey];
 
@@ -209,7 +209,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         FIRCLSTestHashOfTestInstanceID);
 }
 
-- (void)testADIDWasSetButNeverIID {
+- (void)DISABLED_testADIDWasSetButNeverIID {
   // Set up the initial state with a valid adid and uuid.
   [_defaults setObject:@"test_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"test_adid" forKey:FABInstallationADIDKey];
@@ -230,7 +230,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
   XCTAssertNil([_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testADIDWasSetAndIIDBecomesSet {
+- (void)DISABLED_testADIDWasSetAndIIDBecomesSet {
   // Set up the initial state with a valid adid and uuid.
   [_defaults setObject:@"test_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"test_adid" forKey:FABInstallationADIDKey];
@@ -252,7 +252,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testADIDAndIIDWereSet {
+- (void)DISABLED_testADIDAndIIDWereSet {
   // Set up the initial state with a valid iid, adid, and uuid.
   [_defaults setObject:@"test_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"test_adid" forKey:FABInstallationADIDKey];
@@ -275,7 +275,7 @@ static NSString *const FIRCLSTestHashOfTestInstanceID =
                         [_defaults objectForKey:FIRCLSInstallationIIDHashKey]);
 }
 
-- (void)testADIDAndIIDWereSet2 {
+- (void)DISABLED_testADIDAndIIDWereSet2 {
   // Set up the initial state with a valid iid, adid, and uuid.
   [_defaults setObject:@"test_uuid" forKey:FABInstallationUUIDKey];
   [_defaults setObject:@"test_adid" forKey:FABInstallationADIDKey];

--- a/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
@@ -30,7 +30,7 @@
   return [[self resourcePath] stringByAppendingPathComponent:name];
 }
 
-- (void)testCustomExceptionsNeedToBeSubmitted {
+- (void)DISABLED_testCustomExceptionsNeedToBeSubmitted {
   NSString *name = @"metadata_only_report";
 
   NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:name];

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -127,19 +127,19 @@
   return FIRCLSFileReadSections([self.errorBPath fileSystemRepresentation], true, nil);
 }
 
-- (void)testKeyValueWithNilKey {
+- (void)DISABLED_testKeyValueWithNilKey {
   FIRCLSUserLoggingRecordUserKeyValue(nil, @"some string value");
 
   XCTAssertEqual([self incrementalKeyValues].count, 0, @"");
 }
 
-- (void)testKeyValueWithNilValue {
+- (void)DISABLED_testKeyValueWithNilValue {
   FIRCLSUserLoggingRecordUserKeyValue(@"mykey", nil);
 
   XCTAssertEqual([[self incrementalKeyValues] count], 1, @"");
 }
 
-- (void)testKeyValueWithNilValueCompaction {
+- (void)DISABLED_testKeyValueWithNilValueCompaction {
   for (int i = 0; i < FIRCLSUserLoggingMaxKVEntries - 1; i++) {
     FIRCLSUserLoggingRecordUserKeyValue(@"mykey", [NSString stringWithFormat:@"myvalue%i", i]);
   }
@@ -149,13 +149,13 @@
                  @"Key with last value of nil was not removed in compaction.");
 }
 
-- (void)testKeyValueWithNilKeyAndValue {
+- (void)DISABLED_testKeyValueWithNilKeyAndValue {
   FIRCLSUserLoggingRecordUserKeyValue(nil, nil);
 
   XCTAssertEqual([[self incrementalKeyValues] count], 0, @"");
 }
 
-- (void)testKeyValueLog {
+- (void)DISABLED_testKeyValueLog {
   FIRCLSUserLoggingRecordUserKeyValue(@"mykey", @"some string value");
 
   NSArray* keyValues = [self incrementalKeyValues];
@@ -165,7 +165,7 @@
   XCTAssertEqualObjects(keyValues[0][@"value"], @"736f6d6520737472696e672076616c7565", @"");
 }
 
-- (void)testKeyValueLogSingleKeyCompaction {
+- (void)DISABLED_testKeyValueLogSingleKeyCompaction {
   for (NSUInteger i = 0; i < FIRCLSUserLoggingMaxKVEntries; ++i) {
     FIRCLSUserLoggingRecordUserKeyValue(
         @"mykey", [NSString stringWithFormat:@"some string value: %lu", (unsigned long)i]);
@@ -188,7 +188,7 @@
                         @"736f6d6520737472696e672076616c75653a203633", @"");
 }
 
-- (void)testKeyValueLogMoreThanMaxKeys {
+- (void)DISABLED_testKeyValueLogMoreThanMaxKeys {
   // we need to end up with max + 1 keys written
   for (NSUInteger i = 0; i <= _firclsContext.readonly->logging.userKVStorage.maxCount + 1; ++i) {
     NSString* key = [NSString stringWithFormat:@"key%lu", (unsigned long)i];
@@ -211,18 +211,18 @@
   XCTAssertEqual([compactedKeyValues count], 64, @"");
 }
 
-- (void)testEmptyKeysAndValues {
+- (void)DISABLED_testEmptyKeysAndValues {
   FIRCLSUserLoggingRecordUserKeysAndValues(@{});
   XCTAssertEqual([self incrementalKeyValues].count, 0, @"");
 }
 
-- (void)testKeysAndValuesWithNilValue {
+- (void)DISABLED_testKeysAndValuesWithNilValue {
   FIRCLSUserLoggingRecordUserKeysAndValues(@{@"mykey" : [NSNull null]});
 
   XCTAssertEqual([[self incrementalKeyValues] count], 1, @"");
 }
 
-- (void)testKeysAndValuesLog {
+- (void)DISABLED_testKeysAndValuesLog {
   NSDictionary* keysAndValues =
       @{@"mykey" : @"some string value", @"mykey2" : @"some string value 2"};
   FIRCLSUserLoggingRecordUserKeysAndValues(keysAndValues);
@@ -236,7 +236,7 @@
   XCTAssertEqualObjects(keyValues[1][@"value"], @"736f6d6520737472696e672076616c75652032", @"");
 }
 
-- (void)testKeysAndValuesLogKeyCompaction {
+- (void)DISABLED_testKeysAndValuesLogKeyCompaction {
   for (NSUInteger i = 0; i < FIRCLSUserLoggingMaxKVEntries; ++i) {
     NSString* value = [NSString stringWithFormat:@"some string value: %lu", (unsigned long)i];
     FIRCLSUserLoggingRecordUserKeysAndValues(@{@"mykey" : value});
@@ -259,7 +259,7 @@
                         @"736f6d6520737472696e672076616c75653a203633", @"");
 }
 
-- (void)testKeysAndValuesLogMoreThanMaxKeys {
+- (void)DISABLED_testKeysAndValuesLogMoreThanMaxKeys {
   NSUInteger keysAndValuesCount = _firclsContext.readonly->logging.userKVStorage.maxCount + 1;
   NSMutableDictionary* keysAndValuesToBeCompactedIn = [NSMutableDictionary dictionary];
 
@@ -291,7 +291,7 @@
   XCTAssertEqual([compactedKeyValues count], 64, @"");
 }
 
-- (void)testUserLogNil {
+- (void)DISABLED_testUserLogNil {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
   FIRCLSLog(nil);
@@ -300,7 +300,7 @@
   XCTAssertEqual([[self logAContents] count], 0, @"");
 }
 
-- (void)testLargeLogLine {
+- (void)DISABLED_testLargeLogLine {
   size_t strLength = 100 * 1024;  // Attempt to write 100k of data
   char* longLine = malloc(strLength + 1);
   memset(longLine, 'a', strLength);
@@ -318,7 +318,7 @@
                  "message: \"%@\"", message);
 }
 
-- (void)testUserLog {
+- (void)DISABLED_testUserLog {
   FIRCLSLog(@"some value");
 
   NSArray* array = [self logAContents];
@@ -327,7 +327,7 @@
   XCTAssertEqualObjects(array[0][@"log"][@"msg"], @"736f6d652076616c7565", @"");
 }
 
-- (void)testUserLogRotation {
+- (void)DISABLED_testUserLogRotation {
   // tune this carefully, based on max file size
   for (int i = 0; i < 969; ++i) {
     FIRCLSLog(@"some value %d", i);
@@ -340,7 +340,7 @@
   XCTAssertEqual([logB count], 1, @"");
 }
 
-- (void)testUserLogRotationBackToBeginning {
+- (void)DISABLED_testUserLogRotationBackToBeginning {
   // careful tuning needs to be done to make sure there's exactly one entry
   for (int i = 0; i < 1907; ++i) {
     FIRCLSLog(@"some value %d", i);
@@ -360,7 +360,7 @@
                         @"");  // "some value 1905"
 }
 
-- (void)testLoggedError {
+- (void)DISABLED_testLoggedError {
   NSError* error = [NSError errorWithDomain:@"My Custom Domain"
                                        code:-1
                                    userInfo:@{@"key1" : @"value", @"key2" : @"value2"}];
@@ -399,7 +399,7 @@
   XCTAssertEqualObjects(additionalEntries[0], entryOne, @"");
 }
 
-- (void)testWritingMaximumNumberOfLoggedErrors {
+- (void)DISABLED_testWritingMaximumNumberOfLoggedErrors {
   NSError* error = [NSError errorWithDomain:@"My Custom Domain"
                                        code:-1
                                    userInfo:@{@"key1" : @"value", @"key2" : @"value2"}];
@@ -429,7 +429,7 @@
   XCTAssertEqual(*_firclsContext.readonly->logging.errorStorage.entryCount, 2);
 }
 
-- (void)testLoggedErrorWithNullsInAdditionalInfo {
+- (void)DISABLED_testLoggedErrorWithNullsInAdditionalInfo {
   NSError* error = [NSError errorWithDomain:@"Domain" code:-1 userInfo:nil];
 
   FIRCLSUserLoggingRecordError(error, @{@"null-key" : [NSNull null]});

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOBinaryTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOBinaryTests.m
@@ -30,7 +30,7 @@
   return [NSURL fileURLWithPath:path];
 }
 
-- (void)testInstanceIdentifierForSingleArchdSYM {
+- (void)DISABLED_testInstanceIdentifierForSingleArchdSYM {
   FIRCLSMachOBinary* binary;
 
   binary = [[FIRCLSMachOBinary alloc] initWithURL:[self URLForResource:@"x86_64-executable"]];
@@ -39,7 +39,7 @@
                         @"");
 }
 
-- (void)testInstanceIdentifierForMultipleArchitectures {
+- (void)DISABLED_testInstanceIdentifierForMultipleArchitectures {
   FIRCLSMachOBinary* binary;
 
   binary = [[FIRCLSMachOBinary alloc] initWithURL:[self URLForResource:@"armv7-armv7s-executable"]];

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
@@ -42,7 +42,7 @@
   return archs;
 }
 
-- (void)testThinDSYM {
+- (void)DISABLED_testThinDSYM {
   FIRCLSdSYM* dSYM;
   NSString* path;
   NSArray* archs;
@@ -55,7 +55,7 @@
   XCTAssertEqualObjects(@"i386", [archs objectAtIndex:0], @"");
 }
 
-- (void)testFatDSYM {
+- (void)DISABLED_testFatDSYM {
   FIRCLSdSYM* dSYM;
   NSString* path;
   NSArray* archs;
@@ -69,7 +69,7 @@
   XCTAssertEqualObjects(@"armv7s", [archs objectAtIndex:1], @"");
 }
 
-- (void)testFatExecutable {
+- (void)DISABLED_testFatExecutable {
   FIRCLSMachOBinary* binary;
   NSString* path;
   NSArray* archs;
@@ -83,7 +83,7 @@
   XCTAssertEqualObjects(@"armv7s", [archs objectAtIndex:1], @"");
 }
 
-- (void)testArm64 {
+- (void)DISABLED_testArm64 {
   FIRCLSMachOBinary* binary;
   NSString* path;
   NSArray* archs;
@@ -98,7 +98,7 @@
   XCTAssertEqualObjects(@"armv7s", [archs objectAtIndex:2], @"");
 }
 
-- (void)testArmv7k {
+- (void)DISABLED_testArmv7k {
   FIRCLSMachOBinary* binary;
   NSString* path;
   NSArray* archs;
@@ -111,7 +111,7 @@
   XCTAssertEqualObjects(@"armv7k", [archs objectAtIndex:0], @"");
 }
 
-- (void)testReadMinimumWatchOSSDKRequirements {
+- (void)DISABLED_testReadMinimumWatchOSSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -132,7 +132,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testReadMinimumWatchOSSimulatorSDKRequirements {
+- (void)DISABLED_testReadMinimumWatchOSSimulatorSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -153,7 +153,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testReadMinimumTVOSSDKRequirements {
+- (void)DISABLED_testReadMinimumTVOSSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -174,7 +174,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testReadMinimumTVOSSimulatorSDKRequirements {
+- (void)DISABLED_testReadMinimumTVOSSimulatorSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -195,7 +195,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testLinkedDylibs {
+- (void)DISABLED_testLinkedDylibs {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -225,7 +225,7 @@
   XCTAssertEqualObjects([dylibs objectAtIndex:6], @"/usr/lib/libSystem.B.dylib", @"");
 }
 
-- (void)testReadMinimumiOSSDKRequirements {
+- (void)DISABLED_testReadMinimumiOSSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -246,7 +246,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testReadMinimumOSXSDKRequirements {
+- (void)DISABLED_testReadMinimumOSXSDKRequirements {
   FIRCLSMachOBinary* binary;
   FIRCLSMachOSlice* slice;
   NSString* path;
@@ -267,7 +267,7 @@
   XCTAssertEqual((uint32_t)0, version.bugfix, @"");
 }
 
-- (void)testReadx86_64Section {
+- (void)DISABLED_testReadx86_64Section {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"x86_64-executable"];
   struct FIRCLSMachOFile file;
 
@@ -288,7 +288,7 @@
   XCTAssert(ptr != NULL);
 }
 
-- (void)testReadArmv7kSection {
+- (void)DISABLED_testReadArmv7kSection {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"armv7k"];
   struct FIRCLSMachOFile file;
 
@@ -307,7 +307,7 @@
   XCTAssert(ptr != NULL);
 }
 
-- (void)testReadArm64Section {
+- (void)DISABLED_testReadArm64Section {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"armv7-armv7s-arm64.dylib"];
   struct FIRCLSMachOFile file;
 

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSdSYMTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSdSYMTests.m
@@ -22,7 +22,7 @@
   return [[NSBundle bundleForClass:[self class]] resourcePath];
 }
 
-- (void)testBundleIdAndExecutablePath {
+- (void)DISABLED_testBundleIdAndExecutablePath {
   FIRCLSdSYM* dSYM;
   NSString* path;
 
@@ -33,7 +33,7 @@
   XCTAssertTrue([[dSYM executablePath] hasSuffix:@"CrashTest"], @"");
 }
 
-- (void)testUUIDsInFatFile {
+- (void)DISABLED_testUUIDsInFatFile {
   FIRCLSdSYM* dSYM;
   NSString* path;
   NSMutableDictionary* uuids;

--- a/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
@@ -372,14 +372,14 @@ API_AVAILABLE(ios(14))
 
 #pragma mark - Diagnostic Handling
 
-- (void)testEmptyDiagnosticHandling {
+- (void)DISABLED_testEmptyDiagnosticHandling {
   FIRCLSMockMXDiagnosticPayload *emptyPayload = [self createEmptyDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ emptyPayload ]];
   XCTAssertFalse([self metricKitFileExistsInCurrentReport:YES fatalReport:NO],
                  "MetricKit report should not exist");
 }
 
-- (void)testCrashDiagnosticHandling {
+- (void)DISABLED_testCrashDiagnosticHandling {
   [self createUnsentFatalReport];
   FIRCLSMockMXDiagnosticPayload *crashPayload = [self createCrashDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ crashPayload ]];
@@ -420,7 +420,7 @@ API_AVAILABLE(ios(14))
   [self checkMetadata:metadata andThreads:threads];
 }
 
-- (void)testHangDiagnosticHandling {
+- (void)DISABLED_testHangDiagnosticHandling {
   FIRCLSMockMXDiagnosticPayload *hangPayload = [self createHangDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ hangPayload ]];
   XCTAssertTrue([self metricKitFileExistsInCurrentReport:YES fatalReport:NO],
@@ -446,7 +446,7 @@ API_AVAILABLE(ios(14))
   [self checkMetadata:metadata andThreads:threads];
 }
 
-- (void)testCPUExceptionDiagnosticHandling {
+- (void)DISABLED_testCPUExceptionDiagnosticHandling {
   FIRCLSMockMXDiagnosticPayload *cpuPayload = [self createCPUExceptionDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ cpuPayload ]];
   XCTAssertTrue([self metricKitFileExistsInCurrentReport:YES fatalReport:NO],
@@ -473,7 +473,7 @@ API_AVAILABLE(ios(14))
   [self checkMetadata:metadata andThreads:threads];
 }
 
-- (void)testDiskWriteExceptionDiagnosticHandling {
+- (void)DISABLED_testDiskWriteExceptionDiagnosticHandling {
   FIRCLSMockMXDiagnosticPayload *diskWritePayload =
       [self createDiskWriteExceptionDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ diskWritePayload ]];
@@ -501,7 +501,7 @@ API_AVAILABLE(ios(14))
   [self checkMetadata:metadata andThreads:threads];
 }
 
-- (void)testFullDiagnosticHandling {
+- (void)DISABLED_testFullDiagnosticHandling {
   [self createUnsentFatalReport];
   FIRCLSMockMXDiagnosticPayload *fullPayload = [self createFullDiagnosticPayload];
   [self.metricKitManager didReceiveDiagnosticPayloads:@[ fullPayload ]];
@@ -538,7 +538,7 @@ API_AVAILABLE(ios(14))
   XCTAssertNotNil(crashDictionary, "MetricKit event should include a crash diagnostic");
 }
 
-- (void)testPayloadWithMultipleCrashesHandling {
+- (void)DISABLED_testPayloadWithMultipleCrashesHandling {
   [self createUnsentFatalReport];
   FIRCLSMockMXDiagnosticPayload *payloadWithMultipleCrashes =
       [self createDiagnosticPayloadWithMultipleCrashes];
@@ -554,7 +554,7 @@ API_AVAILABLE(ios(14))
   XCTAssertNotNil(crashDictionary, "MetricKit event should include a crash diagnostic");
 }
 
-- (void)testMultiplePayloadsWithCrashesHandling {
+- (void)DISABLED_testMultiplePayloadsWithCrashesHandling {
   [self createUnsentFatalReport];
   FIRCLSMockMXDiagnosticPayload *crashPayload = [self createCrashDiagnosticPayload];
   FIRCLSMockMXDiagnosticPayload *hangPayload = [self createHangDiagnosticPayload];

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -98,6 +98,9 @@
 }
 
 - (void)tearDown {
+  dispatch_sync(self.existingReportManager.operationQueue.underlyingQueue, ^{
+                    // Drain queue.
+                });
   dispatch_sync(self.managerData.dispatchQueue, ^{
                     // Drain queue.
                 });

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -98,6 +98,9 @@
 }
 
 - (void)tearDown {
+  dispatch_sync(self.onDemandModel.operationQueue.underlyingQueue, ^{
+                    // Drain queue.
+                });
   self.onDemandModel = nil;
   [[NSFileManager defaultManager] removeItemAtPath:self.fileManager.rootPath error:nil];
   [super tearDown];

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -98,6 +98,9 @@
 }
 
 - (void)tearDown {
+  dispatch_sync(self.managerData.dispatchQueue, ^{
+                    // Drain queue.
+                });
   dispatch_sync(self.onDemandModel.operationQueue.underlyingQueue, ^{
                     // Drain queue.
                 });

--- a/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
@@ -68,7 +68,7 @@
 
 #if TARGET_OS_IPHONE
 #else
-- (void)testExceptionSymbolication {
+- (void)DISABLED_testExceptionSymbolication {
   // Setup a resolver that will work for the contents of the file
   FIRCLSMockSymbolResolver *resolver = [[FIRCLSMockSymbolResolver alloc] init];
 

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -39,7 +39,7 @@
 }
 
 /// Attempt sending a proto report to the reporting endpoint
-- (void)testSendProtoReport {
+- (void)DISABLED_testSendProtoReport {
   NSString *minCrash =
       [[FIRCLSReportAdapterTests resourcePath] stringByAppendingPathComponent:@"bare_min_crash"];
 
@@ -58,7 +58,7 @@
 }
 
 /// This test is useful for testing the binary output of the proto message
-- (void)testProtoOutput {
+- (void)DISABLED_testProtoOutput {
   NSString *minCrash =
       [[FIRCLSReportAdapterTests resourcePath] stringByAppendingPathComponent:@"bare_min_crash"];
 
@@ -84,7 +84,7 @@
 
 /// It is important that a crash does not occur when reading persisted crash files
 /// Verify various invalid input cases.
-- (void)testInvalidRecordCases {
+- (void)DISABLED_testInvalidRecordCases {
   id adapter __unused = [[FIRCLSReportAdapter alloc] initWithPath:@"nonExistentPath"
                                                       googleAppId:@"appID"
                                                    installIDModel:self.installIDModel];
@@ -99,11 +99,11 @@
   id identity2 __unused = [[FIRCLSRecordIdentity alloc] initWithDict:emptyDict];
 }
 
-- (void)testCorruptMetadataCLSRecordFile {
+- (void)DISABLED_testCorruptMetadataCLSRecordFile {
   id adapter __unused = [self adapterForCorruptMetadata];
 }
 
-- (void)testRecordMetadataFile {
+- (void)DISABLED_testRecordMetadataFile {
   FIRCLSReportAdapter *adapter = [self adapterForValidMetadata];
 
   // Verify identity
@@ -117,7 +117,7 @@
   XCTAssertTrue([adapter.application.display_version isEqualToString:@"1.0"]);
 }
 
-- (void)testReportProto {
+- (void)DISABLED_testReportProto {
   FIRCLSReportAdapter *adapter = [self adapterForAllCrashes];
   google_crashlytics_Report report = [adapter protoReport];
   XCTAssertTrue([self isPBData:report.sdk_version equalToString:adapter.identity.build_version]);

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -188,7 +188,7 @@
 }
 
 #pragma mark - File/Directory Handling
-- (void)testCreatesNewReportOnStart {
+- (void)DISABLED_testCreatesNewReportOnStart {
   FBLPromise<NSNumber *> *promise = [self->_reportManager startWithProfilingMark:0];
 
   XCTestExpectation *expectation =
@@ -264,7 +264,7 @@
   [self processReports:send andExpectReports:YES];
 }
 
-- (void)testExistingUnimportantReportOnStart {
+- (void)DISABLED_testExistingUnimportantReportOnStart {
   // Create a report representing the last run and put it in place
   [self createActiveReport];
 
@@ -280,7 +280,7 @@
   XCTAssertEqual([self.uploadReportArray count], 0);
 }
 
-- (void)testMetricKitResolvesPromiseIfNoDiagnostics {
+- (void)DISABLED_testMetricKitResolvesPromiseIfNoDiagnostics {
   // Create a report representing the last run and put it in place, then create a crashed file
   // marker and MetricKit diagnostic file so that MetricKit manager doesn't resolve the promise
   // immediately.
@@ -301,7 +301,7 @@
   [self waitForPromise:[self startReportManagerWithDataCollectionEnabled:YES] withTimeout:4];
 }
 
-- (void)testExistingUnimportantReportOnStartWithDataCollectionDisabled {
+- (void)DISABLED_testExistingUnimportantReportOnStartWithDataCollectionDisabled {
   // create a report and put it in place
   [self createActiveReport];
 
@@ -314,7 +314,7 @@
   XCTAssertEqual([self.uploadReportArray count], 0);
 }
 
-- (void)testExistingReportOnStart {
+- (void)DISABLED_testExistingReportOnStart {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -337,7 +337,7 @@
   XCTAssertEqualObjects(self.prepareAndSubmitReportArray[0][@"urgent"], @(NO));
 }
 
-- (void)testExistingReportOnStartWithDataCollectionDisabledThenEnabled {
+- (void)DISABLED_testExistingReportOnStartWithDataCollectionDisabledThenEnabled {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -367,7 +367,7 @@
   XCTAssertEqualObjects(self.prepareAndSubmitReportArray[0][@"urgent"], @(NO));
 }
 
-- (void)testExistingReportOnStartWithDataCollectionDisabledAndSend {
+- (void)DISABLED_testExistingReportOnStartWithDataCollectionDisabledAndSend {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -399,7 +399,7 @@
   [self processReports:YES andExpectReports:NO];
 }
 
-- (void)testExistingReportOnStartWithDataCollectionDisabledAndDelete {
+- (void)DISABLED_testExistingReportOnStartWithDataCollectionDisabledAndDelete {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -425,7 +425,7 @@
   XCTAssertEqual([self.prepareAndSubmitReportArray count], 0);
 }
 
-- (void)testExistingUrgentReportOnStart {
+- (void)DISABLED_testExistingUrgentReportOnStart {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -448,7 +448,7 @@
   XCTAssertEqualObjects(self.prepareAndSubmitReportArray[0][@"urgent"], @(YES));
 }
 
-- (void)testExistingUrgentReportOnStartWithDataCollectionDisabled {
+- (void)DISABLED_testExistingUrgentReportOnStartWithDataCollectionDisabled {
   // create a report and put it in place
   FIRCLSInternalReport *report = [self createActiveReport];
 
@@ -480,7 +480,7 @@
   XCTAssertEqualObjects(self.prepareAndSubmitReportArray[0][@"urgent"], @(NO));
 }
 
-- (void)testFilesLeftInProcessing {
+- (void)DISABLED_testFilesLeftInProcessing {
   // put report in processing
   FIRCLSInternalReport *report = [self createActiveReport];
   XCTAssert([_fileManager createDirectoryAtPath:_fileManager.processingPath]);
@@ -501,7 +501,7 @@
  * reports these are not shown to the developer, but they are uploaded / deleted upon
  * calling send / delete.
  */
-- (void)testFilesLeftInProcessingWithDataCollectionDisabled {
+- (void)DISABLED_testFilesLeftInProcessingWithDataCollectionDisabled {
   // Put report in processing.
   FIRCLSInternalReport *report = [self createActiveReport];
   XCTAssert([_fileManager createDirectoryAtPath:_fileManager.processingPath]);
@@ -528,7 +528,7 @@
   XCTAssertEqualObjects(self.prepareAndSubmitReportArray[0][@"urgent"], @(NO));
 }
 
-- (void)testFilesLeftInPrepared {
+- (void)DISABLED_testFilesLeftInPrepared {
   // Drop a phony multipart-mime file in here, with non-zero contents.
   XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
   NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
@@ -554,7 +554,7 @@
  * reports these are not shown to the developer, but they are uploaded / deleted upon
  * calling send / delete.
  */
-- (void)testFilesLeftInPreparedWithDataCollectionDisabled {
+- (void)DISABLED_testFilesLeftInPreparedWithDataCollectionDisabled {
   // drop a phony multipart-mime file in here, with non-zero contents
   XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
   NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
@@ -586,7 +586,7 @@
   XCTAssertEqualObjects(self.uploadReportArray[0][@"path"], path);
 }
 
-- (void)testSuccessfulSubmission {
+- (void)DISABLED_testSuccessfulSubmission {
   // drop a phony multipart-mime file in here, with non-zero contents
   XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
   NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
@@ -612,7 +612,7 @@
   // lol
 }
 
-- (void)testLogInvalidJSONAnalyticsEvents {
+- (void)DISABLED_testLogInvalidJSONAnalyticsEvents {
   NSDictionary *eventAsDict = @{
     @"price" : @(NAN),
     @"count" : @(INFINITY),

--- a/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
@@ -91,7 +91,7 @@ NSString *const TestEndpoint = @"https://reports.crashlytics.com";
 
 #pragma mark - Tests
 
-- (void)testPrepareReport {
+- (void)DISABLED_testPrepareReport {
   NSString *path = [self.fileManager.activePath stringByAppendingPathComponent:@"pkg_uuid"];
   FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:path];
   self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
@@ -106,15 +106,15 @@ NSString *const TestEndpoint = @"https://reports.crashlytics.com";
       [self.fileManager.moveItemAtPath_destDir containsString:self.fileManager.preparedPath]);
 }
 
-- (void)testUploadPackagedReportWithPath {
+- (void)DISABLED_testUploadPackagedReportWithPath {
   [self runUploadPackagedReportWithUrgency:NO];
 }
 
-- (void)testUrgentUploadPackagedReportWithPath {
+- (void)DISABLED_testUrgentUploadPackagedReportWithPath {
   [self runUploadPackagedReportWithUrgency:YES];
 }
 
-- (void)testUploadPackagedReportWithoutDataCollectionToken {
+- (void)DISABLED_testUploadPackagedReportWithoutDataCollectionToken {
   [self setUpForUpload];
 
   [self.uploader uploadPackagedReportAtPath:[self packagePath] dataCollectionToken:nil asUrgent:NO];
@@ -123,7 +123,7 @@ NSString *const TestEndpoint = @"https://reports.crashlytics.com";
   XCTAssertNil(self.mockDataTransport.sendDataEvent_event);
 }
 
-- (void)testUploadPackagedReportNotGDTWritten {
+- (void)DISABLED_testUploadPackagedReportNotGDTWritten {
   [self setUpForUpload];
   self.mockDataTransport.sendDataEvent_wasWritten = NO;
 
@@ -133,7 +133,7 @@ NSString *const TestEndpoint = @"https://reports.crashlytics.com";
   XCTAssertNil(self.fileManager.removedItemAtPath_path);
 }
 
-- (void)testUploadPackagedReportGDTError {
+- (void)DISABLED_testUploadPackagedReportGDTError {
   [self setUpForUpload];
   self.mockDataTransport.sendDataEvent_error = [[NSError alloc] initWithDomain:@"domain"
                                                                           code:1

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -86,7 +86,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   _settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager appIDModel:_appIDModel];
 }
 
-- (void)testDefaultSettings {
+- (void)DISABLED_testDefaultSettings {
   XCTAssertEqual(self.settings.isCacheExpired, YES);
 
   // Default to an hour
@@ -150,7 +150,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self waitForExpectations:@[ self.fileManager.removeExpectation ] timeout:1];
 }
 
-- (void)testActivatedSettingsCached {
+- (void)DISABLED_testActivatedSettingsCached {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsActivated error:&error];
   XCTAssertNil(error, "%@", error);
@@ -175,7 +175,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.onDemandBackoffStepDuration, 6);
 }
 
-- (void)testInverseDefaultSettingsCached {
+- (void)DISABLED_testInverseDefaultSettingsCached {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsInverse error:&error];
   XCTAssertNil(error, "%@", error);
@@ -200,7 +200,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.onDemandBackoffStepDuration, 9);
 }
 
-- (void)testCacheExpiredFromTTL {
+- (void)DISABLED_testCacheExpiredFromTTL {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsActivated error:&error];
   XCTAssertNil(error, "%@", error);
@@ -233,7 +233,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 128000);
 }
 
-- (void)testCacheExpiredFromBuildInstanceID {
+- (void)DISABLED_testCacheExpiredFromBuildInstanceID {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsActivated error:&error];
   XCTAssertNil(error, "%@", error);
@@ -267,7 +267,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 128000);
 }
 
-- (void)testCacheExpiredFromAppVersion {
+- (void)DISABLED_testCacheExpiredFromAppVersion {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsActivated error:&error];
   XCTAssertNil(error, "%@", error);
@@ -302,7 +302,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 128000);
 }
 
-- (void)testGoogleAppIDChanged {
+- (void)DISABLED_testGoogleAppIDChanged {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsInverse error:&error];
   XCTAssertNil(error, "%@", error);
@@ -334,7 +334,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 // This is a weird case where we got settings, but never created a cache key for it. We are
 // treating this as if the cache was invalid and re-fetching in this case.
-- (void)testActivatedSettingsMissingCacheKey {
+- (void)DISABLED_testActivatedSettingsMissingCacheKey {
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsActivated error:&error];
   XCTAssertNil(error, "%@", error);
@@ -366,7 +366,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 // These tests are partially to make sure the SDK doesn't crash when it
 // has corrupted settings.
-- (void)testCorruptCache {
+- (void)DISABLED_testCorruptCache {
   // First write and load a good settings file
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsInverse error:&error];
@@ -395,7 +395,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
 }
 
-- (void)testCorruptCacheKey {
+- (void)DISABLED_testCorruptCacheKey {
   // First write and load a good settings file
   NSError *error = nil;
   [self writeSettings:FIRCLSTestSettingsInverse error:&error];
@@ -430,7 +430,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.onDemandBackoffStepDuration, 6);
 }
 
-- (void)testNewReportEndpointSettings {
+- (void)DISABLED_testNewReportEndpointSettings {
   NSString *settingsJSON =
       @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"report_upload_variant\":2}}";
 
@@ -444,7 +444,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   NSLog(@"[Debug Log] %@", self.settings.settingsDictionary);
 }
 
-- (void)testLegacyReportEndpointSettings {
+- (void)DISABLED_testLegacyReportEndpointSettings {
   NSString *settingsJSON =
       @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"report_upload_variant\":1}}";
 
@@ -456,7 +456,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertNil(error, "%@", error);
 }
 
-- (void)testLegacyReportEndpointSettingsWithNonExistentKey {
+- (void)DISABLED_testLegacyReportEndpointSettingsWithNonExistentKey {
   NSString *settingsJSON = @"{\"settings_version\":3,\"cache_duration\":60}";
 
   NSError *error = nil;
@@ -467,7 +467,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertNil(error, "%@", error);
 }
 
-- (void)testLegacyReportEndpointSettingsWithUnknownValue {
+- (void)DISABLED_testLegacyReportEndpointSettingsWithUnknownValue {
   NSString *newEndpointJSON =
       @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"report_upload_variant\":xyz}}";
 

--- a/Crashlytics/UnitTests/FIRCLSSymbolResolverTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSymbolResolverTests.m
@@ -38,14 +38,14 @@
   return [[self resourcePath] stringByAppendingPathComponent:name];
 }
 
-- (void)testLoadingBinaryImagesWithInvalidFile {
+- (void)DISABLED_testLoadingBinaryImagesWithInvalidFile {
   FIRCLSSymbolResolver* resolver = [[FIRCLSSymbolResolver alloc] init];
 
   XCTAssertFalse([resolver loadBinaryImagesFromFile:nil]);
   XCTAssertFalse([resolver loadBinaryImagesFromFile:@""]);
 }
 
-- (void)testLoadingBinaryImagesWithNullBaseValue {
+- (void)DISABLED_testLoadingBinaryImagesWithNullBaseValue {
   FIRCLSSymbolResolver* resolver = [[FIRCLSSymbolResolver alloc] init];
 
   NSString* binaryImagePath =
@@ -54,7 +54,7 @@
   XCTAssert([resolver loadBinaryImagesFromFile:binaryImagePath]);
 }
 
-- (void)testLoadingBinaryImagesWithMissingBaseValue {
+- (void)DISABLED_testLoadingBinaryImagesWithMissingBaseValue {
   FIRCLSSymbolResolver* resolver = [[FIRCLSSymbolResolver alloc] init];
 
   NSString* binaryImagePath = [self pathForResource:@"binary_images_missing_base_entry.clsrecord"];

--- a/Crashlytics/UnitTests/FIRCLSSymbolicationOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSymbolicationOperationTests.m
@@ -34,7 +34,7 @@
   [super tearDown];
 }
 
-- (void)testOperation {
+- (void)DISABLED_testOperation {
   FIRCLSMockSymbolResolver* resolver = [[FIRCLSMockSymbolResolver alloc] init];
 
   FIRStackFrame* frame = nil;

--- a/Crashlytics/UnitTests/FIRCLSUserDefaultsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUserDefaultsTests.m
@@ -58,7 +58,7 @@
 
 #pragma mark - dictionary representation tests
 
-- (void)testDictionaryRepresentation {
+- (void)DISABLED_testDictionaryRepresentation {
   [_userDefaults removeAllObjects];
 
   NSDictionary* expectedTestDict =
@@ -79,14 +79,14 @@
 
 #pragma mark - remove tests
 
-- (void)testRemoveObjectForKey {
+- (void)DISABLED_testRemoveObjectForKey {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
 
   [_userDefaults removeObjectForKey:_testKey1];
   XCTAssertNil([_userDefaults objectForKey:_testKey1], @"");
 }
 
-- (void)testRemoveAllObjects {
+- (void)DISABLED_testRemoveAllObjects {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
   [_userDefaults setObject:_testString2 forKey:_testKey2];
   [_userDefaults setObject:_testString3 forKey:_testKey3];
@@ -100,57 +100,57 @@
 
 #pragma mark - set/fetch object tests
 
-- (void)testSaveObject {
+- (void)DISABLED_testSaveObject {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
   XCTAssertEqualObjects([_userDefaults objectForKey:_testKey1], _testString1, @"");
 }
 
-- (void)testSaveBool {
+- (void)DISABLED_testSaveBool {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
   XCTAssertEqualObjects([_userDefaults stringForKey:_testKey1], _testString1, @"");
 }
 
-- (void)testSaveString {
+- (void)DISABLED_testSaveString {
   [_userDefaults setBool:_testBool forKey:_testKey1];
   XCTAssertEqual([_userDefaults boolForKey:_testKey1], _testBool, @"");
 }
 
-- (void)testSaveInteger {
+- (void)DISABLED_testSaveInteger {
   [_userDefaults setInteger:_testInteger forKey:_testKey1];
   XCTAssertEqual([_userDefaults integerForKey:_testKey1], _testInteger, @"");
 }
 
 #pragma mark - unset/wrong type object tests
 
-- (void)testLoadObjectUnset {
+- (void)DISABLED_testLoadObjectUnset {
   XCTAssertNil([_userDefaults objectForKey:_testKey1], @"");
 }
 
-- (void)testLoadStringUnset {
+- (void)DISABLED_testLoadStringUnset {
   XCTAssertNil([_userDefaults stringForKey:_testKey1], @"");
 }
 
-- (void)testLoadStringWrongType {
+- (void)DISABLED_testLoadStringWrongType {
   [_userDefaults setObject:[NSNumber numberWithInt:100] forKey:_testKey1];
   XCTAssertNotNil([_userDefaults objectForKey:_testKey1], @"");
   XCTAssertNil([_userDefaults stringForKey:_testKey1], @"");
 }
 
-- (void)testLoadBoolUnset {
+- (void)DISABLED_testLoadBoolUnset {
   XCTAssertFalse([_userDefaults boolForKey:_testKey1], @"");
 }
 
-- (void)testLoadBoolWrongType {
+- (void)DISABLED_testLoadBoolWrongType {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
   XCTAssertNotNil([_userDefaults objectForKey:_testKey1], @"");
   XCTAssertFalse([_userDefaults boolForKey:_testKey1], @"");
 }
 
-- (void)testLoadIntegerUnset {
+- (void)DISABLED_testLoadIntegerUnset {
   XCTAssertEqual([_userDefaults integerForKey:_testKey1], 0, @"");
 }
 
-- (void)testLoadIntegerWrongType {
+- (void)DISABLED_testLoadIntegerWrongType {
   [_userDefaults setObject:_testString1 forKey:_testKey1];
   XCTAssertNotNil([_userDefaults objectForKey:_testKey1], @"");
   XCTAssertEqual([_userDefaults integerForKey:_testKey1], 0, @"");
@@ -158,7 +158,7 @@
 
 #pragma mark - NSUserDefaults migration
 
-- (void)testMigrateFromNSUserDefaults {
+- (void)DISABLED_testMigrateFromNSUserDefaults {
   [[NSUserDefaults standardUserDefaults] setObject:_testString1 forKey:_testKey1];
   [[NSUserDefaults standardUserDefaults] setObject:_testString2 forKey:_testKey2];
   [[NSUserDefaults standardUserDefaults] setBool:_testBool forKey:_testKey3];
@@ -171,7 +171,7 @@
   XCTAssertEqual([_userDefaults boolForKey:_testKey3], _testBool, @"");
 }
 
-- (void)testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyExistsInNSUserDefaults {
+- (void)DISABLED_testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyExistsInNSUserDefaults {
   [[NSUserDefaults standardUserDefaults] setObject:_testString1 forKey:_testKey1];
 
   // Read object and migrate to FIRCLSUserDefaults
@@ -183,14 +183,14 @@
                         [[FIRCLSUserDefaults standardUserDefaults] objectForKey:_testKey1]);
 }
 
-- (void)testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyExistsInFIRCLSUserDefaults {
+- (void)DISABLED_testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyExistsInFIRCLSUserDefaults {
   [[FIRCLSUserDefaults standardUserDefaults] setObject:_testString1 forKey:_testKey1];
   id readObject = [[FIRCLSUserDefaults standardUserDefaults]
       objectForKeyByMigratingFromNSUserDefaults:_testKey1];
   XCTAssertEqualObjects(readObject, _testString1);
 }
 
-- (void)testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyDoesNotExist {
+- (void)DISABLED_testObjectForKeyByMigratingFromNSUserDefaultsWhenKeyDoesNotExist {
   XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:_testKey1]);
   XCTAssertEqualObjects([[NSUserDefaults standardUserDefaults] objectForKey:_testKey1],
                         [[FIRCLSUserDefaults standardUserDefaults]
@@ -198,7 +198,7 @@
 }
 
 #pragma mark - Serialization tests
-- (void)testSynchronize {
+- (void)DISABLED_testSynchronize {
   [_userDefaults setBool:_testBool forKey:_testKey1];
   [_userDefaults setInteger:_testInteger forKey:_testKey4];
   [_userDefaults setObject:_testString2 forKey:_testKey2];
@@ -213,7 +213,7 @@
   XCTAssertEqualObjects([readValue objectForKey:_testKey3], _testString3, @"");
 }
 
-- (void)testSynchronizeOnlyWritesOnChanges {
+- (void)DISABLED_testSynchronizeOnlyWritesOnChanges {
   // test using the private synchronizeWroteToDisk method
 
   [_userDefaults setBool:_testBool forKey:_testKey1];
@@ -251,7 +251,7 @@
 }
 
 #pragma mark - Directory URL tests
-- (void)testGetDirectoryUrl {
+- (void)DISABLED_testGetDirectoryUrl {
 // For the simulator, on tvOS and watchOS can't write to disk
 #if TARGET_OS_SIMULATOR && TARGET_OS_IPHONE
   NSURL* baseURL = [NSURL URLWithString:@"/my/base/dir"];

--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -37,7 +37,7 @@
   [super tearDown];
 }
 
-- (void)testHexFromByte {
+- (void)DISABLED_testHexFromByte {
   char output[2] = {0, 0};
 
   FIRCLSHexFromByte('A', output);
@@ -46,7 +46,7 @@
   XCTAssertEqual(output[1], '1', @"");
 }
 
-- (void)testHexFromByteForNotPrintableCharacter {
+- (void)DISABLED_testHexFromByteForNotPrintableCharacter {
   char output[2] = {0, 0};
 
   FIRCLSHexFromByte(0xd0, output);
@@ -55,7 +55,7 @@
   XCTAssertEqual(output[1], '0', @"");
 }
 
-- (void)testHexToString {
+- (void)DISABLED_testHexToString {
   const uint8_t bytes[8] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
 
   char string[(sizeof(bytes) * 2) + 1];
@@ -67,7 +67,7 @@
   XCTAssertEqualObjects([NSString stringWithUTF8String:string], @"6162636465666768", @"");
 }
 
-- (void)testHexToStringWithNonPrintableCharacters {
+- (void)DISABLED_testHexToStringWithNonPrintableCharacters {
   const uint8_t bytes[4] = {0x52, 0xd0, 0x4e, 0x1f};
 
   char string[(sizeof(bytes) * 2) + 1];
@@ -77,7 +77,7 @@
   XCTAssertEqualObjects([NSString stringWithUTF8String:string], @"52d04e1f", @"");
 }
 
-- (void)testRedactUUIDWithExpectedPattern {
+- (void)DISABLED_testRedactUUIDWithExpectedPattern {
   const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
                          "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - "
                          "DeviceType: iPhone SE (2nd generation)";
@@ -95,7 +95,7 @@
   XCTAssertEqualObjects(actual, expected);
 }
 
-- (void)testRedactUUIDWithMalformedPattern {
+- (void)DISABLED_testRedactUUIDWithMalformedPattern {
   const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
                          "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
   size_t len = strlen(readonly);
@@ -111,7 +111,7 @@
   XCTAssertEqualObjects(actual, expected);
 }
 
-- (void)testRedactUUIDWithoutUUID {
+- (void)DISABLED_testRedactUUIDWithoutUUID {
   const char* readonly = "Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
   size_t len = strlen(readonly);
   char message[len];
@@ -125,7 +125,7 @@
   XCTAssertEqualObjects(actual, expected);
 }
 
-- (void)testRedactUUIDWithNull {
+- (void)DISABLED_testRedactUUIDWithNull {
   char* message = NULL;
   XCTAssertNoThrow(FIRCLSRedactUUID(message));
 }

--- a/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
+++ b/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
@@ -81,7 +81,7 @@
 }
 
 #pragma mark - Public Getter Methods
-- (void)testPropertiesFromMetadatFile {
+- (void)DISABLED_testPropertiesFromMetadatFile {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   XCTAssertEqualObjects(@"772929a7f21f4ad293bb644668f257cd", report.reportID);
@@ -89,7 +89,7 @@
 }
 
 #pragma mark - Public Setter Methods
-- (void)testSetUserID {
+- (void)DISABLED_testSetUserID {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   [report setUserID:@"12345-6"];
@@ -106,7 +106,7 @@
   XCTAssertEqualObjects(entries[0][@"kv"][@"value"], FIRCLSFileHexEncodeString("12345-6"), @"");
 }
 
-- (void)testClearUserID {
+- (void)DISABLED_testClearUserID {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   // Add a user ID
@@ -129,7 +129,7 @@
   XCTAssertEqual([entries count], 0, @"");
 }
 
-- (void)testCustomKeysNoExisting {
+- (void)DISABLED_testCustomKeysNoExisting {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   [report setCustomValue:@"hello" forKey:@"mykey"];
@@ -160,7 +160,7 @@
   XCTAssertEqualObjects(entries[3][@"kv"][@"value"], FIRCLSFileHexEncodeString("10"), @"");
 }
 
-- (void)testCustomKeysWithExisting {
+- (void)DISABLED_testCustomKeysWithExisting {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"ios_all_files_crash"];
 
   [report setCustomValue:@"hello" forKey:@"mykey"];
@@ -191,7 +191,7 @@
   XCTAssertEqualObjects(entries[4][@"kv"][@"value"], FIRCLSFileHexEncodeString("10"), @"");
 }
 
-- (void)testClearCustomKeys {
+- (void)DISABLED_testClearCustomKeys {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   // Add keys
@@ -230,7 +230,7 @@
   XCTAssertEqual([entries count], 0, @"");
 }
 
-- (void)testCustomKeysLimits {
+- (void)DISABLED_testCustomKeysLimits {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"ios_all_files_crash"];
 
   // Write a bunch of keys and values
@@ -254,7 +254,7 @@
   XCTAssertEqual(entriesC.count, 64, @"");
 }
 
-- (void)testLogsNoExisting {
+- (void)DISABLED_testLogsNoExisting {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   [report log:@"Normal log without formatting"];
@@ -272,7 +272,7 @@
                         @"");
 }
 
-- (void)testLogsWithExisting {
+- (void)DISABLED_testLogsWithExisting {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"ios_all_files_crash"];
 
   [report log:@"Normal log without formatting"];
@@ -290,7 +290,7 @@
                         @"");
 }
 
-- (void)testLogLimits {
+- (void)DISABLED_testLogLimits {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   for (int i = 0; i < 2000; i++) {

--- a/Crashlytics/UnitTests/FIRExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRExceptionModelTests.m
@@ -23,7 +23,7 @@
 
 @implementation FIRExceptionModelTests
 
-- (void)testBasicOwnership {
+- (void)DISABLED_testBasicOwnership {
   NSArray *stackTrace = @[
     [FIRStackFrame stackFrameWithSymbol:@"CrashyFunc" file:@"AppLib.m" line:504],
     [FIRStackFrame stackFrameWithSymbol:@"ApplicationMain" file:@"AppleLib" line:1],
@@ -46,7 +46,7 @@
   XCTAssertEqualObjects(model.stackTrace[2].fileName, @"main.m");
 }
 
-- (void)testMutableArrayOwnership {
+- (void)DISABLED_testMutableArrayOwnership {
   NSMutableArray<FIRStackFrame *> *stackTrace = [[NSMutableArray alloc] initWithArray:@[
     [FIRStackFrame stackFrameWithSymbol:@"CrashyFunc" file:@"AppLib.m" line:504],
     [FIRStackFrame stackFrameWithSymbol:@"ApplicationMain" file:@"AppleLib" line:1],

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -59,7 +59,7 @@
   [[NSFileManager defaultManager] removeItemAtPath:self.fileManager.rootPath error:nil];
 }
 
-- (void)testWrittenCLSRecordFile {
+- (void)DISABLED_testWrittenCLSRecordFile {
   NSArray *stackTrace = @[
     [FIRStackFrame stackFrameWithSymbol:@"CrashyFunc" file:@"AppLib.m" line:504],
     [FIRStackFrame stackFrameWithSymbol:@"ApplicationMain" file:@"AppleLib" line:1],

--- a/Crashlytics/UnitTests/FIRStackFrameTests.m
+++ b/Crashlytics/UnitTests/FIRStackFrameTests.m
@@ -22,7 +22,7 @@
 
 @implementation FIRStackFrameTests
 
-- (void)testBasicSymbolicatedCheck {
+- (void)DISABLED_testBasicSymbolicatedCheck {
   FIRStackFrame *stackFrame = [FIRStackFrame stackFrameWithSymbol:@"SYMBOL"
                                                              file:@"FILE"
                                                              line:54321];
@@ -31,7 +31,7 @@
   XCTAssertEqual(stackFrame.lineNumber, 54321);
 }
 
-- (void)testOwnership {
+- (void)DISABLED_testOwnership {
   NSString *symbol = @"SYMBOL";
   NSString *file = @"FILE";
   FIRStackFrame *stackFrame = [FIRStackFrame stackFrameWithSymbol:symbol file:file line:54321];
@@ -42,7 +42,7 @@
   XCTAssertEqual(stackFrame.lineNumber, 54321);
 }
 
-- (void)testIntUIntConversion {
+- (void)DISABLED_testIntUIntConversion {
   FIRStackFrame *stackFrame = [FIRStackFrame stackFrameWithSymbol:@"SYMBOL" file:@"FILE" line:100];
   XCTAssertEqual(stackFrame.lineNumber, 100);
 
@@ -52,7 +52,7 @@
   XCTAssertEqual(stackFrame2.lineNumber, 4294967196);
 }
 
-- (void)testDescription {
+- (void)DISABLED_testDescription {
   FIRStackFrame *stackFrame = [FIRStackFrame stackFrameWithSymbol:@"FIRStackFrameTests"
                                                              file:@"testDescription"
                                                              line:35];

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -47,6 +47,9 @@ args=(
   "-configuration" "Debug"
   # The generated workspace.
   "-workspace" "gen/$pod/$pod.xcworkspace"
+  # TODO(ncooke3): Revert.
+  # Run each test multiple times.
+  "-test-iterations" "1000"
   # Specify the app if all test should run. Otherwise, specify the test scheme.
   "-scheme" "$scheme"
   # Specify Catalyst.

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -49,7 +49,7 @@ args=(
   "-workspace" "gen/$pod/$pod.xcworkspace"
   # TODO(ncooke3): Revert.
   # Run each test multiple times.
-  "-test-iterations" "1000"
+  "-test-iterations" "100"
   # Specify the app if all test should run. Otherwise, specify the test scheme.
   "-scheme" "$scheme"
   # Specify Catalyst.


### PR DESCRIPTION
Locally, I was able to run see the flaky failures when running setting `-test-iterations 1000`.

My hunch is this can be fixed by draining the operation queue between tests. Unfortunately, the tests set some local state I
couldn't figure out how to reset so I'm run against a clean GHA container in each commit.

#no-changelog