### PR TITLE
[v9] Update pinned minor versions for podspecs

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.tvos.weak_framework = 'DeviceCheck'
 
   s.dependency 'FirebaseCore', '~> 9.0'
-  s.dependency 'PromisesObjC', '~> 2.0'
+  s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
 
   s.pod_target_xcconfig = {

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'FirebaseInstallations', '~> 9.0'
-  s.dependency 'PromisesObjC', '~> 2.0'
+  s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleDataTransport', '~> 9.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'nanopb', '~> 2.30908.0'

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
 
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 9.0'
-  s.dependency 'PromisesObjC', '~> 2.0'
+  s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.7'
 

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.dependency 'GoogleDataTransport', '~> 9.1'
   # TODO: Revisit this dependency
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'
-  s.dependency 'SwiftProtobuf', '~> 1.0'
+  s.dependency 'SwiftProtobuf', '~> 1.19'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',


### PR DESCRIPTION
### Context
- Follow-up to #9677
- Bumped `PromisesObjC` to 2.**1**
- Bumped `SwiftProtobuf` to 1.**19**

### Workflow
1. Get the latest `zip` build and inspect its versioned dependency chart in the README
2. `cd` to `firebase-ios-sdk` and grep for each dependency:
     ```console
     git grep 'DEPENDENCY' *.podspec *.podspec.json  
     ``` 
3. If there is a spec dependency that needs bumping: 
    Examples for `PromisesObjC` bumping from `2.0` to `2.1`:
    ```console
    grep -rl "'PromisesObjC', '~> 2.0'" *.podspec | xargs sed -i "" "s/'PromisesObjC', '~> 2.0'/'PromisesObjC', '~> 2.1'/g"
    ```


#no-changelog