### PR TITLE
[v9] Cherry-pick Firestore build fix for Xcode 13.3.1 into `release-9.0`

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,7 +1,5 @@
-# Unreleased
-- [fixed] Fixed build errors in Xcode 13.3.1 (#9702).
-
 # v9.0.0
+- [fixed] Fixed build errors in Xcode 13.3.1 (#9702).
 - [fixed] **Breaking change:** Fixed an issue where returning `nil` from the
   update closure when running a transaction caused a crash in Swift by removing
   the auto-generated `async throw`ing method from the `FirebaseFirestore`

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed build errors in Xcode 13.3.1 (#9702).
+
 # v9.0.0
 - [fixed] **Breaking change:** Fixed an issue where returning `nil` from the
   update closure when running a transaction caused a crash in Swift by removing

--- a/Firestore/Example/GoogleTest.podspec
+++ b/Firestore/Example/GoogleTest.podspec
@@ -17,7 +17,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleTest'
-  s.version          = '1.10.0'
+  s.version          = '99.99.99'
   s.summary          = 'Google Test'
 
   s.description      = <<-DESC
@@ -30,7 +30,7 @@ Google's C++ test framework.
 
   s.source           = {
     :git => 'https://github.com/google/googletest.git',
-    :tag => 'release-' + s.version.to_s
+    :commit => 'bf66935e07825318ae519675d73d0f3e313b3ec6'
   }
 
   s.ios.deployment_target = '10.0'
@@ -92,7 +92,7 @@ Google's C++ test framework.
     # Remove includes of files in internal/custom
     sed -i.bak -e '/include.*internal\/custom/ d' \
       googlemock/include/gmock/gmock-matchers.h \
-      googlemock/include/gmock/gmock-generated-actions.h \
+      googlemock/include/gmock/gmock-more-actions.h \
       googlemock/include/gmock/internal/gmock-port.h \
       googletest/include/gtest/gtest-printers.h \
       googletest/include/gtest/internal/gtest-port.h \

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -539,6 +539,7 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
         ++(*counter);
         // Get the doc once.
         FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+        XCTAssertNotNil(snapshot);
         XCTAssertNil(*error);
         // Do a write outside of the transaction. Because the transaction will retry, set the
         // document to a different value each time.
@@ -557,6 +558,7 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
         // TODO(klimt): Perhaps we shouldn't fail reads for this, but should wait and fail the
         // whole transaction? It's an edge-case anyway, as developers shouldn't be reading the same
         // doc multiple times. But they need to handle read errors anyway.
+        XCTAssertNil(snapshot);
         XCTAssertNotNil(*error);
         return nil;
       }

--- a/Firestore/core/src/credentials/user.h
+++ b/Firestore/core/src/credentials/user.h
@@ -70,6 +70,7 @@ class User {
   }
 #endif  // defined(__OBJC__)
 
+  User(const User& other) = default;
   User& operator=(const User& other) = default;
 
   friend bool operator==(const User& lhs, const User& rhs);

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -18,15 +18,17 @@ if(TARGET googletest OR NOT DOWNLOAD_GOOGLETEST)
   return()
 endif()
 
-set(version 1.10.0)
+# Note: googletest lives at head and encourages to just point to a head commit.
+# https://github.com/google/googletest/blob/bf66935e07/README.md?plain=1#L5-L10
+set(version bf66935e07825318ae519675d73d0f3e313b3ec6)
 
 ExternalProject_Add(
   googletest
 
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME googletest-${version}.tar.gz
-  URL https://github.com/google/googletest/archive/release-${version}.tar.gz
-  URL_HASH SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG "${version}"
+  GIT_SHALLOW "ON"
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
See [#9705](https://github.com/firebase/firebase-ios-sdk/pull/9705) for more context.