### PR TITLE
googletest.cmake: remove GIT_SHALLOW when cloning

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -28,7 +28,6 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG "${version}"
-  GIT_SHALLOW "ON"
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
In https://github.com/firebase/firebase-ios-sdk/pull/9705, the googletest dependency was changed from downloading a release version to cloning the git repository at a pinned commit from HEAD. To optimize this, the `GIT_SHALLOW` argument was specified to cmake's `ExternalProject_Add()` function. This caused the cloned repository to have a different head commit SHA and confused cmake. To fix this, I just removed the `GIT_SHALLOW` argument since the repository is pretty small and doing a deep clone is not that expensive.

#no-changelog