### PR TITLE
Missing NSObject overrides and tests

### DIFF
--- a/FirebaseStorage/Sources/StorageListResult.swift
+++ b/FirebaseStorage/Sources/StorageListResult.swift
@@ -41,7 +41,18 @@ import FirebaseStorageInternal
    */
   @objc public let pageToken: String?
 
+  // MARK: - NSObject overrides
+
+  @objc override open func copy() -> Any {
+    return StorageListResult(impl.copy() as! FIRIMPLStorageListResult)
+  }
+
+  // MARK: - Internal APIs
+
+  internal let impl: FIRIMPLStorageListResult
+
   internal init(_ impl: FIRIMPLStorageListResult) {
+    self.impl = impl
     prefixes = impl.prefixes.map { StorageReference($0) }
     items = impl.items.map { StorageReference($0) }
     pageToken = impl.pageToken

--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -182,6 +182,27 @@ import FirebaseStorageInternal
     self.init(impl: FIRIMPLStorageMetadata(dictionary: dictionary)!)
   }
 
+  // MARK: - NSObject overrides
+
+  @objc override open func copy() -> Any {
+    return StorageMetadata(impl: impl.copy() as! FIRIMPLStorageMetadata)
+  }
+
+  @objc override open func isEqual(_ object: Any?) -> Bool {
+    guard let ref = object as? StorageMetadata else {
+      return false
+    }
+    return impl.isEqual(ref.impl)
+  }
+
+  @objc override public var hash: Int {
+    return impl.hash
+  }
+
+  @objc override public var description: String {
+    return impl.description
+  }
+
   // MARK: - Internal APIs
 
   internal let impl: FIRIMPLStorageMetadata

--- a/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import FirebaseStorage
+
+import XCTest
+
+class StorageMetadataTests: XCTestCase {
+  func testReflexiveMetadataEquality() {
+    let metaDict = ["bucket": "bucket", "name": "/path/to/file"]
+    let metadata0 = StorageMetadata(dictionary: metaDict)
+    let metadata1 = metadata0
+    XCTAssertEqual(metadata0, metadata1)
+  }
+
+  func testMetadataEquality() {
+    let metaDict = [
+      "bucket": "bucket",
+      "name": "/path/to/file",
+      "md5Hash": "d41d8cd98f00b204e9800998ecf8427e",
+    ]
+    let metadata0 = StorageMetadata(dictionary: metaDict)
+    let metadata1 = StorageMetadata(dictionary: metaDict)
+    XCTAssertEqual(metadata0, metadata1)
+  }
+
+  func testMetadataMd5Inequality() {
+    let metaDict0 = ["md5Hash": "d41d8cd98f00b204e9800998ecf8427e"]
+    let metaDict1 = ["md5Hash": "d41d8cd98f00b204e9800998ecf8427f"]
+    let metadata0 = StorageMetadata(dictionary: metaDict0)
+    let metadata1 = StorageMetadata(dictionary: metaDict1)
+    XCTAssertNotEqual(metadata0, metadata1)
+  }
+
+  func testMetadataCopy() {
+    let metaDict = [
+      "bucket": "bucket",
+      "name": "/path/to/file",
+      "md5Hash": "d41d8cd98f00b204e9800998ecf8427e",
+    ]
+    let metadata0 = StorageMetadata(dictionary: metaDict)
+    let metadata1 = metadata0.copy() as? StorageMetadata
+    XCTAssertEqual(metadata0, metadata1)
+  }
+}

--- a/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
@@ -53,6 +53,8 @@ class StorageMetadataTests: XCTestCase {
     ]
     let metadata0 = StorageMetadata(dictionary: metaDict)
     let metadata1 = metadata0.copy() as? StorageMetadata
+    // Verify that copied object has a new reference.
+    XCTAssertFalse(metadata0 === metadata1)
     XCTAssertEqual(metadata0, metadata1)
   }
 }

--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -149,7 +149,7 @@ NSString *const kTestPassword = KPASSWORD;
   XCTAssertEqual(storage1, storage2);
 }
 
-- (void)testDiffferentInstance {
+- (void)testDifferentInstance {
   FIRStorage *storage1 = [FIRStorage storageForApp:self.app];
   FIRStorage *storage2 = [FIRStorage storageForApp:self.app URL:@"gs://foo-bar.appspot.com"];
   XCTAssertNotEqual(storage1, storage2);
@@ -169,6 +169,22 @@ NSString *const kTestPassword = KPASSWORD;
   [ref metadataWithCompletion:^(FIRStorageMetadata *metadata, NSError *error) {
     XCTAssertNotNil(metadata, "Metadata should not be nil");
     XCTAssertNil(error, "Error should be nil");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectations];
+}
+
+- (void)testCopyMetadata {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testGetMetadata"];
+  FIRStorageReference *ref = [self.storage.reference child:@"ios/public/1mb"];
+
+  [ref metadataWithCompletion:^(FIRStorageMetadata *metadata, NSError *error) {
+    XCTAssertNotNil(metadata, "Metadata should not be nil");
+    XCTAssertNil(error, "Error should be nil");
+    FIRStorageMetadata *metadata2 = metadata.copy;
+    XCTAssertNotEqual(metadata, metadata2);
+    XCTAssertEqualObjects(metadata, metadata2);
     [expectation fulfill];
   }];
 
@@ -823,6 +839,24 @@ NSString *const kTestPassword = KPASSWORD;
     XCTAssertNotNil(listResult);
     XCTAssertNil(error);
     XCTAssertNil(listResult.pageToken);
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectations];
+}
+
+- (void)testCopyListResult {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testCopyListResult"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@""];
+
+  [ref listAllWithCompletion:^(FIRStorageListResult *_Nullable listResult,
+                               NSError *_Nullable error) {
+    XCTAssertNotNil(listResult);
+    XCTAssertNil(error);
+    XCTAssertNil(listResult.pageToken);
+    FIRStorageListResult *listResult2 = listResult.copy;
+    XCTAssertEqual(listResult.pageToken, listResult2.pageToken);
     [expectation fulfill];
   }];
 

--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -857,6 +857,7 @@ NSString *const kTestPassword = KPASSWORD;
     XCTAssertNil(listResult.pageToken);
     FIRStorageListResult *listResult2 = listResult.copy;
     XCTAssertEqual(listResult.pageToken, listResult2.pageToken);
+    XCTAssertNotEqual(listResult, listResult2);
     [expectation fulfill];
   }];
 


### PR DESCRIPTION
The games team discovered we missed a few NSObject overrides in the Storage Swift API port.

This PR adds them back along with tests that we never had.