### PR TITLE
update NS_SWIFT_NAME parameter to remove build warnings

### DIFF
--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -72,7 +72,7 @@ NS_SWIFT_NAME(Crashlytics)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
+            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -72,7 +72,8 @@ NS_SWIFT_NAME(Crashlytics)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
+            arguments:(va_list)args
+    __attribute__((__swift_name__("log(format:arguments:)")));  // Avoid `NS_SWIFT_NAME` (#9331).
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
@@ -69,7 +69,8 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
+            arguments:(va_list)args
+    __attribute__((__swift_name__("log(format:arguments:)")));  // Avoid `NS_SWIFT_NAME` (#9331).
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
+            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.


### PR DESCRIPTION
#no-changelog

Should fix build warnings in #9331 