### PR TITLE
[Crashlytics] Don't use `NS_SWIFT_NAME` to avoid collision with 3p macro

### DIFF
--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -72,7 +72,8 @@ NS_SWIFT_NAME(Crashlytics)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
+            arguments:(va_list)args
+    __attribute__((__swift_name__("log(format:arguments:)")));  // Avoid `NS_SWIFT_NAME` (#9331).
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -72,7 +72,7 @@ NS_SWIFT_NAME(Crashlytics)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
+            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
@@ -69,7 +69,8 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
+            arguments:(va_list)args
+    __attribute__((__swift_name__("log(format:arguments:)")));  // Avoid `NS_SWIFT_NAME` (#9331).
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlyticsReport.h
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(CrashlyticsReport)
  * @param args Arguments to substitute into format
  */
 - (void)logWithFormat:(NSString *)format
-            arguments:(va_list)args NS_SWIFT_NAME(log(withFormat:arguments:));
+            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));
 
 /**
  * Sets a custom key and value to be associated with subsequent fatal and non-fatal reports.


### PR DESCRIPTION
### Context
The build warnings reported in #9331 seem to be related to #4851. There is a non-Firebase header getting linked in that defines a macro `log` which seems to interfere with the `log` in `NS_SWIFT_NAME(log(format:arguments:))` (in the Crashlytics public headers).

I was able to reproduce #9331 and tested 5 workarounds:
1. Don't use `NS_SWIFT_NAME(log(format:arguments:))` and rely on the default ObjC → Swift translation.
    -  I expected this to work but for some reason, the default translation wasn't stripping the `with` from `withFormat:` like I thought it would.
3. Use `NS_SWIFT_NAME` but wrap param in double quotes. `NS_SWIFT_NAME("log(format:arguments:)")`
4. Use `NS_SWIFT_NAME` but wrap param in single quotes. `NS_SWIFT_NAME('log(format:arguments:)')`
5. Disable the `log` macro:
```objc
#pragma push_macro("log")
#undef log

- (void)logWithFormat:(NSString *)format
            arguments:(va_list)args NS_SWIFT_NAME(log(format:arguments:));

#pragma pop_macro("log")
```
5. Use `__attribute__((__swift_name__(...` instead of `NS_SWIFT_NAME`
```diff
- NS_SWIFT_NAME(log(withFormat:arguments:));
+ __attribute__((__swift_name__("log(format:arguments:)")));  // Avoid `NS_SWIFT_NAME` (#9331).
```

Only workarounds **4** and **5** worked and out of the two, and **5** seemed to be a more general solution IMO.

Will fix #9331