### PR TITLE
[skip ci] Correct Swift API in `FIROptions.h` doc

### DIFF
--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -38,7 +38,7 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *APIKey NS_SWIFT_NAME(apiKey);
 
 /**
- * The bundle ID for the application. Defaults to `Bundle.mainBundle.bundleID()` when not set
+ * The bundle ID for the application. Defaults to `Bundle.main.bundleIdentifier` when not set
  * manually or in a plist.
  */
 @property(nonatomic, copy) NSString *bundleID;


### PR DESCRIPTION
This is pretty minor but I noticed the discrepancy while reviewing the larger docs update for Firebase 9.

### Context 
Doc comment doesn't use accurate Swift API names. See below links:
- https://developer.apple.com/documentation/foundation/bundle/1410786-main
- https://developer.apple.com/documentation/foundation/bundle/1418023-bundleidentifier

#no-changelog