### PR TITLE
Disable Core macos test target after pod lib lint

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos --skip-tests]
+        target: [ios, tvos, macos --verbose]
     env:
       # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
       POD_LIB_LINT_ONLY: 1

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos --no-analyze]
+        target: [ios, tvos, macos --skip-tests]
     env:
       # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
       POD_LIB_LINT_ONLY: 1
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos --no-analyze]
+        target: [ios, tvos, macos --skip-tests]
         flags: [
           '--use-static-frameworks'
         ]

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos --no-analyze]
     env:
       # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
       POD_LIB_LINT_ONLY: 1
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos --no-analyze]
         flags: [
           '--use-static-frameworks'
         ]

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -66,7 +66,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
       unit_tests.scheme = { :code_coverage => true }
       unit_tests.platforms = {
         :ios => ios_deployment_target,
-        :osx => '10.15',
+        :osx => '12.0',
         :tvos => tvos_deployment_target
       }
       unit_tests.source_files = [
@@ -84,7 +84,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.test_spec 'swift-unit' do |swift_unit_tests|
     swift_unit_tests.platforms = {
       :ios => ios_deployment_target,
-      :osx => osx_deployment_target,
+      :osx => '12.0',
       :tvos => tvos_deployment_target
     }
     swift_unit_tests.source_files = [


### PR DESCRIPTION
#no-changelog

Perhaps address https://github.com/firebase/firebase-ios-sdk/runs/6314031074?check_suite_focus=true which does not repro locally for me