### PR TITLE
[v9.1] Bump GoogleDataTransport dep to ≥9.1.4

### DIFF
--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -34,7 +34,7 @@ iOS SDK for App Distribution for Firebase.
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.7'
   s.dependency 'FirebaseInstallations', '~> 9.0'
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -56,7 +56,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
 
   s.framework = 'Foundation'
 
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'
   s.dependency 'nanopb', '~> 2.30908.0'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -56,7 +56,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'PromisesObjC', '~> 2.1'
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'nanopb', '~> 2.30908.0'
 

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.framework = 'Foundation'
   s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'FirebaseInstallations', '~> 9.0'
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
   # TODO: Revisit this dependency
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'
   s.dependency 'SwiftProtobuf', '~> 1.19'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -64,7 +64,7 @@ device, and it is completely free.
   s.dependency 'GoogleUtilities/Reachability', '~> 7.7'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.7'
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
   s.dependency 'nanopb', '~> 2.30908.0'
 
   s.test_spec 'unit' do |unit_tests|

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -62,7 +62,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'FirebaseCore', '~> 9.0'
   s.dependency 'FirebaseInstallations', '~> 9.0'
   s.dependency 'FirebaseRemoteConfig', '~> 9.0'
-  s.dependency 'GoogleDataTransport', '~> 9.1'
+  s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/ISASwizzler', '~> 7.7'
   s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.7'

--- a/Package.swift
+++ b/Package.swift
@@ -155,7 +155,7 @@ let package = Package(
     .package(
       name: "GoogleDataTransport",
       url: "https://github.com/google/GoogleDataTransport.git",
-      "9.1.2" ..< "10.0.0"
+      "9.1.4" ..< "10.0.0"
     ),
     .package(
       name: "GoogleUtilities",


### PR DESCRIPTION
### Context
- Update product podspecs's dependency on GDT to be ≥9.1.4 (released today to fix 9.1.3)
- Will keep clients from pulling in the buggy 9.1.3 version.
- Pinning from a patch means we can't use the optimistic operator `~>`:
```diff
- s.dependency 'GoogleDataTransport', '~> 9.1'
+ s.dependency 'GoogleDataTransport', '>= 9.1.4', '< 10.0.0'
```

#no-changelog

Fixes #9773
