### PR TITLE
Changing podspec files license from Apache to Apache-2.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -8,7 +8,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -12,7 +12,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -8,7 +8,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
                        DESC
 
   s.homepage                = 'https://firebase.google.com/features/analytics/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   # NOTE that these should not be used externally, this is for Firebase pods to depend on each

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -8,7 +8,7 @@ iOS SDK for App Distribution for Firebase.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -9,7 +9,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseAuthInterop.podspec
+++ b/FirebaseAuthInterop.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   # NOTE that these should not be used externally, this is for Firebase pods to depend on each

--- a/FirebaseAuthTestingSupport.podspec
+++ b/FirebaseAuthTestingSupport.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -9,7 +9,7 @@ for internal testing only. It should not be published.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -8,7 +8,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -10,7 +10,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                          DESC
 
     s.homepage         = 'https://firebase.google.com'
-    s.license          = { :type => 'Apache', :file => 'LICENSE' }
+    s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
     s.authors          = 'Google, Inc.'
 
     s.source           = {

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'Best and lightest-weight crash reporting for mobile, desktop and tvOS.'
   s.description      = 'Firebase Crashlytics helps you track, prioritize, and fix stability issues that erode app quality.'
   s.homepage         = 'https://firebase.google.com/'
-  s.license          = { :type => 'Apache', :file => 'Crashlytics/LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'Crashlytics/LICENSE' }
   s.authors          = 'Google, Inc.'
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -8,7 +8,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'FirebaseDatabase/LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'FirebaseDatabase/LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -8,7 +8,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
                        DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -8,7 +8,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -8,7 +8,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
-  s.license          = { :type => 'Apache', :file => 'Firestore/LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'Firestore/LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -13,7 +13,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
                        DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseFirestoreTestingSupport.podspec
+++ b/FirebaseFirestoreTestingSupport.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -8,7 +8,7 @@ Cloud Functions for Firebase.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -9,7 +9,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -9,7 +9,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
                        DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -11,7 +11,7 @@ device, and it is completely free.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseMessagingInterop.podspec
+++ b/FirebaseMessagingInterop.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   # NOTE that these should not be used externally, this is for Firebase pods to depend on each

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -8,7 +8,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -10,7 +10,7 @@ app update.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -11,7 +11,7 @@ app update.
 
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -10,7 +10,7 @@ Firebase products. FirebaseSharedSwift is not supported for non-Firebase usage.
 
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'FirebaseSharedSwift/LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'FirebaseSharedSwift/LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -8,7 +8,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -8,7 +8,7 @@ Objective C Implementations for FirebaseStorage. This pod should not be directly
                        DESC
 
   s.homepage         = 'https://firebase.google.com'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -10,7 +10,7 @@ Not intended for direct public usage.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/HeartbeatLoggingTestUtils.podspec
+++ b/HeartbeatLoggingTestUtils.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                          DESC
 
   s.homepage                = 'https://developers.google.com/'
-  s.license                 = { :type => 'Apache', :file => 'LICENSE' }
+  s.license                 = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors                 = 'Google, Inc.'
 
   s.source                  = {


### PR DESCRIPTION
Fixes #9781

Changing all podspec files license from Apache to Apache-2.0 specifically on:

`s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }`