### PR TITLE
Crashlytics add more clarifying information to unsent reports log

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
@@ -151,8 +151,8 @@ NSInteger compareNewer(FIRCLSInternalReport *reportA,
   // which should be at the start of the array.
   if (validReports.count > FIRCLSMaxUnsentReports) {
     NSUInteger deletingCount = validReports.count - FIRCLSMaxUnsentReports;
-    FIRCLSInfoLog(@"Deleting %lu unsent reports over the limit of %lu to prevent disk space from "
-                  @"filling up. To prevent this make sure to call send/deleteUnsentReports.",
+    FIRCLSInfoLog(@"Automatic data collection is disabled. Deleting %lu unsent reports over the limit of %lu to prevent disk space from "
+                  @"filling up. To take action on these reports, call send/deleteUnsentReports. To turn on automatic data collection, call setCrashlyticsCollectionEnabled with true",
                   deletingCount, FIRCLSMaxUnsentReports);
   }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.m
@@ -151,9 +151,12 @@ NSInteger compareNewer(FIRCLSInternalReport *reportA,
   // which should be at the start of the array.
   if (validReports.count > FIRCLSMaxUnsentReports) {
     NSUInteger deletingCount = validReports.count - FIRCLSMaxUnsentReports;
-    FIRCLSInfoLog(@"Automatic data collection is disabled. Deleting %lu unsent reports over the limit of %lu to prevent disk space from "
-                  @"filling up. To take action on these reports, call send/deleteUnsentReports. To turn on automatic data collection, call setCrashlyticsCollectionEnabled with true",
-                  deletingCount, FIRCLSMaxUnsentReports);
+    FIRCLSInfoLog(
+        @"Automatic data collection is disabled. Deleting %lu unsent reports over the limit of %lu "
+        @"to prevent disk space from "
+        @"filling up. To take action on these reports, call send/deleteUnsentReports. To turn on "
+        @"automatic data collection, call setCrashlyticsCollectionEnabled with true",
+        deletingCount, FIRCLSMaxUnsentReports);
   }
 
   // Not that validReports is sorted, delete any reports at indices > MAX_UNSENT_REPORTS, and


### PR DESCRIPTION
In response to a customer that was confused about this

#no-changelog