### PR TITLE
Speed up `pod repo push`

### DIFF
--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -31,8 +31,8 @@ extension Constants {
 
 // flags for 'pod push'
 extension Constants {
-  static let flags = ["--skip-tests", "--allow-warnings"]
-  static let umbrellaPodFlags = Constants.flags + ["--skip-import-validation", "--use-json"]
+  static let flags = ["--skip-tests", "--allow-warnings", "--skip-import-validation"]
+  static let umbrellaPodFlags = Constants.flags + ["--use-json"]
 }
 
 // SpecFiles is a wraper of dict mapping from required pods to their path. This


### PR DESCRIPTION
release/prerelease workflows [failed](https://github.com/firebase/firebase-ios-sdk/issues/9696#issuecomment-1121473660) due to long running time. Speed up `pod repo push` by adding `--skip-import-validation` to pods.
