### PR TITLE
Ruby setup for prerlease perf test

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -553,6 +553,9 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+      with:
+        ruby-version: '2.7'
     - name: Get token
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
           bot-access.txt "$bot_token_secret"


### PR DESCRIPTION
Missing ruby setup should fix last macos 12 issue with prerelease workflow