### PR TITLE
Enable run of create_spec_repo

### DIFF
--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -377,7 +377,8 @@ struct SpecRepoBuilder: ParsableCommand {
     let startDate = Date()
     var minutes = 0
     for pod in specFileDict.depInstallOrder {
-      var timer: DispatchSourceTimer = {
+      print("----------\(pod)-----------")
+      let timer: DispatchSourceTimer = {
         let t = DispatchSource.makeTimerSource()
         t.schedule(deadline: .now(), repeating: 60)
         t.setEventHandler(handler: {
@@ -388,7 +389,6 @@ struct SpecRepoBuilder: ParsableCommand {
       }()
       timer.resume()
       var podExitCode: Int32 = 0
-      print("----------\(pod)-----------")
       switch pod {
       case "Firebase":
         podExitCode = pushPodspec(
@@ -420,3 +420,5 @@ struct SpecRepoBuilder: ParsableCommand {
     }
   }
 }
+
+SpecRepoBuilder.main()


### PR DESCRIPTION
Add `SpecRepoBuilder.main()`, which was mistakenly removed in the [previous PR](https://github.com/firebase/firebase-ios-sdk/pull/9789/files#diff-56d9e831e359a173355a51a81b46b99cd8282fdab7b615b1f34c66c12637a3eaL390), to trigger the tool.