### PR TITLE
Fix typos

### DIFF
--- a/AddNewPod.md
+++ b/AddNewPod.md
@@ -68,7 +68,7 @@ For top-level Firebase pods that map to documented products:
 * Make sure the public umbrella header is imported via [Firebase.h](CoreOnly/Sources/Firebase.h)
   wrapped in `__has_include`. Follow the existing examples for details.
 * Update [Firebase.podspec](Firebase.podspec).
-* Register Objective C library via registerInternalLibrary API like this
+* Register Objective-C library via registerInternalLibrary API like this
   [AppCheck example](FirebaseAppCheck/Sources/Core/FIRAppCheck.m).
 * Register Swift library by creating a component like
   [Functions example](FirebaseFunctions/Sources/Internal/FunctionsComponent.swift) and

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -20,7 +20,7 @@ import FirebaseMessagingInterop
 import XCTest
 
 /// This file was intitialized as a direct port of `FirebaseFunctionsSwift/Tests/IntegrationTests.swift`
-/// which itself was ported from the Objective C `FirebaseFunctions/Tests/Integration/FIRIntegrationTests.m`
+/// which itself was ported from the Objective-C `FirebaseFunctions/Tests/Integration/FIRIntegrationTests.m`
 ///
 /// The tests require the emulator to be running with `FirebaseFunctions/Backend/start.sh synchronous`
 /// The Firebase Functions called in the tests are implemented in `FirebaseFunctions/Backend/index.js`.

--- a/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
@@ -339,7 +339,7 @@ static NSString *kUserNotificationDidReceiveResponseSelectorString =
   } else {
     // This class originally did not have an implementation for this selector.
 
-    // We can't actually remove methods in Objective C 2.0, but we could set
+    // We can't actually remove methods in Objective-C 2.0, but we could set
     // its method to something non-existent. This should give us the same
     // behavior as if the method was not implemented.
     // See: http://stackoverflow.com/a/8276527/9849

--- a/FirebaseStorage/Sources/Result.swift
+++ b/FirebaseStorage/Sources/Result.swift
@@ -21,7 +21,7 @@ import Foundation
 ///   - completion: A completion block returning a `Result` enum with either a generic object or
 ///                 an `Error`.
 /// - Returns: A closure parameterized with an optional generic and optional `Error` to match
-///            Objective C APIs.
+///            Objective-C APIs.
 private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Void) -> (_: T?,
                                                                                         _: Error?)
   -> Void {

--- a/FirebaseStorage/Tests/ObjCIntegration/ObjCPPAPITests.mm
+++ b/FirebaseStorage/Tests/ObjCIntegration/ObjCPPAPITests.mm
@@ -150,7 +150,7 @@
     case FIRStorageErrorCodeInvalidArgument:
       return (FIRStorageErrorCode)error.code;
   }
-  // The cast is not needed in plain Objective C.
+  // The cast is not needed in plain Objective-C.
   return (FIRStorageErrorCode)error.code;
 }
 

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC
-Objective C Implementations for FirebaseStorage. This pod should not be directly imported.
+Objective-C Implementations for FirebaseStorage. This pod should not be directly imported.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'

--- a/FirebaseStorageInternal/Sources/FIRStorageDownloadTask_Private.h
+++ b/FirebaseStorageInternal/Sources/FIRStorageDownloadTask_Private.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cancels the download task and passes an appropriate error to the developer.
- * @param error NSError to propegate to the developer.
+ * @param error NSError to propagate to the developer.
  */
 - (void)cancelWithError:(NSError *)error;
 

--- a/FirebaseStorageInternal/Sources/Public/FirebaseStorageInternal/FIRStorageConstants.h
+++ b/FirebaseStorageInternal/Sources/Public/FirebaseStorageInternal/FIRStorageConstants.h
@@ -24,7 +24,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // TODO: The typedefs are not portable to Swift as typealias's to make available
-// back to Objective C. See https://stackoverflow.com/a/48069912/556617
+// back to Objective-C. See https://stackoverflow.com/a/48069912/556617
 /**
  * NSString typedef representing a task listener handle.
  */

--- a/Firestore/core/src/model/field_path.cc
+++ b/Firestore/core/src/model/field_path.cc
@@ -146,7 +146,7 @@ StatusOr<FieldPath> FieldPath::FromServerFormatView(absl::string_view path) {
   while (i < path.size()) {
     const char c = path[i];
     // std::string (and string_view) may contain embedded nulls. For full
-    // compatibility with Objective C behavior, finish upon encountering the
+    // compatibility with Objective-C behavior, finish upon encountering the
     // first terminating null.
     if (c == '\0') {
       break;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@ Firebase should be better integrated with SwiftUI apps. See SwiftUI related
 
 Evaluate impact on Firebase APIs of the
 [Swift Async/await proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md).
-For example, Objective C callback APIs that return a value do not get an
+For example, Objective-C callback APIs that return a value do not get an
 async/await API automatically generated and an explicit function may need to be
 added. See these
 [Firebase Storage examples](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorage/Sources/AsyncAwait.swift).

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -456,7 +456,7 @@ struct FrameworkBuilder {
     // Instead it use build options to specify them. For the zip build, we need the module maps to
     // include the dependent frameworks and libraries. Therefore we reconstruct them by parsing
     // the CocoaPods config files and add them here.
-    // Currently we only do the construction for Objective C since Swift Module directories require
+    // Currently we only do the construction for Objective-C since Swift Module directories require
     // several other files. See https://github.com/firebase/firebase-ios-sdk/pull/5040.
     // Therefore, for Swift we do a simple copy of the Modules files from an Xcode build.
     // This is sufficient for the testing done so far, but more testing is required to determine

--- a/SwiftDashboard.md
+++ b/SwiftDashboard.md
@@ -21,14 +21,14 @@ tasks for additional Swift improvements.
 | **Swift Doc Scrub**   |   ✅  |  ✅   | ✅    | ✅   | ✅   | ✅    |  ✅   |  ✅   |  ✅  |  ✅   |  ✅    | ✅  |  ✅   | ✅   |  ✅   |  ✅   |  ✅|
 
 ### Other Projects
-- Tooling to surface full list of automatically generated Swift API from Objective C and validate.
+- Tooling to surface full list of automatically generated Swift API from Objective-C and validate.
 - Improve singleton naming scheme. Move singletons into a Firebase namespace, like `Firebase.auth()`, `Firebase.storage()`, etc.
 - Swift Generics. Update APIs that are using weakly typed information to use proper generics.
 
 ## Notes
 2. Tests exist. Coverage to be confirmed.
 4. `NS_ERROR_ENUM` used but a larger audit is still needed for more localized errors.
-5. Still needs to unify Objective C and Swift errors.
+5. Still needs to unify Objective-C and Swift errors.
 6. One property wrapper added in [#8614](https://github.com/firebase/firebase-ios-sdk/pull/8614). More to go.
 7. `record(Error)` API should be expanded to collect Swift Errors as well as NSErrors.
 
@@ -47,7 +47,7 @@ for Storage.
 Property Wrappers and likely the SwiftUI lifecycle bits, but an audit and improvements could likely be made. The existing FIAM and Analytics View modifier
 APIs would fit into this category.
 * **Property Wrappers**: Property wrappers are used to improve the API.
-* **Swift Doc Scrub**: Review and update to change Objective C types and call examples to Swift. In addition to updating the documentation content, we
+* **Swift Doc Scrub**: Review and update to change Objective-C types and call examples to Swift. In addition to updating the documentation content, we
 should also investigate using DocC to format the docs.
 
 ## Columns (Firebase Products)

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -158,7 +158,7 @@ s%^./%%
 # Sources pulled in by the Mint package manager
 \%^Mint% d
 
-# Auth Sample Objective C does not format well
+# Auth Sample Objective-C does not format well
 \%^(FirebaseAuth/Tests/Sample/Sample)/% d
 
 # Keep Firebase.h indenting

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -23,7 +23,7 @@
 # and test.
 
 # TODO - Determine why test specs that include `requires_app_host` fail to
-# launch tests. Locally, they will pass if the only Objective C unit test scheme
+# launch tests. Locally, they will pass if the only Objective-C unit test scheme
 # is specified. However, on GHA, they fail to launch both from the test scheme
 # and the app scheme.
 


### PR DESCRIPTION
"Objective C" -> "Objective-C"
"propegate" -> "propagate"

#no-changelog