### PR TITLE
Remove build statuses from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,6 @@
 [![License](https://img.shields.io/cocoapods/l/Firebase.svg?style=flat)](https://cocoapods.org/pods/Firebase)
 [![Platform](https://img.shields.io/cocoapods/p/Firebase.svg?style=flat)](https://cocoapods.org/pods/Firebase)
 
-[![Actions Status][gh-abtesting-badge]][gh-actions]
-[![Actions Status][gh-appcheck-badge]][gh-actions]
-[![Actions Status][gh-appdistribution-badge]][gh-actions]
-[![Actions Status][gh-auth-badge]][gh-actions]
-[![Actions Status][gh-cocoapods-integration-badge]][gh-actions]
-[![Actions Status][gh-core-badge]][gh-actions]
-[![Actions Status][gh-core-diagnostics-badge]][gh-actions]
-[![Actions Status][gh-crashlytics-badge]][gh-actions]
-[![Actions Status][gh-database-badge]][gh-actions]
-[![Actions Status][gh-datatransport-badge]][gh-actions]
-[![Actions Status][gh-dynamiclinks-badge]][gh-actions]
-[![Actions Status][gh-firebasepod-badge]][gh-actions]
-[![Actions Status][gh-firestore-badge]][gh-actions]
-[![Actions Status][gh-functions-badge]][gh-actions]
-[![Actions Status][gh-google-utilities-badge]][gh-actions]
-[![Actions Status][gh-google-utilities-components-badge]][gh-actions]
-[![Actions Status][gh-inappmessaging-badge]][gh-actions]
-[![Actions Status][gh-interop-badge]][gh-actions]
-[![Actions Status][gh-messaging-badge]][gh-actions]
-[![Actions Status][gh-mlmodeldownloader-badge]][gh-actions]
-[![Actions Status][gh-performance-badge]][gh-actions]
-[![Actions Status][gh-remoteconfig-badge]][gh-actions]
-[![Actions Status][gh-storage-badge]][gh-actions]
-[![Actions Status][gh-symbolcollision-badge]][gh-actions]
-[![Actions Status][gh-zip-badge]][gh-actions]
-
 # Firebase Apple Open Source Development
 
 This repository contains all Apple platform Firebase SDK source except FirebaseAnalytics.
@@ -291,30 +265,3 @@ The contents of this repository are licensed under the
 
 Your use of Firebase is governed by the
 [Terms of Service for Firebase Services](https://firebase.google.com/terms/).
-
-[gh-actions]: https://github.com/firebase/firebase-ios-sdk/actions
-[gh-abtesting-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/abtesting/badge.svg
-[gh-appcheck-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/app_check/badge.svg
-[gh-appdistribution-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/appdistribution/badge.svg
-[gh-auth-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/auth/badge.svg
-[gh-cocoapods-integration-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/cocoapods-integration/badge.svg
-[gh-core-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/core/badge.svg
-[gh-core-diagnostics-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/core-diagnostics/badge.svg
-[gh-crashlytics-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/crashlytics/badge.svg
-[gh-database-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/database/badge.svg
-[gh-datatransport-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/datatransport/badge.svg
-[gh-dynamiclinks-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/dynamiclinks/badge.svg
-[gh-firebasepod-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/firebasepod/badge.svg
-[gh-firestore-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/firestore/badge.svg
-[gh-functions-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/functions/badge.svg
-[gh-google-utilities-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/google-utilities/badge.svg
-[gh-google-utilities-components-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/google-utilities-components/badge.svg
-[gh-inappmessaging-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/inappmessaging/badge.svg
-[gh-interop-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/interop/badge.svg
-[gh-messaging-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/messaging/badge.svg
-[gh-mlmodeldownloader-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/mlmodeldownloader/badge.svg
-[gh-performance-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/performance/badge.svg
-[gh-remoteconfig-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/remoteconfig/badge.svg
-[gh-storage-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/storage/badge.svg
-[gh-symbolcollision-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/symbolcollision/badge.svg
-[gh-zip-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/zip/badge.svg


### PR DESCRIPTION
These aren't as important now that we have nightly testing report coming into Issues, and this can be confusing for SwiftPM users. Fixes #9805. 

#no-changelog