### PR TITLE
Preinstall FirebaseCore for release testing.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -126,11 +126,12 @@ jobs:
          bot-access.txt "$bot_token_secret"
     - name: Update SpecsTesting repo
       run: |
+        [[ ${{ matrix.podspec }} == true ]] && ALLOWWARNINGS=true
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
-        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -71,7 +71,7 @@ jobs:
   buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -104,7 +104,7 @@ jobs:
   buildup_SpecsTesting_repo:
     needs: buildup_SpecsTesting_repo_FirebaseCore
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     strategy:
       fail-fast: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -94,7 +94,7 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
-        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder /
+        BOT_TOKEN="${botaccess}" ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh .build/debug/spec-repo-builder /
           --sdk-repo "${local_sdk_repo_dir}" /
           --local-spec-repo-name "${local_repo}" /
           --sdk-repo-name SpecsTesting /
@@ -139,7 +139,7 @@ jobs:
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
-        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder \
+        BOT_TOKEN="${botaccess}" ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh .build/debug/spec-repo-builder \
                                   --sdk-repo "${local_sdk_repo_dir}" \
                                   --local-spec-repo-name "${local_repo}" \
                                   --sdk-repo-name SpecsTesting \

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -94,7 +94,13 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
-        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder /
+          --sdk-repo "${local_sdk_repo_dir}" /
+          --local-spec-repo-name "${local_repo}" /
+          --sdk-repo-name SpecsTesting /
+          --github-account Firebase /
+          --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" /
+          --include-pods "${targeted_pod}" --keep-repo
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |
@@ -133,7 +139,7 @@ jobs:
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
-        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder \
+        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder \
                                   --sdk-repo "${local_sdk_repo_dir}" \
                                   --local-spec-repo-name "${local_repo}" \
                                   --sdk-repo-name SpecsTesting \

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
          ossbotaccess=`cat oss-bot-access.txt`
          git clone --quiet https://${ossbotaccess}@github.com/Firebase/SpecsTesting.git "${local_repo}"
          cd "${local_repo}"
-         # Remove all unhidden dirs, i.e. all podspec dir from the spec repo.
+         # Remove all unhiddenunhided dirs, i.e. all podspec dir from the spec repo.
          rm -Rf -- */
          git add .
          # commit without diff will throw an error. `git diff --exit-code` can avoid such error.
@@ -68,8 +68,41 @@ jobs:
         path: |
           ${{ env.local_sdk_repo_dir }}/*.podspec
           ${{ env.local_sdk_repo_dir }}/*.podspec.json
-  buildup_SpecsTesting_repo:
+  buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    env:
+      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      local_repo: specstesting
+      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
+      targeted_pod: FirebaseCore
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        name: firebase-ios-sdk
+        path: ${{ env.local_sdk_repo_dir }}
+    - name: Get token
+      run: |
+         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
+         bot-access.txt "$bot_token_secret"
+    - name: Update SpecsTesting repo
+      run: |
+        botaccess=`cat bot-access.txt`
+        cd scripts/create_spec_repo/
+        swift build
+        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
+        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+    - name: Clean Artifacts
+      if: ${{ always() }}
+      run: |
+        pod repo remove "${local_repo}"
+        rm -rf bot-access.txt
+
+  buildup_SpecsTesting_repo:
+    needs: buildup_SpecsTesting_repo_FirebaseCore
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
@@ -89,8 +122,6 @@ jobs:
         path: ${{ env.local_sdk_repo_dir }}
     - name: Get token
       run: |
-         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/oss-bot-access.txt.gpg \
-         oss-bot-access.txt "$bot_token_secret"
          scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
          bot-access.txt "$bot_token_secret"
     - name: Update SpecsTesting repo

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -102,7 +102,7 @@ jobs:
         rm -rf bot-access.txt
 
   buildup_SpecsTesting_repo:
-    needs: buildup_SpecsTesting_repo_FirebaseCore
+    needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
     if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -71,7 +71,7 @@ jobs:
   buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -104,7 +104,7 @@ jobs:
   buildup_SpecsTesting_repo:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     strategy:
       fail-fast: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -131,7 +131,16 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
-        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
+        # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
+        # command if ${ALLOWWARNINGS} is not null.
+        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder \
+                                  --sdk-repo "${local_sdk_repo_dir}" \
+                                  --local-spec-repo-name "${local_repo}" \
+                                  --sdk-repo-name SpecsTesting \
+                                  --github-account Firebase \
+                                  --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
+                                  --include-pods "${targeted_pod}" \
+                                  --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
          ossbotaccess=`cat oss-bot-access.txt`
          git clone --quiet https://${ossbotaccess}@github.com/Firebase/SpecsTesting.git "${local_repo}"
          cd "${local_repo}"
-         # Remove all unhiddenunhided dirs, i.e. all podspec dir from the spec repo.
+         # Remove all unhidden dirs, i.e. all podspec dir from the spec repo.
          rm -Rf -- */
          git add .
          # commit without diff will throw an error. `git diff --exit-code` can avoid such error.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,11 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+        BOT_TOKEN="${botaccess}" ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh .build/debug/spec-repo-builder \
+                                --sdk-repo "${local_sdk_repo_dir}" \
+                                --local-spec-repo-name "${local_repo}" \
+                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
+                                --include-pods "${targeted_pod}" --keep-repo
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,11 +129,12 @@ jobs:
          bot-access.txt "$bot_token_secret"
     - name: Update SpecsTesting repo
       run: |
+        [[ ${{ matrix.podspec }} == true ]] && ALLOWWARNINGS=true
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,12 @@ jobs:
          bot-access.txt "$bot_token_secret"
     - name: Update SpecsTesting repo
       run: |
-        [[ ${{ matrix.podspec }} == true ]] && ALLOWWARNINGS=true
+        [[ ${{ matrix.allowwarnings }} == true ]] && ALLOWWARNINGS=true
         echo ${ALLOWWARNINGS:+--allow-warnings}
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
         #        swift build
-        #        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
+        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
         #        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
          git clone --quiet https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git "${local_repo}"
          cd "${local_repo}"
          # Remove all unhidden dirs, i.e. all podspec dir from the spec repo.
-         rm -Rf -- */
+         # rm -Rf -- */
          git add .
          # commit without diff will throw an error. `git diff --exit-code` can avoid such error.
          git diff --staged --exit-code || git commit -m "Empty spec repo."
-         git push
+         #git push
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |
@@ -71,38 +71,38 @@ jobs:
         path: |
           ${{ env.local_sdk_repo_dir }}/*.podspec
           ${{ env.local_sdk_repo_dir }}/*.podspec.json
-          #  buildup_SpecsTesting_repo_FirebaseCore:
-          #    needs: specs_checking
-          #    # Don't run on private repo unless it is a PR.
-          #    if: github.repository == 'Firebase/firebase-ios-sdk'
-          #    runs-on: macos-12
-          #    env:
-          #      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-          #      local_repo: specstesting
-          #      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
-          #      targeted_pod: FirebaseCore
-          #    steps:
-          #    - uses: actions/checkout@v2
-          #    - uses: actions/download-artifact@v3
-          #      with:
-          #        name: firebase-ios-sdk
-          #        path: ${{ env.local_sdk_repo_dir }}
-          #    - name: Get token
-          #      run: |
-          #         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
-          #         bot-access.txt "$bot_token_secret"
-          #    - name: Update SpecsTesting repo
-          #      run: |
-          #        botaccess=`cat bot-access.txt`
-          #        cd scripts/create_spec_repo/
-          #        swift build
-          #        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-          #        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
-          #    - name: Clean Artifacts
-          #      if: ${{ always() }}
-          #      run: |
-          #        pod repo remove "${local_repo}"
-          #        rm -rf bot-access.txt
+  buildup_SpecsTesting_repo_FirebaseCore:
+    needs: specs_checking
+    # Don't run on private repo unless it is a PR.
+    if: github.repository == 'Firebase/firebase-ios-sdk'
+    runs-on: macos-12
+    env:
+      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      local_repo: specstesting
+      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
+      targeted_pod: FirebaseCore
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        name: firebase-ios-sdk
+        path: ${{ env.local_sdk_repo_dir }}
+    - name: Get token
+      run: |
+         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
+         bot-access.txt "$bot_token_secret"
+    - name: Update SpecsTesting repo
+      run: |
+        botaccess=`cat bot-access.txt`
+        cd scripts/create_spec_repo/
+        # swift build
+        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
+        # BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+    - name: Clean Artifacts
+      if: ${{ always() }}
+      run: |
+        pod repo remove "${local_repo}"
+        rm -rf bot-access.txt
 
   buildup_SpecsTesting_repo:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
          git clone --quiet https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git "${local_repo}"
          cd "${local_repo}"
          # Remove all unhidden dirs, i.e. all podspec dir from the spec repo.
-         # rm -Rf -- */
+         rm -Rf -- */
          git add .
          # commit without diff will throw an error. `git diff --exit-code` can avoid such error.
          git diff --staged --exit-code || git commit -m "Empty spec repo."
-         #git push
+         git push
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |
@@ -95,9 +95,9 @@ jobs:
       run: |
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
-        # swift build
+        swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-        # BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |
@@ -130,19 +130,18 @@ jobs:
     - name: Update SpecsTesting repo
       run: |
         [[ ${{ matrix.allowwarnings }} == true ]] && ALLOWWARNINGS=true
-        echo ${ALLOWWARNINGS:+--allow-warnings}
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
-        #        swift build
+        swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
-        #        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
-        #                                --sdk-repo "${local_sdk_repo_dir}" \
-        #                                --local-spec-repo-name "${local_repo}" \
-        #                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
-        #                                --include-pods "${targeted_pod}" \
-        #                                --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
+        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
+                                --sdk-repo "${local_sdk_repo_dir}" \
+                                --local-spec-repo-name "${local_repo}" \
+                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
+                                --include-pods "${targeted_pod}" \
+                                --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -74,7 +74,7 @@ jobs:
   buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -107,7 +107,7 @@ jobs:
   buildup_SpecsTesting_repo:
     needs: buildup_SpecsTesting_repo_FirebaseCore
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         rm -rf bot-access.txt
 
   buildup_SpecsTesting_repo:
-    needs: buildup_SpecsTesting_repo_FirebaseCore
+    needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
     if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,14 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
+        # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
+        # command if ${ALLOWWARNINGS} is not null.
+        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
+                                --sdk-repo "${local_sdk_repo_dir}" \
+                                --local-spec-repo-name "${local_repo}" \
+                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
+                                --include-pods "${targeted_pod}" \
+                                --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,38 +71,38 @@ jobs:
         path: |
           ${{ env.local_sdk_repo_dir }}/*.podspec
           ${{ env.local_sdk_repo_dir }}/*.podspec.json
-  buildup_SpecsTesting_repo_FirebaseCore:
-    needs: specs_checking
-    # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-12
-    env:
-      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      local_repo: specstesting
-      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
-      targeted_pod: FirebaseCore
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v3
-      with:
-        name: firebase-ios-sdk
-        path: ${{ env.local_sdk_repo_dir }}
-    - name: Get token
-      run: |
-         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
-         bot-access.txt "$bot_token_secret"
-    - name: Update SpecsTesting repo
-      run: |
-        botaccess=`cat bot-access.txt`
-        cd scripts/create_spec_repo/
-        swift build
-        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
-        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
-    - name: Clean Artifacts
-      if: ${{ always() }}
-      run: |
-        pod repo remove "${local_repo}"
-        rm -rf bot-access.txt
+          #  buildup_SpecsTesting_repo_FirebaseCore:
+          #    needs: specs_checking
+          #    # Don't run on private repo unless it is a PR.
+          #    if: github.repository == 'Firebase/firebase-ios-sdk'
+          #    runs-on: macos-12
+          #    env:
+          #      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+          #      local_repo: specstesting
+          #      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
+          #      targeted_pod: FirebaseCore
+          #    steps:
+          #    - uses: actions/checkout@v2
+          #    - uses: actions/download-artifact@v3
+          #      with:
+          #        name: firebase-ios-sdk
+          #        path: ${{ env.local_sdk_repo_dir }}
+          #    - name: Get token
+          #      run: |
+          #         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
+          #         bot-access.txt "$bot_token_secret"
+          #    - name: Update SpecsTesting repo
+          #      run: |
+          #        botaccess=`cat bot-access.txt`
+          #        cd scripts/create_spec_repo/
+          #        swift build
+          #        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
+          #        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+          #    - name: Clean Artifacts
+          #      if: ${{ always() }}
+          #      run: |
+          #        pod repo remove "${local_repo}"
+          #        rm -rf bot-access.txt
 
   buildup_SpecsTesting_repo:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
@@ -130,18 +130,19 @@ jobs:
     - name: Update SpecsTesting repo
       run: |
         [[ ${{ matrix.podspec }} == true ]] && ALLOWWARNINGS=true
+        echo ${ALLOWWARNINGS:+--allow-warnings}
         botaccess=`cat bot-access.txt`
         cd scripts/create_spec_repo/
-        swift build
-        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
+        #        swift build
+        #        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
-        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
-                                --sdk-repo "${local_sdk_repo_dir}" \
-                                --local-spec-repo-name "${local_repo}" \
-                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
-                                --include-pods "${targeted_pod}" \
-                                --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
+        #        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
+        #                                --sdk-repo "${local_sdk_repo_dir}" \
+        #                                --local-spec-repo-name "${local_repo}" \
+        #                                --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \
+        #                                --include-pods "${targeted_pod}" \
+        #                                --keep-repo ${ALLOWWARNINGS:+--allow-warnings}
     - name: Clean Artifacts
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
         # ${ALLOWWARNINGS:+--allow-warnings} will add --allow-warnings to the
         # command if ${ALLOWWARNINGS} is not null.
-        ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder \
+        BOT_TOKEN="${botaccess}" ${GITHUB_WORKSPACE}/scripts/third_party/travis/retry.sh .build/debug/spec-repo-builder \
                                 --sdk-repo "${local_sdk_repo_dir}" \
                                 --local-spec-repo-name "${local_repo}" \
                                 --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
          sdk_version_config="${GITHUB_WORKSPACE}/scripts/create_spec_repo/RC_firebase_sdk.textproto" \
          local_sdk_repo_dir="${local_sdk_repo_dir}" \
          podspec_repo_branch="${podspec_repo_branch}" \
-         scripts/release_testing_setup.sh prerelease_testing
+         scripts/release_testing_setup.sh release_testing
     - name: Clean spec repo
       run: |
          botaccess=`cat bot-access.txt`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
          botaccess=`cat bot-access.txt`
          git clone --quiet https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git "${local_repo}"
          cd "${local_repo}"
-         # Remove all unhided dirs, i.e. all podspec dir from the spec repo.
+         # Remove all unhidden dirs, i.e. all podspec dir from the spec repo.
          rm -Rf -- */
          git add .
          # commit without diff will throw an error. `git diff --exit-code` can avoid such error.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,41 @@ jobs:
         path: |
           ${{ env.local_sdk_repo_dir }}/*.podspec
           ${{ env.local_sdk_repo_dir }}/*.podspec.json
-  buildup_SpecsTesting_repo:
+  buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    env:
+      bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      local_repo: specstesting
+      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
+      targeted_pod: FirebaseCore
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        name: firebase-ios-sdk
+        path: ${{ env.local_sdk_repo_dir }}
+    - name: Get token
+      run: |
+         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/bot-access.txt.gpg \
+         bot-access.txt "$bot_token_secret"
+    - name: Update SpecsTesting repo
+      run: |
+        botaccess=`cat bot-access.txt`
+        cd scripts/create_spec_repo/
+        swift build
+        pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/FirebasePrivate/SpecsTesting.git
+        BOT_TOKEN="${botaccess}"  .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --pod-sources 'https://${BOT_TOKEN}@github.com/FirebasePrivate/SpecsTesting' "https://github.com/firebase/SpecsStaging.git" "https://github.com/CocoaPods/Specs.git" --include-pods "${targeted_pod}" --keep-repo
+    - name: Clean Artifacts
+      if: ${{ always() }}
+      run: |
+        pod repo remove "${local_repo}"
+        rm -rf bot-access.txt
+
+  buildup_SpecsTesting_repo:
+    needs: buildup_SpecsTesting_repo_FirebaseCore
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -37,12 +37,16 @@ test_version=$(git tag -l --sort=-version:refname CocoaPods-*[0-9] | head -n 1)
 git config --global user.email "google-oss-bot@example.com"
 git config --global user.name "google-oss-bot"
 git checkout "${podspec_repo_branch}"
+# Ensure the tag version including pod version to avoid warnings.
+# https://github.com/CocoaPods/Core/blob/e6451e172c33f3aa77a3f8baa7b6b5b8c3b5da14/lib/cocoapods-core/specification/linter.rb#L372-L374
+pod_testing_version=`echo "${test_version}" | sed "s/\s*Cocoapods-//"`
 if [ "$TESTINGMODE" = "release_testing" ]; then
   git checkout "${test_version}"
   echo "Podspecs tags of Nightly release testing will be updated to ${test_version}."
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => 'CocoaPods-7.9.0'"
   sed  -i "" "s/\s*:tag.*/:tag => '${test_version}'/" *.podspec
+  sed  -i "" "s/\s*s\.version\s*=.*/s\.version='${pod_testing_version}'/" *.podspec
 elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   tag_version="${test_version}.nightly"
   echo "A new tag, ${tag_version},for prerelease testing will be created."
@@ -56,4 +60,5 @@ elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => ${test_version}.nightly"
   sed  -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec
+  sed  -i "" "s/\s*s\.version\s*=.*/s\.version='${pod_testing_version}'/" *.podspec
 fi

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -40,8 +40,6 @@ git checkout "${podspec_repo_branch}"
 # Ensure the tag version including pod version to avoid warnings.
 # https://github.com/CocoaPods/Core/blob/e6451e172c33f3aa77a3f8baa7b6b5b8c3b5da14/lib/cocoapods-core/specification/linter.rb#L372-L374
 pod_testing_version=`echo "${test_version}" | sed "s/CocoaPods-//"`
-echo "-----"
-echo ${pod_testing_version}
 if [ "$TESTINGMODE" = "release_testing" ]; then
   git checkout "${test_version}"
   echo "Podspecs tags of Nightly release testing will be updated to ${test_version}."

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -46,7 +46,7 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => 'CocoaPods-7.9.0'"
   sed  -i "" "s/\s*:tag.*/:tag => '${test_version}'/" *.podspec
-  sed  -i "" "s/\s*s\.version\s*=.*/s\.version='${pod_testing_version}'/" *.podspec
+  sed  -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
 elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   tag_version="${test_version}.nightly"
   echo "A new tag, ${tag_version},for prerelease testing will be created."
@@ -60,5 +60,5 @@ elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => ${test_version}.nightly"
   sed  -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec
-  sed  -i "" "s/\s*s\.version\s*=.*/s\.version='${pod_testing_version}'/" *.podspec
+  sed  -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
 fi

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -45,8 +45,8 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   echo "Podspecs tags of Nightly release testing will be updated to ${test_version}."
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => 'CocoaPods-7.9.0'"
-  sed  -i "" "s/\s*:tag.*/:tag => '${test_version}'/" *.podspec
-  sed  -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
+  sed -i "" "s/\s*:tag.*/:tag => '${test_version}'/" *.podspec
+  sed -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
 elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   tag_version="${test_version}.nightly"
   echo "A new tag, ${tag_version},for prerelease testing will be created."
@@ -59,6 +59,6 @@ elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   git push origin "${tag_version}"
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => ${test_version}.nightly"
-  sed  -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec
-  sed  -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
+  sed -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec
+  sed -i "" "s/s\.version[[:space:]]*=.*/s\.version='${pod_testing_version}'/" *.podspec
 fi

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -39,7 +39,9 @@ git config --global user.name "google-oss-bot"
 git checkout "${podspec_repo_branch}"
 # Ensure the tag version including pod version to avoid warnings.
 # https://github.com/CocoaPods/Core/blob/e6451e172c33f3aa77a3f8baa7b6b5b8c3b5da14/lib/cocoapods-core/specification/linter.rb#L372-L374
-pod_testing_version=`echo "${test_version}" | sed "s/\s*Cocoapods-//"`
+pod_testing_version=`echo "${test_version}" | sed "s/Cocoapods-//"`
+echo "-----"
+echo ${pod_testing_version}
 if [ "$TESTINGMODE" = "release_testing" ]; then
   git checkout "${test_version}"
   echo "Podspecs tags of Nightly release testing will be updated to ${test_version}."

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -39,7 +39,7 @@ git config --global user.name "google-oss-bot"
 git checkout "${podspec_repo_branch}"
 # Ensure the tag version including pod version to avoid warnings.
 # https://github.com/CocoaPods/Core/blob/e6451e172c33f3aa77a3f8baa7b6b5b8c3b5da14/lib/cocoapods-core/specification/linter.rb#L372-L374
-pod_testing_version=`echo "${test_version}" | sed "s/Cocoapods-//"`
+pod_testing_version=`echo "${test_version}" | sed "s/CocoaPods-//"`
 echo "-----"
 echo ${pod_testing_version}
 if [ "$TESTINGMODE" = "release_testing" ]; then


### PR DESCRIPTION
- [x] Preinstall FirebaseCore before pushing other SDKs
- [x] Pass `--allow-warnings` to the testing from Manifest through the matrix. 
- [x] Add `retry` to push specs to testing spec repo. The `pod repo push` wrapper will rerun once failed, e.g. race condition of pushing spec to the repo.