### PR TITLE
Change unarchiveObjectWithFile in FIAM to conform to the secure coding practices

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Replaced unarchiveObjectWithFile with unarchivedObjectOfClass to conform to secure coding practices, and implemented NSSecureCoding (#9816).
+
 # 8.12.0
 - [fixed] In-App Messaging's test message does not include appData in response. This SDK fix will work once the backend is also updated (#9126).
 

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -167,18 +167,21 @@ static NSString *const kEventExtensionJson = @"extension_js";
 
   NSTimeInterval start = [self.timeFetcher currentTimestampInSeconds];
   id fetchedClearcutRetryRecords;
-    NSData *data = [NSData dataWithContentsOfFile:filePath];
-        if (data) {
-            if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-                fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMClearcutLogRecord *> class] fromData:data error:nil];
-            } else {
-                // Fallback on earlier versions
+  NSData *data = [NSData dataWithContentsOfFile:filePath];
+  if (data) {
+    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+      fetchedClearcutRetryRecords = [NSKeyedUnarchiver
+          unarchivedObjectOfClass:[NSMutableArray<FIRIAMClearcutLogRecord *> class]
+                         fromData:data
+                            error:nil];
+    } else {
+      // Fallback on earlier versions
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+      fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
 #pragma clang diagnostic pop
-            }
-        }
+    }
+  }
   if (fetchedClearcutRetryRecords) {
     @synchronized(self) {
       self.records = (NSMutableArray<FIRIAMClearcutLogRecord *> *)fetchedClearcutRetryRecords;

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -171,9 +171,10 @@ static NSString *const kEventExtensionJson = @"extension_js";
   if (data) {
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
       fetchedClearcutRetryRecords = [NSKeyedUnarchiver
-          unarchivedObjectOfClass:[NSMutableArray<FIRIAMClearcutLogRecord *> class]
-                         fromData:data
-                            error:nil];
+          unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMClearcutLogRecord class],
+                                                          [NSArray class], nil]
+                           fromData:data
+                              error:nil];
     } else {
       // Fallback on earlier versions
 #pragma clang diagnostic push

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -166,8 +166,6 @@ static NSString *const kEventExtensionJson = @"extension_js";
   NSString *filePath = cacheFilePath == nil ? [self.class determineCacheFilePath] : cacheFilePath;
 
   NSTimeInterval start = [self.timeFetcher currentTimestampInSeconds];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   id fetchedClearcutRetryRecords;
     NSData *data = [NSData dataWithContentsOfFile:filePath];
         if (data) {
@@ -175,10 +173,12 @@ static NSString *const kEventExtensionJson = @"extension_js";
                 fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMClearcutLogRecord *> class] fromData:data error:nil];
             } else {
                 // Fallback on earlier versions
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+#pragma clang diagnostic pop
             }
         }
-#pragma clang diagnostic pop
   if (fetchedClearcutRetryRecords) {
     @synchronized(self) {
       self.records = (NSMutableArray<FIRIAMClearcutLogRecord *> *)fetchedClearcutRetryRecords;

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -172,7 +172,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
       fetchedClearcutRetryRecords = [NSKeyedUnarchiver
           unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMClearcutLogRecord class],
-                                                          [NSArray class], nil]
+                                                          [NSMutableArray class], nil]
                            fromData:data
                               error:nil];
     } else {

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -168,7 +168,16 @@ static NSString *const kEventExtensionJson = @"extension_js";
   NSTimeInterval start = [self.timeFetcher currentTimestampInSeconds];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  id fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+  id fetchedClearcutRetryRecords;
+    NSData *data = [NSData dataWithContentsOfFile:filePath];
+        if (data) {
+            if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+                fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMClearcutLogRecord *> class] fromData:data error:nil];
+            } else {
+                // Fallback on earlier versions
+                fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+            }
+        }
 #pragma clang diagnostic pop
   if (fetchedClearcutRetryRecords) {
     @synchronized(self) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -160,7 +160,7 @@ static NSString *const kDetailArchiveKey = @"detail";
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
       fetchedActivityRecords = [NSKeyedUnarchiver
           unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMActivityRecord class],
-                                                          [NSArray class], nil]
+                                                          [NSMutableArray class], nil]
                            fromData:data
                               error:nil];
     } else {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -158,10 +158,11 @@ static NSString *const kDetailArchiveKey = @"detail";
   NSData *data = [NSData dataWithContentsOfFile:filePath];
   if (data) {
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      fetchedActivityRecords =
-          [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMActivityRecord *> class]
-                                            fromData:data
-                                               error:nil];
+      fetchedActivityRecords = [NSKeyedUnarchiver
+          unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMActivityRecord class],
+                                                          [NSArray class], nil]
+                           fromData:data
+                              error:nil];
     } else {
       // Fallback on earlier versions
 #pragma clang diagnostic push

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -154,8 +154,6 @@ static NSString *const kDetailArchiveKey = @"detail";
 
 - (void)loadFromCachePath:(NSString *)cacheFilePath {
   NSString *filePath = cacheFilePath == nil ? [self.class determineCacheFilePath] : cacheFilePath;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   id fetchedActivityRecords;
     NSData *data = [NSData dataWithContentsOfFile:filePath];
         if (data) {
@@ -163,10 +161,12 @@ static NSString *const kDetailArchiveKey = @"detail";
                 fetchedActivityRecords = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMActivityRecord *> class] fromData:data error:nil];
             } else {
                 // Fallback on earlier versions
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 fetchedActivityRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+#pragma clang diagnostic pop
             }
         }
-#pragma clang diagnostic pop
   if (fetchedActivityRecords) {
     @synchronized(self) {
       self.activityRecords = (NSMutableArray<FIRIAMActivityRecord *> *)fetchedActivityRecords;

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -155,18 +155,21 @@ static NSString *const kDetailArchiveKey = @"detail";
 - (void)loadFromCachePath:(NSString *)cacheFilePath {
   NSString *filePath = cacheFilePath == nil ? [self.class determineCacheFilePath] : cacheFilePath;
   id fetchedActivityRecords;
-    NSData *data = [NSData dataWithContentsOfFile:filePath];
-        if (data) {
-            if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-                fetchedActivityRecords = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMActivityRecord *> class] fromData:data error:nil];
-            } else {
-                // Fallback on earlier versions
+  NSData *data = [NSData dataWithContentsOfFile:filePath];
+  if (data) {
+    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+      fetchedActivityRecords =
+          [NSKeyedUnarchiver unarchivedObjectOfClass:[NSMutableArray<FIRIAMActivityRecord *> class]
+                                            fromData:data
+                                               error:nil];
+    } else {
+      // Fallback on earlier versions
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                fetchedActivityRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+      fetchedActivityRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
 #pragma clang diagnostic pop
-            }
-        }
+    }
+  }
   if (fetchedActivityRecords) {
     @synchronized(self) {
       self.activityRecords = (NSMutableArray<FIRIAMActivityRecord *> *)fetchedActivityRecords;

--- a/FirebaseInAppMessaging/Sources/Private/Flows/FIRIAMActivityLogger.h
+++ b/FirebaseInAppMessaging/Sources/Private/Flows/FIRIAMActivityLogger.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSInteger, FIRIAMActivityType) {
 };
 
 NS_ASSUME_NONNULL_BEGIN
-@interface FIRIAMActivityRecord : NSObject <NSCoding>
+@interface FIRIAMActivityRecord : NSObject <NSSecureCoding>
 @property(nonatomic, nonnull, readonly) NSDate *timestamp;
 @property(nonatomic, readonly) FIRIAMActivityType activityType;
 @property(nonatomic, readonly) BOOL success;


### PR DESCRIPTION
Possible fix for #9816.

Changed unarchiveObjectWithFile with unarchivedObjectOfClass to conform to secure coding practices, and implemented NSSecureCoding.  