### PR TITLE
Storage Custom Metadata Deletion

### DIFF
--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -631,26 +631,28 @@ NSString *const kTestPassword = KPASSWORD;
   metadata.contentEncoding = @"gzip";
   metadata.contentLanguage = @"de";
   metadata.contentType = @"content-type-a";
-  metadata.customMetadata = @{@"a" : @"b"};
+  metadata.customMetadata = @{@"a" : @"b", @"y" : @"z"};
 
   [ref updateMetadata:metadata
            completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
              XCTAssertNil(error);
              [self assertMetadata:updatedMetadata
                       contentType:@"content-type-a"
-                   customMetadata:@{@"a" : @"b"}];
+                   customMetadata:@{@"a" : @"b", @"y" : @"z"}];
 
              // Update a subset of the metadata using the existing object.
              FIRStorageMetadata *metadata = updatedMetadata;
              metadata.contentType = @"content-type-b";
-             metadata.customMetadata = @{@"a" : @"b", @"c" : @"d"};
+             metadata.customMetadata = @{@"c" : @"d", @"y" : @""};
 
              [ref updateMetadata:metadata
                       completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
                         XCTAssertNil(error);
                         [self assertMetadata:updatedMetadata
                                  contentType:@"content-type-b"
-                              customMetadata:@{@"a" : @"b", @"c" : @"d"}];
+
+                              // "a" is now deleted and the empty string for "y" remains.
+                              customMetadata:@{@"c" : @"d", @"y" : @""}];
 
                         // Clear all metadata.
                         FIRStorageMetadata *metadata = updatedMetadata;


### PR DESCRIPTION
Update Storage Integration Tests to be clear about the behavior of deleting elements from customMetadata.

See context in #9849