### PR TITLE
Patch abseil in cmake builds to add the missing #include <limits>

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -30,5 +30,7 @@ ExternalProject_Add(
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   TEST_COMMAND ""
+  PATCH_COMMAND patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/abseil-cpp.patch
+
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
 )

--- a/cmake/external/abseil-cpp.patch
+++ b/cmake/external/abseil-cpp.patch
@@ -1,0 +1,16 @@
+diff -Naur a/absl/synchronization/internal/graphcycles.cc b/absl/synchronization/internal/graphcycles.cc
+--- abseil-cpp/absl/synchronization/internal/graphcycles.cc	2020-02-25 17:56:58.000000000 -0500
++++ abseil-cpp-fixed/absl/synchronization/internal/graphcycles.cc	2022-05-30 11:35:14.992431139 -0400
+@@ -37,6 +37,9 @@
+ 
+ #include <algorithm>
+ #include <array>
++// Add #include <limits> because without it builds fail on gLinux workstations
++// due to the usage of std::numeric_limits<uint32_t>::max() that requires it.
++// This problem was fixed in abseil upstream by
++// https://github.com/abseil/abseil-cpp/commit/5bf048b842
++// (Googlers can see cl/339054753)
++#include <limits>
+ #include "absl/base/internal/hide_ptr.h"
+ #include "absl/base/internal/raw_logging.h"
+ #include "absl/base/internal/spinlock.h"

--- a/scripts/check_whitespace.sh
+++ b/scripts/check_whitespace.sh
@@ -26,6 +26,7 @@ options=(
 )
 
 git grep "${options[@]}" -- \
+    ':(exclude)cmake/external/abseil-cpp.patch' \
     ':(exclude)cmake/external/snappy.patch' \
     ':(exclude)Crashlytics/ProtoSupport' \
     ':(exclude)Crashlytics/UnitTests/Data' \


### PR DESCRIPTION
Without this patch, builds fail in some environments (e.g. Google's internal gLinux workstations) with this error:

```
build/external/src/abseil-cpp/absl/synchronization/internal/graphcycles.cc: In member function ‘void absl::lts_20211102::synchronization_internal::GraphCycles::RemoveNode(void*)’:
build/external/src/abseil-cpp/absl/synchronization/internal/graphcycles.cc:451:26: error: ‘numeric_limits’ is not a member of ‘std’
  451 |   if (x->version == std::numeric_limits<uint32_t>::max()) {
      |                          ^~~~~~~~~~~~~~
build/external/src/abseil-cpp/absl/synchronization/internal/graphcycles.cc:451:49: error: expected primary-expression before ‘>’ token
:numeric_limits<uint32_t>::max()) {
      |                                                 ^
build/external/src/abseil-cpp/absl/synchronization/internal/graphcycles.cc:451:52: error: ‘::max’ has not been declared; did you mean ‘std::max’?
:numeric_limits<uint32_t>::max()) {
      |                                                    ^~~
      |                                                    std::max
In file included from /usr/include/c++/11/algorithm:62,
                 from build/external/src/abseil-cpp/absl/synchronization/internal/graphcycles.cc:38:
/usr/include/c++/11/bi::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
```

This PR should be reverted once the abseil dependency is upgraded to a version that includes the upstream fix https://github.com/abseil/abseil-cpp/commit/5bf048b842

#no-changelog