### PR TITLE
Try to address prewarming issue by catching keychain errors instead of using `isProtectedDataAvailable`

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Catch keychain errors instead of using the `isProtectedDataAvailable` API for handling prewarming issue. (#9869)
+
 # 9.0.0
 - [fixed] **Breaking change:** Fixed an ObjC-to-Swift API conversion error where `getStoredUser(forAccessGroup:)` returned a non-optional type. This change is breaking for Swift users only (#8599).
 - [fixed] Fixed an iOS 15 keychain access issue related to prewarming. (#8695)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.2.0
 - [fixed] Catch keychain errors instead of using the `isProtectedDataAvailable` API for handling prewarming issue. (#9869)
 
 # 9.0.0

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -536,24 +536,18 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
           self->_lastNotifiedUserToken = user.rawAccessToken;
         } else {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          if (@available(iOS 14.5, tvOS 14.5, macCatalyst 14.5, *)) {
-            NSArray *underlyingErrorArray = error.underlyingErrors;
-            for (NSError *underlyingError in underlyingErrorArray) {
-              if (underlyingError.code == FIRAuthInternalErrorCodeKeychainError) {
-                // If there's a keychain error, assume it is due to the keychain being accessed
-                // before the device is unlocked as a result of prewarming, and listen for the
-                // UIApplicationProtectedDataDidBecomeAvailable notification.
-                self->_protectedDataDidBecomeAvailableObserver =
-                    [[NSNotificationCenter defaultCenter]
-                        addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                    object:nil
-                                     queue:nil
-                                usingBlock:^(NSNotification *notification) {
-                                  [self protectedDataInitialization];
-                                }];
-                break;
-              }
-            }
+          if (error.code == FIRAuthErrorCodeKeychainError) {
+            // If there's a keychain error, assume it is due to the keychain being accessed
+            // before the device is unlocked as a result of prewarming, and listen for the
+            // UIApplicationProtectedDataDidBecomeAvailable notification.
+            self->_protectedDataDidBecomeAvailableObserver =
+                [[NSNotificationCenter defaultCenter]
+                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                                object:nil
+                                 queue:nil
+                            usingBlock:^(NSNotification *notification) {
+                              [self protectedDataInitialization];
+                            }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -563,24 +557,18 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         [strongSelf internalUseUserAccessGroup:storedUserAccessGroup error:&error];
         if (error) {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          if (@available(iOS 14.5, tvOS 14.5, macCatalyst 14.5, *)) {
-            NSArray *underlyingErrorArray = error.underlyingErrors;
-            for (NSError *underlyingError in underlyingErrorArray) {
-              if (underlyingError.code == FIRAuthInternalErrorCodeKeychainError) {
-                // If there's a keychain error, assume it is due to the keychain being accessed
-                // before the device is unlocked as a result of prewarming, and listen for the
-                // UIApplicationProtectedDataDidBecomeAvailable notification.
-                self->_protectedDataDidBecomeAvailableObserver =
-                    [[NSNotificationCenter defaultCenter]
-                        addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                    object:nil
-                                     queue:nil
-                                usingBlock:^(NSNotification *notification) {
-                                  [self protectedDataInitialization];
-                                }];
-                break;
-              }
-            }
+          if (error.code == FIRAuthErrorCodeKeychainError) {
+            // If there's a keychain error, assume it is due to the keychain being accessed
+            // before the device is unlocked as a result of prewarming, and listen for the
+            // UIApplicationProtectedDataDidBecomeAvailable notification.
+            self->_protectedDataDidBecomeAvailableObserver =
+                [[NSNotificationCenter defaultCenter]
+                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                                object:nil
+                                 queue:nil
+                            usingBlock:^(NSNotification *notification) {
+                              [self protectedDataInitialization];
+                            }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -589,23 +577,18 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       }
     } else {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-      if (@available(iOS 14.5, tvOS 14.5, macCatalyst 14.5, *)) {
-        NSArray *underlyingErrorArray = error.underlyingErrors;
-        for (NSError *underlyingError in underlyingErrorArray) {
-          if (underlyingError.code == FIRAuthInternalErrorCodeKeychainError) {
-            // If there's a keychain error, assume it is due to the keychain being accessed
-            // before the device is unlocked as a result of prewarming, and listen for the
-            // UIApplicationProtectedDataDidBecomeAvailable notification.
-            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+      if (error.code == FIRAuthErrorCodeKeychainError) {
+        // If there's a keychain error, assume it is due to the keychain being accessed
+        // before the device is unlocked as a result of prewarming, and listen for the
+        // UIApplicationProtectedDataDidBecomeAvailable notification.
+        self->_protectedDataDidBecomeAvailableObserver =
+            [[NSNotificationCenter defaultCenter]
                 addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
                             object:nil
                              queue:nil
                         usingBlock:^(NSNotification *notification) {
                           [self protectedDataInitialization];
                         }];
-            break;
-          }
-        }
       }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
       FIRLogError(kFIRLoggerAuth, @"I-AUT000001", @"Error loading saved user when starting up: %@",

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -502,11 +502,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 }
 
 - (void)protectedDataInitialization {
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-  [[NSNotificationCenter defaultCenter] removeObserver:_protectedDataDidBecomeAvailableObserver
-                                                  name:UIApplicationProtectedDataDidBecomeAvailable
-                                                object:nil];
-#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
   // Continue with the rest of initialization in the work thread.
   __weak FIRAuth *weakSelf = self;
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
@@ -617,6 +612,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                    queue:nil
               usingBlock:^(NSNotification *notification) {
                 FIRAuth *strongSelf = weakSelf;
+                [[NSNotificationCenter defaultCenter]
+                    removeObserver:strongSelf->_protectedDataDidBecomeAvailableObserver
+                              name:UIApplicationProtectedDataDidBecomeAvailable
+                            object:nil];
                 [strongSelf protectedDataInitialization];
               }];
 }

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -540,13 +540,15 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
+            __weak FIRAuth *innerWeakSelf = strongSelf;
             strongSelf->_protectedDataDidBecomeAvailableObserver =
                 [[NSNotificationCenter defaultCenter]
                     addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
                                 object:nil
                                  queue:nil
                             usingBlock:^(NSNotification *notification) {
-                              [strongSelf protectedDataInitialization];
+                              FIRAuth *innerStrongSelf = innerWeakSelf;
+                              [innerStrongSelf protectedDataInitialization];
                             }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
@@ -561,13 +563,15 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
+            __weak FIRAuth *innerWeakSelf = strongSelf;
             strongSelf->_protectedDataDidBecomeAvailableObserver =
                 [[NSNotificationCenter defaultCenter]
                     addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
                                 object:nil
                                  queue:nil
                             usingBlock:^(NSNotification *notification) {
-                              [strongSelf protectedDataInitialization];
+                              FIRAuth *innerStrongSelf = innerWeakSelf;
+                              [innerStrongSelf protectedDataInitialization];
                             }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
@@ -581,12 +585,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         // If there's a keychain error, assume it is due to the keychain being accessed
         // before the device is unlocked as a result of prewarming, and listen for the
         // UIApplicationProtectedDataDidBecomeAvailable notification.
+        __weak FIRAuth *innerWeakSelf = strongSelf;
         strongSelf->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
             addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
                         object:nil
                          queue:nil
                     usingBlock:^(NSNotification *notification) {
-                      [strongSelf protectedDataInitialization];
+                      FIRAuth *innerStrongSelf = innerWeakSelf;
+                      [innerStrongSelf protectedDataInitialization];
                     }];
       }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -540,14 +540,13 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            self->_protectedDataDidBecomeAvailableObserver =
-                [[NSNotificationCenter defaultCenter]
-                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                object:nil
-                                 queue:nil
-                            usingBlock:^(NSNotification *notification) {
-                              [self protectedDataInitialization];
-                            }];
+            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *notification) {
+                          [self protectedDataInitialization];
+                        }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -561,14 +560,13 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            self->_protectedDataDidBecomeAvailableObserver =
-                [[NSNotificationCenter defaultCenter]
-                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                object:nil
-                                 queue:nil
-                            usingBlock:^(NSNotification *notification) {
-                              [self protectedDataInitialization];
-                            }];
+            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *notification) {
+                          [self protectedDataInitialization];
+                        }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -581,14 +579,13 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         // If there's a keychain error, assume it is due to the keychain being accessed
         // before the device is unlocked as a result of prewarming, and listen for the
         // UIApplicationProtectedDataDidBecomeAvailable notification.
-        self->_protectedDataDidBecomeAvailableObserver =
-            [[NSNotificationCenter defaultCenter]
-                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *notification) {
-                          [self protectedDataInitialization];
-                        }];
+        self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *notification) {
+                      [self protectedDataInitialization];
+                    }];
       }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
       FIRLogError(kFIRLoggerAuth, @"I-AUT000001", @"Error loading saved user when starting up: %@",

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -540,13 +540,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *notification) {
-                          [self protectedDataInitialization];
-                        }];
+            strongSelf->_protectedDataDidBecomeAvailableObserver =
+                [[NSNotificationCenter defaultCenter]
+                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                                object:nil
+                                 queue:nil
+                            usingBlock:^(NSNotification *notification) {
+                              [strongSelf protectedDataInitialization];
+                            }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -560,13 +561,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
-                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                            object:nil
-                             queue:nil
-                        usingBlock:^(NSNotification *notification) {
-                          [self protectedDataInitialization];
-                        }];
+            strongSelf->_protectedDataDidBecomeAvailableObserver =
+                [[NSNotificationCenter defaultCenter]
+                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                                object:nil
+                                 queue:nil
+                            usingBlock:^(NSNotification *notification) {
+                              [strongSelf protectedDataInitialization];
+                            }];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -579,12 +581,12 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         // If there's a keychain error, assume it is due to the keychain being accessed
         // before the device is unlocked as a result of prewarming, and listen for the
         // UIApplicationProtectedDataDidBecomeAvailable notification.
-        self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+        strongSelf->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
             addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
                         object:nil
                          queue:nil
                     usingBlock:^(NSNotification *notification) {
-                      [self protectedDataInitialization];
+                      [strongSelf protectedDataInitialization];
                     }];
       }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -589,25 +589,24 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       }
     } else {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          if (@available(iOS 14.5, tvOS 14.5, macCatalyst 14.5, *)) {
-            NSArray *underlyingErrorArray = error.underlyingErrors;
-            for (NSError *underlyingError in underlyingErrorArray) {
-              if (underlyingError.code == FIRAuthInternalErrorCodeKeychainError) {
-                // If there's a keychain error, assume it is due to the keychain being accessed
-                // before the device is unlocked as a result of prewarming, and listen for the
-                // UIApplicationProtectedDataDidBecomeAvailable notification.
-                self->_protectedDataDidBecomeAvailableObserver =
-                    [[NSNotificationCenter defaultCenter]
-                        addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                    object:nil
-                                     queue:nil
-                                usingBlock:^(NSNotification *notification) {
-                                  [self protectedDataInitialization];
-                                }];
-                break;
-              }
-            }
+      if (@available(iOS 14.5, tvOS 14.5, macCatalyst 14.5, *)) {
+        NSArray *underlyingErrorArray = error.underlyingErrors;
+        for (NSError *underlyingError in underlyingErrorArray) {
+          if (underlyingError.code == FIRAuthInternalErrorCodeKeychainError) {
+            // If there's a keychain error, assume it is due to the keychain being accessed
+            // before the device is unlocked as a result of prewarming, and listen for the
+            // UIApplicationProtectedDataDidBecomeAvailable notification.
+            self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+                addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *notification) {
+                          [self protectedDataInitialization];
+                        }];
+            break;
           }
+        }
+      }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
       FIRLogError(kFIRLoggerAuth, @"I-AUT000001", @"Error loading saved user when starting up: %@",
                   error);

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -540,16 +540,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            __weak FIRAuth *innerWeakSelf = strongSelf;
-            strongSelf->_protectedDataDidBecomeAvailableObserver =
-                [[NSNotificationCenter defaultCenter]
-                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                object:nil
-                                 queue:nil
-                            usingBlock:^(NSNotification *notification) {
-                              FIRAuth *innerStrongSelf = innerWeakSelf;
-                              [innerStrongSelf protectedDataInitialization];
-                            }];
+            [strongSelf addProtectedDataDidBecomeAvailableObserver];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -563,16 +554,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
             // If there's a keychain error, assume it is due to the keychain being accessed
             // before the device is unlocked as a result of prewarming, and listen for the
             // UIApplicationProtectedDataDidBecomeAvailable notification.
-            __weak FIRAuth *innerWeakSelf = strongSelf;
-            strongSelf->_protectedDataDidBecomeAvailableObserver =
-                [[NSNotificationCenter defaultCenter]
-                    addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                                object:nil
-                                 queue:nil
-                            usingBlock:^(NSNotification *notification) {
-                              FIRAuth *innerStrongSelf = innerWeakSelf;
-                              [innerStrongSelf protectedDataInitialization];
-                            }];
+            [strongSelf addProtectedDataDidBecomeAvailableObserver];
           }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
           FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
@@ -585,15 +567,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         // If there's a keychain error, assume it is due to the keychain being accessed
         // before the device is unlocked as a result of prewarming, and listen for the
         // UIApplicationProtectedDataDidBecomeAvailable notification.
-        __weak FIRAuth *innerWeakSelf = strongSelf;
-        strongSelf->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *notification) {
-                      FIRAuth *innerStrongSelf = innerWeakSelf;
-                      [innerStrongSelf protectedDataInitialization];
-                    }];
+        [strongSelf addProtectedDataDidBecomeAvailableObserver];
       }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
       FIRLogError(kFIRLoggerAuth, @"I-AUT000001", @"Error loading saved user when starting up: %@",
@@ -633,6 +607,20 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 #endif  // TARGET_OS_IOS
   });
 }
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
+- (void)addProtectedDataDidBecomeAvailableObserver {
+  __weak FIRAuth *weakSelf = self;
+  self->_protectedDataDidBecomeAvailableObserver = [[NSNotificationCenter defaultCenter]
+      addObserverForName:UIApplicationProtectedDataDidBecomeAvailable
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *notification) {
+                FIRAuth *strongSelf = weakSelf;
+                [strongSelf protectedDataInitialization];
+              }];
+}
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
 
 - (void)dealloc {
   @synchronized(self) {


### PR DESCRIPTION
#9622 attempted to fix user logout issues that occur because of [prewarming](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence?language=objc#3894431) [[1](https://github.com/firebase/firebase-ios-sdk/issues/8695)][[2](https://sourcediving.com/solving-mysterious-logout-issues-on-ios-15-8b818c089466)] by using the `isProtectedDataAvailable` API to determine if the keychain was accessible.

However, from #9869 it appears that this check may be causing issues. Instead of checking `isProtectedDataAvailable`, we will instead catch keychain errors to determine whether we should listen to the `UIApplicationProtectedDataDidBecomeAvailable` notification.

Fixes #9869