### PR TITLE
Add new GoogleSignIn Swift pod to zip distro

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -311,7 +311,7 @@ extension CarthageUtils {
   /// - Returns: JSON file name for a product.
   private static func getJSONFileName(product: String) -> String {
     var jsonFileName: String
-    if product == "GoogleSignIn" {
+    if product == "GoogleSignInSwiftSupport" {
       jsonFileName = "FirebaseGoogleSignIn"
     } else if product == "Google-Mobile-Ads-SDK" {
       jsonFileName = "FirebaseAdMob"

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -328,7 +328,7 @@ struct ZipBuilder {
     podsToInstall.append(CocoaPodUtils.VersionedPod(name: "Google-Mobile-Ads-SDK",
                                                     version: nil,
                                                     platforms: ["ios"]))
-    podsToInstall.append(CocoaPodUtils.VersionedPod(name: "GoogleSignIn",
+    podsToInstall.append(CocoaPodUtils.VersionedPod(name: "GoogleSignInSwiftSupport",
                                                     version: nil,
                                                     platforms: ["ios"]))
 
@@ -440,7 +440,7 @@ struct ZipBuilder {
     // Skip Analytics and the pods bundled with it.
     let remainingPods = installedPods.filter {
       $0.key == "Google-Mobile-Ads-SDK" ||
-        $0.key == "GoogleSignIn" ||
+        $0.key == "GoogleSignInSwiftSupport" ||
         (firebaseZipPods.contains($0.key) &&
           $0.key != "FirebaseAnalyticsSwift" &&
           $0.key != "Firebase" &&
@@ -685,7 +685,7 @@ struct ZipBuilder {
   /// Describes the dependency on other frameworks for the README file.
   func readmeHeader(podName: String) -> String {
     var header = "## \(podName)"
-    if !(podName == "FirebaseAnalytics" || podName == "GoogleSignIn") {
+    if !(podName == "FirebaseAnalytics" || podName == "GoogleSignInSwiftSupport") {
       header += " (~> FirebaseAnalytics)"
     }
     header += "\n"


### PR DESCRIPTION
Fix #9900

GoogleSignIn recently added a separate zip pod. This PR adds it to the GoogleSignIn folder in the Firebase zip distribution.

cc: @petea 