### PR TITLE
[Feature Proposal]Property Wrapper for RemoteConfig

### DIFF
--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -21,9 +21,9 @@ app update.
 
   s.swift_version           = '5.3'
 
-  ios_deployment_target = '11.0'
+  ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
-  tvos_deployment_target = '11.0'
+  tvos_deployment_target = '10.0'
   watchos_deployment_target = '6.0'
 
   s.ios.deployment_target = ios_deployment_target

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -21,9 +21,9 @@ app update.
 
   s.swift_version           = '5.3'
 
-  ios_deployment_target = '10.0'
+  ios_deployment_target = '11.0'
   osx_deployment_target = '10.12'
-  tvos_deployment_target = '10.0'
+  tvos_deployment_target = '11.0'
   watchos_deployment_target = '6.0'
 
   s.ios.deployment_target = ios_deployment_target
@@ -35,7 +35,7 @@ app update.
   s.prefix_header_file      = false
 
   s.source_files = [
-    'FirebaseRemoteConfigSwift/Sources/*.swift',
+    'FirebaseRemoteConfigSwift/Sources/**/*.swift',
   ]
 
   s.dependency 'FirebaseRemoteConfig', '~> 9.0'

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
@@ -1,8 +1,40 @@
 //
-//  File.swift
+//  PropertyWrapper.swift
 //  
 //
 //  Created by Fumito Ito on 2022/05/25.
 //
 
-import Foundation
+import FirebaseRemoteConfig
+
+@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+@propertyWrapper
+public struct RemoteConfigProperty<T: Decodable> {
+    private let key: String
+    private let remoteConfig: RemoteConfig
+
+    public var wrappedValue: T? {
+        get {
+            try? self.remoteConfig[self.key].decoded(asType: T.self)
+        }
+        @available(*, unavailable, message: "RemoteConfig property wrapper does not support setting property.")
+        set {
+            fatalError("RemoteConfig property wrapper does not support setting property.")
+        }
+    }
+
+    public init(
+        forKey key: String
+    ) {
+        self.key = key
+        self.remoteConfig = RemoteConfig.remoteConfig()
+    }
+
+    public init(
+        forKey key: String,
+        remoteConfig: RemoteConfig
+    ) {
+        self.key = key
+        self.remoteConfig = remoteConfig
+    }
+}

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Fumito Ito on 2022/05/25.
+//
+
+import Foundation

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper.swift
@@ -5,13 +5,20 @@
 //  Created by Fumito Ito on 2022/05/25.
 //
 
+import SwiftUI
 import FirebaseRemoteConfig
 
 @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct RemoteConfigProperty<T: Decodable> {
-    private let key: String
-    private let remoteConfig: RemoteConfig
+    public let key: String
+    public let remoteConfig: RemoteConfig
+    public var lastFetchStatus: RemoteConfigFetchStatus {
+        return self.remoteConfig.lastFetchStatus
+    }
+    public var lastFetchTime: Date? {
+        return self.remoteConfig.lastFetchTime
+    }
 
     public var wrappedValue: T? {
         get {
@@ -21,6 +28,15 @@ public struct RemoteConfigProperty<T: Decodable> {
         set {
             fatalError("RemoteConfig property wrapper does not support setting property.")
         }
+    }
+
+    public var projectedValue: Binding<T?> {
+        .init {
+            self.wrappedValue
+        } set: { newValue in
+            fatalError()
+        }
+
     }
 
     public init(

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
@@ -14,66 +14,68 @@
  * limitations under the License.
  */
 
-import SwiftUI
 import FirebaseRemoteConfig
+import SwiftUI
 
-/// A property wrapper that listens to a Remote Config value.
-@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
-@propertyWrapper
-public struct RemoteConfigProperty<T: Decodable>: DynamicProperty {
-  @State private var configValueObserver: RemoteConfigValueObservable<T>
+#if compiler(>=5.5.2) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
+  /// A property wrapper that listens to a Remote Config value.
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+  @propertyWrapper
+  public struct RemoteConfigProperty<T: Decodable>: DynamicProperty {
+    @State private var configValueObserver: RemoteConfigValueObservable<T>
 
-  /// Remote Config key name for this property
-  public let key: String
+    /// Remote Config key name for this property
+    public let key: String
 
-  /// Remote Config instance for this property
-  public let remoteConfig: RemoteConfig
+    /// Remote Config instance for this property
+    public let remoteConfig: RemoteConfig
 
-  /// Last fetched status of remote config values
-  public var lastFetchStatus: RemoteConfigFetchStatus {
-    return remoteConfig.lastFetchStatus
-  }
+    /// Last fetched status of remote config values
+    public var lastFetchStatus: RemoteConfigFetchStatus {
+      return remoteConfig.lastFetchStatus
+    }
 
-  /// Last fetched time of remote config values
-  public var lastFetchTime: Date? {
-    return remoteConfig.lastFetchTime
-  }
+    /// Last fetched time of remote config values
+    public var lastFetchTime: Date? {
+      return remoteConfig.lastFetchTime
+    }
 
-  public var wrappedValue: T {
-    configValueObserver.configValue
-  }
+    public var wrappedValue: T {
+      configValueObserver.configValue
+    }
 
-  /// Creates an instance by defining key.
-  /// This property depends on default remote config.
-  ///
-  /// - Parameter key: key name
-  public init(forKey key: String) {
-    self.key = key
-    remoteConfig = RemoteConfig.remoteConfig()
+    /// Creates an instance by defining key.
+    /// This property depends on default remote config.
+    ///
+    /// - Parameter key: key name
+    public init(forKey key: String) {
+      self.key = key
+      remoteConfig = RemoteConfig.remoteConfig()
 
-    _configValueObserver = State(
-      wrappedValue: RemoteConfigValueObservable<T>(
-        key: key,
-        remoteConfig: RemoteConfig.remoteConfig()
+      _configValueObserver = State(
+        wrappedValue: RemoteConfigValueObservable<T>(
+          key: key,
+          remoteConfig: RemoteConfig.remoteConfig()
+        )
       )
-    )
-  }
+    }
 
-  /// Creates an instance by defining key and remote config instance.
-  ///
-  /// - Parameters:
-  ///   - key: key name
-  ///   - remoteConfig: remote config instance
-  public init(forKey key: String,
-              remoteConfig: RemoteConfig) {
-    self.key = key
-    self.remoteConfig = remoteConfig
+    /// Creates an instance by defining key and remote config instance.
+    ///
+    /// - Parameters:
+    ///   - key: key name
+    ///   - remoteConfig: remote config instance
+    public init(forKey key: String,
+                remoteConfig: RemoteConfig) {
+      self.key = key
+      self.remoteConfig = remoteConfig
 
-    _configValueObserver = State(
-      wrappedValue: RemoteConfigValueObservable<T>(
-        key: key,
-        remoteConfig: remoteConfig
+      _configValueObserver = State(
+        wrappedValue: RemoteConfigValueObservable<T>(
+          key: key,
+          remoteConfig: remoteConfig
+        )
       )
-    )
+    }
   }
-}
+#endif

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/PropertyWrapper.swift
@@ -1,59 +1,79 @@
-//
-//  PropertyWrapper.swift
-//  
-//
-//  Created by Fumito Ito on 2022/05/25.
-//
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import SwiftUI
 import FirebaseRemoteConfig
 
+/// A property wrapper that listens to a Remote Config value.
 @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
 @propertyWrapper
 public struct RemoteConfigProperty<T: Decodable>: DynamicProperty {
-    @State private var configValueObserver: RemoteConfigValueObservable<T>
+  @State private var configValueObserver: RemoteConfigValueObservable<T>
 
-    public let key: String
-    public let remoteConfig: RemoteConfig
-    public var lastFetchStatus: RemoteConfigFetchStatus {
-        return remoteConfig.lastFetchStatus
-    }
-    public var lastFetchTime: Date? {
-        return remoteConfig.lastFetchTime
-    }
+  /// Remote Config key name for this property
+  public let key: String
 
-    public var wrappedValue: T {
-        get {
-            configValueObserver.configValue
-        }
-    }
+  /// Remote Config instance for this property
+  public let remoteConfig: RemoteConfig
 
-    public init(
-        forKey key: String
-    ) {
-        self.key = key
-        self.remoteConfig = RemoteConfig.remoteConfig()
+  /// Last fetched status of remote config values
+  public var lastFetchStatus: RemoteConfigFetchStatus {
+    return remoteConfig.lastFetchStatus
+  }
 
-        _configValueObserver = State(
-            wrappedValue: RemoteConfigValueObservable<T>(
-                key: key,
-                remoteConfig: RemoteConfig.remoteConfig()
-            )
-        )
-    }
+  /// Last fetched time of remote config values
+  public var lastFetchTime: Date? {
+    return remoteConfig.lastFetchTime
+  }
 
-    public init(
-        forKey key: String,
-        remoteConfig: RemoteConfig
-    ) {
-        self.key = key
-        self.remoteConfig = remoteConfig
+  public var wrappedValue: T {
+    configValueObserver.configValue
+  }
 
-        _configValueObserver = State(
-            wrappedValue: RemoteConfigValueObservable<T>(
-                key: key,
-                remoteConfig: remoteConfig
-            )
-        )
-    }
+  /// Creates an instance by defining key.
+  /// This property depends on default remote config.
+  ///
+  /// - Parameter key: key name
+  public init(forKey key: String) {
+    self.key = key
+    remoteConfig = RemoteConfig.remoteConfig()
+
+    _configValueObserver = State(
+      wrappedValue: RemoteConfigValueObservable<T>(
+        key: key,
+        remoteConfig: RemoteConfig.remoteConfig()
+      )
+    )
+  }
+
+  /// Creates an instance by defining key and remote config instance.
+  ///
+  /// - Parameters:
+  ///   - key: key name
+  ///   - remoteConfig: remote config instance
+  public init(forKey key: String,
+              remoteConfig: RemoteConfig) {
+    self.key = key
+    self.remoteConfig = remoteConfig
+
+    _configValueObserver = State(
+      wrappedValue: RemoteConfigValueObservable<T>(
+        key: key,
+        remoteConfig: remoteConfig
+      )
+    )
+  }
 }

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
@@ -1,79 +1,87 @@
-//
-//  File.swift
-//  
-//
-//  Created by Fumito Ito on 2022/06/08.
-//
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import SwiftUI
 import FirebaseRemoteConfig
 
 @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
 internal class RemoteConfigValueObservable<T: Decodable>: ObservableObject {
-    @Published private(set) var configValue: T
+  @Published private(set) var configValue: T
 
-    private let key: String
+  private let key: String
+  private let remoteConfig: RemoteConfig
+  private var observation: RemoteConfigObsever?
+
+  init(key: String, remoteConfig: RemoteConfig) {
+    self.key = key
+    self.remoteConfig = remoteConfig
+    configValue = try! remoteConfig.configValue(forKey: key).decoded(asType: T.self)
+    observation = RemoteConfigObsever(remoteConfig: remoteConfig,
+                                      forKey: key) { [weak self] newValue, error in
+      if let newValue = newValue {
+        self?.configValue = newValue
+      }
+    }
+  }
+
+  deinit {
+    self.observation?.dispose()
+  }
+
+  class RemoteConfigObsever: NSObject {
+    private let observingKeyPath: String
+    private var didRemoveObserver: Bool
     private let remoteConfig: RemoteConfig
-    private var observation: RemoteConfigObsever?
+    private let configValueKey: String
+    private let handler: (T?, Error?) -> Void
 
-    init(key: String, remoteConfig: RemoteConfig) {
-        self.key = key
-        self.remoteConfig = remoteConfig
-        self.configValue = try! remoteConfig.configValue(forKey: key).decoded(asType: T.self)
-        self.observation = RemoteConfigObsever(remoteConfig: remoteConfig, forKey: key) { [weak self] newValue, error in
-            if let newValue = newValue {
-                self?.configValue = newValue
-            }
-        }
+    init(remoteConfig: RemoteConfig, forKey: String,
+         handler: @escaping ((T?, Error?) -> Void)) {
+      observingKeyPath = #keyPath(RemoteConfig.lastFetchTime)
+      didRemoveObserver = false
+      self.remoteConfig = remoteConfig
+      configValueKey = forKey
+      self.handler = handler
+
+      super.init()
+
+      remoteConfig.addObserver(self, forKeyPath: observingKeyPath, context: nil)
     }
 
-    deinit {
-        self.observation?.dispose()
+    func dispose() {
+      if didRemoveObserver { return }
+
+      didRemoveObserver = true
+      remoteConfig.removeObserver(self, forKeyPath: observingKeyPath, context: nil)
     }
 
-    class RemoteConfigObsever: NSObject {
+    override func observeValue(forKeyPath keyPath: String?,
+                               of object: Any?,
+                               change: [NSKeyValueChangeKey: Any]?,
+                               context: UnsafeMutableRawPointer?) {
+      guard change != nil, object != nil, keyPath == observingKeyPath else {
+        return
+      }
 
-        private let observingKeyPath: String
-        private var didRemoveObserver: Bool
-        private let remoteConfig: RemoteConfig
-        private let configValueKey: String
-        private let handler: ((T?, Error?) -> Void)
-
-        init(remoteConfig: RemoteConfig, forKey: String, handler: @escaping ((T?, Error?) -> Void)) {
-            self.observingKeyPath = #keyPath(RemoteConfig.lastFetchTime)
-            self.didRemoveObserver = false
-            self.remoteConfig = remoteConfig
-            self.configValueKey = forKey
-            self.handler = handler
-
-            super.init()
-
-            remoteConfig.addObserver(self, forKeyPath: observingKeyPath, context: nil)
-        }
-
-        func dispose() {
-            if didRemoveObserver { return }
-
-            didRemoveObserver = true
-            remoteConfig.removeObserver(self, forKeyPath: observingKeyPath, context: nil)
-        }
-
-        override func observeValue(
-            forKeyPath keyPath: String?,
-            of object: Any?,
-            change: [NSKeyValueChangeKey : Any]?,
-            context: UnsafeMutableRawPointer?
-        ) {
-            guard change != nil, object != nil, keyPath == observingKeyPath else {
-                return
-            }
-
-            do {
-                let newValue = try remoteConfig.decoded(asType: T.self)
-                handler(newValue, nil)
-            } catch {
-                handler(nil, error)
-            }
-        }
+      do {
+        let newValue = try remoteConfig.decoded(asType: T.self)
+        handler(newValue, nil)
+      } catch {
+        handler(nil, error)
+      }
     }
+  }
 }

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
@@ -1,0 +1,79 @@
+//
+//  File.swift
+//  
+//
+//  Created by Fumito Ito on 2022/06/08.
+//
+
+import SwiftUI
+import FirebaseRemoteConfig
+
+@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+internal class RemoteConfigValueObservable<T: Decodable>: ObservableObject {
+    @Published private(set) var configValue: T
+
+    private let key: String
+    private let remoteConfig: RemoteConfig
+    private var observation: RemoteConfigObsever?
+
+    init(key: String, remoteConfig: RemoteConfig) {
+        self.key = key
+        self.remoteConfig = remoteConfig
+        self.configValue = try! remoteConfig.configValue(forKey: key).decoded(asType: T.self)
+        self.observation = RemoteConfigObsever(remoteConfig: remoteConfig, forKey: key) { [weak self] newValue, error in
+            if let newValue = newValue {
+                self?.configValue = newValue
+            }
+        }
+    }
+
+    deinit {
+        self.observation?.dispose()
+    }
+
+    class RemoteConfigObsever: NSObject {
+
+        private let observingKeyPath: String
+        private var didRemoveObserver: Bool
+        private let remoteConfig: RemoteConfig
+        private let configValueKey: String
+        private let handler: ((T?, Error?) -> Void)
+
+        init(remoteConfig: RemoteConfig, forKey: String, handler: @escaping ((T?, Error?) -> Void)) {
+            self.observingKeyPath = #keyPath(RemoteConfig.lastFetchTime)
+            self.didRemoveObserver = false
+            self.remoteConfig = remoteConfig
+            self.configValueKey = forKey
+            self.handler = handler
+
+            super.init()
+
+            remoteConfig.addObserver(self, forKeyPath: observingKeyPath, context: nil)
+        }
+
+        func dispose() {
+            if didRemoveObserver { return }
+
+            didRemoveObserver = true
+            remoteConfig.removeObserver(self, forKeyPath: observingKeyPath, context: nil)
+        }
+
+        override func observeValue(
+            forKeyPath keyPath: String?,
+            of object: Any?,
+            change: [NSKeyValueChangeKey : Any]?,
+            context: UnsafeMutableRawPointer?
+        ) {
+            guard change != nil, object != nil, keyPath == observingKeyPath else {
+                return
+            }
+
+            do {
+                let newValue = try remoteConfig.decoded(asType: T.self)
+                handler(newValue, nil)
+            } catch {
+                handler(nil, error)
+            }
+        }
+    }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
@@ -1,9 +1,18 @@
-//
-//  PropertyWrapper.swift
-//  
-//
-//  Created by Fumito Ito on 2022/06/17.
-//
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import FirebaseRemoteConfig
 import FirebaseRemoteConfigSwift
@@ -11,42 +20,43 @@ import FirebaseRemoteConfigSwift
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
-  @available(iOS 14, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
   class PropertyWrapperTests: APITestBase {
     // MARK: - Test fetching Remote Config JSON values into struct property
-      struct Recipe: Decodable {
-        var recipeName: String
-        var ingredients: [String]
-        var cookTime: Int
-      }
+
+    struct Recipe: Decodable {
+      var recipeName: String
+      var ingredients: [String]
+      var cookTime: Int
+    }
 
     struct PropertyWrapperTester {
       @RemoteConfigProperty(forKey: Constants.stringKey)
       var stringValue: String
 
-        @RemoteConfigProperty(forKey: Constants.intKey)
-        var intValue: Int
+      @RemoteConfigProperty(forKey: Constants.intKey)
+      var intValue: Int
 
-        @RemoteConfigProperty(forKey: Constants.floatKey)
-        var floatValue: Float
+      @RemoteConfigProperty(forKey: Constants.floatKey)
+      var floatValue: Float
 
-        @RemoteConfigProperty(forKey: Constants.floatKey)
-        var doubleValue: Double
+      @RemoteConfigProperty(forKey: Constants.floatKey)
+      var doubleValue: Double
 
-        @RemoteConfigProperty(forKey: Constants.decimalKey)
-        var decimalValue: Decimal
+      @RemoteConfigProperty(forKey: Constants.decimalKey)
+      var decimalValue: Decimal
 
-        @RemoteConfigProperty(forKey: Constants.trueKey)
-        var trueValue: Bool
+      @RemoteConfigProperty(forKey: Constants.trueKey)
+      var trueValue: Bool
 
-        @RemoteConfigProperty(forKey: Constants.falseKey)
-        var falseValue: Bool
+      @RemoteConfigProperty(forKey: Constants.falseKey)
+      var falseValue: Bool
 
-        @RemoteConfigProperty(forKey: Constants.dataKey)
-        var dataValue: Data
+      @RemoteConfigProperty(forKey: Constants.dataKey)
+      var dataValue: Data
 
-        @RemoteConfigProperty(forKey: Constants.jsonKey)
-        var recipeValue: Recipe
+      @RemoteConfigProperty(forKey: Constants.jsonKey)
+      var recipeValue: Recipe
     }
 
     func testFetchAndActivateWithPropertyWrapper() async throws {
@@ -54,18 +64,18 @@ import XCTest
       XCTAssertEqual(status, .successFetchedFromRemote)
 
       let tester = PropertyWrapperTester()
-        XCTAssertEqual(tester.stringValue, Constants.stringValue)
-        XCTAssertEqual(tester.intValue, Constants.intValue)
-        XCTAssertEqual(tester.floatValue, Constants.floatValue)
-        XCTAssertEqual(tester.doubleValue, Constants.doubleValue)
-        XCTAssertEqual(tester.floatValue, Constants.floatValue)
-        XCTAssertEqual(tester.trueValue, true)
-        XCTAssertEqual(tester.falseValue, false)
-        XCTAssertEqual(tester.dataValue, Constants.dataValue)
-        let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
-        XCTAssertEqual(tester.recipeValue.recipeName, recipe.recipeName)
-        XCTAssertEqual(tester.recipeValue.ingredients, recipe.ingredients)
-        XCTAssertEqual(tester.recipeValue.cookTime, recipe.cookTime)
+      XCTAssertEqual(tester.stringValue, Constants.stringValue)
+      XCTAssertEqual(tester.intValue, Constants.intValue)
+      XCTAssertEqual(tester.floatValue, Constants.floatValue)
+      XCTAssertEqual(tester.doubleValue, Constants.doubleValue)
+      XCTAssertEqual(tester.floatValue, Constants.floatValue)
+      XCTAssertEqual(tester.trueValue, true)
+      XCTAssertEqual(tester.falseValue, false)
+      XCTAssertEqual(tester.dataValue, Constants.dataValue)
+      let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
+      XCTAssertEqual(tester.recipeValue.recipeName, recipe.recipeName)
+      XCTAssertEqual(tester.recipeValue.ingredients, recipe.ingredients)
+      XCTAssertEqual(tester.recipeValue.cookTime, recipe.cookTime)
     }
   }
 #endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
@@ -68,7 +68,7 @@ import XCTest
       XCTAssertEqual(tester.intValue, Constants.intValue)
       XCTAssertEqual(tester.floatValue, Constants.floatValue)
       XCTAssertEqual(tester.doubleValue, Constants.doubleValue)
-      XCTAssertEqual(tester.floatValue, Constants.floatValue)
+      XCTAssertEqual(tester.decimalValue, Constants.decimalValue)
       XCTAssertEqual(tester.trueValue, true)
       XCTAssertEqual(tester.falseValue, false)
       XCTAssertEqual(tester.dataValue, Constants.dataValue)

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
@@ -1,0 +1,71 @@
+//
+//  PropertyWrapper.swift
+//  
+//
+//  Created by Fumito Ito on 2022/06/17.
+//
+
+import FirebaseRemoteConfig
+import FirebaseRemoteConfigSwift
+
+import XCTest
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+  @available(iOS 14, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  class PropertyWrapperTests: APITestBase {
+    // MARK: - Test fetching Remote Config JSON values into struct property
+      struct Recipe: Decodable {
+        var recipeName: String
+        var ingredients: [String]
+        var cookTime: Int
+      }
+
+    struct PropertyWrapperTester {
+      @RemoteConfigProperty(forKey: Constants.stringKey)
+      var stringValue: String
+
+        @RemoteConfigProperty(forKey: Constants.intKey)
+        var intValue: Int
+
+        @RemoteConfigProperty(forKey: Constants.floatKey)
+        var floatValue: Float
+
+        @RemoteConfigProperty(forKey: Constants.floatKey)
+        var doubleValue: Double
+
+        @RemoteConfigProperty(forKey: Constants.decimalKey)
+        var decimalValue: Decimal
+
+        @RemoteConfigProperty(forKey: Constants.trueKey)
+        var trueValue: Bool
+
+        @RemoteConfigProperty(forKey: Constants.falseKey)
+        var falseValue: Bool
+
+        @RemoteConfigProperty(forKey: Constants.dataKey)
+        var dataValue: Data
+
+        @RemoteConfigProperty(forKey: Constants.jsonKey)
+        var recipeValue: Recipe
+    }
+
+    func testFetchAndActivateWithPropertyWrapper() async throws {
+      let status = try await config.fetchAndActivate()
+      XCTAssertEqual(status, .successFetchedFromRemote)
+
+      let tester = PropertyWrapperTester()
+        XCTAssertEqual(tester.stringValue, Constants.stringValue)
+        XCTAssertEqual(tester.intValue, Constants.intValue)
+        XCTAssertEqual(tester.floatValue, Constants.floatValue)
+        XCTAssertEqual(tester.doubleValue, Constants.doubleValue)
+        XCTAssertEqual(tester.floatValue, Constants.floatValue)
+        XCTAssertEqual(tester.trueValue, true)
+        XCTAssertEqual(tester.falseValue, false)
+        XCTAssertEqual(tester.dataValue, Constants.dataValue)
+        let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
+        XCTAssertEqual(tester.recipeValue.recipeName, recipe.recipeName)
+        XCTAssertEqual(tester.recipeValue.ingredients, recipe.ingredients)
+        XCTAssertEqual(tester.recipeValue.cookTime, recipe.cookTime)
+    }
+  }
+#endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapper.swift
@@ -34,29 +34,73 @@ import XCTest
       @RemoteConfigProperty(forKey: Constants.stringKey)
       var stringValue: String
 
+      var stringKeyName: String {
+        return _stringValue.key
+      }
+
       @RemoteConfigProperty(forKey: Constants.intKey)
       var intValue: Int
+
+      var intKeyName: String {
+        return _intValue.key
+      }
 
       @RemoteConfigProperty(forKey: Constants.floatKey)
       var floatValue: Float
 
+      var floatKeyName: String {
+        return _floatValue.key
+      }
+
       @RemoteConfigProperty(forKey: Constants.floatKey)
       var doubleValue: Double
+
+      var doubleKeyName: String {
+        return _doubleValue.key
+      }
 
       @RemoteConfigProperty(forKey: Constants.decimalKey)
       var decimalValue: Decimal
 
+      var decimalKeyName: String {
+        return _decimalValue.key
+      }
+
       @RemoteConfigProperty(forKey: Constants.trueKey)
       var trueValue: Bool
+
+      var trueKeyName: String {
+        return _trueValue.key
+      }
 
       @RemoteConfigProperty(forKey: Constants.falseKey)
       var falseValue: Bool
 
+      var falseKeyName: String {
+        return _falseValue.key
+      }
+
       @RemoteConfigProperty(forKey: Constants.dataKey)
       var dataValue: Data
 
+      var dataKeyName: String {
+        return _dataValue.key
+      }
+
       @RemoteConfigProperty(forKey: Constants.jsonKey)
       var recipeValue: Recipe
+
+      var recipeKeyName: String {
+        _recipeValue.key
+      }
+
+      var lastFetchTime: Date? {
+        return _stringValue.lastFetchTime
+      }
+
+      var lastFetchStatus: RemoteConfigFetchStatus {
+        return _stringValue.lastFetchStatus
+      }
     }
 
     func testFetchAndActivateWithPropertyWrapper() async throws {
@@ -76,6 +120,23 @@ import XCTest
       XCTAssertEqual(tester.recipeValue.recipeName, recipe.recipeName)
       XCTAssertEqual(tester.recipeValue.ingredients, recipe.ingredients)
       XCTAssertEqual(tester.recipeValue.cookTime, recipe.cookTime)
+    }
+
+    func testPropertyWrapperInstanceValues() async {
+      let tester = PropertyWrapperTester()
+
+      XCTAssertEqual(config.lastFetchTime, tester.lastFetchTime)
+      XCTAssertEqual(config.lastFetchStatus, tester.lastFetchStatus)
+
+      XCTAssertEqual(Constants.stringKey, tester.stringKeyName)
+      XCTAssertEqual(Constants.intKey, tester.intKeyName)
+      XCTAssertEqual(Constants.floatKey, tester.floatKeyName)
+      XCTAssertEqual(Constants.floatKey, tester.doubleKeyName)
+      XCTAssertEqual(Constants.decimalKey, tester.decimalKeyName)
+      XCTAssertEqual(Constants.trueKey, tester.trueKeyName)
+      XCTAssertEqual(Constants.falseKey, tester.falseKeyName)
+      XCTAssertEqual(Constants.dataKey, tester.dataKeyName)
+      XCTAssertEqual(Constants.jsonKey, tester.recipeKeyName)
     }
   }
 #endif


### PR DESCRIPTION
# Why

#9828 

# What

This PR provides a Property Wrapper with DynamicProperty for RemoteConfig. With this feature, users can bind Remote Config values to variables, and at the same time, reflect them in the View of the SwiftUI in real time.

# Known Issues

- The `lastFetchTime` is monitored to detect that the RemoteConfig value has changed. This is not very accurate. For example, if the `defaultValue` is changed, the change will not be detected.
- Only `Decodable` properties are covered. Therefore, users cannot bind the PropertyWrapper to variables of type Any, such as those provided by `jsonValue`.