### PR TITLE
[Infra] Update `localize_podfile.swift`

### DIFF
--- a/scripts/localize_podfile.swift
+++ b/scripts/localize_podfile.swift
@@ -40,6 +40,13 @@ let implicitPods = [
   "FirebaseAuthInterop", "FirebaseMessagingInterop",
   "FirebaseStorageInternal", "FirebaseCoreInternal",
 ]
+
+let binaryPods = [
+  "GoogleAppMeasurement",
+  "GoogleAppMeasurementOnDeviceConversion",
+  "FirebaseAnalytics",
+]
+
 var didImplicits = false
 
 var fileContents = ""
@@ -74,7 +81,7 @@ for line in lines {
       podName = podName.replacingOccurrences(of: "Firebase/", with: "Firebase")
     }
     let podspec = repo.appendingPathComponent(podName + ".podspec").path
-    if FileManager().fileExists(atPath: podspec) {
+    if !binaryPods.contains(podName), FileManager().fileExists(atPath: podspec) {
       if didImplicits == false {
         didImplicits = true
         for implicit in implicitPods {


### PR DESCRIPTION
### Context
- This issue surfaced here: https://github.com/firebase/firebase-ios-sdk/pull/9922#issuecomment-1159295509
- The reasoning was that `localize_podfile.swift` pulls in all local pods ending in `.podspec`, but since I merged #9829, closed source pods were being pulled in and you can't use the `:path` operator on a binary pods.
- The quick fix was to ensure that the `:path` is only added for open source pods

- For future work: maybe the `localize_podfile.swift` can live in release tooling so we have once source of truth (FirebaseManifest.swift). 


#no-changelog