### PR TITLE
Add a StorageMetadata integration test

### DIFF
--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -602,6 +602,7 @@ NSString *const kTestPassword = KPASSWORD;
   XCTAssertEqualObjects(actualMetadata.contentEncoding, @"gzip");
   XCTAssertEqualObjects(actualMetadata.contentLanguage, @"de");
   XCTAssertEqualObjects(actualMetadata.contentType, expectedContentType);
+  XCTAssertEqualObjects(actualMetadata.name, @"1mb");
   XCTAssertTrue([actualMetadata.md5Hash length] == 24);
   for (NSString *key in expectedCustomMetadata) {
     XCTAssertEqualObjects([actualMetadata.customMetadata objectForKey:key],
@@ -684,6 +685,7 @@ NSString *const kTestPassword = KPASSWORD;
     @"contentLanguage" : @"de",
     @"contentType" : @"content-type-a",
     @"md5Hash" : @"123456789012345678901234",  // length 24
+    @"name" : @"1mb",
     @"metadata" : @{@"a" : @"b", @"y" : @"z"}
   }];
 

--- a/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorageInternal/Tests/Integration/FIRStorageIntegrationTests.m
@@ -676,6 +676,44 @@ NSString *const kTestPassword = KPASSWORD;
   [self waitForExpectations];
 }
 
+- (void)testMetadataDictInitAndClear {
+  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:@{
+    @"cacheControl" : @"cache-control",
+    @"contentDisposition" : @"content-disposition",
+    @"contentEncoding" : @"gzip",
+    @"contentLanguage" : @"de",
+    @"contentType" : @"content-type-a",
+    @"md5Hash" : @"123456789012345678901234",  // length 24
+    @"metadata" : @{@"a" : @"b", @"y" : @"z"}
+  }];
+
+  [self assertMetadata:metadata
+           contentType:@"content-type-a"
+        customMetadata:@{@"a" : @"b", @"y" : @"z"}];
+
+  metadata.cacheControl = nil;
+  metadata.contentDisposition = nil;
+  metadata.contentEncoding = @"identity";
+  metadata.contentLanguage = nil;
+  metadata.contentType = nil;
+  metadata.customMetadata = nil;
+  [self assertMetadataNil:metadata];
+
+  metadata.contentEncoding = nil;
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testMetadataDictInitAndClear"];
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
+  [ref updateMetadata:metadata
+           completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
+             XCTAssertNil(error);
+             [self assertMetadataNil:updatedMetadata];
+             XCTAssertNil(updatedMetadata.customMetadata);
+             [expectation fulfill];
+           }];
+  [self waitForExpectations];
+}
+
 - (void)testResumeGetFile {
   XCTestExpectation *expectation = [self expectationWithDescription:@"testResumeGetFile"];
 


### PR DESCRIPTION
For investigations related to #9849 discussions, add a test for initializing StorageMetadata with `initWithDictionary` and then clearing it. Also test the name field.

The test passes in both Firebase 8 and 9.