### PR TITLE
Add FIREBASE_LD_EXECUTABLE cmake cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,22 @@ endif()
 enable_language(C)
 enable_language(CXX)
 
+set(
+  FIREBASE_LD_FILENAME
+  ""
+  CACHE
+  STRING
+  "The filename of the C/C++ linker to use. \
+    For example, the default linker for clang and gcc is ld. \
+    Using a fast linker, like mold (https://github.com/rui314/mold), \
+    could be useful during development to reduce build/test cycle times."
+)
+
+if(NOT ("${FIREBASE_LD_EXECUTABLE}" STREQUAL ""))
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=${FIREBASE_LD_EXECUTABLE}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=${FIREBASE_LD_EXECUTABLE}")
+endif()
+
 option(
   FIREBASE_IOS_BUILD_BENCHMARKS
   "Enable building of C++ and Objective-C benchmarks for this project"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ enable_language(C)
 enable_language(CXX)
 
 set(
-  FIREBASE_LD_FILENAME
+  FIREBASE_LD_EXECUTABLE
   ""
   CACHE
   STRING


### PR DESCRIPTION
The cmake build scripts gain a new cache variable, `FIREBASE_LD_EXECUTABLE`, which, if specified, instructs the C/C++ linking steps to use the specified linker executable instead of the default linker executable (which is `ld` for clang and gcc).

The motivating use case for using a custom linker is to enable using `mold` (https://github.com/rui314/mold), a custom linker that is compatible with, but significantly faster than, the default `ld` linker. For continuous builds and continuous tests, this doesn't really matter and this new cache variable is not intended to be used in this case; however, during build/test cycles the linking time is one of the biggest contributors to the length of such cycles. Reducing the linking time makes local development easier and less distracting.

Personally, using `mold` on my linux box reduced link times for `firestore_remote_test` from 7.70s down to 1.54s, a 5x speed improvement.

To use `mold`, first install it (e.g. via `brew install mold`) and then specify `-DFIREBASE_LD_FILENAME:STRING=mold` to cmake. Voila, you get faster builds!

#no-changelog