### PR TITLE
Update console logging URL

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.3.0
+- [changed] Update the console logging URL to troubleshooting page.
+
 # 8.15.0
 - Remove the unused code for pre-warm detection.
 

--- a/FirebasePerformance/Sources/Common/FPRConsoleURLGenerator.m
+++ b/FirebasePerformance/Sources/Common/FPRConsoleURLGenerator.m
@@ -33,7 +33,7 @@ NSString *const UTM_SOURCE = @"perf-ios-sdk";
                                          bundleID:(NSString *)bundleID
                                         traceName:(NSString *)traceName {
   NSString *rootUrl = [FPRConsoleURLGenerator getRootURLWithProjectID:projectID bundleID:bundleID];
-  return [NSString stringWithFormat:@"%@/metrics/trace/"
+  return [NSString stringWithFormat:@"%@/troubleshooting/trace/"
                                     @"DURATION_TRACE/%@?utm_source=%@&utm_medium=%@",
                                     rootUrl, traceName, UTM_SOURCE, UTM_MEDIUM];
 }
@@ -43,7 +43,7 @@ NSString *const UTM_SOURCE = @"perf-ios-sdk";
                                          bundleID:(NSString *)bundleID
                                         traceName:(NSString *)traceName {
   NSString *rootUrl = [FPRConsoleURLGenerator getRootURLWithProjectID:projectID bundleID:bundleID];
-  return [NSString stringWithFormat:@"%@/metrics/trace/"
+  return [NSString stringWithFormat:@"%@/troubleshooting/trace/"
                                     @"SCREEN_TRACE/%@?utm_source=%@&utm_medium=%@",
                                     rootUrl, traceName, UTM_SOURCE, UTM_MEDIUM];
 }

--- a/FirebasePerformance/Tests/Unit/Common/FPRConsoleURLGeneratorTest.m
+++ b/FirebasePerformance/Tests/Unit/Common/FPRConsoleURLGeneratorTest.m
@@ -42,7 +42,7 @@ static NSString *const TRACE_NAME = @"test-trace";
                                                                     traceName:TRACE_NAME];
   NSString *expectedURL =
       @"https://console.firebase.google.com/project/test-project/performance/app/ios:test-bundle/"
-      @"metrics/trace/DURATION_TRACE/test-trace?utm_source=perf-ios-sdk&utm_medium=ios-ide";
+      @"troubleshooting/trace/DURATION_TRACE/test-trace?utm_source=perf-ios-sdk&utm_medium=ios-ide";
   XCTAssertEqualObjects(url, expectedURL);
 }
 
@@ -53,7 +53,7 @@ static NSString *const TRACE_NAME = @"test-trace";
                                                                     traceName:TRACE_NAME];
   NSString *expectedURL =
       @"https://console.firebase.google.com/project/test-project/performance/app/ios:test-bundle/"
-      @"metrics/trace/SCREEN_TRACE/test-trace?utm_source=perf-ios-sdk&utm_medium=ios-ide";
+      @"troubleshooting/trace/SCREEN_TRACE/test-trace?utm_source=perf-ios-sdk&utm_medium=ios-ide";
   XCTAssertEqualObjects(url, expectedURL);
 }
 


### PR DESCRIPTION
The metrics page is getting deprecated. We need to update the URL to the troubleshooting page.