### PR TITLE
When patching snappy for Firestore, add --binary flag to patch command.

### DIFF
--- a/cmake/external/snappy.cmake
+++ b/cmake/external/snappy.cmake
@@ -34,7 +34,7 @@ ExternalProject_Add(
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""
   TEST_COMMAND      ""
-  PATCH_COMMAND     patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/snappy.patch
+  PATCH_COMMAND     patch -Np1 --binary -i ${CMAKE_CURRENT_LIST_DIR}/snappy.patch
 
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
 )


### PR DESCRIPTION
Firestore's snappy patching in the firebase-cpp-sdk is broken on GitHub Actions runners after upgrading its firebase-ios-sdk dependency from 9.1.0 to 9.2.0 in https://github.com/firebase/firebase-cpp-sdk/pull/1003:

https://github.com/firebase/firebase-cpp-sdk/runs/7023311255

Note that this PR has some special logic in https://github.com/firebase/firebase-cpp-sdk/pull/1003/commits/77f3e708c1505fbf8419effd4481cc19f960b1c3 to remove the patching of the "snappy" library.

The error from the build log is:

```
Performing patch step for 'snappy'
patching file snappy.cc
Assertation failed!

Program: C:\Strawberry\c\bin\patch.exe
File: .\src\patch\2.5.9\patch-2.5.9-src\patch.c, Line 354

Expression: hunk
```

Originally, I was not able to reproduce this locally; however, I was able to reproduce it by doing the following:

1. Download the latest version of Strawberry Perl portable build (e.g. https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit-portable.zip)
2. Extract `patch.exe` from its `c\bin` subdirectory into an empty directory (e.g. `c:\StrawberryPatch`).
3. Prepend the directory containing `patch.exe` to the `PATH` environment variable (e.g. `set PATH=c:\StrawberryPatch;%PATH%`).
4. Run the cmake configure command (e.g. `cmake -S . -B build -DFIREBASE_CPP_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=external\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -A x64`)

Watch the output from cmake closely, and you will see the error.

The problem appears to be that the GitHub Actions runners use the `patch` command that is bundled with Strawberry Perl, which cannot seem to handle the patch file format of [cmake/external/firestore.patch.txt](https://github.com/firebase/firebase-cpp-sdk/blob/dc13f63a440286d9a3995ee4ec881d352b0d9886/cmake/external/firestore.patch.txt).

Note that the `patch.exe` bundled with git (v2.7.6) does handles the patch just fine. The version of patch bundled with Strawberry Perl, and installed via `choco install patch` is 2.5.9, which appears to have some sort of bug.

This PR fixes the issue by specifying `--binary` to `patch.exe`, which is a no-op on posix systems.

#no-changelog