### PR TITLE
Patch nanopb CMakeLists.txt to look for python 3.7 instead of python 2.7

### DIFF
--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -34,5 +34,6 @@ ExternalProject_Add(
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
   TEST_COMMAND ""
+  PATCH_COMMAND patch -Np1 --binary -i ${CMAKE_CURRENT_LIST_DIR}/nanopb.patch
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
 )

--- a/cmake/external/nanopb.patch
+++ b/cmake/external/nanopb.patch
@@ -1,0 +1,12 @@
+diff -Naur nanopb/CMakeLists.txt nanopb-fix/CMakeLists.txt
+--- nanopb/CMakeLists.txt	2021-03-22 08:50:07.000000000 -0400
++++ nanopb-fix/CMakeLists.txt	2022-06-24 16:17:09.130783413 -0400
+@@ -41,7 +41,7 @@
+ if(nanopb_BUILD_GENERATOR)
+     set(generator_protos nanopb plugin)
+ 
+-    find_package(PythonInterp 2.7 REQUIRED)
++    find_package(PythonInterp 3.7 REQUIRED)
+     execute_process(
+         COMMAND ${PYTHON_EXECUTABLE} -c
+             "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"

--- a/scripts/check_whitespace.sh
+++ b/scripts/check_whitespace.sh
@@ -26,6 +26,7 @@ options=(
 )
 
 git grep "${options[@]}" -- \
+    ':(exclude)cmake/external/nanopb.patch' \
     ':(exclude)cmake/external/snappy.patch' \
     ':(exclude)Crashlytics/ProtoSupport' \
     ':(exclude)Crashlytics/UnitTests/Data' \


### PR DESCRIPTION
This fixes the following cmake build error on machines that lack a python 2.7 interpreter (e.g. a fresh macbook):

```
CMake Error at Cellar/cmake/3.23.2/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE) (Required is at
  least version "2.7")
Call Stack (most recent call first):
  Cellar/cmake/3.23.2/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  Cellar/cmake/3.23.2/share/cmake/Modules/FindPythonInterp.cmake:169 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  build/external/src/nanopb/CMakeLists.txt:44 (find_package)
```

when the following command is run:

```
cmake -S . -B build
```

#no-changelog