### PR TITLE
Remove GoogleSignInSwift from binary distros

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Firebase 9.3.0
-- [added] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to
+- [fixed] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to
   infeasibility. The GoogleSignIn distribution continues. (#9937)
 
 # Firebase 9.2.0

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Firebase 9.3.0
-- [added] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to 
+- [added] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to
   infeasibility. The GoogleSignIn distribution continues. (#9937)
 
 # Firebase 9.2.0

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 9.3.0
+- [added] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to 
+  infeasibility. The GoogleSignIn distribution continues. (#9937)
+
 # Firebase 9.2.0
 - [added] Zip and Carthage distributions now include GoogleSignInSwiftSupport. (#9900)
 

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -328,7 +328,7 @@ struct ZipBuilder {
     podsToInstall.append(CocoaPodUtils.VersionedPod(name: "Google-Mobile-Ads-SDK",
                                                     version: nil,
                                                     platforms: ["ios"]))
-    podsToInstall.append(CocoaPodUtils.VersionedPod(name: "GoogleSignInSwiftSupport",
+    podsToInstall.append(CocoaPodUtils.VersionedPod(name: "GoogleSignIn",
                                                     version: nil,
                                                     platforms: ["ios"]))
 
@@ -440,7 +440,7 @@ struct ZipBuilder {
     // Skip Analytics and the pods bundled with it.
     let remainingPods = installedPods.filter {
       $0.key == "Google-Mobile-Ads-SDK" ||
-        $0.key == "GoogleSignInSwiftSupport" ||
+        $0.key == "GoogleSignIn" ||
         (firebaseZipPods.contains($0.key) &&
           $0.key != "FirebaseAnalyticsSwift" &&
           $0.key != "Firebase" &&
@@ -686,7 +686,7 @@ struct ZipBuilder {
   /// Describes the dependency on other frameworks for the README file.
   func readmeHeader(podName: String) -> String {
     var header = "## \(podName)"
-    if !(podName == "FirebaseAnalytics" || podName == "GoogleSignInSwiftSupport") {
+    if !(podName == "FirebaseAnalytics" || podName == "GoogleSignIn") {
       header += " (~> FirebaseAnalytics)"
     }
     header += "\n"


### PR DESCRIPTION
Fix #9937 

We haven't found a way to solve the functionality issues arising from GoogleSignInSwift using a different module name from its pod name, so we won't be able to support from the Firebase distributions in the near term.