### PR TITLE
Remove default value for `max_attempts` argument to `RunTransaction()`.

### DIFF
--- a/Firestore/core/src/api/firestore.h
+++ b/Firestore/core/src/api/firestore.h
@@ -93,11 +93,10 @@ class Firestore : public std::enable_shared_from_this<Firestore> {
   WriteBatch GetBatch();
   core::Query GetCollectionGroup(std::string collection_id);
 
-  // TODO(dconeybe): Remove the default value of `max_attempts` once
-  // the firebase-cpp-sdk has been updated to specify an explicit value.
+  // The default value for `max_attempts` is `kDefaultTransactionMaxAttempts`.
   void RunTransaction(core::TransactionUpdateCallback update_callback,
                       core::TransactionResultCallback result_callback,
-                      int max_attempts = kDefaultTransactionMaxAttempts);
+                      int max_attempts);
 
   void Terminate(util::StatusCallback callback);
   void ClearPersistence(util::StatusCallback callback);


### PR DESCRIPTION
In https://github.com/firebase/firebase-ios-sdk/pull/9838 a new `max_attempts` argument was added to the `RunTransaction()` method in `Firestore/core/src/api/firestore.h` (an internal API, not an API presented to customers). This new argument was given a default value to avoid breaking the build of the firebase-cpp-sdk.

Now that https://github.com/firebase/firebase-cpp-sdk/pull/966 has been merged, this default argument value can be removed, as all call sites explicitly specify a value for `max_attempts`.

#no-changelog