### PR TITLE
alreadyExists returns the wrong code

### DIFF
--- a/FirebaseFunctions/Sources/FunctionsError.swift
+++ b/FirebaseFunctions/Sources/FunctionsError.swift
@@ -121,7 +121,7 @@ internal func FunctionsCodeForHTTPStatus(_ status: NSInteger) -> FunctionsErrorC
   case 404:
     return .notFound
   case 409:
-    return .aborted
+    return .alreadyExists
   case 429:
     return .resourceExhausted
   case 499:
@@ -148,7 +148,7 @@ extension FunctionsErrorCode {
     case "INVALID_ARGUMENT": return .invalidArgument
     case "DEADLINE_EXCEEDED": return .deadlineExceeded
     case "NOT_FOUND": return .notFound
-    case "ALREADY_EXISTS": return .notFound
+    case "ALREADY_EXISTS": return .alreadyExists
     case "PERMISSION_DENIED": return .permissionDenied
     case "RESOURCE_EXHAUSTED": return .resourceExhausted
     case "FAILED_PRECONDITION": return .failedPrecondition


### PR DESCRIPTION
As per @paulb777, here is the PR based on the issue I found: Fix https://github.com/firebase/firebase-ios-sdk/issues/9942

**Step 1: Describe your environment**

Xcode version: 13.4.1
Firebase SDK version: 9.3.0
Installation method: CocoaPods
Firebase Component: Functions
Target platform(s): iOS

**Step 2: Describe the problem**

Functions that throw already-exists generate the right HTTP response (seen in Postman as HTTP 409 Conflict). However, in the iOS client bubbles the error to the client as notFound. The commit mentioned below shows the affected areas and includes a fix.

**Steps to reproduce:**

Simple. Just throw the following from a Cloud Function:

throw new functions.https.HttpsError('already-exists', 'Resource exists')

If you have a downloadable sample project that reproduces the bug you're reporting, you will
likely receive a faster response on your issue.

Relevant Code:

`https://github.com/firebase/firebase-ios-sdk/commit/3e758246f6c25001cb9f36ac9b429101a59219c7
`

Regards,

-- Tito