### PR TITLE
Discontinue bitcode inclusion

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Firebase 9.3.0
+- [changed] Discontinue bitcode inclusion in all binary distributions.
 - [fixed] Remove GoogleSignInSwiftSupport from Zip and Carthage distributions due to
   infeasibility. The GoogleSignIn distribution continues. (#9937)
 

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -215,10 +215,7 @@ struct FrameworkBuilder {
                 "BUILD_DIR=\(buildDir.path)",
                 "-sdk", targetPlatform.sdkName,
                 cFlags]
-    // Add bitcode option for platforms that need it.
-    if targetPlatform.shouldEnableBitcode {
-      args.append("BITCODE_GENERATION_MODE=bitcode")
-    }
+
     // Code signing isn't needed for libraries. Disabling signing is required for
     // Catalyst libs with resources. See
     // https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-573301570

--- a/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/TargetPlatform.swift
@@ -46,17 +46,6 @@ enum TargetPlatform: CaseIterable {
     }
   }
 
-  /// Flag to determine if bitcode should be used for the target platform.
-  var shouldEnableBitcode: Bool {
-    switch self {
-    // TODO: Do we need to include bitcode for Catalyst? We weren't before the latest arm64 changes.
-    case .iOSDevice: return true
-    case .macOS: return true
-    case .tvOSDevice: return true
-    default: return false
-    }
-  }
-
   /// Name of the SDK as used by `xcodebuild` for the target platforms.
   var sdkName: String {
     switch self {


### PR DESCRIPTION
Apple announced the discontinuation of bitcode support.

This drops the zip distribution size from 367MB to 290MB