### PR TITLE
Modify activate path to only update experiments for firebase namespace

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 9.3.0
 - [changed] Arrays and Dictionaries are now supported when initializing defaults from a
   plist. (#8306)
+- [fixed] Activate calls will only update experiment data for `firebase` namespace to ensure correct experiment exposures. (#9972)
 
 # 9.0.0
 - [changed] The `remoteConfig()` singleton now throws an exception when called before

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -467,48 +467,63 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                }];
 }
 
-- (void)testFetch3pNamespaceUpdatesExperiments {
+- (void)testFetchAndActivate3pNamespaceUpdatesExperiments {
   [[_experimentMock expect] updateExperimentsWithResponse:[OCMArg any]];
 
   XCTestExpectation *expectation = [self
-      expectationWithDescription:
-          [NSString
-              stringWithFormat:@"Fetch call for 'firebase' namespace updates experiment data"]];
+      expectationWithDescription:[NSString stringWithFormat:@"FetchAndActivate call for 'firebase' "
+                                                            @"namespace updates experiment data"]];
   XCTAssertEqual(_configInstances[RCNTestRCInstanceDefault].lastFetchStatus,
                  FIRRemoteConfigFetchStatusNoFetchYet);
-  FIRRemoteConfigFetchCompletion fetchCompletion =
-      ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
+
+  FIRRemoteConfigFetchAndActivateCompletion fetchAndActivateCompletion =
+      ^void(FIRRemoteConfigFetchAndActivateStatus status, NSError *error) {
+        XCTAssertEqual(status, FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote);
+        XCTAssertNil(error);
+
         XCTAssertEqual(self->_configInstances[RCNTestRCInstanceDefault].lastFetchStatus,
                        FIRRemoteConfigFetchStatusSuccess);
-        XCTAssertNil(error);
+        XCTAssertNotNil(self->_configInstances[RCNTestRCInstanceDefault].lastFetchTime);
+        XCTAssertGreaterThan(
+            self->_configInstances[RCNTestRCInstanceDefault].lastFetchTime.timeIntervalSince1970, 0,
+            @"last fetch time interval should be set.");
         [expectation fulfill];
       };
-  [_configInstances[RCNTestRCInstanceDefault] fetchWithExpirationDuration:43200
-                                                        completionHandler:fetchCompletion];
+
+  [_configInstances[RCNTestRCInstanceDefault]
+      fetchAndActivateWithCompletionHandler:fetchAndActivateCompletion];
   [self waitForExpectationsWithTimeout:_expectationTimeout
                                handler:^(NSError *error) {
                                  XCTAssertNil(error);
                                }];
 }
 
-- (void)testFetchOtherNamespaceDoesntUpdateExperiments {
+- (void)testFetchAndActivateOtherNamespaceDoesntUpdateExperiments {
   [[_experimentMock reject] updateExperimentsWithResponse:[OCMArg any]];
 
-  XCTestExpectation *expectation =
-      [self expectationWithDescription:
-                [NSString stringWithFormat:@"Fetch call for namespace other than 'firebase' "
-                                           @"doesn't update experiment data"]];
+  XCTestExpectation *expectation = [self
+      expectationWithDescription:
+          [NSString stringWithFormat:@"FetchAndActivate call for namespace other than 'firebase' "
+                                     @"doesn't update experiment data"]];
   XCTAssertEqual(_configInstances[RCNTestRCInstanceSecondNamespace].lastFetchStatus,
                  FIRRemoteConfigFetchStatusNoFetchYet);
-  FIRRemoteConfigFetchCompletion fetchCompletion =
-      ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
+
+  FIRRemoteConfigFetchAndActivateCompletion fetchAndActivateCompletion =
+      ^void(FIRRemoteConfigFetchAndActivateStatus status, NSError *error) {
+        XCTAssertEqual(status, FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote);
+        XCTAssertNil(error);
+
         XCTAssertEqual(self->_configInstances[RCNTestRCInstanceSecondNamespace].lastFetchStatus,
                        FIRRemoteConfigFetchStatusSuccess);
-        XCTAssertNil(error);
+        XCTAssertNotNil(self->_configInstances[RCNTestRCInstanceSecondNamespace].lastFetchTime);
+        XCTAssertGreaterThan(self->_configInstances[RCNTestRCInstanceSecondNamespace]
+                                 .lastFetchTime.timeIntervalSince1970,
+                             0, @"last fetch time interval should be set.");
         [expectation fulfill];
       };
-  [_configInstances[RCNTestRCInstanceSecondNamespace] fetchWithExpirationDuration:43200
-                                                                completionHandler:fetchCompletion];
+
+  [_configInstances[RCNTestRCInstanceSecondNamespace]
+      fetchAndActivateWithCompletionHandler:fetchAndActivateCompletion];
   [self waitForExpectationsWithTimeout:_expectationTimeout
                                handler:^(NSError *error) {
                                  XCTAssertNil(error);


### PR DESCRIPTION
Similar fix to https://github.com/firebase/firebase-ios-sdk/pull/7604, which only updated the fetch path but not activate

Tracked internally in b/211879339