### PR TITLE
Get rid of objc blocks inside dyld callback

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.h
@@ -64,8 +64,7 @@ typedef struct {
   FIRCLSBinaryImageRuntimeNode nodes[CLS_BINARY_IMAGE_RUNTIME_NODE_COUNT];
 } FIRCLSBinaryImageReadWriteContext;
 
-void FIRCLSBinaryImageInit(FIRCLSBinaryImageReadOnlyContext* roContext,
-                           FIRCLSBinaryImageReadWriteContext* rwContext);
+void FIRCLSBinaryImageInit(void);
 
 #if CLS_COMPACT_UNWINDING_SUPPORTED
 bool FIRCLSBinaryImageSafeFindImageForAddress(uintptr_t address,

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -158,8 +158,7 @@ bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager*
     _firclsContext.readonly->binaryimage.path =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportBinaryImageFile);
 
-    FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage,
-                          &_firclsContext.writable->binaryImage);
+    FIRCLSBinaryImageInit();
   });
 
   dispatch_group_async(group, queue, ^{

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h
@@ -56,6 +56,10 @@ typedef void (^FIRCLSMachOSliceIterator)(FIRCLSMachOSliceRef slice);
 typedef void (^FIRCLSMachOLoadCommandIterator)(uint32_t type,
                                                uint32_t size,
                                                const struct load_command* cmd);
+typedef void (*FIRCLSMachOLoadCommandIteratorFunc)(uint32_t type,
+                                                   uint32_t size,
+                                                   const struct load_command* cmd,
+                                                   void* context);
 
 __BEGIN_DECLS
 
@@ -69,6 +73,9 @@ struct FIRCLSMachOSlice FIRCLSMachOFileSliceWithArchitectureName(FIRCLSMachOFile
 void FIRCLSMachOEnumerateSlicesAtAddress(void* executableData, FIRCLSMachOSliceIterator block);
 void FIRCLSMachOSliceEnumerateLoadCommands(FIRCLSMachOSliceRef slice,
                                            FIRCLSMachOLoadCommandIterator block);
+void FIRCLSMachOSliceEnumerateLoadCommands_f(FIRCLSMachOSliceRef slice,
+                                             void* context,
+                                             FIRCLSMachOLoadCommandIteratorFunc function);
 struct FIRCLSMachOSlice FIRCLSMachOSliceGetCurrent(void);
 struct FIRCLSMachOSlice FIRCLSMachOSliceWithHeader(void* machHeader);
 

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -219,6 +219,25 @@ static bool FIRCLSMachOSliceIsValid(FIRCLSMachOSliceRef slice) {
   return true;
 }
 
+void FIRCLSMachOSliceEnumerateLoadCommands_f(FIRCLSMachOSliceRef slice,
+                                             void* context,
+                                             FIRCLSMachOLoadCommandIteratorFunc function) {
+  const struct load_command* cmd;
+  uint32_t cmdCount;
+
+  if (!FIRCLSMachOSliceIsValid(slice)) {
+    return;
+  }
+
+  FIRCLSMachOHeaderValues(slice, &cmd, &cmdCount);
+
+  for (uint32_t i = 0; cmd != NULL && i < cmdCount; ++i) {
+    function(cmd->cmd, cmd->cmdsize, cmd, context);
+
+    cmd = (struct load_command*)((uintptr_t)cmd + cmd->cmdsize);
+  }
+}
+
 void FIRCLSMachOSliceEnumerateLoadCommands(FIRCLSMachOSliceRef slice,
                                            FIRCLSMachOLoadCommandIterator block) {
   const struct load_command* cmd;


### PR DESCRIPTION
Objective-C blocks may invoke certain methods that attempt to acquire the Objective-C runtime lock. Simultaneously, _dyld_register_func_for_add_image is called once for each image currently part of the program, with its critical section protected by the dyld internal lock. Moreover, the Objective-C runtime frequently accesses dyld, as seen in objc_copyImageNames calling dyld_image_path_containing_address with the Objective-C runtime lock already held https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/objc-runtime-new.mm#L5540.
The lock/unlock policies between dyld and Objective-C runtime appear uncertain and potentially dangerous, making it preferable to avoid using the Objective-C runtime inside dyld callbacks.

These changes aim to enhance the stability and safety of the code by preventing potential deadlocks caused by the unclear lock policies between dyld and Objective-C runtime.