### PR TITLE
Fix Overlay bug with nested field deletion

### DIFF
--- a/Firestore/core/src/model/mutation.cc
+++ b/Firestore/core/src/model/mutation.cc
@@ -167,7 +167,7 @@ TransformMap Mutation::Rep::LocalTransformResults(
 
 absl::optional<Mutation> Mutation::CalculateOverlayMutation(
     const MutableDocument& doc, const absl::optional<FieldMask>& mask) {
-  if ((!doc.has_local_mutations()) || (mask.has_value() && mask->empty())) {
+  if ((!doc.has_local_mutations())) {
     return absl::nullopt;
   }
 
@@ -199,9 +199,13 @@ absl::optional<Mutation> Mutation::CalculateOverlayMutation(
           path = path.PopLast();
           value = doc_value.Get(path);
         }
-        HARD_ASSERT(value.has_value());
-        patch_value.Set(
-            path, Message<google_firestore_v1_Value>(DeepClone(value.value())));
+        if (value.has_value()) {
+          patch_value.Set(path, Message<google_firestore_v1_Value>(
+                                    DeepClone(value.value())));
+        } else {
+          patch_value.Delete(path);
+        }
+
         mask_set.insert(path);
       }
     }


### PR DESCRIPTION
Fix for https://github.com/firebase/firebase-ios-sdk/issues/9985

Beside this particular fix, this PR also has a fix for MutationTest.VerifyOverlayRoundTrips itself. It has been passing the wrong field mask, and all tests are treating overlay as set mutations as a result. This test fix also uncovered another bug, which is also fixed in this PR.