### PR TITLE
Bump Google Sign-In SDK version for Auth sample app.

### DIFF
--- a/FirebaseAuth/Tests/Sample/Podfile
+++ b/FirebaseAuth/Tests/Sample/Podfile
@@ -16,7 +16,7 @@ target 'AuthSample' do
   pod 'FirebaseAuth', :path => '../../../', :testspecs => ['unit']
   pod 'FirebaseInstallations', :path => '../../..'
   pod 'FBSDKLoginKit'
-  pod 'GoogleSignIn', '~> 5'
+  pod 'GoogleSignIn', '~> 6'
   pod 'GTMSessionFetcher/Core'
 
   target 'Auth_ApiTests' do


### PR DESCRIPTION
M1 Macs require Google Sign-In SDK v6 or greater; bumping the version in the auth test app by following https://developers.google.com/identity/sign-in/ios/quick-migration-guide.

#no-changelog