### PR TITLE
Implement get recaptcha config

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend+MultiFactor.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend+MultiFactor.m
@@ -24,7 +24,7 @@
 + (void)startMultiFactorEnrollment:(FIRStartMFAEnrollmentRequest *)request
                           callback:(FIRStartMFAEnrollmentResponseCallback)callback {
   FIRStartMFAEnrollmentResponse *response = [[FIRStartMFAEnrollmentResponse alloc] init];
-  [[self implementation] postWithRequest:request
+  [[self implementation] callWithRequest:request
                                 response:response
                                 callback:^(NSError *error) {
                                   if (error) {
@@ -38,7 +38,7 @@
 + (void)finalizeMultiFactorEnrollment:(FIRFinalizeMFAEnrollmentRequest *)request
                              callback:(FIRFinalizeMFAEnrollmentResponseCallback)callback {
   FIRFinalizeMFAEnrollmentResponse *response = [[FIRFinalizeMFAEnrollmentResponse alloc] init];
-  [[self implementation] postWithRequest:request
+  [[self implementation] callWithRequest:request
                                 response:response
                                 callback:^(NSError *error) {
                                   if (error) {
@@ -52,7 +52,7 @@
 + (void)startMultiFactorSignIn:(FIRStartMFASignInRequest *)request
                       callback:(FIRStartMFASignInResponseCallback)callback {
   FIRStartMFASignInResponse *response = [[FIRStartMFASignInResponse alloc] init];
-  [[self implementation] postWithRequest:request
+  [[self implementation] callWithRequest:request
                                 response:response
                                 callback:^(NSError *error) {
                                   if (error) {
@@ -66,7 +66,7 @@
 + (void)finalizeMultiFactorSignIn:(FIRFinalizeMFASignInRequest *)request
                          callback:(FIRFinalizeMFASignInResponseCallback)callback {
   FIRFinalizeMFASignInResponse *response = [[FIRFinalizeMFASignInResponse alloc] init];
-  [[self implementation] postWithRequest:request
+  [[self implementation] callWithRequest:request
                                 response:response
                                 callback:^(NSError *error) {
                                   if (error) {
@@ -80,7 +80,7 @@
 + (void)withdrawMultiFactor:(FIRWithdrawMFARequest *)request
                    callback:(FIRWithdrawMFAResponseCallback)callback {
   FIRWithdrawMFAResponse *response = [[FIRWithdrawMFAResponse alloc] init];
-  [[self implementation] postWithRequest:request
+  [[self implementation] callWithRequest:request
                                 response:response
                                 callback:^(NSError *error) {
                                   if (error) {

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -445,12 +445,12 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(
 @protocol FIRAuthBackendRPCIssuer <NSObject>
 
 /** @fn asyncCallToURLWithRequestConfiguration:URL:body:contentType:completionHandler:
-    @brief Asynchronously sends a POST request.
+    @brief Asynchronously sends a HTTP request.
     @param requestConfiguration The request to be made.
     @param URL The request URL.
     @param body Request body.
     @param contentType Content type of the body.
-    @param handler provided that handles POST response. Invoked asynchronously on the auth global
+    @param handler provided that handles HTTP response. Invoked asynchronously on the auth global
         work queue in the future.
  */
 - (void)asyncCallToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
@@ -629,7 +629,7 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(
              callback:(FIRResetPasswordCallback)callback;
 
 /** @fn callWithRequest:response:callback:
-    @brief Calls the RPC using HTTP POST.
+    @brief Calls the RPC using HTTP request.
     @remarks Possible error responses:
         @see FIRAuthInternalErrorCodeRPCRequestEncodingError
         @see FIRAuthInternalErrorCodeJSONSerializationError

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -54,6 +54,8 @@
 @class FIRSignInWithGameCenterResponse;
 @class FIRSignUpNewUserRequest;
 @class FIRSignUpNewUserResponse;
+@class FIRGetRecaptchaConfigRequest;
+@class FIRGetRecaptchaConfigResponse;
 
 @protocol FIRAuthBackendImplementation;
 @protocol FIRAuthBackendRPCIssuer;
@@ -229,6 +231,15 @@ typedef void (^FIRVerifyClientResponseCallback)(FIRVerifyClientResponse *_Nullab
  */
 typedef void (^FIRSignInWithGameCenterResponseCallback)(
     FIRSignInWithGameCenterResponse *_Nullable response, NSError *_Nullable error);
+
+/** @typedef FIRGetRecaptchaConfigResponseCallback
+    @brief The type of block used to return the result of a call to the getRecaptchaConfig endpoint.
+    @param response The received response, if any.
+    @param error The error which occurred, if any.
+    @remarks One of response or error will be non-nil.
+ */
+typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigResponse *_Nullable response,
+                                                NSError *_Nullable error);
 
 /** @class FIRAuthBackend
     @brief Simple static class with methods representing the backend RPCs.
@@ -414,6 +425,15 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
  */
 + (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
+
+/** @fn getRecaptchaConfig:callback:
+    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha configs including site key, provider enablement status.
+    @param request The request parameters.
+    @param callback The callback.
+ */
++ (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
+                  callback:(FIRGetRecaptchaConfigResponseCallback)callback;
+
 #endif
 
 @end
@@ -424,7 +444,7 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
 @protocol FIRAuthBackendRPCIssuer <NSObject>
 
 /** @fn asyncPostToURLWithRequestConfiguration:URL:body:contentType:completionHandler:
-    @brief Asynchronously seXnds a POST request.
+    @brief Asynchronously sends a POST request.
     @param requestConfiguration The request to be made.
     @param URL The request URL.
     @param body Request body.
@@ -588,6 +608,14 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
  */
 - (void)signInWithGameCenter:(FIRSignInWithGameCenterRequest *)request
                     callback:(FIRSignInWithGameCenterResponseCallback)callback;
+
+/** @fn getRecaptchaConfig:callback:
+    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha configs including site key, provider enablement status.
+    @param request The request parameters.
+    @param callback The callback.
+ */
+- (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
+                  callback:(FIRGetRecaptchaConfigResponseCallback)callback;
 
 /** @fn resetPassword:callback
     @brief Calls the resetPassword endpoint, which is responsible for resetting a user's password

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -443,7 +443,7 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
  */
 @protocol FIRAuthBackendRPCIssuer <NSObject>
 
-/** @fn asyncPostToURLWithRequestConfiguration:URL:body:contentType:completionHandler:
+/** @fn asyncCallToURLWithRequestConfiguration:URL:body:contentType:completionHandler:
     @brief Asynchronously sends a POST request.
     @param requestConfiguration The request to be made.
     @param URL The request URL.
@@ -452,7 +452,7 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
     @param handler provided that handles POST response. Invoked asynchronously on the auth global
         work queue in the future.
  */
-- (void)asyncPostToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+- (void)asyncCallToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
                                            URL:(NSURL *)URL
                                           body:(nullable NSData *)body
                                    contentType:(NSString *)contentType
@@ -626,7 +626,7 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
 - (void)resetPassword:(FIRResetPasswordRequest *)request
              callback:(FIRResetPasswordCallback)callback;
 
-/** @fn postWithRequest:response:callback:
+/** @fn callWithRequest:response:callback:
     @brief Calls the RPC using HTTP POST.
     @remarks Possible error responses:
         @see FIRAuthInternalErrorCodeRPCRequestEncodingError
@@ -639,7 +639,7 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
     @param response The empty response to be filled.
     @param callback The callback for both success and failure.
 */
-- (void)postWithRequest:(id<FIRAuthRPCRequest>)request
+- (void)callWithRequest:(id<FIRAuthRPCRequest>)request
                response:(id<FIRAuthRPCResponse>)response
                callback:(void (^)(NSError *_Nullable error))callback;
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -238,8 +238,8 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
     @param error The error which occurred, if any.
     @remarks One of response or error will be non-nil.
  */
-typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigResponse *_Nullable response,
-                                                NSError *_Nullable error);
+typedef void (^FIRGetRecaptchaConfigResponseCallback)(
+    FIRGetRecaptchaConfigResponse *_Nullable response, NSError *_Nullable error);
 
 /** @class FIRAuthBackend
     @brief Simple static class with methods representing the backend RPCs.
@@ -427,7 +427,8 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
             callback:(FIRVerifyClientResponseCallback)callback;
 
 /** @fn getRecaptchaConfig:callback:
-    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha configs including site key, provider enablement status.
+    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha
+   configs including site key, provider enablement status.
     @param request The request parameters.
     @param callback The callback.
  */
@@ -610,7 +611,8 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(FIRGetRecaptchaConfigRespo
                     callback:(FIRSignInWithGameCenterResponseCallback)callback;
 
 /** @fn getRecaptchaConfig:callback:
-    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha configs including site key, provider enablement status.
+    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha
+   configs including site key, provider enablement status.
     @param request The request parameters.
     @param callback The callback.
  */

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -398,6 +398,15 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(
 + (void)signInWithGameCenter:(FIRSignInWithGameCenterRequest *)request
                     callback:(FIRSignInWithGameCenterResponseCallback)callback;
 
+/** @fn getRecaptchaConfig:callback:
+    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha
+   configs including site key, provider enablement status.
+    @param request The request parameters.
+    @param callback The callback.
+ */
++ (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
+                  callback:(FIRGetRecaptchaConfigResponseCallback)callback;
+
 #if TARGET_OS_IOS
 /** @fn sendVerificationCode:callback:
     @brief Calls the sendVerificationCode endpoint, which is responsible for sending the
@@ -425,15 +434,6 @@ typedef void (^FIRGetRecaptchaConfigResponseCallback)(
  */
 + (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
-
-/** @fn getRecaptchaConfig:callback:
-    @brief Calls the getRecaptchaConfig endpoint, which is responsible for retrieving the recaptcha
-   configs including site key, provider enablement status.
-    @param request The request parameters.
-    @param callback The callback.
- */
-+ (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
-                  callback:(FIRGetRecaptchaConfigResponseCallback)callback;
 
 #endif
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -673,7 +673,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   return self;
 }
 
-- (void)asyncPostToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+- (void)asyncCallToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
                                            URL:(NSURL *)URL
                                           body:(nullable NSData *)body
                                    contentType:(NSString *)contentType
@@ -707,7 +707,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)createAuthURI:(FIRCreateAuthURIRequest *)request
              callback:(FIRCreateAuthURIResponseCallback)callback {
   FIRCreateAuthURIResponse *response = [[FIRCreateAuthURIResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -721,7 +721,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)getAccountInfo:(FIRGetAccountInfoRequest *)request
               callback:(FIRGetAccountInfoResponseCallback)callback {
   FIRGetAccountInfoResponse *response = [[FIRGetAccountInfoResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -735,7 +735,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)getProjectConfig:(FIRGetProjectConfigRequest *)request
                 callback:(FIRGetProjectConfigResponseCallback)callback {
   FIRGetProjectConfigResponse *response = [[FIRGetProjectConfigResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -749,7 +749,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)setAccountInfo:(FIRSetAccountInfoRequest *)request
               callback:(FIRSetAccountInfoResponseCallback)callback {
   FIRSetAccountInfoResponse *response = [[FIRSetAccountInfoResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -764,7 +764,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                callback:(FIRVerifyAssertionResponseCallback)callback {
   FIRVerifyAssertionResponse *response = [[FIRVerifyAssertionResponse alloc] init];
   [self
-      postWithRequest:request
+      callWithRequest:request
              response:response
              callback:^(NSError *error) {
                if (error) {
@@ -793,7 +793,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)verifyCustomToken:(FIRVerifyCustomTokenRequest *)request
                  callback:(FIRVerifyCustomTokenResponseCallback)callback {
   FIRVerifyCustomTokenResponse *response = [[FIRVerifyCustomTokenResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -808,7 +808,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
               callback:(FIRVerifyPasswordResponseCallback)callback {
   FIRVerifyPasswordResponse *response = [[FIRVerifyPasswordResponse alloc] init];
   [self
-      postWithRequest:request
+      callWithRequest:request
              response:response
              callback:^(NSError *error) {
                if (error) {
@@ -838,7 +838,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                callback:(FIREmailLinkSigninResponseCallback)callback {
   FIREmailLinkSignInResponse *response = [[FIREmailLinkSignInResponse alloc] init];
   [self
-      postWithRequest:request
+      callWithRequest:request
              response:response
              callback:^(NSError *error) {
                if (error) {
@@ -867,7 +867,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)secureToken:(FIRSecureTokenRequest *)request
            callback:(FIRSecureTokenResponseCallback)callback {
   FIRSecureTokenResponse *response = [[FIRSecureTokenResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -881,7 +881,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)request
                       callback:(FIRGetOOBConfirmationCodeResponseCallback)callback {
   FIRGetOOBConfirmationCodeResponse *response = [[FIRGetOOBConfirmationCodeResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -895,7 +895,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)signUpNewUser:(FIRSignUpNewUserRequest *)request
              callback:(FIRSignupNewUserCallback)callback {
   FIRSignUpNewUserResponse *response = [[FIRSignUpNewUserResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -908,14 +908,14 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 - (void)deleteAccount:(FIRDeleteAccountRequest *)request callback:(FIRDeleteCallBack)callback {
   FIRDeleteAccountResponse *response = [[FIRDeleteAccountResponse alloc] init];
-  [self postWithRequest:request response:response callback:callback];
+  [self callWithRequest:request response:response callback:callback];
 }
 
 #if TARGET_OS_IOS
 - (void)sendVerificationCode:(FIRSendVerificationCodeRequest *)request
                     callback:(FIRSendVerificationCodeResponseCallback)callback {
   FIRSendVerificationCodeResponse *response = [[FIRSendVerificationCodeResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -930,7 +930,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                  callback:(FIRVerifyPhoneNumberResponseCallback)callback {
   FIRVerifyPhoneNumberResponse *response = [[FIRVerifyPhoneNumberResponse alloc] init];
   [self
-      postWithRequest:request
+      callWithRequest:request
              response:response
              callback:^(NSError *error) {
                if (error) {
@@ -955,7 +955,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 - (void)verifyClient:(id)request callback:(FIRVerifyClientResponseCallback)callback {
   FIRVerifyClientResponse *response = [[FIRVerifyClientResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -970,7 +970,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)resetPassword:(FIRResetPasswordRequest *)request
              callback:(FIRResetPasswordCallback)callback {
   FIRResetPasswordResponse *response = [[FIRResetPasswordResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -984,7 +984,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)signInWithGameCenter:(FIRSignInWithGameCenterRequest *)request
                     callback:(FIRSignInWithGameCenterResponseCallback)callback {
   FIRSignInWithGameCenterResponse *response = [[FIRSignInWithGameCenterResponse alloc] init];
-  [self postWithRequest:request
+  [self callWithRequest:request
                response:response
                callback:^(NSError *error) {
                  if (error) {
@@ -1002,7 +1002,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 - (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
                   callback:(FIRGetRecaptchaConfigResponseCallback)callback {
     FIRGetRecaptchaConfigResponse *response = [[FIRGetRecaptchaConfigResponse alloc] init];
-    [self postWithRequest:request
+    [self callWithRequest:request
                  response:response
                  callback:^(NSError *error) {
                    if (error) {
@@ -1019,7 +1019,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 #pragma mark - Generic RPC handling methods
 
-/** @fn postWithRequest:response:callback:
+/** @fn callWithRequest:response:callback:
     @brief Calls the RPC using HTTP POST.
     @remarks Possible error responses:
         @see FIRAuthInternalErrorCodeRPCRequestEncodingError
@@ -1032,7 +1032,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
     @param response The empty response to be filled.
     @param callback The callback for both success and failure.
  */
-- (void)postWithRequest:(id<FIRAuthRPCRequest>)request
+- (void)callWithRequest:(id<FIRAuthRPCRequest>)request
                response:(id<FIRAuthRPCResponse>)response
                callback:(void (^)(NSError *_Nullable error))callback {
   NSError *error;
@@ -1069,7 +1069,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   [_RPCIssuer
-      asyncPostToURLWithRequestConfiguration:[request requestConfiguration]
+      asyncCallToURLWithRequestConfiguration:[request requestConfiguration]
                                          URL:[request requestURL]
                                         body:bodyData
                                  contentType:kJSONContentType

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -1020,7 +1020,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 #pragma mark - Generic RPC handling methods
 
 /** @fn callWithRequest:response:callback:
-    @brief Calls the RPC using HTTP POST.
+    @brief Calls the RPC using HTTP request.
     @remarks Possible error responses:
         @see FIRAuthInternalErrorCodeRPCRequestEncodingError
         @see FIRAuthInternalErrorCodeJSONSerializationError

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -59,6 +59,8 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyCustomTokenResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordResponse.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPhoneNumberRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPhoneNumberResponse.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
@@ -605,6 +607,11 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [[self implementation] resetPassword:request callback:callback];
 }
 
++ (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
+                  callback:(FIRGetRecaptchaConfigResponseCallback)callback {
+    [[self implementation] getRecaptchaConfig:request callback:callback];
+}
+
 + (NSString *)authUserAgent {
   return [NSString stringWithFormat:@"FirebaseAuth.iOS/%@ %@", FIRFirebaseVersion(),
                                     GTMFetcherStandardUserAgentString(nil)];
@@ -636,6 +643,8 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   if (languageCode.length) {
     [request setValue:languageCode forHTTPHeaderField:kFirebaseLocalHeader];
   }
+    NSString *HTTPMethod = requestConfiguration.HTTPMethod;
+    [request setValue:HTTPMethod forKey:@"HTTPMethod"];
   return request;
 }
 
@@ -988,6 +997,24 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                    }
                  }
                }];
+}
+
+- (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
+                  callback:(FIRGetRecaptchaConfigResponseCallback)callback {
+    FIRGetRecaptchaConfigResponse *response = [[FIRGetRecaptchaConfigResponse alloc] init];
+    [self postWithRequest:request
+                 response:response
+                 callback:^(NSError *error) {
+                   if (error) {
+                     if (callback) {
+                       callback(nil, error);
+                     }
+                   } else {
+                     if (callback) {
+                       callback(response, nil);
+                     }
+                   }
+                 }];
 }
 
 #pragma mark - Generic RPC handling methods

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -39,6 +39,8 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetProjectConfigRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetProjectConfigResponse.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.h"
@@ -59,8 +61,6 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyCustomTokenResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordResponse.h"
-#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
-#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPhoneNumberRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPhoneNumberResponse.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
@@ -609,7 +609,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 + (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
                   callback:(FIRGetRecaptchaConfigResponseCallback)callback {
-    [[self implementation] getRecaptchaConfig:request callback:callback];
+  [[self implementation] getRecaptchaConfig:request callback:callback];
 }
 
 + (NSString *)authUserAgent {
@@ -643,8 +643,8 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   if (languageCode.length) {
     [request setValue:languageCode forHTTPHeaderField:kFirebaseLocalHeader];
   }
-    NSString *HTTPMethod = requestConfiguration.HTTPMethod;
-    [request setValue:HTTPMethod forKey:@"HTTPMethod"];
+  NSString *HTTPMethod = requestConfiguration.HTTPMethod;
+  [request setValue:HTTPMethod forKey:@"HTTPMethod"];
   return request;
 }
 
@@ -1001,20 +1001,20 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 - (void)getRecaptchaConfig:(FIRGetRecaptchaConfigRequest *)request
                   callback:(FIRGetRecaptchaConfigResponseCallback)callback {
-    FIRGetRecaptchaConfigResponse *response = [[FIRGetRecaptchaConfigResponse alloc] init];
-    [self callWithRequest:request
-                 response:response
-                 callback:^(NSError *error) {
-                   if (error) {
-                     if (callback) {
-                       callback(nil, error);
-                     }
-                   } else {
-                     if (callback) {
-                       callback(response, nil);
-                     }
+  FIRGetRecaptchaConfigResponse *response = [[FIRGetRecaptchaConfigResponse alloc] init];
+  [self callWithRequest:request
+               response:response
+               callback:^(NSError *error) {
+                 if (error) {
+                   if (callback) {
+                     callback(nil, error);
                    }
-                 }];
+                 } else {
+                   if (callback) {
+                     callback(response, nil);
+                   }
+                 }
+               }];
 }
 
 #pragma mark - Generic RPC handling methods

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -47,6 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *languageCode;
 
+/** @property HTTPMethod
+    @brief The HTTP method used in the request.
+ */
+@property(nonatomic, copy, nonnull) NSString *HTTPMethod;
+
 /** @property additionalFrameworkMarker
     @brief Additional framework marker that will be added as part of the header of every request.
  */

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
     _APIKey = [APIKey copy];
     _appID = [appID copy];
     _heartbeatLogger = heartbeatLogger;
+    _HTTPMethod = @"POST";
   }
   return self;
 }

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
@@ -66,6 +66,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSURL *)requestURL;
 
+/** @fn queryParams
+    @brief Gets the request's quert parameters.
+ */
+- (nullable NSString *)queryParams;
+
 /** @fn requestConfiguration
     @brief Gets the request's configuration.
  */

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURL *)requestURL;
 
 /** @fn queryParams
-    @brief Gets the request's quert parameters.
+    @brief Gets the request's query parameters.
  */
 - (nullable NSString *)queryParams;
 

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h
@@ -42,6 +42,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, readonly, nullable) NSString *tenantID;
 
+/** @property useIdentityPlatform
+    @brief The toggle of using Identity Platform endpoints.
+ */
+@property(nonatomic) BOOL useIdentityPlatform;
+
+/** @property useStaging
+    @brief The toggle of using staging endpoints.
+ */
+@property(nonatomic) BOOL useStaging;
+
 /** @fn init
     @brief Please use initWithEndpoint:APIKey:
  */
@@ -55,11 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithEndpoint:(NSString *)endpoint
                      requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
-
-- (nullable instancetype)initWithEndpoint:(NSString *)endpoint
-                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
-                      useIdentityPlatform:(BOOL)useIdentityPlatform
-                               useStaging:(BOOL)useStaging;
 
 /** @fn requestURL
     @brief Gets the request's full URL.

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
@@ -39,10 +39,6 @@ static NSString *kIdentityPlatformStagingAPIHost =
 
 @implementation FIRIdentityToolkitRequest {
   FIRAuthRequestConfiguration *_requestConfiguration;
-
-  BOOL _useIdentityPlatform;
-
-  BOOL _useStaging;
 }
 
 - (nullable instancetype)initWithEndpoint:(NSString *)endpoint
@@ -62,18 +58,6 @@ static NSString *kIdentityPlatformStagingAPIHost =
     } @catch (NSException *e) {
       _tenantID = nil;
     }
-  }
-  return self;
-}
-
-- (nullable instancetype)initWithEndpoint:(NSString *)endpoint
-                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
-                      useIdentityPlatform:(BOOL)useIdentityPlatform
-                               useStaging:(BOOL)useStaging {
-  self = [self initWithEndpoint:endpoint requestConfiguration:requestConfiguration];
-  if (self) {
-    _useIdentityPlatform = useIdentityPlatform;
-    _useStaging = useStaging;
   }
   return self;
 }

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
@@ -82,6 +82,10 @@ static NSString *kIdentityPlatformStagingAPIHost =
   return YES;
 }
 
+- (nullable NSString *)queryParams {
+    return nil;
+}
+
 - (NSURL *)requestURL {
   NSString *apiURLFormat;
   NSString *apiProtocol;
@@ -115,8 +119,14 @@ static NSString *kIdentityPlatformStagingAPIHost =
       apiHostAndPathPrefix = kFirebaseAuthAPIHost;
     }
   }
-  NSString *URLString = [NSString
+  NSMutableString *URLString = [NSMutableString
       stringWithFormat:apiURLFormat, apiProtocol, apiHostAndPathPrefix, _endpoint, _APIKey];
+    
+    NSString *queryParams = [self queryParams];
+    if (queryParams) {
+        [URLString appendString:queryParams];
+    }
+    
   NSURL *URL = [NSURL URLWithString:URLString];
   return URL;
 }

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
@@ -83,7 +83,7 @@ static NSString *kIdentityPlatformStagingAPIHost =
 }
 
 - (nullable NSString *)queryParams {
-    return nil;
+  return nil;
 }
 
 - (NSURL *)requestURL {
@@ -121,12 +121,12 @@ static NSString *kIdentityPlatformStagingAPIHost =
   }
   NSMutableString *URLString = [NSMutableString
       stringWithFormat:apiURLFormat, apiProtocol, apiHostAndPathPrefix, _endpoint, _APIKey];
-    
-    NSString *queryParams = [self queryParams];
-    if (queryParams) {
-        [URLString appendString:queryParams];
-    }
-    
+
+  NSString *queryParams = [self queryParams];
+  if (queryParams) {
+    [URLString appendString:queryParams];
+  }
+
   NSURL *URL = [NSURL URLWithString:URLString];
   return URL;
 }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable) NSString *version;
 
 /** @fn initWithEndpoint:requestConfiguration:
-    @brief Please use initWithTenantId:clientType:version:requestConfiguration:
+    @brief Please use initWithClientType:version:requestConfiguration:
  */
 - (nullable instancetype)initWithEndpoint:(NSString *)endpoint
                      requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
+#import "FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @class FIRGetRecaptchaConfigRequest
+    @brief Represents the parameters for the getRecaptchaConfig endpoint.
+ */
+@interface FIRGetRecaptchaConfigRequest : FIRIdentityToolkitRequest <FIRAuthRPCRequest>
+
+/** @property clientType
+    @brief The client type should always be "ios".
+ */
+@property(nonatomic, copy, nullable) NSString *clientType;
+
+/** @property version
+    @brief The version of the reCAPTCHA service should be always be "enterprise".
+ */
+@property(nonatomic, copy, nullable) NSString *version;
+
+/** @fn initWithEndpoint:requestConfiguration:
+    @brief Please use initWithTenantId:clientType:version:requestConfiguration:
+ */
+- (nullable instancetype)initWithEndpoint:(NSString *)endpoint
+                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+    NS_UNAVAILABLE;
+
+/** @fn initWithEmail:password:requestConfiguration:
+    @brief Designated initializer.
+    @param clientType The client type.
+    @param version The version of the reCAPTCHA service.
+    @param requestConfiguration The config.
+ */
+- (nullable instancetype)initWithClientType:(NSString *)clientType
+                                    version:(NSString *)version
+                       requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+    NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @var kGetRecaptchaConfigEndpoint
+    @brief The "getRecaptchaConfig" endpoint.
+ */
+static NSString *const kGetRecaptchaConfigEndpoint = @"recaptchaConfig";
+
+/** @var kClientType
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientTypeKey = @"clientType";
+
+/** @var kVersionKey
+    @brief The key for the "version" value in the request.
+ */
+static NSString *const kVersionKey = @"version";
+
+/** @var kTenantIDKey
+    @brief The key for the tenant id value in the request.
+ */
+static NSString *const kTenantIDKey = @"tenantId";
+
+@implementation FIRGetRecaptchaConfigRequest
+
+- (nullable instancetype)initWithClientType:(NSString *)clientType
+                                    version:(NSString *)version
+                       requestConfiguration:(nonnull FIRAuthRequestConfiguration *)requestConfiguration {
+    requestConfiguration.HTTPMethod = @"GET";
+  self = [super initWithEndpoint:kGetRecaptchaConfigEndpoint requestConfiguration:requestConfiguration useIdentityPlatform:YES useStaging:NO];
+  if (self) {
+    _clientType = [clientType copy];
+    _version = [version copy];
+  }
+  return self;
+}
+
+- (BOOL)containsPostBody {
+  return NO;
+}
+
+- (nullable NSString *)queryParams {
+    NSMutableString *queryParams = [[NSMutableString alloc] init];
+    [queryParams appendFormat:@"&%@=%@&%@=%@", kClientTypeKey, _clientType, kVersionKey, _version];
+    if (self.tenantID) {
+        [queryParams appendFormat:@"&%@=%@", kTenantIDKey, self.tenantID];
+    }
+    return queryParams;
+}
+
+- (nullable id)unencodedHTTPRequestBodyWithError:(NSError *_Nullable *_Nullable)error {
+    return nil;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
@@ -46,9 +46,8 @@ static NSString *const kTenantIDKey = @"tenantId";
                            (nonnull FIRAuthRequestConfiguration *)requestConfiguration {
   requestConfiguration.HTTPMethod = @"GET";
   self = [super initWithEndpoint:kGetRecaptchaConfigEndpoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+            requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _clientType = [clientType copy];
     _version = [version copy];

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.m
@@ -42,9 +42,13 @@ static NSString *const kTenantIDKey = @"tenantId";
 
 - (nullable instancetype)initWithClientType:(NSString *)clientType
                                     version:(NSString *)version
-                       requestConfiguration:(nonnull FIRAuthRequestConfiguration *)requestConfiguration {
-    requestConfiguration.HTTPMethod = @"GET";
-  self = [super initWithEndpoint:kGetRecaptchaConfigEndpoint requestConfiguration:requestConfiguration useIdentityPlatform:YES useStaging:NO];
+                       requestConfiguration:
+                           (nonnull FIRAuthRequestConfiguration *)requestConfiguration {
+  requestConfiguration.HTTPMethod = @"GET";
+  self = [super initWithEndpoint:kGetRecaptchaConfigEndpoint
+            requestConfiguration:requestConfiguration
+             useIdentityPlatform:YES
+                      useStaging:NO];
   if (self) {
     _clientType = [clientType copy];
     _version = [version copy];
@@ -57,16 +61,16 @@ static NSString *const kTenantIDKey = @"tenantId";
 }
 
 - (nullable NSString *)queryParams {
-    NSMutableString *queryParams = [[NSMutableString alloc] init];
-    [queryParams appendFormat:@"&%@=%@&%@=%@", kClientTypeKey, _clientType, kVersionKey, _version];
-    if (self.tenantID) {
-        [queryParams appendFormat:@"&%@=%@", kTenantIDKey, self.tenantID];
-    }
-    return queryParams;
+  NSMutableString *queryParams = [[NSMutableString alloc] init];
+  [queryParams appendFormat:@"&%@=%@&%@=%@", kClientTypeKey, _clientType, kVersionKey, _version];
+  if (self.tenantID) {
+    [queryParams appendFormat:@"&%@=%@", kTenantIDKey, self.tenantID];
+  }
+  return queryParams;
 }
 
 - (nullable id)unencodedHTTPRequestBodyWithError:(NSError *_Nullable *_Nullable)error {
-    return nil;
+  return nil;
 }
 
 @end

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthRPCResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @class FIRVerifyPasswordResponse
+    @brief Represents the response from the getRecaptchaConfig endpoint.
+ */
+@interface FIRGetRecaptchaConfigResponse : NSObject <FIRAuthRPCResponse>
+
+/** @property recaptchaKey
+    @brief The recaptcha key of the project.
+ */
+@property(nonatomic, copy, nullable) NSString *recaptchaKey;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FIRGetRecaptchaConfigResponse
+
+- (BOOL)setWithDictionary:(NSDictionary *)dictionary error:(NSError *_Nullable *_Nullable)error {
+    _recaptchaKey = [dictionary[@"recaptchaKey"] copy];
+    
+    return YES;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.m
@@ -21,9 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRGetRecaptchaConfigResponse
 
 - (BOOL)setWithDictionary:(NSDictionary *)dictionary error:(NSError *_Nullable *_Nullable)error {
-    _recaptchaKey = [dictionary[@"recaptchaKey"] copy];
-    
-    return YES;
+  _recaptchaKey = [dictionary[@"recaptchaKey"] copy];
+
+  return YES;
 }
 
 @end

--- a/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Enroll/FIRFinalizeMFAEnrollmentRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Enroll/FIRFinalizeMFAEnrollmentRequest.m
@@ -30,9 +30,8 @@ static NSString *const kTenantIDKey = @"tenantId";
                         verificationInfo:(FIRAuthProtoFinalizeMFAPhoneRequestInfo *)verificationInfo
                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kFinalizeMFAEnrollmentEndPoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+            requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _IDToken = IDToken;
     _displayName = displayName;

--- a/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Enroll/FIRStartMFAEnrollmentRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Enroll/FIRStartMFAEnrollmentRequest.m
@@ -31,9 +31,8 @@ static NSString *const kTenantIDKey = @"tenantId";
                           enrollmentInfo:(FIRAuthProtoStartMFAPhoneRequestInfo *)enrollmentInfo
                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kStartMFAEnrollmentEndPoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+            requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _IDToken = IDToken;
     _enrollmentInfo = enrollmentInfo;

--- a/FirebaseAuth/Sources/Backend/RPC/MultiFactor/SignIn/FIRFinalizeMFASignInRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/MultiFactor/SignIn/FIRFinalizeMFASignInRequest.m
@@ -30,9 +30,8 @@ static NSString *const kTenantIDKey = @"tenantId";
                 verificationInfo:(FIRAuthProtoFinalizeMFAPhoneRequestInfo *)verificationInfo
             requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kFinalizeMFASignInEndPoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+            requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _MFAPendingCredential = MFAPendingCredential;
     _verificationInfo = verificationInfo;

--- a/FirebaseAuth/Sources/Backend/RPC/MultiFactor/SignIn/FIRStartMFASignInRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/MultiFactor/SignIn/FIRStartMFASignInRequest.m
@@ -30,10 +30,8 @@ static NSString *const kTenantIDKey = @"tenantId";
                  MFAEnrollmentID:(NSString *)MFAEnrollmentID
                       signInInfo:(FIRAuthProtoStartMFAPhoneRequestInfo *)signInInfo
             requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
-  self = [super initWithEndpoint:kStartMFASignInEndPoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+  self = [super initWithEndpoint:kStartMFASignInEndPoint requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _MFAPendingCredential = MFAPendingCredential;
     _MFAEnrollmentID = MFAEnrollmentID;

--- a/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Unenroll/FIRWithdrawMFARequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/MultiFactor/Unenroll/FIRWithdrawMFARequest.m
@@ -30,10 +30,8 @@ static NSString *const kTenantIDKey = @"tenantId";
 - (nullable instancetype)initWithIDToken:(NSString *)IDToken
                          MFAEnrollmentID:(NSString *)MFAEnrollmentID
                     requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
-  self = [super initWithEndpoint:kWithdrawMFAEndPoint
-            requestConfiguration:requestConfiguration
-             useIdentityPlatform:YES
-                      useStaging:NO];
+  self = [super initWithEndpoint:kWithdrawMFAEndPoint requestConfiguration:requestConfiguration];
+  self.useIdentityPlatform = YES;
   if (self) {
     _IDToken = IDToken;
     _MFAEnrollmentID = MFAEnrollmentID;

--- a/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m
@@ -122,7 +122,7 @@ static NSString *const kTestValue = @"TestValue";
  */
 @interface FIRAuthBackendRPCImplementation : NSObject <FIRAuthBackendImplementation>
 
-/** @fn postWithRequest:response:callback:
+/** @fn callWithRequest:response:callback:
     @brief Calls the RPC using HTTP POST.
     @remarks Possible error responses:
         @see FIRAuthInternalErrorCodeRPCRequestEncodingError
@@ -135,7 +135,7 @@ static NSString *const kTestValue = @"TestValue";
     @param response The empty response to be filled.
     @param callback The callback for both success and failure.
  */
-- (void)postWithRequest:(id<FIRAuthRPCRequest>)request
+- (void)callWithRequest:(id<FIRAuthRPCRequest>)request
                response:(id<FIRAuthRPCResponse>)response
                callback:(void (^)(NSError *error))callback;
 
@@ -385,7 +385,7 @@ static NSString *const kTestValue = @"TestValue";
 
 /** @class FIRAuthBackendRPCImplementationTests
     @brief This set of unit tests is designed primarily to test the possible outcomes of the
-        @c FIRAuthBackendRPCImplementation.postWithRequest:response:callback: method.
+        @c FIRAuthBackendRPCImplementation.callWithRequest:response:callback: method.
  */
 @interface FIRAuthBackendRPCImplementationTests : XCTestCase
 @end
@@ -417,7 +417,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testRequest_IncludesHeartbeatPayload_WhenHeartbeatsNeedSending
-    @brief This test checks the behavior of @c postWithRequest:response:callback:
+    @brief This test checks the behavior of @c callWithRequest:response:callback:
         to verify that a heartbeats payload is attached as a header to an
         outgoing request when there are stored heartbeats that need sending.
  */
@@ -442,7 +442,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -456,7 +456,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testRequest_DoesNotIncludeAHeartbeatPayload_WhenNoHeartbeatsNeedSending
-    @brief This test checks the behavior of @c postWithRequest:response:callback:
+    @brief This test checks the behavior of @c callWithRequest:response:callback:
         to verify that a request header does not contain heartbeat data in the
         case that there are no stored heartbeats that need sending.
  */
@@ -481,7 +481,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -493,7 +493,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testRequestEncodingError
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         request passed returns an error during it's unencodedHTTPRequestBodyWithError: method.
         The error returned should be delivered to the caller without any change.
  */
@@ -506,7 +506,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -540,7 +540,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testBodyDataSerializationError
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         request returns an object which isn't serializable by @c NSJSONSerialization.
         The error from @c NSJSONSerialization should be returned as the underlyingError for an
         @c NSError with the code @c FIRAuthErrorCodeJSONSerializationError.
@@ -551,7 +551,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -592,7 +592,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -628,7 +628,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testUnparsableErrorResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response isn't deserializable by @c NSJSONSerialization and an error
         condition (with an associated error response message) was expected. We are expecting to
         receive the original network error wrapped in an @c NSError with the code
@@ -640,7 +640,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -677,7 +677,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testUnparsableSuccessResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response isn't deserializable by @c NSJSONSerialization and no error
         condition was indicated. We are expecting to
         receive the @c NSJSONSerialization error wrapped in an @c NSError with the code
@@ -689,7 +689,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -723,7 +723,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testNonDictionaryErrorResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization is not a dictionary, and an error was
         expected. We are expecting to receive the original network error wrapped in an @c NSError
         with the code @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded response
@@ -736,7 +736,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -776,7 +776,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testNonDictionarySuccessResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization is not a dictionary, and no error was
         expected. We are expecting to receive an @c NSError with the code
         @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded response in the
@@ -789,7 +789,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -826,7 +826,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testCaptchaRequiredResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         we get an error message indicating captcha is required. The backend should not be returning
         this error to mobile clients. If it does, we should wrap it in an @c NSError with the code
         @c FIRAuthInternalErrorCodeUnexpectedErrorResponse with the decoded error message in the
@@ -839,7 +839,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -875,7 +875,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testCaptchaCheckFailedResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         we get an error message indicating captcha check failed. The backend should not be returning
         this error to mobile clients. If it does, we should wrap it in an @c NSError with the code
         @c FIRAuthErrorCodeUnexpectedServerResponse with the decoded error message in the
@@ -888,7 +888,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -906,7 +906,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testCaptchaRequiredInvalidPasswordResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         we get an error message indicating captcha is required and an invalid password was entered.
         The backend should not be returning this error to mobile clients. If it does, we should wrap
         it in an @c NSError with the code
@@ -920,7 +920,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -957,7 +957,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testDecodableErrorResponseWithUnknownMessage
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization represents a valid error response (and an
         error was indicated) but we didn't receive an error message we know about. We are expecting
         to receive the original network error wrapped in an @c NSError with the code
@@ -971,7 +971,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -1009,7 +1009,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testErrorResponseWithNoErrorMessage
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response deserialized by @c NSJSONSerialization is a dictionary, and an error was indicated,
         but no error information was present in the decoded response. We are expecting to receive
         the original network error wrapped in an @c NSError with the code
@@ -1023,7 +1023,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -1058,7 +1058,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testClientErrorResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response contains a client error specified by an error messsage sent from the backend.
  */
 - (void)testClientErrorResponse {
@@ -1067,7 +1067,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackerror;
   __block BOOL callBackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callBackInvoked = YES;
@@ -1086,7 +1086,7 @@ static NSString *const kTestValue = @"TestValue";
 }
 
 /** @fn testUndecodableSuccessResponse
-    @brief This test checks the behaviour of @c postWithRequest:response:callback: when the
+    @brief This test checks the behaviour of @c callWithRequest:response:callback: when the
         response isn't decodable by the response class but no error condition was expected. We are
         expecting to receive an @c NSError with the code
         @c FIRAuthErrorCodeUnexpectedServerResponse and the error from @c setWithDictionary:error:
@@ -1098,7 +1098,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;
@@ -1138,7 +1138,7 @@ static NSString *const kTestValue = @"TestValue";
 
   __block NSError *callbackError;
   __block BOOL callbackInvoked;
-  [_RPCImplementation postWithRequest:request
+  [_RPCImplementation callWithRequest:request
                              response:response
                              callback:^(NSError *error) {
                                callbackInvoked = YES;

--- a/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
+++ b/FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.m
@@ -35,7 +35,7 @@ static NSString *const kFakeErrorDomain = @"fake domain";
   FIRAuthBackendRPCIssuerCompletionHandler _handler;
 }
 
-- (void)asyncPostToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
+- (void)asyncCallToURLWithRequestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
                                            URL:(NSURL *)URL
                                           body:(NSData *)body
                                    contentType:(NSString *)contentType

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
+#import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+
+/** @var kGetRecaptchaConfigEndPoint
+    @brief The "getRecaptchaConfig" endpoint.
+ */
+static NSString *const kGetRecaptchaConfigEndPoint = @"recaptchaConfig";
+
+/** @var kTestAPIKey
+    @brief Fake API key used for testing.
+ */
+static NSString *const kTestAPIKey = @"APIKey";
+
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
+/** @var kAPIURLFormat
+    @brief URL format for server API calls.
+ */
+static NSString *const kAPIURLFormat = @"https://identitytoolkit.googleapis.com/v2/%@?key=%@";
+
+/** @var gAPIHost
+    @brief Host for server API calls.
+ */
+static NSString *gAPIHost = @"www.googleapis.com";
+
+@interface FIRGetRecaptchaConfigRequestTests : XCTestCase
+@end
+
+@implementation FIRGetRecaptchaConfigRequestTests {
+  /** @var _RPCIssuer
+      @brief This backend RPC issuer is used to fake network responses for each test in the suite.
+          In the @c setUp method we initialize this and set @c FIRAuthBackend's RPC issuer to it.
+   */
+  FIRFakeBackendRPCIssuer *_RPCIssuer;
+}
+
+- (void)setUp {
+  [super setUp];
+  FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
+  _RPCIssuer = RPCIssuer;
+}
+
+- (void)tearDown {
+  _RPCIssuer = nil;
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [super tearDown];
+}
+
+/** @fn testGetRecaptchaConfigRequest
+    @brief Tests get Recaptcha config request.
+ */
+- (void)testGetRecaptchaConfigRequest {
+  FIRAuthRequestConfiguration *requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
+  FIRGetRecaptchaConfigRequest *request =
+      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS" version:@"RECAPTCHA_ENTERPRISE" requestConfiguration:requestConfiguration];
+
+  [FIRAuthBackend
+      getRecaptchaConfig:request
+              callback:^(FIRGetRecaptchaConfigResponse *_Nullable response, NSError *_Nullable error){
+
+              }];
+  XCTAssertFalse([request containsPostBody]);
+  // Confirm that the quest has no decoded body as it is get request.
+  XCTAssertNil(_RPCIssuer.decodedRequest);
+  NSMutableString *URLString =
+      [NSMutableString stringWithFormat:kAPIURLFormat, kGetRecaptchaConfigEndPoint, kTestAPIKey];
+    [URLString appendFormat:@"&%@=%@&%@=%@", @"clientType", @"CLIENT_TYPE_IOS", @"version", @"RECAPTCHA_ENTERPRISE"];
+  XCTAssertEqualObjects(URLString, [request requestURL].absoluteString);
+}
+
+@end

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigRequestTests.m
@@ -77,19 +77,22 @@ static NSString *gAPIHost = @"www.googleapis.com";
   FIRAuthRequestConfiguration *requestConfiguration =
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
   FIRGetRecaptchaConfigRequest *request =
-      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS" version:@"RECAPTCHA_ENTERPRISE" requestConfiguration:requestConfiguration];
+      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS"
+                                                       version:@"RECAPTCHA_ENTERPRISE"
+                                          requestConfiguration:requestConfiguration];
 
-  [FIRAuthBackend
-      getRecaptchaConfig:request
-              callback:^(FIRGetRecaptchaConfigResponse *_Nullable response, NSError *_Nullable error){
+  [FIRAuthBackend getRecaptchaConfig:request
+                            callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
+                                       NSError *_Nullable error){
 
-              }];
+                            }];
   XCTAssertFalse([request containsPostBody]);
   // Confirm that the quest has no decoded body as it is get request.
   XCTAssertNil(_RPCIssuer.decodedRequest);
   NSMutableString *URLString =
       [NSMutableString stringWithFormat:kAPIURLFormat, kGetRecaptchaConfigEndPoint, kTestAPIKey];
-    [URLString appendFormat:@"&%@=%@&%@=%@", @"clientType", @"CLIENT_TYPE_IOS", @"version", @"RECAPTCHA_ENTERPRISE"];
+  [URLString appendFormat:@"&%@=%@&%@=%@", @"clientType", @"CLIENT_TYPE_IOS", @"version",
+                          @"RECAPTCHA_ENTERPRISE"];
   XCTAssertEqualObjects(URLString, [request requestURL].absoluteString);
 }
 

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
@@ -69,20 +69,21 @@ static NSString *const kTestRecaptchaKey = @"projects/123/keys/456";
 - (void)testSuccessFulGetRecaptchaConfigRequest {
   FIRAuthRequestConfiguration *requestConfiguration =
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
-    FIRGetRecaptchaConfigRequest *request =
-        [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS" version:@"RECAPTCHA_ENTERPRISE" requestConfiguration:requestConfiguration];
-
+  FIRGetRecaptchaConfigRequest *request =
+      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS"
+                                                       version:@"RECAPTCHA_ENTERPRISE"
+                                          requestConfiguration:requestConfiguration];
 
   __block BOOL callbackInvoked;
   __block FIRGetRecaptchaConfigResponse *RPCResponse;
   __block NSError *RPCError;
   [FIRAuthBackend getRecaptchaConfig:request
-                          callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
-                                     NSError *_Nullable error) {
-                            callbackInvoked = YES;
-                            RPCResponse = response;
-                            RPCError = error;
-                          }];
+                            callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
+                                       NSError *_Nullable error) {
+                              callbackInvoked = YES;
+                              RPCResponse = response;
+                              RPCError = error;
+                            }];
 
   [_RPCIssuer respondWithJSON:@{
     @"recaptchaKey" : kTestRecaptchaKey,

--- a/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetRecaptchaConfigResponseTests.m
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h"
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
+#import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
+#import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+
+/** @var kTestAPIKey
+    @brief Fake API key used for testing.
+ */
+static NSString *const kTestAPIKey = @"APIKey";
+
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
+/** @var kTestRecaptchaID
+    @brief Fake Recaptcha ID used for testing.
+ */
+static NSString *const kTestRecaptchaKey = @"projects/123/keys/456";
+
+@interface FIRGetRecaptchaConfigResponseTests : XCTestCase
+@end
+
+@implementation FIRGetRecaptchaConfigResponseTests {
+  /** @var _RPCIssuer
+      @brief This backend RPC issuer is used to fake network responses for each test in the suite.
+          In the @c setUp method we initialize this and set @c FIRAuthBackend's RPC issuer to it.
+   */
+  FIRFakeBackendRPCIssuer *_RPCIssuer;
+}
+
+- (void)setUp {
+  [super setUp];
+  FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
+  _RPCIssuer = RPCIssuer;
+}
+
+- (void)tearDown {
+  _RPCIssuer = nil;
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [super tearDown];
+}
+
+/** @fn testSuccessFulGetRecaptchaConfigRequest
+    @brief This test simulates a successful @c getRecaptchaConfig Flow.
+ */
+- (void)testSuccessFulGetRecaptchaConfigRequest {
+  FIRAuthRequestConfiguration *requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey appID:kTestFirebaseAppID];
+    FIRGetRecaptchaConfigRequest *request =
+        [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS" version:@"RECAPTCHA_ENTERPRISE" requestConfiguration:requestConfiguration];
+
+
+  __block BOOL callbackInvoked;
+  __block FIRGetRecaptchaConfigResponse *RPCResponse;
+  __block NSError *RPCError;
+  [FIRAuthBackend getRecaptchaConfig:request
+                          callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
+                                     NSError *_Nullable error) {
+                            callbackInvoked = YES;
+                            RPCResponse = response;
+                            RPCError = error;
+                          }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"recaptchaKey" : kTestRecaptchaKey,
+  }];
+  XCTAssert(callbackInvoked);
+  XCTAssertNil(RPCError);
+  XCTAssertEqualObjects(kTestRecaptchaKey, RPCResponse.recaptchaKey);
+}
+
+@end

--- a/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
@@ -72,9 +72,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration
-                                      useIdentityPlatform:NO
-                                               useStaging:YES];
+                                     requestConfiguration:requestConfiguration];
+  request.useStaging = YES;
   NSString *expectedURL = [NSString
       stringWithFormat:
           @"https://staging-www.sandbox.googleapis.com/identitytoolkit/v3/relyingparty/%@?key=%@",
@@ -92,9 +91,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration
-                                      useIdentityPlatform:YES
-                                               useStaging:NO];
+                                     requestConfiguration:requestConfiguration];
+  request.useIdentityPlatform = YES;
   NSString *expectedURL = [NSString
       stringWithFormat:@"https://identitytoolkit.googleapis.com/v2/%@?key=%@", kEndpoint, kAPIKey];
 
@@ -110,9 +108,9 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration
-                                      useIdentityPlatform:YES
-                                               useStaging:YES];
+                                     requestConfiguration:requestConfiguration];
+  request.useIdentityPlatform = YES;
+  request.useStaging = YES;
   NSString *expectedURL = [NSString
       stringWithFormat:@"https://staging-identitytoolkit.sandbox.googleapis.com/v2/%@?key=%@",
                        kEndpoint, kAPIKey];
@@ -148,9 +146,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration
-                                      useIdentityPlatform:YES
-                                               useStaging:NO];
+                                     requestConfiguration:requestConfiguration];
+  request.useIdentityPlatform = YES;
   NSString *expectedURL =
       [NSString stringWithFormat:@"http://%@/identitytoolkit.googleapis.com/v2/%@?key=%@",
                                  kEmulatorHostAndPort, kEndpoint, kAPIKey];


### PR DESCRIPTION
This PR updates the 4 email auth apis (sign in, sign up, password reset, email link sign in) to support recaptcha enterprise. [go/gcip-recaptcha-client-sdk-api](http://go/gcip-recaptcha-client-sdk-api)

### Development progress
- Implement getRecaptchaConfig API This PR - https://github.com/firebase/firebase-ios-sdk/pull/10038
- New backend error types
- Update backend apis
- Implement recaptcha enterprise verifier
- Wire recaptcha enterprise verifier to email auth flows