### PR TITLE
Backend apis

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -16,8 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <recaptcha/recaptcha.h>
-
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 
 #if __has_include(<UIKit/UIKit.h>)
@@ -46,8 +44,6 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"
-#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
-#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSendVerificationCodeRequest.h"
@@ -763,57 +759,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                         anonymous:NO
                                          callback:callback];
             }];
-  //  FIRGetRecaptchaConfigRequest *request =
-  //      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS"
-  //                                                       version:@"RECAPTCHA_ENTERPRISE"
-  //                                          requestConfiguration:_requestConfiguration];
-  //  [FIRAuthBackend getRecaptchaConfig:request
-  //                            callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
-  //                                       NSError *_Nullable error) {
-  //      if (error) {
-  //          NSLog(@"%@", error);
-  //      } else {
-  //                              NSLog(@"%@", response.recaptchaKey);
-  //      }
-  //                            }];
-
-  RecaptchaClient *recaptchaClient =
-      [[RecaptchaClient alloc] initWithSiteKey:@"6Lf5tkkfAAAAAEBTVMfbuPCvYzuBnZNauhPJqji3"];
-  [recaptchaClient execute:[[RecaptchaAction alloc] initWithAction:RecaptchaActionTypeLogin]
-         onFinishedExecute:^(RecaptchaToken *_Nullable token, RecaptchaError *_Nullable error) {
-           if (error) {
-             NSLog(@ "!!!!! error %@", error);
-           } else {
-             NSLog(@ "!!!!! token %@", token.recaptchaToken);
-             FIRVerifyPasswordRequest *request =
-                 [[FIRVerifyPasswordRequest alloc] initWithEmail:email
-                                                        password:password
-                                                 captchaResponse:nil
-                                                      clientType:nil
-                                                recaptchaVersion:nil
-                                            requestConfiguration:self->_requestConfiguration];
-
-             if (![request.password length]) {
-               callback(nil, [FIRAuthErrorUtils wrongPasswordErrorWithMessage:nil]);
-               return;
-             }
-             [FIRAuthBackend
-                 verifyPassword:request
-                       callback:^(FIRVerifyPasswordResponse *_Nullable response,
-                                  NSError *_Nullable error) {
-                         if (error) {
-                           NSLog(@ "!!!!! error %@", error);
-                           callback(nil, error);
-                           return;
-                         }
-                         [self completeSignInWithAccessToken:response.IDToken
-                                   accessTokenExpirationDate:response.approximateExpirationDate
-                                                refreshToken:response.refreshToken
-                                                   anonymous:NO
-                                                    callback:callback];
-                       }];
-           }
-         }];
 }
 
 /** @fn internalSignInAndRetrieveDataWithEmail:password:callback:

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <recaptcha/recaptcha.h>
+
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 
 #if __has_include(<UIKit/UIKit.h>)
@@ -44,6 +46,8 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRGetRecaptchaConfigResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSendVerificationCodeRequest.h"
@@ -759,6 +763,57 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                         anonymous:NO
                                          callback:callback];
             }];
+  //  FIRGetRecaptchaConfigRequest *request =
+  //      [[FIRGetRecaptchaConfigRequest alloc] initWithClientType:@"CLIENT_TYPE_IOS"
+  //                                                       version:@"RECAPTCHA_ENTERPRISE"
+  //                                          requestConfiguration:_requestConfiguration];
+  //  [FIRAuthBackend getRecaptchaConfig:request
+  //                            callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
+  //                                       NSError *_Nullable error) {
+  //      if (error) {
+  //          NSLog(@"%@", error);
+  //      } else {
+  //                              NSLog(@"%@", response.recaptchaKey);
+  //      }
+  //                            }];
+
+  RecaptchaClient *recaptchaClient =
+      [[RecaptchaClient alloc] initWithSiteKey:@"6Lf5tkkfAAAAAEBTVMfbuPCvYzuBnZNauhPJqji3"];
+  [recaptchaClient execute:[[RecaptchaAction alloc] initWithAction:RecaptchaActionTypeLogin]
+         onFinishedExecute:^(RecaptchaToken *_Nullable token, RecaptchaError *_Nullable error) {
+           if (error) {
+             NSLog(@ "!!!!! error %@", error);
+           } else {
+             NSLog(@ "!!!!! token %@", token.recaptchaToken);
+             FIRVerifyPasswordRequest *request =
+                 [[FIRVerifyPasswordRequest alloc] initWithEmail:email
+                                                        password:password
+                                                 captchaResponse:nil
+                                                      clientType:nil
+                                                recaptchaVersion:nil
+                                            requestConfiguration:self->_requestConfiguration];
+
+             if (![request.password length]) {
+               callback(nil, [FIRAuthErrorUtils wrongPasswordErrorWithMessage:nil]);
+               return;
+             }
+             [FIRAuthBackend
+                 verifyPassword:request
+                       callback:^(FIRVerifyPasswordResponse *_Nullable response,
+                                  NSError *_Nullable error) {
+                         if (error) {
+                           NSLog(@ "!!!!! error %@", error);
+                           callback(nil, error);
+                           return;
+                         }
+                         [self completeSignInWithAccessToken:response.IDToken
+                                   accessTokenExpirationDate:response.approximateExpirationDate
+                                                refreshToken:response.refreshToken
+                                                   anonymous:NO
+                                                    callback:callback];
+                       }];
+           }
+         }];
 }
 
 /** @fn internalSignInAndRetrieveDataWithEmail:password:callback:

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1306,6 +1306,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     }
     FIRGetOOBConfirmationCodeRequest *request = [FIRGetOOBConfirmationCodeRequest
         passwordResetRequestWithEmail:email
+                      captchaResponse:nil
+                           clientType:nil
+                     recaptchaVersion:nil
                    actionCodeSettings:actionCodeSettings
                  requestConfiguration:self->_requestConfiguration];
     [FIRAuthBackend getOOBConfirmationCode:request
@@ -1335,6 +1338,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     }
     FIRGetOOBConfirmationCodeRequest *request =
         [FIRGetOOBConfirmationCodeRequest signInWithEmailLinkRequest:email
+                                                     captchaResponse:nil
+                                                          clientType:nil
+                                                    recaptchaVersion:nil
                                                   actionCodeSettings:actionCodeSettings
                                                 requestConfiguration:self->_requestConfiguration];
     [FIRAuthBackend getOOBConfirmationCode:request
@@ -1736,6 +1742,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       [[FIRSignUpNewUserRequest alloc] initWithEmail:email
                                             password:password
                                          displayName:nil
+                                     captchaResponse:nil
+                                          clientType:nil
+                                    recaptchaVersion:nil
                                 requestConfiguration:_requestConfiguration];
   if (![request.password length]) {
     completion(

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1306,9 +1306,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     }
     FIRGetOOBConfirmationCodeRequest *request = [FIRGetOOBConfirmationCodeRequest
         passwordResetRequestWithEmail:email
-                      captchaResponse:nil
-                           clientType:nil
-                     recaptchaVersion:nil
                    actionCodeSettings:actionCodeSettings
                  requestConfiguration:self->_requestConfiguration];
     [FIRAuthBackend getOOBConfirmationCode:request
@@ -1338,9 +1335,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     }
     FIRGetOOBConfirmationCodeRequest *request =
         [FIRGetOOBConfirmationCodeRequest signInWithEmailLinkRequest:email
-                                                     captchaResponse:nil
-                                                          clientType:nil
-                                                    recaptchaVersion:nil
                                                   actionCodeSettings:actionCodeSettings
                                                 requestConfiguration:self->_requestConfiguration];
     [FIRAuthBackend getOOBConfirmationCode:request
@@ -1742,9 +1736,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       [[FIRSignUpNewUserRequest alloc] initWithEmail:email
                                             password:password
                                          displayName:nil
-                                     captchaResponse:nil
-                                          clientType:nil
-                                    recaptchaVersion:nil
                                 requestConfiguration:_requestConfiguration];
   if (![request.password length]) {
     completion(

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
@@ -112,21 +112,6 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 @property(copy, nonatomic, nullable) NSString *dynamicLinkDomain;
 
-/** @property captchaResponse
-    @brief Response to the captcha.
- */
-@property(nonatomic, copy, nullable) NSString *captchaResponse;
-
-/** @property clientType
-    @brief The reCAPTCHA client type.
- */
-@property(nonatomic, copy, nullable) NSString *clientType;
-
-/** @property captchaResponse
-    @brief The reCAPTCHA version.
- */
-@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
-
 /** @fn passwordResetRequestWithEmail:actionCodeSettings:requestConfiguration:
     @brief Creates a password reset request.
     @param email The user's email address.
@@ -137,9 +122,6 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
-                  captchaResponse:(nullable NSString *)captchaResponse
-                       clientType:(nullable NSString *)clientType
-                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 
@@ -166,9 +148,6 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
-               captchaResponse:(nullable NSString *)captchaResponse
-                    clientType:(nullable NSString *)clientType
-              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
@@ -137,9 +137,6 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
-                  captchaResponse:(nullable NSString *)captchaResponse
-                       clientType:(nullable NSString *)clientType
-                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 
@@ -166,9 +163,6 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
-               captchaResponse:(nullable NSString *)captchaResponse
-                    clientType:(nullable NSString *)clientType
-              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h
@@ -112,6 +112,21 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 @property(copy, nonatomic, nullable) NSString *dynamicLinkDomain;
 
+/** @property captchaResponse
+    @brief Response to the captcha.
+ */
+@property(nonatomic, copy, nullable) NSString *captchaResponse;
+
+/** @property clientType
+    @brief The reCAPTCHA client type.
+ */
+@property(nonatomic, copy, nullable) NSString *clientType;
+
+/** @property captchaResponse
+    @brief The reCAPTCHA version.
+ */
+@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
+
 /** @fn passwordResetRequestWithEmail:actionCodeSettings:requestConfiguration:
     @brief Creates a password reset request.
     @param email The user's email address.
@@ -122,6 +137,9 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
+                  captchaResponse:(nullable NSString *)captchaResponse
+                       clientType:(nullable NSString *)clientType
+                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 
@@ -148,6 +166,9 @@ typedef NS_ENUM(NSInteger, FIRGetOOBConfirmationCodeRequestType) {
  */
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
+               captchaResponse:(nullable NSString *)captchaResponse
+                    clientType:(nullable NSString *)clientType
+              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -142,9 +142,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
-                             captchaResponse:(nullable NSString *)captchaResponse
-                                  clientType:(nullable NSString *)clientType
-                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
@@ -173,18 +170,12 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
-                  captchaResponse:(nullable NSString *)captchaResponse
-                       clientType:(nullable NSString *)clientType
-                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypePasswordReset
                                      email:email
                                   newEmail:nil
                                accessToken:nil
-                           captchaResponse:captchaResponse
-                                clientType:clientType
-                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -197,27 +188,18 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                      email:nil
                                   newEmail:nil
                                accessToken:accessToken
-                           captchaResponse:nil
-                                clientType:nil
-                          recaptchaVersion:nil
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
-               captchaResponse:(nullable NSString *)captchaResponse
-                    clientType:(nullable NSString *)clientType
-              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypeEmailLink
                                      email:email
                                   newEmail:nil
                                accessToken:nil
-                           captchaResponse:captchaResponse
-                                clientType:clientType
-                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -232,9 +214,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                   email:nil
                                newEmail:newEmail
                             accessToken:accessToken
-                        captchaResponse:nil
-                             clientType:nil
-                       recaptchaVersion:nil
                      actionCodeSettings:actionCodeSettings
                    requestConfiguration:requestConfiguration];
 }
@@ -243,9 +222,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
-                             captchaResponse:(nullable NSString *)captchaResponse
-                                  clientType:(nullable NSString *)clientType
-                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kGetOobConfirmationCodeEndpoint
@@ -262,9 +238,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
     _androidInstallApp = actionCodeSettings.androidInstallIfNotAvailable;
     _handleCodeInApp = actionCodeSettings.handleCodeInApp;
     _dynamicLinkDomain = actionCodeSettings.dynamicLinkDomain;
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
   }
   return self;
 }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -111,21 +111,6 @@ static NSString *const kVerifyBeforeUpdateEmailRequestTypeValue = @"VERIFY_AND_C
  */
 static NSString *const kTenantIDKey = @"tenantId";
 
-/** @var kCaptchaResponseKey
-    @brief The key for the "captchaResponse" value in the request.
- */
-static NSString *const kCaptchaResponseKey = @"captchaResponse";
-
-/** @var kClientType
-    @brief The key for the "clientType" value in the request.
- */
-static NSString *const kClientType = @"clientType";
-
-/** @var kRecaptchaVersion
-    @brief The key for the "recaptchaVersion" value in the request.
- */
-static NSString *const kRecaptchaVersion = @"recaptchaVersion";
-
 @interface FIRGetOOBConfirmationCodeRequest ()
 
 /** @fn initWithRequestType:email:APIKey:
@@ -142,9 +127,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
-                             captchaResponse:(nullable NSString *)captchaResponse
-                                  clientType:(nullable NSString *)clientType
-                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
@@ -173,18 +155,12 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
-                  captchaResponse:(nullable NSString *)captchaResponse
-                       clientType:(nullable NSString *)clientType
-                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypePasswordReset
                                      email:email
                                   newEmail:nil
                                accessToken:nil
-                           captchaResponse:captchaResponse
-                                clientType:clientType
-                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -197,27 +173,18 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                      email:nil
                                   newEmail:nil
                                accessToken:accessToken
-                           captchaResponse:nil
-                                clientType:nil
-                          recaptchaVersion:nil
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
-               captchaResponse:(nullable NSString *)captchaResponse
-                    clientType:(nullable NSString *)clientType
-              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypeEmailLink
                                      email:email
                                   newEmail:nil
                                accessToken:nil
-                           captchaResponse:captchaResponse
-                                clientType:clientType
-                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -232,9 +199,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                   email:nil
                                newEmail:newEmail
                             accessToken:accessToken
-                        captchaResponse:nil
-                             clientType:nil
-                       recaptchaVersion:nil
                      actionCodeSettings:actionCodeSettings
                    requestConfiguration:requestConfiguration];
 }
@@ -243,9 +207,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
-                             captchaResponse:(nullable NSString *)captchaResponse
-                                  clientType:(nullable NSString *)clientType
-                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kGetOobConfirmationCodeEndpoint
@@ -262,9 +223,6 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
     _androidInstallApp = actionCodeSettings.androidInstallIfNotAvailable;
     _handleCodeInApp = actionCodeSettings.handleCodeInApp;
     _dynamicLinkDomain = actionCodeSettings.dynamicLinkDomain;
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
   }
   return self;
 }
@@ -322,17 +280,9 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
   if (_handleCodeInApp) {
     body[kCanHandleCodeInAppKey] = @YES;
   }
+
   if (_dynamicLinkDomain) {
     body[kDynamicLinkDomainKey] = _dynamicLinkDomain;
-  }
-  if (_captchaResponse) {
-    body[kCaptchaResponseKey] = _captchaResponse;
-  }
-  if (_clientType) {
-    body[kClientType] = _clientType;
-  }
-  if (_recaptchaVersion) {
-    body[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (self.tenantID) {
     body[kTenantIDKey] = self.tenantID;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -111,6 +111,21 @@ static NSString *const kVerifyBeforeUpdateEmailRequestTypeValue = @"VERIFY_AND_C
  */
 static NSString *const kTenantIDKey = @"tenantId";
 
+/** @var kCaptchaResponseKey
+    @brief The key for the "captchaResponse" value in the request.
+ */
+static NSString *const kCaptchaResponseKey = @"captchaResponse";
+
+/** @var kClientType
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientType = @"clientType";
+
+/** @var kRecaptchaVersion
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersion = @"recaptchaVersion";
+
 @interface FIRGetOOBConfirmationCodeRequest ()
 
 /** @fn initWithRequestType:email:APIKey:
@@ -127,6 +142,9 @@ static NSString *const kTenantIDKey = @"tenantId";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
+                             captchaResponse:(nullable NSString *)captchaResponse
+                                  clientType:(nullable NSString *)clientType
+                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
@@ -155,12 +173,18 @@ static NSString *const kTenantIDKey = @"tenantId";
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     passwordResetRequestWithEmail:(NSString *)email
+                  captchaResponse:(nullable NSString *)captchaResponse
+                       clientType:(nullable NSString *)clientType
+                 recaptchaVersion:(nullable NSString *)recaptchaVersion
                actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
              requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypePasswordReset
                                      email:email
                                   newEmail:nil
                                accessToken:nil
+                           captchaResponse:captchaResponse
+                                clientType:clientType
+                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -173,18 +197,27 @@ static NSString *const kTenantIDKey = @"tenantId";
                                      email:nil
                                   newEmail:nil
                                accessToken:accessToken
+                           captchaResponse:nil
+                                clientType:nil
+                          recaptchaVersion:nil
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
 
 + (nullable FIRGetOOBConfirmationCodeRequest *)
     signInWithEmailLinkRequest:(NSString *)email
+               captchaResponse:(nullable NSString *)captchaResponse
+                    clientType:(nullable NSString *)clientType
+              recaptchaVersion:(nullable NSString *)recaptchaVersion
             actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
           requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   return [[self alloc] initWithRequestType:FIRGetOOBConfirmationCodeRequestTypeEmailLink
                                      email:email
                                   newEmail:nil
                                accessToken:nil
+                           captchaResponse:captchaResponse
+                                clientType:clientType
+                          recaptchaVersion:recaptchaVersion
                         actionCodeSettings:actionCodeSettings
                       requestConfiguration:requestConfiguration];
 }
@@ -199,6 +232,9 @@ static NSString *const kTenantIDKey = @"tenantId";
                                   email:nil
                                newEmail:newEmail
                             accessToken:accessToken
+                        captchaResponse:nil
+                             clientType:nil
+                       recaptchaVersion:nil
                      actionCodeSettings:actionCodeSettings
                    requestConfiguration:requestConfiguration];
 }
@@ -207,6 +243,9 @@ static NSString *const kTenantIDKey = @"tenantId";
                                        email:(nullable NSString *)email
                                     newEmail:(nullable NSString *)newEmail
                                  accessToken:(nullable NSString *)accessToken
+                             captchaResponse:(nullable NSString *)captchaResponse
+                                  clientType:(nullable NSString *)clientType
+                            recaptchaVersion:(nullable NSString *)recaptchaVersion
                           actionCodeSettings:(nullable FIRActionCodeSettings *)actionCodeSettings
                         requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kGetOobConfirmationCodeEndpoint
@@ -223,6 +262,9 @@ static NSString *const kTenantIDKey = @"tenantId";
     _androidInstallApp = actionCodeSettings.androidInstallIfNotAvailable;
     _handleCodeInApp = actionCodeSettings.handleCodeInApp;
     _dynamicLinkDomain = actionCodeSettings.dynamicLinkDomain;
+    _captchaResponse = [captchaResponse copy];
+    _clientType = [clientType copy];
+    _recaptchaVersion = [recaptchaVersion copy];
   }
   return self;
 }
@@ -280,9 +322,17 @@ static NSString *const kTenantIDKey = @"tenantId";
   if (_handleCodeInApp) {
     body[kCanHandleCodeInAppKey] = @YES;
   }
-
   if (_dynamicLinkDomain) {
     body[kDynamicLinkDomainKey] = _dynamicLinkDomain;
+  }
+  if (_captchaResponse) {
+    body[kCaptchaResponseKey] = _captchaResponse;
+  }
+  if (_clientType) {
+    body[kClientType] = _clientType;
+  }
+  if (_recaptchaVersion) {
+    body[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (self.tenantID) {
     body[kTenantIDKey] = self.tenantID;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -246,52 +246,42 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
   NSMutableDictionary *body =
       [@{kRequestTypeKey : [[self class] requestTypeStringValueForRequestType:_requestType]}
           mutableCopy];
-
   // For password reset requests, we only need an email address in addition to the already required
   // fields.
   if (_requestType == FIRGetOOBConfirmationCodeRequestTypePasswordReset) {
     body[kEmailKey] = _email;
   }
-
   // For verify email requests, we only need an STS Access Token in addition to the already required
   // fields.
   if (_requestType == FIRGetOOBConfirmationCodeRequestTypeVerifyEmail) {
     body[kIDTokenKey] = _accessToken;
   }
-
   // For email sign-in link requests, we only need an email address in addition to the already
   // required fields.
   if (_requestType == FIRGetOOBConfirmationCodeRequestTypeEmailLink) {
     body[kEmailKey] = _email;
   }
-
   // For email sign-in link requests, we only need an STS Access Token, a new email address in
   // addition to the already required fields.
   if (_requestType == FIRGetOOBConfirmationCodeRequestTypeVerifyBeforeUpdateEmail) {
     body[kNewEmailKey] = _updatedEmail;
     body[kIDTokenKey] = _accessToken;
   }
-
   if (_continueURL) {
     body[kContinueURLKey] = _continueURL;
   }
-
   if (_iOSBundleID) {
     body[kIosBundleIDKey] = _iOSBundleID;
   }
-
   if (_androidPackageName) {
     body[kAndroidPackageNameKey] = _androidPackageName;
   }
-
   if (_androidMinimumVersion) {
     body[kAndroidMinimumVersionKey] = _androidMinimumVersion;
   }
-
   if (_androidInstallApp) {
     body[kAndroidInstallAppKey] = @YES;
   }
-
   if (_handleCodeInApp) {
     body[kCanHandleCodeInAppKey] = @YES;
   }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
@@ -38,6 +38,21 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *displayName;
 
+/** @property captchaResponse
+    @brief Response to the captcha.
+ */
+@property(nonatomic, copy, nullable) NSString *captchaResponse;
+
+/** @property clientType
+    @brief The reCAPTCHA client type.
+ */
+@property(nonatomic, copy, nullable) NSString *clientType;
+
+/** @property captchaResponse
+    @brief The reCAPTCHA version.
+ */
+@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
+
 /** @property returnSecureToken
     @brief Whether the response should return access token and refresh token directly.
     @remarks The default value is @c YES .
@@ -64,6 +79,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
+                       captchaResponse:(nullable NSString *)captchaResponse
+                            clientType:(nullable NSString *)clientType
+                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
@@ -79,9 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h
@@ -38,21 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *displayName;
 
-/** @property captchaResponse
-    @brief Response to the captcha.
- */
-@property(nonatomic, copy, nullable) NSString *captchaResponse;
-
-/** @property clientType
-    @brief The reCAPTCHA client type.
- */
-@property(nonatomic, copy, nullable) NSString *clientType;
-
-/** @property captchaResponse
-    @brief The reCAPTCHA version.
- */
-@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
-
 /** @property returnSecureToken
     @brief Whether the response should return access token and refresh token directly.
     @remarks The default value is @c YES .
@@ -79,9 +64,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
@@ -68,18 +68,12 @@ static NSString *const kTenantIDKey = @"tenantId";
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kSignupNewUserEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
     _displayName = [displayName copy];
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;
@@ -90,9 +84,6 @@ static NSString *const kTenantIDKey = @"tenantId";
   self = [self initWithEmail:nil
                     password:nil
                  displayName:nil
-             captchaResponse:nil
-                  clientType:nil
-            recaptchaVersion:nil
         requestConfiguration:requestConfiguration];
   return self;
 }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
@@ -38,21 +38,6 @@ static NSString *const kPasswordKey = @"password";
  */
 static NSString *const kDisplayNameKey = @"displayName";
 
-/** @var kCaptchaResponseKey
-    @brief The key for the "captchaResponse" value in the request.
- */
-static NSString *const kCaptchaResponseKey = @"captchaResponse";
-
-/** @var kClientType
-    @brief The key for the "clientType" value in the request.
- */
-static NSString *const kClientType = @"clientType";
-
-/** @var kRecaptchaVersion
-    @brief The key for the "recaptchaVersion" value in the request.
- */
-static NSString *const kRecaptchaVersion = @"recaptchaVersion";
-
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -68,18 +53,12 @@ static NSString *const kTenantIDKey = @"tenantId";
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kSignupNewUserEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
     _displayName = [displayName copy];
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;
@@ -90,9 +69,6 @@ static NSString *const kTenantIDKey = @"tenantId";
   self = [self initWithEmail:nil
                     password:nil
                  displayName:nil
-             captchaResponse:nil
-                  clientType:nil
-            recaptchaVersion:nil
         requestConfiguration:requestConfiguration];
   return self;
 }
@@ -107,15 +83,6 @@ static NSString *const kTenantIDKey = @"tenantId";
   }
   if (_displayName) {
     postBody[kDisplayNameKey] = _displayName;
-  }
-  if (_captchaResponse) {
-    postBody[kCaptchaResponseKey] = _captchaResponse;
-  }
-  if (_clientType) {
-    postBody[kClientType] = _clientType;
-  }
-  if (_recaptchaVersion) {
-    postBody[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (_returnSecureToken) {
     postBody[kReturnSecureTokenKey] = @YES;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
@@ -38,6 +38,21 @@ static NSString *const kPasswordKey = @"password";
  */
 static NSString *const kDisplayNameKey = @"displayName";
 
+/** @var kCaptchaResponseKey
+    @brief The key for the "captchaResponse" value in the request.
+ */
+static NSString *const kCaptchaResponseKey = @"captchaResponse";
+
+/** @var kClientType
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientType = @"clientType";
+
+/** @var kRecaptchaVersion
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersion = @"recaptchaVersion";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -53,12 +68,18 @@ static NSString *const kTenantIDKey = @"tenantId";
 - (nullable instancetype)initWithEmail:(nullable NSString *)email
                               password:(nullable NSString *)password
                            displayName:(nullable NSString *)displayName
+                       captchaResponse:(nullable NSString *)captchaResponse
+                            clientType:(nullable NSString *)clientType
+                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kSignupNewUserEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
     _displayName = [displayName copy];
+    _captchaResponse = [captchaResponse copy];
+    _clientType = [clientType copy];
+    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;
@@ -69,6 +90,9 @@ static NSString *const kTenantIDKey = @"tenantId";
   self = [self initWithEmail:nil
                     password:nil
                  displayName:nil
+             captchaResponse:nil
+                  clientType:nil
+            recaptchaVersion:nil
         requestConfiguration:requestConfiguration];
   return self;
 }
@@ -83,6 +107,15 @@ static NSString *const kTenantIDKey = @"tenantId";
   }
   if (_displayName) {
     postBody[kDisplayNameKey] = _displayName;
+  }
+  if (_captchaResponse) {
+    postBody[kCaptchaResponseKey] = _captchaResponse;
+  }
+  if (_clientType) {
+    postBody[kClientType] = _clientType;
+  }
+  if (_recaptchaVersion) {
+    postBody[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (_returnSecureToken) {
     postBody[kReturnSecureTokenKey] = @YES;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
@@ -52,6 +52,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *captchaResponse;
 
+/** @property clientType
+    @brief The reCAPTCHA client type.
+ */
+@property(nonatomic, copy, nullable) NSString *clientType;
+
+/** @property captchaResponse
+    @brief The reCAPTCHA version.
+ */
+@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
+
 /** @property returnSecureToken
     @brief Whether the response should return access token and refresh token directly.
     @remarks The default value is @c YES .
@@ -73,6 +83,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
+                       captchaResponse:(nullable NSString *)captchaResponse
+                            clientType:(nullable NSString *)clientType
+                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
@@ -83,9 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h
@@ -52,16 +52,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *captchaResponse;
 
-/** @property clientType
-    @brief The reCAPTCHA client type.
- */
-@property(nonatomic, copy, nullable) NSString *clientType;
-
-/** @property captchaResponse
-    @brief The reCAPTCHA version.
- */
-@property(nonatomic, copy, nullable) NSString *recaptchaVersion;
-
 /** @property returnSecureToken
     @brief Whether the response should return access token and refresh token directly.
     @remarks The default value is @c YES .
@@ -83,9 +73,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
@@ -72,17 +72,11 @@ static NSString *const kTenantIDKey = @"tenantId";
 
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(nonnull FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kVerifyPasswordEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
@@ -48,6 +48,16 @@ static NSString *const kCaptchaChallengeKey = @"captchaChallenge";
  */
 static NSString *const kCaptchaResponseKey = @"captchaResponse";
 
+/** @var kClientType
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientType = @"clientType";
+
+/** @var kRecaptchaVersion
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersion = @"recaptchaVersion";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -62,11 +72,17 @@ static NSString *const kTenantIDKey = @"tenantId";
 
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
+                       captchaResponse:(nullable NSString *)captchaResponse
+                            clientType:(nullable NSString *)clientType
+                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(nonnull FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kVerifyPasswordEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
+    _captchaResponse = [captchaResponse copy];
+    _clientType = [clientType copy];
+    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;
@@ -88,6 +104,12 @@ static NSString *const kTenantIDKey = @"tenantId";
   }
   if (_captchaResponse) {
     postBody[kCaptchaResponseKey] = _captchaResponse;
+  }
+  if (_clientType) {
+    postBody[kClientType] = _clientType;
+  }
+  if (_recaptchaVersion) {
+    postBody[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (_returnSecureToken) {
     postBody[kReturnSecureTokenKey] = @YES;

--- a/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.m
@@ -48,16 +48,6 @@ static NSString *const kCaptchaChallengeKey = @"captchaChallenge";
  */
 static NSString *const kCaptchaResponseKey = @"captchaResponse";
 
-/** @var kClientType
-    @brief The key for the "clientType" value in the request.
- */
-static NSString *const kClientType = @"clientType";
-
-/** @var kRecaptchaVersion
-    @brief The key for the "recaptchaVersion" value in the request.
- */
-static NSString *const kRecaptchaVersion = @"recaptchaVersion";
-
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -72,17 +62,11 @@ static NSString *const kTenantIDKey = @"tenantId";
 
 - (nullable instancetype)initWithEmail:(NSString *)email
                               password:(NSString *)password
-                       captchaResponse:(nullable NSString *)captchaResponse
-                            clientType:(nullable NSString *)clientType
-                      recaptchaVersion:(nullable NSString *)recaptchaVersion
                   requestConfiguration:(nonnull FIRAuthRequestConfiguration *)requestConfiguration {
   self = [super initWithEndpoint:kVerifyPasswordEndpoint requestConfiguration:requestConfiguration];
   if (self) {
     _email = [email copy];
     _password = [password copy];
-    _captchaResponse = [captchaResponse copy];
-    _clientType = [clientType copy];
-    _recaptchaVersion = [recaptchaVersion copy];
     _returnSecureToken = YES;
   }
   return self;
@@ -104,12 +88,6 @@ static NSString *const kTenantIDKey = @"tenantId";
   }
   if (_captchaResponse) {
     postBody[kCaptchaResponseKey] = _captchaResponse;
-  }
-  if (_clientType) {
-    postBody[kClientType] = _clientType;
-  }
-  if (_recaptchaVersion) {
-    postBody[kRecaptchaVersion] = _recaptchaVersion;
   }
   if (_returnSecureToken) {
     postBody[kReturnSecureTokenKey] = @YES;

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
@@ -150,7 +150,7 @@ static NSString *const kCaptchaResponseKey = @"captchaResponse";
 /** @var kTestCaptchaResponse
     @brief Fake captchaResponse for testing the request.
  */
-static NSString *const kTestCaptchaResponse = @"captchaResponse";
+static NSString *const kTestCaptchaResponse = @"testCaptchaResponse";
 
 /** @var kClientTypeKey
     @brief The key for the "clientType" value in the request.
@@ -160,7 +160,7 @@ static NSString *const kClientTypeKey = @"clientType";
 /** @var kTestClientType
     @brief Fake clientType for testing the request.
  */
-static NSString *const kTestClientType = @"clientType";
+static NSString *const kTestClientType = @"testClientType";
 
 /** @var kRecaptchaVersionKey
     @brief The key for the "recaptchaVersion" value in the request.
@@ -170,7 +170,7 @@ static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
 /** @var kTestRecaptchaVersion
     @brief Fake recaptchaVersion for testing the request.
  */
-static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+static NSString *const kTestRecaptchaVersion = @"testRecaptchaVersion";
 
 /** @class FIRGetOOBConfirmationCodeRequestTests
     @brief Tests for @c FIRGetOOBConfirmationCodeRequest.

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
@@ -142,6 +142,36 @@ static NSString *const kDynamicLinkDomainKey = @"dynamicLinkDomain";
  */
 static NSString *const kDynamicLinkDomain = @"test.page.link";
 
+/** @var kCaptchaResponseKey
+    @brief The key for the "captchaResponse" value in the request.
+ */
+static NSString *const kCaptchaResponseKey = @"captchaResponse";
+
+/** @var kTestCaptchaResponse
+    @brief Fake captchaResponse for testing the request.
+ */
+static NSString *const kTestCaptchaResponse = @"captchaResponse";
+
+/** @var kClientTypeKey
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientTypeKey = @"clientType";
+
+/** @var kTestClientType
+    @brief Fake clientType for testing the request.
+ */
+static NSString *const kTestClientType = @"clientType";
+
+/** @var kRecaptchaVersionKey
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
+
+/** @var kTestRecaptchaVersion
+    @brief Fake recaptchaVersion for testing the request.
+ */
+static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+
 /** @class FIRGetOOBConfirmationCodeRequestTests
     @brief Tests for @c FIRGetOOBConfirmationCodeRequest.
  */
@@ -287,6 +317,92 @@ static NSString *const kDynamicLinkDomain = @"test.page.link";
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCanHandleCodeInAppKey],
                         [NSNumber numberWithBool:YES]);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDynamicLinkDomainKey], kDynamicLinkDomain);
+}
+
+/** @fn testPasswordResetRequestOptionalFields
+    @brief Tests the encoding of a password reset request with optional fields.
+ */
+- (void)testPasswordResetRequestOptionalFields {
+  FIRGetOOBConfirmationCodeRequest *request =
+      [FIRGetOOBConfirmationCodeRequest passwordResetRequestWithEmail:kTestEmail
+                                                   actionCodeSettings:[self fakeActionCodeSettings]
+                                                 requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRGetOOBConfirmationCodeResponse *RPCResponse;
+  __block NSError *RPCError;
+  request.captchaResponse = kTestCaptchaResponse;
+  request.clientType = kTestClientType;
+  request.recaptchaVersion = kTestRecaptchaVersion;
+  [FIRAuthBackend getOOBConfirmationCode:request
+                                callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
+  XCTAssertNotNil(_RPCIssuer.decodedRequest);
+  XCTAssert([_RPCIssuer.decodedRequest isKindOfClass:[NSDictionary class]]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kEmailKey], kTestEmail);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRequestTypeKey], kPasswordResetRequestTypeValue);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kContinueURLKey], kContinueURL);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kIosBundleIDKey], kIosBundleID);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidPackageNameKey], kAndroidPackageName);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidMinimumVersionKey],
+                        kAndroidMinimumVersion);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidInstallAppKey],
+                        [NSNumber numberWithBool:YES]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCanHandleCodeInAppKey],
+                        [NSNumber numberWithBool:YES]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDynamicLinkDomainKey], kDynamicLinkDomain);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCaptchaResponseKey], kTestCaptchaResponse);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kClientTypeKey], kTestClientType);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRecaptchaVersionKey], kTestRecaptchaVersion);
+}
+
+/** @fn testSignInWithEmailLinkRequestOptionalFields
+    @brief Tests the encoding of a email sign-in link request with optional fields.
+ */
+- (void)testSignInWithEmailLinkRequestOptionalFields {
+  FIRGetOOBConfirmationCodeRequest *request =
+      [FIRGetOOBConfirmationCodeRequest signInWithEmailLinkRequest:kTestEmail
+                                                actionCodeSettings:[self fakeActionCodeSettings]
+                                              requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRGetOOBConfirmationCodeResponse *RPCResponse;
+  __block NSError *RPCError;
+  request.captchaResponse = kTestCaptchaResponse;
+  request.clientType = kTestClientType;
+  request.recaptchaVersion = kTestRecaptchaVersion;
+  [FIRAuthBackend getOOBConfirmationCode:request
+                                callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
+  XCTAssertNotNil(_RPCIssuer.decodedRequest);
+  XCTAssert([_RPCIssuer.decodedRequest isKindOfClass:[NSDictionary class]]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kEmailKey], kTestEmail);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRequestTypeKey], kEmailLinkSignInTypeValue);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kContinueURLKey], kContinueURL);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kIosBundleIDKey], kIosBundleID);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidPackageNameKey], kAndroidPackageName);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidMinimumVersionKey],
+                        kAndroidMinimumVersion);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kAndroidInstallAppKey],
+                        [NSNumber numberWithBool:YES]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCanHandleCodeInAppKey],
+                        [NSNumber numberWithBool:YES]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDynamicLinkDomainKey], kDynamicLinkDomain);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCaptchaResponseKey], kTestCaptchaResponse);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kClientTypeKey], kTestClientType);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRecaptchaVersionKey], kTestRecaptchaVersion);
 }
 
 #pragma mark - Helpers

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
@@ -70,6 +70,36 @@ static NSString *const kPasswordKey = @"password";
  */
 static NSString *const kTestPassword = @"Password";
 
+/** @var kCaptchaResponseKey
+    @brief The key for the "captchaResponse" value in the request.
+ */
+static NSString *const kCaptchaResponseKey = @"captchaResponse";
+
+/** @var kTestCaptchaResponse
+    @brief Fake captchaResponse for testing the request.
+ */
+static NSString *const kTestCaptchaResponse = @"captchaResponse";
+
+/** @var kClientTypeKey
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientTypeKey = @"clientType";
+
+/** @var kTestClientType
+    @brief Fake clientType for testing the request.
+ */
+static NSString *const kTestClientType = @"clientType";
+
+/** @var kRecaptchaVersionKey
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
+
+/** @var kTestRecaptchaVersion
+    @brief Fake recaptchaVersion for testing the request.
+ */
+static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -150,6 +180,35 @@ static NSString *const kReturnSecureTokenKey = @"returnSecureToken";
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPasswordKey], kTestPassword);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDisplayNameKey], kTestDisplayName);
   XCTAssertTrue([_RPCIssuer.decodedRequest[kReturnSecureTokenKey] boolValue]);
+}
+
+/** @fn testSignUpNewUserRequestOptionalFields
+    @brief Tests the encoding of a sign up new user request with optional fields.
+ */
+- (void)testSignUpNewUserRequestOptionalFields {
+  FIRSignUpNewUserRequest *request =
+      [[FIRSignUpNewUserRequest alloc] initWithEmail:kTestEmail
+                                            password:kTestPassword
+                                         displayName:kTestDisplayName
+                                requestConfiguration:_requestConfiguration];
+  request.captchaResponse = kTestCaptchaResponse;
+  request.clientType = kTestClientType;
+  request.recaptchaVersion = kTestRecaptchaVersion;
+  [FIRAuthBackend
+      signUpNewUser:request
+           callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error){
+           }];
+
+  XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
+  XCTAssertNotNil(_RPCIssuer.decodedRequest);
+  XCTAssert([_RPCIssuer.decodedRequest isKindOfClass:[NSDictionary class]]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kEmailKey], kTestEmail);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPasswordKey], kTestPassword);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDisplayNameKey], kTestDisplayName);
+  XCTAssertTrue([_RPCIssuer.decodedRequest[kReturnSecureTokenKey] boolValue]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCaptchaResponseKey], kTestCaptchaResponse);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kClientTypeKey], kTestClientType);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRecaptchaVersionKey], kTestRecaptchaVersion);
 }
 
 @end

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
@@ -78,7 +78,7 @@ static NSString *const kCaptchaResponseKey = @"captchaResponse";
 /** @var kTestCaptchaResponse
     @brief Fake captchaResponse for testing the request.
  */
-static NSString *const kTestCaptchaResponse = @"captchaResponse";
+static NSString *const kTestCaptchaResponse = @"testCaptchaResponse";
 
 /** @var kClientTypeKey
     @brief The key for the "clientType" value in the request.
@@ -88,7 +88,7 @@ static NSString *const kClientTypeKey = @"clientType";
 /** @var kTestClientType
     @brief Fake clientType for testing the request.
  */
-static NSString *const kTestClientType = @"clientType";
+static NSString *const kTestClientType = @"testClientType";
 
 /** @var kRecaptchaVersionKey
     @brief The key for the "recaptchaVersion" value in the request.
@@ -98,7 +98,7 @@ static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
 /** @var kTestRecaptchaVersion
     @brief Fake recaptchaVersion for testing the request.
  */
-static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+static NSString *const kTestRecaptchaVersion = @"testRecaptchaVersion";
 
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
@@ -83,6 +83,26 @@ static NSString *const kCaptchaResponseKey = @"captchaResponse";
  */
 static NSString *const kTestCaptchaResponse = @"captchaResponse";
 
+/** @var kClientTypeKey
+    @brief The key for the "clientType" value in the request.
+ */
+static NSString *const kClientTypeKey = @"clientType";
+
+/** @var kTestClientType
+    @brief Fake clientType for testing the request.
+ */
+static NSString *const kTestClientType = @"clientType";
+
+/** @var kRecaptchaVersionKey
+    @brief The key for the "recaptchaVersion" value in the request.
+ */
+static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
+
+/** @var kTestRecaptchaVersion
+    @brief Fake recaptchaVersion for testing the request.
+ */
+static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -162,6 +182,8 @@ static NSString *const kExpectedAPIURL =
   request.pendingIDToken = kTestPendingToken;
   request.captchaChallenge = kTestCaptchaChallenge;
   request.captchaResponse = kTestCaptchaResponse;
+  request.clientType = kTestClientType;
+  request.recaptchaVersion = kTestRecaptchaVersion;
   [FIRAuthBackend
       verifyPassword:request
             callback:^(FIRVerifyPasswordResponse *_Nullable response, NSError *_Nullable error){
@@ -173,6 +195,8 @@ static NSString *const kExpectedAPIURL =
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPasswordKey], kTestPassword);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCaptchaChallengeKey], kTestCaptchaChallenge);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kCaptchaResponseKey], kTestCaptchaResponse);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kClientTypeKey], kTestClientType);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kRecaptchaVersionKey], kTestRecaptchaVersion);
   XCTAssertTrue([_RPCIssuer.decodedRequest[kReturnSecureTokenKey] boolValue]);
 }
 

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
@@ -81,7 +81,7 @@ static NSString *const kCaptchaResponseKey = @"captchaResponse";
 /** @var kTestCaptchaResponse
     @brief Fake captchaResponse for testing the request.
  */
-static NSString *const kTestCaptchaResponse = @"captchaResponse";
+static NSString *const kTestCaptchaResponse = @"testCaptchaResponse";
 
 /** @var kClientTypeKey
     @brief The key for the "clientType" value in the request.
@@ -91,7 +91,7 @@ static NSString *const kClientTypeKey = @"clientType";
 /** @var kTestClientType
     @brief Fake clientType for testing the request.
  */
-static NSString *const kTestClientType = @"clientType";
+static NSString *const kTestClientType = @"testClientType";
 
 /** @var kRecaptchaVersionKey
     @brief The key for the "recaptchaVersion" value in the request.
@@ -101,7 +101,7 @@ static NSString *const kRecaptchaVersionKey = @"recaptchaVersion";
 /** @var kTestRecaptchaVersion
     @brief Fake recaptchaVersion for testing the request.
  */
-static NSString *const kTestRecaptchaVersion = @"recaptchaVersion";
+static NSString *const kTestRecaptchaVersion = @"testRecaptchaVersion";
 
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.


### PR DESCRIPTION
This PR updates the 4 email auth apis (sign in, sign up, password reset, email link sign in) to support recaptcha enterprise. [go/gcip-recaptcha-client-sdk-api](http://go/gcip-recaptcha-client-sdk-api)

### Development progress
- Implement getRecaptchaConfig API https://github.com/firebase/firebase-ios-sdk/pull/10038
- New backend error types https://github.com/firebase/firebase-ios-sdk/pull/10048
- Update backend apis https://github.com/firebase/firebase-ios-sdk/pull/10063
- Implement recaptcha enterprise verifier
- Wire recaptcha enterprise verifier to email auth flows