### PR TITLE
Realtime rc failsafe

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -290,8 +290,10 @@ static bool gIsFeatureDisabled;
 
   NSString *namespace = [_namespace substringToIndex:[_namespace rangeOfString:@":"].location];
   NSString *postBody = [NSString
-                        stringWithFormat:@"{project:'%@', namespace:'%@', lastKnownVersionNumber:'%@', appId:'%@', sdkVersion:'%@'}",
-                        [self->_options GCMSenderID], namespace, _configFetch.templateVersionNumber, _options.googleAppID, FIRRemoteConfigPodVersion()];
+      stringWithFormat:@"{project:'%@', namespace:'%@', lastKnownVersionNumber:'%@', appId:'%@', "
+                       @"sdkVersion:'%@'}",
+                       [self->_options GCMSenderID], namespace, _configFetch.templateVersionNumber,
+                       _options.googleAppID, FIRRemoteConfigPodVersion()];
   NSData *postData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
   NSError *compressionError;
   NSData *compressedContent = [NSData gul_dataByGzippingData:postData error:&compressionError];
@@ -463,12 +465,12 @@ static bool gIsFeatureDisabled;
   NSString *targetTemplateVersion = _configFetch.templateVersionNumber;
   if (dataError == nil) {
     targetTemplateVersion = [response objectForKey:kTemplateVersionNumberKey];
-      if ([response objectForKey:kIsFeatureDisabled]) {
-          gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
-          if (gIsFeatureDisabled) {
-              [self pauseRealtimeStream];
-          }
+    if ([response objectForKey:kIsFeatureDisabled]) {
+      gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
+      if (gIsFeatureDisabled) {
+        [self pauseRealtimeStream];
       }
+    }
   }
 
   [self autoFetch:gFetchAttempts targetVersion:[targetTemplateVersion integerValue]];

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -450,18 +450,7 @@ static bool gIsRealtimeDisabled;
 
 #pragma mark - NSURLSession Delegates
 
-/// Delegate to asynchronously handle every new notification that comes over the wire. Auto-fetches
-/// and runs callback for each new notification
-- (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-    didReceiveData:(NSData *)data {
-  NSError *dataError;
-  NSString *strData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  strData = [strData substringFromIndex:1];
-  data = [strData dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary *response = [NSJSONSerialization JSONObjectWithData:data
-                                                           options:NSJSONReadingMutableContainers
-                                                             error:&dataError];
+- (void)evaluateStreamResponse:(NSDictionary *)response error:(NSError *)dataError {
   NSString *targetTemplateVersion = _configFetch.templateVersionNumber;
   if (dataError == nil) {
     if ([response objectForKey:kTemplateVersionNumberKey]) {
@@ -492,6 +481,21 @@ static bool gIsRealtimeDisabled;
   if (!gIsRealtimeDisabled) {
     [self autoFetch:gFetchAttempts targetVersion:[targetTemplateVersion integerValue]];
   }
+}
+
+/// Delegate to asynchronously handle every new notification that comes over the wire. Auto-fetches
+/// and runs callback for each new notification
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data {
+  NSError *dataError;
+  NSString *strData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  strData = [strData substringFromIndex:1];
+  data = [strData dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *response = [NSJSONSerialization JSONObjectWithData:data
+                                                           options:NSJSONReadingMutableContainers
+                                                             error:&dataError];
+  [self evaluateStreamResponse:response error:dataError];
 }
 
 /// Delegate that checks the final response of the connection and retries if necessary

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -464,11 +464,11 @@ static bool gIsFeatureDisabled;
                                                              error:&dataError];
   NSString *targetTemplateVersion = _configFetch.templateVersionNumber;
   if (dataError == nil) {
-      if ([response objectForKey:kTemplateVersionNumberKey]) {
-          targetTemplateVersion = [response objectForKey:kTemplateVersionNumberKey];
-      }
-      if ([response objectForKey:kIsFeatureDisabled]) {
-          gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
+    if ([response objectForKey:kTemplateVersionNumberKey]) {
+      targetTemplateVersion = [response objectForKey:kTemplateVersionNumberKey];
+    }
+    if ([response objectForKey:kIsFeatureDisabled]) {
+      gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
       if (gIsFeatureDisabled) {
         [self pauseRealtimeStream];
       }

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -464,9 +464,11 @@ static bool gIsFeatureDisabled;
                                                              error:&dataError];
   NSString *targetTemplateVersion = _configFetch.templateVersionNumber;
   if (dataError == nil) {
-    targetTemplateVersion = [response objectForKey:kTemplateVersionNumberKey];
-    if ([response objectForKey:kIsFeatureDisabled]) {
-      gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
+      if ([response objectForKey:kTemplateVersionNumberKey]) {
+          targetTemplateVersion = [response objectForKey:kTemplateVersionNumberKey];
+      }
+      if ([response objectForKey:kIsFeatureDisabled]) {
+          gIsFeatureDisabled = [response objectForKey:kIsFeatureDisabled];
       if (gIsFeatureDisabled) {
         [self pauseRealtimeStream];
       }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1692,7 +1692,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
   }
 }
 
-- (void)testRealtimeBackoffDisabled {
+- (void)testRealtimeDisabled {
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {


### PR DESCRIPTION
Add back off flag to Realtime. If enabled, this will prevent Realtime from working until the app restarts.
Backend will have a new field called featureDisabled added to stream response. If this field is enabled, this will set stop Realtime from working until the next time the app is restarted. The current back off state in the SDK will be represented by the flag gIsBackoffEnabled.