### PR TITLE
[CoreInternal] Add explicit generics typing for Array.Index usage

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/RingBuffer.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/RingBuffer.swift
@@ -32,7 +32,7 @@ struct RingBuffer<Element>: Sequence {
   /// An array of heartbeats treated as a circular queue and intialized with a fixed capacity.
   private var circularQueue: [Element?]
   /// The current "tail" and insert point for the `circularQueue`.
-  private var tailIndex: Array.Index
+  private var tailIndex: Array<Element?>.Index
 
   /// Designated initializer.
   /// - Parameter capacity: An `Int` representing the capacity.


### PR DESCRIPTION
### Context
While the current code works fine, older Swift toolchains may have trouble with inferring what array the index will be used in. Being more explicit here just makes for safer code in general.

#no-changelog