### PR TITLE
[Infra] Use watchOS device when using `scripts/build.sh` for watchOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,3 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
-
-# Run CI

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
+
+# Run CI

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -166,7 +166,8 @@ tvos_flags=(
   -destination 'platform=tvOS Simulator,name=Apple TV'
 )
 watchos_flags=(
-  -destination 'platform=iOS Simulator,name=iPhone 13 Pro'
+  -destination 'platform=WatchOS Simulator,name=Apple Watch Series 7 - 45mm'
+  #-destination 'platform=iOS Simulator,name=iPhone 13 Pro'
 )
 catalyst_flags=(
   ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES -sdk macosx

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -167,7 +167,6 @@ tvos_flags=(
 )
 watchos_flags=(
   -destination 'platform=WatchOS Simulator,name=Apple Watch Series 7 - 45mm'
-  #-destination 'platform=iOS Simulator,name=iPhone 13 Pro'
 )
 catalyst_flags=(
   ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES -sdk macosx


### PR DESCRIPTION
### Context
Originally, [when the watchOS option in `scripts/build.sh`](https://github.com/firebase/firebase-ios-sdk/blob/a61f7b367b013b8fd9596aa85d6e0de0fad9d5d4/scripts/build.sh#L168-L170) was written, standalone watchOS apps were not yet a thing. So instead, the `--destination` of watchOS schemes ran on an iPhone as a companion target. This works but hid some failures that running on a watchOS destination would have surfaced (see #10085).

#no-changelog