### PR TITLE
[Core] Exclude lifecycle-dependent tests from watchOS

### DIFF
--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -827,6 +827,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 #pragma mark - Core Telemetry
 
+#if !TARGET_OS_WATCH
 - (void)testCoreDiagnosticsLoggedWhenAppDidBecomeActive {
   FIRApp *app = [self createConfiguredAppWithName:NSStringFromSelector(_cmd)];
   [self expectCoreDiagnosticsDataLogWithOptions:app.options];
@@ -844,6 +845,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                                          object:nil];
   OCMVerifyAll(self.mockHeartbeatLogger);
 }
+#endif  // TARGET_OS_WATCH
 
 #pragma mark - private
 


### PR DESCRIPTION
### Context
The two tests in this PR have an implicit assumption that they are running *not* running on watchOS. I have therefore excluded them from running on watchOS.

#no-changelog