### PR TITLE
[Infra] Some workflows haven't been triggered on Gemfile changes

### DIFF
--- a/.github/workflows/app_check.yml
+++ b/.github/workflows/app_check.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'FirebaseAppCheck**'
     - '.github/workflows/app_check.yml'
+    - 'Gemfile*'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'scripts/release_testing_setup.sh'
     - '.github/workflows/release.yml'
+    - 'Gemfile*'
   workflow_dispatch:
   schedule:
     # Run every day at 9pm (PST) - cron uses UTC times


### PR DESCRIPTION
### Context
I think the failing watchOS workflow in #10088 may be attributed to #10082. I noticed that triggering a global CI run in #10082 did not trigger this workflow. Further investigation revealed that the AppCheck workflow has not triggered on `Gemfile*` changes. This PR adds it as a trigger.

I also did an audit of the other workflows and added `Gemfile*` triggering where necessary so that all workflows that have at least one non-cron job trigger on the `Gemfile*` changes. (I excluded irrelevant workflows like notice generation and code coverage).


#no-changelog