### PR TITLE
[AppCheck] DeviceCheck provider is supported by watchOS 9.0+

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.5.0
+- [added] AppCheck's DeviceCheck provider is available for watchOS 9.0+.  
+
 # 9.0.0
 - [added] **Breaking change:** `FirebaseAppCheck` has exited beta and is now
   generally available for use.

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 9.5.0
-- [added] AppCheck's DeviceCheck provider is available for watchOS 9.0+.  
+- [added] AppCheck's DeviceCheck provider is available for watchOS 9.0+.
 
 # 9.0.0
 - [added] **Breaking change:** `FirebaseAppCheck` has exited beta and is now

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
@@ -16,9 +16,24 @@
 
 // Availability conditions for different App Check SDK components.
 
+#import <Foundation/Foundation.h>
 #import <TargetConditionals.h>
 
 #pragma mark - DeviceCheck
+
+// DeviceCheck availability was extended to watchOS in Xcode 14.
+#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+
+// Targets where DeviceCheck framework is available to be used in preprocessor conditions.
+#define FIR_DEVICE_CHECK_SUPPORTED_TARGETS \
+  TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
+
+// `DeviceCheckProvider` availability.
+#define FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY \
+  API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0), watchos(9.0))
+
+// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
+#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 // Targets where DeviceCheck framework is available to be used in preprocessor conditions.
 #define FIR_DEVICE_CHECK_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
@@ -26,6 +41,8 @@
 // `DeviceCheckProvider` availability.
 #define FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY \
   API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0)) API_UNAVAILABLE(watchos)
+
+#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 #pragma mark - App Attest
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -38,6 +38,10 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
+// Because the DeviceCheck provider is the default provider for AppCheck. There
+// may be test cases that are dependent on DeviceCheck being available.
+#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+
 // The FAC token value returned when an error occurs.
 static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
@@ -1009,3 +1013,5 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 }
 
 @end
+
+#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -38,8 +38,8 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
-// Because the DeviceCheck provider is the default provider for AppCheck. There
-// may be test cases that are dependent on DeviceCheck being available.
+// Since DeviceCheck is the default attestation provider for AppCheck, disable
+// test cases that may be dependent on DeviceCheck being available.
 #if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
 
 // The FAC token value returned when an error occurs.

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -28,22 +28,24 @@
 
 #import "SharedTestUtilities/AppCheckBackoffWrapperFake/FIRAppCheckBackoffWrapperFake.h"
 
-API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0))
-API_UNAVAILABLE(watchos)
+#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+
+FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
+@interface FIRDeviceCheckProvider (Tests)
+
+- (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
+              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
+                    backoffWrapper:(id<FIRAppCheckBackoffWrapperProtocol>)backoffWrapper;
+
+@end
+
+FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 @interface FIRDeviceCheckProviderTests : XCTestCase
 
 @property(nonatomic) FIRDeviceCheckProvider *provider;
 @property(nonatomic) id fakeAPIService;
 @property(nonatomic) id fakeTokenGenerator;
 @property(nonatomic) FIRAppCheckBackoffWrapperFake *fakeBackoffWrapper;
-
-@end
-
-@interface FIRDeviceCheckProvider (Tests)
-
-- (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
-              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
-                    backoffWrapper:(id<FIRAppCheckBackoffWrapperProtocol>)backoffWrapper;
 
 @end
 
@@ -268,3 +270,5 @@ API_UNAVAILABLE(watchos)
 }
 
 @end
+
+#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS


### PR DESCRIPTION
### Context
This PR achieves two things:
1. Resolves recent [AppCheck / watchOS CI issue](https://github.com/firebase/firebase-ios-sdk/pull/10088#issuecomment-1210908096). 
2. `DeviceCheck` now has [beta support for watchOS 9.0+](https://developer.apple.com/documentation/devicecheck) in Xcode 14. This means that we can update AppCheck's DeviceCheck provider to reflect the new availability.

I validated that `app_check / spm (watchOS)`'s underlying script passed locally on Xcode 13.3.1.