### PR TITLE
[AppCheck] App Attest provider is supported by watchOS 9.0+

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 9.5.0
-- [added] AppCheck's App Attest provider is available for tvOS 15.0+.
-- [added] AppCheck's DeviceCheck provider is available for watchOS 9.0+.
+- [added] DeviceCheck and App Attest providers are supported by watchOS 9.0+
+- [added] App Attest provider availability updated to support tvOS 15.0+.
 
 # 9.0.0
 - [added] **Breaking change:** `FirebaseAppCheck` has exited beta and is now
@@ -21,13 +21,17 @@
 # 8.5.0
 - [changed] App Check SDK available for all supported platforms/OS versions, but App Attest and
 DeviceCheck providers availability changed to match underlying platfrom API availability. (#8388)
+
 # 8.4.0
 - [fixed] Fixed build issues introduced in Xcode 13 beta 3. (#8401)
 - [fixed] Bump Promises dependency. (#8365)
+
 # 8.3.0
 - [added] Token API for 3P use. (#8266)
+
 # 8.2.0
 - [added] Apple's App Attest attestation provider support. (#8133)
 - [changed] Token auto-refresh optimizations. (#8232)
+
 # 8.0.0
 - [added] Firebase abuse reduction support SDK. (#7928, #7937, #7948)

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 9.5.0
-- [added] DeviceCheck and App Attest providers are supported by watchOS 9.0+
-- [added] App Attest provider availability updated to support tvOS 15.0+.
+- [added] DeviceCheck and App Attest providers are supported by watchOS 9.0+. (#10094, #10098)
+- [added] App Attest provider availability updated to support tvOS 15.0+. (#10093)
 
 # 9.0.0
 - [added] **Breaking change:** `FirebaseAppCheck` has exited beta and is now

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
@@ -46,9 +46,22 @@
 
 #pragma mark - App Attest
 
+#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+
+// Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
+#define FIR_APP_ATTEST_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
+
+// `AppAttestProvider` availability annotations
+#define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \
+  API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0), watchos(9.0))
+
+#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+
 // Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
 #define FIR_APP_ATTEST_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
 
 // `AppAttestProvider` availability annotations
 #define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \
   API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0)) API_UNAVAILABLE(watchos)
+
+#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
@@ -49,7 +49,8 @@
 #if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 // Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
-#define FIR_APP_ATTEST_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
+#define FIR_APP_ATTEST_SUPPORTED_TARGETS \
+  TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
 
 // `AppAttestProvider` availability annotations
 #define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
@@ -56,6 +56,7 @@
 #define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \
   API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0), watchos(9.0))
 
+// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
 #else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 // Targets where `DCAppAttestService` is available to be used in preprocessor conditions.


### PR DESCRIPTION
Successor PR to #10093 and #10094. This is last PR in the series.

In #10094, availability logic was updated to allow support for DeviceCheck on watchOS 9.0+. This PR allows support for **App Attest** on watchOS 9.0+.

### Context
App Attest now has [beta support for watchOS 9.0+](https://developer.apple.com/documentation/devicecheck/dcappattestservice) in Xcode 14. This means that we can update AppCheck's App Attest provider to reflect the new availability.
