### PR TITLE
Remove erroneous logic in ComputeViews.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 - [fixed] Fixed an intermittent crash if `ListenerRegistration::Remove()` was
   invoked concurrently (#10065).
+- [fixed] Fixed a crash if multiple large write batches with overlapping
+  documents were executed where at least one batch performed a delete operation
+  (#9965).
 
 # 9.4.0
 - [fixed] Fixed a crash during app start (#9985, #10018).

--- a/Firestore/core/src/local/local_documents_view.cc
+++ b/Firestore/core/src/local/local_documents_view.cc
@@ -266,7 +266,6 @@ model::OverlayedDocumentMap LocalDocumentsView::ComputeViews(
           {doc->key(), overlay_it->second.mutation().field_mask()});
       overlay_it->second.mutation().ApplyToLocalView(*doc, absl::nullopt,
                                                      Timestamp::Now());
-      docs = docs.insert(docs_entry.first, *doc);
     }
   }
 


### PR DESCRIPTION
See similar logic in [Android](https://cs.opensource.google/firebase-sdk/firebase-android-sdk/+/master:firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java;l=173-176?q=LocalDocumentsView.java&ss=firebase-sdk%2Ffirebase-android-sdk) and [Web](https://cs.opensource.google/firebase-sdk/firebase-js-sdk/+/master:packages/firestore/src/local/local_documents_view.ts;l=239-244?q=computeviews&ss=firebase-sdk%2Ffirebase-js-sdk).

This is inserting into a map while its being iterated over. Note that SortedMap
does not guarantee pointer stability. In fact, upon insertion, SortedMap may
[switch](https://cs.opensource.google/firebase-sdk/firebase-ios-sdk/+/master:Firestore/core/src/immutable/sorted_map.h;l=186-197?q=sorted_map.h&ss=firebase-sdk%2Ffirebase-ios-sdk) to using a different underlying data structure (tree rather than array)
which invalidates pointers.

Fixes https://github.com/firebase/firebase-ios-sdk/issues/9965.