### PR TITLE
Update Firestore CHANGELOG for Firebase 9.5.0

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.5.0
 - [fixed] Fixed an intermittent crash if `ListenerRegistration::Remove()` was
   invoked concurrently (#10065).
 - [fixed] Fixed a crash if multiple large write batches with overlapping


### PR DESCRIPTION
Added the unreleased CHANGELOG entries from Firestore in preparation for the Firebase 9.5.0 release.