### PR TITLE
[Core] Support watchOS lifecycle notifications

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -876,7 +876,16 @@ static FIRApp *sDefaultApp;
 #elif TARGET_OS_OSX
   NSNotificationName notificationName = NSApplicationDidBecomeActiveNotification;
 #elif TARGET_OS_WATCH
-  NSNotificationName notificationName = WKApplicationDidBecomeActiveNotification;
+  // TODO(ncooke3): Remove when minimum supported watchOS version is watchOS 7.0.
+  // On watchOS 7.0+, heartbeats are logged when the watch app becomes active.
+  // On watchOS 6.0, heartbeats are logged when the Firebase app is configuring.
+  // While it does not cover all use cases, logging when the Firebase app is
+  // configuring is done because watchOS lifecycle notifications are a
+  // watchOS 7.0+ feature.
+  NSNotificationName notificationName = kFIRAppReadyToConfigureSDKNotification;
+  if (@available(watchOS 7.0, *)) {
+    notificationName = WKApplicationDidBecomeActiveNotification;
+  }
 #endif
 
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -22,6 +22,10 @@
 #import <AppKit/AppKit.h>
 #endif
 
+#if __has_include(<WatchKit/WatchKit.h>)
+#import <WatchKit/WatchKit.h>
+#endif
+
 #import "FirebaseCore/Sources/Public/FirebaseCore/FIRApp.h"
 
 #import "FirebaseCore/Sources/FIRAnalyticsConfiguration.h"
@@ -871,14 +875,14 @@ static FIRApp *sDefaultApp;
   NSNotificationName notificationName = UIApplicationDidBecomeActiveNotification;
 #elif TARGET_OS_OSX
   NSNotificationName notificationName = NSApplicationDidBecomeActiveNotification;
+#elif TARGET_OS_WATCH
+  NSNotificationName notificationName = WKApplicationDidBecomeActiveNotification;
 #endif
 
-#if !TARGET_OS_WATCH
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(appDidBecomeActive:)
                                                name:notificationName
                                              object:nil];
-#endif
 }
 
 - (void)appDidBecomeActive:(NSNotification *)notification {

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -903,7 +903,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 #elif TARGET_OS_OSX
   return NSApplicationDidBecomeActiveNotification;
 #elif TARGET_OS_WATCH
-  return WKApplicationDidBecomeActiveNotification;
+  // See comment in `- [FIRApp subscribeForAppDidBecomeActiveNotifications]`.
+  if (@available(watchOS 7.0, *)) {
+    return WKApplicationDidBecomeActiveNotification;
+  } else {
+    return kFIRAppReadyToConfigureSDKNotification;
+  }
 #endif
 }
 

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -12,6 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
+#endif
+
+#if __has_include(<AppKit/AppKit.h>)
+#import <AppKit/AppKit.h>
+#endif
+
+#if __has_include(<WatchKit/WatchKit.h>)
+#import <WatchKit/WatchKit.h>
+#endif
+
 #import "FirebaseCore/Tests/Unit/FIRTestCase.h"
 #import "FirebaseCore/Tests/Unit/FIRTestComponents.h"
 
@@ -827,7 +839,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 #pragma mark - Core Telemetry
 
-#if !TARGET_OS_WATCH
 - (void)testCoreDiagnosticsLoggedWhenAppDidBecomeActive {
   FIRApp *app = [self createConfiguredAppWithName:NSStringFromSelector(_cmd)];
   [self expectCoreDiagnosticsDataLogWithOptions:app.options];
@@ -845,7 +856,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                                          object:nil];
   OCMVerifyAll(self.mockHeartbeatLogger);
 }
-#endif  // TARGET_OS_WATCH
 
 #pragma mark - private
 
@@ -890,10 +900,10 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 - (NSNotificationName)appDidBecomeActiveNotificationName {
 #if TARGET_OS_IOS || TARGET_OS_TV
   return UIApplicationDidBecomeActiveNotification;
-#endif
-
-#if TARGET_OS_OSX
+#elif TARGET_OS_OSX
   return NSApplicationDidBecomeActiveNotification;
+#elif TARGET_OS_WATCH
+  return WKApplicationDidBecomeActiveNotification;
 #endif
 }
 


### PR DESCRIPTION
### Context
Lifecycle notifications have not been observed on watchOS so watchOS heartbeats are not created. 

The [`WKApplicationDidBecomeActiveNotification`](https://developer.apple.com/documentation/watchkit/wkapplicationdidbecomeactivenotification?language=objc) notification that is being observed it only available on `watchOS 7.0+`.

Our [SPM distribution has watchOS `7.0`](https://github.com/firebase/firebase-ios-sdk/blob/master/Package.swift#L26) as the minimum version but our [CocoaPods specs have `6.0`](https://github.com/firebase/firebase-ios-sdk/search?l=Ruby&q=watchos).

In an effort to maintain compatibility with `watchOS 6.0`, this PR adds support for the following behavior:
- On watchOS 7.0+, heartbeats are captured when the `WKApplicationDidBecomeActiveNotification` is fired.
- On watchOS 6.0, heartbeats are captured on app configuration. This is triggered by the already existing [`kFIRAppReadyToConfigureSDKNotification`](https://github.com/firebase/firebase-ios-sdk/blob/f8ee68bfc7873efbfdfcea831a20435c4b89f875/FirebaseCore/Sources/FIRApp.m#L459) notification.

#no-changelog
