### PR TITLE
modified url for app engine test-app

### DIFF
--- a/FirebaseAuth/Tests/Sample/E2eTests/BYOAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/E2eTests/BYOAuthTests.m
@@ -17,7 +17,7 @@
 #import "FIRAuthE2eTestsBase.h"
 
 /** The url for obtaining a valid custom token string used to test BYOAuth. */
-static NSString *const kCustomTokenUrl = @"https://fb-sa-1211.appspot.com/token";
+static NSString *const kCustomTokenUrl = @"https://gcip-testapps.wl.r.appspot.com/token";
 
 /** The invalid custom token string for testing BYOAuth. */
 static NSString *const kInvalidCustomToken = @"invalid token.";

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+AutoTests.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+AutoTests.m
@@ -34,9 +34,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString *const kCustomTokenUrl = @"https://fb-sa-1211.appspot.com/token";
+static NSString *const kCustomTokenUrl = @"https://gcip-testapps.wl.r.appspot.com/token";
 
-static NSString *const kExpiredCustomTokenUrl = @"https://fb-sa-1211.appspot.com/expired_token";
+static NSString *const kExpiredCustomTokenUrl = @"https://gcip-testapps.wl.r.appspot.com/expired_token";
 
 static NSString *const kInvalidCustomToken = @"invalid custom token.";
 


### PR DESCRIPTION
Changed token URL to point to new test-app. The test app at https://fb-sa-1211.appspot.com/token is not maintained anymore.