### PR TITLE
[watchOS] Bump watchOS minimum version support to watchOS 7.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -58,7 +58,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'Analytics' do |ss|
@@ -90,7 +90,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'AppDistribution' do |ss|
@@ -104,7 +104,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'Auth' do |ss|
@@ -114,7 +114,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'Crashlytics' do |ss|
@@ -124,7 +124,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '9.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'Database' do |ss|
@@ -169,7 +169,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'MLModelDownloader' do |ss|
@@ -190,7 +190,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
   s.subspec 'Storage' do |ss|
@@ -200,7 +200,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '6.0'
+    ss.watchos.deployment_target = '7.0'
   end
 
 end

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -25,7 +25,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  s.watchos.deployment_target = '7.0'
 
   s.source_files = 'FirebaseAppCheck/Interop/*.[hm]'
   s.public_header_files = 'FirebaseAppCheck/Interop/*.h'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -22,7 +22,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseAuthInterop.podspec
+++ b/FirebaseAuthInterop.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  s.watchos.deployment_target = '7.0'
 
   s.source_files = 'FirebaseAuth/Interop/*.[hm]'
   s.public_header_files = 'FirebaseAuth/Interop/*.h'

--- a/FirebaseAuthTestingSupport.podspec
+++ b/FirebaseAuthTestingSupport.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -24,7 +24,7 @@ for internal testing only. It should not be published.
   ios_deployment_target = '13.0'
   osx_deployment_target = '10.15'
   tvos_deployment_target = '13.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -21,7 +21,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 9.6.0
+- [changed] Firebase's minimum support version for watchOS is now watchOS 7.0. (#10112)
+
 # Firebase 9.5.0
 - [fixed] Zip Distribution Fixed Promises module name issue impacting lld builds. (#10071)
 

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -23,7 +23,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '9.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '6.0'
+    s.watchos.deployment_target = '7.0'
 
     s.source_files = 'FirebaseCore/Extension/*.[hm]'
     s.public_header_files = 'FirebaseCore/Extension/*.h'

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseFirestoreTestingSupport.podspec
+++ b/FirebaseFirestoreTestingSupport.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -21,7 +21,7 @@ Cloud Functions for Firebase.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '9.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -23,7 +23,7 @@ device, and it is completely free.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseMessaging/Apps/AdvancedSample/Podfile
+++ b/FirebaseMessaging/Apps/AdvancedSample/Podfile
@@ -30,7 +30,7 @@ target 'AppClips' do
 end
 
 target 'SampleWatchWatchKitExtension' do
-  platform :watchos, '6.0'
+  platform :watchos, '7.0'
   shared_pods
 end
 

--- a/FirebaseMessagingInterop.podspec
+++ b/FirebaseMessagingInterop.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '6.0'
+  s.watchos.deployment_target = '7.0'
 
   s.source_files = 'FirebaseMessaging/Interop/*.[hm]'
   s.public_header_files = 'FirebaseMessaging/Interop/*.h'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -21,7 +21,7 @@ app update.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -24,7 +24,7 @@ app update.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -23,7 +23,7 @@ Firebase products. FirebaseSharedSwift is not supported for non-Firebase usage.
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -20,7 +20,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -20,7 +20,7 @@ Objective-C Implementations for FirebaseStorage. This pod should not be directly
   ios_deployment_target = '10.0'
   osx_deployment_target = '10.12'
   tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/HeartbeatLoggingTestUtils.podspec
+++ b/HeartbeatLoggingTestUtils.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = '9.0'
   s.osx.deployment_target     = '10.12'
   s.tvos.deployment_target    = '10.0'
-  s.watchos.deployment_target = '6.0'
+  s.watchos.deployment_target = '7.0'
 
   s.source_files = [
     'HeartbeatLoggingTestUtils/Sources/**/*.swift',


### PR DESCRIPTION
### Context
This will unblock use of watchOS 7.0+ APIs

```
git grep --name-only "'6.0'" | xargs sed -i '' 's/'6.0'/'7.0'/g'
```