### PR TITLE
Limit GTMSessionFetcher version update to < 2.1.0

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Firebase 9.5.0
 - [fixed] Zip Distribution Fixed Promises module name issue impacting lld builds. (#10071)
+- [fixed] Limit dependency GTMSessionFetcher version update to < 2.1.0 to avoid a new deprecation
+  warning. (#10123)
 
 # Firebase 9.4.1
 - [fixed] Swift Package Manager only release to fix a 9.4.0 tagging issue impacting some users. (#10083)

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -44,7 +44,7 @@ Objective-C Implementations for FirebaseStorage. This pod should not be directly
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 9.0'
-  s.dependency 'GTMSessionFetcher/Core', '>= 1.7', '< 3.0'
+  s.dependency 'GTMSessionFetcher/Core', '>= 1.7', '< 2.1'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/Package.swift
+++ b/Package.swift
@@ -165,7 +165,7 @@ let package = Package(
     .package(
       name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "1.7.2" ..< "3.0.0"
+      "1.7.2" ..< "2.1.0"
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
Limit dependency GTMSessionFetcher version update to < 2.1.0 to avoid a new deprecation warning.

Fix #10055

GTMSessionFetcher deprecated an API used by FirebaseStorageInternal.

    - WARN  | xcodebuild:  /Users/paulbeusterien/gh5/firebase-ios-sdk/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.h:35:50: warning: 'GTMFetcherAuthorizationProtocol' is deprecated: implement GTMSessionFetcherAuthorizer instead [-Wdeprecated-declarations]
    - NOTE  | xcodebuild:  GTMSessionFetcher/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h:644:1: note: 'GTMFetcherAuthorizationProtocol' has been explicitly marked deprecated here
    - WARN  | xcodebuild:  /Users/paulbeusterien/gh5/firebase-ios-sdk/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.m:61:1: warning: implementing deprecated method [-Wdeprecated-implementations]
    - NOTE  | xcodebuild:  GTMSessionFetcher/Sources/Core/Public/GTMSessionFetcher/GTMSessionFetcher.h:657:1: note: method 'authorizeRequest:delegate:didFinishSelector:' declared here

It would be a breaking change to update to the new 2.1.0 API.

I'm proposing to cherry-pick this to the 9.5 release branch