### PR TITLE
Return nil instead of throwing for RCValues

### DIFF
--- a/FirebaseRemoteConfigSwift/Sources/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/Codable.swift
@@ -26,13 +26,12 @@ public extension RemoteConfigValue {
   /// Extracts a RemoteConfigValue JSON-encoded object and decodes it to the requested type.
   ///
   /// - Parameter asType: The type to decode the JSON-object to
-  func decoded<Value: Decodable>(asType: Value.Type = Value.self) throws -> Value {
+  func decoded<Value: Decodable>(asType: Value.Type = Value.self) -> Value? {
+    // Date is not yet supported for decoding.
     if asType == Date.self {
-      throw RemoteConfigValueCodableError
-        .unsupportedType("Date type is not currently supported for " +
-          " Remote Config Value decoding. Please file a feature request")
+      return nil
     }
-    return try FirebaseDataDecoder()
+    return try? FirebaseDataDecoder()
       .decode(Value.self, from: FirebaseRemoteConfigValueDecoderHelper(value: self))
   }
 }

--- a/FirebaseRemoteConfigSwift/Sources/Value.swift
+++ b/FirebaseRemoteConfigSwift/Sources/Value.swift
@@ -24,7 +24,7 @@ public extension RemoteConfig {
   /// - Parameter key: A Remote Config key.
   /// - Returns: A typed RemoteConfigValue.
   subscript<T: Decodable>(decodedValue key: String) -> T? {
-    return try? configValue(forKey: key).decoded()
+    return configValue(forKey: key).decoded()
   }
 
   /// Return a Dictionary for a RemoteConfig JSON key.

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -63,15 +63,8 @@ import XCTest
     func testFetchAndActivateWithCodableBadJson() async throws {
       let status = try await config.fetchAndActivate()
       XCTAssertEqual(status, .successFetchedFromRemote)
-      do {
-        _ = try config[Constants.nonJsonKey].decoded(asType: Recipe.self)
-      } catch let DecodingError.typeMismatch(_, context) {
-        XCTAssertEqual(context.debugDescription,
-                       "Expected to decode Dictionary<String, Any> but found " +
-                         "FirebaseRemoteConfigValueDecoderHelper instead.")
-        return
-      }
-      XCTFail("Failed to catch trying to decode non-JSON key as JSON")
+      let failJson = config[Constants.nonJsonKey].decoded(asType: Recipe.self)
+      XCTAssertNil(failJson)
     }
 
     // MARK: - Test setting Remote Config defaults via an encodable struct

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -135,39 +135,39 @@ import XCTest
     func testStrongTypingViaDecoderAlternateDecoderApi() async throws {
       let status = try await config.fetchAndActivate()
       XCTAssertEqual(status, .successFetchedFromRemote)
-      let myString: String = try config[Constants.stringKey].decoded()
+      let myString: String? = config[Constants.stringKey].decoded()
       XCTAssertEqual(myString, Constants.stringValue)
-      let myInt: Int = try config[Constants.intKey].decoded()
+      let myInt: Int? = config[Constants.intKey].decoded()
       XCTAssertEqual(myInt, Constants.intValue)
-      let myInt8: Int8 = try config[Constants.intKey].decoded()
+      let myInt8: Int8? = config[Constants.intKey].decoded()
       XCTAssertEqual(myInt8, Int8(Constants.intValue))
-      let myInt16: Int16 = try config[Constants.intKey].decoded()
+      let myInt16: Int16? = config[Constants.intKey].decoded()
       XCTAssertEqual(myInt16, Int16(Constants.intValue))
-      let myInt32: Int32 = try config[Constants.intKey].decoded()
+      let myInt32: Int32? = config[Constants.intKey].decoded()
       XCTAssertEqual(myInt32, Int32(Constants.intValue))
-      let myInt64: Int64 = try config[Constants.intKey].decoded()
+      let myInt64: Int64? = config[Constants.intKey].decoded()
       XCTAssertEqual(myInt64, Int64(Constants.intValue))
-      let myUInt: UInt = try config[Constants.intKey].decoded()
+      let myUInt: UInt? = config[Constants.intKey].decoded()
       XCTAssertEqual(myUInt, UInt(Constants.intValue))
-      let myUInt8: UInt8 = try config[Constants.intKey].decoded()
+      let myUInt8: UInt8? = config[Constants.intKey].decoded()
       XCTAssertEqual(myUInt8, UInt8(Constants.intValue))
-      let myUInt16: UInt16 = try config[Constants.intKey].decoded()
+      let myUInt16: UInt16? = config[Constants.intKey].decoded()
       XCTAssertEqual(myUInt16, UInt16(Constants.intValue))
-      let myUInt32: UInt32 = try config[Constants.intKey].decoded()
+      let myUInt32: UInt32? = config[Constants.intKey].decoded()
       XCTAssertEqual(myUInt32, UInt32(Constants.intValue))
-      let myUInt64: UInt64 = try config[Constants.intKey].decoded()
+      let myUInt64: UInt64? = config[Constants.intKey].decoded()
       XCTAssertEqual(myUInt64, UInt64(Constants.intValue))
-      let myDecimal: Decimal = try config[Constants.floatKey].decoded()
+      let myDecimal: Decimal? = config[Constants.floatKey].decoded()
       XCTAssertEqual(myDecimal, Decimal(Constants.doubleValue))
-      let myFloat: Float = try config[Constants.floatKey].decoded()
+      let myFloat: Float? = config[Constants.floatKey].decoded()
       XCTAssertEqual(myFloat, Constants.floatValue)
-      let myDouble: Double = try config[Constants.floatKey].decoded()
+      let myDouble: Double? = config[Constants.floatKey].decoded()
       XCTAssertEqual(myDouble, Constants.doubleValue)
-      let myTrue: Bool = try config[Constants.trueKey].decoded()
+      let myTrue: Bool? = config[Constants.trueKey].decoded()
       XCTAssertEqual(myTrue, true)
-      let myFalse: Bool = try config[Constants.falseKey].decoded()
+      let myFalse: Bool? = config[Constants.falseKey].decoded()
       XCTAssertEqual(myFalse, false)
-      let myData: Data = try config[Constants.stringKey].decoded()
+      let myData: Data? = config[Constants.stringKey].decoded()
       XCTAssertEqual(myData, Constants.stringValue.data(using: .utf8))
     }
 
@@ -183,15 +183,8 @@ import XCTest
     func testDateDecodingNotYetSupported() async throws {
       let status = try await config.fetchAndActivate()
       XCTAssertEqual(status, .successFetchedFromRemote)
-      do {
-        let _: Date = try config[Constants.stringKey].decoded()
-      } catch let RemoteConfigValueCodableError.unsupportedType(message) {
-        XCTAssertEqual(message,
-                       "Date type is not currently supported for  Remote Config Value decoding. " +
-                         "Please file a feature request")
-        return
-      }
-      XCTFail("Failed to throw unsupported Date error.")
+      let date: Date? = config[Constants.stringKey].decoded()
+      XCTAssertNil(date)
     }
   }
 #endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -72,62 +72,62 @@ import XCTest
       let status = try await config.fetchAndActivate()
       XCTAssertEqual(status, .successFetchedFromRemote)
       XCTAssertEqual(
-        try config[Constants.stringKey].decoded(asType: String.self),
+        config[Constants.stringKey].decoded(asType: String.self),
         Constants.stringValue
       )
-      XCTAssertEqual(try config[Constants.intKey].decoded(asType: Int.self), Constants.intValue)
+      XCTAssertEqual(config[Constants.intKey].decoded(asType: Int.self), Constants.intValue)
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int8.self),
+        config[Constants.intKey].decoded(asType: Int8.self),
         Int8(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int16.self),
+        config[Constants.intKey].decoded(asType: Int16.self),
         Int16(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int32.self),
+        config[Constants.intKey].decoded(asType: Int32.self),
         Int32(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int64.self),
+        config[Constants.intKey].decoded(asType: Int64.self),
         Int64(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt.self),
+        config[Constants.intKey].decoded(asType: UInt.self),
         UInt(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt8.self),
+        config[Constants.intKey].decoded(asType: UInt8.self),
         UInt8(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt16.self),
+        config[Constants.intKey].decoded(asType: UInt16.self),
         UInt16(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt32.self),
+        config[Constants.intKey].decoded(asType: UInt32.self),
         UInt32(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt64.self),
+        config[Constants.intKey].decoded(asType: UInt64.self),
         UInt64(Constants.intValue)
       )
       XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Decimal.self),
+        config[Constants.floatKey].decoded(asType: Decimal.self),
         Decimal(Constants.doubleValue)
       )
       XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Float.self),
+        config[Constants.floatKey].decoded(asType: Float.self),
         Constants.floatValue
       )
       XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Double.self),
+        config[Constants.floatKey].decoded(asType: Double.self),
         Constants.doubleValue
       )
-      XCTAssertEqual(try config[Constants.trueKey].decoded(asType: Bool.self), true)
-      XCTAssertEqual(try config[Constants.falseKey].decoded(asType: Bool.self), false)
+      XCTAssertEqual(config[Constants.trueKey].decoded(asType: Bool.self), true)
+      XCTAssertEqual(config[Constants.falseKey].decoded(asType: Bool.self), false)
       XCTAssertEqual(
-        try config[Constants.stringKey].decoded(asType: Data.self),
+        config[Constants.stringKey].decoded(asType: Data.self),
         Constants.stringValue.data(using: .utf8)
       )
     }


### PR DESCRIPTION
API change for Remove Config values to return nil instead of throwing errors to better support usage with property wrappers and historical Remote Config behavior.
