### PR TITLE
Reenable any GTMSessionFetcher 2.x dependency

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 9.6.0
+- [fixed] Update dependency specification for GTMSessionFetcher to allow all 2.x versions. (#10131)
+
 # Firebase 9.5.0
 - [fixed] Zip Distribution Fixed Promises module name issue impacting lld builds. (#10071)
 - [fixed] Limit dependency GTMSessionFetcher version update to < 2.1.0 to avoid a new deprecation

--- a/FirebaseStorageInternal.podspec
+++ b/FirebaseStorageInternal.podspec
@@ -44,7 +44,7 @@ Objective-C Implementations for FirebaseStorage. This pod should not be directly
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 9.0'
-  s.dependency 'GTMSessionFetcher/Core', '>= 1.7', '< 2.1'
+  s.dependency 'GTMSessionFetcher/Core', '>= 1.7', '< 3.0'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.h
+++ b/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.h
@@ -32,7 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
  * If no authentication provider exists or no token is found, no token is added
  * and the request is passed.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @interface FIRStorageTokenAuthorizer : NSObject <GTMFetcherAuthorizationProtocol>
+#pragma clang diagnostic pop
 
 /**
  * Initializes the token authorizer with an instance of FIRApp.

--- a/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.m
+++ b/FirebaseStorageInternal/Sources/FIRStorageTokenAuthorizer.m
@@ -58,9 +58,12 @@ static NSString *const kAuthHeader = @"Authorization";
 
 #pragma mark - GTMFetcherAuthorizationProtocol methods
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)authorizeRequest:(NSMutableURLRequest *)request
                 delegate:(id)delegate
        didFinishSelector:(SEL)sel {
+#pragma clang diagnostic push
   // Set version header on each request
   NSString *versionString = [NSString stringWithFormat:@"ios/%@", FIRFirebaseVersion()];
   [request setValue:versionString forHTTPHeaderField:@"x-firebase-storage-version"];

--- a/Package.swift
+++ b/Package.swift
@@ -165,7 +165,7 @@ let package = Package(
     .package(
       name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "1.7.2" ..< "2.1.0"
+      "1.7.2" ..< "3.0.0"
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
More term long-term sustainable solution than #10123 to the deprecation warning introduced by GTMSessionFetcher 2.1