### PR TITLE
[Infra] Add SPM debug info to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -144,7 +144,7 @@ body:
         <br>
 
         ```yml
-        
+
         Replace this line with the contents of your Podfile.lock!
 
         ```

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -124,7 +124,7 @@ body:
         <br>
 
         ```json
-        
+
         Replace this line with the contents of your Package.resolved.
 
         ```

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -114,6 +114,26 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: If using Swift Package Manager, the project's Package.resolved
+      description: The `Package.resolved` can help us debug versioning issues.
+      value: |
+        <!--- Look below for instructions on how to share your Package.resolved. --->
+
+        <details>
+        <summary>Expand <code>Package.resolved</code> snippet</summary>
+        <br>
+
+        ```json
+        
+        Replace this line with the contents of your Package.resolved.
+
+        ```
+
+        </details>
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: If using CocoaPods, the project's Podfile.lock
       description: The `Podfile.lock` can help us debug versioning issues.
       value: |
@@ -124,11 +144,8 @@ body:
         <br>
 
         ```yml
-        <!--- Paste the contents of your Podfile.lock *inside* this code block.
-          This will be automatically formatted into code.
-        --->
-
-
+        
+        Replace this line with the contents of your Podfile.lock!
 
         ```
 


### PR DESCRIPTION
### Context
For CocoaPods-related issues, we request the `Podfile.lock`.

Now, for SwiftPM-related issues, we request the `Package.resolved`. Thanks @rizafran for the idea!

See render template at [here](https://github.com/firebase/firebase-ios-sdk/blob/nc/swiftpm-issue-template/.github/ISSUE_TEMPLATE/BUG_REPORT.yml)

#no-changelog