### PR TITLE
[RC] Fix retry logic to respect max retry count

### DIFF
--- a/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
+++ b/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
@@ -103,10 +103,21 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
       }
       FIRRemoteConfigSettings *settings = [[FIRRemoteConfigSettings alloc] init];
       settings.fetchTimeout = 300;
-      settings.minimumFetchInterval = 0;
+      settings.minimumFetchInterval = 300;
       ((FIRRemoteConfig *)(self.RCInstances[namespaceString][appString])).configSettings = settings;
     }
   }
+  // Add realtime listener for firebase namespace
+  [self.RCInstances[FIRNamespaceGoogleMobilePlatform][FIRDefaultFIRAppName]
+      addOnConfigUpdateListener:^(NSError *_Nullable error) {
+        if (error != nil) {
+          [[FRCLog sharedInstance]
+              logToConsole:[NSString
+                               stringWithFormat:@"Realtime Error: %@", error.localizedDescription]];
+        } else {
+          [[FRCLog sharedInstance] logToConsole:[NSString stringWithFormat:@"Config updated!"]];
+        }
+      }];
   [[FRCLog sharedInstance] logToConsole:@"RC instances inited"];
 
   self.namespacePicker.dataSource = self;


### PR DESCRIPTION
Currently we are optimistically resetting the retry count in `beginRealtimeStream` immediately after starting the data task, however the request may fail, and the reset retry count causes us to retry infinitely (see internal b/241811665)

- Moving the logic to be handled in the data task delegates and only reset retry count when request has succeeded.
- Removed some duplicate checks in `retryHTTPConnection` because `beginRealtimeStream` has the same checks
- Some minor renaming

Able to repro/verify in the sample app by turning off the device network to generate an error

Ideally this should be covered in a unit test, however there is no existing testing for any of the data task interactions, so it's slightly tricky to add and will be done in a following PR