### PR TITLE
[AppCheck] Disable tests that use keychain

### DIFF
--- a/FirebaseAppCheck/Tests/Integration/FIRDeviceCheckAPIServiceE2ETests.m
+++ b/FirebaseAppCheck/Tests/Integration/FIRDeviceCheckAPIServiceE2ETests.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
 // Tests that use the Keychain require a host app and Swift Package Manager
 // does not support adding a host app to test targets.
 #if !SWIFT_PACKAGE

--- a/FirebaseAppCheck/Tests/Integration/FIRDeviceCheckAPIServiceE2ETests.m
+++ b/FirebaseAppCheck/Tests/Integration/FIRDeviceCheckAPIServiceE2ETests.m
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+// Tests that use the Keychain require a host app and Swift Package Manager
+// does not support adding a host app to test targets.
+#if !SWIFT_PACKAGE
+
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
 #import <XCTest/XCTest.h>
 
 #import "FBLPromise+Testing.h"
@@ -84,3 +93,7 @@
 }
 
 @end
+
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif  // !SWIFT_PACKAGE

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
 // Tests that use the Keychain require a host app and Swift Package Manager
 // does not support adding a host app to test targets.
 #if !SWIFT_PACKAGE

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+// Tests that use the Keychain require a host app and Swift Package Manager
+// does not support adding a host app to test targets.
+#if !SWIFT_PACKAGE
+
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
@@ -50,8 +59,6 @@
   self.storage = nil;
   [super tearDown];
 }
-
-#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 
 - (void)testSetAndGetArtifact {
   [self assertSetGetForStorage];
@@ -271,6 +278,9 @@
   [storage2 setArtifact:nil forKey:keyID];
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
 }
-#endif  // !TARGET_OS_MACCATALYST
 
 @end
+
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif  // !SWIFT_PACKAGE

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -18,6 +18,8 @@
 
 #import <OCMock/OCMock.h>
 
+#import <TargetConditionals.h>
+
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProviderFactory.h"

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -128,7 +128,15 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
+// Tests that use the Keychain require a host app and Swift Package Manager
+// does not support adding a host app to test targets.
+#if !SWIFT_PACKAGE
+
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
 - (void)testSetAppCheckProviderFactoryWithDefaultApp {
   NSString *appName = kFIRDefaultAppName;
 
@@ -172,7 +180,10 @@ NS_ASSUME_NONNULL_BEGIN
   OCMVerifyAll(self.mockProviderFactory);
   OCMVerifyAll(self.mockAppCheckProvider);
 }
-#endif  // !TARGET_OS_MACCATALYST
+
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif  // !SWIFT_PACKAGE
 
 #pragma mark - Helpers
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -64,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, nullable) id mockAppCheckProvider;
 @property(nonatomic, nullable) id mockTokenRefresher;
 
+- (void)testDefaultAppCheckProvider FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY;
+
 @end
 
 @implementation FIRAppCheckIntegrationTests
@@ -81,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)tearDown {
   [FIRApp resetApps];
 
-  if (@available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, *)) {
+  if (@available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, watchOS 9.0, *)) {
     // Recover default provider factory.
     [FIRAppCheck setAppCheckProviderFactory:[[FIRDeviceCheckProviderFactory alloc] init]];
   }
@@ -97,37 +99,33 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testDefaultAppCheckProvider {
-  if (@available(iOS 11.0, tvOS 11.0, macOS 10.15, *)) {
-    NSString *appName = @"testDefaultAppCheckProvider";
+  NSString *appName = @"testDefaultAppCheckProvider";
 
-    // 1. Expect FIRDeviceCheckProvider to be instantiated.
+  // 1. Expect FIRDeviceCheckProvider to be instantiated.
 
-    id deviceCheckProviderMock = OCMClassMock([FIRDeviceCheckProvider class]);
-    id appValidationArg = [OCMArg checkWithBlock:^BOOL(FIRApp *app) {
-      XCTAssertEqualObjects(app.name, appName);
-      return YES;
-    }];
+  id deviceCheckProviderMock = OCMClassMock([FIRDeviceCheckProvider class]);
+  id appValidationArg = [OCMArg checkWithBlock:^BOOL(FIRApp *app) {
+    XCTAssertEqualObjects(app.name, appName);
+    return YES;
+  }];
 
-    OCMStub([deviceCheckProviderMock alloc]).andReturn(deviceCheckProviderMock);
-    OCMExpect([deviceCheckProviderMock initWithApp:appValidationArg])
-        .andReturn(deviceCheckProviderMock);
+  OCMStub([deviceCheckProviderMock alloc]).andReturn(deviceCheckProviderMock);
+  OCMExpect([deviceCheckProviderMock initWithApp:appValidationArg])
+      .andReturn(deviceCheckProviderMock);
 
-    // 2. Configure Firebase
-    [self configureAppWithName:appName];
+  // 2. Configure Firebase
+  [self configureAppWithName:appName];
 
-    FIRApp *app = [FIRApp appNamed:appName];
-    XCTAssertNotNil(FIR_COMPONENT(FIRAppCheckInterop, app.container));
+  FIRApp *app = [FIRApp appNamed:appName];
+  XCTAssertNotNil(FIR_COMPONENT(FIRAppCheckInterop, app.container));
 
-    // 3. Verify
-    OCMVerifyAll(deviceCheckProviderMock);
+  // 3. Verify
+  OCMVerifyAll(deviceCheckProviderMock);
 
-    // 4. Cleanup
-    // Recover default provider factory.
-    [FIRAppCheck setAppCheckProviderFactory:[[FIRDeviceCheckProviderFactory alloc] init]];
-    [deviceCheckProviderMock stopMocking];
-  } else {
-    // Fallback on earlier versions
-  }
+  // 4. Cleanup
+  // Recover default provider factory.
+  [FIRAppCheck setAppCheckProviderFactory:[[FIRDeviceCheckProviderFactory alloc] init]];
+  [deviceCheckProviderMock stopMocking];
 }
 
 // Tests that use the Keychain require a host app and Swift Package Manager

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -34,6 +34,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+
 @interface DummyAppCheckProvider : NSObject <FIRAppCheckProvider>
 @end
 
@@ -223,5 +225,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+
+#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+// Tests that use the Keychain require a host app and Swift Package Manager
+// does not support adding a host app to test targets.
+#if !SWIFT_PACKAGE
+
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
@@ -49,8 +58,6 @@
   self.storage = nil;
   [super tearDown];
 }
-
-#if !TARGET_OS_MACCATALYST  // Catalyst should be possible with Xcode 12.5+
 
 - (void)testSetAndGetToken {
   FIRAppCheckToken *tokenToStore = [[FIRAppCheckToken alloc] initWithToken:@"token"
@@ -181,6 +188,9 @@
   XCTAssertNil(getPromise.value);
   XCTAssertNil(getPromise.error);
 }
-#endif  // !TARGET_OS_MACCATALYST
 
 @end
+
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif  // !SWIFT_PACKAGE

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckStorageTests.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
 // Tests that use the Keychain require a host app and Swift Package Manager
 // does not support adding a host app to test targets.
 #if !SWIFT_PACKAGE

--- a/Package.swift
+++ b/Package.swift
@@ -1256,12 +1256,6 @@ let package = Package(
       exclude: [
         // Disable Swift tests as mixed targets are not supported (Xcode 12.3).
         "Unit/Swift",
-
-        // Disable Keychain dependent tests as they require a host application on iOS.
-        "Integration",
-        "Unit/AppAttestProvider/Storage/FIRAppAttestArtifactStorageTests.m",
-        "Unit/Core/FIRAppCheckIntegrationTests.m",
-        "Unit/Core/FIRAppCheckStorageTests.m",
       ],
       resources: [
         .process("Fixture"),


### PR DESCRIPTION
### Context
- Intentionally caused by https://github.com/google/GoogleUtilities/pull/75
- While we do lose some coverage on CI, [GoogleUtilities/#75](https://github.com/google/GoogleUtilities/pull/75) makes the macOS keychain behave like the iOS style keychain (which is tested on CI).
- Also cleaned up the `AppCheckUnit` test target in the Package manifest. I think prefer excluding at the test file level to keep things consistent between build systems and the source of truth in the test file.
- Unblocks some of the CI in #10145

### Future work
- [ ] Open a PR to update AppCheck CHANGELOG with note mentioning new macOS constraint (need to use Keychain Sharing capability)

#no-changelog