### PR TITLE
[Core] Link `WatchKit` for watchOS in `FirebaseCore.podspec`

### DIFF
--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -45,6 +45,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
+  s.watchos.framework = 'WatchKit'
 
   # Remember to also update version in `cmake/external/GoogleUtilities.cmake`
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'


### PR DESCRIPTION
### Context
In #10112, a `WatchKit` API was added in `FirebaseCore`. It seems that CocoaPods
builds require that `WatchKit` be linked in if watchOS APIs are being used.

The `FirebaseCore.podspec` didn't need to import `WatchKit` before because we weren't using any `WatchKit` APIs.

Fixes #10156

#no-changelog
