### PR TITLE
Storage v2 API proof of concept

### DIFF
--- a/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
@@ -81,6 +81,7 @@ internal class StorageUploadTaskV2: StorageTask {
       uploadFetcher.comment = "File UploadTask"
     }
     uploadFetcher.maxRetryInterval = reference.storage.maxUploadRetryInterval
+    uploadFetcher.stopFetchingTriggersCompletionHandler = true
 
     if let progressBlock = progressBlock {
       uploadFetcher.sendProgressBlock = { (bytesSent: Int64, totalBytesSent: Int64,

--- a/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
@@ -35,6 +35,9 @@ internal class StorageUploadTaskV2: StorageTask {
    * Prepares a GTMSessionFetcher task and does an upload.
    */
   internal func upload() async throws -> StorageMetadata {
+    if progress.isCancelled {
+      throw StorageError.cancelled
+    }
     if let contentValidationError = isContentToUploadInvalid() {
       throw StorageError.swiftConvert(objcError: contentValidationError)
     }

--- a/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
@@ -89,6 +89,9 @@ internal class StorageUploadTaskV2: StorageTask {
           self.progress.totalUnitCount = totalBytesExpectedToSend
           self.metadata = self.uploadMetadata
           progressBlock(self.progress)
+          if self.progress.isCancelled {
+            uploadFetcher.stopFetching()
+          }
       }
     }
 
@@ -142,12 +145,16 @@ internal class StorageUploadTaskV2: StorageTask {
                 file: URL? = nil,
                 data: Data? = nil,
                 metadata: StorageMetadata,
+                progress: Progress? = nil,
                 progressBlock: ((Progress) -> Void)? = nil) {
     uploadMetadata = metadata
     uploadData = data
     fileURL = file
     self.progressBlock = progressBlock
     super.init(reference: reference, service: service, queue: queue)
+    if let progress = progress {
+      self.progress = progress
+    }
 
     if uploadMetadata.contentType == nil {
       uploadMetadata.contentType = StorageUtils.MIMETypeForExtension(file?.pathExtension)

--- a/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUploadTaskV2.swift
@@ -1,0 +1,186 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+#if COCOAPODS
+  import GTMSessionFetcher
+#else
+  import GTMSessionFetcherCore
+#endif
+
+/**
+ * `StorageUploadTaskV2` implements resumable uploads to a file in Firebase Storage.
+ * Uploads can be done via an async/await function or with a completion callback with a
+ * Swift task return value.
+ * Uploads can be initialized from `Data` in memory, or a URL to a file on disk.
+ * Uploads are performed on a background queue, and callbacks are raised on the developer
+ * specified `callbackQueue` in Storage, or the main queue if unspecified.
+ * Currently all uploads must be initiated and managed on the main queue.
+ */
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+internal class StorageUploadTaskV2: StorageTask {
+  /**
+   * Prepares a GTMSessionFetcher task and does an upload.
+   */
+  internal func upload() async throws -> StorageMetadata {
+    if let contentValidationError = isContentToUploadInvalid() {
+      throw StorageError.swiftConvert(objcError: contentValidationError)
+    }
+
+    var request = baseRequest
+    request.httpMethod = "POST"
+    request.timeoutInterval = reference.storage.maxUploadRetryTime
+
+    let dataRepresentation = uploadMetadata.dictionaryRepresentation()
+    let bodyData = try? JSONSerialization.data(withJSONObject: dataRepresentation)
+
+    request.httpBody = bodyData
+    request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+    if let count = bodyData?.count {
+      request.setValue("\(count)", forHTTPHeaderField: "Content-Length")
+    }
+
+    var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+    if components?.host == "www.googleapis.com",
+       let path = components?.path {
+      components?.percentEncodedPath = "/upload\(path)"
+    }
+    guard let path = GCSEscapedString(uploadMetadata.path) else {
+      fatalError("Internal error enqueueing a Storage task")
+    }
+    components?.percentEncodedQuery = "uploadType=resumable&name=\(path)"
+
+    request.url = components?.url
+
+    guard let contentType = uploadMetadata.contentType else {
+      fatalError("Internal error enqueueing a Storage task")
+    }
+    let uploadFetcher = GTMSessionUploadFetcher(
+      request: request,
+      uploadMIMEType: contentType,
+      chunkSize: Int64.max,
+      fetcherService: fetcherService
+    )
+    if let data = uploadData {
+      uploadFetcher.uploadData = data
+      uploadFetcher.comment = "Data UploadTask"
+    } else if let fileURL = fileURL {
+      uploadFetcher.uploadFileURL = fileURL
+      uploadFetcher.comment = "File UploadTask"
+    }
+    uploadFetcher.maxRetryInterval = reference.storage.maxUploadRetryInterval
+
+    if let progressBlock = progressBlock {
+      uploadFetcher.sendProgressBlock = { (bytesSent: Int64, totalBytesSent: Int64,
+                                           totalBytesExpectedToSend: Int64) in
+          self.progress.completedUnitCount = totalBytesSent
+          self.progress.totalUnitCount = totalBytesExpectedToSend
+          self.metadata = self.uploadMetadata
+          progressBlock(self.progress)
+      }
+    }
+
+    let (data, error) = await beginFetch(uploadFetcher: uploadFetcher)
+    defer {
+      uploadFetcher.stopFetching()
+    }
+
+    // Handle potential issues with upload
+    if let error = error {
+      throw StorageError.swiftConvert(objcError: StorageErrorCode.error(
+        withServerError: error as NSError, ref: reference
+      ))
+    }
+
+    guard let data = data else {
+      fatalError("Internal Error: fetcherCompletion returned with nil data and nil error")
+    }
+
+    if let responseDictionary = try? JSONSerialization
+      .jsonObject(with: data) as? [String: AnyHashable] {
+      let metadata = StorageMetadata(dictionary: responseDictionary)
+      metadata.fileType = .file
+      return metadata
+    } else {
+      throw StorageError.swiftConvert(objcError: StorageErrorCode.error(withInvalidRequest: data))
+    }
+  }
+
+  private func beginFetch(uploadFetcher: GTMSessionUploadFetcher) async -> (Data?, Error?) {
+    return await withCheckedContinuation { continuation in
+      uploadFetcher.beginFetch { data, error in
+        continuation.resume(returning: (data, error))
+      }
+    }
+  }
+
+  private let uploadMetadata: StorageMetadata
+  private let uploadData: Data?
+  private let progressBlock: ((Progress) -> Void)?
+  /**
+   * The file to download to or upload from
+   */
+  private let fileURL: URL?
+
+  // MARK: - Internal Implementations
+
+  internal init(reference: StorageReference,
+                service: GTMSessionFetcherService,
+                queue: DispatchQueue,
+                file: URL? = nil,
+                data: Data? = nil,
+                metadata: StorageMetadata,
+                progressBlock: ((Progress) -> Void)? = nil) {
+    uploadMetadata = metadata
+    uploadData = data
+    fileURL = file
+    self.progressBlock = progressBlock
+    super.init(reference: reference, service: service, queue: queue)
+
+    if uploadMetadata.contentType == nil {
+      uploadMetadata.contentType = StorageUtils.MIMETypeForExtension(file?.pathExtension)
+    }
+  }
+
+  internal func isContentToUploadInvalid() -> NSError? {
+    // TODO: - Does checkResourceIsReachableAndReturnError need to be ported here?
+    if uploadData != nil {
+      return nil
+    }
+    if let resourceValues = try? fileURL?.resourceValues(forKeys: [.isRegularFileKey]),
+       let isFile = resourceValues.isRegularFile,
+       isFile == true {
+      return nil
+    }
+    let userInfo = [NSLocalizedDescriptionKey:
+      "File at URL: \(fileURL?.absoluteString ?? "") is not reachable."
+      + " Ensure file URL is not a directory, symbolic link, or invalid url."]
+    return NSError(
+      domain: StorageErrorDomain,
+      code: StorageErrorCode.unknown.rawValue,
+      userInfo: userInfo
+    )
+  }
+
+  private func GCSEscapedString(_ input: String?) -> String? {
+    guard let input = input else {
+      return nil
+    }
+    let GCSObjectAllowedCharacterSet =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$'()*,=:@"
+    let allowedCharacters = CharacterSet(charactersIn: GCSObjectAllowedCharacterSet)
+    return input.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
+  }
+}

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import Foundation
-import GTMSessionFetcher
+#if COCOAPODS
+  import GTMSessionFetcher
+#else
+  import GTMSessionFetcherCore
+#endif
 
 /// The error domain for codes in the `StorageErrorCode` enum.
 public let StorageErrorDomain: String = "FIRStorageErrorDomain"

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import GTMSessionFetcher
 
 /// The error domain for codes in the `StorageErrorCode` enum.
 public let StorageErrorDomain: String = "FIRStorageErrorDomain"
@@ -51,6 +52,7 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     case 402: errorCode = .quotaExceeded
     case 403: errorCode = .unauthorized
     case 404: errorCode = .objectNotFound
+    case GTMSessionFetcherError.userCancelled.rawValue: errorCode = .cancelled
     default: errorCode = .unknown
     }
 

--- a/FirebaseStorage/Sources/StorageReferenceV2.swift
+++ b/FirebaseStorage/Sources/StorageReferenceV2.swift
@@ -50,6 +50,8 @@ public extension StorageReference {
    *   - fileURL: A URL representing the system file path of the object to be uploaded.
    *   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
    *       about the object being uploaded.
+   *   - progress: Pass a `Progress` handle in for `pause`, `resume`, and `cancel` run control.
+   *   - progressBlock: A block to execute to do progress updates.
    * - Returns: A `StorageMetadata` on success.
    * - Throws: A StorageError on failure
    */
@@ -59,10 +61,6 @@ public extension StorageReference {
                  progress: Progress? = nil,
                  progressBlock: ((Progress) -> Void)? = nil) async throws -> StorageMetadata {
     var putMetadata: StorageMetadata
-    if let progress = progress,
-       progress.isCancelled {
-      throw StorageError.cancelled
-    }
     if metadata == nil {
       putMetadata = StorageMetadata()
       if let path = path.object {

--- a/FirebaseStorage/Sources/StorageReferenceV2.swift
+++ b/FirebaseStorage/Sources/StorageReferenceV2.swift
@@ -1,0 +1,114 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+public extension StorageReference {
+  /**
+   * Asynchronously uploads data to the currently specified `StorageReference`.
+   * This is not recommended for large files, and one should instead upload a file from disk.
+   * - Parameters:
+   *   - uploadData: The data to upload.
+   *   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
+   *       about the object being uploaded.
+   * - Returns: A `StorageMetadata` on success.
+   * - Throws: A StorageError on failure
+   */
+  @discardableResult
+  func putDataV2(_ uploadData: Data,
+                 metadata: StorageMetadata? = nil) async throws -> StorageMetadata {
+    let putMetadata = metadata ?? StorageMetadata()
+    if let path = path.object {
+      putMetadata.path = path
+      putMetadata.name = (path as NSString).lastPathComponent as String
+    }
+    let fetcherService = storage.fetcherServiceForApp
+    let task = StorageUploadTaskV2(reference: self,
+                                   service: fetcherService,
+                                   queue: storage.dispatchQueue,
+                                   data: uploadData,
+                                   metadata: putMetadata)
+
+    return try await task.upload()
+  }
+
+  /**
+   * Asynchronously uploads a file to the currently specified `StorageReference`.
+   * - Parameters:
+   *   - fileURL: A URL representing the system file path of the object to be uploaded.
+   *   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
+   *       about the object being uploaded.
+   * - Returns: A `StorageMetadata` on success.
+   * - Throws: A StorageError on failure
+   */
+  @discardableResult
+  func putFileV2(from fileURL: URL, metadata: StorageMetadata? = nil,
+                 progressBlock: ((Progress) -> Void)? = nil) async throws -> StorageMetadata {
+    var putMetadata: StorageMetadata
+    if metadata == nil {
+      putMetadata = StorageMetadata()
+      if let path = path.object {
+        putMetadata.path = path
+        putMetadata.name = (path as NSString).lastPathComponent as String
+      }
+    } else {
+      putMetadata = metadata!
+    }
+    let fetcherService = storage.fetcherServiceForApp
+    let uploadTask = StorageUploadTaskV2(reference: self,
+                                         service: fetcherService,
+                                         queue: storage.dispatchQueue,
+                                         file: fileURL,
+                                         metadata: putMetadata,
+                                         progressBlock: progressBlock)
+    return try await uploadTask.upload()
+  }
+
+  /**
+   * Asynchronously uploads a file to the currently specified `StorageReference`.
+   * - Parameters:
+   *   - fileURL: A URL representing the system file path of the object to be uploaded.
+   *   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
+   *       about the object being uploaded.
+   *   - completion: A completion block that either returns the object metadata on success,
+   *       or an error on failure.
+   * - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage the upload.
+   */
+  @discardableResult
+  func putFileHandle(from fileURL: URL,
+                     metadata: StorageMetadata? = nil,
+                     progressBlock: ((Progress) -> Void)? = nil,
+                     completion: ((Result<StorageMetadata, Error>) -> Void)?) -> Task<Void, Never> {
+    let task = Task {
+      do {
+        let metadata = try await putFileV2(from: fileURL, metadata: metadata,
+                                           progressBlock: progressBlock)
+
+        if let completion = completion {
+          if Task.isCancelled {
+            completion(.failure(StorageError.cancelled))
+          } else {
+            completion(.success(metadata))
+          }
+        }
+      } catch {
+        if let completion = completion {
+          completion(.failure(error))
+        }
+      }
+    }
+    return task
+  }
+}

--- a/FirebaseStorage/Sources/StorageReferenceV2.swift
+++ b/FirebaseStorage/Sources/StorageReferenceV2.swift
@@ -89,25 +89,15 @@ public extension StorageReference {
   @discardableResult
   func putFileHandle(from fileURL: URL,
                      metadata: StorageMetadata? = nil,
-                     progressBlock: ((Progress) -> Void)? = nil,
-                     completion: ((Result<StorageMetadata, Error>) -> Void)?) -> Task<Void, Never> {
+                     progressBlock: ((Progress) -> Void)? = nil) async throws
+    -> Task<StorageMetadata, Error> {
     let task = Task {
-      do {
-        let metadata = try await putFileV2(from: fileURL, metadata: metadata,
-                                           progressBlock: progressBlock)
-
-        if let completion = completion {
-          if Task.isCancelled {
-            completion(.failure(StorageError.cancelled))
-          } else {
-            completion(.success(metadata))
-          }
-        }
-      } catch {
-        if let completion = completion {
-          completion(.failure(error))
-        }
+      if Task.isCancelled {
+        throw StorageError.cancelled
       }
+      let returnValue = try await putFileV2(from: fileURL, metadata: metadata,
+                          progressBlock: progressBlock)
+      return returnValue
     }
     return task
   }

--- a/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
+++ b/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
@@ -127,8 +127,8 @@ class StorageApiV2Tests: StorageIntegrationCommon {
   }
 
   func testSimplePutFileWithCancel() async throws {
-    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
-    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let data = try await ref.data(maxSize: 1024 * 1024)
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)

--- a/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
+++ b/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
@@ -1,0 +1,212 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseAuth
+import FirebaseCore
+import FirebaseStorage
+import XCTest
+
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class StorageApiV2Tests: StorageIntegrationCommon {
+  func testDeleteWithNilCompletion() async throws {
+    let ref = storage.reference(withPath: "ios/public/fileToDelete")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    try await ref.putDataV2(data)
+    ref.delete(completion: nil)
+  }
+
+  func testSimplePutData() async throws {
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let metadata = try await ref.putDataV2(data)
+    XCTAssertEqual(metadata.name, "testBytesUpload")
+  }
+
+  func testSimplePutSpecialCharacter() async throws {
+    let ref = storage.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let metadata = try await ref.putDataV2(data)
+    XCTAssertEqual(metadata.name, "-._~!$'()*,=:@&+;")
+  }
+
+  func testSimplePutDataInBackgroundQueue() async throws {
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let workerTask = Task {
+      try await ref.putDataV2(data)
+    }
+    let metadata = try await workerTask.value
+    XCTAssertEqual(metadata.name, "testBytesUpload")
+  }
+
+  func testSimplePutEmptyData() async throws {
+    let ref = storage.reference(withPath: "ios/public/testSimplePutEmptyData")
+    let data = Data()
+    let metadata = try await ref.putDataV2(data)
+    XCTAssertEqual(metadata.name, "testSimplePutEmptyData")
+  }
+
+  func testSimplePutDataUnauthorized() async throws {
+    let file = "ios/private/secretfile.txt"
+    let ref = storage.reference(withPath: file)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    do {
+      try await ref.putDataV2(data)
+    } catch {
+      let error = try XCTUnwrap(error as? StorageError)
+      switch error {
+      case let .unauthorized(bucket, object):
+        XCTAssertEqual(bucket, "ios-opensource-samples.appspot.com")
+        XCTAssertEqual(object, file)
+      default:
+        XCTFail("Failed with unexpected error: \(error)")
+      }
+      return
+    }
+    XCTFail("Unexpected success from unauthorized putData")
+  }
+
+  func testSimplePutFileWithProgress() throws {
+    let progressTestedExpectation = expectation(description: "progressTested")
+    let putFileExpectation = expectation(description: "putFile")
+    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+
+    var uploadedBytes: Int64 = -1
+    var fulfilled = false
+    let progressBlock = { (progress: Progress) in
+      XCTAssertGreaterThanOrEqual(progress.completedUnitCount, uploadedBytes)
+      uploadedBytes = progress.completedUnitCount
+      if !fulfilled {
+        progressTestedExpectation.fulfill()
+        fulfilled = true
+      }
+    }
+
+    ref.putFileHandle(from: fileURL, progressBlock: progressBlock) { result in
+      switch result {
+      case let .success(value):
+        XCTAssertEqual(value.name, "testSimplePutFile")
+      case let .failure(error):
+        XCTFail("Unexpected error \(error)")
+      }
+      putFileExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 20.0)
+  }
+
+  func testSimplePutFileWithCancel() throws {
+    let putFileExpectation = expectation(description: "putFile")
+    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+
+    let task = ref.putFileHandle(from: fileURL) { result in
+      XCTAssertNotNil(result)
+      switch result {
+      case .success:
+        XCTFail("Unexpected success after cancellation")
+      case let .failure(error):
+        let storageError = try! XCTUnwrap(error as? StorageError)
+        switch storageError {
+        case .cancelled: XCTAssertTrue(true)
+        default: XCTFail("Unexpected error")
+        }
+      }
+      putFileExpectation.fulfill()
+    }
+    task.cancel()
+
+    waitForExpectations(timeout: 20.0)
+  }
+
+  func testSimplePutFileWithCancelFromProgress() throws {
+    let progressTestedExpectation = expectation(description: "progressTested")
+    let putFileExpectation = expectation(description: "putFile")
+    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+
+    var uploadedBytes: Int64 = -1
+    var fulfilled = false
+    var task: Task<Void, Never>?
+    let progressBlock = { (progress: Progress) in
+      XCTAssertGreaterThanOrEqual(progress.completedUnitCount, uploadedBytes)
+      uploadedBytes = progress.completedUnitCount
+      if !fulfilled {
+        progressTestedExpectation.fulfill()
+        fulfilled = true
+        task?.cancel()
+      }
+    }
+
+    task = ref.putFileHandle(from: fileURL, progressBlock: progressBlock) { result in
+      switch result {
+      case .success:
+        XCTFail("Unexpected success after cancellation")
+      case let .failure(error):
+        XCTAssertEqual("cancelled", "\(error)")
+      }
+      putFileExpectation.fulfill()
+    }
+    waitForExpectations(timeout: 20.0)
+  }
+
+  func testAttemptToUploadDirectoryShouldFail() async throws {
+    // This `.numbers` file is actually a directory.
+    let fileName = "HomeImprovement.numbers"
+    let bundle = Bundle(for: StorageIntegrationCommon.self)
+    let fileURL = try XCTUnwrap(bundle.url(forResource: fileName, withExtension: ""),
+                                "Failed to get filePath")
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
+    do {
+      try await ref.putFileV2(from: fileURL)
+    } catch {
+      let error = try XCTUnwrap(error as? StorageError)
+      switch error {
+      case let .unknown(message):
+        print(message)
+        XCTAssertTrue(message.hasSuffix("is not reachable. Ensure file URL is not a directory, " +
+            "symbolic link, or invalid url."))
+      default:
+        XCTFail("Failed with unexpected error: \(error)")
+      }
+      return
+    }
+    XCTFail("Unexpected success from unauthorized putData")
+  }
+
+  func testPutFileWithSpecialCharacters() async throws {
+    let fileName = "hello&+@_ .txt"
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+
+    let metadata = try await ref.putFileV2(from: fileURL)
+    XCTAssertEqual(fileName, metadata.name)
+    // TODO: Update getMetadata here.
+//        ref.getMetadata { result in
+//          self.assertResultSuccess(result)
+//        }
+  }
+}

--- a/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
+++ b/FirebaseStorage/Tests/Integration/IntegrationApiV2.swift
@@ -216,9 +216,7 @@ class StorageApiV2Tests: StorageIntegrationCommon {
 
     let metadata = try await ref.putFileV2(from: fileURL)
     XCTAssertEqual(fileName, metadata.name)
-    // TODO: Update getMetadata here.
-//        ref.getMetadata { result in
-//          self.assertResultSuccess(result)
-//        }
+    let metadataRef = try await ref.getMetadata()
+    XCTAssertEqual(fileName, metadataRef.name)
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -164,8 +164,8 @@ let package = Package(
     ),
     .package(
       name: "GTMSessionFetcher",
-      url: "https://github.com/google/gtm-session-fetcher.git",
-      "2.1.0" ..< "4.0.0"
+      url: "https://github.com/paulb777/gtm-session-fetcher.git",
+      .branch("cancel-and-callback")
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
Proof of concept of a Swift-only API for the StorageReference APIs available for iOS 13+. This PR provides an example implementation and integration tests for `putFile` and `putData` .

- The v2 API is now an async/await API that returns on completion and throws on errors
- If task control(cancel, pause, resume) is wanted, it can be controlled by a passed in `Progress` instance. See https://developer.apple.com/documentation/foundation/progress

For example, the new API for putFile are :

-       @discardableResult
        func putFileV2(from fileURL: URL,
                 metadata: StorageMetadata? = nil,
                 progress: Progress? = nil,
                 progressBlock: ((Progress) -> Void)? = nil) async throws -> StorageMetadata {

- The public StorageUploadTask class is replaced by the internal helper StorageUploadTaskV2 class.
- progress tracking is available via an optional callback instead of a state management system
- An immediate `cancel` works, but `cancel` from a progress callback causes 
```
SWIFT TASK CONTINUATION MISUSE: beginFetch(uploadFetcher:) leaked its continuation!
2022-09-02 13:47:25.949984-0700 AppHost-FirebaseStorage-Unit-Tests[38388:17164810] SWIFT TASK CONTINUATION MISUSE: beginFetch(uploadFetcher:) leaked its continuation!
```
I believe it's because GTMSessionFetcher deallocates its callbacks after a call to `stopFetching`. 
