### PR TITLE
[Messaging] macOS keychain auth prompt fix

### DIFF
--- a/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
@@ -65,6 +65,13 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
   if ([service length] && ![kFIRMessagingKeychainWildcardIdentifier isEqualToString:service]) {
     finalQuery[(__bridge NSString *)kSecAttrService] = service;
   }
+
+  if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)) {
+    // Ensures that the keychain query behaves the same across all platforms.
+    // See go/firebase-macos-keychain-popups for details.
+    finalQuery[(__bridge id)kSecUseDataProtectionKeychain] = (__bridge id)kCFBooleanTrue;
+  }
+
   return finalQuery;
 }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -215,6 +215,11 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
 }
 
 - (void)testQueryCachedKeychainItems {
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
   XCTestExpectation *addItemToKeychainExpectation =
       [self expectationWithDescription:@"Test added item should be cached properly"];
   // A wildcard query should return empty data when there's nothing in keychain
@@ -273,9 +278,17 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
+
+#endif
+
 }
 
 - (void)testCachedKeychainOverwrite {
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
   XCTestExpectation *overwriteCachedKeychainExpectation =
       [self expectationWithDescription:@"Test the cached keychain item is overwrite properly"];
 
@@ -318,9 +331,16 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
+
+#endif
 }
 
 - (void)testSetKeychainItemShouldDeleteOldEntry {
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
   XCTestExpectation *overwriteCachedKeychainExpectation = [self
       expectationWithDescription:@"Test keychain entry should be deleted before adding a new one"];
 
@@ -357,6 +377,8 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
+
+#endif
 }
 
 - (void)testInvalidQuery {
@@ -378,6 +400,11 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
 }
 
 - (void)testQueryAndAddEntry {
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
   FIRMessagingAuthKeychain *keychain =
       [[FIRMessagingAuthKeychain alloc] initWithIdentifier:kFIRMessagingTestKeychainId];
 
@@ -394,6 +421,8 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   XCTAssertNil([keychain dataForService:service account:account2]);
   // Service and account2 should exist in cache.
   XCTAssertNotNil(keychain.cachedKeychainData[service][account2]);
+
+#endif
 }
 
 #pragma mark - helper function

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -214,12 +214,12 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
 #endif
 }
 
-- (void)testQueryCachedKeychainItems {
 // Skip keychain tests on Catalyst and macOS. Tests are skipped because they
 // involve interactions with the keychain that require a provisioning profile.
 // See go/firebase-macos-keychain-popups for more details.
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
 
+- (void)testQueryCachedKeychainItems {
   XCTestExpectation *addItemToKeychainExpectation =
       [self expectationWithDescription:@"Test added item should be cached properly"];
   // A wildcard query should return empty data when there's nothing in keychain
@@ -278,17 +278,9 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-
-#endif
-
 }
 
 - (void)testCachedKeychainOverwrite {
-// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
-// involve interactions with the keychain that require a provisioning profile.
-// See go/firebase-macos-keychain-popups for more details.
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-
   XCTestExpectation *overwriteCachedKeychainExpectation =
       [self expectationWithDescription:@"Test the cached keychain item is overwrite properly"];
 
@@ -331,16 +323,9 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-
-#endif
 }
 
 - (void)testSetKeychainItemShouldDeleteOldEntry {
-// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
-// involve interactions with the keychain that require a provisioning profile.
-// See go/firebase-macos-keychain-popups for more details.
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-
   XCTestExpectation *overwriteCachedKeychainExpectation = [self
       expectationWithDescription:@"Test keychain entry should be deleted before adding a new one"];
 
@@ -377,8 +362,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-
-#endif
 }
 
 - (void)testInvalidQuery {
@@ -400,11 +383,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
 }
 
 - (void)testQueryAndAddEntry {
-// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
-// involve interactions with the keychain that require a provisioning profile.
-// See go/firebase-macos-keychain-popups for more details.
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-
   FIRMessagingAuthKeychain *keychain =
       [[FIRMessagingAuthKeychain alloc] initWithIdentifier:kFIRMessagingTestKeychainId];
 
@@ -421,9 +399,9 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   XCTAssertNil([keychain dataForService:service account:account2]);
   // Service and account2 should exist in cache.
   XCTAssertNotNil(keychain.cachedKeychainData[service][account2]);
+}
 
 #endif
-}
 
 #pragma mark - helper function
 - (NSData *)tokenDataWithAuthorizedEntity:(NSString *)authorizedEntity


### PR DESCRIPTION
This is fix for Messaging to match change made to core here -> https://github.com/google/GoogleUtilities/pull/75

The fix is to avoid auth alerts (popups) on macOS when using Keychain.

Background: go/firebase-macos-keychain-popups
