### PR TITLE
Fix name collision with "result" in pretty printing logic in generated proto code.

### DIFF
--- a/Firestore/Protos/lib/pretty_printing.py
+++ b/Firestore/Protos/lib/pretty_printing.py
@@ -98,8 +98,8 @@ class MessagePrettyPrinting:
 
     result = '''\
 std::string %s::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "%s", this);
-    std::string result;\n\n''' % (
+    std::string tostring_header = PrintHeader(indent, "%s", this);
+    std::string tostring_result;\n\n''' % (
     self.full_classname, self._short_classname)
 
     for field in self._fields:
@@ -109,17 +109,17 @@ std::string %s::ToString(int indent) const {
     if can_be_empty:
       result += '''
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }\n\n'''
     else:
       result += '''
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }\n\n'''
 
     return result
@@ -276,7 +276,7 @@ class FieldPrettyPrinting:
       always_print: Whether to print the field if it has its default value.
     """
 
-    format_str = '%sresult += %s("%s ",%s%s, indent + 1, %s);\n'
+    format_str = '%stostring_result += %s("%s ",%s%s, indent + 1, %s);\n'
     for maybe_linebreak in [' ', '\n' + _indent(indent_level + 1)]:
       args = (
         _indent(indent_level), function_name, display_name, maybe_linebreak,

--- a/Firestore/Protos/nanopb/firestore/bundle.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/bundle.nanopb.cc
@@ -114,98 +114,106 @@ const char* EnumToString(
 }
 
 std::string firestore_BundledQuery::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BundledQuery", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BundledQuery", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
     switch (which_query_type) {
     case firestore_BundledQuery_structured_query_tag:
-        result += PrintMessageField("structured_query ",
+        tostring_result += PrintMessageField("structured_query ",
             structured_query, indent + 1, true);
         break;
     }
-    result += PrintEnumField("limit_type: ", limit_type, indent + 1, false);
+    tostring_result += PrintEnumField("limit_type: ",
+        limit_type, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string firestore_NamedQuery::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "NamedQuery", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "NamedQuery", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("bundled_query ",
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("bundled_query ",
         bundled_query, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_BundledDocumentMetadata::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BundledDocumentMetadata", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BundledDocumentMetadata", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
-    result += PrintPrimitiveField("exists: ", exists, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
+    tostring_result += PrintPrimitiveField("exists: ",
+        exists, indent + 1, false);
     for (pb_size_t i = 0; i != queries_count; ++i) {
-        result += PrintPrimitiveField("queries: ",
+        tostring_result += PrintPrimitiveField("queries: ",
             queries[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_BundleMetadata::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BundleMetadata", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BundleMetadata", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("id: ", id, indent + 1, false);
-    result += PrintMessageField("create_time ",
+    tostring_result += PrintPrimitiveField("id: ", id, indent + 1, false);
+    tostring_result += PrintMessageField("create_time ",
         create_time, indent + 1, false);
-    result += PrintPrimitiveField("version: ", version, indent + 1, false);
-    result += PrintPrimitiveField("total_documents: ",
+    tostring_result += PrintPrimitiveField("version: ",
+        version, indent + 1, false);
+    tostring_result += PrintPrimitiveField("total_documents: ",
         total_documents, indent + 1, false);
-    result += PrintPrimitiveField("total_bytes: ",
+    tostring_result += PrintPrimitiveField("total_bytes: ",
         total_bytes, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_BundleElement::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BundleElement", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BundleElement", this);
+    std::string tostring_result;
 
     switch (which_element_type) {
     case firestore_BundleElement_metadata_tag:
-        result += PrintMessageField("metadata ", metadata, indent + 1, true);
+        tostring_result += PrintMessageField("metadata ",
+            metadata, indent + 1, true);
         break;
     case firestore_BundleElement_named_query_tag:
-        result += PrintMessageField("named_query ",
+        tostring_result += PrintMessageField("named_query ",
             named_query, indent + 1, true);
         break;
     case firestore_BundleElement_document_metadata_tag:
-        result += PrintMessageField("document_metadata ",
+        tostring_result += PrintMessageField("document_metadata ",
             document_metadata, indent + 1, true);
         break;
     case firestore_BundleElement_document_tag:
-        result += PrintMessageField("document ", document, indent + 1, true);
+        tostring_result += PrintMessageField("document ",
+            document, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.cc
@@ -83,51 +83,54 @@ PB_STATIC_ASSERT((pb_membersize(firestore_client_NoDocument, read_time) < 256 &&
 
 
 std::string firestore_client_NoDocument::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "NoDocument", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "NoDocument", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_client_UnknownDocument::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "UnknownDocument", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "UnknownDocument", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("version ", version, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("version ",
+        version, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_client_MaybeDocument::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "MaybeDocument", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "MaybeDocument", this);
+    std::string tostring_result;
 
     switch (which_document_type) {
     case firestore_client_MaybeDocument_no_document_tag:
-        result += PrintMessageField("no_document ",
+        tostring_result += PrintMessageField("no_document ",
             no_document, indent + 1, true);
         break;
     case firestore_client_MaybeDocument_document_tag:
-        result += PrintMessageField("document ", document, indent + 1, true);
+        tostring_result += PrintMessageField("document ",
+            document, indent + 1, true);
         break;
     case firestore_client_MaybeDocument_unknown_document_tag:
-        result += PrintMessageField("unknown_document ",
+        tostring_result += PrintMessageField("unknown_document ",
             unknown_document, indent + 1, true);
         break;
     }
-    result += PrintPrimitiveField("has_committed_mutations: ",
+    tostring_result += PrintPrimitiveField("has_committed_mutations: ",
         has_committed_mutations, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.cc
@@ -77,40 +77,42 @@ PB_STATIC_ASSERT((pb_membersize(firestore_client_WriteBatch, local_write_time) <
 
 
 std::string firestore_client_MutationQueue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "MutationQueue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "MutationQueue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("last_acknowledged_batch_id: ",
+    tostring_result += PrintPrimitiveField("last_acknowledged_batch_id: ",
         last_acknowledged_batch_id, indent + 1, false);
-    result += PrintPrimitiveField("last_stream_token: ",
+    tostring_result += PrintPrimitiveField("last_stream_token: ",
         last_stream_token, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string firestore_client_WriteBatch::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "WriteBatch", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "WriteBatch", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("batch_id: ", batch_id, indent + 1, false);
+    tostring_result += PrintPrimitiveField("batch_id: ",
+        batch_id, indent + 1, false);
     for (pb_size_t i = 0; i != writes_count; ++i) {
-        result += PrintMessageField("writes ", writes[i], indent + 1, true);
+        tostring_result += PrintMessageField("writes ",
+            writes[i], indent + 1, true);
     }
-    result += PrintMessageField("local_write_time ",
+    tostring_result += PrintMessageField("local_write_time ",
         local_write_time, indent + 1, false);
     for (pb_size_t i = 0; i != base_writes_count; ++i) {
-        result += PrintMessageField("base_writes ",
+        tostring_result += PrintMessageField("base_writes ",
             base_writes[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 }  // namespace firestore

--- a/Firestore/Protos/nanopb/firestore/local/target.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/target.nanopb.cc
@@ -82,46 +82,49 @@ PB_STATIC_ASSERT((pb_membersize(firestore_client_Target, query) < 256 && pb_memb
 
 
 std::string firestore_client_Target::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Target", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Target", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("target_id: ", target_id, indent + 1, false);
-    result += PrintMessageField("snapshot_version ",
+    tostring_result += PrintPrimitiveField("target_id: ",
+        target_id, indent + 1, false);
+    tostring_result += PrintMessageField("snapshot_version ",
         snapshot_version, indent + 1, false);
-    result += PrintPrimitiveField("resume_token: ",
+    tostring_result += PrintPrimitiveField("resume_token: ",
         resume_token, indent + 1, false);
-    result += PrintPrimitiveField("last_listen_sequence_number: ",
+    tostring_result += PrintPrimitiveField("last_listen_sequence_number: ",
         last_listen_sequence_number, indent + 1, false);
     switch (which_target_type) {
     case firestore_client_Target_query_tag:
-        result += PrintMessageField("query ", query, indent + 1, true);
+        tostring_result += PrintMessageField("query ",
+            query, indent + 1, true);
         break;
     case firestore_client_Target_documents_tag:
-        result += PrintMessageField("documents ", documents, indent + 1, true);
+        tostring_result += PrintMessageField("documents ",
+            documents, indent + 1, true);
         break;
     }
-    result += PrintMessageField("last_limbo_free_snapshot_version ",
+    tostring_result += PrintMessageField("last_limbo_free_snapshot_version ",
         last_limbo_free_snapshot_version, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string firestore_client_TargetGlobal::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "TargetGlobal", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "TargetGlobal", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("highest_target_id: ",
+    tostring_result += PrintPrimitiveField("highest_target_id: ",
         highest_target_id, indent + 1, false);
-    result += PrintPrimitiveField("highest_listen_sequence_number: ",
+    tostring_result += PrintPrimitiveField("highest_listen_sequence_number: ",
         highest_listen_sequence_number, indent + 1, false);
-    result += PrintMessageField("last_remote_snapshot_version ",
+    tostring_result += PrintMessageField("last_remote_snapshot_version ",
         last_remote_snapshot_version, indent + 1, false);
-    result += PrintPrimitiveField("target_count: ",
+    tostring_result += PrintPrimitiveField("target_count: ",
         target_count, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 }  // namespace firestore

--- a/Firestore/Protos/nanopb/google/api/http.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/api/http.nanopb.cc
@@ -88,75 +88,81 @@ PB_STATIC_ASSERT((pb_membersize(google_api_HttpRule, custom) < 256), YOU_MUST_DE
 
 
 std::string google_api_Http::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Http", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Http", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != rules_count; ++i) {
-        result += PrintMessageField("rules ", rules[i], indent + 1, true);
+        tostring_result += PrintMessageField("rules ",
+            rules[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("fully_decode_reserved_expansion: ",
+    tostring_result += PrintPrimitiveField("fully_decode_reserved_expansion: ",
         fully_decode_reserved_expansion, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_api_HttpRule::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "HttpRule", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "HttpRule", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("selector: ", selector, indent + 1, false);
+    tostring_result += PrintPrimitiveField("selector: ",
+        selector, indent + 1, false);
     switch (which_pattern) {
     case google_api_HttpRule_get_tag:
-        result += PrintPrimitiveField("get: ", get, indent + 1, true);
+        tostring_result += PrintPrimitiveField("get: ", get, indent + 1, true);
         break;
     case google_api_HttpRule_put_tag:
-        result += PrintPrimitiveField("put: ", put, indent + 1, true);
+        tostring_result += PrintPrimitiveField("put: ", put, indent + 1, true);
         break;
     case google_api_HttpRule_post_tag:
-        result += PrintPrimitiveField("post: ", post, indent + 1, true);
+        tostring_result += PrintPrimitiveField("post: ",
+            post, indent + 1, true);
         break;
     case google_api_HttpRule_delete_tag:
-        result += PrintPrimitiveField("delete: ", delete_, indent + 1, true);
+        tostring_result += PrintPrimitiveField("delete: ",
+            delete_, indent + 1, true);
         break;
     case google_api_HttpRule_patch_tag:
-        result += PrintPrimitiveField("patch: ", patch, indent + 1, true);
+        tostring_result += PrintPrimitiveField("patch: ",
+            patch, indent + 1, true);
         break;
     case google_api_HttpRule_custom_tag:
-        result += PrintMessageField("custom ", custom, indent + 1, true);
+        tostring_result += PrintMessageField("custom ",
+            custom, indent + 1, true);
         break;
     }
-    result += PrintPrimitiveField("body: ", body, indent + 1, false);
+    tostring_result += PrintPrimitiveField("body: ", body, indent + 1, false);
     for (pb_size_t i = 0; i != additional_bindings_count; ++i) {
-        result += PrintMessageField("additional_bindings ",
+        tostring_result += PrintMessageField("additional_bindings ",
             additional_bindings[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_api_CustomHttpPattern::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CustomHttpPattern", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CustomHttpPattern", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("kind: ", kind, indent + 1, false);
-    result += PrintPrimitiveField("path: ", path, indent + 1, false);
+    tostring_result += PrintPrimitiveField("kind: ", kind, indent + 1, false);
+    tostring_result += PrintPrimitiveField("path: ", path, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/api/resource.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/api/resource.nanopb.cc
@@ -89,41 +89,43 @@ const char* EnumToString(
 }
 
 std::string google_api_ResourceDescriptor::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ResourceDescriptor", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ResourceDescriptor", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("type: ", type, indent + 1, false);
+    tostring_result += PrintPrimitiveField("type: ", type, indent + 1, false);
     for (pb_size_t i = 0; i != pattern_count; ++i) {
-        result += PrintPrimitiveField("pattern: ",
+        tostring_result += PrintPrimitiveField("pattern: ",
             pattern[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("name_field: ",
+    tostring_result += PrintPrimitiveField("name_field: ",
         name_field, indent + 1, false);
-    result += PrintEnumField("history: ", history, indent + 1, false);
-    result += PrintPrimitiveField("plural: ", plural, indent + 1, false);
-    result += PrintPrimitiveField("singular: ", singular, indent + 1, false);
+    tostring_result += PrintEnumField("history: ", history, indent + 1, false);
+    tostring_result += PrintPrimitiveField("plural: ",
+        plural, indent + 1, false);
+    tostring_result += PrintPrimitiveField("singular: ",
+        singular, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_api_ResourceReference::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ResourceReference", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ResourceReference", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("type: ", type, indent + 1, false);
-    result += PrintPrimitiveField("child_type: ",
+    tostring_result += PrintPrimitiveField("type: ", type, indent + 1, false);
+    tostring_result += PrintPrimitiveField("child_type: ",
         child_type, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.cc
@@ -110,45 +110,47 @@ const char* EnumToString(
 }
 
 std::string google_firestore_admin_v1_Index::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Index", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Index", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintEnumField("query_scope: ", query_scope, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintEnumField("query_scope: ",
+        query_scope, indent + 1, false);
     for (pb_size_t i = 0; i != fields_count; ++i) {
-        result += PrintMessageField("fields ", fields[i], indent + 1, true);
+        tostring_result += PrintMessageField("fields ",
+            fields[i], indent + 1, true);
     }
-    result += PrintEnumField("state: ", state, indent + 1, false);
+    tostring_result += PrintEnumField("state: ", state, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_admin_v1_Index_IndexField::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "IndexField", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "IndexField", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("field_path: ",
+    tostring_result += PrintPrimitiveField("field_path: ",
         field_path, indent + 1, false);
     switch (which_value_mode) {
     case google_firestore_admin_v1_Index_IndexField_order_tag:
-        result += PrintEnumField("order: ", order, indent + 1, true);
+        tostring_result += PrintEnumField("order: ", order, indent + 1, true);
         break;
     case google_firestore_admin_v1_Index_IndexField_array_config_tag:
-        result += PrintEnumField("array_config: ",
+        tostring_result += PrintEnumField("array_config: ",
             array_config, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.cc
@@ -90,99 +90,102 @@ PB_STATIC_ASSERT((pb_membersize(google_firestore_v1_Precondition, update_time) <
 
 
 std::string google_firestore_v1_DocumentMask::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentMask", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentMask", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != field_paths_count; ++i) {
-        result += PrintPrimitiveField("field_paths: ",
+        tostring_result += PrintPrimitiveField("field_paths: ",
             field_paths[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_Precondition::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Precondition", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Precondition", this);
+    std::string tostring_result;
 
     switch (which_condition_type) {
     case google_firestore_v1_Precondition_exists_tag:
-        result += PrintPrimitiveField("exists: ", exists, indent + 1, true);
+        tostring_result += PrintPrimitiveField("exists: ",
+            exists, indent + 1, true);
         break;
     case google_firestore_v1_Precondition_update_time_tag:
-        result += PrintMessageField("update_time ",
+        tostring_result += PrintMessageField("update_time ",
             update_time, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_TransactionOptions::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "TransactionOptions", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "TransactionOptions", this);
+    std::string tostring_result;
 
     switch (which_mode) {
     case google_firestore_v1_TransactionOptions_read_only_tag:
-        result += PrintMessageField("read_only ", read_only, indent + 1, true);
+        tostring_result += PrintMessageField("read_only ",
+            read_only, indent + 1, true);
         break;
     case google_firestore_v1_TransactionOptions_read_write_tag:
-        result += PrintMessageField("read_write ",
+        tostring_result += PrintMessageField("read_write ",
             read_write, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_TransactionOptions_ReadWrite::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ReadWrite", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ReadWrite", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("retry_transaction: ",
+    tostring_result += PrintPrimitiveField("retry_transaction: ",
         retry_transaction, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_TransactionOptions_ReadOnly::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ReadOnly", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ReadOnly", this);
+    std::string tostring_result;
 
     switch (which_consistency_selector) {
     case google_firestore_v1_TransactionOptions_ReadOnly_read_time_tag:
-        result += PrintMessageField("read_time ", read_time, indent + 1, true);
+        tostring_result += PrintMessageField("read_time ",
+            read_time, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.cc
@@ -114,136 +114,141 @@ PB_STATIC_ASSERT((pb_membersize(google_firestore_v1_Document, create_time) < 256
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 
 std::string google_firestore_v1_Document::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Document", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Document", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
     for (pb_size_t i = 0; i != fields_count; ++i) {
-        result += PrintMessageField("fields ", fields[i], indent + 1, true);
+        tostring_result += PrintMessageField("fields ",
+            fields[i], indent + 1, true);
     }
-    result += PrintMessageField("create_time ",
+    tostring_result += PrintMessageField("create_time ",
         create_time, indent + 1, false);
     if (has_update_time) {
-        result += PrintMessageField("update_time ",
+        tostring_result += PrintMessageField("update_time ",
             update_time, indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_Document_FieldsEntry::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldsEntry", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldsEntry", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("key: ", key, indent + 1, false);
-    result += PrintMessageField("value ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("key: ", key, indent + 1, false);
+    tostring_result += PrintMessageField("value ", value, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Value", this);
+    std::string tostring_result;
 
     switch (which_value_type) {
     case google_firestore_v1_Value_boolean_value_tag:
-        result += PrintPrimitiveField("boolean_value: ",
+        tostring_result += PrintPrimitiveField("boolean_value: ",
             boolean_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_integer_value_tag:
-        result += PrintPrimitiveField("integer_value: ",
+        tostring_result += PrintPrimitiveField("integer_value: ",
             integer_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_double_value_tag:
-        result += PrintPrimitiveField("double_value: ",
+        tostring_result += PrintPrimitiveField("double_value: ",
             double_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_reference_value_tag:
-        result += PrintPrimitiveField("reference_value: ",
+        tostring_result += PrintPrimitiveField("reference_value: ",
             reference_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_map_value_tag:
-        result += PrintMessageField("map_value ", map_value, indent + 1, true);
+        tostring_result += PrintMessageField("map_value ",
+            map_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_geo_point_value_tag:
-        result += PrintMessageField("geo_point_value ",
+        tostring_result += PrintMessageField("geo_point_value ",
             geo_point_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_array_value_tag:
-        result += PrintMessageField("array_value ",
+        tostring_result += PrintMessageField("array_value ",
             array_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_timestamp_value_tag:
-        result += PrintMessageField("timestamp_value ",
+        tostring_result += PrintMessageField("timestamp_value ",
             timestamp_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_null_value_tag:
-        result += PrintEnumField("null_value: ", null_value, indent + 1, true);
+        tostring_result += PrintEnumField("null_value: ",
+            null_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_string_value_tag:
-        result += PrintPrimitiveField("string_value: ",
+        tostring_result += PrintPrimitiveField("string_value: ",
             string_value, indent + 1, true);
         break;
     case google_firestore_v1_Value_bytes_value_tag:
-        result += PrintPrimitiveField("bytes_value: ",
+        tostring_result += PrintPrimitiveField("bytes_value: ",
             bytes_value, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_ArrayValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ArrayValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ArrayValue", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != values_count; ++i) {
-        result += PrintMessageField("values ", values[i], indent + 1, true);
+        tostring_result += PrintMessageField("values ",
+            values[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_MapValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "MapValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "MapValue", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != fields_count; ++i) {
-        result += PrintMessageField("fields ", fields[i], indent + 1, true);
+        tostring_result += PrintMessageField("fields ",
+            fields[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_MapValue_FieldsEntry::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldsEntry", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldsEntry", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("key: ", key, indent + 1, false);
-    result += PrintMessageField("value ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("key: ", key, indent + 1, false);
+    tostring_result += PrintMessageField("value ", value, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 }  // namespace firestore

--- a/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.cc
@@ -285,559 +285,596 @@ const char* EnumToString(
 }
 
 std::string google_firestore_v1_GetDocumentRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "GetDocumentRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "GetDocumentRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("mask ", mask, indent + 1, false);
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("mask ", mask, indent + 1, false);
     switch (which_consistency_selector) {
     case google_firestore_v1_GetDocumentRequest_transaction_tag:
-        result += PrintPrimitiveField("transaction: ",
+        tostring_result += PrintPrimitiveField("transaction: ",
             transaction, indent + 1, true);
         break;
     case google_firestore_v1_GetDocumentRequest_read_time_tag:
-        result += PrintMessageField("read_time ", read_time, indent + 1, true);
+        tostring_result += PrintMessageField("read_time ",
+            read_time, indent + 1, true);
         break;
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_ListDocumentsRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListDocumentsRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListDocumentsRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
-    result += PrintPrimitiveField("collection_id: ",
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("collection_id: ",
         collection_id, indent + 1, false);
-    result += PrintPrimitiveField("page_size: ", page_size, indent + 1, false);
-    result += PrintPrimitiveField("page_token: ",
+    tostring_result += PrintPrimitiveField("page_size: ",
+        page_size, indent + 1, false);
+    tostring_result += PrintPrimitiveField("page_token: ",
         page_token, indent + 1, false);
-    result += PrintPrimitiveField("order_by: ", order_by, indent + 1, false);
-    result += PrintMessageField("mask ", mask, indent + 1, false);
+    tostring_result += PrintPrimitiveField("order_by: ",
+        order_by, indent + 1, false);
+    tostring_result += PrintMessageField("mask ", mask, indent + 1, false);
     switch (which_consistency_selector) {
     case google_firestore_v1_ListDocumentsRequest_transaction_tag:
-        result += PrintPrimitiveField("transaction: ",
+        tostring_result += PrintPrimitiveField("transaction: ",
             transaction, indent + 1, true);
         break;
     case google_firestore_v1_ListDocumentsRequest_read_time_tag:
-        result += PrintMessageField("read_time ", read_time, indent + 1, true);
+        tostring_result += PrintMessageField("read_time ",
+            read_time, indent + 1, true);
         break;
     }
-    result += PrintPrimitiveField("show_missing: ",
+    tostring_result += PrintPrimitiveField("show_missing: ",
         show_missing, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_ListDocumentsResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListDocumentsResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListDocumentsResponse", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != documents_count; ++i) {
-        result += PrintMessageField("documents ",
+        tostring_result += PrintMessageField("documents ",
             documents[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("next_page_token: ",
+    tostring_result += PrintPrimitiveField("next_page_token: ",
         next_page_token, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_CreateDocumentRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CreateDocumentRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CreateDocumentRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
-    result += PrintPrimitiveField("collection_id: ",
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("collection_id: ",
         collection_id, indent + 1, false);
-    result += PrintPrimitiveField("document_id: ",
+    tostring_result += PrintPrimitiveField("document_id: ",
         document_id, indent + 1, false);
-    result += PrintMessageField("document ", document, indent + 1, false);
-    result += PrintMessageField("mask ", mask, indent + 1, false);
+    tostring_result += PrintMessageField("document ",
+        document, indent + 1, false);
+    tostring_result += PrintMessageField("mask ", mask, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_UpdateDocumentRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "UpdateDocumentRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "UpdateDocumentRequest", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("document ", document, indent + 1, false);
-    result += PrintMessageField("update_mask ",
+    tostring_result += PrintMessageField("document ",
+        document, indent + 1, false);
+    tostring_result += PrintMessageField("update_mask ",
         update_mask, indent + 1, false);
-    result += PrintMessageField("mask ", mask, indent + 1, false);
-    result += PrintMessageField("current_document ",
+    tostring_result += PrintMessageField("mask ", mask, indent + 1, false);
+    tostring_result += PrintMessageField("current_document ",
         current_document, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_DeleteDocumentRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DeleteDocumentRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DeleteDocumentRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("name: ", name, indent + 1, false);
-    result += PrintMessageField("current_document ",
+    tostring_result += PrintPrimitiveField("name: ", name, indent + 1, false);
+    tostring_result += PrintMessageField("current_document ",
         current_document, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_BatchGetDocumentsRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BatchGetDocumentsRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BatchGetDocumentsRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
     for (pb_size_t i = 0; i != documents_count; ++i) {
-        result += PrintPrimitiveField("documents: ",
+        tostring_result += PrintPrimitiveField("documents: ",
             documents[i], indent + 1, true);
     }
-    result += PrintMessageField("mask ", mask, indent + 1, false);
+    tostring_result += PrintMessageField("mask ", mask, indent + 1, false);
     switch (which_consistency_selector) {
     case google_firestore_v1_BatchGetDocumentsRequest_transaction_tag:
-        result += PrintPrimitiveField("transaction: ",
+        tostring_result += PrintPrimitiveField("transaction: ",
             transaction, indent + 1, true);
         break;
     case google_firestore_v1_BatchGetDocumentsRequest_new_transaction_tag:
-        result += PrintMessageField("new_transaction ",
+        tostring_result += PrintMessageField("new_transaction ",
             new_transaction, indent + 1, true);
         break;
     case google_firestore_v1_BatchGetDocumentsRequest_read_time_tag:
-        result += PrintMessageField("read_time ", read_time, indent + 1, true);
+        tostring_result += PrintMessageField("read_time ",
+            read_time, indent + 1, true);
         break;
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_BatchGetDocumentsResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BatchGetDocumentsResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BatchGetDocumentsResponse", this);
+    std::string tostring_result;
 
     switch (which_result) {
     case google_firestore_v1_BatchGetDocumentsResponse_found_tag:
-        result += PrintMessageField("found ", found, indent + 1, true);
+        tostring_result += PrintMessageField("found ",
+            found, indent + 1, true);
         break;
     case google_firestore_v1_BatchGetDocumentsResponse_missing_tag:
-        result += PrintPrimitiveField("missing: ", missing, indent + 1, true);
+        tostring_result += PrintPrimitiveField("missing: ",
+            missing, indent + 1, true);
         break;
     }
-    result += PrintPrimitiveField("transaction: ",
+    tostring_result += PrintPrimitiveField("transaction: ",
         transaction, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_BeginTransactionRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BeginTransactionRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BeginTransactionRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
-    result += PrintMessageField("options ", options, indent + 1, false);
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
+    tostring_result += PrintMessageField("options ",
+        options, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_BeginTransactionResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BeginTransactionResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BeginTransactionResponse", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("transaction: ",
+    tostring_result += PrintPrimitiveField("transaction: ",
         transaction, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_CommitRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CommitRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CommitRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
     for (pb_size_t i = 0; i != writes_count; ++i) {
-        result += PrintMessageField("writes ", writes[i], indent + 1, true);
+        tostring_result += PrintMessageField("writes ",
+            writes[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("transaction: ",
+    tostring_result += PrintPrimitiveField("transaction: ",
         transaction, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_CommitResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CommitResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CommitResponse", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != write_results_count; ++i) {
-        result += PrintMessageField("write_results ",
+        tostring_result += PrintMessageField("write_results ",
             write_results[i], indent + 1, true);
     }
-    result += PrintMessageField("commit_time ",
+    tostring_result += PrintMessageField("commit_time ",
         commit_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_RollbackRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "RollbackRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "RollbackRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
-    result += PrintPrimitiveField("transaction: ",
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
+    tostring_result += PrintPrimitiveField("transaction: ",
         transaction, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_RunQueryRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "RunQueryRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "RunQueryRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
     switch (which_query_type) {
     case google_firestore_v1_RunQueryRequest_structured_query_tag:
-        result += PrintMessageField("structured_query ",
+        tostring_result += PrintMessageField("structured_query ",
             query_type.structured_query, indent + 1, true);
         break;
     }
     switch (which_consistency_selector) {
     case google_firestore_v1_RunQueryRequest_transaction_tag:
-        result += PrintPrimitiveField("transaction: ",
+        tostring_result += PrintPrimitiveField("transaction: ",
             consistency_selector.transaction, indent + 1, true);
         break;
     case google_firestore_v1_RunQueryRequest_new_transaction_tag:
-        result += PrintMessageField("new_transaction ",
+        tostring_result += PrintMessageField("new_transaction ",
             consistency_selector.new_transaction, indent + 1, true);
         break;
     case google_firestore_v1_RunQueryRequest_read_time_tag:
-        result += PrintMessageField("read_time ",
+        tostring_result += PrintMessageField("read_time ",
             consistency_selector.read_time, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_RunQueryResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "RunQueryResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "RunQueryResponse", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("document ", document, indent + 1, false);
-    result += PrintPrimitiveField("transaction: ",
+    tostring_result += PrintMessageField("document ",
+        document, indent + 1, false);
+    tostring_result += PrintPrimitiveField("transaction: ",
         transaction, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
-    result += PrintPrimitiveField("skipped_results: ",
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
+    tostring_result += PrintPrimitiveField("skipped_results: ",
         skipped_results, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_WriteRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "WriteRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "WriteRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
-    result += PrintPrimitiveField("stream_id: ", stream_id, indent + 1, false);
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
+    tostring_result += PrintPrimitiveField("stream_id: ",
+        stream_id, indent + 1, false);
     for (pb_size_t i = 0; i != writes_count; ++i) {
-        result += PrintMessageField("writes ", writes[i], indent + 1, true);
+        tostring_result += PrintMessageField("writes ",
+            writes[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("stream_token: ",
+    tostring_result += PrintPrimitiveField("stream_token: ",
         stream_token, indent + 1, false);
     for (pb_size_t i = 0; i != labels_count; ++i) {
-        result += PrintMessageField("labels ", labels[i], indent + 1, true);
+        tostring_result += PrintMessageField("labels ",
+            labels[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_WriteRequest_LabelsEntry::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "LabelsEntry", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "LabelsEntry", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("key: ", key, indent + 1, false);
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("key: ", key, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_WriteResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "WriteResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "WriteResponse", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("stream_id: ", stream_id, indent + 1, false);
-    result += PrintPrimitiveField("stream_token: ",
+    tostring_result += PrintPrimitiveField("stream_id: ",
+        stream_id, indent + 1, false);
+    tostring_result += PrintPrimitiveField("stream_token: ",
         stream_token, indent + 1, false);
     for (pb_size_t i = 0; i != write_results_count; ++i) {
-        result += PrintMessageField("write_results ",
+        tostring_result += PrintMessageField("write_results ",
             write_results[i], indent + 1, true);
     }
-    result += PrintMessageField("commit_time ",
+    tostring_result += PrintMessageField("commit_time ",
         commit_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_ListenRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListenRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListenRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("database: ", database, indent + 1, false);
+    tostring_result += PrintPrimitiveField("database: ",
+        database, indent + 1, false);
     switch (which_target_change) {
     case google_firestore_v1_ListenRequest_add_target_tag:
-        result += PrintMessageField("add_target ",
+        tostring_result += PrintMessageField("add_target ",
             add_target, indent + 1, true);
         break;
     case google_firestore_v1_ListenRequest_remove_target_tag:
-        result += PrintPrimitiveField("remove_target: ",
+        tostring_result += PrintPrimitiveField("remove_target: ",
             remove_target, indent + 1, true);
         break;
     }
     for (pb_size_t i = 0; i != labels_count; ++i) {
-        result += PrintMessageField("labels ", labels[i], indent + 1, true);
+        tostring_result += PrintMessageField("labels ",
+            labels[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_ListenRequest_LabelsEntry::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "LabelsEntry", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "LabelsEntry", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("key: ", key, indent + 1, false);
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("key: ", key, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_ListenResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListenResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListenResponse", this);
+    std::string tostring_result;
 
     switch (which_response_type) {
     case google_firestore_v1_ListenResponse_target_change_tag:
-        result += PrintMessageField("target_change ",
+        tostring_result += PrintMessageField("target_change ",
             target_change, indent + 1, true);
         break;
     case google_firestore_v1_ListenResponse_document_change_tag:
-        result += PrintMessageField("document_change ",
+        tostring_result += PrintMessageField("document_change ",
             document_change, indent + 1, true);
         break;
     case google_firestore_v1_ListenResponse_document_delete_tag:
-        result += PrintMessageField("document_delete ",
+        tostring_result += PrintMessageField("document_delete ",
             document_delete, indent + 1, true);
         break;
     case google_firestore_v1_ListenResponse_filter_tag:
-        result += PrintMessageField("filter ", filter, indent + 1, true);
+        tostring_result += PrintMessageField("filter ",
+            filter, indent + 1, true);
         break;
     case google_firestore_v1_ListenResponse_document_remove_tag:
-        result += PrintMessageField("document_remove ",
+        tostring_result += PrintMessageField("document_remove ",
             document_remove, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_Target::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Target", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Target", this);
+    std::string tostring_result;
 
     switch (which_target_type) {
     case google_firestore_v1_Target_query_tag:
-        result += PrintMessageField("query ",
+        tostring_result += PrintMessageField("query ",
             target_type.query, indent + 1, true);
         break;
     case google_firestore_v1_Target_documents_tag:
-        result += PrintMessageField("documents ",
+        tostring_result += PrintMessageField("documents ",
             target_type.documents, indent + 1, true);
         break;
     }
     switch (which_resume_type) {
     case google_firestore_v1_Target_resume_token_tag:
-        result += PrintPrimitiveField("resume_token: ",
+        tostring_result += PrintPrimitiveField("resume_token: ",
             resume_type.resume_token, indent + 1, true);
         break;
     case google_firestore_v1_Target_read_time_tag:
-        result += PrintMessageField("read_time ",
+        tostring_result += PrintMessageField("read_time ",
             resume_type.read_time, indent + 1, true);
         break;
     }
-    result += PrintPrimitiveField("target_id: ", target_id, indent + 1, false);
-    result += PrintPrimitiveField("once: ", once, indent + 1, false);
+    tostring_result += PrintPrimitiveField("target_id: ",
+        target_id, indent + 1, false);
+    tostring_result += PrintPrimitiveField("once: ", once, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_Target_DocumentsTarget::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentsTarget", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentsTarget", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != documents_count; ++i) {
-        result += PrintPrimitiveField("documents: ",
+        tostring_result += PrintPrimitiveField("documents: ",
             documents[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_Target_QueryTarget::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "QueryTarget", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "QueryTarget", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
     switch (which_query_type) {
     case google_firestore_v1_Target_QueryTarget_structured_query_tag:
-        result += PrintMessageField("structured_query ",
+        tostring_result += PrintMessageField("structured_query ",
             structured_query, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_TargetChange::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "TargetChange", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "TargetChange", this);
+    std::string tostring_result;
 
-    result += PrintEnumField("target_change_type: ",
+    tostring_result += PrintEnumField("target_change_type: ",
         target_change_type, indent + 1, false);
     for (pb_size_t i = 0; i != target_ids_count; ++i) {
-        result += PrintPrimitiveField("target_ids: ",
+        tostring_result += PrintPrimitiveField("target_ids: ",
             target_ids[i], indent + 1, true);
     }
     if (has_cause) {
-        result += PrintMessageField("cause ", cause, indent + 1, true);
+        tostring_result += PrintMessageField("cause ",
+            cause, indent + 1, true);
     }
-    result += PrintPrimitiveField("resume_token: ",
+    tostring_result += PrintPrimitiveField("resume_token: ",
         resume_token, indent + 1, false);
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_ListCollectionIdsRequest::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListCollectionIdsRequest", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListCollectionIdsRequest", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("parent: ", parent, indent + 1, false);
-    result += PrintPrimitiveField("page_size: ", page_size, indent + 1, false);
-    result += PrintPrimitiveField("page_token: ",
+    tostring_result += PrintPrimitiveField("parent: ",
+        parent, indent + 1, false);
+    tostring_result += PrintPrimitiveField("page_size: ",
+        page_size, indent + 1, false);
+    tostring_result += PrintPrimitiveField("page_token: ",
         page_token, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_ListCollectionIdsResponse::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListCollectionIdsResponse", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListCollectionIdsResponse", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != collection_ids_count; ++i) {
-        result += PrintPrimitiveField("collection_ids: ",
+        tostring_result += PrintPrimitiveField("collection_ids: ",
             collection_ids[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("next_page_token: ",
+    tostring_result += PrintPrimitiveField("next_page_token: ",
         next_page_token, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.cc
@@ -203,182 +203,192 @@ const char* EnumToString(
 }
 
 std::string google_firestore_v1_StructuredQuery::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "StructuredQuery", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "StructuredQuery", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("select ", select, indent + 1, false);
+    tostring_result += PrintMessageField("select ", select, indent + 1, false);
     for (pb_size_t i = 0; i != from_count; ++i) {
-        result += PrintMessageField("from ", from[i], indent + 1, true);
+        tostring_result += PrintMessageField("from ",
+            from[i], indent + 1, true);
     }
-    result += PrintMessageField("where ", where, indent + 1, false);
+    tostring_result += PrintMessageField("where ", where, indent + 1, false);
     for (pb_size_t i = 0; i != order_by_count; ++i) {
-        result += PrintMessageField("order_by ",
+        tostring_result += PrintMessageField("order_by ",
             order_by[i], indent + 1, true);
     }
     if (has_limit) {
-        result += PrintMessageField("limit ", limit, indent + 1, true);
+        tostring_result += PrintMessageField("limit ",
+            limit, indent + 1, true);
     }
-    result += PrintPrimitiveField("offset: ", offset, indent + 1, false);
-    result += PrintMessageField("start_at ", start_at, indent + 1, false);
-    result += PrintMessageField("end_at ", end_at, indent + 1, false);
+    tostring_result += PrintPrimitiveField("offset: ",
+        offset, indent + 1, false);
+    tostring_result += PrintMessageField("start_at ",
+        start_at, indent + 1, false);
+    tostring_result += PrintMessageField("end_at ", end_at, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_StructuredQuery_CollectionSelector::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CollectionSelector", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CollectionSelector", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("collection_id: ",
+    tostring_result += PrintPrimitiveField("collection_id: ",
         collection_id, indent + 1, false);
-    result += PrintPrimitiveField("all_descendants: ",
+    tostring_result += PrintPrimitiveField("all_descendants: ",
         all_descendants, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_StructuredQuery_Filter::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Filter", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Filter", this);
+    std::string tostring_result;
 
     switch (which_filter_type) {
     case google_firestore_v1_StructuredQuery_Filter_composite_filter_tag:
-        result += PrintMessageField("composite_filter ",
+        tostring_result += PrintMessageField("composite_filter ",
             composite_filter, indent + 1, true);
         break;
     case google_firestore_v1_StructuredQuery_Filter_field_filter_tag:
-        result += PrintMessageField("field_filter ",
+        tostring_result += PrintMessageField("field_filter ",
             field_filter, indent + 1, true);
         break;
     case google_firestore_v1_StructuredQuery_Filter_unary_filter_tag:
-        result += PrintMessageField("unary_filter ",
+        tostring_result += PrintMessageField("unary_filter ",
             unary_filter, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_StructuredQuery_CompositeFilter::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "CompositeFilter", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "CompositeFilter", this);
+    std::string tostring_result;
 
-    result += PrintEnumField("op: ", op, indent + 1, false);
+    tostring_result += PrintEnumField("op: ", op, indent + 1, false);
     for (pb_size_t i = 0; i != filters_count; ++i) {
-        result += PrintMessageField("filters ", filters[i], indent + 1, true);
+        tostring_result += PrintMessageField("filters ",
+            filters[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_StructuredQuery_FieldFilter::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldFilter", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldFilter", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("field ", field, indent + 1, false);
-    result += PrintEnumField("op: ", op, indent + 1, false);
-    result += PrintMessageField("value ", value, indent + 1, false);
+    tostring_result += PrintMessageField("field ", field, indent + 1, false);
+    tostring_result += PrintEnumField("op: ", op, indent + 1, false);
+    tostring_result += PrintMessageField("value ", value, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_StructuredQuery_UnaryFilter::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "UnaryFilter", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "UnaryFilter", this);
+    std::string tostring_result;
 
-    result += PrintEnumField("op: ", op, indent + 1, false);
+    tostring_result += PrintEnumField("op: ", op, indent + 1, false);
     switch (which_operand_type) {
     case google_firestore_v1_StructuredQuery_UnaryFilter_field_tag:
-        result += PrintMessageField("field ", field, indent + 1, true);
+        tostring_result += PrintMessageField("field ",
+            field, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_StructuredQuery_Order::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Order", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Order", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("field ", field, indent + 1, false);
-    result += PrintEnumField("direction: ", direction, indent + 1, false);
+    tostring_result += PrintMessageField("field ", field, indent + 1, false);
+    tostring_result += PrintEnumField("direction: ",
+        direction, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_StructuredQuery_FieldReference::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldReference", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldReference", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("field_path: ",
+    tostring_result += PrintPrimitiveField("field_path: ",
         field_path, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_StructuredQuery_Projection::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Projection", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Projection", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != fields_count; ++i) {
-        result += PrintMessageField("fields ", fields[i], indent + 1, true);
+        tostring_result += PrintMessageField("fields ",
+            fields[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_Cursor::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Cursor", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Cursor", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != values_count; ++i) {
-        result += PrintMessageField("values ", values[i], indent + 1, true);
+        tostring_result += PrintMessageField("values ",
+            values[i], indent + 1, true);
     }
-    result += PrintPrimitiveField("before: ", before, indent + 1, false);
+    tostring_result += PrintPrimitiveField("before: ",
+        before, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.cc
@@ -136,176 +136,191 @@ const char* EnumToString(
 }
 
 std::string google_firestore_v1_Write::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Write", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Write", this);
+    std::string tostring_result;
 
     switch (which_operation) {
     case google_firestore_v1_Write_update_tag:
-        result += PrintMessageField("update ", update, indent + 1, true);
+        tostring_result += PrintMessageField("update ",
+            update, indent + 1, true);
         break;
     case google_firestore_v1_Write_delete_tag:
-        result += PrintPrimitiveField("delete: ", delete_, indent + 1, true);
+        tostring_result += PrintPrimitiveField("delete: ",
+            delete_, indent + 1, true);
         break;
     case google_firestore_v1_Write_verify_tag:
-        result += PrintPrimitiveField("verify: ", verify, indent + 1, true);
+        tostring_result += PrintPrimitiveField("verify: ",
+            verify, indent + 1, true);
         break;
     case google_firestore_v1_Write_transform_tag:
-        result += PrintMessageField("transform ", transform, indent + 1, true);
+        tostring_result += PrintMessageField("transform ",
+            transform, indent + 1, true);
         break;
     }
     if (has_update_mask) {
-        result += PrintMessageField("update_mask ",
+        tostring_result += PrintMessageField("update_mask ",
             update_mask, indent + 1, true);
     }
     if (has_current_document) {
-        result += PrintMessageField("current_document ",
+        tostring_result += PrintMessageField("current_document ",
             current_document, indent + 1, true);
     }
     for (pb_size_t i = 0; i != update_transforms_count; ++i) {
-        result += PrintMessageField("update_transforms ",
+        tostring_result += PrintMessageField("update_transforms ",
             update_transforms[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_DocumentTransform::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentTransform", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentTransform", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("document: ", document, indent + 1, false);
+    tostring_result += PrintPrimitiveField("document: ",
+        document, indent + 1, false);
     for (pb_size_t i = 0; i != field_transforms_count; ++i) {
-        result += PrintMessageField("field_transforms ",
+        tostring_result += PrintMessageField("field_transforms ",
             field_transforms[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_DocumentTransform_FieldTransform::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldTransform", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldTransform", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("field_path: ",
+    tostring_result += PrintPrimitiveField("field_path: ",
         field_path, indent + 1, false);
     switch (which_transform_type) {
     case google_firestore_v1_DocumentTransform_FieldTransform_set_to_server_value_tag:
-        result += PrintEnumField("set_to_server_value: ",
+        tostring_result += PrintEnumField("set_to_server_value: ",
             set_to_server_value, indent + 1, true);
         break;
     case google_firestore_v1_DocumentTransform_FieldTransform_increment_tag:
-        result += PrintMessageField("increment ", increment, indent + 1, true);
+        tostring_result += PrintMessageField("increment ",
+            increment, indent + 1, true);
         break;
     case google_firestore_v1_DocumentTransform_FieldTransform_maximum_tag:
-        result += PrintMessageField("maximum ", maximum, indent + 1, true);
+        tostring_result += PrintMessageField("maximum ",
+            maximum, indent + 1, true);
         break;
     case google_firestore_v1_DocumentTransform_FieldTransform_minimum_tag:
-        result += PrintMessageField("minimum ", minimum, indent + 1, true);
+        tostring_result += PrintMessageField("minimum ",
+            minimum, indent + 1, true);
         break;
     case google_firestore_v1_DocumentTransform_FieldTransform_append_missing_elements_tag:
-        result += PrintMessageField("append_missing_elements ",
+        tostring_result += PrintMessageField("append_missing_elements ",
             append_missing_elements, indent + 1, true);
         break;
     case google_firestore_v1_DocumentTransform_FieldTransform_remove_all_from_array_tag:
-        result += PrintMessageField("remove_all_from_array ",
+        tostring_result += PrintMessageField("remove_all_from_array ",
             remove_all_from_array, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_firestore_v1_WriteResult::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "WriteResult", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "WriteResult", this);
+    std::string tostring_result;
 
     if (has_update_time) {
-        result += PrintMessageField("update_time ",
+        tostring_result += PrintMessageField("update_time ",
             update_time, indent + 1, true);
     }
     for (pb_size_t i = 0; i != transform_results_count; ++i) {
-        result += PrintMessageField("transform_results ",
+        tostring_result += PrintMessageField("transform_results ",
             transform_results[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_DocumentChange::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentChange", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentChange", this);
+    std::string tostring_result;
 
-    result += PrintMessageField("document ", document, indent + 1, false);
+    tostring_result += PrintMessageField("document ",
+        document, indent + 1, false);
     for (pb_size_t i = 0; i != target_ids_count; ++i) {
-        result += PrintPrimitiveField("target_ids: ",
+        tostring_result += PrintPrimitiveField("target_ids: ",
             target_ids[i], indent + 1, true);
     }
     for (pb_size_t i = 0; i != removed_target_ids_count; ++i) {
-        result += PrintPrimitiveField("removed_target_ids: ",
+        tostring_result += PrintPrimitiveField("removed_target_ids: ",
             removed_target_ids[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_DocumentDelete::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentDelete", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentDelete", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("document: ", document, indent + 1, false);
+    tostring_result += PrintPrimitiveField("document: ",
+        document, indent + 1, false);
     if (has_read_time) {
-        result += PrintMessageField("read_time ", read_time, indent + 1, true);
+        tostring_result += PrintMessageField("read_time ",
+            read_time, indent + 1, true);
     }
     for (pb_size_t i = 0; i != removed_target_ids_count; ++i) {
-        result += PrintPrimitiveField("removed_target_ids: ",
+        tostring_result += PrintPrimitiveField("removed_target_ids: ",
             removed_target_ids[i], indent + 1, true);
     }
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_DocumentRemove::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DocumentRemove", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DocumentRemove", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("document: ", document, indent + 1, false);
+    tostring_result += PrintPrimitiveField("document: ",
+        document, indent + 1, false);
     for (pb_size_t i = 0; i != removed_target_ids_count; ++i) {
-        result += PrintPrimitiveField("removed_target_ids: ",
+        tostring_result += PrintPrimitiveField("removed_target_ids: ",
             removed_target_ids[i], indent + 1, true);
     }
-    result += PrintMessageField("read_time ", read_time, indent + 1, false);
+    tostring_result += PrintMessageField("read_time ",
+        read_time, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_firestore_v1_ExistenceFilter::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ExistenceFilter", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ExistenceFilter", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("target_id: ", target_id, indent + 1, false);
-    result += PrintPrimitiveField("count: ", count, indent + 1, false);
+    tostring_result += PrintPrimitiveField("target_id: ",
+        target_id, indent + 1, false);
+    tostring_result += PrintPrimitiveField("count: ",
+        count, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/protobuf/any.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/any.nanopb.cc
@@ -45,16 +45,18 @@ const pb_field_t google_protobuf_Any_fields[3] = {
 
 
 std::string google_protobuf_Any::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Any", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Any", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("type_url: ", type_url, indent + 1, false);
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("type_url: ",
+        type_url, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.cc
@@ -43,14 +43,14 @@ const pb_field_t google_protobuf_Empty_fields[1] = {
 
 
 std::string google_protobuf_Empty::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Empty", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Empty", this);
+    std::string tostring_result;
 
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.cc
@@ -105,84 +105,87 @@ const char* EnumToString(
 }
 
 std::string google_protobuf_Struct::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Struct", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Struct", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != fields_count; ++i) {
-        result += PrintMessageField("fields ", fields[i], indent + 1, true);
+        tostring_result += PrintMessageField("fields ",
+            fields[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_Struct_FieldsEntry::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FieldsEntry", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FieldsEntry", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("key: ", key, indent + 1, false);
-    result += PrintMessageField("value ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("key: ", key, indent + 1, false);
+    tostring_result += PrintMessageField("value ", value, indent + 1, false);
 
-    std::string tail = PrintTail(indent);
-    return header + result + tail;
+    std::string tostring_tail = PrintTail(indent);
+    return tostring_header + tostring_result + tostring_tail;
 }
 
 std::string google_protobuf_Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Value", this);
+    std::string tostring_result;
 
     switch (which_kind) {
     case google_protobuf_Value_null_value_tag:
-        result += PrintEnumField("null_value: ", null_value, indent + 1, true);
+        tostring_result += PrintEnumField("null_value: ",
+            null_value, indent + 1, true);
         break;
     case google_protobuf_Value_number_value_tag:
-        result += PrintPrimitiveField("number_value: ",
+        tostring_result += PrintPrimitiveField("number_value: ",
             number_value, indent + 1, true);
         break;
     case google_protobuf_Value_string_value_tag:
-        result += PrintPrimitiveField("string_value: ",
+        tostring_result += PrintPrimitiveField("string_value: ",
             string_value, indent + 1, true);
         break;
     case google_protobuf_Value_bool_value_tag:
-        result += PrintPrimitiveField("bool_value: ",
+        tostring_result += PrintPrimitiveField("bool_value: ",
             bool_value, indent + 1, true);
         break;
     case google_protobuf_Value_struct_value_tag:
-        result += PrintMessageField("struct_value ",
+        tostring_result += PrintMessageField("struct_value ",
             struct_value, indent + 1, true);
         break;
     case google_protobuf_Value_list_value_tag:
-        result += PrintMessageField("list_value ",
+        tostring_result += PrintMessageField("list_value ",
             list_value, indent + 1, true);
         break;
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_ListValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "ListValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "ListValue", this);
+    std::string tostring_result;
 
     for (pb_size_t i = 0; i != values_count; ++i) {
-        result += PrintMessageField("values ", values[i], indent + 1, true);
+        tostring_result += PrintMessageField("values ",
+            values[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.cc
@@ -45,16 +45,18 @@ const pb_field_t google_protobuf_Timestamp_fields[3] = {
 
 
 std::string google_protobuf_Timestamp::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Timestamp", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Timestamp", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("seconds: ", seconds, indent + 1, false);
-    result += PrintPrimitiveField("nanos: ", nanos, indent + 1, false);
+    tostring_result += PrintPrimitiveField("seconds: ",
+        seconds, indent + 1, false);
+    tostring_result += PrintPrimitiveField("nanos: ",
+        nanos, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.cc
@@ -90,135 +90,144 @@ const pb_field_t google_protobuf_BytesValue_fields[2] = {
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 
 std::string google_protobuf_DoubleValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "DoubleValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "DoubleValue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_FloatValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "FloatValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "FloatValue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_Int64Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Int64Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Int64Value", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_UInt64Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "UInt64Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "UInt64Value", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_Int32Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Int32Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Int32Value", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_UInt32Value::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "UInt32Value", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "UInt32Value", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_BoolValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BoolValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BoolValue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_StringValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "StringValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "StringValue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }
 }
 
 std::string google_protobuf_BytesValue::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "BytesValue", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "BytesValue", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("value: ", value, indent + 1, false);
+    tostring_result += PrintPrimitiveField("value: ",
+        value, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/rpc/status.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/rpc/status.nanopb.cc
@@ -46,19 +46,21 @@ const pb_field_t google_rpc_Status_fields[4] = {
 
 
 std::string google_rpc_Status::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "Status", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "Status", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("code: ", code, indent + 1, false);
-    result += PrintPrimitiveField("message: ", message, indent + 1, false);
+    tostring_result += PrintPrimitiveField("code: ", code, indent + 1, false);
+    tostring_result += PrintPrimitiveField("message: ",
+        message, indent + 1, false);
     for (pb_size_t i = 0; i != details_count; ++i) {
-        result += PrintMessageField("details ", details[i], indent + 1, true);
+        tostring_result += PrintMessageField("details ",
+            details[i], indent + 1, true);
     }
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }

--- a/Firestore/Protos/nanopb/google/type/latlng.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/type/latlng.nanopb.cc
@@ -51,16 +51,18 @@ const pb_field_t google_type_LatLng_fields[3] = {
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 
 std::string google_type_LatLng::ToString(int indent) const {
-    std::string header = PrintHeader(indent, "LatLng", this);
-    std::string result;
+    std::string tostring_header = PrintHeader(indent, "LatLng", this);
+    std::string tostring_result;
 
-    result += PrintPrimitiveField("latitude: ", latitude, indent + 1, false);
-    result += PrintPrimitiveField("longitude: ", longitude, indent + 1, false);
+    tostring_result += PrintPrimitiveField("latitude: ",
+        latitude, indent + 1, false);
+    tostring_result += PrintPrimitiveField("longitude: ",
+        longitude, indent + 1, false);
 
     bool is_root = indent == 0;
-    if (!result.empty() || is_root) {
-      std::string tail = PrintTail(indent);
-      return header + result + tail;
+    if (!tostring_result.empty() || is_root) {
+      std::string tostring_tail = PrintTail(indent);
+      return tostring_header + tostring_result + tostring_tail;
     } else {
       return "";
     }


### PR DESCRIPTION
When generating the C++ code from the .proto files, it was discovered that if a proto message happens to have a field named "result", "header", or "tail" then the generated C++ code would fail to compile with an error like this:

```
In file included from firestore.nanopb.cc:22:
pretty_printing.h: In instantiation of ‘std::string firebase::firestore::nanopb::PrintMessageField(...)’:
firestore.nanopb.cc:630:32:   required from here
pretty_printing.h:59:25: error: ‘const class std::__cxx11::basic_string<char>’ has no member named ‘ToString’
   59 |   auto contents = value.ToString(indent_level);
      |                   ~~~~~~^~~~~~~~
```

The root cause was that the ToString() methods defined local variables named "result", "header", and "tail" which would collide with other local variable names created for the proto messages' fields if they were also coincidentally named "result", "header", or "tail".

The fix in this PR changes those local variable names to "tostring_result", "tostring_header", and "tostring_tail", respectively, to avoid such naming conflicts in the future. Admittedly, if a future proto message happens to have a field named "tostring_result", for example, then this problem will resurface; however, that seems like an unlikely scenario and we'll deal with that if it ever happens.

When reviewing this PR, the only file that was modified by hand was `Firestore/Protos/lib/pretty_printing.py`; all of the other changes in this PR are the regenerated C++ code from the .proto files.

#no-changelog