### PR TITLE
firestore_client.cc: increase the kRegularBackfillDelay from 1ms to 1000ms

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [added] Expose client side indexing feature with `FIRFirestore.setIndexConfigurationFromJSON` and
   `FIRFirestore.setIndexConfigurationFromStream` (#10090).
+- [fixed] Fixed high CPU usage whenever Firestore was in use (#10168).
 
 # 9.5.0
 - [fixed] Fixed an intermittent crash if `ListenerRegistration::Remove()` was

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -113,7 +113,7 @@ static const auto kRegularGCDelay = std::chrono::minutes(5);
 /** How long we wait to try running index backfill after SDK initialization. */
 static const auto kInitialBackfillDelay = std::chrono::milliseconds(15);
 /** Minimum amount of time between backfill checks, after the first one. */
-static const auto kRegularBackfillDelay = std::chrono::milliseconds(1);
+static const auto kRegularBackfillDelay = std::chrono::milliseconds(1000);
 
 }  // namespace
 


### PR DESCRIPTION
Fix CPU thrashing from the index backfiller, which was being scheduled for execution every 1ms. The fix in this PR is to increase the scheduling period to 1000ms.

This also works around an intermittent crash on Firestore's shutdown, which cause the integration tests in the firebase-cpp-sdk to crash.

This bug was introduced in 9.5.0 by https://github.com/firebase/firebase-ios-sdk/pull/10021.

Googlers see b/244656664 for details.

Fixes #10168