### PR TITLE
[CoreInternal] Add explicit generics typing for Array.Index usage (2)

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Firebase 9.6.0
+- [fixed] Fixed `Array.Index`-related compile time errors when building with older Swift versions. (#10171)
 - [fixed] Update dependency specification for GTMSessionFetcher to allow all 2.x versions. (#10131)
 
 # Firebase 9.5.0

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
@@ -103,12 +103,14 @@ public final class HeartbeatController {
       )
     }
 
-    // Synchronously gets and returns the stored heartbeats, resetting storage
-    // using the given transform. If the operation throws, assume no
-    // heartbeat(s) were retrieved or set.
-    if let heartbeatsBundle = try? storage.getAndSet(using: resetTransform) {
-      return heartbeatsBundle.makeHeartbeatsPayload()
-    } else {
+    do {
+      // Synchronously gets and returns the stored heartbeats, resetting storage
+      // using the given transform.
+      let heartbeatsBundle = try storage.getAndSet(using: resetTransform)
+      // If no heartbeats bundle was stored, return an empty payload.
+      return heartbeatsBundle?.makeHeartbeatsPayload() ?? HeartbeatsPayload.emptyPayload
+    } catch {
+      // If the operation throws, assume no heartbeat(s) were retrieved or set.
       return HeartbeatsPayload.emptyPayload
     }
   }

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsBundle.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsBundle.swift
@@ -72,7 +72,7 @@ struct HeartbeatsBundle: Codable, HeartbeatsPayloadConvertible {
         lastAddedHeartbeatDates[$0] = heartbeat.date
       }
 
-    } catch let error as RingBufferError {
+    } catch let error as RingBuffer<Heartbeat>.Error {
       // A ring buffer error occurred while pushing to the buffer so the bundle
       // is reset.
       self = HeartbeatsBundle(capacity: capacity)

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/RingBuffer.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/RingBuffer.swift
@@ -14,25 +14,25 @@
 
 import Foundation
 
-/// Error types for `RingBuffer` operations.
-enum RingBufferError: LocalizedError {
-  case outOfBoundsPush(pushIndex: Array.Index, endIndex: Array.Index)
-
-  var errorDescription: String {
-    switch self {
-    case let .outOfBoundsPush(pushIndex, endIndex):
-      return "Out-of-bounds push at index \(pushIndex) to ring buffer with" +
-        "end index of \(endIndex)."
-    }
-  }
-}
-
 /// A generic circular queue structure.
 struct RingBuffer<Element>: Sequence {
   /// An array of heartbeats treated as a circular queue and intialized with a fixed capacity.
   private var circularQueue: [Element?]
   /// The current "tail" and insert point for the `circularQueue`.
   private var tailIndex: Array<Element?>.Index
+
+  /// Error types for `RingBuffer` operations.
+  enum Error: LocalizedError {
+    case outOfBoundsPush(pushIndex: Array<Element?>.Index, endIndex: Array<Element?>.Index)
+
+    var errorDescription: String {
+      switch self {
+      case let .outOfBoundsPush(pushIndex, endIndex):
+        return "Out-of-bounds push at index \(pushIndex) to ring buffer with" +
+          "end index of \(endIndex)."
+      }
+    }
+  }
 
   /// Designated initializer.
   /// - Parameter capacity: An `Int` representing the capacity.
@@ -54,7 +54,7 @@ struct RingBuffer<Element>: Sequence {
 
     guard circularQueue.indices.contains(tailIndex) else {
       // We have somehow entered an invalid state (#10025).
-      throw RingBufferError.outOfBoundsPush(
+      throw Self.Error.outOfBoundsPush(
         pushIndex: tailIndex,
         endIndex: circularQueue.endIndex
       )


### PR DESCRIPTION
### Context
Follow-up to #10075. Older Swift versions (< 5.3) do not like referencing the
`Array` type without specifying the generic type for the array. This can result
in a buildtime error when building with a Swift version under 5.3.

Prevents #10171
