### PR TITLE
[Infra] Commits should exclude .build/ folder from nested dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ DerivedData
 
 # Swift Package Manager
 Package.resolved
-*/.build
+**/.build
 ReleaseTooling/.swiftpm
 ReleaseTooling/Packages
 ReleaseTooling/*.xcodeproj


### PR DESCRIPTION
### Context
VSCode's git plugin always wants to commit .build/ folders. This includes those
in subdirectories.

I propose doing a recursive match of all `.build/` folders.

#no-changelog
