### PR TITLE
[v9.6.0] Update CHANGELOGs for macOS keychain fix

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 9.6.0
+- [fixed] Mac apps using this product will no longer prompt the user for
+  permission when storing/retrieving SDK data in the keychain. Using this
+  product on macOS now requires that the target be signed with a
+  provisioning profile that has the Keychain Sharing capability
+  enabled. (#9392)
+
 # 9.5.0
 - [added] DeviceCheck and App Attest providers are supported by watchOS 9.0+. (#10094, #10098)
 - [added] App Attest provider availability updated to support tvOS 15.0+. (#10093)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Firebase 9.6.0
+- [fixed] Mac apps using Firebase products that store SDK data in the keychain
+  will no longer prompt the user for permission to access the keychain. This
+  requires that Mac apps using Firebase be signed with a provisioning profile
+  that has the Keychain Sharing capability enabled. (#9392)
 - [fixed] Update dependency specification for GTMSessionFetcher to allow all 2.x versions. (#10131)
 
 # Firebase 9.5.0

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 9.6.0
+- [fixed] Mac apps using this product will no longer prompt the user for
+  permission when storing/retrieving SDK data in the keychain. Using this
+  product on macOS now requires that the target be signed with a
+  provisioning profile that has the Keychain Sharing capability
+  enabled. (#9392)
+
 # 9.0.0
 - [fixed] Swift-only: Updated symbol name kFirebaseInstallationsErrorDomain to
   InstallationsErrorDomain. (#9275)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 9.6.0
+- [fixed] Mac apps using this product will no longer prompt the user for
+  permission when storing/retrieving SDK data in the keychain. Using this
+  product on macOS now requires that the target be signed with a
+  provisioning profile that has the Keychain Sharing capability
+  enabled. (#9392)
+
 # 8.12.0
 - [changed] Improved reporting for SQLite errors when failing to open a local database (#8699).
 


### PR DESCRIPTION
### Context
Completely addressing #9392 required several PRs to eliminate the permission pop-ups on macOS:
- https://github.com/google/GoogleUtilities/pull/75
- https://github.com/firebase/firebase-ios-sdk/pull/10148
- https://github.com/firebase/firebase-ios-sdk/pull/10146
- https://github.com/firebase/firebase-ios-sdk/pull/10166

The fix involved making the macOS keychain behave like the iOS-style keychain. The iOS-style keychain is sandboxed per application by default. This does not happen by default on macOS and requires using the `kSecUseDataProtectionKeychain` attribute when interacting with the Keychain. The `kSecUseDataProtectionKeychain`  attribute tells macOS to treat a given keychain item like it is part of a keychain access group that the app knows and trusts. To synthesize and officiate this access group, it is required that macOS apps enable the `Keychain Sharing` capability for targets that depend on Firebase.

Fixes #9392