### PR TITLE
Fix zip bloat issue

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -460,7 +460,7 @@ struct ZipBuilder {
                                        withInstalledPods: installedPods,
                                        rootZipDir: zipDir,
                                        builtFrameworks: frameworksToAssemble,
-                                       podsToIgnore: analyticsPods)
+                                       frameworksToIgnore: analyticsPods)
         // Update the README.
         readmeDeps += dependencyString(for: folder, in: productDir, frameworks: podFrameworks)
       } catch {
@@ -572,7 +572,7 @@ struct ZipBuilder {
   func copyFrameworks(fromPods installedPods: [String],
                       toDirectory dir: URL,
                       frameworkLocations: [String: [URL]],
-                      podsToIgnore: [String] = []) throws -> [String] {
+                      frameworksToIgnore: [String] = []) throws -> [String] {
     let fileManager = FileManager.default
     if !fileManager.directoryExists(at: dir) {
       try fileManager.createDirectory(at: dir, withIntermediateDirectories: false, attributes: nil)
@@ -585,8 +585,7 @@ struct ZipBuilder {
     // it to the destination directory.
     for podName in installedPods {
       // Skip the Firebase pod and specifically ignored frameworks.
-      guard podName != "Firebase",
-            !podsToIgnore.contains(podName) else {
+      guard podName != "Firebase" else {
         continue
       }
 
@@ -602,6 +601,10 @@ struct ZipBuilder {
       // Copy each of the frameworks over, unless it's explicitly ignored.
       for xcframework in xcframeworks {
         let xcframeworkName = xcframework.lastPathComponent
+        let name = (xcframeworkName as NSString).deletingPathExtension
+        if frameworksToIgnore.contains(name) {
+          continue
+        }
         let destination = dir.appendingPathComponent(xcframeworkName)
         try fileManager.copyItem(at: xcframework, to: destination)
         copiedFrameworkNames
@@ -713,8 +716,8 @@ struct ZipBuilder {
                                 withInstalledPods installedPods: [String: CocoaPodUtils.PodInfo],
                                 rootZipDir: URL,
                                 builtFrameworks: [String: [URL]],
-                                podsToIgnore: [String] = []) throws -> (productDir: URL,
-                                                                        frameworks: [String]) {
+                                frameworksToIgnore: [String] = []) throws
+    -> (productDir: URL, frameworks: [String]) {
     let podsToCopy = [podName] +
       CocoaPodUtils.transitiveMasterPodDependencies(for: podName, in: installedPods)
     // Remove any duplicates from the `podsToCopy` array. The easiest way to do this is to wrap it
@@ -726,11 +729,11 @@ struct ZipBuilder {
     let namedFrameworks = try copyFrameworks(fromPods: dedupedPods,
                                              toDirectory: productDir,
                                              frameworkLocations: builtFrameworks,
-                                             podsToIgnore: podsToIgnore)
+                                             frameworksToIgnore: frameworksToIgnore)
 
     let copiedFrameworks = namedFrameworks.filter {
-      // Skip frameworks that aren't contained in the "podsToIgnore" array and the Firebase pod.
-      !(podsToIgnore.contains($0) || $0 == "Firebase")
+      // Skip frameworks that aren't contained in the "frameworksToIgnore" array and the Firebase pod.
+      !(frameworksToIgnore.contains($0) || $0 == "Firebase")
     }
 
     return (productDir, copiedFrameworks)


### PR DESCRIPTION
#10073 exposed an existing bug caused by conflating framework names and pod names, which led to FBLPromises.xcpromises being duplicated in every zip folder, eg
```
Only in Firebase/FirebaseInAppMessaging: FBLPromises.xcframework
Only in Firebase/FirebaseMLModelDownloader: FBLPromises.xcframework
Only in Firebase/FirebaseMessaging: FBLPromises.xcframework
Only in Firebase/FirebasePerformance: FBLPromises.xcframework
Only in Firebase/FirebaseRemoteConfig: FBLPromises.xcframework
Only in Firebase/FirebaseStorage: FBLPromises.xcframework
...
```

This PR fixes the issue by identifying the variable correctly as `frameworksToIgnore` and comparing against frameworks instead of pods.
