### PR TITLE
GoogleAppMeasurement versioning issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -150,7 +150,7 @@ let package = Package(
       url: "https://github.com/google/GoogleAppMeasurement.git",
       // Note that CI changes the version to the head of main for CI.
       // See scripts/setup_spm_tests.sh.
-      .exact("9.6.0")
+      .exact("9.3.0")
     ),
     .package(
       name: "GoogleDataTransport",


### PR DESCRIPTION
Version 9.6.0 is not tagged, it should be 9.3.0 or issues with CI on firebase using projects arise. Alternatively v9.6.0 on GoogleAppMeasurement could be tagged

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
