### PR TITLE
Add new throwing reference(for url:URL) API

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 10.0.0
 - [changed] FirebaseStorage is now completely implemented in Swift. Swift-specific API improvements
   are planned for subsequent releases. (#9963)
+- [added] New API `open func ref(forURL url: String) throws -> StorageReference` equivalent to
+  `open func reference(forURL url: String) throws -> StorageReference` except it throws instead of
+  erroring. (#6974)
 - [changed] The `FirebaseStorageInternal` CocoaPod has been discontinued.
 - [changed] Remove the `storageReference` property of `StorageMetadata`. It had never been implemented
   and always returned `nil`.

--- a/FirebaseStorage/Sources/Internal/StoragePath.swift
+++ b/FirebaseStorage/Sources/Internal/StoragePath.swift
@@ -42,7 +42,7 @@ internal class StoragePath: NSCopying, Equatable {
       return try path(HTTPURL: string)
     } else {
       // Invalid scheme, throw an error!
-      throw StoragePathError.storagePathError("Internal error: URL scheme must be one" +
+      throw StoragePathError.storagePathError("Internal error: URL scheme must be one " +
         "of gs://, http://, or https://")
     }
   }
@@ -64,9 +64,8 @@ internal class StoragePath: NSCopying, Equatable {
         return StoragePath(with: String(bucketObject))
       }
     }
-    throw StoragePathError
-      .storagePathError("Internal error: URI must be in the form of " +
-        "gs://<bucket>/<path/to/object>")
+    throw StoragePathError.storagePathError("Internal error: URI must be in the form of " +
+      "gs://<bucket>/<path/to/object>")
   }
 
   /**

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -159,8 +159,8 @@ import FirebaseAuthInterop
       }
       // If there exists a default bucket, throw if provided a different bucket.
       if path.bucket != storageBucket {
-        fatalError("Provided bucket:`\(path.bucket)` does not match the Storage bucket of the current " +
-          "instance:`\(storageBucket)`")
+        fatalError("Provided bucket: `\(path.bucket)` does not match the Storage bucket of the current " +
+          "instance: `\(storageBucket)`")
       }
       return StorageReference(storage: self, path: path)
     } catch let StoragePathError.storagePathError(message) {
@@ -198,8 +198,8 @@ import FirebaseAuthInterop
     // If there exists a default bucket, throw if provided a different bucket.
     if path.bucket != storageBucket {
       throw StorageError
-        .bucketMismatch("Provided bucket:`\(path.bucket)` does not match the Storage " +
-          "bucket of the current instance:`\(storageBucket)`")
+        .bucketMismatch("Provided bucket: `\(path.bucket)` does not match the Storage " +
+          "bucket of the current instance: `\(storageBucket)`")
     }
     return StorageReference(storage: self, path: path)
   }

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -180,11 +180,11 @@ import FirebaseAuthInterop
    * - Throws: Throws an Error if `url` is not associated with the `FirebaseApp` used to initialize
    *     this Storage instance.
    */
-  open func ref(forURL url: String) throws -> StorageReference {
+  open func reference(for url: URL) throws -> StorageReference {
     ensureConfigured()
     var path: StoragePath
     do {
-      path = try StoragePath.path(string: url)
+      path = try StoragePath.path(string: url.absoluteString)
     } catch let StoragePathError.storagePathError(message) {
       throw StorageError.pathError(message)
     } catch {

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -155,6 +155,8 @@ public enum StorageError: Error {
   case cancelled
   case invalidArgument(String)
   case internalError(String)
+  case bucketMismatch(String)
+  case pathError(String)
 
   static func swiftConvert(objcError: NSError) -> StorageError {
     let userInfo = objcError.userInfo

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -60,8 +60,8 @@ class StorageReferenceTests: XCTestCase {
       let url = try XCTUnwrap(URL(string: "gs://bcket/"))
       _ = try storage!.reference(for: url)
     } catch let StorageError.bucketMismatch(string) {
-      XCTAssertEqual(string, "Provided bucket:`bcket` does not match the Storage " +
-        "bucket of the current instance:`bucket`")
+      XCTAssertEqual(string, "Provided bucket: `bcket` does not match the Storage " +
+        "bucket of the current instance: `bucket`")
       return
     }
     XCTFail()

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -64,7 +64,10 @@ class StorageReferenceTests: XCTestCase {
     do {
       _ = try storage!.ref(forURL: "htttp://bucket/")
     } catch let StorageError.pathError(string) {
-      XCTAssertEqual(string, "Internal error: URL scheme must be one of gs://, http://, or https://")
+      XCTAssertEqual(
+        string,
+        "Internal error: URL scheme must be one of gs://, http://, or https://"
+      )
       return
     }
     XCTFail()

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -33,7 +33,7 @@ class StorageReferenceTests: XCTestCase {
 
   var storage: Storage?
   override func setUp() {
-    guard let app = try? getApp(bucket: "") else {
+    guard let app = try? getApp(bucket: "bucket") else {
       fatalError("")
     }
     storage = Storage.storage(app: app)
@@ -47,6 +47,27 @@ class StorageReferenceTests: XCTestCase {
   func testRootWithNoPath() throws {
     let ref = storage!.reference(forURL: "gs://bucket/")
     XCTAssertEqual(ref.root().description, "gs://bucket/")
+  }
+
+  func testMismatchedBucket() throws {
+    do {
+      _ = try storage!.ref(forURL: "gs://bcket/")
+    } catch let StorageError.bucketMismatch(string) {
+      XCTAssertEqual(string, "Provided bucket:`bcket` does not match the Storage " +
+        "bucket of the current instance:`bucket`")
+      return
+    }
+    XCTFail()
+  }
+
+  func testBadBucketScheme() throws {
+    do {
+      _ = try storage!.ref(forURL: "htttp://bucket/")
+    } catch let StorageError.pathError(string) {
+      XCTAssertEqual(string, "Internal error: URL scheme must be one of gs://, http://, or https://")
+      return
+    }
+    XCTFail()
   }
 
   func testSingleChild() throws {

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -44,6 +44,12 @@ class StorageReferenceTests: XCTestCase {
     XCTAssertEqual(ref.root().description, "gs://bucket/")
   }
 
+  func testRootWithURLAPI() throws {
+    let url = try XCTUnwrap(URL(string: "gs://bucket/path/to/object"))
+    let ref = try storage!.reference(for: url)
+    XCTAssertEqual(ref.root().description, "gs://bucket/")
+  }
+
   func testRootWithNoPath() throws {
     let ref = storage!.reference(forURL: "gs://bucket/")
     XCTAssertEqual(ref.root().description, "gs://bucket/")
@@ -51,7 +57,8 @@ class StorageReferenceTests: XCTestCase {
 
   func testMismatchedBucket() throws {
     do {
-      _ = try storage!.ref(forURL: "gs://bcket/")
+      let url = try XCTUnwrap(URL(string: "gs://bcket/"))
+      _ = try storage!.reference(for: url)
     } catch let StorageError.bucketMismatch(string) {
       XCTAssertEqual(string, "Provided bucket:`bcket` does not match the Storage " +
         "bucket of the current instance:`bucket`")
@@ -62,7 +69,8 @@ class StorageReferenceTests: XCTestCase {
 
   func testBadBucketScheme() throws {
     do {
-      _ = try storage!.ref(forURL: "htttp://bucket/")
+      let url = try XCTUnwrap(URL(string: "htttp://bucket/"))
+      _ = try storage!.reference(for: url)
     } catch let StorageError.pathError(string) {
       XCTAssertEqual(
         string,


### PR DESCRIPTION
Fix #6974 

Provide a throwing API for failures instead of `fatalError`. Also use a `URL` type for the url parameter instead of `String`

New API `open func reference(for url: URL) throws -> StorageReference` equivalent to
  `open func reference(forURL url: String) -> StorageReference` except it throws instead of
  erroring. 