### PR TITLE
FIRFirestoreSettings.mm: remove unnecessary extern "C"

### DIFF
--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -19,8 +19,6 @@
 #include "Firestore/core/src/api/settings.h"
 #include "Firestore/core/src/util/exception.h"
 #include "Firestore/core/src/util/string_apple.h"
-#include "absl/base/attributes.h"
-#include "absl/memory/memory.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,8 +28,7 @@ using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 // Public constant
-ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
-    Settings::CacheSizeUnlimited;
+extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings
 

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -30,7 +30,7 @@ using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 // Public constant
-ABSL_CONST_INIT const int64_t kFIRFirestoreCacheSizeUnlimited =
+ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
     Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -30,7 +30,7 @@ using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 // Public constant
-ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
+ABSL_CONST_INIT const int64_t kFIRFirestoreCacheSizeUnlimited =
     Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings


### PR DESCRIPTION
require_constant_initialization is incompatible with extern "C"

ABSL_CONST_INIT uses the require_constant_initialization clang attribute, which is now present in the apple cross compiler. This attribute can only be used in C++.

https://clang.llvm.org/docs/AttributeReference.html#require-constant-initialization-constinit-c-20

Googlers can see cl/473006027 for additional context.

#no-changelog