### PR TITLE
FIAM: Remove extraneous `foo` constant in Swift preview helpers

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.0.0
+- [removed] Removed `foo` constant from Swift `InAppMessagingPreviewHelpers` API (#10222).
+
 # 9.2.0
 - [changed] Replaced unarchiveObjectWithFile with unarchivedObjectOfClass to conform to secure coding practices, and implemented NSSecureCoding (#9816).
 

--- a/FirebaseInAppMessaging/Swift/Source/SwiftUIPreviewHelpers.swift
+++ b/FirebaseInAppMessaging/Swift/Source/SwiftUIPreviewHelpers.swift
@@ -20,7 +20,6 @@ import FirebaseInAppMessaging
 @available(iOSApplicationExtension, unavailable)
 @available(tvOSApplicationExtension, unavailable)
 public enum InAppMessagingPreviewHelpers {
-  public static let foo = UIColor.black
   public static func cardMessage(campaignName: String = "Card message campaign",
                                  title: String = "Title for modal message",
                                  body: String? = "Body for modal message",


### PR DESCRIPTION
Removed an unintentional constant named "foo" from the Firebase In-App Messaging Swift API. This constant is not of use to developers (simply containing UIColor.black) and was only added accidentally. Closes #9998.