### PR TITLE
Firestore: Fix @param comparator doc compiler warning

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed compiler warning about `@param comparator` (#10226).
+
+# 9.6.0
 - [added] Expose client side indexing feature with `FIRFirestore.setIndexConfigurationFromJSON` and
   `FIRFirestore.setIndexConfigurationFromStream` (#10090).
 - [fixed] Fixed high CPU usage whenever Firestore was in use (#10168).

--- a/Firestore/core/src/util/set_util.h
+++ b/Firestore/core/src/util/set_util.h
@@ -36,7 +36,7 @@ namespace util {
  *
  * @param existing - The elements that exist in the original set.
  * @param new_entries - The elements to diff against the original set.
- * @param comparator - The comparator for the elements in before and after.
+ * @param cmp - The comparator for the elements in before and after.
  * @param on_add - A function to invoke for every element that is part of `
  * after` but not `before`.
  * @param on_remove - A function to invoke for every element that is part of


### PR DESCRIPTION
Fixes #10226