### PR TITLE
FDL: Mark FIRDynamicLink's init as NS_UNAVAILABLE

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.0.0
+- [removed] Removed bare initializer from `DynamicLink`. (#10236)
+
 # 9.0.0
 - [fixed] Fixed async/await crash when retrieving a dynamic link from a universal link fails. (#9612)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 10.0.0
-- [removed] Removed bare initializer from `DynamicLink`. (#10236)
+- [removed] Removed bare initializer from `DynamicLink`. (#10000)
 
 # 9.0.0
 - [fixed] Fixed async/await crash when retrieving a dynamic link from a universal link fails. (#9612)

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -413,13 +413,13 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 
   if ([self canParseUniversalLinkURL:url]) {
     if (url.query.length > 0) {
-      NSDictionary *parameters = FIRDLDictionaryFromQuery(url.query);
+      NSDictionary<NSString *, NSString *> *parameters = FIRDLDictionaryFromQuery(url.query);
       if (parameters[kFIRDLParameterLink]) {
-        FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] init];
         NSString *urlString = parameters[kFIRDLParameterLink];
         NSURL *deepLinkURL = [NSURL URLWithString:urlString];
         if (deepLinkURL) {
-          dynamicLink.url = deepLinkURL;
+          FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc]
+              initWithParametersDictionary:@{kFIRDLParameterDeepLinkIdentifier : urlString}];
           dynamicLink.matchType = FIRDLMatchTypeUnique;
           dynamicLink.minimumAppVersion = parameters[kFIRDLParameterMinimumAppVersion];
           // Call resolveShortLink:completion: to do logging.

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -83,6 +83,8 @@ NS_SWIFT_NAME(DynamicLink)
  */
 @property(nonatomic, copy, readonly, nullable) NSString *minimumAppVersion;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
DynamicLink's initializer was not intended to be publicly available. Marking it as NS_UNAVAILABLE hides it from both ObjC and Swift callers; resolves #10000.