### PR TITLE
Firestore: Fix Windows build due to decltype of captured lambda

### DIFF
--- a/Firestore/core/src/local/local_store.cc
+++ b/Firestore/core/src/local/local_store.cc
@@ -662,15 +662,10 @@ absl::optional<bundle::NamedQuery> LocalStore::GetNamedQuery(
 
 void LocalStore::ConfigureFieldIndexes(
     std::vector<FieldIndex> new_field_indexes) {
-  auto cmp = [](const FieldIndex& left, const FieldIndex& right) {
-    return FieldIndex::SemanticCompare(left, right) ==
-           util::ComparisonResult::Ascending;
-  };
-
   // This lambda function takes a rvalue vector as parameter,
   // then coverts it to a sorted set based on the compare function above.
-  auto convertToSet = [&](std::vector<FieldIndex>&& vec) {
-    std::set<FieldIndex, decltype(cmp)> result(cmp);
+  auto convertToSet = [](std::vector<FieldIndex>&& vec) {
+    std::set<FieldIndex, FieldIndex::SemanticLess> result;
     for (auto& index : vec) {
       result.insert(std::move(index));
     }
@@ -678,7 +673,7 @@ void LocalStore::ConfigureFieldIndexes(
   };
 
   return persistence_->Run("Configure indexes", [&] {
-    return util::DiffSets<FieldIndex, decltype(cmp)>(
+    return util::DiffSets<FieldIndex, FieldIndex::SemanticLess>(
         convertToSet(index_manager_->GetFieldIndexes()),
         convertToSet(std::move(new_field_indexes)), FieldIndex::SemanticCompare,
         [this](const model::FieldIndex& index) {

--- a/Firestore/core/src/model/field_index.h
+++ b/Firestore/core/src/model/field_index.h
@@ -285,6 +285,14 @@ class FieldIndex {
   /** Returns the ArrayContains/ArrayContainsAny segment for this index. */
   absl::optional<Segment> GetArraySegment() const;
 
+  /**
+   * A type that can be used as the "Compare" template parameter of ordered
+   * collections to have the elements ordered using
+   * `FieldIndex::SemanticCompare()`.
+   *
+   * Example:
+   * std::set<FieldIndex, FieldIndex::SemanticLess> result;
+   */
   struct SemanticLess {
     bool operator()(const FieldIndex& left, const FieldIndex& right) const {
       return FieldIndex::SemanticCompare(left, right) ==

--- a/Firestore/core/src/model/field_index.h
+++ b/Firestore/core/src/model/field_index.h
@@ -285,6 +285,13 @@ class FieldIndex {
   /** Returns the ArrayContains/ArrayContainsAny segment for this index. */
   absl::optional<Segment> GetArraySegment() const;
 
+  struct SemanticLess {
+    bool operator()(const FieldIndex& left, const FieldIndex& right) const {
+      return FieldIndex::SemanticCompare(left, right) ==
+             util::ComparisonResult::Ascending;
+    }
+  };
+
  private:
   friend bool operator==(const FieldIndex& lhs, const FieldIndex& rhs);
   friend bool operator!=(const FieldIndex& lhs, const FieldIndex& rhs);

--- a/Firestore/core/test/unit/local/leveldb_local_store_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_local_store_test.cc
@@ -69,12 +69,7 @@ std::unique_ptr<LocalStoreTestHelper> Factory() {
 // This lambda function takes a rvalue vector as parameter,
 // then coverts it to a sorted set based on the compare function.
 auto convertToSet = [](std::vector<FieldIndex>&& vec) {
-  auto cmp = [](const FieldIndex& left, const FieldIndex& right) {
-    return FieldIndex::SemanticCompare(left, right) ==
-           util::ComparisonResult::Ascending;
-  };
-
-  std::set<FieldIndex, decltype(cmp)> result(cmp);
+  std::set<FieldIndex, FieldIndex::SemanticLess> result;
   for (auto& index : vec) {
     result.insert(std::move(index));
   }


### PR DESCRIPTION
This fixes the following build error on Windows:

```
local_store.cc(681): error C2664: 'void firebase::firestore::util::DiffSets<firebase::firestore::model::FieldIndex,firebase::firestore::local::LocalStore::ConfigureFieldIndexes::<lambda_bf22b4eef787b0dba8fa48c35f79fcdb>>(std::set<firebase::firestore::model::FieldIndex,firebase::firestore::local::LocalStore::ConfigureFieldIndexes::<lambda_bf22b4eef787b0dba8fa48c35f79fcdb>,std::allocator<_Ty>>,std::set<firebase::firestore::model::FieldIndex,firebase::firestore::local::LocalStore::ConfigureFieldIndexes::<lambda_bf22b4eef787b0dba8fa48c35f79fcdb>,std::allocator<_Ty>>,std::function<firebase::firestore::util::ComparisonResult (const firebase::firestore::model::FieldIndex &,const firebase::firestore::model::FieldIndex &)>,std::function<void (const firebase::firestore::model::FieldIndex &)>,std::function<void (const firebase::firestore::model::FieldIndex &)>)': cannot convert argument 1 from 'std::set<firebase::firestore::model::FieldIndex,firebase::firestore::local::LocalStore::ConfigureFieldIndexes::<lambda_bf22b4eef787b0dba8fa48c35f79fcdb> &,std::allocator<_Ty>>' to 'std::set<firebase::firestore::model::FieldIndex,firebase::firestore::local::LocalStore::ConfigureFieldIndexes::<lambda_bf22b4eef787b0dba8fa48c35f79fcdb>,std::allocator<_Ty>>'
local_store.cc(689): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
```

The problem was that the `decltype(cmp)` was calculated to be a reference, and it was expected to be a direct value (i.e. neither a reference nor a pointer) at its use site.

The fix in this PR creates a new struct `FieldIndex::SemanticLess` that satisfies the contract required by the "Compare" template parameter of `std::set` and using that instead. That way, the object is copyable and movable and we don't have to worry about different compilers having different properties for lambdas.

Googlers see b/247902377 for details.

#no-changelog