### PR TITLE
Address 9963 review feedback

### DIFF
--- a/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
@@ -63,9 +63,7 @@ internal class StorageDeleteTask: StorageTask, StorageTaskManagement {
         if let error = error, self.error == nil {
           self.error = StorageErrorCode.error(withServerError: error, ref: strongSelf.reference)
         }
-        if let callback = callback {
-          callback(self.error)
-        }
+        callback?(self.error)
         self.fetcherCompletion = nil
       }
 

--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -79,9 +79,7 @@ internal class StorageGetDownloadURLTask: StorageTask, StorageTaskManagement {
             self.error = StorageErrorCode.error(withInvalidRequest: data)
           }
         }
-        if let callback = callback {
-          callback(downloadURL, self.error)
-        }
+        callback?(downloadURL, self.error)
         self.fetcherCompletion = nil
       }
 

--- a/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
@@ -75,9 +75,7 @@ internal class StorageGetMetadataTask: StorageTask, StorageTaskManagement {
             self.error = StorageErrorCode.error(withInvalidRequest: data)
           }
         }
-        if let callback = callback {
-          callback(metadata, self.error)
-        }
+        callback?(metadata, self.error)
         self.fetcherCompletion = nil
       }
 

--- a/FirebaseStorage/Sources/Internal/StorageListTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageListTask.swift
@@ -118,9 +118,7 @@ internal class StorageListTask: StorageTask, StorageTaskManagement {
           }
         }
 
-        if let callback = callback {
-          callback(listResult, self.error)
-        }
+        callback?(listResult, self.error)
         self.fetcherCompletion = nil
       }
 

--- a/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
@@ -84,9 +84,7 @@ internal class StorageUpdateMetadataTask: StorageTask, StorageTaskManagement {
             self.error = StorageErrorCode.error(withInvalidRequest: data)
           }
         }
-        if let callback = callback {
-          callback(metadata, self.error)
-        }
+        callback?(metadata, self.error)
         self.fetcherCompletion = nil
       }
 

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -36,7 +36,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Prepares a task and begins execution.
    */
   @objc open func enqueue() {
-    enqueue()
+    enqueueImplementation()
   }
 
   /**
@@ -83,7 +83,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
         weakSelf?.fire(for: .resume, snapshot: snapshot)
       }
       weakSelf?.state = .running
-      weakSelf?.enqueue(resumeWith: self.downloadData)
+      weakSelf?.enqueueImplementation(resumeWith: self.downloadData)
     }
   }
 
@@ -104,7 +104,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
     self.fetcher?.stopFetching()
   }
 
-  internal func enqueue(resumeWith resumeData: Data?) {
+  internal func enqueueImplementation(resumeWith resumeData: Data? = nil) {
     weak var weakSelf = self
     DispatchQueue.global(qos: .background).async {
       guard let strongSelf = weakSelf else { return }

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -36,7 +36,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Prepares a task and begins execution.
    */
   @objc open func enqueue() {
-    enqueue(with: nil)
+    enqueue()
   }
 
   /**
@@ -83,7 +83,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
         weakSelf?.fire(for: .resume, snapshot: snapshot)
       }
       weakSelf?.state = .running
-      weakSelf?.enqueue(with: self.downloadData)
+      weakSelf?.enqueue(resumeWith: self.downloadData)
     }
   }
 
@@ -104,7 +104,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
     self.fetcher?.stopFetching()
   }
 
-  internal func enqueue(with resumeData: Data?) {
+  internal func enqueue(resumeWith resumeData: Data?) {
     weak var weakSelf = self
     DispatchQueue.global(qos: .background).async {
       guard let strongSelf = weakSelf else { return }

--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -27,7 +27,7 @@ import Foundation
   /**
    * The name of the bucket containing this object.
    */
-  @objc public let bucket: String?
+  @objc public let bucket: String
 
   /**
    * Cache-Control directive for the object data.
@@ -150,7 +150,7 @@ import Foundation
    */
   @objc public init(dictionary: [String: AnyHashable]) {
     initialMetadata = dictionary
-    bucket = dictionary["bucket"] as? String ?? nil
+    bucket = dictionary["bucket"] as? String ?? ""
     cacheControl = dictionary["cacheControl"] as? String ?? nil
     contentDisposition = dictionary["contentDisposition"] as? String ?? nil
     contentEncoding = dictionary["contentEncoding"] as? String ?? nil

--- a/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
@@ -217,6 +217,7 @@ class StorageMetadataTests: StorageTestHelpers {
     let expectedUpdate = [
       "contentLanguage": "new",
       "metadata": ["foo": "new"],
+      "bucket": "",
     ] as [String: AnyHashable]
     XCTAssertEqual(update, expectedUpdate)
   }
@@ -228,7 +229,7 @@ class StorageMetadataTests: StorageTestHelpers {
     ] as [String: AnyHashable]
     let metadata = StorageMetadata(dictionary: oldMetadata)
     let update = metadata.updatedMetadata()
-    XCTAssertEqual(update, [:])
+    XCTAssertEqual(update, ["bucket": ""])
   }
 
   func testUpdatedMetadataWithDelete() {
@@ -241,7 +242,8 @@ class StorageMetadataTests: StorageTestHelpers {
     metadata.customMetadata = ["foo": "old"]
     let update = metadata.updatedMetadata()
 
-    let expected = ["contentLanguage": NSNull(),
+    let expected = ["bucket": "",
+                    "contentLanguage": NSNull(),
                     "metadata": ["bar": NSNull()]] as [String: AnyHashable]
     XCTAssertEqual(update, expected)
   }


### PR DESCRIPTION
- Use `callback?` instead of `if let callback ...`
- Better StorageDownloadTask `enqueue` signature
- Restore non-optional `bucket` property in StorageMetadata

Initializing an unspecified `bucket` property as `""` instead of `nil` when creating `StorageMetadata` with a dictionary was an inadvertent Firebase 9 change from Firebase 8. This PR keeps the Firebase 9 behavior onto Firebase 10.
