### PR TITLE
Separate GoogleUtilities Carthage build

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -24,7 +24,6 @@ public let shared = Manifest(
   version: "9.6.0",
   pods: [
     Pod("FirebaseSharedSwift"),
-    Pod("FirebaseCoreDiagnostics"),
     Pod("FirebaseCoreInternal"),
     Pod("FirebaseCore"),
     Pod("FirebaseCoreExtension"),

--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -72,9 +72,9 @@ extension CarthageUtils {
   ///   - packagedDir: The packaged directory assembled for the Carthage distribution.
   ///   - templateDir: The template project directory, contains the dummy Firebase library.
   ///   - jsonDir: Location of directory containing all JSON Carthage manifests.
-  ///   - firebaseVersion: The version of the Firebase pod.
-  ///   - coreDiagnosticsPath: The path to the Core Diagnostics framework built for Carthage.
+  ///   - artifacts: Build artifacts.
   ///   - outputDir: The directory where all artifacts should be created.
+  ///   - versionCheckEnabled: Checking if Carthage version already exists.
 
   private static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
                                               templateDir: URL,

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -530,7 +530,6 @@ enum CocoaPodUtils {
       let podspecs = try! FileManager.default.contentsOfDirectory(atPath: localURL.path)
       for podspec in podspecs {
         if podspec == "FirebaseInstallations.podspec" ||
-          podspec == "FirebaseCoreDiagnostics.podspec" ||
           podspec == "FirebaseCore.podspec" ||
           podspec == "FirebaseCoreExtension.podspec" ||
           podspec == "FirebaseCoreInternal.podspec" ||

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -147,7 +147,7 @@ struct FrameworkBuilder {
   /// Build all thin slices for an open source pod.
   /// - Parameter framework: The name of the framework to be built.
   /// - Parameter logsDir: The path to the directory to place build logs.
-  /// - Parameter setCarthage: Set Carthage flag in CoreDiagnostics for metrics.
+  /// - Parameter setCarthage: Set Carthage flag in GoogleUtilities for metrics.
   /// - Returns: A dictionary of URLs to the built thin libraries keyed by platform.
   private func buildFrameworksForAllPlatforms(withName framework: String,
                                               logsDir: URL,
@@ -173,7 +173,7 @@ struct FrameworkBuilder {
   ///   - targetPlatform: The target platform to target for the build.
   ///   - buildDir: Location where the project should be built.
   ///   - logRoot: Root directory where all logs should be written.
-  ///   - setCarthage: Set Carthage flag in CoreDiagnostics for metrics.
+  ///   - setCarthage: Set Carthage flag in GoogleUtilities for metrics.
   /// - Returns: A URL to the framework that was built.
   private func buildSlicedFramework(withName framework: String,
                                     targetPlatform: TargetPlatform,

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -179,7 +179,7 @@ struct ZipBuilder {
     // the folders in each product directory.
     let linkage: CocoaPodUtils.LinkageType = dynamicFrameworks ? .dynamic : .standardStatic
     var groupedFrameworks: [String: [URL]] = [:]
-    var carthageCoreDiagnosticsFrameworks: [URL] = []
+    var carthageGoogleUtilitiesFrameworks: [URL] = []
     var podsBuilt: [String: CocoaPodUtils.PodInfo] = [:]
     var xcframeworks: [String: [URL]] = [:]
     var resources: [String: URL] = [:]
@@ -241,13 +241,13 @@ struct ZipBuilder {
                                                  podInfo: podInfo)
           groupedFrameworks[podName] = (groupedFrameworks[podName] ?? []) + frameworks
 
-          if includeCarthage, podName == "FirebaseCoreDiagnostics" {
+          if includeCarthage, podName == "GoogleUtilities" {
             let (cdFrameworks, _) = builder.compileFrameworkAndResources(withName: podName,
                                                                          logsOutputDir: paths
                                                                            .logsOutputDir,
                                                                          setCarthage: true,
                                                                          podInfo: podInfo)
-            carthageCoreDiagnosticsFrameworks += cdFrameworks
+            carthageGoogleUtilitiesFrameworks += cdFrameworks
           }
           if resourceContents != nil {
             resources[podName] = resourceContents
@@ -299,13 +299,13 @@ struct ZipBuilder {
       fatalError("Could not create XCFrameworks Carthage directory: \(error)")
     }
 
-    let carthageCoreDiagnosticsXcframework = FrameworkBuilder.makeXCFramework(
-      withName: "FirebaseCoreDiagnostics",
-      frameworks: carthageCoreDiagnosticsFrameworks,
+    let carthageGoogleUtilitiesXcframework = FrameworkBuilder.makeXCFramework(
+      withName: "GoogleUtilities",
+      frameworks: carthageGoogleUtilitiesFrameworks,
       xcframeworksDir: xcframeworksCarthageDir,
       resourceContents: nil
     )
-    return (podsBuilt, xcframeworks, carthageCoreDiagnosticsXcframework)
+    return (podsBuilt, xcframeworks, carthageGoogleUtilitiesXcframework)
   }
 
   /// Try to build and package the contents of the Zip file. This will throw an error as soon as it
@@ -333,7 +333,7 @@ struct ZipBuilder {
                                                     platforms: ["ios"]))
 
     print("Final expected versions for the Zip file: \(podsToInstall)")
-    let (installedPods, frameworks, carthageCoreDiagnosticsXcframeworkFirebase) =
+    let (installedPods, frameworks, carthageGoogleUtilitiesXcframeworkFirebase) =
       buildAndAssembleZip(podsToInstall: podsToInstall,
                           includeCarthage: true,
                           // Always include dependencies for Firebase zips.
@@ -346,8 +346,8 @@ struct ZipBuilder {
         "installed: \(installedPods)")
     }
 
-    guard let carthageCoreDiagnosticsXcframework = carthageCoreDiagnosticsXcframeworkFirebase else {
-      fatalError("CoreDiagnosticsXcframework is missing")
+    guard let carthageGoogleUtilitiesXcframework = carthageGoogleUtilitiesXcframeworkFirebase else {
+      fatalError("GoogleUtilitiesXcframework is missing")
     }
 
     let zipDir = try assembleDistributions(withPackageKind: "Firebase",
@@ -357,7 +357,7 @@ struct ZipBuilder {
                                            firebasePod: firebasePod)
     // Replace Core Diagnostics
     var carthageFrameworks = frameworks
-    carthageFrameworks["FirebaseCoreDiagnostics"] = [carthageCoreDiagnosticsXcframework]
+    carthageFrameworks["GoogleUtilities"] = [carthageGoogleUtilitiesXcframework]
     let carthageDir = try assembleDistributions(withPackageKind: "CarthageFirebase",
                                                 podsToInstall: podsToInstall,
                                                 installedPods: installedPods,


### PR DESCRIPTION
Fix #10186

Do separate Carthage build for GoogleUtilities instead of FirebaseCoreDiagnostics to enable Platform Logging distinction between Carthage and zip.