### PR TITLE
[SPM] Bump GoogleUtils lower bound for Firebase 10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,7 +160,7 @@ let package = Package(
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.8.0" ..< "8.0.0"
+      "7.9.0" ..< "8.0.0"
     ),
     .package(
       name: "GTMSessionFetcher",


### PR DESCRIPTION
### Context
GoogleUtilities 7.9.0 released today. It was an SPM-only release. To ensure developers using the upcoming Firebase 10 always have this fix, the `Package.swift` has been updated to use 7.9.0 as the lower bound for the GoogleUtils dependency. CocoaPods remains unchanged at 7.8.0.

#no-changelog