### PR TITLE
[AppCheck] Refine public docs

### DIFF
--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
@@ -24,12 +24,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Firebase App Check provider that verifies app integrity using the
+/// [DeviceCheck](https://developer.apple.com/documentation/devicecheck/dcappattestservice) API.
+/// This class is available on all platforms for select OS versions. See
+/// https://firebase.google.com/docs/ios/learn-more for more details.
 FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 NS_SWIFT_NAME(AppAttestProvider)
 @interface FIRAppAttestProvider : NSObject <FIRAppCheckProvider>
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/// The default initializer.
+/// @param app A `FirebaseApp` instance.
+/// @return An instance of `AppAttestProvider` if the provided `FirebaseApp` instance contains all
+/// required parameters.
 - (nullable instancetype)initWithApp:(FIRApp *)app;
 
 @end

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Firebase App Check provider that verifies app integrity using the
 /// [DeviceCheck](https://developer.apple.com/documentation/devicecheck) API.
-/// This class is available on iOS, macOS Catalyst, macOS, and tvOS only.
+/// This class is available on all platforms for select OS versions. See
+/// https://firebase.google.com/docs/ios/learn-more for more details.
 FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 NS_SWIFT_NAME(DeviceCheckProvider)
 @interface FIRDeviceCheckProvider : NSObject <FIRAppCheckProvider>

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProviderFactory.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProviderFactory.h
@@ -28,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// `DeviceCheckProvider` for the specified `FirebaseApp` on request. Currently
 /// `DeviceCheckProviderFactory` is the default that will be used by Firebase App Check if no other
 /// provider is specified. See `AppCheck` class for more details.
-/// This class is available on iOS, macOS Catalyst, macOS, and tvOS only.
+/// This class is available on all platforms for select OS versions. See
+/// https://firebase.google.com/docs/ios/learn-more for more details.
 FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 NS_SWIFT_NAME(DeviceCheckProviderFactory)
 @interface FIRDeviceCheckProviderFactory : NSObject <FIRAppCheckProviderFactory>


### PR DESCRIPTION
### Context
Noticed some inconsistencies in the platforms that the public AppCheck docs mentioned and the platforms that the SDK actually supports. This PR refines the docs to use [this ](https://firebase.google.com/docs/ios/learn-more) as the source of truth.

#no-changelog