### PR TITLE
[AppCheck][WIP] Add isSupported to providers

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -185,6 +185,10 @@ NS_ASSUME_NONNULL_BEGIN
       });
 }
 
+- (BOOL)isSupported {
+  return self.appAttestService.isSupported;
+}
+
 - (FBLPromise<FIRAppCheckToken *> *)getToken {
   return [FBLPromise onQueue:self.queue
                           do:^id _Nullable {

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h
@@ -32,6 +32,11 @@ NS_SWIFT_NAME(AppCheckProvider)
     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getToken(completion:));
 
+// Maybe this could be static. With DeviceCheck and App Attest we could check if it's supported
+// without instantiating a FIRAppAttestProvider but this may not be universally true (e.g., custom
+// providers).
+- (BOOL)isSupported NS_SWIFT_NAME(supported());
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Added an `isSupported` method to the `FIRAppCheckProvider` protocol. This would allow developers to easily check if a provider is supported on the device/OS and to fallback to other providers if it's not available.

[skip ci] - just an idea, not ready for review