### PR TITLE
[Firestore] Remove encoding/decoding strategy type aliases

### DIFF
--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -1,13 +1,10 @@
 # 10.0.0
-- [changed] `Firestore.Encoder` and `Firestore.Decoder` now wraps the shared `FirebaseDataEncoder` and `FirebaseDataDecoder` types which provides new customization options for encoding and decoding date to and from Firestore - similar to the options present on `JSONEncoder` and `JSONDecoder` from `Foundation`.
-- [added] `Firestore.Encoder.KeyEncodingStrategy`
-- [added] `Firestore.Encoder.DateEncodingStrategy`
-- [added] `Firestore.Encoder.DataEncodingStrategy`
-- [added] `Firestore.Encoder.NonConformingFloatEncodingStrategy`
-- [added] `Firestore.Decoder.KeyDecodingStrategy`
-- [added] `Firestore.Decoder.DateDecodingStrategy`
-- [added] `Firestore.Decoder.DataDecodingStrategy`
-- [added] `Firestore.Decoder.NonConformingFloatDecodingStrategy`
+- [changed] `Firestore.Encoder` and `Firestore.Decoder` now wraps the shared
+  `FirebaseDataEncoder` and `FirebaseDataDecoder` types, which provides new
+  customization options for encoding and decoding data to and from Firestore
+  into `Codable`s - similar to the options present on `JSONEncoder` and
+  `JSONDecoder` from `Foundation`.
+- [added] Added a `FirebaseDataEncoder.DateEncodingStrategy` for `Timestamp`s.
 
 # 9.0.0
 - [added] **Breaking change:** `FirebaseFirestoreSwift` has exited beta and is

--- a/Firestore/Swift/Source/Codable/EncoderDecoder.swift
+++ b/Firestore/Swift/Source/Codable/EncoderDecoder.swift
@@ -27,7 +27,8 @@ public extension Firestore {
     public var dataEncodingStrategy: FirebaseDataEncoder.DataEncodingStrategy = .base64
 
     /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
-    public var nonConformingFloatEncodingStrategy: FirebaseDataEncoder.NonConformingFloatEncodingStrategy = .throw
+    public var nonConformingFloatEncodingStrategy: FirebaseDataEncoder
+      .NonConformingFloatEncodingStrategy = .throw
 
     /// The strategy to use for encoding keys. Defaults to `.useDefaultKeys`.
     public var keyEncodingStrategy: FirebaseDataEncoder.KeyEncodingStrategy = .useDefaultKeys
@@ -65,7 +66,8 @@ public extension Firestore {
     public var dataDecodingStrategy: FirebaseDataDecoder.DataDecodingStrategy = .base64
 
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
-    public var nonConformingFloatDecodingStrategy: FirebaseDataDecoder.NonConformingFloatDecodingStrategy = .throw
+    public var nonConformingFloatDecodingStrategy: FirebaseDataDecoder
+      .NonConformingFloatDecodingStrategy = .throw
 
     /// The strategy to use for decoding keys. Defaults to `.useDefaultKeys`.
     public var keyDecodingStrategy: FirebaseDataDecoder.KeyDecodingStrategy = .useDefaultKeys

--- a/Firestore/Swift/Source/Codable/EncoderDecoder.swift
+++ b/Firestore/Swift/Source/Codable/EncoderDecoder.swift
@@ -20,23 +20,17 @@ import Foundation
 
 public extension Firestore {
   class Encoder {
-    public typealias DateEncodingStrategy = FirebaseDataEncoder.DateEncodingStrategy
-    public typealias DataEncodingStrategy = FirebaseDataEncoder.DataEncodingStrategy
-    public typealias NonConformingFloatEncodingStrategy = FirebaseDataEncoder
-      .NonConformingFloatEncodingStrategy
-    public typealias KeyEncodingStrategy = FirebaseDataEncoder.KeyEncodingStrategy
-
     /// The strategy to use in encoding dates. Defaults to `.timestamp`.
-    public var dateEncodingStrategy: DateEncodingStrategy = .timestamp
+    public var dateEncodingStrategy: FirebaseDataEncoder.DateEncodingStrategy = .timestamp
 
     /// The strategy to use in encoding binary data. Defaults to `.base64`.
-    public var dataEncodingStrategy: DataEncodingStrategy = .base64
+    public var dataEncodingStrategy: FirebaseDataEncoder.DataEncodingStrategy = .base64
 
     /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
-    public var nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy = .throw
+    public var nonConformingFloatEncodingStrategy: FirebaseDataEncoder.NonConformingFloatEncodingStrategy = .throw
 
     /// The strategy to use for encoding keys. Defaults to `.useDefaultKeys`.
-    public var keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys
+    public var keyEncodingStrategy: FirebaseDataEncoder.KeyEncodingStrategy = .useDefaultKeys
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey: Any] = [:]
@@ -64,23 +58,17 @@ public extension Firestore {
   }
 
   class Decoder {
-    public typealias DateDecodingStrategy = FirebaseDataDecoder.DateDecodingStrategy
-    public typealias DataDecodingStrategy = FirebaseDataDecoder.DataDecodingStrategy
-    public typealias NonConformingFloatDecodingStrategy = FirebaseDataDecoder
-      .NonConformingFloatDecodingStrategy
-    public typealias KeyDecodingStrategy = FirebaseDataDecoder.KeyDecodingStrategy
-
     /// The strategy to use in decoding dates. Defaults to `.timestamp`.
-    public var dateDecodingStrategy: DateDecodingStrategy = .timestamp
+    public var dateDecodingStrategy: FirebaseDataDecoder.DateDecodingStrategy = .timestamp
 
     /// The strategy to use in decoding binary data. Defaults to `.base64`.
-    public var dataDecodingStrategy: DataDecodingStrategy = .base64
+    public var dataDecodingStrategy: FirebaseDataDecoder.DataDecodingStrategy = .base64
 
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
-    public var nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy = .throw
+    public var nonConformingFloatDecodingStrategy: FirebaseDataDecoder.NonConformingFloatDecodingStrategy = .throw
 
     /// The strategy to use for decoding keys. Defaults to `.useDefaultKeys`.
-    public var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
+    public var keyDecodingStrategy: FirebaseDataDecoder.KeyDecodingStrategy = .useDefaultKeys
 
     /// Contextual user-provided information for use during decoding.
     public var userInfo: [CodingUserInfoKey: Any] = [:]

--- a/Firestore/Swift/Source/Codable/TimestampDecodingStrategy.swift
+++ b/Firestore/Swift/Source/Codable/TimestampDecodingStrategy.swift
@@ -16,10 +16,11 @@
 
 import Foundation
 import FirebaseFirestore
+import FirebaseSharedSwift
 
-public extension Firestore.Decoder.DateDecodingStrategy {
+public extension FirebaseDataDecoder.DateDecodingStrategy {
   /// Decode the `Date` from a Firestore `Timestamp`
-  static var timestamp: Firestore.Decoder.DateDecodingStrategy {
+  static var timestamp: FirebaseDataDecoder.DateDecodingStrategy {
     return .custom { decoder in
       let container = try decoder.singleValueContainer()
       let value = try container.decode(Timestamp.self)

--- a/Firestore/Swift/Source/Codable/TimestampEncodingStrategy.swift
+++ b/Firestore/Swift/Source/Codable/TimestampEncodingStrategy.swift
@@ -15,11 +15,12 @@
  */
 
 import FirebaseFirestore
+import FirebaseSharedSwift
 import Foundation
 
-public extension Firestore.Encoder.DateEncodingStrategy {
+public extension FirebaseDataEncoder.DateEncodingStrategy {
   /// Encode the `Date` as a Firestore `Timestamp`.
-  static var timestamp: Firestore.Encoder.DateEncodingStrategy {
+  static var timestamp: FirebaseDataEncoder.DateEncodingStrategy {
     return .custom { date, encoder in
       var container = encoder.singleValueContainer()
       try container.encode(Timestamp(date: date))


### PR DESCRIPTION
Removed the `Firestore.Encoder` and `Firestore.Decoder` encoding/decoding strategy type aliases and directly used the types from `FirebaseDataEncoder` and `FirebaseDataDecoder`.

Note: This requires the `TimestampEncoding/DecodingStrategy` extension to be added to `FirebaseDataEncoder/Decoder` instead of `Firestore.Encoder` and `Firestore.Decoder`. This will make the `timestamp` strategy visible to all users of the `FirebaseDataEncoder/Decoder` (that have FirestoreSwift installed), even though `Timestamp` is a Firestore-specific type.