### PR TITLE
[Firestore] Update CHANGELOG for new Count API (#10246)

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Unreleased
+# 10.0.0
 - [feature] Added `Query.count()`, which fetches the number of documents in the
   result set without actually downloading the documents (#10246).
-
-# 10.0.0
 - [fixed] Fixed compiler warning about `@param comparator` (#10226).
 
 # 9.6.0


### PR DESCRIPTION
### Context
Meant to roll this into the other Firestore PRs. The count API PR has the changelog entry under `# Unreleased`; moving it under `# 10.0.0`.
