### PR TITLE
Initial commit of Firebase Sessions SDK

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -822,6 +822,7 @@ static FIRApp *sDefaultApp;
   // Dictionary of class names that conform to `FIRLibrary` and their user agents. These should only
   // be SDKs that are written in Swift but still visible to ObjC.
   NSDictionary<NSString *, NSString *> *swiftComponents = @{
+    @"FIRSessions" : @"fire-sessions",
     @"FIRFunctionsComponent" : @"fire-fun",
     @"FIRStorageComponent" : @"fire-str",
   };

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -1,0 +1,45 @@
+Pod::Spec.new do |s|
+  s.name             = 'FirebaseSessions'
+  s.version          = '10.0.0'
+  s.summary          = 'Firebase Sessions'
+
+  s.description      = <<-DESC
+  Firebase Sessions.
+                       DESC
+
+  s.homepage         = 'https://firebase.google.com'
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
+  s.authors          = 'Google, Inc.'
+
+  s.source           = {
+    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+    :tag => 'CocoaPods-' + s.version.to_s
+  }
+  s.social_media_url = 'https://twitter.com/Firebase'
+
+  ios_deployment_target = '11.0'
+  osx_deployment_target = '10.13'
+  tvos_deployment_target = '12.0'
+  watchos_deployment_target = '6.0'
+
+  s.swift_version = '5.3'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
+
+  s.cocoapods_version = '>= 1.4.0'
+  s.prefix_header_file = false
+
+  s.source_files = "FirebaseSessions/Sources/**/*.swift"
+
+  s.dependency 'FirebaseCore', '~> 10.0'
+  s.dependency 'FirebaseCoreExtension', '~> 10.0'
+  s.dependency 'FirebaseInstallations', '~> 10.0'
+
+  s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
+  }
+end

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -4,7 +4,8 @@ Pod::Spec.new do |s|
   s.summary          = 'Firebase Sessions'
 
   s.description      = <<-DESC
-  Firebase Sessions.
+  Not for public use.
+  SDK for sending events for Firebase App Quality Sessions.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import FirebaseCore
+
+// Avoids exposing internal FirebaseCore APIs to Swift users.
+@_implementationOnly import FirebaseCoreExtension
+
+@objc(FIRSessionsProvider)
+protocol SessionsProvider {
+  @objc static func sessions() -> Void
+}
+
+@objc(FIRSessions) class Sessions: NSObject, Library, SessionsProvider {
+  // MARK: - Private Variables
+
+  /// The app associated with all sessions.
+  private let googleAppID: String
+
+  // MARK: - Initializers
+
+  required init(app: FirebaseApp) {
+    googleAppID = app.options.googleAppID
+  }
+
+  // MARK: - Library conformance
+
+  static func componentsToRegister() -> [Component] {
+    return [Component(SessionsProvider.self,
+                      instantiationTiming: .alwaysEager,
+                      dependencies: []) { container, isCacheable in
+        // Sessions SDK only works for the default app
+        guard let app = container.app, app.isDefaultApp else { return nil }
+        isCacheable.pointee = true
+        return self.init(app: app)
+      }]
+  }
+
+  // MARK: - SessionsProvider conformance
+
+  static func sessions() {}
+}


### PR DESCRIPTION
Paired with: @jeremyjiang-dev 

# Notes
 - We haven't setup any SDKs with the Sessions SDK as a dependency, so this should not go out to users (unless they specify it directly)
 - We've only setup CocoaPods so far (for development), not SPM

# Questions
 - We were using [FunctionsComponent.swift](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseFunctions/Sources/Internal/FunctionsComponent.swift#L24-L33) as a reference. We see there is a protocol and initializer there. Our protocol isn't being called, and I'm not sure where their `functions(...` protocol method is being called
   - Is the protocol needed?
   - It looks like it's needed as something to pass into the `Component` constructor

#no-changelog
#sessions