### PR TITLE
Fix sign in alert shown inconsistently when triggered in viewDidAppear

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 9.0.1
-- [fixed] Fixed inconsistent sign in prompts in single scenes (#8096).
+- [fixed] Fixed inconsistent sign in prompts in single scene apps (#8096).
 
 # 9.0.0
 - [fixed] Marked `releaseNotes` as `nullable` as they don't always exist (#8602).

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 9.0.1
+# 10.1.0
 - [fixed] Fixed inconsistent sign in prompts in single scene apps (#8096).
 
 # 9.0.0

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.0.1
+- [fixed] Fixed inconsistent sign in prompts in single scenes (#8096).
+
 # 9.0.0
 - [fixed] Marked `releaseNotes` as `nullable` as they don't always exist (#8602).
 - [fixed] **Breaking change:** Fixed an ObjC-to-Swift API conversion error where`checkForUpdate()`

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -215,7 +215,10 @@ SFAuthenticationSession *_safariAuthenticationVC;
       self.window = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
       FIRFADInfoLog(@"No foreground scene found.");
-      self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+      // If no connected scene is found, we attach the window to one of the scenes
+      // that's available.
+      UIWindowScene *anyScene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
+      self.window = [[UIWindow alloc] initWithWindowScene:anyScene];
     }
   } else {
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -220,6 +220,7 @@ SFAuthenticationSession *_safariAuthenticationVC;
       UIWindowScene *scene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
       self.window = [[UIWindow alloc] initWithWindowScene:scene];
     } else {
+      // TODO: Consider using UISceneDidActivateNotification.
       FIRFADInfoLog(@"No foreground scene found.");
       self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     }

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -217,7 +217,8 @@ SFAuthenticationSession *_safariAuthenticationVC;
       // There are situations where a scene isn't considered foreground in viewDidAppear
       // and this fixes the issue in single scene apps.
       // https://github.com/firebase/firebase-ios-sdk/issues/8096
-      UIWindowScene *scene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
+      UIWindowScene *scene =
+          (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
       self.window = [[UIWindow alloc] initWithWindowScene:scene];
     } else {
       // TODO: Consider using UISceneDidActivateNotification.

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -214,6 +214,9 @@ SFAuthenticationSession *_safariAuthenticationVC;
     if (foregroundedScene) {
       self.window = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else if ([UIApplication sharedApplication].connectedScenes.count == 1) {
+      // There are situations where a scene isn't considered foreground in viewDidAppear
+      // and this fixes the issue in single scene apps.
+      // https://github.com/firebase/firebase-ios-sdk/issues/8096
       UIWindowScene *scene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
       self.window = [[UIWindow alloc] initWithWindowScene:scene];
     } else {

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -213,12 +213,12 @@ SFAuthenticationSession *_safariAuthenticationVC;
 
     if (foregroundedScene) {
       self.window = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
+    } else if ([UIApplication sharedApplication].connectedScenes.count == 1) {
+      UIWindowScene *scene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
+      self.window = [[UIWindow alloc] initWithWindowScene:scene];
     } else {
       FIRFADInfoLog(@"No foreground scene found.");
-      // If no connected scene is found, we attach the window to one of the scenes
-      // that's available.
-      UIWindowScene *anyScene = (UIWindowScene *)[UIApplication sharedApplication].connectedScenes.anyObject;
-      self.window = [[UIWindow alloc] initWithWindowScene:anyScene];
+      self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     }
   } else {
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];


### PR DESCRIPTION
This fixes the issue (#8096) where a scene may not be considered foreground in viewDidAppear.

There can still be issues for apps that have multiple scenes, and the right approach for that would involve using `UISceneDidActivateNotification`.

An example is https://github.com/firebase/firebase-ios-sdk/pull/9169.