### PR TITLE
DocumentId property wrapper: Emit error message on a single line

### DIFF
--- a/Firestore/Swift/Source/Codable/DocumentID.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID.swift
@@ -131,7 +131,7 @@ public struct DocumentID<Value: DocumentIDWrappable & Codable>:
       code: "I-FST000002",
       message: """
       Attempting to initialize or set a @DocumentID property with a non-nil \
-      value: \(value). The document ID is managed by Firestore and any \
+      value: "\(value)". The document ID is managed by Firestore and any \
       initialized or set value will be ignored. The ID is automatically set \
       when reading from Firestore.
       """

--- a/Firestore/Swift/Source/Codable/DocumentID.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID.swift
@@ -130,10 +130,10 @@ public struct DocumentID<Value: DocumentIDWrappable & Codable>:
       service: "[FirebaseFirestoreSwift]",
       code: "I-FST000002",
       message: """
-      Attempting to initialize or set a @DocumentID property with a non-nil
-      value: \(value). The document ID is managed by Firestore and any
-      initialized or set value will be ignored. The ID is automatically set
-      when reading from Firestore."
+      Attempting to initialize or set a @DocumentID property with a non-nil \
+      value: \(value). The document ID is managed by Firestore and any \
+      initialized or set value will be ignored. The ID is automatically set \
+      when reading from Firestore.
       """
     )
   }


### PR DESCRIPTION
This addresses a late review comment (https://github.com/firebase/firebase-ios-sdk/pull/10167#discussion_r982250978) on #10167, and ensures the error message is rendered on a single line.

Before:
```
2022-09-28 12:49:44.813075+0200 Make It So[29167:1864911] 10.0.0 - [FirebaseFirestoreSwift][I-FST000002] Attempting to initialize or set a @DocumentID property with a non-nil
value: B89FE0DD-7ACB-4D55-9FBE-CFC70512E760. The document ID is managed by Firestore and any
initialized or set value will be ignored. The ID is automatically set
when reading from Firestore."
```

After:
```
2022-09-29 18:41:42.906942+0200 Make It So[91334:3600697] 10.0.0 - [FirebaseFirestoreSwift][I-FST000002] Attempting to initialize or set a @DocumentID property with a non-nil value: 123. The document ID is managed by Firestore and any initialized or set value will be ignored. The ID is automatically set when reading from Firestore.
```

#no-changelog