### PR TITLE
[Infra] Check for improper FirebaseCoreExtension imports

### DIFF
--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -24,7 +24,7 @@ import FirebaseAuthInterop
 #endif
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
-import FirebaseCoreExtension
+@_implementationOnly  import FirebaseCoreExtension
 
 /**
  * Firebase Storage is a service that supports uploading and downloading binary objects,

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -24,7 +24,7 @@ import FirebaseAuthInterop
 #endif
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
-@_implementationOnly  import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 
 /**
  * Firebase Storage is a service that supports uploading and downloading binary objects,

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -24,7 +24,7 @@ import FirebaseAuthInterop
 #endif
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
-@_implementationOnly import FirebaseCoreExtension
+import FirebaseCoreExtension
 
 /**
  * Firebase Storage is a service that supports uploading and downloading binary objects,

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -64,7 +64,8 @@ private class ErrorLogger {
   }
 }
 
-private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL) {
+private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL,
+                       isSwiftFile: Bool) {
   var fileContents = ""
   do {
     fileContents = try String(contentsOfFile: file, encoding: .utf8)
@@ -73,6 +74,22 @@ private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL)
     // Not a source file, give up and return.
     return
   }
+
+  guard !isSwiftFile else {
+    // Swift specific checks.
+    fileContents.components(separatedBy: .newlines)
+      .enumerated() // [(lineNum, line), ...]
+      .filter { $1.starts(with: "import FirebaseCoreExtension") }
+      .forEach { lineNum, line in
+        logger
+          .importLog(
+            "Use `@_implementationOnly import FirebaseCoreExtension` when importing `FirebaseCoreExtension`.",
+            file, lineNum
+          )
+      }
+    return
+  }
+
   let isPublic = file.range(of: "/Public/") != nil &&
     // TODO: Skip legacy GDTCCTLibrary file that isn't Public and should be moved.
     // This test is used in the GoogleDataTransport's repo's CI clone of this repo.
@@ -186,7 +203,8 @@ private func main() -> Int32 {
         if !(file.hasSuffix(".h") ||
           file.hasSuffix(".m") ||
           file.hasSuffix(".mm") ||
-          file.hasSuffix(".c")) {
+          file.hasSuffix(".c") ||
+          file.hasSuffix(".swift")) {
           continue
         }
         let fullTransformPath = rootURL.path + "/" + file
@@ -195,7 +213,12 @@ private func main() -> Int32 {
             continue whileLoop
           }
         }
-        checkFile(fullTransformPath, logger: logger, inRepo: repoURL)
+        checkFile(
+          fullTransformPath,
+          logger: logger,
+          inRepo: repoURL,
+          isSwiftFile: file.hasSuffix(".swift")
+        )
       }
     }
   }


### PR DESCRIPTION
### Context
- `@_implementationOnly` is used when importing `FirebaseCoreExtension` to
  prevent the module from re-exporting `FirebaseCoreExtension`, which is an
  internal target.
- Update the `scripts/check_imports.swift` to check `*.swift` files for
  importing `FirebaseCoreExtension` without the `@_implementationOnly`
  attribute.

#no-changelog

