### PR TITLE
Enable COUNT integration tests, now that backend support has rolled out

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -61,11 +61,6 @@
 }
 
 - (void)testCanRunCountQuery {
-  // TODO(b/246758022): Remove this (and below) once COUNT is release for the backend.
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},
@@ -77,10 +72,6 @@
 }
 
 - (void)testCanRunCountWithFilters {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},
@@ -93,10 +84,6 @@
 }
 
 - (void)testCanRunCountWithOrderBys {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},
@@ -110,10 +97,6 @@
 }
 
 - (void)testSnapshotEquals {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},
@@ -152,10 +135,6 @@
 }
 
 - (void)testTerminateDoesNotCrashWithFlyingCountQuery {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},
@@ -172,10 +151,6 @@
 }
 
 - (void)testCanRunCollectionGroupCountQuery {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   NSString* collectionGroup =
       [NSString stringWithFormat:@"%@%@", @"b",
                                  [self.db collectionWithPath:@"foo"].documentWithAutoID.documentID];
@@ -205,10 +180,6 @@
 }
 
 - (void)testCanRunCountWithFiltersAndLimits {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"a"},
@@ -233,10 +204,6 @@
 }
 
 - (void)testCanRunCountOnNonExistentCollection {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRef];
 
   FIRAggregateQuerySnapshot* snapshot = [self readSnapshotForAggregate:[testCollection count]];
@@ -248,10 +215,6 @@
 }
 
 - (void)testFailWithoutNetwork {
-  if (![FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
-
   FIRCollectionReference* testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{@"k" : @"a"},
     @"b" : @{@"k" : @"b"},


### PR DESCRIPTION
Enable the integration tests for COUNT that were added in https://github.com/firebase/firebase-ios-sdk/pull/10254 now that the RunAggregationQuery RPC has been fully rolled out.

#no-changelog