### PR TITLE
FirestoreSwift: Make DocumentID setter internal

### DIFF
--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -2,8 +2,8 @@
 - [changed] **Breaking Change:** Made the `@DocumentID` property wrapper value
   setter internal to clarify that the value is ignored during writes. (#9368)
 - [changed] Initializing a `@DocumentID` property wrapper with a non-nil value
-  or using the `@DocumentID` property wrapper value setter will log a warning.
-  This is because the set value will be ignored. (#9368)
+  will log a warning and sets the value to nil. This is because the set value
+  is ignored. (#9368)
 - [changed] `Firestore.Encoder` and `Firestore.Decoder` now wraps the shared
   `FirebaseDataEncoder` and `FirebaseDataDecoder` types, which provides new
   customization options for encoding and decoding data to and from Firestore

--- a/Firestore/Swift/Source/Codable/DocumentID.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID.swift
@@ -125,7 +125,6 @@ public struct DocumentID<Value: DocumentIDWrappable & Codable>:
     self.value = nil
   }
 
-  
   /// Gets the document identifier if populated; `nil` otherwise.
   ///
   /// - Important: This property is read-only; the setter is `internal`.

--- a/Firestore/Swift/Source/Codable/DocumentID.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID.swift
@@ -105,21 +105,34 @@ internal protocol DocumentIDProtocol {
 @propertyWrapper
 public struct DocumentID<Value: DocumentIDWrappable & Codable>:
   StructureCodingUncodedUnkeyed {
-  private var value: Value? = nil
+  private var value: Value?
 
+  /// Constructs a `DocumentID` property wrapper with a value of `nil`.
+  ///
+  /// The `DocumentID` property wrapper should be considered read-only, the
+  /// `@DocumentID` field is populated with a document identifier when the
+  /// `Codable` is read using the Firestore APIs.
+  ///
+  /// - Parameter wrappedValue: An initial `String`, `DocumentReference` or
+  ///   `nil` value that will be ignored.
+  ///
+  /// - Important: The initial value is always `nil` regardless of the value
+  ///   specified in the `wrappedValue` parameter.
   public init(wrappedValue value: Value?) {
     if let value = value {
       logIgnoredValueWarning(value: value)
     }
-    self.value = value
+    self.value = nil
   }
 
-  public var wrappedValue: Value? {
+  
+  /// Gets the document identifier if populated; `nil` otherwise.
+  ///
+  /// - Important: This property is read-only; the setter is `internal`.
+  public internal(set) var wrappedValue: Value? {
     get { value }
     set {
-      if let someNewValue = newValue {
-        logIgnoredValueWarning(value: someNewValue)
-      }
+      // The setter can only be accessed internally or with `@testable`.
       value = newValue
     }
   }

--- a/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
+++ b/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
@@ -33,7 +33,7 @@ class ConditionalConformanceTests: XCTestCase {
   func testDocumentIDOfString() {
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: String?
-      
+
       init(x: String?) {
         self.x = x
       }
@@ -45,15 +45,15 @@ class ConditionalConformanceTests: XCTestCase {
     let dict: [Model: String] = [Model(x: "42"): "foo"]
     XCTAssertEqual("foo", dict[Model(x: "42")])
   }
-  
+
   func testDocumentIDConstructorSetsNilString() {
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: String? = "foo"
     }
-    
+
     let model1 = Model()
     let model2 = Model(x: "bar")
-    
+
     XCTAssertNil(model1.x)
     XCTAssertNil(model2.x)
   }
@@ -63,7 +63,7 @@ class ConditionalConformanceTests: XCTestCase {
     // and that's automatically bridged to conform to Swift `Hashable`.
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: DocumentReference?
-      
+
       init(x: DocumentReference?) {
         self.x = x
       }
@@ -80,15 +80,15 @@ class ConditionalConformanceTests: XCTestCase {
     let dict: [Model: String] = [Model(x: doc1): "foo"]
     XCTAssertEqual("foo", dict[Model(x: doc2)])
   }
-  
+
   func testDocumentIDConstructorSetsNilDocumentReference() {
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: DocumentReference? = FSTTestDocRef("abc/xyz")
     }
-    
+
     let model1 = Model()
     let model2 = Model(x: FSTTestDocRef("abc/def"))
-    
+
     XCTAssertNil(model1.x)
     XCTAssertNil(model2.x)
   }

--- a/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
+++ b/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
@@ -15,7 +15,7 @@
  */
 
 import FirebaseFirestore
-import FirebaseFirestoreSwift
+@testable import FirebaseFirestoreSwift
 import Foundation
 import XCTest
 
@@ -33,6 +33,10 @@ class ConditionalConformanceTests: XCTestCase {
   func testDocumentIDOfString() {
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: String?
+      
+      init(x: String?) {
+        self.x = x
+      }
     }
 
     XCTAssertTrue(Model(x: "42") == Model(x: "42"))
@@ -41,12 +45,28 @@ class ConditionalConformanceTests: XCTestCase {
     let dict: [Model: String] = [Model(x: "42"): "foo"]
     XCTAssertEqual("foo", dict[Model(x: "42")])
   }
+  
+  func testDocumentIDConstructorSetsNilString() {
+    struct Model: Codable, Equatable, Hashable {
+      @DocumentID var x: String? = "foo"
+    }
+    
+    let model1 = Model()
+    let model2 = Model(x: "bar")
+    
+    XCTAssertNil(model1.x)
+    XCTAssertNil(model2.x)
+  }
 
   func testDocumentIDOfDocumentReference() {
     // This works because `FIRDocumentReference` implements a `hash` selector
     // and that's automatically bridged to conform to Swift `Hashable`.
     struct Model: Codable, Equatable, Hashable {
       @DocumentID var x: DocumentReference?
+      
+      init(x: DocumentReference?) {
+        self.x = x
+      }
     }
 
     let doc1 = FSTTestDocRef("abc/xyz")
@@ -59,6 +79,18 @@ class ConditionalConformanceTests: XCTestCase {
 
     let dict: [Model: String] = [Model(x: doc1): "foo"]
     XCTAssertEqual("foo", dict[Model(x: doc2)])
+  }
+  
+  func testDocumentIDConstructorSetsNilDocumentReference() {
+    struct Model: Codable, Equatable, Hashable {
+      @DocumentID var x: DocumentReference? = FSTTestDocRef("abc/xyz")
+    }
+    
+    let model1 = Model()
+    let model2 = Model(x: FSTTestDocRef("abc/def"))
+    
+    XCTAssertNil(model1.x)
+    XCTAssertNil(model2.x)
   }
 
   func testExplicitNull() {

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 import FirebaseFirestore
-import FirebaseFirestoreSwift
+@testable import FirebaseFirestoreSwift
 import XCTest
 
 class FirestoreEncoderTests: XCTestCase {
@@ -536,7 +536,13 @@ class FirestoreEncoderTests: XCTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: DocumentReference?
+      
+      init(name: String, docId: DocumentReference?) {
+        self.name = name
+        self.docId = docId
+      }
     }
+
     assertThat(["name": "abc"], in: "abc/123")
       .decodes(to: Model(name: "abc", docId: FSTTestDocRef("abc/123")))
   }
@@ -545,7 +551,13 @@ class FirestoreEncoderTests: XCTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: String?
+      
+      init(name: String, docId: String?) {
+        self.name = name
+        self.docId = docId
+      }
     }
+
     assertThat(["name": "abc"], in: "abc/123")
       .decodes(to: Model(name: "abc", docId: "123"))
   }

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -536,7 +536,7 @@ class FirestoreEncoderTests: XCTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: DocumentReference?
-      
+
       init(name: String, docId: DocumentReference?) {
         self.name = name
         self.docId = docId
@@ -551,7 +551,7 @@ class FirestoreEncoderTests: XCTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: String?
-      
+
       init(name: String, docId: String?) {
         self.name = name
         self.docId = docId

--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -214,6 +214,11 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: DocumentReference?
+      
+      init(name: String, docId: DocumentReference?) {
+        self.name = name
+        self.docId = docId
+      }
     }
 
     let docToWrite = documentRef()

--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -214,7 +214,7 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: DocumentReference?
-      
+
       init(name: String, docId: DocumentReference?) {
         self.name = name
         self.docId = docId


### PR DESCRIPTION
**This is an alternative to the warning-only approach proposed in the latest `DocumentID` API review.**

Made the `@DocumentID` property wrapper's value setter internal. `DocumentID` is currently read-only and is only populated when reading from Firestore. This PR limits access to the setter since the value is ignored when writing to Firestore.

Updated the constructor to always set `nil`, regardless of the `wrappedValue` provided. Developers are notified of this via an existing log message warning them that the value is ignored.

Added conformance tests to verify (and demonstrate) the functionality change.