### PR TITLE
Firestore: run sanitizers on macos in addition to ubuntu

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -126,13 +126,14 @@ jobs:
   sanitizers:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    # TODO(b/231154868): GRPC 1.44 cause link issues on Mac, moving it to Ubuntu for now and add Mac when it is resolved.
-    runs-on: ubuntu-latest
     needs: check
 
     strategy:
       matrix:
+        os: [macos-12, ubuntu-latest]
         sanitizer: [asan, tsan]
+
+    runs-on: ${{ matrix.os }}
 
     env:
       SANITIZERS: ${{ matrix.sanitizer }}


### PR DESCRIPTION
Undo the switch of the Firestore sanitizer builds to run on ubuntu instead of macos, made in https://github.com/firebase/firebase-ios-sdk/pull/9488.

#no-changelog