### PR TITLE
Disable watchOS pod lib lint tests

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -27,7 +27,7 @@ jobs:
       POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -141,8 +141,8 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        # The macos and tvos tests can hang, and watchOS doesn't have tests.
-        target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
+        # The macos and tvos tests can hang.
+        target: [ios, tvos --skip-tests, macos --skip-tests]
         flags: [
           '--use-static-frameworks'
         ]

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos --skip-tests]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -110,8 +110,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        # Disable watchos because it does not support XCTest.
-        target: [ios, tvos, macos, watchos --skip-tests]
+        target: [ios, tvos, macos]
         flags: [
           '--use-static-frameworks'
         ]

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -120,7 +120,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -138,20 +138,6 @@ jobs:
       run: ([ -z $plist_secret ] ||
             scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Messaging false swift)
 
-  pod-lib-lint-watchos:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-12
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Build and test
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests --platforms=watchos
-
-
   messaging-cron-only:
     # Don't run on private repo.
     if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
@@ -170,24 +156,6 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: PodLibLint Messaging Cron
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=${{ matrix.target }}
-
-  messaging-watchos-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-12
-    strategy:
-      matrix:
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod-lib-lint-watchos
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint Messaging Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=watchos
 
   messaging-sample-build-test:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -59,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
         podspec: [FirebaseRemoteConfig.podspec, FirebaseRemoteConfigSwift.podspec --skip-tests]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos --skip-tests]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
@@ -122,7 +122,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
+        target: [ios, tvos, macos]
     needs: pod-lib-lint
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`pod lib lint` does not work for watchOS with Xcode 14. See https://github.com/CocoaPods/CocoaPods/issues/11558

This PR disables the tests for now.

Created #10316 to track restoring the tests.