### PR TITLE
[FirestoreSwift] Add FirebaseCore dependency to avoid linker issues

### DIFF
--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -6,6 +6,8 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
     Not for public use.
     Common FirebaseCore APIs for use in Firebase product SDKs.
+    When depending on `FirebaseCoreExtension`, also depend on `FirebaseCore` to
+    avoid potential linker issues.
                          DESC
 
     s.homepage         = 'https://firebase.google.com'

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -34,6 +34,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/Swift/Source/**/*.swift',
   ]
 
+  s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'
   s.dependency 'FirebaseFirestore', '~> 10.0'
   s.dependency 'FirebaseSharedSwift', '~> 10.0'

--- a/Package.swift
+++ b/Package.swift
@@ -242,6 +242,8 @@ let package = Package(
     // MARK: - Firebase Core Extension
 
     // Extension of FirebaseCore for consuming by Swift product SDKs.
+    // When depending on `FirebaseCoreExtension`, also depend on `FirebaseCore`
+    // to avoid potential linker issues.
     .target(
       name: "FirebaseCoreExtension",
       path: "FirebaseCore/Extension",

--- a/Package.swift
+++ b/Package.swift
@@ -702,6 +702,7 @@ let package = Package(
     .target(
       name: "FirebaseFirestoreSwift",
       dependencies: [
+        "FirebaseCore",
         "FirebaseCoreExtension",
         "FirebaseFirestore",
         "FirebaseSharedSwift",


### PR DESCRIPTION
### Context
- FirebaseCoreExtension was added as a dependency to FirebaseFirestoreSwift in
  #10167. After this was done, FirebaseFirestoreSwift still not have a direct dependency on FirebaseCore. FirestoreSwift directly depended on FirebaseCoreExtension and **transitively** depended on FirebaseCore. We suspect this caused a linker issue that showed up in the [nightlies](https://github.com/firebase/firebase-ios-sdk/issues/10293#issuecomment-1271666340).

  It seems that all other SDKs that currently depend on FirebaseCoreExtension
  also directly depend on FirebaseCore (with the exception of FirebaseFirestoreSwift):
```shell
➜  firebase-ios-sdk git:(master) ✗ 
‣ git grep -C 5 "dependency 'FirebaseCoreExtension'" *.podspec                                                                                                                                                                                                                                                       
FirebaseFirestoreSwift.podspec-
FirebaseFirestoreSwift.podspec:  s.dependency 'FirebaseCoreExtension', '~> 10.0'
FirebaseFirestoreSwift.podspec-  s.dependency 'FirebaseFirestore', '~> 10.0'
FirebaseFirestoreSwift.podspec-  s.dependency 'FirebaseSharedSwift', '~> 10.0'
FirebaseFirestoreSwift.podspec-
--
FirebaseFunctions.podspec-
FirebaseFunctions.podspec-  s.dependency 'FirebaseCore', '~> 10.0'
FirebaseFunctions.podspec:  s.dependency 'FirebaseCoreExtension', '~> 10.0'
FirebaseFunctions.podspec-  s.dependency 'FirebaseAppCheckInterop', '~> 10.0'
FirebaseFunctions.podspec-  s.dependency 'FirebaseAuthInterop', '~> 10.0'
FirebaseFunctions.podspec-  s.dependency 'FirebaseMessagingInterop', '~> 10.0'
FirebaseFunctions.podspec-  s.dependency 'FirebaseSharedSwift', '~> 10.0'
FirebaseFunctions.podspec-  s.dependency 'GTMSessionFetcher/Core', '~> 2.1'
--
FirebaseSessions.podspec-
FirebaseSessions.podspec-  s.dependency 'FirebaseCore', '~> 10.0'
FirebaseSessions.podspec:  s.dependency 'FirebaseCoreExtension', '~> 10.0'
FirebaseSessions.podspec-  s.dependency 'FirebaseInstallations', '~> 10.0'
FirebaseSessions.podspec-
--
FirebaseStorage.podspec-
FirebaseStorage.podspec-  s.dependency 'FirebaseAppCheckInterop', '~> 10.0'
FirebaseStorage.podspec-  s.dependency 'FirebaseAuthInterop', '~> 10.0'
FirebaseStorage.podspec-  s.dependency 'FirebaseCore', '~> 10.0'
FirebaseStorage.podspec:  s.dependency 'FirebaseCoreExtension', '~> 10.0'
FirebaseStorage.podspec-  s.dependency 'GTMSessionFetcher/Core', '~> 2.1'
FirebaseStorage.podspec-
```

Fixes #10293

#no-changelog


### Next steps
- [ ] Cherry-pick into release branch
- [ ] Retag release
- [ ] Push `FirebaseFirestore.podspec` to SpecStaging
