### PR TITLE
[Messaging] Xcode 14 watchkit extension bundle id fix

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.1.0
+- [fixed] App bundle identifier gets incorrectly shortened for watchOS apps created on Xcode 14 (#10147)
+
 # 8.12.0
 - [changed] Improved reporting for SQLite errors when failing to open a local database (#8699).
 

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.h
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT int64_t FIRMessagingCurrentTimestampInMilliseconds(void);
 FOUNDATION_EXPORT NSString *FIRMessagingCurrentAppVersion(void);
 FOUNDATION_EXPORT NSString *FIRMessagingAppIdentifier(void);
 FOUNDATION_EXPORT NSString *FIRMessagingFirebaseAppID(void);
+FOUNDATION_EXPORT BOOL FIRMessagingIsWatchKitExtension(void);
 
 #pragma mark - Others
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
@@ -69,6 +69,8 @@
 
 - (void)testAppIdentifierReturnsExpectedValue {
 #if TARGET_OS_WATCH
+  NSDictionary *fakeInfoDictionary = @{@"NSExtension" : @{@"NSExtensionPointIdentifier" : @"com.apple.watchkit"}};
+  [[[_mainBundleMock stub] andReturn:fakeInfoDictionary] infoDictionary];
   NSString *bundleIdentifier = @"com.me.myapp.watchkit.watchkitextensions";
   NSString *expectedIdentifier = @"com.me.myapp.watchkit";
 #else

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
@@ -69,7 +69,8 @@
 
 - (void)testAppIdentifierReturnsExpectedValue {
 #if TARGET_OS_WATCH
-  NSDictionary *fakeInfoDictionary = @{@"NSExtension" : @{@"NSExtensionPointIdentifier" : @"com.apple.watchkit"}};
+  NSDictionary *fakeInfoDictionary =
+      @{@"NSExtension" : @{@"NSExtensionPointIdentifier" : @"com.apple.watchkit"}};
   [[[_mainBundleMock stub] andReturn:fakeInfoDictionary] infoDictionary];
   NSString *bundleIdentifier = @"com.me.myapp.watchkit.watchkitextensions";
   NSString *expectedIdentifier = @"com.me.myapp.watchkit";


### PR DESCRIPTION

### Discussion

Fix for https://github.com/firebase/firebase-ios-sdk/issues/10147

In versions of Xcode prior to Xcode 14, whenever a watch app was created, Xcode always created two targets 
Watch App (contained assets for the app but no code)
Watch Kit Extension (contained the code / logic for the app)

Xcode 14 onwards, no watch kit extension target is created for watchOS apps. There is a consolidated Watch App target that contains both code and assets. 

Firebase Messaging code used to strip out the watch extension suffix and use the watch app bundle ID for FCM registration. Since there is no extension anymore, the code is inadvertently stripping out the last component of the app bundle identifier itself, resulting in an incorrect bundle ID being used for FCM registration. 

This change detects if code is running in an extension by looking for the watch kit NSExtensionPointIdentifier in the Info.plist before stripping out the last component of the bundle identifier. 

### Testing

- Created a sample app with watch kit extension on Xcode 13 and confirmed that function returned YES (true) for extension. 
- Created a sample watch app (with no extension) on Xcode 14 and confirmed that function returned NO.

### API Changes
None