### PR TITLE
Add new danger check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -181,9 +181,9 @@ end
 # Warn if a new public header file is added but no umbrella header changes
 # are detected. Prevents regression of #10301
 if @has_public_additions && !@has_umbrella_changes
-  warning = "New public headers were added, "\
+  error = "New public headers were added, "\
       "did you remember to add them to the umbrella header?"
-  warn(warning)
+  fail(error)
 end
 
 # Error on license edits

--- a/Dangerfile
+++ b/Dangerfile
@@ -24,6 +24,18 @@ def hasChangesIn(paths)
   return false
 end
 
+# Determine if any new files were added to paths matching any of the
+# path patterns provided.
+def hasAdditionsIn(paths)
+  path_array = Array(paths)
+  path_array.each do |dir|
+    if !git.added_files.grep(/#{dir}/).empty?
+      return true
+    end
+  end
+  return false
+end
+
 # Adds the provided labels to the current PR.
 def addLabels(label_array)
   issue_number = github.pr_json["number"]
@@ -118,6 +130,8 @@ has_license_changes = didModify(["LICENSE"])
 @has_storage_changes = hasChangesIn("FirebaseStorage")
 
 @has_releasetooling_changes = hasChangesIn("ReleaseTooling/")
+@has_public_additions = hasAdditionsIn("Public/")
+@has_umbrella_changes = hasChangesIn("Firebase*.h")
 
 # Convenient flag for all API changes.
 @has_api_changes = @has_abtesting_api_changes ||
@@ -162,6 +176,14 @@ if has_sdk_changes
       " to the PR description to silence this warning.)"
     warn(warning)
   end
+end
+
+# Warn if a new public header file is added but no umbrella header changes
+# are detected. Prevents regression of #10301
+if @has_public_additions && !@has_umbrella_changes
+  warning = "New public headers were added, "\
+      "did you remember to add them to the umbrella header?"
+  warn(warning)
 end
 
 # Error on license edits

--- a/FirebaseCore/Sources/Public/FIRTestFile.h
+++ b/FirebaseCore/Sources/Public/FIRTestFile.h
@@ -1,2 +1,0 @@
-// Test file.
-

--- a/FirebaseCore/Sources/Public/FIRTestFile.h
+++ b/FirebaseCore/Sources/Public/FIRTestFile.h
@@ -1,0 +1,2 @@
+// Test file.
+


### PR DESCRIPTION
Prevents regression of #10301.

Note that this PR doesn't check which umbrella header is modified, so a change that updates multiple SDKs could still not warn if not all of the requisite umbrella headers were updated.