### PR TITLE
Add changelog entry for bitcode removal in Firebase 10.1.0

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Firebase 10.1.0
+- [changed] Bitcode is no longer included in Firebase binary distributions. Xcode 14 does not
+  support bitcode. tvOS apps using a Firebase binary distribution will now need to use
+  Xcode 14. (#10372)
+
 # Firebase 10.0.0
 - [changed] **Breaking change**: Firebase's minimum supported versions have
   updated for the following platforms:


### PR DESCRIPTION
Added an entry explaining the removal of bitcode in the Firebase 10.1.0 (M123) release.