### PR TITLE
[Storage] Debug updateMetadata customMetadata iniWithDictionary issue

### DIFF
--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -146,6 +146,7 @@ import Foundation
   // MARK: - Public Initializers
 
   @objc override public convenience init() {
+    // Approach 2: `initialMetadata` is `[:]`
     self.init(dictionary: [:])
   }
 
@@ -203,6 +204,8 @@ import Foundation
   // MARK: - Internal APIs
 
   internal func updatedMetadata() -> [String: AnyHashable] {
+    // In Approach 1 `initialMetadata` is populated, in Approach 2 it's `[:]`.
+    print("Initial Metadata: \(initialMetadata)")
     return remove(matchingMetadata: dictionaryRepresentation(), oldMetadata: initialMetadata)
   }
 

--- a/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
@@ -729,28 +729,35 @@ NSString *const kTestPassword = KPASSWORD;
   // This custom metadata will be removed when using
   // initWithDictionary method
   dictionary[@"metadata"] = expectedMetadata;
-  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:dictionary];
-  XCTAssertEqualObjects(expectedMetadata, metadata.customMetadata);
+  FIRStorageMetadata *metadata1 = [[FIRStorageMetadata alloc] initWithDictionary:dictionary];
+  XCTAssertEqualObjects(expectedMetadata, metadata1.customMetadata);
+
+  // Approach 2 - Works
+
+  FIRStorageMetadata *metadata2 = [[FIRStorageMetadata alloc] init];
+  metadata2.customMetadata = @{@"foo" : @"bar"};
+  XCTAssertEqualObjects(expectedMetadata, metadata2.customMetadata);
+
+  XCTAssertEqualObjects([metadata1 dictionaryRepresentation], [metadata2 dictionaryRepresentation]);
+
+  // Testing Approach 1
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdateMetadata1"];
-  [ref updateMetadata:metadata
+  [ref updateMetadata:metadata1
            completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
              [expectation fulfill];
              XCTAssertNil(error);
              XCTAssertNotNil(updatedMetadata);
              XCTAssertNotNil(updatedMetadata.customMetadata);
+             // Failing Assertion: ("{ foo = bar; }") is not equal to ("{ }")
              XCTAssertEqualObjects(expectedMetadata, updatedMetadata.customMetadata);
            }];
   [self waitForExpectations:@[ expectation ] timeout:kFIRStorageIntegrationTestTimeout];
 
-  // Approach 2 - Works
-
-  metadata = [[FIRStorageMetadata alloc] init];
-  metadata.customMetadata = @{@"foo" : @"bar"};
-  XCTAssertEqualObjects(expectedMetadata, metadata.customMetadata);
+  // Testing Approach 2
 
   expectation = [self expectationWithDescription:@"testUpdateMetadata2"];
-  [ref updateMetadata:metadata
+  [ref updateMetadata:metadata2
            completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
              [expectation fulfill];
              XCTAssertNil(error);


### PR DESCRIPTION
Debugging the issue `updateMetadata` method fails to update `customMetadata` when you initialize metadata with `initWithDictionary`. See #10374 issue 6 for further details.