### PR TITLE
[Infra] Fix ignoring of Mint sources when checking style

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -156,7 +156,7 @@ s%^./%%
 \%^/?vendor/bundle/% d
 
 # Sources pulled in by the Mint package manager
-\%^Mint% d
+\%^mint% d
 
 # Auth Sample Objective-C does not format well
 \%^(FirebaseAuth/Tests/Sample/Sample)/% d


### PR DESCRIPTION
### Context
This should fix `check` flakes in GDT repo (see https://github.com/google/GoogleDataTransport/pull/87). The issue seemed to be that the styling paths to be excluded are case-sensitive. This has preivously worked for some time so maybe the GHA runner was configured differently.

Previously experimented with whether this would work in #10423


#no-changelog