### PR TITLE
Force to recaptcha verification flow for phone auth in Simulators

### DIFF
--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <TargetConditionals.h>
+
 #if TARGET_OS_IOS
 
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthSettings.h"
@@ -593,6 +595,10 @@ extern NSString *const FIRPhoneMultiFactorID;
  */
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
+  if ([GULAppEnvironmentUtil isSimulator]) {
+    [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+    return;
+  }
   if (_auth.appCredentialManager.credential) {
     completion(_auth.appCredentialManager.credential, nil, nil);
     return;

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -595,16 +595,17 @@ extern NSString *const FIRPhoneMultiFactorID;
  */
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
-  // Remove the simulator check below after FCM supports APNs in simulators
+// Remove the simulator check below after FCM supports APNs in simulators
+#if TARGET_OS_SIMULATOR
   if (@available(iOS 16, *)) {
-    if ([GULAppEnvironmentUtil isSimulator]) {
-      NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-      if ((environment[@"XCTestConfigurationFilePath"] == nil)) {
-        [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
-        return;
-      }
+    NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+    if ((environment[@"XCTestConfigurationFilePath"] == nil)) {
+      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+      return;
     }
   }
+#endif
+
   if (_auth.appCredentialManager.credential) {
     completion(_auth.appCredentialManager.credential, nil, nil);
     return;

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -596,7 +596,6 @@ extern NSString *const FIRPhoneMultiFactorID;
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
   // Remove the simulator check below after FCM supports APNs in simulators
-#if TESTING
   if (@available(iOS 17, *)) {
     if ([GULAppEnvironmentUtil isSimulator]) {
       NSDictionary *environment = [[NSProcessInfo processInfo] environment];

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -596,12 +596,12 @@ extern NSString *const FIRPhoneMultiFactorID;
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
   // Remove the simulator check below after FCM supports APNs in simulators
-  if (@available(iOS 16, *)) {
-    if ([GULAppEnvironmentUtil isSimulator]) {
-      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
-      return;
-    }
-  }
+//  if (@available(iOS 16, *)) {
+//    if ([GULAppEnvironmentUtil isSimulator]) {
+//      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+//      return;
+//    }
+//  }
   if (_auth.appCredentialManager.credential) {
     completion(_auth.appCredentialManager.credential, nil, nil);
     return;

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -596,10 +596,14 @@ extern NSString *const FIRPhoneMultiFactorID;
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
   // Remove the simulator check below after FCM supports APNs in simulators
+#if TESTING
   if (@available(iOS 17, *)) {
     if ([GULAppEnvironmentUtil isSimulator]) {
-      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
-      return;
+      NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+      if ((environment[@"XCTestConfigurationFilePath"] == nil)) {
+        [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+        return;
+      }
     }
   }
   if (_auth.appCredentialManager.credential) {

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -596,12 +596,12 @@ extern NSString *const FIRPhoneMultiFactorID;
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
   // Remove the simulator check below after FCM supports APNs in simulators
-//  if (@available(iOS 16, *)) {
-//    if ([GULAppEnvironmentUtil isSimulator]) {
-//      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
-//      return;
-//    }
-//  }
+  if (@available(iOS 17, *)) {
+    if ([GULAppEnvironmentUtil isSimulator]) {
+      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+      return;
+    }
+  }
   if (_auth.appCredentialManager.credential) {
     completion(_auth.appCredentialManager.credential, nil, nil);
     return;

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -595,9 +595,12 @@ extern NSString *const FIRPhoneMultiFactorID;
  */
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
-  if ([GULAppEnvironmentUtil isSimulator]) {
-    [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
-    return;
+  // Remove the simulator check below after FCM supports APNs in simulators
+  if (@available(iOS 16, *)) {
+    if ([GULAppEnvironmentUtil isSimulator]) {
+      [self reCAPTCHAFlowWithUIDelegate:UIDelegate completion:completion];
+      return;
+    }
   }
   if (_auth.appCredentialManager.credential) {
     completion(_auth.appCredentialManager.credential, nil, nil);

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <TargetConditionals.h>
-
 #if TARGET_OS_IOS
 
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthSettings.h"

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -596,7 +596,7 @@ extern NSString *const FIRPhoneMultiFactorID;
 - (void)verifyClientWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(FIRVerifyClientCallback)completion {
   // Remove the simulator check below after FCM supports APNs in simulators
-  if (@available(iOS 17, *)) {
+  if (@available(iOS 16, *)) {
     if ([GULAppEnvironmentUtil isSimulator]) {
       NSDictionary *environment = [[NSProcessInfo processInfo] environment];
       if ((environment[@"XCTestConfigurationFilePath"] == nil)) {


### PR DESCRIPTION
In the latest Xcode and macOS versions, APNs is now supported in simulators. Before that, phone auth will always fallback to the recaptcha verification flow.
Since FCM doesn't support iOS 16 simulators yet, https://github.com/firebase/firebase-ios-sdk/issues/9968, this change force the phone auth flow fallback to recaptcha in simulators.