### PR TITLE
[Sessions] Prevent gathering MCCMNC when under simulator

### DIFF
--- a/FirebaseSessions/Sources/NetworkInfo.swift
+++ b/FirebaseSessions/Sources/NetworkInfo.swift
@@ -22,10 +22,20 @@ protocol NetworkInfoProtocol {
 
 class NetworkInfo: NetworkInfoProtocol {
   var mobileCountryCode: String? {
+    // Don't look these up when in the simulator because they always fail
+    // and put unnecessary logs in the customer's output
+    #if targetEnvironment(simulator)
+    return ""
+    #else
     return FIRSESNetworkMobileCountryCode()
+    #endif // targetEnvironment(simulator)
   }
 
   var mobileNetworkCode: String? {
+    #if targetEnvironment(simulator)
+    return ""
+    #else
     return FIRSESNetworkMobileNetworkCode()
+    #endif // targetEnvironment(simulator)
   }
 }

--- a/FirebaseSessions/Sources/NetworkInfo.swift
+++ b/FirebaseSessions/Sources/NetworkInfo.swift
@@ -25,17 +25,17 @@ class NetworkInfo: NetworkInfoProtocol {
     // Don't look these up when in the simulator because they always fail
     // and put unnecessary logs in the customer's output
     #if targetEnvironment(simulator)
-    return ""
+      return ""
     #else
-    return FIRSESNetworkMobileCountryCode()
+      return FIRSESNetworkMobileCountryCode()
     #endif // targetEnvironment(simulator)
   }
 
   var mobileNetworkCode: String? {
     #if targetEnvironment(simulator)
-    return ""
+      return ""
     #else
-    return FIRSESNetworkMobileNetworkCode()
+      return FIRSESNetworkMobileNetworkCode()
     #endif // targetEnvironment(simulator)
   }
 }


### PR DESCRIPTION
Without this, customers get many failed xpc errors in their console logs. 

```
2022-10-31 15:41:59.824110-0400 AppQualityDevApp[95667:2639392] [Client] Updating selectors failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.824197-0400 AppQualityDevApp[95667:2639271] [Client] Synchronous remote object proxy returned error: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.824375-0400 AppQualityDevApp[95667:2639390] [Client] Updating selectors failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.824503-0400 AppQualityDevApp[95667:2639271] [Client] Synchronous remote object proxy returned error: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.824666-0400 AppQualityDevApp[95667:2639271] [Client] Synchronous remote object proxy returned error: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.824675-0400 AppQualityDevApp[95667:2639392] [Client] Updating selectors failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.827712-0400 AppQualityDevApp[95667:2639390] [Client] Updating selectors failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
2022-10-31 15:41:59.827794-0400 AppQualityDevApp[95667:2639390] [Client] Updating selectors after delegate addition failed with: Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process." UserInfo={NSDebugDescription=The connection to service named com.apple.commcenter.coretelephony.xpc was invalidated: failed at lookup with error 3 - No such process.}
```

#no-changelog