### PR TITLE
[Sessions] Log events to console command line flag, fix encoding

### DIFF
--- a/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
+++ b/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+class DevEventConsoleLogger: EventGDTLoggerProtocol {
+  private let commandLineArgument = "-FIRSessionsDebugEvents"
+
+  func logEvent(event: SessionStartEvent, completion: @escaping (Result<Void, Error>) -> Void) {
+    if !ProcessInfo.processInfo.arguments.contains(commandLineArgument) {
+      return
+    }
+
+    let proto = event.encodeDecodeEvent()
+    prettyPrint(proto: proto)
+  }
+
+  func prettyPrint(proto: firebase_appquality_sessions_SessionEvent) {
+    let logOutput = """
+    Logging Session Event due to \"\(commandLineArgument)\" command line argument
+    Session Event:
+      event_type: \(proto.event_type)
+      session_data
+        session_id: \(proto.session_data.session_id.description)
+        previous_session_id: \(proto.session_data.previous_session_id.description)
+        event_timestamp_us: \(proto.session_data.event_timestamp_us)
+        data_collection_status
+          crashlytics: \(proto.session_data.data_collection_status.crashlytics)
+          performance: \(proto.session_data.data_collection_status.performance)
+      application_info
+        app_id: \(proto.application_info.app_id.description)
+        device_model: \(proto.application_info.device_model.description)
+        development_platform_name: \(proto.application_info.development_platform_name.description)
+        development_platform_version: \(proto.application_info.development_platform_version
+      .description)
+        session_sdk_version: \(proto.application_info.session_sdk_version.description)
+        apple_app_info
+          bundle_short_version: \(proto.application_info.apple_app_info.bundle_short_version
+      .description)
+          network_connection_info
+            network_type: \(proto.application_info.apple_app_info.network_connection_info
+      .network_type.rawValue)
+            mobile_subtype: \(proto.application_info.apple_app_info.network_connection_info
+      .mobile_subtype.rawValue)
+          os_name: \(proto.application_info.apple_app_info.os_name.description)
+          mcc_mnc: \(proto.application_info.apple_app_info.mcc_mnc.description)
+    """
+
+    Logger.logInfo(logOutput)
+  }
+}

--- a/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
+++ b/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
@@ -1,0 +1,103 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+///
+/// These extensions allows us to console log properties of our Session Events
+/// proto for development and debugging purposes without having to call decode
+/// on each field manually. Instead you can read `<field>.description`.
+///
+
+extension firebase_appquality_sessions_EventType: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case firebase_appquality_sessions_EventType_SESSION_START:
+      return "SESSION_START"
+    case firebase_appquality_sessions_EventType_EVENT_TYPE_UNKNOWN:
+      return "UNKNOWN"
+    default:
+      return "Unrecognized EventType. Please update the firebase_appquality_sessions_EventType CustomStringConvertible extension"
+    }
+  }
+}
+
+extension firebase_appquality_sessions_DataCollectionState: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_ENABLED:
+      return "ENABLED"
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_SAMPLED:
+      return "SAMPLED"
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_UNKNOWN:
+      return "UNKNOWN"
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_DISABLED:
+      return "DISABLED"
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_DISABLED_REMOTE:
+      return "DISABLED_REMOTE"
+    case firebase_appquality_sessions_DataCollectionState_COLLECTION_SDK_NOT_INSTALLED:
+      return "SDK_NOT_INSTALLED"
+    default:
+      return "Unrecognized DataCollectionState. Please update the firebase_appquality_sessions_DataCollectionState CustomStringConvertible extension"
+    }
+  }
+}
+
+extension firebase_appquality_sessions_OsName: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case firebase_appquality_sessions_OsName_IOS:
+      return "IOS"
+    case firebase_appquality_sessions_OsName_IPADOS:
+      return "IPADOS"
+    case firebase_appquality_sessions_OsName_TVOS:
+      return "TVOS"
+    case firebase_appquality_sessions_OsName_IOS_ON_MAC:
+      return "IOS_ON_MAC"
+    case firebase_appquality_sessions_OsName_MACOS:
+      return "MACOS"
+    case firebase_appquality_sessions_OsName_MACCATALYST:
+      return "MACCATALYST"
+    case firebase_appquality_sessions_OsName_WATCHOS:
+      return "WATCHOS"
+    case firebase_appquality_sessions_OsName_UNKNOWN_OSNAME:
+      return "UNKNOWN_OSNAME"
+    case firebase_appquality_sessions_OsName_UNSPECIFIED:
+      return "UNSPECIFIED"
+    default:
+      return "Unrecognized OsName. Please update the firebase_appquality_sessions_OsName CustomStringConvertible extension"
+    }
+  }
+}
+
+extension UnsafeMutablePointer<pb_bytes_array_t>: CustomStringConvertible {
+  public var description: String {
+    let decoded = FIRSESDecodeString(self)
+    if decoded.count == 0 {
+      return "<EMPTY>"
+    }
+    return decoded
+  }
+}
+
+// For an optional field
+extension UnsafeMutablePointer<pb_bytes_array_t>?: CustomStringConvertible {
+  public var description: String {
+    guard let this = self else {
+      return "<NULL>"
+    }
+    return this.description
+  }
+}

--- a/FirebaseSessions/Sources/EventGDTLogger.swift
+++ b/FirebaseSessions/Sources/EventGDTLogger.swift
@@ -28,9 +28,12 @@ protocol EventGDTLoggerProtocol {
 ///
 class EventGDTLogger: EventGDTLoggerProtocol {
   let googleDataTransport: GoogleDataTransportProtocol
+  let devEventConsoleLogger: EventGDTLoggerProtocol
 
-  init(googleDataTransport: GoogleDataTransportProtocol) {
+  init(googleDataTransport: GoogleDataTransportProtocol,
+       devEventConsoleLogger: EventGDTLoggerProtocol = DevEventConsoleLogger()) {
     self.googleDataTransport = googleDataTransport
+    self.devEventConsoleLogger = devEventConsoleLogger
   }
 
   /// Logs the event to FireLog, taking into account debugging cases such as running
@@ -43,6 +46,8 @@ class EventGDTLogger: EventGDTLoggerProtocol {
       Logger.logDebug("Logging events using fast QOS due to running on a simulator")
       gdtEvent.qosTier = GDTCOREventQoS.qoSFast
     #endif // targetEnvironment(simulator)
+
+    devEventConsoleLogger.logEvent(event: event) { _ in }
 
     googleDataTransport.logGDTEvent(event: gdtEvent, completion: completion)
   }

--- a/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.h
+++ b/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.h
@@ -30,6 +30,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Returns an error associated with the istream. Written in Objective-C because Swift does not
+/// support C language macros
+NSString* FIRSESPBGetError(pb_istream_t istream);
+
 // It seems impossible to specify the nullability of the `fields` parameter below,
 // yet the compiler complains that it's missing a nullability specifier. Google
 // yields no results at this time.
@@ -49,6 +53,14 @@ pb_bytes_array_t* _Nullable FIRSESEncodeData(NSData* _Nullable data);
 /// @note Memory needs to be freed manually, through pb_free or pb_release.
 /// @param string The string to encode as pb_bytes.
 pb_bytes_array_t* _Nullable FIRSESEncodeString(NSString* _Nullable string);
+
+/// Decodes an array of nanopb bytes into an NSData object
+/// @param pbData nanopb data
+NSData* FIRSESDecodeData(pb_bytes_array_t* pbData);
+
+/// Decodes an array of nanopb bytes into an NSString object
+/// @param pbData nanopb data
+NSString* FIRSESDecodeString(pb_bytes_array_t* pbData);
 
 /// Checks if 2 nanopb arrays are equal
 /// @param array array to check

--- a/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
@@ -31,6 +31,10 @@ NSError *FIRSESMakeEncodeError(NSString *description) {
                          userInfo:@{@"NSLocalizedDescriptionKey" : description}];
 }
 
+NSString *FIRSESPBGetError(pb_istream_t istream) {
+  return [NSString stringWithCString:PB_GET_ERROR(&istream) encoding:NSASCIIStringEncoding];
+}
+
 // It seems impossible to specify the nullability of the `fields` parameter below,
 // yet the compiler complains that it's missing a nullability specifier. Google
 // yields no results at this time.
@@ -93,8 +97,28 @@ pb_bytes_array_t *_Nullable FIRSESEncodeString(NSString *_Nullable string) {
     string = nil;
   }
   NSString *stringToEncode = string ? string : @"";
-  NSData *stringBytes = [stringToEncode dataUsingEncoding:NSUTF8StringEncoding];
+  // There was a bug where length 32 strings were sometimes null after encoding
+  // and decoding. I found that this was due to the null terminator sometimes not
+  // being included. This was fixed by using `cStringUsingEncoding` instead of
+  // `dataUsingEncoding` because `cStringUsingEncoding` includes the null
+  // terminator of a c string.
+  const char *cStr = [stringToEncode cStringUsingEncoding:NSUTF8StringEncoding];
+  // `strlen` does not include the null terminator, so we must add 1 here.
+  NSData *stringBytes = [NSData dataWithBytes:cStr length:strlen(cStr) + 1];
   return FIRSESEncodeData(stringBytes);
+}
+
+NSData *FIRSESDecodeData(pb_bytes_array_t *pbData) {
+  NSData *data = [NSData dataWithBytes:&(pbData->bytes) length:pbData->size];
+  return data;
+}
+
+NSString *FIRSESDecodeString(pb_bytes_array_t *pbData) {
+  if (pbData->size == 0) {
+    return @"";
+  }
+  NSData *data = FIRSESDecodeData(pbData);
+  return [NSString stringWithCString:[data bytes] encoding:NSUTF8StringEncoding];
 }
 
 BOOL FIRSESIsPBArrayEqual(pb_bytes_array_t *_Nullable array, pb_bytes_array_t *_Nullable expected) {

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -36,8 +36,6 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.session_data.previous_session_id = makeProtoStringOrNil(identifiers.previousSessionID)
     proto.session_data.event_timestamp_us = time.timestampUS
 
-    // `which_platform_info` tells nanopb which oneof we're choosing to fill in for our proto
-    proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
     proto.application_info.app_id = makeProtoString(appInfo.appID)
     proto.application_info.session_sdk_version = makeProtoString(appInfo.sdkVersion)
 //    proto.application_info.device_model = makeProtoString(appInfo.deviceModel)

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -44,6 +44,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 //    proto.application_info.development_platform_name;
 //    proto.application_info.development_platform_version;
 
+    // `which_platform_info` tells nanopb which oneof we're choosing to fill in for our proto
+    proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
     proto.application_info.apple_app_info.bundle_short_version = makeProtoString(appInfo.bundleID)
 //    proto.application_info.apple_app_info.network_connection_info
     proto.application_info.apple_app_info.os_name = convertOSName(osName: appInfo.osName)
@@ -103,5 +105,25 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
       Logger.logWarning("Found unknown OSName: \"\(osName)\" while converting.")
       return firebase_appquality_sessions_OsName_UNKNOWN_OSNAME
     }
+  }
+
+  /// Encodes the proto in this SessionStartEvent to Data, and then decodes the Data back into
+  /// the proto object and returns the decoded proto. This is used for validating encoding works
+  /// and should not be used in production code.
+  func encodeDecodeEvent() -> firebase_appquality_sessions_SessionEvent {
+    let transportBytes = self.transportBytes()
+    var proto = firebase_appquality_sessions_SessionEvent()
+    var fields = firebase_appquality_sessions_SessionEvent_fields
+
+    let bytes = (transportBytes as NSData).bytes
+    var istream: pb_istream_t = pb_istream_from_buffer(bytes, transportBytes.count)
+
+    if !pb_decode(&istream, &fields.0, &proto) {
+      let errorMessage = FIRSESPBGetError(istream)
+      if errorMessage.count > 0 {
+        Logger.logInfo("Failed to decode transportBytes: \(errorMessage)")
+      }
+    }
+    return proto
   }
 }

--- a/FirebaseSessions/Tests/TestApp/AppQualityDevApp.xcodeproj/xcshareddata/xcschemes/AppQualityDevApp_iOS.xcscheme
+++ b/FirebaseSessions/Tests/TestApp/AppQualityDevApp.xcodeproj/xcshareddata/xcschemes/AppQualityDevApp_iOS.xcscheme
@@ -73,6 +73,10 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = "-FIRSessionsDebugEvents"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-FIRDebugEnabled"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -30,22 +30,39 @@ class SessionStartEventTests: XCTestCase {
     appInfo = MockApplicationInfo()
   }
 
+  /// This function runs the `testCase` twice, once for the proto object stored in
+  /// the event, and once after encoding and decoding the proto. This is useful for
+  /// testing cases where the proto hasn't been encoded correctly.
+  func testProtoAndDecodedProto(sessionEvent: SessionStartEvent,
+                                testCase: (firebase_appquality_sessions_SessionEvent) -> Void) {
+    let proto = sessionEvent.proto
+    testCase(proto)
+
+    /// If you are getting failures in this test case, and not the one above, the
+    /// problem likely lies in encoding the proto
+    let decodedProto = sessionEvent.encodeDecodeEvent()
+    testCase(decodedProto)
+  }
+
   func test_init_setsSessionIDs() {
     identifiers.mockAllValidIDs()
 
     let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
-    assertEqualProtoString(
-      event.proto.session_data.session_id,
-      expected: MockIdentifierProvider.testSessionID,
-      fieldName: "session_id"
-    )
-    assertEqualProtoString(
-      event.proto.session_data.previous_session_id,
-      expected: MockIdentifierProvider.testPreviousSessionID,
-      fieldName: "previous_session_id"
-    )
 
-    XCTAssertEqual(event.proto.session_data.event_timestamp_us, 123)
+    testProtoAndDecodedProto(sessionEvent: event) { proto in
+      assertEqualProtoString(
+        proto.session_data.session_id,
+        expected: MockIdentifierProvider.testSessionID,
+        fieldName: "session_id"
+      )
+      assertEqualProtoString(
+        proto.session_data.previous_session_id,
+        expected: MockIdentifierProvider.testPreviousSessionID,
+        fieldName: "previous_session_id"
+      )
+
+      XCTAssertEqual(proto.session_data.event_timestamp_us, 123)
+    }
   }
 
   func test_init_setsApplicationInfo() {
@@ -53,32 +70,34 @@ class SessionStartEventTests: XCTestCase {
 
     let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
 
-    assertEqualProtoString(
-      event.proto.application_info.app_id,
-      expected: MockApplicationInfo.testAppID,
-      fieldName: "app_id"
-    )
-    assertEqualProtoString(
-      event.proto.application_info.session_sdk_version,
-      expected: MockApplicationInfo.testSDKVersion,
-      fieldName: "session_sdk_version"
-    )
-    assertEqualProtoString(
-      event.proto.application_info.apple_app_info.bundle_short_version,
-      expected: MockApplicationInfo.testBundleID,
-      fieldName: "bundle_short_version"
-    )
-    assertEqualProtoString(
-      event.proto.application_info.apple_app_info.mcc_mnc,
-      expected: MockApplicationInfo.testMCCMNC,
-      fieldName: "mcc_mnc"
-    )
+    testProtoAndDecodedProto(sessionEvent: event) { proto in
+      assertEqualProtoString(
+        proto.application_info.app_id,
+        expected: MockApplicationInfo.testAppID,
+        fieldName: "app_id"
+      )
+      assertEqualProtoString(
+        proto.application_info.session_sdk_version,
+        expected: MockApplicationInfo.testSDKVersion,
+        fieldName: "session_sdk_version"
+      )
+      assertEqualProtoString(
+        proto.application_info.apple_app_info.bundle_short_version,
+        expected: MockApplicationInfo.testBundleID,
+        fieldName: "bundle_short_version"
+      )
+      assertEqualProtoString(
+        proto.application_info.apple_app_info.mcc_mnc,
+        expected: MockApplicationInfo.testMCCMNC,
+        fieldName: "mcc_mnc"
+      )
 
-    // Ensure we convert the test OS name into the enum.
-    XCTAssertEqual(
-      event.proto.application_info.apple_app_info.os_name,
-      firebase_appquality_sessions_OsName_IOS
-    )
+      // Ensure we convert the test OS name into the enum.
+      XCTAssertEqual(
+        proto.application_info.apple_app_info.os_name,
+        firebase_appquality_sessions_OsName_IOS
+      )
+    }
   }
 
   func test_setInstallationID_setsInstallationID() {
@@ -86,11 +105,14 @@ class SessionStartEventTests: XCTestCase {
 
     let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
     event.setInstallationID(identifiers: identifiers)
-    assertEqualProtoString(
-      event.proto.session_data.firebase_installation_id,
-      expected: MockIdentifierProvider.testInstallationID,
-      fieldName: "firebase_installation_id"
-    )
+
+    testProtoAndDecodedProto(sessionEvent: event) { proto in
+      assertEqualProtoString(
+        proto.session_data.firebase_installation_id,
+        expected: MockIdentifierProvider.testInstallationID,
+        fieldName: "firebase_installation_id"
+      )
+    }
   }
 
   func test_convertOSName_convertsCorrectly() {
@@ -110,7 +132,9 @@ class SessionStartEventTests: XCTestCase {
 
       let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
 
-      XCTAssertEqual(event.proto.application_info.apple_app_info.os_name, expected)
+      testProtoAndDecodedProto(sessionEvent: event) { proto in
+        XCTAssertEqual(event.proto.application_info.apple_app_info.os_name, expected)
+      }
     }
   }
 }


### PR DESCRIPTION
This CL does the following:
 - Moved to https://github.com/firebase/firebase-ios-sdk/pull/10459 ~Fixes a critical bug where apple_application_info wasn't encoded correctly. This is because we didn't have the `oneof` that we're choosing specified using `which_platform_info`.~
 - Fixes a critical bug where session_id and other strings were commonly printing as `<NULL>` even after being set. This was due to a string encoding proble.
   - This surely impacts other SDKs, including Crashlytics.
   - https://stackoverflow.com/questions/33287801/nsstring-datausingencoding-gives-garbage-at-end-of-string-in-ios-9-not-ios
 - Adds new tests to SessionStartEventTests so that in addition to ensuring the fields are correct, it encodes and decodes the protos and does the same assertions against the decoded proto.
 - Adds a new CLI argument `-FIRSessionsDebugEvents` that prints events to the console after being encoded and decoded right before being logged to FireLog.

## Session ID Problem
 - There was a weird issue where **session_id is empty** after encoding and decoding. It seemed to happen randomly. 
 - Turns out it was _not a race condition_, but a problem of string null termination
 - We have this same bug in Crashlytics and Performance, but it might be due to converting from Swift to NSString

Before:

```
  NSData *stringBytes = [stringToEncode dataUsingEncoding:NSUTF8StringEncoding];
```


After:

```
  // There was a bug where length 32 strings were sometimes null after encoding
  // and decoding. I found that this was due to the null terminator sometimes not
  // being included. This was fixed by using `cStringUsingEncoding` instead of
  // `dataUsingEncoding` because `cStringUsingEncoding` includes the null
  // terminator of a c string.
  const char *cStr = [stringToEncode cStringUsingEncoding:NSUTF8StringEncoding];
  // `strlen` does not include the null terminator, so we must add 1 here.
  NSData *stringBytes = [NSData dataWithBytes:cStr length:strlen(cStr) + 1];
```

## Output
```
2022-11-03 12:00:34.650195-0400 AppQualityDevApp_iOS[48304:4595552] 10.2.0 - [FirebaseSessions][I-SES000000] Logging Session Event due to "-FIRSessionsDebugEvents" command line argument
Session Event:
  event_type: SESSION_START
  session_data
    session_id: bb0890914af04ad68f2e4672eaf5540e
    previous_session_id: <NULL>
    event_timestamp_us: 1667491234000000
    data_collection_status
      crashlytics: UNKNOWN
      performance: UNKNOWN
  application_info
    app_id: 1:1080744134505:ios:bbb8009438b93cc673dff8
    device_model: <NULL>
    development_platform_name: <NULL>
    development_platform_version: <NULL>
    session_sdk_version: 10.2.0
    apple_app_info
      bundle_short_version: com.firebase.AppQualityDevApp
      network_connection_info
        network_type: -1
        mobile_subtype: 0
      os_name: IOS
      mcc_mnc: <EMPTY>
```


#no-changelog