### PR TITLE
[Sessions] Fix how Session ID is generated

### DIFF
--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -33,7 +33,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 
     proto.event_type = firebase_appquality_sessions_EventType_SESSION_START
     proto.session_data.session_id = makeProtoString(identifiers.sessionID)
-    proto.session_data.previous_session_id = makeProtoString(identifiers.previousSessionID)
+    proto.session_data.previous_session_id = makeProtoStringOrNil(identifiers.previousSessionID)
     proto.session_data.event_timestamp_us = time.timestampUS
 
     proto.application_info.app_id = makeProtoString(appInfo.appID)
@@ -69,6 +69,13 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
   }
 
   // MARK: - Data Conversion
+
+  private func makeProtoStringOrNil(_ string: String?) -> UnsafeMutablePointer<pb_bytes_array_t>? {
+    guard let string = string else {
+      return nil
+    }
+    return FIRSESEncodeString(string)
+  }
 
   private func makeProtoString(_ string: String) -> UnsafeMutablePointer<pb_bytes_array_t>? {
     return FIRSESEncodeString(string)

--- a/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
+++ b/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
@@ -48,10 +48,18 @@ class IdentifiersTests: XCTestCase {
     return true
   }
 
+  // This test case isn't important behavior. When Crash and Perf integrate
+  // with the Sessions SDK, we may want to move to a lazy solution where
+  // sessionID can never be empty
+  func test_sessionID_beforeGenerateReturnsNothing() throws {
+    XCTAssert(identifiers.sessionID.count == 0)
+    XCTAssertNil(identifiers.previousSessionID)
+  }
+
   func test_generateNewSessionID_generatesValidID() throws {
     identifiers.generateNewSessionID()
     XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssert(identifiers.previousSessionID.count == 0)
+    XCTAssertNil(identifiers.previousSessionID)
   }
 
   /// Ensures that generating a Session ID multiple times results in the last Session ID being set in the previousSessionID field
@@ -60,15 +68,15 @@ class IdentifiersTests: XCTestCase {
 
     let firstSessionID = identifiers.sessionID
     XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssert(identifiers.previousSessionID.count == 0)
+    XCTAssertNil(identifiers.previousSessionID)
 
     identifiers.generateNewSessionID()
 
     XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssert(isValidSessionID(identifiers.previousSessionID))
+    XCTAssert(isValidSessionID(identifiers.previousSessionID ?? ""))
 
     // Ensure the new lastSessionID is equal to the sessionID from earlier
-    XCTAssert(identifiers.previousSessionID.compare(firstSessionID) == ComparisonResult.orderedSame)
+    XCTAssert((identifiers.previousSessionID ?? "").compare(firstSessionID) == ComparisonResult.orderedSame)
   }
 
   // Fetching FIIDs requires that we are on a background thread.

--- a/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
+++ b/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
@@ -73,11 +73,10 @@ class IdentifiersTests: XCTestCase {
     identifiers.generateNewSessionID()
 
     XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssert(isValidSessionID(identifiers.previousSessionID ?? ""))
+    XCTAssert(isValidSessionID(identifiers.previousSessionID!))
 
     // Ensure the new lastSessionID is equal to the sessionID from earlier
-    XCTAssert((identifiers.previousSessionID ?? "").compare(firstSessionID) == ComparisonResult
-      .orderedSame)
+    XCTAssertEqual(identifiers.previousSessionID, firstSessionID)
   }
 
   // Fetching FIIDs requires that we are on a background thread.

--- a/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
+++ b/FirebaseSessions/Tests/Unit/IdentifiersTests.swift
@@ -76,7 +76,8 @@ class IdentifiersTests: XCTestCase {
     XCTAssert(isValidSessionID(identifiers.previousSessionID ?? ""))
 
     // Ensure the new lastSessionID is equal to the sessionID from earlier
-    XCTAssert((identifiers.previousSessionID ?? "").compare(firstSessionID) == ComparisonResult.orderedSame)
+    XCTAssert((identifiers.previousSessionID ?? "").compare(firstSessionID) == ComparisonResult
+      .orderedSame)
   }
 
   // Fetching FIIDs requires that we are on a background thread.

--- a/FirebaseSessions/Tests/Unit/Mocks/MockIdentifierProvider.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockIdentifierProvider.swift
@@ -20,7 +20,7 @@ import Foundation
 class MockIdentifierProvider: IdentifierProvider {
   var sessionID: String = ""
 
-  var previousSessionID: String = ""
+  var previousSessionID: String?
 
   var installationID: String = ""
 


### PR DESCRIPTION
 - Before, Session IDs would persist forever. So the previousSessionID would be set to the last sessionID, even if the app had cold started.
 - Now, previousSessionID is only set if the sessionID rolls over in a background-foreground initiation. It is not persisted across runs of the app

#no-changelog