### PR TITLE
nanopb.patch: fix nanopb `invalid mode: 'rU'` build error in python 3.11

### DIFF
--- a/cmake/external/nanopb.patch
+++ b/cmake/external/nanopb.patch
@@ -10,3 +10,17 @@ diff -Naur nanopb/CMakeLists.txt nanopb-fix/CMakeLists.txt
      execute_process(
          COMMAND ${PYTHON_EXECUTABLE} -c
              "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
+diff -Naur nanopb/generator/nanopb_generator.py nanopb-fix/generator/nanopb_generator.py
+--- nanopb/generator/nanopb_generator.py	2021-03-22 08:50:07.000000000 -0400
++++ nanopb-fix/generator/nanopb_generator.py	2022-11-01 15:37:38.112297044 -0400
+@@ -1641,7 +1641,9 @@
+             optfilename = os.path.join(p, optfilename)
+             if options.verbose:
+                 sys.stderr.write('Reading options from ' + optfilename + '\n')
+-            Globals.separate_options = read_options_file(open(optfilename, "rU"))
++            # Patch in https://github.com/nanopb/nanopb/commit/01e9186a8b to avoid
++            # using "U" in the filemode, whose support was removed in Python 3.11.
++            Globals.separate_options = read_options_file(open(optfilename, 'r', encoding = 'utf-8'))
+             break
+     else:
+         # If we are given a full filename and it does not exist, give an error.


### PR DESCRIPTION
Fix the following build error if the python version is 3.11:

```
Traceback (most recent call last):
  File "Firestore/Protos/tmppvd8n0nr.py", line 431, in <module>
    main()
  File "Firestore/Protos/tmppvd8n0nr.py", line 62, in main
    parsed_files = nanopb_parse_files(request, options)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Firestore/Protos/tmppvd8n0nr.py", line 202, in nanopb_parse_files
    parsed_files[fdesc.name] = nanopb.parse_file(fdesc.name, fdesc, options)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "build/external/src/nanopb/generator/nanopb_generator.py", line 1644, in parse_file
    Globals.separate_options = read_options_file(open(optfilename, "rU"))
                                                 ^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid mode: 'rU'
--nanopb_out: protoc-gen-nanopb: Plugin failed with status code 1.
```

Example: https://github.com/firebase/firebase-ios-sdk/actions/runs/3371684453/jobs/5594284042

The problem is that support for the the `U` argument to `open()` was deprecated in Python 3.3, and removed in Python 3.11: https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11.

The fix is to just omit the `U`. This is just an upstream patch from https://github.com/nanopb/nanopb/commit/01e9186a8b

#no-changelog