### PR TITLE
[Infra] Bump clang-format to v15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@14
+    brew install clang-format@15
     brew install mint
     ```
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ GitHub Actions will verify that any code changes are done in a style compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@14
+brew install clang-format@15
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@14
+brew install clang-format@15
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -42,7 +42,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  14)
+  15)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -51,7 +51,7 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 14."
+    echo "Please upgrade to clang-format version 15."
     echo "If it's installed via homebrew you can run:"
     echo "brew upgrade clang-format"
     exit 1


### PR DESCRIPTION
Related to clang-format not managing brew versioning properly. See https://github.com/llvm/llvm-project/issues/49340

#no-changelog