### PR TITLE
Add development environment to the proto message ApplicationInfo.

### DIFF
--- a/FirebaseSessions/ProtoSupport/Protos/sessions.proto
+++ b/FirebaseSessions/ProtoSupport/Protos/sessions.proto
@@ -101,7 +101,7 @@ enum DataCollectionState {
 }
 
 // App-level information collected from the device.
-// Next tag: 8
+// Next tag: 9
 message ApplicationInfo {
   // Commonly known as the GMP App Id
   string app_id = 1;
@@ -113,6 +113,8 @@ message ApplicationInfo {
   string development_platform_version = 4;
   // The version of the Firebase-Sessions SDK in use
   string session_sdk_version = 7;
+  // The destination environment to send the logs to
+  LogEnvironment log_environment = 8;
 
   oneof platform_info {
     // App info relevant only to Android apps
@@ -174,4 +176,12 @@ enum OsName {
   IPADOS = 7;
   // Indicates no data was provided by the device (old sdk, Android)
   UNSPECIFIED = 8;
+}
+
+// Enum containing the destination environment the events will be sent to.
+enum LogEnvironment {
+  LOG_ENVIRONMENT_UNKNOWN = 0;
+  LOG_ENVIRONMENT_AUTOPUSH = 1;
+  LOG_ENVIRONMENT_STAGING = 2;
+  LOG_ENVIRONMENT_PROD = 3;
 }

--- a/FirebaseSessions/Protogen/nanopb/sessions.nanopb.c
+++ b/FirebaseSessions/Protogen/nanopb/sessions.nanopb.c
@@ -49,7 +49,7 @@ const pb_field_t firebase_appquality_sessions_DataCollectionStatus_fields[4] = {
     PB_LAST_FIELD
 };
 
-const pb_field_t firebase_appquality_sessions_ApplicationInfo_fields[8] = {
+const pb_field_t firebase_appquality_sessions_ApplicationInfo_fields[9] = {
     PB_FIELD(  1, BYTES   , SINGULAR, POINTER , FIRST, firebase_appquality_sessions_ApplicationInfo, app_id, app_id, 0),
     PB_FIELD(  2, BYTES   , SINGULAR, POINTER , OTHER, firebase_appquality_sessions_ApplicationInfo, device_model, app_id, 0),
     PB_FIELD(  3, BYTES   , SINGULAR, POINTER , OTHER, firebase_appquality_sessions_ApplicationInfo, development_platform_name, device_model, 0),
@@ -57,6 +57,7 @@ const pb_field_t firebase_appquality_sessions_ApplicationInfo_fields[8] = {
     PB_ANONYMOUS_ONEOF_FIELD(platform_info,   5, MESSAGE , ONEOF, STATIC  , OTHER, firebase_appquality_sessions_ApplicationInfo, android_app_info, development_platform_version, &firebase_appquality_sessions_AndroidApplicationInfo_fields),
     PB_ANONYMOUS_ONEOF_FIELD(platform_info,   6, MESSAGE , ONEOF, STATIC  , UNION, firebase_appquality_sessions_ApplicationInfo, apple_app_info, development_platform_version, &firebase_appquality_sessions_AppleApplicationInfo_fields),
     PB_FIELD(  7, BYTES   , SINGULAR, POINTER , OTHER, firebase_appquality_sessions_ApplicationInfo, session_sdk_version, apple_app_info, 0),
+    PB_FIELD(  8, UENUM   , SINGULAR, STATIC  , OTHER, firebase_appquality_sessions_ApplicationInfo, log_environment, session_sdk_version, 0),
     PB_LAST_FIELD
 };
 
@@ -73,6 +74,7 @@ const pb_field_t firebase_appquality_sessions_AppleApplicationInfo_fields[5] = {
     PB_FIELD(  5, BYTES   , SINGULAR, POINTER , OTHER, firebase_appquality_sessions_AppleApplicationInfo, mcc_mnc, os_name, 0),
     PB_LAST_FIELD
 };
+
 
 
 

--- a/FirebaseSessions/Protogen/nanopb/sessions.nanopb.h
+++ b/FirebaseSessions/Protogen/nanopb/sessions.nanopb.h
@@ -65,6 +65,16 @@ typedef enum _firebase_appquality_sessions_OsName {
 #define _firebase_appquality_sessions_OsName_MAX firebase_appquality_sessions_OsName_UNSPECIFIED
 #define _firebase_appquality_sessions_OsName_ARRAYSIZE ((firebase_appquality_sessions_OsName)(firebase_appquality_sessions_OsName_UNSPECIFIED+1))
 
+typedef enum _firebase_appquality_sessions_LogEnvironment {
+    firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_UNKNOWN = 0,
+    firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_AUTOPUSH = 1,
+    firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_STAGING = 2,
+    firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_PROD = 3
+} firebase_appquality_sessions_LogEnvironment;
+#define _firebase_appquality_sessions_LogEnvironment_MIN firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_UNKNOWN
+#define _firebase_appquality_sessions_LogEnvironment_MAX firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_PROD
+#define _firebase_appquality_sessions_LogEnvironment_ARRAYSIZE ((firebase_appquality_sessions_LogEnvironment)(firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_PROD+1))
+
 /* Struct definitions */
 typedef struct _firebase_appquality_sessions_AndroidApplicationInfo {
     pb_bytes_array_t *package_name;
@@ -98,6 +108,7 @@ typedef struct _firebase_appquality_sessions_ApplicationInfo {
         firebase_appquality_sessions_AppleApplicationInfo apple_app_info;
     };
     pb_bytes_array_t *session_sdk_version;
+    firebase_appquality_sessions_LogEnvironment log_environment;
 /* @@protoc_insertion_point(struct:firebase_appquality_sessions_ApplicationInfo) */
 } firebase_appquality_sessions_ApplicationInfo;
 
@@ -123,13 +134,13 @@ typedef struct _firebase_appquality_sessions_SessionEvent {
 #define firebase_appquality_sessions_SessionEvent_init_default {_firebase_appquality_sessions_EventType_MIN, firebase_appquality_sessions_SessionInfo_init_default, firebase_appquality_sessions_ApplicationInfo_init_default}
 #define firebase_appquality_sessions_SessionInfo_init_default {NULL, NULL, NULL, 0, firebase_appquality_sessions_DataCollectionStatus_init_default}
 #define firebase_appquality_sessions_DataCollectionStatus_init_default {_firebase_appquality_sessions_DataCollectionState_MIN, _firebase_appquality_sessions_DataCollectionState_MIN, 0}
-#define firebase_appquality_sessions_ApplicationInfo_init_default {NULL, NULL, NULL, NULL, 0, {firebase_appquality_sessions_AndroidApplicationInfo_init_default}, NULL}
+#define firebase_appquality_sessions_ApplicationInfo_init_default {NULL, NULL, NULL, NULL, 0, {firebase_appquality_sessions_AndroidApplicationInfo_init_default}, NULL, _firebase_appquality_sessions_LogEnvironment_MIN}
 #define firebase_appquality_sessions_AndroidApplicationInfo_init_default {NULL, NULL}
 #define firebase_appquality_sessions_AppleApplicationInfo_init_default {NULL, NetworkConnectionInfo_init_default, _firebase_appquality_sessions_OsName_MIN, NULL}
 #define firebase_appquality_sessions_SessionEvent_init_zero {_firebase_appquality_sessions_EventType_MIN, firebase_appquality_sessions_SessionInfo_init_zero, firebase_appquality_sessions_ApplicationInfo_init_zero}
 #define firebase_appquality_sessions_SessionInfo_init_zero {NULL, NULL, NULL, 0, firebase_appquality_sessions_DataCollectionStatus_init_zero}
 #define firebase_appquality_sessions_DataCollectionStatus_init_zero {_firebase_appquality_sessions_DataCollectionState_MIN, _firebase_appquality_sessions_DataCollectionState_MIN, 0}
-#define firebase_appquality_sessions_ApplicationInfo_init_zero {NULL, NULL, NULL, NULL, 0, {firebase_appquality_sessions_AndroidApplicationInfo_init_zero}, NULL}
+#define firebase_appquality_sessions_ApplicationInfo_init_zero {NULL, NULL, NULL, NULL, 0, {firebase_appquality_sessions_AndroidApplicationInfo_init_zero}, NULL, _firebase_appquality_sessions_LogEnvironment_MIN}
 #define firebase_appquality_sessions_AndroidApplicationInfo_init_zero {NULL, NULL}
 #define firebase_appquality_sessions_AppleApplicationInfo_init_zero {NULL, NetworkConnectionInfo_init_zero, _firebase_appquality_sessions_OsName_MIN, NULL}
 
@@ -150,6 +161,7 @@ typedef struct _firebase_appquality_sessions_SessionEvent {
 #define firebase_appquality_sessions_ApplicationInfo_development_platform_name_tag 3
 #define firebase_appquality_sessions_ApplicationInfo_development_platform_version_tag 4
 #define firebase_appquality_sessions_ApplicationInfo_session_sdk_version_tag 7
+#define firebase_appquality_sessions_ApplicationInfo_log_environment_tag 8
 #define firebase_appquality_sessions_SessionInfo_session_id_tag 1
 #define firebase_appquality_sessions_SessionInfo_previous_session_id_tag 2
 #define firebase_appquality_sessions_SessionInfo_firebase_installation_id_tag 3
@@ -163,7 +175,7 @@ typedef struct _firebase_appquality_sessions_SessionEvent {
 extern const pb_field_t firebase_appquality_sessions_SessionEvent_fields[4];
 extern const pb_field_t firebase_appquality_sessions_SessionInfo_fields[6];
 extern const pb_field_t firebase_appquality_sessions_DataCollectionStatus_fields[4];
-extern const pb_field_t firebase_appquality_sessions_ApplicationInfo_fields[8];
+extern const pb_field_t firebase_appquality_sessions_ApplicationInfo_fields[9];
 extern const pb_field_t firebase_appquality_sessions_AndroidApplicationInfo_fields[3];
 extern const pb_field_t firebase_appquality_sessions_AppleApplicationInfo_fields[5];
 


### PR DESCRIPTION
Add the proto field containing the development environment that can be used to differentiate Autopush/Staging/Prod for Firelog/backend to differentiate.

#no-changelog