### PR TITLE
[Firestore] Expose error in LoadBundleTaskProgress

### DIFF
--- a/Firestore/Source/API/FIRLoadBundleTask.mm
+++ b/Firestore/Source/API/FIRLoadBundleTask.mm
@@ -40,6 +40,7 @@ using firebase::firestore::util::ThrowInvalidArgument;
     _documentsLoaded = progress.documents_loaded();
     _totalBytes = (NSInteger)progress.total_bytes();
     _totalDocuments = progress.total_documents();
+    _error = progress.error_status().ToNSError();
 
     switch (progress.state()) {
       case api::LoadBundleTaskState::kInProgress:
@@ -67,7 +68,8 @@ using firebase::firestore::util::ThrowInvalidArgument;
   return self.documentsLoaded == otherProgress.documentsLoaded &&
          self.totalDocuments == otherProgress.totalDocuments &&
          self.bytesLoaded == otherProgress.bytesLoaded &&
-         self.totalBytes == otherProgress.totalBytes && self.state == otherProgress.state;
+         self.totalBytes == otherProgress.totalBytes && self.state == otherProgress.state &&
+         [self.error isEqual:otherProgress.error];
 }
 
 @end

--- a/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h
@@ -50,6 +50,9 @@ NS_SWIFT_NAME(LoadBundleTaskProgress)
 /** The total number of bytes in the bundle. 0 if the bundle failed to parse. */
 @property(readonly, nonatomic) NSInteger totalBytes;
 
+/** An error if loading failed. `nil` if the task is in progress or finished successfully. */
+@property(readonly, nonatomic, strong, nullable) NSError *error;
+
 /** The current state of `LoadBundleTask`. */
 @property(readonly, nonatomic) FIRLoadBundleTaskState state;
 


### PR DESCRIPTION
Propagates errors, if any, from the underlying [`LoadBundleTaskProgress`](https://github.com/firebase/firebase-ios-sdk/blob/bdac2b87f6d6e604deae914a970a75136b3a62b5/Firestore/core/src/api/load_bundle_task.h#L43-L124) C++ type to [`FIRLoadBundleTaskProgress`](https://github.com/firebase/firebase-ios-sdk/blob/9f2a3132fa650b2ecf4d3d1f376d713417183bf8/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h#L37-L56) in the ObjC layer. This allows callers to inspect the type of [error](https://github.com/firebase/firebase-ios-sdk/blob/bdac2b87f6d6e604deae914a970a75136b3a62b5/Firestore/core/src/api/load_bundle_task.h#L108-L110) that occurred when observing bundle loading progress using the [`addObserver:`](https://github.com/firebase/firebase-ios-sdk/blob/9f2a3132fa650b2ecf4d3d1f376d713417183bf8/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h#L68-L75) API in [`FIRLoadBundleTask`](https://github.com/firebase/firebase-ios-sdk/blob/9f2a3132fa650b2ecf4d3d1f376d713417183bf8/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h#L61-L89).

In its current form, callers can check whether an error occurred by looking at `FIRLoadBundleTaskProgress`'s [`state`](https://github.com/firebase/firebase-ios-sdk/blob/9f2a3132fa650b2ecf4d3d1f376d713417183bf8/Firestore/Source/Public/FirebaseFirestore/FIRLoadBundleTask.h#L53-L54) but cannot retrieve any details about the error. However, error details are already exposed when using the [`loadBundle:completion:`](https://github.com/firebase/firebase-ios-sdk/blob/9f2a3132fa650b2ecf4d3d1f376d713417183bf8/Firestore/Source/Public/FirebaseFirestore/FIRFirestore.h#L273-L286) API in `FIRFirestore`.

**Needs API review.**