### PR TITLE
[Sessions] Fix oneof specification for nanopb

### DIFF
--- a/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.h
+++ b/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.h
@@ -65,6 +65,11 @@ BOOL FIRSESIsPBStringEqual(pb_bytes_array_t* _Nullable pbString, NSString* _Null
 /// @param data NSData that's expected
 BOOL FIRSESIsPBDataEqual(pb_bytes_array_t* _Nullable pbArray, NSData* _Nullable data);
 
+/// Returns the protobuf tag number. Use this to specify which oneof message type we are
+/// using for the platform\_info field. This function is required to be in Objective-C because
+/// Swift does not support c-style macros.
+pb_size_t FIRSESGetAppleApplicationInfoTag(void);
+
 /// Returns the cellular mobile country code (mnc) if CoreTelephony is supported, otherwise nil
 NSString* _Nullable FIRSESNetworkMobileCountryCode(void);
 

--- a/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
@@ -126,6 +126,10 @@ BOOL FIRSESIsPBDataEqual(pb_bytes_array_t *_Nullable pbArray, NSData *_Nullable 
   return equal;
 }
 
+pb_size_t FIRSESGetAppleApplicationInfoTag(void) {
+  return firebase_appquality_sessions_ApplicationInfo_apple_app_info_tag;
+}
+
 #ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 CTTelephonyNetworkInfo *_Nullable FIRSESNetworkInfo(void) {
   static CTTelephonyNetworkInfo *networkInfo;

--- a/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.m
@@ -17,6 +17,8 @@
 
 #import "FirebaseSessions/Sources/NanoPB/FIRSESNanoPBHelpers.h"
 
+#import "FirebaseSessions/Protogen/nanopb/sessions.nanopb.h"
+
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -36,6 +36,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.session_data.previous_session_id = makeProtoStringOrNil(identifiers.previousSessionID)
     proto.session_data.event_timestamp_us = time.timestampUS
 
+    // `which_platform_info` tells nanopb which oneof we're choosing to fill in for our proto
+    proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
     proto.application_info.app_id = makeProtoString(appInfo.appID)
     proto.application_info.session_sdk_version = makeProtoString(appInfo.sdkVersion)
 //    proto.application_info.device_model = makeProtoString(appInfo.deviceModel)


### PR DESCRIPTION
This CL does the following:

 - Fixes a critical bug where apple_application_info wasn't encoded correctly. This is because we didn't have the oneof that we're choosing specified using which_platform_info.

#no-changelog