### PR TITLE
Enable GTMSessionFetcher 3.x

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -54,7 +54,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.8'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
-  s.dependency 'GTMSessionFetcher/Core', '~> 2.1'
+  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
 
   # Using environment variable because of the dependency on the unpublished
   # HeartbeatLoggingTestUtils.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 10.2.0
+- Update GTMSessionFetcher dependency specifications to enable support for the compatible
+  GTMSessionFetcher 3.x versions.
+
 # Firebase 10.1.0
 - [changed] Bitcode is no longer included in Firebase binary distributions. Xcode 14 does not
   support bitcode. tvOS apps using a Firebase binary distribution will now need to use

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -43,7 +43,7 @@ Cloud Functions for Firebase.
   s.dependency 'FirebaseAuthInterop', '~> 10.0'
   s.dependency 'FirebaseMessagingInterop', '~> 10.0'
   s.dependency 'FirebaseSharedSwift', '~> 10.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 2.1'
+  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
 
   s.test_spec 'objc' do |objc_tests|
     objc_tests.platforms = {

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -41,7 +41,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.dependency 'FirebaseAuthInterop', '~> 10.0'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 2.1'
+  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
 
   s.test_spec 'ObjCIntegration' do |objc_tests|
     objc_tests.scheme = { :code_coverage => true }

--- a/Package.swift
+++ b/Package.swift
@@ -165,7 +165,7 @@ let package = Package(
     .package(
       name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "2.1.0" ..< "3.0.0"
+      "2.1.0" ..< "4.0.0"
     ),
     .package(
       name: "nanopb",


### PR DESCRIPTION
The only difference between GTMSessionFetcher 2.3 and 3.0 is a minimum iOS version bump from 9.0 to 10.0