### PR TITLE
Add error code testing after cancel

### DIFF
--- a/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
@@ -624,6 +624,7 @@ NSString *const kTestPassword = KPASSWORD;
                 XCTAssertTrue([[snapshot description] containsString:@"State: Failed"]);
                 if (!fulfilled) {
                   fulfilled = YES;
+                  XCTAssertEqual(snapshot.error.code, FIRStorageErrorCodeCancelled);
                   [expectation fulfill];
                 }
               }];


### PR DESCRIPTION
Investigate internal b/258460959. I added tests to confirm the cancelled error code is still returned after a task cancel.

#no-changelog