### PR TITLE
Use dedicated queue for Storage instead of global queue

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.3.0
+- [fixed] Use dedicated queue for Storage uploads and downloads instead of global queue. Fixes regression
+  introduced in 10.0.0. (#10487)
+
 # 10.2.0
 - [fixed] Fixed an issue where using Storage with more than one FirebaseApp instance caused non-default Storage instances to deadlock (#10463).
 - [fixed] Fixed a race condition where a download size could exceed the value of the `maxSize` parameter. (#10358)

--- a/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
@@ -45,7 +45,7 @@ internal class StorageDeleteTask: StorageTask, StorageTaskManagement {
    */
   internal func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       strongSelf.state = .queueing
       var request = strongSelf.baseRequest

--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -45,7 +45,7 @@ internal class StorageGetDownloadURLTask: StorageTask, StorageTaskManagement {
    */
   internal func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       var request = strongSelf.baseRequest
       request.httpMethod = "GET"

--- a/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
@@ -45,7 +45,7 @@ internal class StorageGetMetadataTask: StorageTask, StorageTaskManagement {
    */
   internal func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       strongSelf.state = .queueing
       var request = strongSelf.baseRequest

--- a/FirebaseStorage/Sources/Internal/StorageListTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageListTask.swift
@@ -64,7 +64,7 @@ internal class StorageListTask: StorageTask, StorageTaskManagement {
    */
   internal func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       var queryParams = [String: String]()
 

--- a/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
@@ -48,7 +48,7 @@ internal class StorageUpdateMetadataTask: StorageTask, StorageTaskManagement {
    */
   internal func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       var request = strongSelf.baseRequest
       let updateDictionary = strongSelf.updateMetadata.updatedMetadata()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -44,7 +44,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    */
   @objc open func pause() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       if strongSelf.state == .paused || strongSelf.state == .pausing {
         return
@@ -77,7 +77,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    */
   @objc open func resume() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       weakSelf?.state = .resuming
       if let snapshot = weakSelf?.snapshot {
         weakSelf?.fire(for: .resume, snapshot: snapshot)
@@ -106,7 +106,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
 
   internal func enqueueImplementation(resumeWith resumeData: Data? = nil) {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       strongSelf.state = .queueing
       var request = strongSelf.baseRequest
@@ -188,7 +188,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
 
   internal func cancel(withError error: NSError) {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       weakSelf?.state = .cancelled
       weakSelf?.fetcher?.stopFetching()
       weakSelf?.error = error

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -37,7 +37,7 @@ import Foundation
    */
   @objc open func enqueue() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       guard let strongSelf = weakSelf else { return }
       if let contentValidationError = strongSelf.contentUploadError() {
         strongSelf.error = contentValidationError
@@ -148,7 +148,7 @@ import Foundation
    */
   @objc open func pause() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       weakSelf?.state = .paused
       weakSelf?.uploadFetcher?.pauseFetching()
       if weakSelf?.state != .success {
@@ -165,7 +165,7 @@ import Foundation
    */
   @objc open func cancel() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       weakSelf?.state = .cancelled
       weakSelf?.uploadFetcher?.stopFetching()
       if weakSelf?.state != .success {
@@ -186,7 +186,7 @@ import Foundation
    */
   @objc open func resume() {
     weak var weakSelf = self
-    DispatchQueue.global(qos: .background).async {
+    dispatchQueue.async {
       weakSelf?.state = .resuming
       weakSelf?.uploadFetcher?.resumeFetching()
       if weakSelf?.state != .success {


### PR DESCRIPTION
Use dedicated queue for Storage uploads and downloads instead of global queue. Fixes regression
introduced in 10.0.0 and restores the pre-10.0.0 behavior.

The Storage queue is created at https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorage/Sources/Storage.swift#L295

Fix #10487