### PR TITLE
Fdl/removes nsnull values

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- [fixed] Fixes utm params breaking certaing flows
+- [fixed] Fixes issue where `utmParametersDictionary` / `minimumAppVersion` were not provided and their value were set to `[NSNull null]` instead of `nil`. 
 
 # 10.2.0
 - [fixed] Fixes utm parameters not being returned to dynamic link when using universal links (#10341)

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [fixed] Fixes utm params breaking certaing flows
+
 # 10.2.0
 - [fixed] Fixes utm parameters not being returned to dynamic link when using universal links (#10341)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # unreleased
-- [fixed] Fixes issue where `utmParametersDictionary` / `minimumAppVersion` were not provided and their value were set to `[NSNull null]` instead of `nil`. 
+- [fixed] Fixes issue where `utmParametersDictionary` / `minimumAppVersion` were not provided and their value were set to `[NSNull null]` instead of `nil`.
 
 # 10.2.0
 - [fixed] Fixes utm parameters not being returned to dynamic link when using universal links (#10341)

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -417,17 +417,32 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
         NSString *urlString = parameters[kFIRDLParameterLink];
         NSURL *deepLinkURL = [NSURL URLWithString:urlString];
         if (deepLinkURL) {
-          FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:@{
-            kFIRDLParameterDeepLinkIdentifier : urlString,
-            kFIRDLParameterCampaign : parameters[kFIRDLParameterCampaign] ?: [NSNull null],
-            kFIRDLParameterContent : parameters[kFIRDLParameterContent] ?: [NSNull null],
-            kFIRDLParameterMedium : parameters[kFIRDLParameterMedium] ?: [NSNull null],
-            kFIRDLParameterSource : parameters[kFIRDLParameterSource] ?: [NSNull null],
-            kFIRDLParameterTerm : parameters[kFIRDLParameterTerm] ?: [NSNull null],
-            kFIRDLParameterMinimumAppVersion : parameters[kFIRDLParameterMinimumAppVersion]
-                ?: [NSNull null],
-          }];
+          NSMutableDictionary *paramsDictionary =
+                    [[NSMutableDictionary alloc] initWithDictionary:@{kFIRDLParameterDeepLinkIdentifier: urlString}];
+
+          if (parameters[kFIRDLParameterSource] != nil) {
+            [paramsDictionary setValue:parameters[kFIRDLParameterSource] forKey:kFIRDLParameterSource];
+          }
+
+          if (parameters[kFIRDLParameterMedium] != nil) {
+            [paramsDictionary setValue:parameters[kFIRDLParameterMedium] forKey:kFIRDLParameterMedium];
+          }
+
+          if (parameters[kFIRDLParameterTerm] != nil) {
+            [paramsDictionary setValue:parameters[kFIRDLParameterTerm] forKey:kFIRDLParameterTerm];
+          }
+
+           if (parameters[kFIRDLParameterCampaign] != nil) {
+             [paramsDictionary setValue:parameters[kFIRDLParameterCampaign] forKey:(kFIRDLParameterCampaign)];
+           }
+
+           if (parameters[kFIRDLParameterContent] != nil) {
+             [paramsDictionary setValue:parameters[kFIRDLParameterContent] forKey:kFIRDLParameterContent];
+           }
+
+          FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:paramsDictionary];
           dynamicLink.matchType = FIRDLMatchTypeUnique;
+          dynamicLink.minimumAppVersion = parameters[kFIRDLParameterMinimumAppVersion];
 
           // Call resolveShortLink:completion: to do logging.
           // TODO: Create dedicated logging function to prevent this.

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -417,30 +417,35 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
         NSString *urlString = parameters[kFIRDLParameterLink];
         NSURL *deepLinkURL = [NSURL URLWithString:urlString];
         if (deepLinkURL) {
-          NSMutableDictionary *paramsDictionary =
-                    [[NSMutableDictionary alloc] initWithDictionary:@{kFIRDLParameterDeepLinkIdentifier: urlString}];
+          NSMutableDictionary *paramsDictionary = [[NSMutableDictionary alloc]
+              initWithDictionary:@{kFIRDLParameterDeepLinkIdentifier : urlString}];
 
           if (parameters[kFIRDLParameterSource] != nil) {
-            [paramsDictionary setValue:parameters[kFIRDLParameterSource] forKey:kFIRDLParameterSource];
+            [paramsDictionary setValue:parameters[kFIRDLParameterSource]
+                                forKey:kFIRDLParameterSource];
           }
 
           if (parameters[kFIRDLParameterMedium] != nil) {
-            [paramsDictionary setValue:parameters[kFIRDLParameterMedium] forKey:kFIRDLParameterMedium];
+            [paramsDictionary setValue:parameters[kFIRDLParameterMedium]
+                                forKey:kFIRDLParameterMedium];
           }
 
           if (parameters[kFIRDLParameterTerm] != nil) {
             [paramsDictionary setValue:parameters[kFIRDLParameterTerm] forKey:kFIRDLParameterTerm];
           }
 
-           if (parameters[kFIRDLParameterCampaign] != nil) {
-             [paramsDictionary setValue:parameters[kFIRDLParameterCampaign] forKey:(kFIRDLParameterCampaign)];
-           }
+          if (parameters[kFIRDLParameterCampaign] != nil) {
+            [paramsDictionary setValue:parameters[kFIRDLParameterCampaign]
+                                forKey:(kFIRDLParameterCampaign)];
+          }
 
-           if (parameters[kFIRDLParameterContent] != nil) {
-             [paramsDictionary setValue:parameters[kFIRDLParameterContent] forKey:kFIRDLParameterContent];
-           }
+          if (parameters[kFIRDLParameterContent] != nil) {
+            [paramsDictionary setValue:parameters[kFIRDLParameterContent]
+                                forKey:kFIRDLParameterContent];
+          }
 
-          FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] initWithParametersDictionary:paramsDictionary];
+          FIRDynamicLink *dynamicLink =
+              [[FIRDynamicLink alloc] initWithParametersDictionary:paramsDictionary];
           dynamicLink.matchType = FIRDLMatchTypeUnique;
           dynamicLink.minimumAppVersion = parameters[kFIRDLParameterMinimumAppVersion];
 

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -894,6 +894,55 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   XCTAssertEqualObjects(expectedMinVersion, minVersion, @"Min version didn't match imv= parameter");
 }
 
+- (void) testDynamicLinkFromUniversalLinkURLReturnsUTMParams {
+  NSString *expectedUtmSource = @"utm_source";
+  NSString *expectedUtmMedium =  @"utm_medium";
+  NSString *expectedUtmCampaign = @"utm_campaign";
+  NSString *expectedUtmTerm = @"utm_term";
+  NSString *expectedUtmContent = @"utm_content";
+
+  NSString *utmParamsString =
+    [NSString stringWithFormat:@"utm_source=%@&utm_medium=%@&utm_campaign=%@&utm_term=%@&utm_content=%@", expectedUtmSource, expectedUtmMedium, expectedUtmCampaign, expectedUtmTerm, expectedUtmContent];
+  NSString *urlSuffix =
+      [NSString stringWithFormat:@"%@&%@", kEncodedComplicatedURLString, utmParamsString];
+
+  NSString *urlString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtSubdomainDeepLink, urlSuffix];
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:url
+   completion: ^(FIRDynamicLink *_Nullable dynamicLink,
+                 NSError *_Nullable error) {
+    XCTAssertTrue([NSThread isMainThread]);
+    NSDictionary *utmParameters = dynamicLink.utmParametersDictionary;
+    NSString *utmSource = [utmParameters objectForKey:@"utm_source"];
+    XCTAssertEqualObjects(utmSource, expectedUtmSource, @"UtmSource doesn't match utm_source parameter");
+
+    NSString *utmMedium = [utmParameters objectForKey:@"utm_medium"];
+    XCTAssertEqualObjects(utmMedium, expectedUtmMedium, @"UtmMedium doesn't match utm_medium parameter");
+
+    NSString *utmCampaign = [utmParameters objectForKey:@"utm_campaign"];
+    XCTAssertEqualObjects(utmCampaign, expectedUtmCampaign, @"UtmCampaign doesn't match utm_campaign parameter");
+
+    NSString *utmTerm = [utmParameters objectForKey:@"utm_term"];
+    XCTAssertEqualObjects(utmTerm, expectedUtmTerm, @"UtmTerm doesn't match utm_term parameter");
+
+    NSString *utmContent = [utmParameters objectForKey:@"utm_content"];
+    XCTAssertEqualObjects(utmContent, expectedUtmContent, @"UtmContent doesn't match utm_content parameter");
+
+
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
+}
+
 - (void)testDynamicLinkFromUniversalLinkURLCompletionReturnsDLMinimumVersion {
   NSString *expectedMinVersion = @"03-9g03hfd";
   NSString *urlSuffix =

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -894,15 +894,17 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   XCTAssertEqualObjects(expectedMinVersion, minVersion, @"Min version didn't match imv= parameter");
 }
 
-- (void) testDynamicLinkFromUniversalLinkURLReturnsUTMParams {
+- (void)testDynamicLinkFromUniversalLinkURLReturnsUTMParams {
   NSString *expectedUtmSource = @"utm_source";
-  NSString *expectedUtmMedium =  @"utm_medium";
+  NSString *expectedUtmMedium = @"utm_medium";
   NSString *expectedUtmCampaign = @"utm_campaign";
   NSString *expectedUtmTerm = @"utm_term";
   NSString *expectedUtmContent = @"utm_content";
 
-  NSString *utmParamsString =
-    [NSString stringWithFormat:@"utm_source=%@&utm_medium=%@&utm_campaign=%@&utm_term=%@&utm_content=%@", expectedUtmSource, expectedUtmMedium, expectedUtmCampaign, expectedUtmTerm, expectedUtmContent];
+  NSString *utmParamsString = [NSString
+      stringWithFormat:@"utm_source=%@&utm_medium=%@&utm_campaign=%@&utm_term=%@&utm_content=%@",
+                       expectedUtmSource, expectedUtmMedium, expectedUtmCampaign, expectedUtmTerm,
+                       expectedUtmContent];
   NSString *urlSuffix =
       [NSString stringWithFormat:@"%@&%@", kEncodedComplicatedURLString, utmParamsString];
 
@@ -917,28 +919,34 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:url
-   completion: ^(FIRDynamicLink *_Nullable dynamicLink,
-                 NSError *_Nullable error) {
-    XCTAssertTrue([NSThread isMainThread]);
-    NSDictionary *utmParameters = dynamicLink.utmParametersDictionary;
-    NSString *utmSource = [utmParameters objectForKey:@"utm_source"];
-    XCTAssertEqualObjects(utmSource, expectedUtmSource, @"UtmSource doesn't match utm_source parameter");
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
+                             NSDictionary *utmParameters = dynamicLink.utmParametersDictionary;
+                             NSString *utmSource = [utmParameters objectForKey:@"utm_source"];
+                             XCTAssertEqualObjects(utmSource, expectedUtmSource,
+                                                   @"UtmSource doesn't match utm_source parameter");
 
-    NSString *utmMedium = [utmParameters objectForKey:@"utm_medium"];
-    XCTAssertEqualObjects(utmMedium, expectedUtmMedium, @"UtmMedium doesn't match utm_medium parameter");
+                             NSString *utmMedium = [utmParameters objectForKey:@"utm_medium"];
+                             XCTAssertEqualObjects(utmMedium, expectedUtmMedium,
+                                                   @"UtmMedium doesn't match utm_medium parameter");
 
-    NSString *utmCampaign = [utmParameters objectForKey:@"utm_campaign"];
-    XCTAssertEqualObjects(utmCampaign, expectedUtmCampaign, @"UtmCampaign doesn't match utm_campaign parameter");
+                             NSString *utmCampaign = [utmParameters objectForKey:@"utm_campaign"];
+                             XCTAssertEqualObjects(
+                                 utmCampaign, expectedUtmCampaign,
+                                 @"UtmCampaign doesn't match utm_campaign parameter");
 
-    NSString *utmTerm = [utmParameters objectForKey:@"utm_term"];
-    XCTAssertEqualObjects(utmTerm, expectedUtmTerm, @"UtmTerm doesn't match utm_term parameter");
+                             NSString *utmTerm = [utmParameters objectForKey:@"utm_term"];
+                             XCTAssertEqualObjects(utmTerm, expectedUtmTerm,
+                                                   @"UtmTerm doesn't match utm_term parameter");
 
-    NSString *utmContent = [utmParameters objectForKey:@"utm_content"];
-    XCTAssertEqualObjects(utmContent, expectedUtmContent, @"UtmContent doesn't match utm_content parameter");
+                             NSString *utmContent = [utmParameters objectForKey:@"utm_content"];
+                             XCTAssertEqualObjects(
+                                 utmContent, expectedUtmContent,
+                                 @"UtmContent doesn't match utm_content parameter");
 
-
-    [expectation fulfill];
-  }];
+                             [expectation fulfill];
+                           }];
 
   [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }


### PR DESCRIPTION
On this PR: [10413](https://github.com/firebase/firebase-ios-sdk/pull/10413), we use `NSNull` for values inside the dictionary. Some tests were broken because of that. 

