### PR TITLE
Rename the class "Indentifiers" to "Session"

### DIFF
--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -38,7 +38,7 @@ protocol SessionsProvider {
   /// Top-level Classes in the Sessions SDK
   private let coordinator: SessionCoordinator
   private let initiator: SessionInitiator
-  private let identifiers: Identifiers
+  private let session: Session
   private let appInfo: ApplicationInfo
 
   // MARK: - Initializers
@@ -53,24 +53,24 @@ protocol SessionsProvider {
 
     let fireLogger = EventGDTLogger(googleDataTransport: googleDataTransport!)
 
-    let identifiers = Identifiers(installations: installations)
-    let coordinator = SessionCoordinator(identifiers: identifiers, fireLogger: fireLogger)
+    let session = Session(installations: installations)
+    let coordinator = SessionCoordinator(session: session, fireLogger: fireLogger)
     let initiator = SessionInitiator()
     let appInfo = ApplicationInfo(appID: appID)
 
     self.init(appID: appID,
-              identifiers: identifiers,
+              session: session,
               coordinator: coordinator,
               initiator: initiator,
               appInfo: appInfo)
   }
 
   // Initializes the SDK and begines the process of listening for lifecycle events and logging events
-  init(appID: String, identifiers: Identifiers, coordinator: SessionCoordinator,
+  init(appID: String, session: Session, coordinator: SessionCoordinator,
        initiator: SessionInitiator, appInfo: ApplicationInfo) {
     self.appID = appID
 
-    self.identifiers = identifiers
+    self.session = session
     self.coordinator = coordinator
     self.initiator = initiator
     self.appInfo = appInfo
@@ -78,8 +78,8 @@ protocol SessionsProvider {
     super.init()
 
     self.initiator.beginListening {
-      self.identifiers.generateNewSessionID()
-      let event = SessionStartEvent(identifiers: self.identifiers, appInfo: self.appInfo)
+      self.session.generateNewSessionID()
+      let event = SessionStartEvent(session: self.session, appInfo: self.appInfo)
       DispatchQueue.global().async {
         self.coordinator.attemptLoggingSessionStart(event: event) { result in
         }

--- a/FirebaseSessions/Sources/Session.swift
+++ b/FirebaseSessions/Sources/Session.swift
@@ -17,7 +17,7 @@ import Foundation
 
 @_implementationOnly import FirebaseInstallations
 
-protocol IdentifierProvider {
+protocol SessionProtocol {
   var installationID: String {
     get
   }
@@ -32,13 +32,13 @@ protocol IdentifierProvider {
 }
 
 ///
-/// Identifiers is responsible for:
+/// Session is responsible for:
 ///   1) Getting the Installation ID from Installations
 ///   2) Generating the Session ID
 ///   3) Persisting and reading the Session ID from the last session
 ///   (Maybe) 4) Persisting, reading, and incrementing an increasing index
 ///
-class Identifiers: IdentifierProvider {
+class Session: SessionProtocol {
   private let installations: InstallationsProtocol
 
   private var _sessionID: String?
@@ -61,7 +61,7 @@ class Identifiers: IdentifierProvider {
     if Thread.isMainThread {
       Logger
         .logError(
-          "Error: Identifiers.installationID getter must be called on a background thread. Using an empty ID"
+          "Error: Session.installationID getter must be called on a background thread. Using an empty ID"
         )
       return ""
     }

--- a/FirebaseSessions/Sources/SessionCoordinator.swift
+++ b/FirebaseSessions/Sources/SessionCoordinator.swift
@@ -19,18 +19,18 @@ import Foundation
 /// involved with sending a Session Start event.
 ///
 class SessionCoordinator {
-  let identifiers: IdentifierProvider
+  let session: SessionProtocol
   let fireLogger: EventGDTLoggerProtocol
 
-  init(identifiers: IdentifierProvider, fireLogger: EventGDTLoggerProtocol) {
-    self.identifiers = identifiers
+  init(session: SessionProtocol, fireLogger: EventGDTLoggerProtocol) {
+    self.session = session
     self.fireLogger = fireLogger
   }
 
   // Begins the process of logging a SessionStartEvent to FireLog, while taking into account Data Collection, Sampling, and fetching Settings
   func attemptLoggingSessionStart(event: SessionStartEvent,
                                   callback: @escaping (Result<Void, Error>) -> Void) {
-    event.setInstallationID(identifiers: identifiers)
+    event.setInstallationID(session: session)
 
     fireLogger.logEvent(event: event) { result in
       switch result {

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -25,15 +25,15 @@ import Foundation
 class SessionStartEvent: NSObject, GDTCOREventDataObject {
   var proto: firebase_appquality_sessions_SessionEvent
 
-  init(identifiers: IdentifierProvider, appInfo: ApplicationInfoProtocol,
+  init(session: SessionProtocol, appInfo: ApplicationInfoProtocol,
        time: TimeProvider = Time()) {
     proto = firebase_appquality_sessions_SessionEvent()
 
     super.init()
 
     proto.event_type = firebase_appquality_sessions_EventType_SESSION_START
-    proto.session_data.session_id = makeProtoString(identifiers.sessionID)
-    proto.session_data.previous_session_id = makeProtoStringOrNil(identifiers.previousSessionID)
+    proto.session_data.session_id = makeProtoString(session.sessionID)
+    proto.session_data.previous_session_id = makeProtoStringOrNil(session.previousSessionID)
     proto.session_data.event_timestamp_us = time.timestampUS
 
     proto.application_info.app_id = makeProtoString(appInfo.appID)
@@ -51,8 +51,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.application_info.apple_app_info.mcc_mnc = makeProtoString(appInfo.mccMNC)
   }
 
-  func setInstallationID(identifiers: IdentifierProvider) {
-    proto.session_data.firebase_installation_id = makeProtoString(identifiers.installationID)
+  func setInstallationID(session: SessionProtocol) {
+    proto.session_data.firebase_installation_id = makeProtoString(session.installationID)
   }
 
   // MARK: - GDTCOREventDataObject

--- a/FirebaseSessions/Tests/Unit/Mocks/MockSessionProvider.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockSessionProvider.swift
@@ -17,7 +17,7 @@ import Foundation
 
 @testable import FirebaseSessions
 
-class MockIdentifierProvider: IdentifierProvider {
+class MockSessionProvider: SessionProtocol {
   var sessionID: String = ""
 
   var previousSessionID: String?
@@ -29,8 +29,8 @@ class MockIdentifierProvider: IdentifierProvider {
   static let testInstallationID = "testInstallationID"
 
   func mockAllValidIDs() {
-    sessionID = MockIdentifierProvider.testSessionID
-    previousSessionID = MockIdentifierProvider.testPreviousSessionID
-    installationID = MockIdentifierProvider.testInstallationID
+    sessionID = MockSessionProvider.testSessionID
+    previousSessionID = MockSessionProvider.testPreviousSessionID
+    installationID = MockSessionProvider.testInstallationID
   }
 }

--- a/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import FirebaseSessions
 
 class SessionCoordinatorTests: XCTestCase {
-  var identifiers = MockIdentifierProvider()
+  var session = MockSessionProvider()
   var time = MockTimeProvider()
   var fireLogger = MockGDTLogger()
   var appInfo = MockApplicationInfo()
@@ -28,13 +28,13 @@ class SessionCoordinatorTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    coordinator = SessionCoordinator(identifiers: identifiers, fireLogger: fireLogger)
+    coordinator = SessionCoordinator(session: session, fireLogger: fireLogger)
   }
 
   func test_attemptLoggingSessionStart_logsToGDT() throws {
-    identifiers.mockAllValidIDs()
+    session.mockAllValidIDs()
 
-    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+    let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
     var resultSuccess = false
     coordinator.attemptLoggingSessionStart(event: event) { result in
       switch result {
@@ -47,7 +47,7 @@ class SessionCoordinatorTests: XCTestCase {
     // Make sure we've set the Installation ID
     assertEqualProtoString(
       event.proto.session_data.firebase_installation_id,
-      expected: MockIdentifierProvider.testInstallationID,
+      expected: MockSessionProvider.testInstallationID,
       fieldName: "installation_id"
     )
 
@@ -57,10 +57,10 @@ class SessionCoordinatorTests: XCTestCase {
   }
 
   func test_attemptLoggingSessionStart_handlesGDTError() throws {
-    identifiers.mockAllValidIDs()
+    session.mockAllValidIDs()
     fireLogger.result = .failure(NSError(domain: "TestError", code: -1))
 
-    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+    let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
 
     // Start success so it must be set to false
     var resultSuccess = true
@@ -76,7 +76,7 @@ class SessionCoordinatorTests: XCTestCase {
     // Make sure we've set the Installation ID
     assertEqualProtoString(
       event.proto.session_data.firebase_installation_id,
-      expected: MockIdentifierProvider.testInstallationID,
+      expected: MockSessionProvider.testInstallationID,
       fieldName: "installation_id"
     )
 

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -18,14 +18,14 @@ import XCTest
 @testable import FirebaseSessions
 
 class SessionStartEventTests: XCTestCase {
-  var identifiers: MockIdentifierProvider!
+  var session: MockSessionProvider!
   var time: MockTimeProvider!
   var appInfo: MockApplicationInfo!
 
   override func setUp() {
     super.setUp()
 
-    identifiers = MockIdentifierProvider()
+    session = MockSessionProvider()
     time = MockTimeProvider()
     appInfo = MockApplicationInfo()
   }
@@ -45,19 +45,19 @@ class SessionStartEventTests: XCTestCase {
   }
 
   func test_init_setsSessionIDs() {
-    identifiers.mockAllValidIDs()
+    session.mockAllValidIDs()
 
-    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+    let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
 
     testProtoAndDecodedProto(sessionEvent: event) { proto in
       assertEqualProtoString(
         proto.session_data.session_id,
-        expected: MockIdentifierProvider.testSessionID,
+        expected: MockSessionProvider.testSessionID,
         fieldName: "session_id"
       )
       assertEqualProtoString(
         proto.session_data.previous_session_id,
-        expected: MockIdentifierProvider.testPreviousSessionID,
+        expected: MockSessionProvider.testPreviousSessionID,
         fieldName: "previous_session_id"
       )
 
@@ -68,7 +68,7 @@ class SessionStartEventTests: XCTestCase {
   func test_init_setsApplicationInfo() {
     appInfo.mockAllInfo()
 
-    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+    let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
 
     testProtoAndDecodedProto(sessionEvent: event) { proto in
       assertEqualProtoString(
@@ -101,15 +101,15 @@ class SessionStartEventTests: XCTestCase {
   }
 
   func test_setInstallationID_setsInstallationID() {
-    identifiers.mockAllValidIDs()
+    session.mockAllValidIDs()
 
-    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
-    event.setInstallationID(identifiers: identifiers)
+    let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
+    event.setInstallationID(session: session)
 
     testProtoAndDecodedProto(sessionEvent: event) { proto in
       assertEqualProtoString(
         proto.session_data.firebase_installation_id,
-        expected: MockIdentifierProvider.testInstallationID,
+        expected: MockSessionProvider.testInstallationID,
         fieldName: "firebase_installation_id"
       )
     }
@@ -130,7 +130,7 @@ class SessionStartEventTests: XCTestCase {
     expectations.forEach { (given: String, expected: firebase_appquality_sessions_OsName) in
       appInfo.osName = given
 
-      let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+      let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
 
       testProtoAndDecodedProto(sessionEvent: event) { proto in
         XCTAssertEqual(event.proto.application_info.apple_app_info.os_name, expected)
@@ -156,7 +156,7 @@ class SessionStartEventTests: XCTestCase {
                             expected: firebase_appquality_sessions_LogEnvironment) in
         appInfo.environment = given
 
-        let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+        let event = SessionStartEvent(session: session, appInfo: appInfo, time: time)
 
         XCTAssertEqual(event.proto.application_info.log_environment, expected)
     }

--- a/FirebaseSessions/Tests/Unit/SessionTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionTests.swift
@@ -18,9 +18,9 @@ import XCTest
 @testable import FirebaseSessions
 @testable import FirebaseInstallations
 
-class IdentifiersTests: XCTestCase {
+class SessionTests: XCTestCase {
   var installations: MockInstallationsProtocol!
-  var identifiers: Identifiers!
+  var session: Session!
 
   override func setUp() {
     // Clear all UserDefaults
@@ -29,7 +29,7 @@ class IdentifiersTests: XCTestCase {
     }
 
     installations = MockInstallationsProtocol()
-    identifiers = Identifiers(installations: installations)
+    session = Session(installations: installations)
   }
 
   func isValidSessionID(_ sessionID: String) -> Bool {
@@ -52,31 +52,31 @@ class IdentifiersTests: XCTestCase {
   // with the Sessions SDK, we may want to move to a lazy solution where
   // sessionID can never be empty
   func test_sessionID_beforeGenerateReturnsNothing() throws {
-    XCTAssert(identifiers.sessionID.count == 0)
-    XCTAssertNil(identifiers.previousSessionID)
+    XCTAssert(session.sessionID.count == 0)
+    XCTAssertNil(session.previousSessionID)
   }
 
   func test_generateNewSessionID_generatesValidID() throws {
-    identifiers.generateNewSessionID()
-    XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssertNil(identifiers.previousSessionID)
+    session.generateNewSessionID()
+    XCTAssert(isValidSessionID(session.sessionID))
+    XCTAssertNil(session.previousSessionID)
   }
 
   /// Ensures that generating a Session ID multiple times results in the last Session ID being set in the previousSessionID field
   func test_generateNewSessionID_rotatesPreviousID() throws {
-    identifiers.generateNewSessionID()
+    session.generateNewSessionID()
 
-    let firstSessionID = identifiers.sessionID
-    XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssertNil(identifiers.previousSessionID)
+    let firstSessionID = session.sessionID
+    XCTAssert(isValidSessionID(session.sessionID))
+    XCTAssertNil(session.previousSessionID)
 
-    identifiers.generateNewSessionID()
+    session.generateNewSessionID()
 
-    XCTAssert(isValidSessionID(identifiers.sessionID))
-    XCTAssert(isValidSessionID(identifiers.previousSessionID!))
+    XCTAssert(isValidSessionID(session.sessionID))
+    XCTAssert(isValidSessionID(session.previousSessionID!))
 
     // Ensure the new lastSessionID is equal to the sessionID from earlier
-    XCTAssertEqual(identifiers.previousSessionID, firstSessionID)
+    XCTAssertEqual(session.previousSessionID, firstSessionID)
   }
 
   // Fetching FIIDs requires that we are on a background thread.
@@ -88,7 +88,7 @@ class IdentifiersTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Get the Installation ID Asynchronously")
 
     DispatchQueue.global().async { [self] in
-      XCTAssertEqual(self.identifiers.installationID, testID)
+      XCTAssertEqual(self.session.installationID, testID)
       expectation.fulfill()
     }
 
@@ -102,7 +102,7 @@ class IdentifiersTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Get the Installation ID Asynchronously")
 
     DispatchQueue.global().async { [self] in
-      XCTAssertEqual(self.identifiers.installationID, "")
+      XCTAssertEqual(self.session.installationID, "")
       expectation.fulfill()
     }
 


### PR DESCRIPTION
Rename the class `Indentifiers` to `Session` since the class caters to all the necessary details of a session.

This is a precursor to bring in the "Sampling" changes.

#no-changelog