### PR TITLE
Xcode 14 - support push notifications in iOS simulator

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.3.0
+- [changed] Allow notification support on iOS 16 Simulator on Xcode 14 (Reference: Xcode 14 Release Notes -> Simulator -> New Features: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)
+
 # 10.1.0
 - [fixed] App bundle identifier gets incorrectly shortened for watchOS apps created on Xcode 14 (#10147)
 

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 10.3.0
-- [changed] Allow notification support on iOS 16 Simulator on Xcode 14 (Reference: Xcode 14 Release Notes -> Simulator -> New Features: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)
+- [changed] Allow notification support on iOS 16 Simulator on Xcode 14 (#9968) (Reference: Xcode 14 Release Notes -> Simulator -> New Features: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)
 
 # 10.1.0
 - [fixed] App bundle identifier gets incorrectly shortened for watchOS apps created on Xcode 14 (#10147)

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -180,6 +180,14 @@
     [tokenOptions addEntriesFromDictionary:options];
   }
 
+  #if TARGET_OS_SIMULATOR && TARGET_OS_IOS
+  if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil) {
+    // If APNS token is available on iOS Simulator, we must use the sandbox profile
+    // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
+    tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] = @(YES);
+  }
+  #endif
+
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil &&
       tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] == nil) {
     // APNS key was given, but server type is missing. Supply the server type with automatic
@@ -643,10 +651,16 @@
     return;
   }
   // Use this token type for when we have to automatically fetch tokens in the future
+#if TARGET_OS_SIMULATOR && TARGET_OS_IOS
+  // If APNS token is available on iOS Simulator, we must use the sandbox profile
+  // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
+  BOOL isSandboxApp = YES;
+#else
   BOOL isSandboxApp = (type == FIRMessagingAPNSTokenTypeSandbox);
   if (type == FIRMessagingAPNSTokenTypeUnknown) {
     isSandboxApp = FIRMessagingIsSandboxApp();
   }
+#endif
 
   // Pro-actively invalidate the default token, if the APNs change makes it
   // invalid. Previously, we invalidated just before fetching the token.

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -180,13 +180,13 @@
     [tokenOptions addEntriesFromDictionary:options];
   }
 
-  #if TARGET_OS_SIMULATOR && TARGET_OS_IOS
+#if TARGET_OS_SIMULATOR && TARGET_OS_IOS
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil) {
     // If APNS token is available on iOS Simulator, we must use the sandbox profile
     // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
     tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] = @(YES);
   }
-  #endif
+#endif
 
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil &&
       tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] == nil) {

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -642,7 +642,6 @@
     }
     return;
   }
-  NSInteger type = [userInfo[kFIRMessagingAPNSTokenType] integerValue];
 
   // The APNS token is being added, or has changed (rare)
   if ([self.currentAPNSInfo.deviceToken isEqualToData:APNSToken]) {
@@ -656,6 +655,7 @@
   // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
   BOOL isSandboxApp = YES;
 #else
+  NSInteger type = [userInfo[kFIRMessagingAPNSTokenType] integerValue];
   BOOL isSandboxApp = (type == FIRMessagingAPNSTokenTypeSandbox);
   if (type == FIRMessagingAPNSTokenTypeUnknown) {
     isSandboxApp = FIRMessagingIsSandboxApp();


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-ios-sdk/issues/9968

### Discussion
Xcode 14 supports push notifications on iOS 16 Simulator when running on macOS 13. When these conditions exist, an APNS token is generated but if these conditions don't exist, an APNS token is not generated by iOS. Based on this, the change checks when APNS token is generated and if its running in a simulator. If this exists, the sandbox profile is used for push notifications.

### Testing

Setup a sample app that ran on a iOS 16.1 simulator running on macOS 13. The APNS token was registered with FCM and I was able to send an alert to the FCM token to which this APNS token was mapped. 

When same setup was run on macOS 12.x, an APNS token doesn't get generated and no FCM token is generated. This is as expected. 

