### PR TITLE
Fix Firestore Changelog for 10.3.0

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,8 +1,10 @@
+# 10.3.0
+- [feature] Add MultiDb support.
+
 # 10.2.0
 - [fixed] Fix FAILED_PRECONDITION when writing to a deleted document in a
   transaction (#10431).
 - [fixed] Fixed data race in credentials provider (#10393).
-- [feature] Add MultiDb support.
 - [fixed] Fix Firestore failing to raise initial snapshot from empty local cache
   result (#10437).
 


### PR DESCRIPTION
It looks like MultiDB support was added last week and missed the 10.2.0 release.