### PR TITLE
[Sessions] Use deviceSimulatorModel only for compatibility with Crashlytics

### DIFF
--- a/FirebaseSessions/Sources/ApplicationInfo.swift
+++ b/FirebaseSessions/Sources/ApplicationInfo.swift
@@ -78,11 +78,7 @@ class ApplicationInfo: ApplicationInfoProtocol {
   }
 
   var deviceModel: String {
-    #if targetEnvironment(simulator)
-      return GULAppEnvironmentUtil.deviceSimulatorModel() ?? ""
-    #else
-      return GULAppEnvironmentUtil.deviceModel() ?? ""
-    #endif // targetEnvironment(simulator)
+    return GULAppEnvironmentUtil.deviceSimulatorModel() ?? ""
   }
 
   var mccMNC: String {


### PR DESCRIPTION
 - `deviceSimulatorModel` can work on simulators and devices.
 - It will also have similar outputs as `deviceModel` on a device.

Crashlytics will only use `deviceSimulatorModel`, so this PR updates Sessions to do the exact same thing.

#no-changelog