### PR TITLE
[Sessions] Replace bundleID with appDisplayVersion

### DIFF
--- a/FirebaseSessions/ProtoSupport/Protos/sessions.proto
+++ b/FirebaseSessions/ProtoSupport/Protos/sessions.proto
@@ -212,7 +212,7 @@ message AndroidApplicationInfo {
 // - country
 // Next tag: 6
 message AppleApplicationInfo {
-  // The application's bundle id. Eg. com.google.search
+  // The application's display version, eg. 1.2.3
   string bundle_short_version = 1;
   // Describes the network connectivity of the device
   NetworkConnectionInfo network_connection_info = 3;

--- a/FirebaseSessions/Sources/ApplicationInfo.swift
+++ b/FirebaseSessions/Sources/ApplicationInfo.swift
@@ -29,9 +29,6 @@ protocol ApplicationInfoProtocol {
   /// Google App ID / GMP App ID
   var appID: String { get }
 
-  /// App's bundle ID / bundle short version
-  var bundleID: String { get }
-
   /// Version of the Firebase SDK
   var sdkVersion: String { get }
 
@@ -66,10 +63,6 @@ class ApplicationInfo: ApplicationInfoProtocol {
     self.appID = appID
     networkInformation = networkInfo
     self.envParams = envParams
-  }
-
-  var bundleID: String {
-    return Bundle.main.bundleIdentifier ?? ""
   }
 
   var sdkVersion: String {

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -46,7 +46,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 
     // `which_platform_info` tells nanopb which oneof we're choosing to fill in for our proto
     proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
-    proto.application_info.apple_app_info.bundle_short_version = makeProtoString(appInfo.bundleID)
+    proto.application_info.apple_app_info.bundle_short_version = makeProtoString(appInfo.appDisplayVersion)
     proto.application_info.apple_app_info.network_connection_info
       .network_type = convertNetworkType(networkType: appInfo.networkInfo.networkType)
     proto.application_info.apple_app_info.network_connection_info

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -46,7 +46,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 
     // `which_platform_info` tells nanopb which oneof we're choosing to fill in for our proto
     proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
-    proto.application_info.apple_app_info.bundle_short_version = makeProtoString(appInfo.appDisplayVersion)
+    proto.application_info.apple_app_info
+      .bundle_short_version = makeProtoString(appInfo.appDisplayVersion)
     proto.application_info.apple_app_info.network_connection_info
       .network_type = convertNetworkType(networkType: appInfo.networkInfo.networkType)
     proto.application_info.apple_app_info.network_connection_info

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -85,7 +85,7 @@ class SessionStartEventTests: XCTestCase {
       )
       assertEqualProtoString(
         proto.application_info.apple_app_info.bundle_short_version,
-        expected: MockApplicationInfo.testBundleID,
+        expected: MockApplicationInfo.testAppDisplayVersion,
         fieldName: "bundle_short_version"
       )
       assertEqualProtoString(


### PR DESCRIPTION
`bundle_short_version` is app display version, not the bundle id

#no-changelog