### PR TITLE
Apply settings configs

### DIFF
--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -55,13 +55,6 @@ protocol SessionsProvider {
     let fireLogger = EventGDTLogger(googleDataTransport: googleDataTransport!)
 
     let identifiers = Identifiers()
-    let coordinator = SessionCoordinator(
-      identifiers: identifiers,
-      installations: installations,
-      fireLogger: fireLogger,
-      sampler: SessionSampler()
-    )
-    let initiator = SessionInitiator()
     let appInfo = ApplicationInfo(appID: appID)
     let settings = Settings(
       appInfo: appInfo,
@@ -71,6 +64,14 @@ protocol SessionsProvider {
         installations: installations
       )
     )
+    let coordinator = SessionCoordinator(
+      identifiers: identifiers,
+      installations: installations,
+      fireLogger: fireLogger,
+      sampler: SessionSampler(sessionSamplingRate: settings.samplingRate),
+      loggingEnabled: settings.sessionsEnabled
+    )
+    let initiator = SessionInitiator(sessionTimeout: settings.sessionTimeout)
 
     self.init(appID: appID,
               identifiers: identifiers,

--- a/FirebaseSessions/Sources/SessionCoordinator.swift
+++ b/FirebaseSessions/Sources/SessionCoordinator.swift
@@ -23,15 +23,18 @@ class SessionCoordinator {
   let installations: InstallationsProtocol
   let fireLogger: EventGDTLoggerProtocol
   let sampler: SessionSamplerProtocol
+  let loggingEnabled: Bool
 
   init(identifiers: IdentifierProvider,
        installations: InstallationsProtocol,
        fireLogger: EventGDTLoggerProtocol,
-       sampler: SessionSamplerProtocol) {
+       sampler: SessionSamplerProtocol,
+       loggingEnabled: Bool) {
     self.identifiers = identifiers
     self.installations = installations
     self.fireLogger = fireLogger
     self.sampler = sampler
+    self.loggingEnabled = loggingEnabled
   }
 
   // Begins the process of logging a SessionStartEvent to FireLog, while taking into account Data Collection, Sampling, and fetching Settings
@@ -41,7 +44,10 @@ class SessionCoordinator {
     /// 1. Check if the session can be sent. If yes, move to 2. Else, drop the event.
     /// 2. Fetch the installations Id. If successful, move to 3. Else, drop sending the event.
     /// 3. Log the event. If successful, all is good. Else, log the message with error.
-    if sampler.shouldSendEventForSession(sessionId: identifiers.sessionID) {
+    if !loggingEnabled {
+      Logger.logDebug("Logging disabled by configuration settings.")
+      callback(.success(()))
+    } else if sampler.shouldSendEventForSession(sessionId: identifiers.sessionID) {
       installations.installationID { result in
         switch result {
         case let .success(fiid):

--- a/FirebaseSessions/Sources/SessionInitiator.swift
+++ b/FirebaseSessions/Sources/SessionInitiator.swift
@@ -28,12 +28,13 @@ import Foundation
 ///      and comes to the foreground.
 ///
 class SessionInitiator {
-  let sessionTimeout: TimeInterval = 30 * 60 // 30 minutes
+  let sessionTimeout: TimeInterval
   let currentTime: () -> Date
   var backgroundTime = Date.distantFuture
   var initiateSessionStart: () -> Void = {}
 
-  init(currentTimeProvider: @escaping () -> Date = Date.init) {
+  init(sessionTimeout: TimeInterval, currentTimeProvider: @escaping () -> Date = Date.init) {
+    self.sessionTimeout = sessionTimeout
     currentTime = currentTimeProvider
   }
 

--- a/FirebaseSessions/Tests/Unit/InitiatorTests.swift
+++ b/FirebaseSessions/Tests/Unit/InitiatorTests.swift
@@ -18,9 +18,10 @@ import XCTest
 class InitiatorTests: XCTestCase {
   // 2021-11-01 @ 00:00:00 (EST)
   let date = Date(timeIntervalSince1970: 1_635_739_200)
+  let sessionTimeout: TimeInterval = 30 * 60 // 30 minutes
 
   func test_beginListening_initiatesColdStart() throws {
-    let initiator = SessionInitiator()
+    let initiator = SessionInitiator(sessionTimeout: sessionTimeout)
     var initiateCalled = false
     initiator.beginListening {
       initiateCalled = true
@@ -31,7 +32,10 @@ class InitiatorTests: XCTestCase {
   func test_appForegrounded_initiatesNewSession() throws {
     // Given
     var pausedClock = date
-    let initiator = SessionInitiator(currentTimeProvider: { pausedClock })
+    let initiator = SessionInitiator(
+      sessionTimeout: sessionTimeout,
+      currentTimeProvider: { pausedClock }
+    )
     var sessionCount = 0
     initiator.beginListening {
       sessionCount += 1

--- a/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
@@ -34,9 +34,36 @@ class SessionCoordinatorTests: XCTestCase {
       identifiers: identifiers,
       installations: installations,
       fireLogger: fireLogger,
-      sampler: sampler
+      sampler: sampler,
+      loggingEnabled: true
     )
     sampler.sessionSamplingRate = 1.0
+  }
+
+  func test_attemptLoggingSessionStart_logsNothingWhenDisabled() throws {
+    identifiers.mockAllValidIDs()
+    coordinator = SessionCoordinator(
+      identifiers: identifiers,
+      installations: installations,
+      fireLogger: fireLogger,
+      sampler: sampler,
+      loggingEnabled: false // logging is disabled
+    )
+
+    let event = SessionStartEvent(identifiers: identifiers, appInfo: appInfo, time: time)
+    var resultSuccess = false
+    coordinator.attemptLoggingSessionStart(event: event) { result in
+      switch result {
+      case .success(()):
+        resultSuccess = true
+      case .failure:
+        resultSuccess = false
+      }
+    }
+
+    // We should have logged nothing
+    XCTAssertNil(fireLogger.loggedEvent)
+    XCTAssertTrue(resultSuccess)
   }
 
   func test_attemptLoggingSessionStart_logsToGDT() throws {


### PR DESCRIPTION
Apply the Settings config only once at the beginning of app-start to the rest of `FirebaseSessions` SDK:
1. enable/disable logging (b/257076205)
2. sampling rate (b/262250981)
3. session timeout (b/257076041)


#no-changelog