### PR TITLE
[Messaging] - Decline Registration when there is no APNS Token

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 10.4.0
-- [changed] On app startup, an APNS Token must be provided to FCM SDK before retrieving an FCM Token otherwise an error will be returned as part of the completion. 
+- [changed] On app startup, an APNS Token must be provided to FCM SDK before retrieving an FCM Token otherwise an error will be returned as part of the completion.
 
 # 10.3.0
 - [changed] Allow notification support on iOS 16 Simulator on Xcode 14 (#9968) (Reference: Xcode 14 Release Notes -> Simulator -> New Features: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.4.0
+- [changed] On app startup, an APNS Token must be provided to FCM SDK before retrieving an FCM Token otherwise an error will be returned as part of the completion. 
+
 # 10.3.0
 - [changed] Allow notification support on iOS 16 Simulator on Xcode 14 (#9968) (Reference: Xcode 14 Release Notes -> Simulator -> New Features: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)
 

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -578,7 +578,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   } else {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeAPNSTokenNotAvailableDuringTokenFetch,
                            @"APNS device token not set before retrieving FCM Token for Sender ID "
-                           @"'%@'. Notifications to this FCM Token will not be delivered over APNS."
+                           @"'%@'."
                            @"Be sure to re-retrieve the FCM token once the APNS device token is "
                            @"set.",
                            senderID);

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingErrorCode) {
   kFIRMessagingErrorCodeMissingAuthorizedEntity = 502,
   kFIRMessagingErrorCodeMissingScope = 503,
   kFIRMessagingErrorCodeMissingFid = 504,
+  kFIRMessagingErrorCodeMissingDeviceToken = 505,
 
   // Upstream send errors
   kFIRMessagingErrorCodeServiceNotAvailable = 1001,

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -180,13 +180,15 @@
     [tokenOptions addEntriesFromDictionary:options];
   }
 
-  //ensure we have an APNS Token
+  // ensure we have an APNS Token
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] == nil) {
-    //we don't have an APNS token. Don't fetch or return a FCM Token
+    // we don't have an APNS token. Don't fetch or return a FCM Token
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeAPNSTokenNotAvailableDuringTokenFetch,
                            @"Declining request for FCM Token since no APNS Token specified");
     dispatch_async(dispatch_get_main_queue(), ^{
-      NSError *missingAPNSTokenError = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeMissingDeviceToken failureReason:@"No APNS token specified before fetching FCM Token"];
+      NSError *missingAPNSTokenError =
+          [NSError messagingErrorWithCode:kFIRMessagingErrorCodeMissingDeviceToken
+                            failureReason:@"No APNS token specified before fetching FCM Token"];
       handler(nil, missingAPNSTokenError);
     });
     return;

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -180,6 +180,18 @@
     [tokenOptions addEntriesFromDictionary:options];
   }
 
+  //ensure we have an APNS Token
+  if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] == nil) {
+    //we don't have an APNS token. Don't fetch or return a FCM Token
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeAPNSTokenNotAvailableDuringTokenFetch,
+                           @"Declining request for FCM Token since no APNS Token specified");
+    dispatch_async(dispatch_get_main_queue(), ^{
+      NSError *missingAPNSTokenError = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeMissingDeviceToken failureReason:@"No APNS token specified before fetching FCM Token"];
+      handler(nil, missingAPNSTokenError);
+    });
+    return;
+  }
+
 #if TARGET_OS_SIMULATOR && TARGET_OS_IOS
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil) {
     // If APNS token is available on iOS Simulator, we must use the sandbox profile

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingPubSubTest.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingPubSubTest.swift
@@ -35,6 +35,9 @@
 
     override func setUpWithError() throws {
       messaging = try XCTUnwrap(Messaging.messaging())
+      // fake APNS Token
+      messaging.apnsToken = "eb706b132b2f9270faac751e4ceab283f1803b729ac1dd399db3fd2a98bb101b"
+        .data(using: .utf8)
     }
 
     override func tearDown() {

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
@@ -44,6 +44,9 @@
 
     override func setUpWithError() throws {
       messaging = try XCTUnwrap(Messaging.messaging())
+      // fake APNS Token
+      messaging.apnsToken = "eb706b132b2f9270faac751e4ceab283f1803b729ac1dd399db3fd2a98bb101b"
+        .data(using: .utf8)
     }
 
     override func tearDown() {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
@@ -206,6 +206,24 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   [self waitForExpectationsWithTimeout:0.1 handler:nil];
 }
 
+- (void)testReturnsErrorWhenFetchingTokenWithoutAPNSToken {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Returned an error fetching token without APNS Token"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  [self.messaging
+      retrieveFCMTokenForSenderID:@"12345"
+                       completion:^(NSString *_Nullable FCMToken, NSError *_Nullable error) {
+                         if (error != nil) {
+                           [expectation fulfill];
+                         }
+                       }];
+#pragma clang diagnostic pop
+  [self waitForExpectationsWithTimeout:0.1 handler:nil];
+}
+
+
+
 - (void)testReturnsErrorWhenFetchingTokenWithEmptySenderID {
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Returned an error fetching token with empty Sender ID"];

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
@@ -222,8 +222,6 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   [self waitForExpectationsWithTimeout:0.1 handler:nil];
 }
 
-
-
 - (void)testReturnsErrorWhenFetchingTokenWithEmptySenderID {
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Returned an error fetching token with empty Sender ID"];


### PR DESCRIPTION

### Discussion
FCM SDK should not vend an FCM Token when there is no APNS token available or set. This means SDK will no trigger a registration till an APNS Token is provided. 

### Testing
Added unit test to check for NSError when declining FCM Token request. 

Tested following scenarios to check for regression - 
- Fresh install of app with keychain cleared.
- Reinstall of app via Xcode
- Fresh install of app with keychain not cleared. 

For each scenario, confirmed that a notification was sent as expected to the vended FCM Token. 

