### PR TITLE
[Firestore] Encode Data as Blob instead of String

### DIFF
--- a/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
+++ b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
@@ -936,8 +936,7 @@ extension __JSONEncoder {
       // Respect Date encoding strategy
       return try self.box((value as! Date))
     } else if type == Data.self || type == NSData.self {
-      // Respect Data encoding strategy
-      return try self.box((value as! Data))
+      return (value as! NSData)
     } else if type == URL.self || type == NSURL.self {
       // Encode URLs as single strings.
       return self.box((value as! URL).absoluteString)


### PR DESCRIPTION
**[WIP]** For debugging, updated FirebaseDataEncoder's handling of Data values to match the previous [FirestoreEncoder](https://github.com/firebase/firebase-ios-sdk/blob/161c046ded212fe76fe68f3e8bd4e32ec462960a/Firestore/third_party/FirestoreEncoder/FirestoreEncoder.swift#L456-L457) implementation.

This results in a Data value being encoded as a Blob, as before, in Firestore.

Note: This cannot be submitted as-is since it breaks support for `DataEncodingStrategy`.