### PR TITLE
Restore 9.x Firestore Data Codable behavior

### DIFF
--- a/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
+++ b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
@@ -139,10 +139,10 @@ public class FirebaseDataEncoder {
     /// Defer to `Data` for choosing an encoding.
     case deferredToData
 
-    /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
+    /// Encode the `Data` as a Base64-encoded string. This is the default strategy.
     case base64
 
-    /// Encoded the `Data` as an `NSData` blob.
+    /// Encode the `Data` as an `NSData` blob.
     case blob
 
     /// Encode the `Data` as a custom value encoded by the given closure.

--- a/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
+++ b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
@@ -142,6 +142,9 @@ public class FirebaseDataEncoder {
     /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
     case base64
 
+    /// Encoded the `Data` as an `NSData` blob.
+    case blob
+
     /// Encode the `Data` as a custom value encoded by the given closure.
     ///
     /// If the closure fails to encode a value into the given encoder, the encoder will encode an empty automatic container in its place.
@@ -874,6 +877,9 @@ extension __JSONEncoder {
     case .base64:
       return NSString(string: data.base64EncodedString())
 
+    case .blob:
+      return data as NSData
+
     case .custom(let closure):
       let depth = self.storage.count
       do {
@@ -1091,6 +1097,9 @@ public class FirebaseDataDecoder {
 
     /// Decode the `Data` from a Base64-encoded string. This is the default strategy.
     case base64
+
+    /// Decode the `Data` as an `NSData` blob.
+    case blob
 
     /// Decode the `Data` as a custom value decoded by the given closure.
     case custom((_ decoder: Swift.Decoder) throws -> Data)
@@ -2482,6 +2491,12 @@ extension __JSONDecoder {
         throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Encountered Data is not valid Base64."))
       }
 
+      return data
+
+    case .blob:
+      guard let data = value as? Data else {
+        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+      }
       return data
 
     case .custom(let closure):

--- a/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
+++ b/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
@@ -413,6 +413,37 @@ class TestFirebaseDataEncoder: XCTestCase {
     _testRoundTrip(of: Optional(data), expected: expected)
   }
 
+  func testEncodingDataBlob() {
+    let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+    _testRoundTrip(of: data,
+                   expected: data,
+                   dataEncodingStrategy: .blob,
+                   dataDecodingStrategy: .blob)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: Optional(data),
+                   expected: data,
+                   dataEncodingStrategy: .blob,
+                   dataDecodingStrategy: .blob)
+  }
+
+  func testEncodingData2Blob() {
+    let string = "abcdef"
+    let data = string.data(using: .utf8)!
+
+    _testRoundTrip(of: data,
+                   expected: data,
+                   dataEncodingStrategy: .blob,
+                   dataDecodingStrategy: .blob)
+
+    // Optional data should encode the same way.
+    _testRoundTrip(of: Optional(data),
+                   expected: data,
+                   dataEncodingStrategy: .blob,
+                   dataDecodingStrategy: .blob)
+  }
+
   func testEncodingDataCustom() {
     // We'll encode a number instead of data.
     let encode = { (_ data: Data, _ encoder: Encoder) throws -> Void in

--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.4.0
+- [fixed] Restore 9.x Codable behavior of encoding `Data` types as an `NSData`
+  blob instead of a String.
+
 # 10.0.0
 - [changed] **Breaking Change:** The `DocumentID` constructor from a
   `DocumentReference` is now internal; this does not affect instantiating a

--- a/Firestore/Swift/Source/Codable/EncoderDecoder.swift
+++ b/Firestore/Swift/Source/Codable/EncoderDecoder.swift
@@ -63,7 +63,7 @@ public extension Firestore {
     public var dateDecodingStrategy: FirebaseDataDecoder.DateDecodingStrategy = .timestamp
 
     /// Firestore decodes Data from `NSData` blobs versus the default .base64 strings.
-    public var dataEncodingStrategy: FirebaseDataDecoder.DataEncodingStrategy = .blob
+    public var dataDecodingStrategy: FirebaseDataDecoder.DataDecodingStrategy = .blob
 
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
     public var nonConformingFloatDecodingStrategy: FirebaseDataDecoder

--- a/Firestore/Swift/Source/Codable/EncoderDecoder.swift
+++ b/Firestore/Swift/Source/Codable/EncoderDecoder.swift
@@ -23,8 +23,8 @@ public extension Firestore {
     /// The strategy to use in encoding dates. Defaults to `.timestamp`.
     public var dateEncodingStrategy: FirebaseDataEncoder.DateEncodingStrategy = .timestamp
 
-    /// The strategy to use in encoding binary data. Defaults to `.base64`.
-    public var dataEncodingStrategy: FirebaseDataEncoder.DataEncodingStrategy = .base64
+    /// Firestore encodes Data as `NSData` blobs versus the default .base64 strings.
+    public var dataEncodingStrategy: FirebaseDataEncoder.DataEncodingStrategy = .blob
 
     /// The strategy to use in encoding non-conforming numbers. Defaults to `.throw`.
     public var nonConformingFloatEncodingStrategy: FirebaseDataEncoder
@@ -62,8 +62,8 @@ public extension Firestore {
     /// The strategy to use in decoding dates. Defaults to `.timestamp`.
     public var dateDecodingStrategy: FirebaseDataDecoder.DateDecodingStrategy = .timestamp
 
-    /// The strategy to use in decoding binary data. Defaults to `.base64`.
-    public var dataDecodingStrategy: FirebaseDataDecoder.DataDecodingStrategy = .base64
+    /// Firestore decodes Data from `NSData` blobs versus the default .base64 strings.
+    public var dataEncodingStrategy: FirebaseDataDecoder.DataEncodingStrategy = .blob
 
     /// The strategy to use in decoding non-conforming numbers. Defaults to `.throw`.
     public var nonConformingFloatDecodingStrategy: FirebaseDataDecoder


### PR DESCRIPTION
Internal b/262520379

Version 10.x changed the default behavior of coding and decoding `Data` types in Firestore. This PR restores the old behavior by implementing the `blob` data encoding and decoding strategy.