### PR TITLE
Handle decoding base64-encoded strings as blob data in Codables

### DIFF
--- a/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
+++ b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
@@ -2494,10 +2494,13 @@ extension __JSONDecoder {
       return data
 
     case .blob:
-      guard let data = value as? Data else {
-        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+      if let data = value as? Data {
+        return data
+      } else if let string = value as? String, let data = Data(base64Encoded: string) {
+        return data
       }
-      return data
+
+      throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
 
     case .custom(let closure):
       self.storage.push(container: value)

--- a/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
+++ b/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
@@ -481,6 +481,35 @@ class TestFirebaseDataEncoder: XCTestCase {
                    dataEncodingStrategy: .custom(encode),
                    dataDecodingStrategy: .custom(decode))
   }
+  
+  func testDecodingBase64StringAsBlobData() {
+    let data = "abcdef".data(using: .utf8)!
+    let base64String = "YWJjZGVm"
+    
+    let encoder = FirebaseDataEncoder()
+    encoder.dataEncodingStrategy = .base64
+    var payload: Any! = nil
+    do {
+      payload = try encoder.encode(data)
+    } catch {
+      XCTFail("Failed to encode \(Data.self): \(error)")
+    }
+    
+    XCTAssertEqual(
+      base64String,
+      payload as? String,
+      "Encoding did not produce the expected base64-encoded \(String.self)."
+    )
+    
+    let decoder = FirebaseDataDecoder()
+    decoder.dataDecodingStrategy = .blob
+    do {
+      let decoded = try decoder.decode(Data.self, from: payload!)
+      XCTAssertEqual(data, decoded, "Decoding the base64-encoded payload did not produce a \(Data.self).")
+    } catch {
+      XCTFail("Failed to decode \(Data.self): \(error)")
+    }
+  }
 
   // MARK: - Non-Conforming Floating Point Strategy Tests
 

--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 10.4.0
 - [fixed] Restore 9.x Codable behavior of encoding `Data` types as an `NSData`
   blob instead of a String.
+- [added] Added support for decoding base64-encoded strings when using the
+  `blob` `DataEncodingStrategy` for `Codable`s with `Data` types.
 
 # 10.0.0
 - [changed] **Breaking Change:** The `DocumentID` constructor from a


### PR DESCRIPTION
Version 10.x changed the default behaviour of encoding and decoding `Data` types in Firestore, resulting in them being stored as base64-encoded `String` fields instead of `Blob` (bytes) fields. PR #10598 restores the old coding behaviour from 9.x (defaulting to `blob`).

To prevent potential type mismatch errors when upgrading to the next version, this PR allows base64-encoded string values to be decoded as blob data when using the [`blob`](https://github.com/firebase/firebase-ios-sdk/blob/a2ea36c31796f9d71becf86c4c8b3bac49241a4b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift#L145-L146) `DataDecodingStrategy`.