### PR TITLE
Add Storage API to limit upload chunk size

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.5.0
 - [added] Added Storage API to limit upload chunk size. (#10137)
 
 # 10.3.0

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [added] Added Storage API to limit upload chunk size. (#10137)
+
 # 10.3.0
 - [fixed] Use dedicated serial queue for Storage uploads and downloads instead of a (concurrent) global queue.
   Fixes regression introduced in 10.0.0. (#10487)

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -124,6 +124,12 @@ import FirebaseAuthInterop
   }
 
   /**
+   * Specify the maximum upload chunk size. Values less than 256K (262144) will be rounded up to 256K. Values
+   * above 256K will be rounded down to the nearest 256K multiple. The default is no maximum.
+   */
+  @objc public var uploadChunkSize: Int64 = .max
+
+  /**
    * A `DispatchQueue` that all developer callbacks are fired on. Defaults to the main queue.
    */
   @objc public var callbackQueue: DispatchQueue {

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -127,7 +127,7 @@ import FirebaseAuthInterop
    * Specify the maximum upload chunk size. Values less than 256K (262144) will be rounded up to 256K. Values
    * above 256K will be rounded down to the nearest 256K multiple. The default is no maximum.
    */
-  @objc public var uploadChunkSize: Int64 = .max
+  @objc public var uploadChunkSizeBytes: Int64 = .max
 
   /**
    * A `DispatchQueue` that all developer callbacks are fired on. Defaults to the main queue.

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -76,7 +76,7 @@ import Foundation
       let uploadFetcher = GTMSessionUploadFetcher(
         request: request,
         uploadMIMEType: contentType,
-        chunkSize: Int64.max,
+        chunkSize: self.reference.storage.uploadChunkSize,
         fetcherService: self.fetcherService
       )
       if let data = self.uploadData {

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -76,7 +76,7 @@ import Foundation
       let uploadFetcher = GTMSessionUploadFetcher(
         request: request,
         uploadMIMEType: contentType,
-        chunkSize: self.reference.storage.uploadChunkSize,
+        chunkSize: self.reference.storage.uploadChunkSizeBytes,
         fetcherService: self.fetcherService
       )
       if let data = self.uploadData {

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -281,7 +281,7 @@ class StorageResultTests: StorageIntegrationCommon {
     try data.write(to: fileURL, options: .atomicWrite)
 
     // Limit the upload chunk size
-    storage.uploadChunkSize = 256_000
+    storage.uploadChunkSizeBytes = 256_000
 
     let task = ref.putFile(from: fileURL) { result in
       XCTAssertGreaterThanOrEqual(progressCount, 4)
@@ -308,7 +308,7 @@ class StorageResultTests: StorageIntegrationCommon {
       uploadedBytes = progress.completedUnitCount
     }
     waitForExpectations()
-    storage.uploadChunkSize = Int64.max
+    storage.uploadChunkSizeBytes = Int64.max
   }
 
   func testAttemptToUploadDirectoryShouldFail() throws {

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -266,6 +266,10 @@ class StorageResultTests: StorageIntegrationCommon {
   }
 
   func testPutFileLimitedChunk() throws {
+    defer {
+      // Reset since tests share storage instance.
+      storage.uploadChunkSizeBytes = Int64.max
+    }
     let expectation = self.expectation(description: #function)
     let putFileExpectation = self.expectation(description: "putFile")
     let ref = storage.reference(withPath: "ios/public/testPutFilePauseResume")
@@ -308,7 +312,57 @@ class StorageResultTests: StorageIntegrationCommon {
       uploadedBytes = progress.completedUnitCount
     }
     waitForExpectations()
-    storage.uploadChunkSizeBytes = Int64.max
+  }
+
+  func testPutFileTinyChunk() throws {
+    defer {
+      // Reset since tests share storage instance.
+      storage.uploadChunkSizeBytes = Int64.max
+    }
+    let expectation = self.expectation(description: #function)
+    let putFileExpectation = self.expectation(description: "putFile")
+    let ref = storage.reference(withPath: "ios/public/testPutFilePauseResume")
+    let bundle = Bundle(for: StorageIntegrationCommon.self)
+    let filePath = try XCTUnwrap(bundle.path(forResource: "1mb", ofType: "dat"),
+                                 "Failed to get filePath")
+    let data = try XCTUnwrap(try Data(contentsOf: URL(fileURLWithPath: filePath)),
+                             "Failed to load file")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("LargePutFile.txt")
+    var progressCount = 0
+
+    try data.write(to: fileURL, options: .atomicWrite)
+
+    // Limit the upload chunk size. This should behave exactly like the previous
+    // test since small chunk sizes are rounded up to 256K.
+    storage.uploadChunkSizeBytes = 1
+
+    let task = ref.putFile(from: fileURL) { result in
+      XCTAssertGreaterThanOrEqual(progressCount, 4)
+      XCTAssertLessThanOrEqual(progressCount, 6)
+      self.assertResultSuccess(result)
+      putFileExpectation.fulfill()
+    }
+
+    task.observe(StorageTaskStatus.success) { snapshot in
+      XCTAssertEqual(snapshot.description, "<State: Success>")
+      expectation.fulfill()
+    }
+
+    var uploadedBytes: Int64 = -1
+
+    task.observe(StorageTaskStatus.progress) { snapshot in
+      XCTAssertTrue(snapshot.description.starts(with: "<State: Progress") ||
+        snapshot.description.starts(with: "<State: Resume"))
+      guard let progress = snapshot.progress else {
+        XCTFail("Failed to get snapshot.progress")
+        return
+      }
+      progressCount = progressCount + 1
+      XCTAssertGreaterThanOrEqual(progress.completedUnitCount, uploadedBytes)
+      uploadedBytes = progress.completedUnitCount
+    }
+    waitForExpectations()
   }
 
   func testAttemptToUploadDirectoryShouldFail() throws {


### PR DESCRIPTION
Fix #10137

Googlers: API proposal at [go/firebase-storage-chunk-size](http://goto.google.com/firebase-storage-chunk-size)