### PR TITLE
[Infra] Favor `SWIFTPM_MODULE_BUNDLE` macro over C function across repo

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
+++ b/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
@@ -43,7 +43,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSDwarfTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfTests.m
@@ -43,7 +43,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
@@ -24,7 +24,7 @@
 
 - (NSString *)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOBinaryTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOBinaryTests.m
@@ -20,7 +20,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
 #else
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];
 #endif

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
@@ -24,7 +24,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
 #else
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];
 #endif

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSdSYMTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSdSYMTests.m
@@ -20,7 +20,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
 #else
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];
 #endif

--- a/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
@@ -43,7 +43,7 @@
 
 - (NSString *)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -169,7 +169,7 @@
 
 + (NSString *)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -131,7 +131,7 @@
 #pragma mark - Path Helpers
 - (NSString *)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCLSSymbolResolverTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSymbolResolverTests.m
@@ -32,7 +32,7 @@
 
 - (NSString*)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle* bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle* bundle = [NSBundle bundleForClass:[self class]];

--- a/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
+++ b/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
@@ -56,7 +56,7 @@
 
 - (NSString *)resourcePath {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_FirebaseCrashlyticsUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   return [bundle.resourcePath stringByAppendingPathComponent:@"Data"];
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.m
+++ b/FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSBundle *)getBundle {
 #if SWIFT_PACKAGE
-  return Firebase_ABTestingUnit_SWIFTPM_MODULE_BUNDLE();
+  return SWIFTPM_MODULE_BUNDLE;
 #else
   return [NSBundle bundleForClass:[ABTTestUtilities class]];
 #endif

--- a/FirebaseDatabase/Tests/Unit/FSyncPointTests.m
+++ b/FirebaseDatabase/Tests/Unit/FSyncPointTests.m
@@ -465,7 +465,7 @@ typedef NSDictionary * (^fbt_nsdictionary_void)(void);
 - (NSArray *)loadSpecs {
   static NSArray *json;
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_DatabaseUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[FSyncPointTests class]];
 #endif

--- a/FirebasePerformance/Tests/Unit/FPRTestUtils.m
+++ b/FirebasePerformance/Tests/Unit/FPRTestUtils.m
@@ -31,7 +31,7 @@ static NSInteger const kLogSource = 462;  // LogRequest_LogSource_Fireperf
 
 + (NSBundle *)getBundle {
 #if SWIFT_PACKAGE
-  return Firebase_PerformanceUnit_SWIFTPM_MODULE_BUNDLE();
+  return SWIFTPM_MODULE_BUNDLE;
 #else
   return [NSBundle bundleForClass:[FPRTestUtils class]];
 #endif

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -255,7 +255,7 @@
 
 + (NSData *)payloadDataFromTestFile {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
 #else
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
 #endif

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1270,7 +1270,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
 // Manage different bundle locations for Swift Package Manager, CocoaPods static, CocoaPods dynamic.
 - (void)setDefaultsFor:(FIRRemoteConfig *)config {
 #if SWIFT_PACKAGE
-  NSBundle *bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
+  NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
   NSString *plistFile = [bundle pathForResource:@"Defaults-testInfo" ofType:@"plist"];
 #else
   NSBundle *bundle = [NSBundle mainBundle];
@@ -1497,7 +1497,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
 - (FIROptions *)secondAppOptions {
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
 #if SWIFT_PACKAGE
-  bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
+  bundle = SWIFTPM_MODULE_BUNDLE;
 #endif
   NSString *plistPath = [bundle pathForResource:@"SecondApp-GoogleService-Info" ofType:@"plist"];
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:plistPath];


### PR DESCRIPTION
### Context
The name of the C function used to access the resource bundle is incorrect. I suspect the C function name changed as a result of reorganizing the target over time. I suggest the `SWIFTPM_MODULE_BUNDLE` macro as it is more future proof.

This was reproducible running `swift test --filter FirebaseRemoteConfigSwift` on `master`. I'm not sure how this didn't surface earlier.

#no-changelog