### PR TITLE
Add required dependency between Crashlytics and Sessions

### DIFF
--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -192,6 +192,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 + (void)load {
   [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self withName:@"firebase-crashlytics"];
+  [FIRSessionsDependencies addDependencyWithName:FIRSessionsSubscriberNameCrashlytics];
 }
 
 + (NSArray<FIRComponent *> *)componentsToRegister {

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -56,6 +56,8 @@
 
 #import <GoogleDataTransport/GoogleDataTransport.h>
 
+@import FirebaseSessions;
+
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #endif
@@ -73,7 +75,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 @protocol FIRCrashlyticsInstanceProvider <NSObject>
 @end
 
-@interface FIRCrashlytics () <FIRLibrary, FIRCrashlyticsInstanceProvider>
+@interface FIRCrashlytics () <FIRLibrary, FIRCrashlyticsInstanceProvider, FIRSessionsSubscriber>
 
 @property(nonatomic) BOOL didPreviouslyCrash;
 @property(nonatomic, copy) NSString *googleAppID;
@@ -100,7 +102,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 - (instancetype)initWithApp:(FIRApp *)app
                     appInfo:(NSDictionary *)appInfo
               installations:(FIRInstallations *)installations
-                  analytics:(id<FIRAnalyticsInterop>)analytics {
+                  analytics:(id<FIRAnalyticsInterop>)analytics
+                   sessions:(id<FIRSessionsProvider>)sessions {
   self = [super init];
 
   if (self) {
@@ -125,6 +128,15 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     _fileManager = [[FIRCLSFileManager alloc] init];
     _googleAppID = app.options.googleAppID;
     _dataArbiter = [[FIRCLSDataCollectionArbiter alloc] initWithApp:app withAppInfo:appInfo];
+
+    if (sessions) {
+      FIRCLSDebugLog(@"Registering Sessions SDK subscription for session data");
+
+      // Subscription should be made after the DataCollectionArbiter
+      // is initialized so that the Sessions SDK can immediately get
+      // the data collection state.
+      [sessions registerWithSubscriber:self];
+    }
 
     FIRCLSApplicationIdentifierModel *appModel = [[FIRCLSApplicationIdentifierModel alloc] init];
     FIRCLSSettings *settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager
@@ -186,6 +198,9 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
   FIRDependency *analyticsDep =
       [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop)];
 
+  FIRDependency *sessionsDep =
+      [FIRDependency dependencyWithProtocol:@protocol(FIRSessionsProvider)];
+
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
     if (!container.app.isDefaultApp) {
@@ -194,6 +209,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     }
 
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
+    id<FIRSessionsProvider> sessions = FIR_COMPONENT(FIRSessionsProvider, container);
 
     FIRInstallations *installations = [FIRInstallations installationsWithApp:container.app];
 
@@ -202,13 +218,14 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     return [[FIRCrashlytics alloc] initWithApp:container.app
                                        appInfo:NSBundle.mainBundle.infoDictionary
                                  installations:installations
-                                     analytics:analytics];
+                                     analytics:analytics
+                                      sessions:sessions];
   };
 
   FIRComponent *component =
       [FIRComponent componentWithProtocol:@protocol(FIRCrashlyticsInstanceProvider)
                       instantiationTiming:FIRInstantiationTimingEagerInDefaultApp
-                             dependencies:@[ analyticsDep ]
+                             dependencies:@[ analyticsDep, sessionsDep ]
                             creationBlock:creationBlock];
   return @[ component ];
 }
@@ -367,6 +384,20 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       recordOnDemandExceptionIfQuota:exceptionModel
            withDataCollectionEnabled:[self.dataArbiter isCrashlyticsCollectionEnabled]
           usingExistingReportManager:self.existingReportManager];
+}
+
+#pragma mark - FIRSessionsSubscriber
+
+- (void)onSessionIDChanged:(NSString *)sessionID {
+  FIRCLSDebugLog(@"Session ID changed: %@", sessionID);
+}
+
+- (BOOL)isDataCollectionEnabled {
+  return self.dataArbiter.isCrashlyticsCollectionEnabled;
+}
+
+- (FIRSessionsSubscriberName)sessionsSubscriberName {
+  return FIRSessionsSubscriberNameCrashlytics;
 }
 
 @end

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseInstallations', '~> 10.0'
+  s.dependency 'FirebaseSessions', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.10'
   s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'PromisesSwift', '~> 2.1'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -107,6 +107,8 @@ private enum GoogleDataTransportConfig {
       // Generating a Session ID early is important as Subscriber
       // SDKs will need to read it immediately upon registration.
       let sessionInfo = self.sessionGenerator.generateNewSession()
+
+      // Post a notification so subscriber SDKs can get an updated Session ID
       NotificationCenter.default.post(name: Sessions.SessionIDChangedNotificationName,
                                       object: nil)
 

--- a/FirebaseSessions/Sources/Public/SessionsDependencies.swift
+++ b/FirebaseSessions/Sources/Public/SessionsDependencies.swift
@@ -15,9 +15,18 @@
 
 import Foundation
 
-// Sessions Provider is the Session SDK's internal
-// interface for other 1P SDKs to talk to.
-@objc(FIRSessionsProvider)
-public protocol SessionsProvider {
-  @objc func register(subscriber: SessionsSubscriber)
+// Sessions Dependencies determines when a dependent SDK is
+// installed in the app. The Sessions SDK uses this to figure
+// out which dependencies to wait for to getting the data
+// collection state.
+//
+// This is important because the Sessions SDK starts up before
+// dependent SDKs
+@objc(FIRSessionsDependencies)
+public class SessionsDependencies: NSObject {
+  static var dependencies: Set<SessionsSubscriberName> = .init()
+
+  @objc public static func addDependency(name: SessionsSubscriberName) {
+    SessionsDependencies.dependencies.insert(name)
+  }
 }

--- a/FirebaseSessions/Sources/Public/SessionsProvider.swift
+++ b/FirebaseSessions/Sources/Public/SessionsProvider.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@objc(FIRSessionsProvider)
+public protocol SessionsProvider {
+  @objc func register(subscriber: SessionsSubscriber)
+}

--- a/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
+++ b/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
@@ -15,18 +15,20 @@
 
 import Foundation
 
-@objc(FIRSessionsSubscriberName)
-public enum SessionsSubscriberName: Int {
-  case Unknown
-  case Crashlytics
-  case Performance
-}
-
+// Sessions Subscriber is an interface that dependent SDKs
+// must implement.
 @objc(FIRSessionsSubscriber)
 public protocol SessionsSubscriber {
   func onSessionIDChanged(_ sessionID: String)
   var isDataCollectionEnabled: Bool { get }
   var sessionsSubscriberName: SessionsSubscriberName { get }
+}
+
+@objc(FIRSessionsSubscriberName)
+public enum SessionsSubscriberName: Int {
+  case Unknown
+  case Crashlytics
+  case Performance
 }
 
 extension SessionsSubscriberName: CustomStringConvertible {

--- a/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
+++ b/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
@@ -1,0 +1,43 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@objc(FIRSessionsSubscriberName)
+public enum SessionsSubscriberName: Int {
+  case Unknown
+  case Crashlytics
+  case Performance
+}
+
+@objc(FIRSessionsSubscriber)
+public protocol SessionsSubscriber {
+  func onSessionIDChanged(_ sessionID: String)
+  var isDataCollectionEnabled: Bool { get }
+  var sessionsSubscriberName: SessionsSubscriberName { get }
+}
+
+extension SessionsSubscriberName: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .Crashlytics:
+      return "Crashlytics"
+    case .Performance:
+      return "Performance"
+    default:
+      return "Unknown"
+    }
+  }
+}

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -78,6 +78,19 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.session_data.data_collection_status.session_sampling_rate = samplingRate
   }
 
+  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool) {
+    let dataCollectionState = makeDataCollectionProto(isDataCollectionEnabled)
+    switch subscriber {
+    case .Crashlytics:
+      proto.session_data.data_collection_status.crashlytics = dataCollectionState
+    case .Performance:
+      proto.session_data.data_collection_status.performance = dataCollectionState
+    default:
+      Logger
+        .logWarning("Attempted to set Data Collection status for unknown Subscriber: \(subscriber)")
+    }
+  }
+
   // MARK: - GDTCOREventDataObject
 
   func transportBytes() -> Data {
@@ -95,6 +108,15 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
   }
 
   // MARK: - Data Conversion
+
+  func makeDataCollectionProto(_ isDataCollectionEnabled: Bool)
+    -> firebase_appquality_sessions_DataCollectionState {
+    if isDataCollectionEnabled {
+      return firebase_appquality_sessions_DataCollectionState_COLLECTION_ENABLED
+    } else {
+      return firebase_appquality_sessions_DataCollectionState_COLLECTION_DISABLED
+    }
+  }
 
   private func makeProtoStringOrNil(_ string: String?) -> UnsafeMutablePointer<pb_bytes_array_t>? {
     guard let string = string else {

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+final class FirebaseSessionsTests: XCTestCase {
+//    override func setUpWithError() throws {
+//        // Put setup code here. This method is called before the invocation of each test method in the class.
+//    }
+//
+//    override func tearDownWithError() throws {
+//        // Put teardown code here. This method is called after the invocation of each test method in the class.
+//    }
+
+  func testExample() throws {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // Any test you write for XCTest can be annotated as throws and async.
+    // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+    // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1089,11 +1089,11 @@ let package = Package(
         "FirebaseInstallations",
         "FirebaseCoreExtension",
         "FirebaseSessionsObjC",
+        .product(name: "Promises", package: "Promises"),
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
       ],
       path: "FirebaseSessions/Sources",
-      publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath(".."),
         .define("DISPLAY_VERSION", to: firebaseVersion),

--- a/Package.swift
+++ b/Package.swift
@@ -491,7 +491,7 @@ let package = Package(
     ),
     .target(
       name: "FirebaseCrashlytics",
-      dependencies: ["FirebaseCore", "FirebaseInstallations",
+      dependencies: ["FirebaseCore", "FirebaseInstallations", "FirebaseSessions",
                      .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
                      .product(name: "GULEnvironment", package: "GoogleUtilities"),
                      .product(name: "FBLPromises", package: "Promises"),
@@ -1093,6 +1093,7 @@ let package = Package(
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
       ],
       path: "FirebaseSessions/Sources",
+      publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath(".."),
         .define("DISPLAY_VERSION", to: firebaseVersion),


### PR DESCRIPTION
Alternative to https://github.com/firebase/firebase-ios-sdk/pull/10619 where the dependency is hard.

# TODO

- [x] Rebase on https://github.com/firebase/firebase-ios-sdk/pull/10637 and make sure Settings Fetch is outside the block that disables the SDK
- [ ] Add tests
- [ ] Ensure future backgrounds still resolve the promises