### PR TITLE
[FirestoreSharedSwift] Write base64 decode test as throwing XCTest

### DIFF
--- a/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
+++ b/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
@@ -482,10 +482,9 @@ class TestFirebaseDataEncoder: XCTestCase {
                    dataDecodingStrategy: .custom(decode))
   }
 
+  // Tests implicit migration of data that was written with .base64 (String type) using Firestore
+  // 10.0 through 10.3 (see PR #10604).
   func testDecodingBase64StringAsBlobData() throws {
-    // Tests implicit migration of data that was written with .base64 (String type) using
-    // Firestore 10.0 through 10.3 (see PR #10604).
-
     let inputString = "abcdef"
     let data = inputString.data(using: .utf8)!
     let base64String = "YWJjZGVm"


### PR DESCRIPTION
Small refactor to simplify the error handling in `testDecodingBase64StringAsBlobData` by making it a throwing test. As a side-effect, this will prevent the test from continuing if an earlier step throws (similar to `continueAfterFailure` set to `false`) which may make failures easier to debug.

Updated to use `XCTUnwrap` to explicitly check for optionals when performing type coercion.

Note: Did not refactor other tests in the file to reduce diversion from the original `swift/test/stdlib/TestJSONEncoder.swift` source.

#no-changelog