### PR TITLE
Delete extra copies of the Crashlytics tools for testapps

### DIFF
--- a/Crashlytics/generate_project.sh
+++ b/Crashlytics/generate_project.sh
@@ -20,3 +20,8 @@ readonly DIR="$( git rev-parse --show-toplevel )"
 "$DIR/Crashlytics/ProtoSupport/generate_crashlytics_protos.sh" || echo "Something went wrong generating protos.";
 
 pod gen "${DIR}/FirebaseCrashlytics.podspec" --auto-open --gen-directory="${DIR}/gen" --local-sources="${DIR}" --platforms=ios,macos,tvos --clean
+
+# Upon a `pod install`, Crashlytics will copy these files at the root directory
+# due to a funky interaction with its cocoapod. This line deletes these extra
+# copies of the files as they should only live in Crashlytics/
+rm -f $DIR/run $DIR/upload-symbols

--- a/FirebaseSessions/generate_testapp.sh
+++ b/FirebaseSessions/generate_testapp.sh
@@ -48,4 +48,10 @@ fi
 echoColor "Running 'pod install'"
 cd $DIR/FirebaseSessions/Tests/TestApp
 pod install
+
+# Upon a `pod install`, Crashlytics will copy these files at the root directory
+# due to a funky interaction with its cocoapod. This line deletes these extra
+# copies of the files as they should only live in Crashlytics/
+rm -f $DIR/run $DIR/upload-symbols
+
 open *.xcworkspace


### PR DESCRIPTION
After running `generate_testapp`, since Crashlytics is now one of the targets, it copies the run and upload-symbols tools from Crashlytics into the root directory of firebase-ios-sdk. To prevent these accidental duplications, this updates the scripts to delete them.

<img width="588" alt="Screenshot 2023-01-09 at 11 10 33 AM" src="https://user-images.githubusercontent.com/555046/211354227-3821c1a2-3048-4742-9f44-d2aa6f472231.png">
