### PR TITLE
[Sessions] Audit logging and update README with strategy

### DIFF
--- a/FirebaseSessions/README.md
+++ b/FirebaseSessions/README.md
@@ -6,11 +6,14 @@ Follow the [Main Firebase Readme](https://github.com/firebase/firebase-ios-sdk#d
 ## Development
 ### Generating the Project and Test Project
 
- - `generate_project.sh` uses [cocoapods-generate](https://github.com/square/cocoapods-generate) to create an Xcode Workspace that has the SDK installed for all the SDK's supported platforms. This is useful for test-based development.
+ - Test-based Development:
+    - **Option 1:** `generate_project.sh` uses [cocoapods-generate](https://github.com/square/cocoapods-generate) to create an Xcode Workspace that has the SDK installed for all the SDK's supported platforms. This is useful for test-based development.
+    - **Option 2:** `open Package.swift` in the root of the firebase-ios-sdk repo. You can run tests using the `FirebaseSessionsUnit` Scheme
  - `generate_testapp.sh` generates and opens a test app with the Sessions SDK included. This is useful for developing the Sessions SDK against a real app.
 
-### Switching dev environments - Autopush/Staging/Prod
+### Debugging Options
 
+#### Switching Dev Environments - Autopush/Staging/Prod
 SDK is configured to send events to different environments. To enforce different environments for sending events, we use an environment variable to configure the specific environment. Since environment variables are enforced in the context of the App, use the TestApp to send events to different environments after using the following configuration steps.
 
 - Enter "Edit scheme" - On the title bar menu "Product" > "Scheme" > "Edit Scheme"
@@ -23,12 +26,17 @@ SDK is configured to send events to different environments. To enforce different
 
 NOTE: Default is PROD. Not configuring any flags would mean the events are sent to PROD environment.
 
-### Debugging
-
-### Command Line Arguments
+#### Debugging Events
 You can access command line parameters by following: Press `CMD-Shift-,` => Run => Arguments.
 
  - `-FIRSessionsDebugEvents` will print Session Start events to the console for debugging purposes.
+
+#### Overriding Settings
+You can override the Settings values fetched from the server using the app's Info.plist. The full list of override plist keys can be found in `LocalOverrideSettings.swift`.
+
+ - **FirebaseSessionsEnabled**: Bool representing whether to make any network calls
+ - **FirebaseSessionsTimeout**: Float number of seconds representing the time that an app must be backgrounded before generating a new session
+ - **FirebaseSessionsSampingRate**: Float between 0 and 1 representing how often events are sent. 0 is drop everything, 1 is send everything.
 
 ### Updating the Proto
 #### Prerequesites
@@ -42,3 +50,11 @@ brew install protobuf
  1. Follow the directions in `sessions.proto` for updating it
  1. Run the following to regenerate the nanopb source files: `./FirebaseSessions/ProtoSupport/generate_protos.sh`
  1. Update the SDK to use the new proto fields
+
+
+### Logging
+The Sessions SDK uses the following strategy when determining log level:
+ - **Info** should be used rarely. Because the Sessions SDK is a dependency of other products, customers will not expect regular logs from the SDK. Therefore, info events are not recommended except under circumstances where the code path is blocked by another debug parameter (eg. `-FIRSessionsDebugEvents` will log under info because we don't want to require it be paired with `-FIRDebugEnabled`)
+ - **Debug** Is recommended to be used generously in the Sessions SDK for the purposes of debugging customer issues.
+ - **Warning** Is used when the Sessions SDK runs into a recoverable issue that still results in events being sent. For example, a problem converting between values that results in an incorrect value being reported.
+ - **Error** Is used when the Sessions SDK runs into an unrecoverable issue that prevents functionality from working. If we would want customers to reach out to us when a issue happens, then error logs should be used to convey the issue.

--- a/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
+++ b/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
@@ -33,7 +33,7 @@ class DevEventConsoleLogger: EventGDTLoggerProtocol {
 
   func prettyPrint(proto: firebase_appquality_sessions_SessionEvent) {
     let logOutput = """
-    Logging Session Event due to \"\(commandLineArgument)\" command line argument
+    Printing Session Event due to \"\(commandLineArgument)\" command line argument
     Session Event:
       event_type: \(proto.event_type)
       session_data

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -140,7 +140,10 @@ private enum GoogleDataTransportConfig {
       self.subscriberPromises[subscriberName] = Promise<Void>.pending()
     }
 
-    Logger.logDebug("Expecting subscriptions from: \(SessionsDependencies.dependencies)")
+    Logger
+      .logDebug(
+        "Version \(FirebaseVersion()). Expecting subscriptions from: \(SessionsDependencies.dependencies)"
+      )
 
     self.initiator.beginListening {
       // Generating a Session ID early is important as Subscriber

--- a/FirebaseSessions/Sources/SessionCoordinator.swift
+++ b/FirebaseSessions/Sources/SessionCoordinator.swift
@@ -33,14 +33,14 @@ class SessionCoordinator: SessionCoordinatorProtocol {
     self.fireLogger = fireLogger
   }
 
-  // Begins the process of logging a SessionStartEvent to FireLog, while taking into account Data Collection, Sampling, and fetching Settings
+  /// Begins the process of logging a SessionStartEvent to FireLog after
+  /// it has been approved for sending
   func attemptLoggingSessionStart(event: SessionStartEvent,
                                   callback: @escaping (Result<Void, FirebaseSessionsError>)
                                     -> Void) {
     /// Order of execution
-    /// 1. Check if the session can be sent. If yes, move to 2. Else, drop the event.
-    /// 2. Fetch the installations Id. If successful, move to 3. Else, drop sending the event.
-    /// 3. Log the event. If successful, all is good. Else, log the message with error.
+    /// 1. Fetch the installations Id. If successful, move to 3. Else, drop sending the event.
+    /// 2. Log the event. If successful, all is good. Else, log the message with error.
     installations.installationID { result in
       switch result {
       case let .success(fiid):
@@ -48,6 +48,7 @@ class SessionCoordinator: SessionCoordinatorProtocol {
         self.fireLogger.logEvent(event: event) { logResult in
           switch logResult {
           case .success():
+            Logger.logDebug("Successfully logged Session Start event to GoogleDataTransport")
             callback(.success(()))
           case let .failure(error):
             callback(.failure(FirebaseSessionsError.DataTransportError(error)))

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -126,10 +126,11 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     var error: NSError?
     let data = FIRSESEncodeProto(&fields.0, &proto, &error)
     if error != nil {
-      Logger.logError(error.debugDescription)
+      Logger
+        .logError("Session Event failed to encode as proto with error: \(error.debugDescription)")
     }
     guard let data = data else {
-      Logger.logError("Session event generated nil transportBytes. Returning empty data.")
+      Logger.logError("Session Event generated nil transportBytes. Returning empty data.")
       return Data()
     }
     return data
@@ -193,7 +194,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     if !pb_decode(&istream, &fields.0, &proto) {
       let errorMessage = FIRSESPBGetError(istream)
       if errorMessage.count > 0 {
-        Logger.logInfo("Failed to decode transportBytes: \(errorMessage)")
+        Logger.logError("Session Event failed to decode transportBytes: \(errorMessage)")
       }
     }
     return proto


### PR DESCRIPTION
Updated README: https://github.com/firebase/firebase-ios-sdk/blob/bc76232a4e0bf58daf00b7c3c4640805722d1477/FirebaseSessions/README.md

Example with `-FIRDebugEnabled`

```
[FirebaseSessions][I-SES000000] Version 10.4.0
[FirebaseSessions][I-SES000000] [Settings] Cache is not expired, no fetch will be made.
[FirebaseSessions][I-SES000000] Initiated new Session with ID: 3152c81f3bad4b518c2a1e0b4459509f
[FirebaseSessions][I-SES000000] Logging events using fast QOS due to running on a simulator
[FirebaseSessions][I-SES000000] Printing Session Event due to "-FIRSessionsDebugEvents" command line argument
[FirebaseSessions][I-SES000000] Successfully logged Session Start event to GoogleDataTransport

```

#no-changelog 