### PR TITLE
Add required dependency between Crashlytics and Session

### DIFF
--- a/.github/workflows/sessions-integration-tests.yml
+++ b/.github/workflows/sessions-integration-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
 
-  # Public repository: Build and run the Integration Tests for the Firebase sessions E2E Test App.
+  # Public repository: Build and run the Integration Tests for the Firebase sessions E2E Test App across all environments.
   sessions-integration-tests:
     if: github.repository == 'Firebase/firebase-ios-sdk'
     env:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -6,7 +6,6 @@ on:
     - 'FirebaseStorage**'
     - 'FirebaseAuth/Interop/*.h'
     - '.github/workflows/storage.yml'
-    - 'scripts/**'
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile*'
   schedule:

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -56,6 +56,8 @@
 
 #import <GoogleDataTransport/GoogleDataTransport.h>
 
+@import FirebaseSessions;
+
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #endif
@@ -73,7 +75,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 @protocol FIRCrashlyticsInstanceProvider <NSObject>
 @end
 
-@interface FIRCrashlytics () <FIRLibrary, FIRCrashlyticsInstanceProvider>
+@interface FIRCrashlytics () <FIRLibrary, FIRCrashlyticsInstanceProvider, FIRSessionsSubscriber>
 
 @property(nonatomic) BOOL didPreviouslyCrash;
 @property(nonatomic, copy) NSString *googleAppID;
@@ -100,7 +102,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 - (instancetype)initWithApp:(FIRApp *)app
                     appInfo:(NSDictionary *)appInfo
               installations:(FIRInstallations *)installations
-                  analytics:(id<FIRAnalyticsInterop>)analytics {
+                  analytics:(id<FIRAnalyticsInterop>)analytics
+                   sessions:(id<FIRSessionsProvider>)sessions {
   self = [super init];
 
   if (self) {
@@ -125,6 +128,15 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     _fileManager = [[FIRCLSFileManager alloc] init];
     _googleAppID = app.options.googleAppID;
     _dataArbiter = [[FIRCLSDataCollectionArbiter alloc] initWithApp:app withAppInfo:appInfo];
+
+    if (sessions) {
+      FIRCLSDebugLog(@"Registering Sessions SDK subscription for session data");
+
+      // Subscription should be made after the DataCollectionArbiter
+      // is initialized so that the Sessions SDK can immediately get
+      // the data collection state.
+      [sessions registerWithSubscriber:self];
+    }
 
     FIRCLSApplicationIdentifierModel *appModel = [[FIRCLSApplicationIdentifierModel alloc] init];
     FIRCLSSettings *settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager
@@ -180,11 +192,15 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 + (void)load {
   [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self withName:@"firebase-crashlytics"];
+  [FIRSessionsDependencies addDependencyWithName:FIRSessionsSubscriberNameCrashlytics];
 }
 
 + (NSArray<FIRComponent *> *)componentsToRegister {
   FIRDependency *analyticsDep =
       [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop)];
+
+  FIRDependency *sessionsDep =
+      [FIRDependency dependencyWithProtocol:@protocol(FIRSessionsProvider)];
 
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
@@ -194,6 +210,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     }
 
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
+    id<FIRSessionsProvider> sessions = FIR_COMPONENT(FIRSessionsProvider, container);
 
     FIRInstallations *installations = [FIRInstallations installationsWithApp:container.app];
 
@@ -202,13 +219,14 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     return [[FIRCrashlytics alloc] initWithApp:container.app
                                        appInfo:NSBundle.mainBundle.infoDictionary
                                  installations:installations
-                                     analytics:analytics];
+                                     analytics:analytics
+                                      sessions:sessions];
   };
 
   FIRComponent *component =
       [FIRComponent componentWithProtocol:@protocol(FIRCrashlyticsInstanceProvider)
                       instantiationTiming:FIRInstantiationTimingEagerInDefaultApp
-                             dependencies:@[ analyticsDep ]
+                             dependencies:@[ analyticsDep, sessionsDep ]
                             creationBlock:creationBlock];
   return @[ component ];
 }
@@ -367,6 +385,20 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       recordOnDemandExceptionIfQuota:exceptionModel
            withDataCollectionEnabled:[self.dataArbiter isCrashlyticsCollectionEnabled]
           usingExistingReportManager:self.existingReportManager];
+}
+
+#pragma mark - FIRSessionsSubscriber
+
+- (void)onSessionIDChanged:(NSString *)sessionID {
+  FIRCLSDebugLog(@"Session ID changed: %@", sessionID);
+}
+
+- (BOOL)isDataCollectionEnabled {
+  return self.dataArbiter.isCrashlyticsCollectionEnabled;
+}
+
+- (FIRSessionsSubscriberName)sessionsSubscriberName {
+  return FIRSessionsSubscriberNameCrashlytics;
 }
 
 @end

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -711,8 +711,8 @@ extern NSString *const FIRPhoneMultiFactorID;
                                      if (error) {
                                        if (completion) {
                                          completion(nil, error);
-                                         return;
                                        }
+                                       return;
                                      }
                                      NSString *bundleID = [NSBundle mainBundle].bundleIdentifier;
                                      NSString *clientID = self->_auth.app.options.clientID;

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseInstallations', '~> 10.0'
+  s.dependency 'FirebaseSessions', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/FirebaseMessaging/Apps/SampleStandaloneWatchApp/SampleStandaloneWatchApp.xcodeproj/project.pbxproj
+++ b/FirebaseMessaging/Apps/SampleStandaloneWatchApp/SampleStandaloneWatchApp.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		D6E7BFE0293AAD81007A9699 /* SampleStandaloneWatchApp Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = D6E7BFDF293AAD81007A9699 /* SampleStandaloneWatchApp Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D6E7BFE5293AAD81007A9699 /* SampleStandaloneWatchAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E7BFE4293AAD81007A9699 /* SampleStandaloneWatchAppApp.swift */; };
 		D6E7BFE7293AAD81007A9699 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E7BFE6293AAD81007A9699 /* ContentView.swift */; };
-		D6E7BFF8293AB0EF007A9699 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = D6E7BFF7293AB0EF007A9699 /* FirebaseMessaging */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,7 +57,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6E7BFF8293AB0EF007A9699 /* FirebaseMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,7 +137,6 @@
 			);
 			name = "SampleStandaloneWatchApp Watch App";
 			packageProductDependencies = (
-				D6E7BFF7293AB0EF007A9699 /* FirebaseMessaging */,
 			);
 			productName = "SampleStandaloneWatchApp Watch App";
 			productReference = D6E7BFDF293AAD81007A9699 /* SampleStandaloneWatchApp Watch App.app */;
@@ -173,7 +170,6 @@
 			);
 			mainGroup = D6E7BFD2293AAD81007A9699;
 			packageReferences = (
-				D6E7BFF6293AB0EF007A9699 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = D6E7BFDA293AAD81007A9699 /* Products */;
 			projectDirPath = "";
@@ -480,25 +476,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		D6E7BFF6293AB0EF007A9699 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		D6E7BFF7293AB0EF007A9699 /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D6E7BFF6293AB0EF007A9699 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D6E7BFD3293AAD81007A9699 /* Project object */;
 }

--- a/FirebaseMessaging/Apps/SampleStandaloneWatchApp/SampleStandaloneWatchAppWatchApp/SampleStandaloneWatchAppApp.swift
+++ b/FirebaseMessaging/Apps/SampleStandaloneWatchApp/SampleStandaloneWatchAppWatchApp/SampleStandaloneWatchAppApp.swift
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import SwiftUI
-import Firebase
+import FirebaseCore
+import FirebaseMessaging
 
 @main
 struct SampleStandaloneWatchApp_Watch_AppApp: App {

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.10'
   s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'PromisesSwift', '~> 2.1'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -18,15 +18,11 @@ import Foundation
 @_implementationOnly import FirebaseCoreExtension
 @_implementationOnly import FirebaseInstallations
 @_implementationOnly import GoogleDataTransport
+@_implementationOnly import Promises
 
 private enum GoogleDataTransportConfig {
   static let sessionsLogSource = "1974"
   static let sessionsTarget = GDTCORTarget.FLL
-}
-
-@objc(FIRSessionsProvider)
-protocol SessionsProvider {
-  @objc static func sessions() -> Void
 }
 
 @objc(FIRSessions) final class Sessions: NSObject, Library, SessionsProvider {
@@ -41,6 +37,19 @@ protocol SessionsProvider {
   private let sessionGenerator: SessionGenerator
   private let appInfo: ApplicationInfo
   private let settings: SessionsSettings
+
+  /// Subscribers
+  /// `subscribers` are used to determine the Data Collection state of the Sessions SDK.
+  /// If any Subscribers has Data Collection enabled, the Sessions SDK will send events
+  private var subscribers: [SessionsSubscriber] = []
+  /// `subscriberPromises` are used to wait until all Subscribers have registered
+  /// themselves. Subscribers must have Data Collection state available upon registering.
+  private var subscriberPromises: [SessionsSubscriberName: Promise<Void>] = [:]
+
+  /// Notifications
+  static let SessionIDChangedNotificationName = Notification
+    .Name("SessionIDChangedNotificationName")
+  let notificationCenter = NotificationCenter()
 
   // MARK: - Initializers
 
@@ -89,21 +98,102 @@ protocol SessionsProvider {
 
     super.init()
 
+    SessionsDependencies.dependencies.forEach { subscriberName in
+      self.subscriberPromises[subscriberName] = Promise<Void>.pending()
+    }
+
+    Logger.logDebug("Expecting subscriptions from: \(SessionsDependencies.dependencies)")
+
     self.initiator.beginListening {
-      // On each session start, first update Settings if expired
-      self.settings.updateSettings()
-      let session = self.sessionGenerator.generateNewSession()
-      // Generate a session start event only when session data collection is enabled and if the session is allowed to dispatch events
-      if self.settings.sessionsEnabled, session.shouldDispatchEvents {
-        let event = SessionStartEvent(sessionInfo: session, appInfo: self.appInfo)
-        DispatchQueue.global().async {
-          self.coordinator.attemptLoggingSessionStart(event: event) { result in
-          }
+      // Generating a Session ID early is important as Subscriber
+      // SDKs will need to read it immediately upon registration.
+      let sessionInfo = self.sessionGenerator.generateNewSession()
+
+      // Post a notification so subscriber SDKs can get an updated Session ID
+      self.notificationCenter.post(name: Sessions.SessionIDChangedNotificationName,
+                                   object: nil)
+
+      let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: self.appInfo)
+
+      // Wait until all subscriber promises have been fulfilled before
+      // doing any data collection.
+      all(self.subscriberPromises.values).then(on: .global(qos: .background)) { _ in
+        guard self.isAnyDataCollectionEnabled else {
+          Logger
+            .logDebug(
+              "Data Collection is disabled for all subscribers. Skipping this Session Event"
+            )
+          return
         }
-      } else {
-        Logger.logDebug("Session logging is disabled by configuration settings.")
+
+        Logger.logDebug("Data Collection is enabled for at least one Subscriber")
+
+        // Fetch settings if they have expired. This must happen after the check for
+        // data collection because it uses the network, but it must happen before the
+        // check for sessionsEnabled from Settings because otherwise we would permanently
+        // turn off the Sessions SDK when we disabled it.
+        self.settings.updateSettings()
+
+        self.addEventDataCollectionState(event: event)
+
+        if !(self.settings.sessionsEnabled && sessionInfo.shouldDispatchEvents) {
+          Logger
+            .logDebug(
+              "Session Event logging is disabled sessionsEnabled: \(self.settings.sessionsEnabled), shouldDispatchEvents: \(sessionInfo.shouldDispatchEvents)"
+            )
+          return
+        }
+
+        self.coordinator.attemptLoggingSessionStart(event: event) { result in
+        }
       }
     }
+  }
+
+  // MARK: - Data Collection
+
+  var isAnyDataCollectionEnabled: Bool {
+    for subscriber in subscribers {
+      if subscriber.isDataCollectionEnabled {
+        return true
+      }
+    }
+    return false
+  }
+
+  func addEventDataCollectionState(event: SessionStartEvent) {
+    subscribers.forEach { subscriber in
+      event.set(subscriber: subscriber.sessionsSubscriberName,
+                isDataCollectionEnabled: subscriber.isDataCollectionEnabled)
+    }
+  }
+
+  // MARK: - SessionsProvider
+
+  var currentSessionDetails: SessionDetails {
+    return SessionDetails(sessionId: sessionGenerator.currentSession?.sessionId)
+  }
+
+  func register(subscriber: SessionsSubscriber) {
+    Logger
+      .logDebug(
+        "Registering Sessions SDK subscriber with name: \(subscriber.sessionsSubscriberName), data collection enabled: \(subscriber.isDataCollectionEnabled)"
+      )
+
+    notificationCenter.addObserver(
+      forName: Sessions.SessionIDChangedNotificationName,
+      object: nil,
+      queue: nil
+    ) { notification in
+      subscriber.onSessionChanged(self.currentSessionDetails)
+    }
+    // Immediately call the callback because the Sessions SDK starts
+    // before subscribers, so subscribers will miss the first Notification
+    subscriber.onSessionChanged(currentSessionDetails)
+
+    // Fulfil this subscriber's promise
+    subscribers.append(subscriber)
+    subscriberPromises[subscriber.sessionsSubscriberName]?.fulfill(())
   }
 
   // MARK: - Library conformance
@@ -119,8 +209,4 @@ protocol SessionsProvider {
         return self.init(appID: app.options.googleAppID, installations: installations)
       }]
   }
-
-  // MARK: - SessionsProvider conformance
-
-  static func sessions() {}
 }

--- a/FirebaseSessions/Sources/Public/SessionsDependencies.swift
+++ b/FirebaseSessions/Sources/Public/SessionsDependencies.swift
@@ -1,0 +1,32 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// Sessions Dependencies determines when a dependent SDK is
+// installed in the app. The Sessions SDK uses this to figure
+// out which dependencies to wait for to getting the data
+// collection state.
+//
+// This is important because the Sessions SDK starts up before
+// dependent SDKs
+@objc(FIRSessionsDependencies)
+public class SessionsDependencies: NSObject {
+  static var dependencies: Set<SessionsSubscriberName> = .init()
+
+  @objc public static func addDependency(name: SessionsSubscriberName) {
+    SessionsDependencies.dependencies.insert(name)
+  }
+}

--- a/FirebaseSessions/Sources/Public/SessionsProvider.swift
+++ b/FirebaseSessions/Sources/Public/SessionsProvider.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// Sessions Provider is the Session SDK's internal
+// interface for other 1P SDKs to talk to.
+@objc(FIRSessionsProvider)
+public protocol SessionsProvider {
+  @objc func register(subscriber: SessionsSubscriber)
+}

--- a/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
+++ b/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Sessions Subscriber is an interface that dependent SDKs
+/// must implement.
+@objc(FIRSessionsSubscriber)
+public protocol SessionsSubscriber {
+  func onSessionChanged(_ session: SessionDetails)
+  var isDataCollectionEnabled: Bool { get }
+  var sessionsSubscriberName: SessionsSubscriberName { get }
+}
+
+/// Session Payload is a container for Session Data passed to Subscribers
+/// whenever the Session changes
+@objc(FIRSessionDetails)
+public class SessionDetails: NSObject {
+  var sessionId: String?
+
+  public init(sessionId: String?) {
+    self.sessionId = sessionId
+    super.init()
+  }
+}
+
+/// Session Subscriber Names are used for identifying subscribers
+@objc(FIRSessionsSubscriberName)
+public enum SessionsSubscriberName: Int, CustomStringConvertible {
+  case Unknown
+  case Crashlytics
+  case Performance
+
+  public var description: String {
+    switch self {
+    case .Crashlytics:
+      return "Crashlytics"
+    case .Performance:
+      return "Performance"
+    default:
+      return "Unknown"
+    }
+  }
+}

--- a/FirebaseSessions/Sources/SessionGenerator.swift
+++ b/FirebaseSessions/Sources/SessionGenerator.swift
@@ -62,7 +62,7 @@ class SessionGenerator {
     return newSession
   }
 
-  func currentSession() -> SessionInfo? {
+  var currentSession: SessionInfo? {
     return thisSession
   }
 }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -65,9 +65,9 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.application_info.apple_app_info.mcc_mnc = makeProtoString(appInfo.mccMNC)
 
     proto.session_data.data_collection_status
-      .crashlytics = firebase_appquality_sessions_DataCollectionState_COLLECTION_UNKNOWN
+      .crashlytics = firebase_appquality_sessions_DataCollectionState_COLLECTION_SDK_NOT_INSTALLED
     proto.session_data.data_collection_status
-      .performance = firebase_appquality_sessions_DataCollectionState_COLLECTION_UNKNOWN
+      .performance = firebase_appquality_sessions_DataCollectionState_COLLECTION_SDK_NOT_INSTALLED
   }
 
   func setInstallationID(installationId: String) {
@@ -76,6 +76,19 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 
   func setSamplingRate(samplingRate: Double) {
     proto.session_data.data_collection_status.session_sampling_rate = samplingRate
+  }
+
+  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool) {
+    let dataCollectionState = makeDataCollectionProto(isDataCollectionEnabled)
+    switch subscriber {
+    case .Crashlytics:
+      proto.session_data.data_collection_status.crashlytics = dataCollectionState
+    case .Performance:
+      proto.session_data.data_collection_status.performance = dataCollectionState
+    default:
+      Logger
+        .logWarning("Attempted to set Data Collection status for unknown Subscriber: \(subscriber)")
+    }
   }
 
   // MARK: - GDTCOREventDataObject
@@ -95,6 +108,15 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
   }
 
   // MARK: - Data Conversion
+
+  func makeDataCollectionProto(_ isDataCollectionEnabled: Bool)
+    -> firebase_appquality_sessions_DataCollectionState {
+    if isDataCollectionEnabled {
+      return firebase_appquality_sessions_DataCollectionState_COLLECTION_ENABLED
+    } else {
+      return firebase_appquality_sessions_DataCollectionState_COLLECTION_DISABLED
+    }
+  }
 
   private func makeProtoStringOrNil(_ string: String?) -> UnsafeMutablePointer<pb_bytes_array_t>? {
     guard let string = string else {

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+final class FirebaseSessionsTests: XCTestCase {
+//    override func setUpWithError() throws {
+//        // Put setup code here. This method is called before the invocation of each test method in the class.
+//    }
+//
+//    override func tearDownWithError() throws {
+//        // Put teardown code here. This method is called after the invocation of each test method in the class.
+//    }
+
+  func testExample() throws {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // Any test you write for XCTest can be annotated as throws and async.
+    // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+    // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+  }
+}

--- a/FirebaseSessions/Tests/Unit/SessionGeneratorTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionGeneratorTests.swift
@@ -76,7 +76,7 @@ class SessionGeneratorTests: XCTestCase {
   // with the Sessions SDK, we may want to move to a lazy solution where
   // sessionID can never be empty
   func test_sessionID_beforeGenerateReturnsNothing() throws {
-    XCTAssertNil(generator.currentSession())
+    XCTAssertNil(generator.currentSession)
   }
 
   func test_generateNewSessionID_generatesValidID() throws {

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -208,11 +208,11 @@ class SessionStartEventTests: XCTestCase {
     testProtoAndDecodedProto(sessionEvent: event) { proto in
       XCTAssertEqual(
         proto.session_data.data_collection_status.performance,
-        firebase_appquality_sessions_DataCollectionState_COLLECTION_UNKNOWN
+        firebase_appquality_sessions_DataCollectionState_COLLECTION_SDK_NOT_INSTALLED
       )
       XCTAssertEqual(
         proto.session_data.data_collection_status.crashlytics,
-        firebase_appquality_sessions_DataCollectionState_COLLECTION_UNKNOWN
+        firebase_appquality_sessions_DataCollectionState_COLLECTION_SDK_NOT_INSTALLED
       )
     }
   }

--- a/Package.swift
+++ b/Package.swift
@@ -491,7 +491,7 @@ let package = Package(
     ),
     .target(
       name: "FirebaseCrashlytics",
-      dependencies: ["FirebaseCore", "FirebaseInstallations",
+      dependencies: ["FirebaseCore", "FirebaseInstallations", "FirebaseSessions",
                      .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
                      .product(name: "GULEnvironment", package: "GoogleUtilities"),
                      .product(name: "FBLPromises", package: "Promises"),

--- a/Package.swift
+++ b/Package.swift
@@ -1089,6 +1089,7 @@ let package = Package(
         "FirebaseInstallations",
         "FirebaseCoreExtension",
         "FirebaseSessionsObjC",
+        .product(name: "Promises", package: "Promises"),
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
       ],

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -527,9 +527,29 @@ case "$product-$platform-$method" in
     pod_gen FirebaseSessions.podspec --platforms=ios --clean
     cd FirebaseSessions/Tests/TestApp; pod install; cd -
 
+    # Run E2E Integration Tests for Prod.
+    RunXcodebuild \
+      -workspace 'FirebaseSessions/Tests/TestApp/AppQualityDevApp.xcworkspace' \
+      -scheme "AppQualityDevApp_iOS" \
+      "${ios_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+
+    # Run E2E Integration Tests for Staging.
+    RunXcodebuild \
+      -workspace 'FirebaseSessions/Tests/TestApp/AppQualityDevApp.xcworkspace' \
+      -scheme "AppQualityDevApp_iOS" \
+      FirebaseSessionsRunEnvironment=STAGING \
+      "${ios_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+
     # Run E2E Integration Tests for Autopush.
     RunXcodebuild \
       -workspace 'FirebaseSessions/Tests/TestApp/AppQualityDevApp.xcworkspace' \
+      FirebaseSessionsRunEnvironment=AUTOPUSH \
       -scheme "AppQualityDevApp_iOS" \
       "${ios_flags[@]}" \
       "${xcb_flags[@]}" \


### PR DESCRIPTION
Alternative to https://github.com/firebase/firebase-ios-sdk/pull/10619 where the dependency is required.

Replaces https://github.com/firebase/firebase-ios-sdk/pull/10636

# TODO
- [x] Add tests done in https://github.com/firebase/firebase-ios-sdk/pull/10669
- [x] Ensure future backgrounds still resolve the promises done in https://github.com/firebase/firebase-ios-sdk/pull/10669