### PR TITLE
[Auth Exchange] Add a model for an ExchangeTokenResponse

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
@@ -23,9 +23,8 @@
 // These macros generate a function to force a symbol for the containing .o, to work around an issue
 // where strip will not strip debug information without a symbol to strip.
 #define DUMMY_FUNCTION_NAME(x) CONCAT(fircls_strip_this_, x)
-#define INJECT_STRIP_SYMBOL(x)        \
-  void DUMMY_FUNCTION_NAME(x)(void) { \
-  }
+#define INJECT_STRIP_SYMBOL(x) \
+  void DUMMY_FUNCTION_NAME(x)(void) {}
 
 // These make some target os types available to previous versions of xcode that do not yet have them
 // in their SDKs

--- a/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
+++ b/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
@@ -113,7 +113,9 @@ final class ModelTests: XCTestCase {
 
   func testDecodeExchangeTokenResponse() throws {
     let accessToken = "test-access-token"
-    let timeToLive = "3.141592653s"
+    let timeToLiveSeconds: Int64 = 3
+    let timeToLiveNanos: Int32 = 141592653
+    let timeToLive = "\(timeToLiveSeconds).\(timeToLiveNanos)s"
     let responseJSON = """
     {
       "token": {
@@ -129,6 +131,8 @@ final class ModelTests: XCTestCase {
 
     let response = try jsonDecoder.decode(ExchangeTokenResponse.self, from: responseJSON)
 
+    XCTAssertEqual(response.token.timeToLive.seconds, timeToLiveSeconds)
+    XCTAssertEqual(response.token.timeToLive.nanoseconds, timeToLiveNanos)
     XCTAssertEqual(response, expectedResponse)
   }
 }

--- a/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
+++ b/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
@@ -25,6 +25,10 @@ final class ModelTests: XCTestCase {
     return encoder
   }()
 
+  let jsonDecoder = JSONDecoder()
+
+  // MARK: - Request Model Encoding Tests
+
   func testEncodeExchangeInstallationAuthTokenRequest() throws {
     let installationAuthToken = "test-installation-token"
     let request = ExchangeInstallationAuthTokenRequest(
@@ -38,7 +42,7 @@ final class ModelTests: XCTestCase {
 
     let json = try encodeAsJSON(request)
 
-    XCTAssertEqual(expectedJSON, json)
+    XCTAssertEqual(json, expectedJSON)
   }
 
   func testEncodeExchangeCustomTokenRequest() throws {
@@ -54,7 +58,7 @@ final class ModelTests: XCTestCase {
 
     let json = try encodeAsJSON(request)
 
-    XCTAssertEqual(expectedJSON, json)
+    XCTAssertEqual(json, expectedJSON)
   }
 
   func testEncodeExchangeOidcTokenRequestWithImplicitCredentials() throws {
@@ -73,7 +77,7 @@ final class ModelTests: XCTestCase {
 
     let json = try encodeAsJSON(request)
 
-    XCTAssertEqual(expectedJSON, json)
+    XCTAssertEqual(json, expectedJSON)
   }
 
   func testEncodeExchangeOidcTokenRequestWithAuthCodeCredentials() throws {
@@ -97,11 +101,41 @@ final class ModelTests: XCTestCase {
 
     let json = try encodeAsJSON(request)
 
-    XCTAssertEqual(expectedJSON, json)
+    XCTAssertEqual(json, expectedJSON)
   }
 
   private func encodeAsJSON(_ entity: Encodable) throws -> String {
     let data = try jsonEncoder.encode(entity)
     return String(data: data, encoding: .utf8)!
+  }
+
+  // MARK: - Response Model Decoding Tests
+
+  func testDecodeExchangeTokenResponse() throws {
+    let accessToken = "test-access-token"
+    let timeToLive = "3.141592653s"
+    let responseJSON = """
+    {
+      "token": {
+        "accessToken": "\(accessToken)",
+        "ttl": "\(timeToLive)"
+      }
+    }
+    """
+    let expectedResponse = ExchangeTokenResponse(token: ExchangeTokenResponse.AuthExchangeToken(
+      accessToken: accessToken,
+      timeToLive: try ProtobufDuration(json: timeToLive)
+    ))
+
+    let response = try jsonDecoder.decode(ExchangeTokenResponse.self, from: responseJSON)
+
+    XCTAssertEqual(response, expectedResponse)
+  }
+}
+
+private extension JSONDecoder {
+  func decode<T>(_ type: T.Type, from string: String) throws -> T where T: Decodable {
+    let data: Data = string.data(using: .utf8)!
+    return try decode(T.self, from: data)
   }
 }

--- a/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
+++ b/FirebaseAuthExchange/Tests/Unit/ExchangeServiceModelTests.swift
@@ -114,7 +114,7 @@ final class ModelTests: XCTestCase {
   func testDecodeExchangeTokenResponse() throws {
     let accessToken = "test-access-token"
     let timeToLiveSeconds: Int64 = 3
-    let timeToLiveNanos: Int32 = 141592653
+    let timeToLiveNanos: Int32 = 141_592_653
     let timeToLive = "\(timeToLiveSeconds).\(timeToLiveNanos)s"
     let responseJSON = """
     {


### PR DESCRIPTION
Added a model for the response to an `ExchangeInstallationAuthTokenRequest` or `ExchangeCustomTokenRequest`.

#no-changelog