### PR TITLE
Add test for missing SessionCoordinator code coverage

### DIFF
--- a/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionCoordinatorTests.swift
@@ -94,4 +94,30 @@ class SessionCoordinatorTests: XCTestCase {
     XCTAssertEqual(fireLogger.loggedEvent, event)
     XCTAssertFalse(resultSuccess)
   }
+
+  func test_attemptLoggingSessionStart_handlesInstallationsError() throws {
+    installations.result = .failure(NSError(domain: "TestInstallationsError", code: -1))
+
+    let sessionInfo = SessionInfo(
+      sessionId: "testSessionId",
+      previousSessionId: "testPreviousSessionId",
+      dispatchEvents: true
+    )
+    let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: appInfo, time: time)
+
+    // Start success so it must be set to false
+    var resultSuccess = true
+    coordinator.attemptLoggingSessionStart(event: event) { result in
+      switch result {
+      case .success(()):
+        resultSuccess = true
+      case .failure:
+        resultSuccess = false
+      }
+    }
+
+    // We should have logged the event, but with a failed result
+    XCTAssertNil(fireLogger.loggedEvent)
+    XCTAssertFalse(resultSuccess)
+  }
 }


### PR DESCRIPTION
This section was missing coverage:
<img width="912" alt="Screenshot 2023-01-13 at 12 43 23 PM" src="https://user-images.githubusercontent.com/555046/212385849-0314b33d-16b3-4d0b-8eec-8864d90a32f9.png">


# How to Generate Code Coverage

<img width="1264" alt="Screenshot 2023-01-13 at 12 44 12 PM" src="https://user-images.githubusercontent.com/555046/212385813-3d1b71c8-cfa9-441c-b875-95fe3456b8a7.png">

#no-changelog 