### PR TITLE
[Infra] Update 'actions/checkout' version in 'update-cpp-sdk-on-release.yaml'

### DIFF
--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.7
 
       - name: Check out firebase-cpp-sdk
-        uses: actions/checkout@v3.3.1
+        uses: actions/checkout@v3
         with:
           repository: firebase/firebase-cpp-sdk
           ref: main


### PR DESCRIPTION
### Context

When I published 10.4.0., I got an email notification regarding the update-cpp-sdk-on-release.yam [failing](https://github.com/firebase/firebase-ios-sdk/actions/runs/3943423218).

I think that version may not be installed on the VM so I pinned the `checkout` action to the major version.

#no-changelog