### PR TITLE
[Infra] Fix action name in 'health-metrics-release.yml'

### DIFF
--- a/.github/workflows/health-metrics-release.yml
+++ b/.github/workflows/health-metrics-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
       - name: Authenticate Google Cloud SDK
         run: |
           scripts/decrypt_gha_secret.sh \


### PR DESCRIPTION
### Context

When I published 10.4.0., I got an email notification regarding the `health-metrics-release.yml` [failing](https://github.com/firebase/firebase-ios-sdk/actions/runs/3943423199).

Looks like `google-github-actions/setup-gcloud` action repo switched from `master` → `main`.

#no-changelog
