### PR TITLE
change sessionId from the subscriber payload to public

### DIFF
--- a/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
+++ b/FirebaseSessions/Sources/Public/SessionsSubscriber.swift
@@ -28,7 +28,7 @@ public protocol SessionsSubscriber {
 /// whenever the Session changes
 @objc(FIRSessionDetails)
 public class SessionDetails: NSObject {
-  var sessionId: String?
+  @objc public var sessionId: String?
 
   public init(sessionId: String?) {
     self.sessionId = sessionId


### PR DESCRIPTION
Both https://github.com/firebase/firebase-ios-sdk/pull/10704 and https://github.com/firebase/firebase-ios-sdk/pull/10682 requires this change, otherwise Crashlytics and Performance can't access the session id in the payload given by Sessions SDK.


#no-changelog