### PR TITLE
Update Crashlytics SDK to send Session ID in crash reports

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -86,6 +86,7 @@ typedef struct {
   const char* rootPath;
   const char* previouslyCrashedFileRootPath;
   const char* sessionId;
+  const char* appQualitySessionId;
   const char* betaToken;
   bool errorsEnabled;
   bool customExceptionsEnabled;
@@ -96,10 +97,12 @@ typedef struct {
 } FIRCLSContextInitData;
 
 #ifdef __OBJC__
-bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
-                             FIRCLSSettings* settings,
-                             FIRCLSFileManager* fileManager);
-
+bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager* fileManager);
+FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
+                                                 FIRCLSSettings* settings,
+                                                 FIRCLSFileManager* fileManager,
+                                                 NSString* appQualitySessionId);
+bool FIRCLSContextRecordMetadata(NSString* rootPath, const FIRCLSContextInitData* initData);
 #endif
 
 void FIRCLSContextBaseInit(void);

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -47,13 +47,13 @@
 
 static const int64_t FIRCLSContextInitWaitTime = 5LL * NSEC_PER_SEC;
 
-static bool FIRCLSContextRecordMetadata(const char* path, const FIRCLSContextInitData* initData);
 static const char* FIRCLSContextAppendToRoot(NSString* root, NSString* component);
 static void FIRCLSContextAllocate(FIRCLSContext* context);
 
 FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
                                                  FIRCLSSettings* settings,
-                                                 FIRCLSFileManager* fileManager) {
+                                                 FIRCLSFileManager* fileManager,
+                                                 NSString* appQualitySessionId) {
   // Because we need to start the crash reporter right away,
   // it starts up either with default settings, or cached settings
   // from the last time they were fetched
@@ -64,6 +64,7 @@ FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
 
   initData.customBundleId = nil;
   initData.sessionId = [[report identifier] UTF8String];
+  initData.appQualitySessionId = [appQualitySessionId UTF8String];
   initData.rootPath = [[report path] UTF8String];
   initData.previouslyCrashedFileRootPath = [[fileManager rootPath] UTF8String];
   initData.errorsEnabled = [settings errorReportingEnabled];
@@ -77,12 +78,7 @@ FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
   return initData;
 }
 
-bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
-                             FIRCLSSettings* settings,
-                             FIRCLSFileManager* fileManager) {
-  FIRCLSContextInitData initDataObj = FIRCLSContextBuildInitData(report, settings, fileManager);
-  FIRCLSContextInitData* initData = &initDataObj;
-
+bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager* fileManager) {
   if (!initData) {
     return false;
   }
@@ -100,7 +96,7 @@ bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
 
   // setup our SDK log file synchronously, because other calls may depend on it
   _firclsContext.readonly->logPath = FIRCLSContextAppendToRoot(rootPath, @"sdk.log");
-  _firclsContext.readonly->initialReportPath = FIRCLSDupString([report.path UTF8String]);
+  _firclsContext.readonly->initialReportPath = FIRCLSDupString(initData->rootPath);
   if (!FIRCLSUnlinkIfExists(_firclsContext.readonly->logPath)) {
     FIRCLSErrorLog(@"Unable to write initialize SDK write paths %s", strerror(errno));
   }
@@ -209,9 +205,7 @@ bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
   }
 
   dispatch_group_async(group, queue, ^{
-    const char* metaDataPath = [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile]
-        fileSystemRepresentation];
-    if (!FIRCLSContextRecordMetadata(metaDataPath, initData)) {
+    if (!FIRCLSContextRecordMetadata(rootPath, initData)) {
       FIRCLSSDKLog("Unable to record context metadata\n");
     }
   });
@@ -368,6 +362,8 @@ static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const FIRCLSContextIni
   FIRCLSFileWriteHashEntryString(file, "build_version", FIRCLSSDKVersion().UTF8String);
   FIRCLSFileWriteHashEntryUint64(file, "started_at", time(NULL));
 
+  FIRCLSFileWriteHashEntryString(file, "app_quality_session_id", initData->appQualitySessionId);
+
   FIRCLSFileWriteHashEntryString(file, "session_id", initData->sessionId);
   // install_id is written into the proto directly. This is only left here to
   // support Apple Report Converter.
@@ -402,7 +398,9 @@ static bool FIRCLSContextRecordApplication(FIRCLSFile* file, const char* customB
   return true;
 }
 
-static bool FIRCLSContextRecordMetadata(const char* path, const FIRCLSContextInitData* initData) {
+bool FIRCLSContextRecordMetadata(NSString* rootPath, const FIRCLSContextInitData* initData) {
+  const char* path =
+      [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile] fileSystemRepresentation];
   if (!FIRCLSUnlinkIfExists(path)) {
     FIRCLSSDKLog("Unable to unlink existing metadata file %s\n", strerror(errno));
   }

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h
@@ -1,0 +1,43 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "Crashlytics/Crashlytics/Models/FIRCLSFileManager.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSSettings.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+///
+/// The ContextManager determines when to build the context object,
+/// and write its metadata. It was created because the FIRCLSContext
+/// is interacted with via functions, which makes it hard to include in tests.
+/// In addition, we this class is responsible for re-writing the Metadata object
+/// when the App Quality Session ID changes.
+///
+@interface FIRCLSContextManager : NSObject
+
+/// This should be set immediately when the FirebaseSessions SDK generates
+/// a new Session ID.
+@property(nonatomic, copy) NSString *appQualitySessionId;
+
+- (BOOL)setupContextWithReport:(FIRCLSInternalReport *)report
+                      settings:(FIRCLSSettings *)settings
+                   fileManager:(FIRCLSFileManager *)fileManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
@@ -1,0 +1,78 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
+
+#import "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+
+@interface FIRCLSContextManager ()
+
+@property(nonatomic, assign) BOOL hasInitializedContext;
+
+@property(nonatomic, strong) FIRCLSInternalReport *report;
+@property(nonatomic, strong) FIRCLSSettings *settings;
+@property(nonatomic, strong) FIRCLSFileManager *fileManager;
+
+@end
+
+@implementation FIRCLSContextManager
+
+- (instancetype)init {
+  self = [super init];
+  if (!self) {
+    return self;
+  }
+
+  _appQualitySessionId = @"";
+
+  return self;
+}
+
+- (BOOL)setupContextWithReport:(FIRCLSInternalReport *)report
+                      settings:(FIRCLSSettings *)settings
+                   fileManager:(FIRCLSFileManager *)fileManager {
+  _report = report;
+  _settings = settings;
+  _fileManager = fileManager;
+
+  _hasInitializedContext = true;
+
+  FIRCLSContextInitData initDataObj = self.buildInitData;
+  return FIRCLSContextInitialize(&initDataObj, self.fileManager);
+}
+
+- (void)setAppQualitySessionId:(NSString *)appQualitySessionId {
+  _appQualitySessionId = appQualitySessionId;
+
+  // This may be called before the context is originally initialized. In that case
+  // skip the write because it will be written as soon as the context is initialized.
+  // On future Session ID updates, this will be true and the context metadata will be
+  // rewritten.
+  if (!self.hasInitializedContext) {
+    return;
+  }
+
+  FIRCLSContextInitData initDataObj = self.buildInitData;
+  if (!FIRCLSContextRecordMetadata(self.report.path, &initDataObj)) {
+    FIRCLSErrorLog(@"Failed to write context file while updating App Quality Session ID");
+  }
+}
+
+- (FIRCLSContextInitData)buildInitData {
+  return FIRCLSContextBuildInitData(self.report, self.settings, self.fileManager,
+                                    self.appQualitySessionId);
+}
+
+@end

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class FIRCLSOnDemandModel;
 @class FIRCLSSettings;
 @class FIRCLSLaunchMarkerModel;
+@class FIRCLSContextManager;
 @class GDTCORTransport;
 @protocol FIRAnalyticsInterop;
 
@@ -79,6 +80,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Settings fetched from the server
 @property(nonatomic, strong) FIRCLSSettings *settings;
+
+// Sets up the Context and writes Metadata files to the crash report
+@property(nonatomic, strong) FIRCLSContextManager *contextManager;
 
 // These queues function together as a single startup queue
 @property(nonatomic, strong) NSOperationQueue *operationQueue;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.m
@@ -15,6 +15,7 @@
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h"
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSApplication.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSExecutionIdentifierModel.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSSettings.h"
@@ -44,6 +45,7 @@
   _dataArbiter = dataArbiter;
   _settings = settings;
   _onDemandModel = onDemandModel;
+  _contextManager = [[FIRCLSContextManager alloc] init];
 
   _appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
   _installIDModel = [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:installations];

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.h
@@ -22,6 +22,7 @@
 @class FIRCLSExistingReportManager;
 @class FIRCLSAnalyticsManager;
 @class FIRCLSManagerData;
+@class FIRCLSContextManager;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -41,6 +41,7 @@
 #import "Crashlytics/Crashlytics/Components/FIRCLSApplication.h"
 #import "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSAnalyticsManager.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSExistingReportManager.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSMetricKitManager.h"
@@ -135,6 +136,8 @@ typedef NSNumber FIRCLSWrappedReportAction;
 @property(nonatomic, strong) FIRCLSAnalyticsManager *analyticsManager;
 @property(nonatomic, strong) FIRCLSExistingReportManager *existingReportManager;
 
+@property(nonatomic, strong) FIRCLSContextManager *contextManager;
+
 // Internal Managers
 @property(nonatomic, strong) FIRCLSSettingsManager *settingsManager;
 @property(nonatomic, strong) FIRCLSNotificationManager *notificationManager;
@@ -165,6 +168,7 @@ typedef NSNumber FIRCLSWrappedReportAction;
   _installIDModel = managerData.installIDModel;
   _settings = managerData.settings;
   _executionIDModel = managerData.executionIDModel;
+  _contextManager = managerData.contextManager;
 
   _existingReportManager = existingReportManager;
   _analyticsManager = analyticsManager;
@@ -416,7 +420,9 @@ typedef NSNumber FIRCLSWrappedReportAction;
     return NO;
   }
 
-  if (!FIRCLSContextInitialize(report, self.settings, _fileManager)) {
+  if (![self.contextManager setupContextWithReport:report
+                                          settings:self.settings
+                                       fileManager:_fileManager]) {
     return NO;
   }
 

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
@@ -19,5 +19,6 @@
 @interface FIRCLSRecordIdentity : FIRCLSRecordBase
 
 @property(nonatomic, copy) NSString *build_version;
+@property(nonatomic, copy) NSString *app_quality_session_id;
 
 @end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
@@ -22,6 +22,7 @@
   self = [super initWithDict:dict];
   if (self) {
     _build_version = dict[@"build_version"];
+    _app_quality_session_id = dict[@"app_quality_session_id"];
   }
   return self;
 }

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -155,6 +155,7 @@
   report.platform = [self protoPlatformFromString:self.host.platform];
   report.installation_uuid = FIRCLSEncodeString(self.installIDModel.installID);
   report.firebase_installation_id = FIRCLSEncodeString(self.fiid);
+  report.app_quality_session_id = FIRCLSEncodeString(self.identity.app_quality_session_id);
   report.build_version = FIRCLSEncodeString(self.application.build_version);
   report.display_version = FIRCLSEncodeString(self.application.display_version);
   report.apple_payload = [self protoFilesPayload];

--- a/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
@@ -68,9 +68,9 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 }
 
 - (void)test_notSettingSessionID_protoHasNilSessionID {
-  [self.contextManager initContextWithReport:self.report
-                                    settings:self.mockSettings
-                                 fileManager:self.fileManager];
+  [self.contextManager setupContextWithReport:self.report
+                                     settings:self.mockSettings
+                                  fileManager:self.fileManager];
 
   FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
                                                                googleAppId:@"TestGoogleAppID"
@@ -81,13 +81,13 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 }
 
 - (void)test_settingSessionIDMultipleTimes_protoHasLastSessionID {
-  [self.contextManager updateAppQualitySessionId:TestContextSessionID];
+  [self.contextManager setAppQualitySessionId:TestContextSessionID];
 
-  [self.contextManager initContextWithReport:self.report
-                                    settings:self.mockSettings
-                                 fileManager:self.fileManager];
+  [self.contextManager setupContextWithReport:self.report
+                                     settings:self.mockSettings
+                                  fileManager:self.fileManager];
 
-  [self.contextManager updateAppQualitySessionId:TestContextSessionID2];
+  [self.contextManager setAppQualitySessionId:TestContextSessionID2];
 
   FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
                                                                googleAppId:@"TestGoogleAppID"
@@ -99,13 +99,13 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 }
 
 - (void)test_settingSessionIDOutOfOrder_protoHasLastSessionID {
-  [self.contextManager initContextWithReport:self.report
-                                    settings:self.mockSettings
-                                 fileManager:self.fileManager];
+  [self.contextManager setupContextWithReport:self.report
+                                     settings:self.mockSettings
+                                  fileManager:self.fileManager];
 
-  [self.contextManager updateAppQualitySessionId:TestContextSessionID];
+  [self.contextManager setAppQualitySessionId:TestContextSessionID];
 
-  [self.contextManager updateAppQualitySessionId:TestContextSessionID2];
+  [self.contextManager setAppQualitySessionId:TestContextSessionID2];
 
   FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
                                                                googleAppId:@"TestGoogleAppID"

--- a/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
@@ -1,0 +1,119 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
+#import "Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.h"
+#import "Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter_Private.h"
+#import "Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h"
+
+#import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
+#import "Crashlytics/UnitTests/Mocks/FIRCLSMockFileManager.h"
+#import "Crashlytics/UnitTests/Mocks/FIRCLSMockSettings.h"
+#import "Crashlytics/UnitTests/Mocks/FIRMockInstallations.h"
+
+NSString *const TestContextReportID = @"TestContextReportID";
+NSString *const TestContextSessionID = @"TestContextSessionID";
+NSString *const TestContextSessionID2 = @"TestContextSessionID2";
+
+@interface FIRCLSContextManagerTests : XCTestCase
+
+@property(nonatomic, strong) FIRCLSMockFileManager *fileManager;
+@property(nonatomic, strong) FIRCLSMockSettings *mockSettings;
+@property(nonatomic, strong) FIRCLSContextManager *contextManager;
+@property(nonatomic, strong) FIRCLSInternalReport *report;
+@property(nonatomic, strong) FIRCLSInstallIdentifierModel *installIDModel;
+@end
+
+@implementation FIRCLSContextManagerTests
+
+- (void)setUp {
+  self.fileManager = [[FIRCLSMockFileManager alloc] init];
+  [self.fileManager createReportDirectories];
+  [self.fileManager setupNewPathForExecutionIdentifier:TestContextReportID];
+
+  FIRCLSApplicationIdentifierModel *appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
+  _mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
+                                                       appIDModel:appIDModel];
+
+  //  NSString *name = @"exception_model_report";
+  NSString *reportPath =
+      [self.fileManager.activePath stringByAppendingPathComponent:TestContextReportID];
+
+  self.report = [[FIRCLSInternalReport alloc] initWithPath:reportPath
+                                       executionIdentifier:TestContextReportID];
+
+  self.contextManager = [[FIRCLSContextManager alloc] init];
+
+  FIRMockInstallations *iid = [[FIRMockInstallations alloc] initWithFID:@"test_token"];
+  self.installIDModel = [[FIRCLSInstallIdentifierModel alloc] initWithInstallations:iid];
+}
+
+- (void)tearDown {
+  [[NSFileManager defaultManager] removeItemAtPath:self.fileManager.rootPath error:nil];
+  [super tearDown];
+}
+
+- (void)test_notSettingSessionID_protoHasNilSessionID {
+  [self.contextManager initContextWithReport:self.report
+                                    settings:self.mockSettings
+                                 fileManager:self.fileManager];
+
+  FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
+                                                               googleAppId:@"TestGoogleAppID"
+                                                            installIDModel:self.installIDModel
+                                                                      fiid:@"TestFIID"];
+
+  XCTAssertEqualObjects(adapter.identity.app_quality_session_id, @"");
+}
+
+- (void)test_settingSessionIDMultipleTimes_protoHasLastSessionID {
+  [self.contextManager updateAppQualitySessionId:TestContextSessionID];
+
+  [self.contextManager initContextWithReport:self.report
+                                    settings:self.mockSettings
+                                 fileManager:self.fileManager];
+
+  [self.contextManager updateAppQualitySessionId:TestContextSessionID2];
+
+  FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
+                                                               googleAppId:@"TestGoogleAppID"
+                                                            installIDModel:self.installIDModel
+                                                                      fiid:@"TestFIID"];
+  NSLog(@"reportPath: %@", self.report.path);
+
+  XCTAssertEqualObjects(adapter.identity.app_quality_session_id, TestContextSessionID2);
+}
+
+- (void)test_settingSessionIDOutOfOrder_protoHasLastSessionID {
+  [self.contextManager initContextWithReport:self.report
+                                    settings:self.mockSettings
+                                 fileManager:self.fileManager];
+
+  [self.contextManager updateAppQualitySessionId:TestContextSessionID];
+
+  [self.contextManager updateAppQualitySessionId:TestContextSessionID2];
+
+  FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
+                                                               googleAppId:@"TestGoogleAppID"
+                                                            installIDModel:self.installIDModel
+                                                                      fiid:@"TestFIID"];
+  NSLog(@"reportPath: %@", self.report.path);
+
+  XCTAssertEqualObjects(adapter.identity.app_quality_session_id, TestContextSessionID2);
+}
+
+@end

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -15,6 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #include "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSManagerData.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSExecutionIdentifierModel.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
@@ -96,7 +97,10 @@
       [[FIRCLSInternalReport alloc] initWithPath:reportPath
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
-  FIRCLSContextInitialize(report, self.mockSettings, self.fileManager);
+  FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
+  [contextManager initContextWithReport:report
+                               settings:self.mockSettings
+                            fileManager:self.fileManager];
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -98,9 +98,9 @@
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
   FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
-  [contextManager initContextWithReport:report
-                               settings:self.mockSettings
-                            fileManager:self.fileManager];
+  [contextManager setupContextWithReport:report
+                                settings:self.mockSettings
+                             fileManager:self.fileManager];
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -18,6 +18,7 @@
 #import "Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRStackFrame.h"
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
 #import "Crashlytics/UnitTests/Mocks/FABMockApplicationIdentifierModel.h"
@@ -52,7 +53,10 @@
       [[FIRCLSInternalReport alloc] initWithPath:self.reportPath
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
-  FIRCLSContextInitialize(report, self.mockSettings, self.fileManager);
+  FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
+  [contextManager initContextWithReport:report
+                               settings:self.mockSettings
+                            fileManager:self.fileManager];
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -54,9 +54,9 @@
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
   FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
-  [contextManager initContextWithReport:report
-                               settings:self.mockSettings
-                            fileManager:self.fileManager];
+  [contextManager setupContextWithReport:report
+                                settings:self.mockSettings
+                             fileManager:self.fileManager];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
#no-changelog

TODO:

- [x] Tests
- [x] Incorporate https://github.com/firebase/firebase-ios-sdk/pull/10750