### PR TITLE
Fix Sessions Local Overrides

### DIFF
--- a/FirebaseSessions/Sources/Settings/LocalOverrideSettings.swift
+++ b/FirebaseSessions/Sources/Settings/LocalOverrideSettings.swift
@@ -32,7 +32,7 @@ class LocalOverrideSettings: SettingsProvider, SettingsProtocol {
 
   var sessionTimeout: TimeInterval? {
     let timeout = plistValueForConfig(configName: LocalOverrideSettings
-      .PlistKey_sessions_timeout) as? String
+      .PlistKey_sessions_timeout) as? Double
     if timeout != nil {
       return Double(timeout!)
     }
@@ -41,7 +41,7 @@ class LocalOverrideSettings: SettingsProvider, SettingsProtocol {
 
   var samplingRate: Double? {
     let rate = plistValueForConfig(configName: LocalOverrideSettings
-      .PlistKey_sessions_samplingRate) as? String
+      .PlistKey_sessions_samplingRate) as? Double
     if rate != nil {
       return Double(rate!)
     }


### PR DESCRIPTION
#no-changelog

When I put in a Plist value:
<img width="600" alt="Screenshot 2023-01-19 at 12 27 03 PM" src="https://user-images.githubusercontent.com/555046/213517571-86eb8f3d-9d49-4ef3-8977-828f4b9a6aa8.png">

When we cast as a String, it returns nil because it isn't a String
<img width="717" alt="Screenshot 2023-01-19 at 12 27 49 PM" src="https://user-images.githubusercontent.com/555046/213517584-9ccf289c-79e2-4b58-a9d3-1f3099b1b3e4.png">

Fix is to cast as Double:
<img width="740" alt="Screenshot 2023-01-19 at 12 28 09 PM" src="https://user-images.githubusercontent.com/555046/213517594-a9602534-ecca-4b5d-8c48-e87623efb3b5.png">
