### PR TITLE
Prevent capturing network info when Perf data collection off

### DIFF
--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -209,10 +209,8 @@ private enum GoogleDataTransportConfig {
   func addSubscriberFields(event: SessionStartEvent) {
     subscribers.forEach { subscriber in
       event.set(subscriber: subscriber.sessionsSubscriberName,
-                isDataCollectionEnabled: subscriber.isDataCollectionEnabled)
-
-      event.setRestrictedFields(subscriber: subscriber.sessionsSubscriberName,
-                                appInfo: self.appInfo)
+                isDataCollectionEnabled: subscriber.isDataCollectionEnabled,
+                appInfo:self.appInfo)
     }
   }
 

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -210,7 +210,7 @@ private enum GoogleDataTransportConfig {
     subscribers.forEach { subscriber in
       event.set(subscriber: subscriber.sessionsSubscriberName,
                 isDataCollectionEnabled: subscriber.isDataCollectionEnabled,
-                appInfo:self.appInfo)
+                appInfo: self.appInfo)
     }
   }
 

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -81,7 +81,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.session_data.data_collection_status.session_sampling_rate = samplingRate
   }
 
-  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool, appInfo: ApplicationInfoProtocol) {
+  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool,
+           appInfo: ApplicationInfoProtocol) {
     let dataCollectionState = makeDataCollectionProto(isDataCollectionEnabled)
     switch subscriber {
     case .Crashlytics:
@@ -96,14 +97,15 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     // Only set restricted fields if Data Collection is enabled. If it's disabled,
     // we're treating that as if the product isn't installed.
     if isDataCollectionEnabled {
-      self.setRestrictedFields(subscriber: subscriber,
-                               appInfo: appInfo)
+      setRestrictedFields(subscriber: subscriber,
+                          appInfo: appInfo)
     }
   }
 
   /// This method should be called for every subscribed Subscriber. This is for cases where
   /// fields should only be collected if a specific SDK is installed.
-  private func setRestrictedFields(subscriber: SessionsSubscriberName, appInfo: ApplicationInfoProtocol) {
+  private func setRestrictedFields(subscriber: SessionsSubscriberName,
+                                   appInfo: ApplicationInfoProtocol) {
     switch subscriber {
     case .Performance:
       proto.application_info.apple_app_info.mcc_mnc = makeProtoString(appInfo.mccMNC)

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -81,7 +81,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.session_data.data_collection_status.session_sampling_rate = samplingRate
   }
 
-  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool) {
+  func set(subscriber: SessionsSubscriberName, isDataCollectionEnabled: Bool, appInfo: ApplicationInfoProtocol) {
     let dataCollectionState = makeDataCollectionProto(isDataCollectionEnabled)
     switch subscriber {
     case .Crashlytics:
@@ -92,11 +92,18 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
       Logger
         .logWarning("Attempted to set Data Collection status for unknown Subscriber: \(subscriber)")
     }
+
+    // Only set restricted fields if Data Collection is enabled. If it's disabled,
+    // we're treating that as if the product isn't installed.
+    if isDataCollectionEnabled {
+      self.setRestrictedFields(subscriber: subscriber,
+                               appInfo: appInfo)
+    }
   }
 
   /// This method should be called for every subscribed Subscriber. This is for cases where
   /// fields should only be collected if a specific SDK is installed.
-  func setRestrictedFields(subscriber: SessionsSubscriberName, appInfo: ApplicationInfoProtocol) {
+  private func setRestrictedFields(subscriber: SessionsSubscriberName, appInfo: ApplicationInfoProtocol) {
     switch subscriber {
     case .Performance:
       proto.application_info.apple_app_info.mcc_mnc = makeProtoString(appInfo.mccMNC)

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -230,7 +230,10 @@ class SessionStartEventTests: XCTestCase {
     let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: appInfo, time: time)
 
     // These fields will not be filled in when Crashlytics is installed
-    event.setRestrictedFields(subscriber: .Crashlytics, appInfo: appInfo)
+    event.set(subscriber: .Crashlytics, isDataCollectionEnabled: true, appInfo: appInfo)
+
+    // They should also not be filled in when Performance data collection is disabled
+    event.set(subscriber: .Performance, isDataCollectionEnabled: false, appInfo: appInfo)
 
     // Expect empty because Crashlytics is installed, but not Perf
     testProtoAndDecodedProto(sessionEvent: event) { proto in
@@ -250,7 +253,7 @@ class SessionStartEventTests: XCTestCase {
     }
 
     // These fields will only be filled in when the Perf SDK is installed
-    event.setRestrictedFields(subscriber: .Performance, appInfo: appInfo)
+    event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
 
     // Now the field should be set with the real thing
     testProtoAndDecodedProto(sessionEvent: event) { proto in
@@ -314,7 +317,7 @@ class SessionStartEventTests: XCTestCase {
       let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: appInfo, time: time)
 
       // These fields will only be filled in when the Perf SDK is installed
-      event.setRestrictedFields(subscriber: .Performance, appInfo: appInfo)
+      event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
 
       testProtoAndDecodedProto(sessionEvent: event) { proto in
         XCTAssertEqual(
@@ -399,7 +402,7 @@ class SessionStartEventTests: XCTestCase {
           let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: appInfo, time: time)
 
           // These fields will only be filled in when the Perf SDK is installed
-          event.setRestrictedFields(subscriber: .Performance, appInfo: appInfo)
+          event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
 
           testProtoAndDecodedProto(sessionEvent: event) { proto in
             XCTAssertEqual(
@@ -493,7 +496,7 @@ class SessionStartEventTests: XCTestCase {
           let event = SessionStartEvent(sessionInfo: sessionInfo, appInfo: appInfo, time: time)
 
           // These fields will only be filled in when the Perf SDK is installed
-          event.setRestrictedFields(subscriber: .Performance, appInfo: appInfo)
+          event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
 
           testProtoAndDecodedProto(sessionEvent: event) { proto in
             XCTAssertEqual(


### PR DESCRIPTION
We're treating data collection off as SDK not installed

#no-changelog 