### PR TITLE
Fix a crash on FIRCLSFileWriteString

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -358,7 +358,7 @@ static const char* FIRCLSContextAppendToRoot(NSString* root, NSString* component
       [[root stringByAppendingPathComponent:component] fileSystemRepresentation]);
 }
 
-static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const FIRCLSContextInitData* initData) {
+static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const char* sessionId, const char* betaToken) {
   FIRCLSFileWriteSectionStart(file, "identity");
 
   FIRCLSFileWriteHashStart(file);
@@ -368,11 +368,11 @@ static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const FIRCLSContextIni
   FIRCLSFileWriteHashEntryString(file, "build_version", FIRCLSSDKVersion().UTF8String);
   FIRCLSFileWriteHashEntryUint64(file, "started_at", time(NULL));
 
-  FIRCLSFileWriteHashEntryString(file, "session_id", initData->sessionId);
+  FIRCLSFileWriteHashEntryString(file, "session_id", sessionId);
   // install_id is written into the proto directly. This is only left here to
   // support Apple Report Converter.
   FIRCLSFileWriteHashEntryString(file, "install_id", "");
-  FIRCLSFileWriteHashEntryString(file, "beta_token", initData->betaToken);
+  FIRCLSFileWriteHashEntryString(file, "beta_token", betaToken);
   FIRCLSFileWriteHashEntryBoolean(file, "absolute_log_timestamps", true);
 
   FIRCLSFileWriteHashEnd(file);
@@ -403,6 +403,10 @@ static bool FIRCLSContextRecordApplication(FIRCLSFile* file, const char* customB
 }
 
 static bool FIRCLSContextRecordMetadata(const char* path, const FIRCLSContextInitData* initData) {
+  const char* sessionId = initData->sessionId;
+  const char* betaToken = initData->betaToken;
+  const char* customBundleId = initData->customBundleId;
+
   if (!FIRCLSUnlinkIfExists(path)) {
     FIRCLSSDKLog("Unable to unlink existing metadata file %s\n", strerror(errno));
   }
@@ -414,7 +418,7 @@ static bool FIRCLSContextRecordMetadata(const char* path, const FIRCLSContextIni
     return false;
   }
 
-  if (!FIRCLSContextRecordIdentity(&file, initData)) {
+  if (!FIRCLSContextRecordIdentity(&file, sessionId, betaToken)) {
     FIRCLSSDKLog("Unable to write out identity metadata\n");
   }
 
@@ -422,7 +426,7 @@ static bool FIRCLSContextRecordMetadata(const char* path, const FIRCLSContextIni
     FIRCLSSDKLog("Unable to write out host metadata\n");
   }
 
-  if (!FIRCLSContextRecordApplication(&file, initData->customBundleId)) {
+  if (!FIRCLSContextRecordApplication(&file, customBundleId)) {
     FIRCLSSDKLog("Unable to write out application metadata\n");
   }
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -358,7 +358,9 @@ static const char* FIRCLSContextAppendToRoot(NSString* root, NSString* component
       [[root stringByAppendingPathComponent:component] fileSystemRepresentation]);
 }
 
-static bool FIRCLSContextRecordIdentity(FIRCLSFile* file, const char* sessionId, const char* betaToken) {
+static bool FIRCLSContextRecordIdentity(FIRCLSFile* file,
+                                        const char* sessionId,
+                                        const char* betaToken) {
   FIRCLSFileWriteSectionStart(file, "identity");
 
   FIRCLSFileWriteHashStart(file);


### PR DESCRIPTION
Fixes #10104.

In `FIRCLSContextInitialize()`,

1.  A instance of the `FIRCLSContextInitData` struct is assigned to `initDataObj`.
2.  The pointer of it is assigned to `initData`.
3.  The `initData` is passed to asynchronous functions and captured by blocks.
4.  Wait the asynchornous processes for 5 seconds.
5.  The `initDataObj` and the properties of it is released as soon as the `FIRCLSContextInitialize` is exited.

`FIRCLSContextRecordMetadata` is called in the asynchronous function, and in the function,

1.  `FIRCLSUnlinkIfExists` and `FIRCLSFileInitWithPath` access the file system.
2.  `FIRCLSContextRecordIdentity` use `initData`.

If either `FIRCLSUnlinkIfExists` or `FIRCLSFileInitWithPath` takes longer than 5 seconds to process, `FIRCLSContextRecordIdentity` access `initData` that was already released and `EXC_BAD_ACCESS` will occur.

In my environment, adding `sleep(120)` before `FIRCLSContextRecordIdentity` reproduce the crash.

```objc
 if (!FIRCLSFileInitWithPath(&file, path, false)) {
   FIRCLSSDKLog("Unable to open metadata file %s\n", strerror(errno));
   return false;
 }

+sleep(120);
 if (!FIRCLSContextRecordIdentity(&file, sessionId, betaToken)) {
   FIRCLSSDKLog("Unable to write out identity metadata\n");
 }
```

This problem should be solved by keeping a reference to the properties of `initData` inside the asynchronous function.