### PR TITLE
Compare p13n metadata values as dictionaries.

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -428,7 +428,8 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
 
   // add params with new/updated p13n metadata
   for (NSString *key in [fetchedP13n allKeys]) {
-    if (activeP13n[key] == nil || ![activeP13n[key] isEqualToString:fetchedP13n[key]]) {
+      NSLog(@"key: %@", activeP13n[key]);
+    if (activeP13n[key] == nil || ![activeP13n[key] isEqualToDictionary:fetchedP13n[key]]) {
       [updatedKeys addObject:key];
     }
   }

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -428,7 +428,6 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
 
   // add params with new/updated p13n metadata
   for (NSString *key in [fetchedP13n allKeys]) {
-      NSLog(@"key: %@", activeP13n[key]);
     if (activeP13n[key] == nil || ![activeP13n[key] isEqualToDictionary:fetchedP13n[key]]) {
       [updatedKeys addObject:key];
     }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -431,8 +431,8 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
   NSString *namespace = @"test_namespace";
   NSString *existingParam = @"key1";
   NSString *value1 = @"value1";
-  NSString *oldMetadata = @"metadata1";
-  NSString *updatedMetadata = @"metadata2";
+  NSDictionary *oldMetadata = @{@"arm_index" : @"1"};
+  NSDictionary *updatedMetadata = @{@"arm_index" : @"2"};
 
   // popuate fetched config
   NSMutableDictionary *fetchResponse =


### PR DESCRIPTION
Compare keyed P13n metadata using `isEqualToDictionary:`. P13n metadata are [stored in dictionaries](https://github.com/firebase/firebase-ios-sdk/blob/48b529dd1598242004948919273486f7416b4b98/FirebaseRemoteConfig/Sources/RCNConfigContent.m#L35-L39), ex. `{"param_key": NSDictionary, "param_key_2": NSDictionary}`.

Comparing as strings raises an exception: `'NSInvalidArgumentException', reason: '-[__NSDictionaryI isEqualToString:]: unrecognized selector sent to instance 0x600003f63f80'
terminating with uncaught exception of type NSException`

#no-changelog