### PR TITLE
[Auth] Add 'kSecUseDataProtectionKeychain' flag to keychain access

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -98,6 +98,13 @@ supports email and password accounts, as well as several 3rd party authenticatio
       unit_tests.requires_app_host = true
       unit_tests.dependency 'OCMock'
       unit_tests.dependency 'HeartbeatLoggingTestUtils'
+
+      # This pre-processor directive is used to selectively disable keychain
+      # related code that blocks unit testing on macOS.
+      s.osx.pod_target_xcconfig = {
+        'GCC_PREPROCESSOR_DEFINITIONS' => 'FIREBASE_AUTH_MACOS_TESTING=1'
+      }
+
     end
   end
 end

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.5.0
+- [fixed] Prevent keychain pop-up when accessing Auth keychain. (#10582)
+
 # 10.4.0
 - [fixed] Fix secure coding bugs in MFA. (#10632)
 - [fixed] Added handling of error returned from a blocking cloud function. (#10628)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 10.5.0
 - [fixed] Prevent keychain pop-up when accessing Auth keychain in a Mac
-   app. Note that using Firebase Auth in Mac apps requires that the app
+   app. Note that using Firebase Auth in a Mac app requires that the app
    is signed with a provisioning profile that has the Keychain Sharing
-   capability enabled (see Firebase 9.6.0 relase notes). (#10582)
+   capability enabled (see Firebase 9.6.0 release notes). (#10582)
 
 # 10.4.0
 - [fixed] Fix secure coding bugs in MFA. (#10632)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 10.5.0
-- [fixed] Prevent keychain pop-up when accessing Auth keychain. (#10582)
+- [fixed] Prevent keychain pop-up when accessing Auth keychain in a Mac
+   app. Note that using Firebase Auth in Mac apps requires that the app
+   is signed with a provisioning profile that has the Keychain Sharing
+   capability enabled (see Firebase 9.6.0 relase notes). (#10582)
 
 # 10.4.0
 - [fixed] Fix secure coding bugs in MFA. (#10632)


### PR DESCRIPTION
### Context
- This keychain interface was missed when auditing Firebase's keychain access leading up to Firebase 9.6.0.
- Related to go/firebase-macos-keychain-popups
- I could not find a better way to do this and resorted to this approach when I started to spin my wheels. I'm open to any better ideas...

Fixes #10582