### PR TITLE
Realtime RC QA Bug Fix: Checks for type of P13N keys

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -428,7 +428,8 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
 
   // add params with new/updated p13n metadata
   for (NSString *key in [fetchedP13n allKeys]) {
-    if (activeP13n[key] == nil || ![activeP13n[key] isEqualToString:fetchedP13n[key]]) {
+    if (activeP13n[key] == nil || ([fetchedP13n[key] isKindOfClass:[NSString class]] &&
+                                   ![activeP13n[key] isEqualToString:fetchedP13n[key]])) {
       [updatedKeys addObject:key];
     }
   }


### PR DESCRIPTION
Fixes bug uncovered by manual QA: https://buganizer.corp.google.com/issues/267284784
TLDR: App crashes when P13N param is deleted.