### PR TITLE
Fix tester sign in URL

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -148,7 +148,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
     }
 
     NSString *requestURL = [NSString
-        stringWithFormat:@"https://appdistribution.firebase.dev/pub/testerapps/%@/"
+        stringWithFormat:@"https://appdistribution.firebase.google.com/pub/testerapps/%@/"
                          @"installations/%@/buildalerts?appName=%@",
                          [[FIRApp defaultApp] options].googleAppID, identifier, [self getAppName]];
 


### PR DESCRIPTION
This was errantly updated to the correct new path without updating the host from `appdistribution.firebase.dev`  to `appdistribution.firebase.google.com`.

See [10772](https://github.com/firebase/firebase-ios-sdk/issues/10772)
