### PR TITLE
[auth-swift] Remove commented-out imports

### DIFF
--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -31,12 +31,6 @@
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebUtils.h"
 
-// #if TARGET_OS_IOS
-// #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRPhoneAuthProvider.h"
-//
-// #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
-// #endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 /** @var kUserIDCodingKey


### PR DESCRIPTION
### Context
Remove unused imports (the imported types have been since re-defined in Swift)

#no-changelog