### PR TITLE
[auth-swift] Remove `module.modulemap` as it is unneeded

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -45,7 +45,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'FirebaseCore/Extension/*.h',
     'FirebaseAuth/Interop/*.h',
   ]
-  s.module_map = source + 'Public/FirebaseAuth/FirebaseAuth.modulemap'
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
 
   # All headers except the ones in the `Public` should be private.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FirebaseAuth.modulemap
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FirebaseAuth.modulemap
@@ -1,5 +1,0 @@
-// TODO(ncooke3): Investigate if this file is necessary for the private
-// module map to work.
-framework module FirebaseAuth {
-    umbrella header "FirebaseAuth.h"
-}

--- a/scripts/build_private_module_map.rb
+++ b/scripts/build_private_module_map.rb
@@ -75,7 +75,6 @@ def main(args)
     else
         # Overwrite the private module map with the generated contents.
         File.write(
-            # TODO(ncooke3): See if you can throw it in the public headers directory?
             "#{spec.module_name}/Sources/#{spec.module_name}.private.modulemap",
             private_module_map_contents
         )


### PR DESCRIPTION
### Context
- A manual module map is unneeded. CocoaPods will generate one. It seems to work fine with the recently added private module map.
- This is nice because achieving interoperability that's on par with SwiftPM does not require any new build files–– just the build script.

#no-changelog