### PR TITLE
Fix unit test failure

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -54,30 +54,8 @@ private let kIdentityPlatformStagingAPIHost =
 
   let _useStaging: Bool
 
-  /** @fn initWithEndpoint:APIKey:
-   @brief Designated initializer.
-   @param endpoint The endpoint name.
-   @param requestConfiguration An object containing configurations to be added to the request.
-   */
-  @objc public init(endpoint: String, requestConfiguration: AuthRequestConfiguration) {
-    self.endpoint = endpoint
-    APIKey = requestConfiguration.APIKey
-    _requestConfiguration = requestConfiguration
-    _useIdentityPlatform = false
-    _useStaging = false
-
-    // Automatically set the tenant ID. If the request is initialized before FIRAuth is configured,
-    // set tenant ID to nil.
-    if FirebaseApp.app() == nil {
-      tenantID = nil
-    } else {
-      tenantID = Auth.auth().tenantID
-    }
-  }
-
-  // TODO: Is there a way to share code between two designated intializers?
   @objc public init(endpoint: String, requestConfiguration: AuthRequestConfiguration,
-                    useIdentityPlatform: Bool, useStaging: Bool) {
+                    useIdentityPlatform: Bool = false, useStaging: Bool = false) {
     self.endpoint = endpoint
     APIKey = requestConfiguration.APIKey
     _requestConfiguration = requestConfiguration

--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+@_implementationOnly import FirebaseCore
 
 private let kHttpsProtocol = "https:"
 private let kHttpProtocol = "http:"
@@ -67,9 +68,14 @@ private let kIdentityPlatformStagingAPIHost =
 
     // Automatically set the tenant ID. If the request is initialized before FIRAuth is configured,
     // set tenant ID to nil.
-    tenantID = Auth.auth().tenantID
+    if FirebaseApp.app() == nil {
+      tenantID = nil
+    } else {
+      tenantID = Auth.auth().tenantID
+    }
   }
 
+  // TODO: Is there a way to share code between two designated intializers?
   @objc public init(endpoint: String, requestConfiguration: AuthRequestConfiguration,
                     useIdentityPlatform: Bool, useStaging: Bool) {
     self.endpoint = endpoint
@@ -80,7 +86,11 @@ private let kIdentityPlatformStagingAPIHost =
 
     // Automatically set the tenant ID. If the request is initialized before FIRAuth is configured,
     // set tenant ID to nil.
-    tenantID = Auth.auth().tenantID
+    if FirebaseApp.app() == nil {
+      tenantID = nil
+    } else {
+      tenantID = Auth.auth().tenantID
+    }
   }
 
   @objc public func containsPostBody() -> Bool {

--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -62,6 +62,8 @@ private let kIdentityPlatformStagingAPIHost =
     _useIdentityPlatform = useIdentityPlatform
     _useStaging = useStaging
 
+    // TODO: tenantID should be set via a parameter, since it might not be the default app (#10748)
+    // TODO: remove FirebaseCore import when #10748 is fixed.
     // Automatically set the tenant ID. If the request is initialized before FIRAuth is configured,
     // set tenant ID to nil.
     if FirebaseApp.app() == nil {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
@@ -39,7 +39,7 @@ private let kIDTokenKey = "idToken"
   /** @fn initWithEndpoint:requestConfiguration:requestConfiguration
       @brief Please use initWithAccessToken:requestConfiguration: instead.
    */
-  override init(endpoint: String, requestConfiguration: AuthRequestConfiguration) {
+  init(endpoint: String, requestConfiguration: AuthRequestConfiguration) {
     fatalError("-")
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
@@ -36,13 +36,6 @@ private let kIDTokenKey = "idToken"
    */
   @objc public let accessToken: String
 
-  /** @fn initWithEndpoint:requestConfiguration:requestConfiguration
-      @brief Please use initWithAccessToken:requestConfiguration: instead.
-   */
-  init(endpoint: String, requestConfiguration: AuthRequestConfiguration) {
-    fatalError("-")
-  }
-
   /** @fn initWithAccessToken:requestConfiguration
       @brief Designated initializer.
       @param accessToken The Access Token of the authenticated user.

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
@@ -40,12 +40,6 @@ public class VerifyClientRequest: IdentityToolkitRequest, AuthRPCRequest {
   /// The flag that denotes if the appToken  pertains to Sandbox or Production.
   @objc public private(set) var isSandbox: Bool
 
-  // TODO(ncooke3): This API should be unneccessary...
-  @objc public init(endpoint: String,
-                    requestConfiguration: AuthRequestConfiguration) {
-    fatalError("-")
-  }
-
   @objc public init(withAppToken: String?,
                     isSandbox: Bool,
                     requestConfiguration: AuthRequestConfiguration) {

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
@@ -41,8 +41,8 @@ public class VerifyClientRequest: IdentityToolkitRequest, AuthRPCRequest {
   @objc public private(set) var isSandbox: Bool
 
   // TODO(ncooke3): This API should be unneccessary...
-  @objc override public init(endpoint: String,
-                             requestConfiguration: AuthRequestConfiguration) {
+  @objc public init(endpoint: String,
+                    requestConfiguration: AuthRequestConfiguration) {
     fatalError("-")
   }
 

--- a/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
@@ -55,7 +55,9 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey appID:kFirebaseAppID];
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration];
+                                     requestConfiguration:requestConfiguration
+                                      useIdentityPlatform:NO
+                                               useStaging:NO];
   NSString *expectedURL = [NSString
       stringWithFormat:@"https://www.googleapis.com/identitytoolkit/v3/relyingparty/%@?key=%@",
                        kEndpoint, kAPIKey];
@@ -130,7 +132,9 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
   requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
   FIRIdentityToolkitRequest *request =
       [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
-                                     requestConfiguration:requestConfiguration];
+                                     requestConfiguration:requestConfiguration
+                                      useIdentityPlatform:NO
+                                               useStaging:NO];
   NSString *expectedURL = [NSString
       stringWithFormat:@"http://%@/www.googleapis.com/identitytoolkit/v3/relyingparty/%@?key=%@",
                        kEmulatorHostAndPort, kEndpoint, kAPIKey];


### PR DESCRIPTION
This fixes the one test failure we've had for awhile.

It seems that running the unit tests from Swift will fail with NSInternalInconsistencyException from https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseAuth/Sources/Auth/FIRAuth.m#L443 but not when run from Objective C.

This change fixes that problem by not calling `Auth.auth()` too early.