### PR TITLE
[Messaging] - Validate APNS token in the configure flow

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.6.0
+- [fixed] Configure flow validates existence of an APNS token before fetching an FCM token (#10742). This also addresses the scenario 1 mentioned in the comment - https://github.com/firebase/firebase-ios-sdk/issues/10679#issuecomment-1402776795
+
 # 10.5.0
 - [fixed] Fixed a crash for strongSelf dereference (#10707).
 


### PR DESCRIPTION
### Discussion

The FirebaseApp.configure() flow triggers a FCM token fetch, which can be racy and occur before we have received and set an APNS token.  The change in this PR validates that we have an APNS token in the configure flow before fetching the FCM token. 

This PR addresses the scenario 1 identified in this comment - https://github.com/firebase/firebase-ios-sdk/issues/10679#issuecomment-1402776795

Should fix https://github.com/firebase/firebase-ios-sdk/issues/10742