### PR TITLE
Fix Session Event printout for sampling, log_environment

### DIFF
--- a/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
+++ b/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
@@ -86,6 +86,23 @@ extension firebase_appquality_sessions_OsName: CustomStringConvertible {
   }
 }
 
+extension firebase_appquality_sessions_LogEnvironment: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_PROD:
+      return "PROD"
+    case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_STAGING:
+      return "STAGING"
+    case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_AUTOPUSH:
+      return "Autopush"
+    case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_UNKNOWN:
+      return "Unknown"
+    default:
+      return "Unrecognized LogEnvironment. Please update the firebase_appquality_sessions_LogEnvironment CustomStringConvertible extension"
+    }
+  }
+}
+
 extension UnsafeMutablePointer<pb_bytes_array_t>: CustomStringConvertible {
   public var description: String {
     let decoded = FIRSESDecodeString(self)

--- a/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
+++ b/FirebaseSessions/Sources/Development/NanoPB+CustomStringConvertible.swift
@@ -94,9 +94,9 @@ extension firebase_appquality_sessions_LogEnvironment: CustomStringConvertible {
     case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_STAGING:
       return "STAGING"
     case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_AUTOPUSH:
-      return "Autopush"
+      return "AUTOPUSH"
     case firebase_appquality_sessions_LogEnvironment_LOG_ENVIRONMENT_UNKNOWN:
-      return "Unknown"
+      return "UNKNOWN"
     default:
       return "Unrecognized LogEnvironment. Please update the firebase_appquality_sessions_LogEnvironment CustomStringConvertible extension"
     }

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -181,6 +181,7 @@ private enum GoogleDataTransportConfig {
         self.settings.updateSettings()
 
         self.addSubscriberFields(event: event)
+        event.setSamplingRate(samplingRate: self.settings.samplingRate)
 
         guard sessionInfo.shouldDispatchEvents else {
           loggedEventCallback(.failure(.SessionSamplingError))

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+DataCollection.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+DataCollection.swift
@@ -158,4 +158,26 @@ final class FirebaseSessionsTestsBase_DataCollection: FirebaseSessionsTestsBase 
       }
     )
   }
+
+  func test_defaultSamplingRate_isSetInProto() {
+    runSessionsSDK(
+      subscriberSDKs: [
+        mockCrashlyticsSubscriber,
+
+      ], preSessionsInit: { _ in
+        // Nothing
+      }, postSessionsInit: {
+        sessions.register(subscriber: self.mockCrashlyticsSubscriber)
+        // Nothing
+
+      }, postLogEvent: { result, subscriberSDKs in
+        // Make sure we set the sampling rate in the proto
+        XCTAssertEqual(
+          self.mockCoordinator.loggedEvent?.proto.session_data.data_collection_status
+            .session_sampling_rate,
+          1.0
+        )
+      }
+    )
+  }
 }


### PR DESCRIPTION
Before:

```
Session Event:
...
      session_sampling_rate: 0.0
...
      log_environment: _firebase_appquality_sessions_LogEnvironment(rawValue: 3)
```

After:

```
Session Event:
...
      session_sampling_rate: 1.0
...
      log_environment: PROD
```

#no-changelog 