### PR TITLE
Add Sessions to release manifest

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -31,6 +31,7 @@ public let shared = Manifest(
     Pod("FirebaseAuthInterop"),
     Pod("FirebaseMessagingInterop"),
     Pod("FirebaseInstallations"),
+    Pod("FirebaseSessions"),
     Pod("GoogleAppMeasurement", isClosedSource: true),
     Pod("GoogleAppMeasurementOnDeviceConversion", isClosedSource: true, platforms: ["ios"]),
     Pod("FirebaseAnalytics", isClosedSource: true),


### PR DESCRIPTION
Stage and release Sessions for 10.6.0 and beyond

Note, the zip release build will fail until Sessions is actually staged.