### PR TITLE
[SPI] Add SPIManifest for external docs link

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://firebase.google.com/docs/ios/setup"


### PR DESCRIPTION
Added a Swift Package Index [manifest file](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation) that specifies an [external documentation link](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.15.0/documentation/spimanifest/commonusecases#Configure-a-documentation-URL-for-existing-documentation) to the "Add Firebase to your Apple project" [guide](https://firebase.google.com/docs/ios/setup). This will result in the guide being linked from https://swiftpackageindex.com/firebase/firebase-ios-sdk.

Testing: Validated the manifest file using the [validate-spi-manifest](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.15.0/documentation/spimanifest/validation) tool.

#no-changelog