### PR TITLE
Multi-app fix

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -81,6 +81,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
         'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
         'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
         'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
+        'FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m',
       ]
       unit_tests.tvos.exclude_files = [
         'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',
@@ -93,6 +94,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
         'FirebaseAuth/Tests/Unit/FIRVerifyClient*',
         'FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumber*',
         'FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m',
+        'FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m',
       ]
       # app_host is needed for tests with keychain
       unit_tests.requires_app_host = true

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.6.0
+- [fixed] Fixed a bug where user is created in a specific tenant although tenantID was not specified. (#10748)
+- [fixed] Fixed a bug where the resolver exposed in MFA is not associated to the correct app. (#10690)
+
 # 10.5.0
 - [fixed] Use team player ID, game player ID and fetchItems for signature verification. (#10441)
 - [fixed] Prevent keychain pop-up when accessing Auth keychain in a Mac

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -487,6 +487,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     _listenerHandles = [NSMutableArray array];
     _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
                                                                           appID:appID
+                                                                           auth:self
                                                                 heartbeatLogger:heartbeatLogger];
     _firebaseAppName = [appName copy];
 #if TARGET_OS_IOS

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -776,7 +776,9 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                    }
                    NSError *multiFactorRequiredError = [FIRAuthErrorUtils
                        secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
-                                                                hints:multiFactorInfo];
+                                                                hints:multiFactorInfo
+                                                                 auth:request.requestConfiguration
+                                                                          .auth];
                    callback(nil, multiFactorRequiredError);
 #endif
                  } else {
@@ -820,7 +822,9 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                    }
                    NSError *multiFactorRequiredError = [FIRAuthErrorUtils
                        secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
-                                                                hints:multiFactorInfo];
+                                                                hints:multiFactorInfo
+                                                                 auth:request.requestConfiguration
+                                                                          .auth];
                    callback(nil, multiFactorRequiredError);
 #endif
                  } else {
@@ -850,7 +854,9 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                    }
                    NSError *multiFactorRequiredError = [FIRAuthErrorUtils
                        secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential
-                                                                hints:multiFactorInfo];
+                                                                hints:multiFactorInfo
+                                                                 auth:request.requestConfiguration
+                                                                          .auth];
                    callback(nil, multiFactorRequiredError);
 #endif
                  } else {

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, readonly) NSString *appID;
 
-@property(nonatomic, strong, readonly) FIRAuth *auth;
+@property(nonatomic, readonly, nullable) FIRAuth *auth;
 
 /** @property heartbeatLogger
     @brief The heartbeat logger used to add heartbeats to the corresponding request's header.

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -38,6 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, readonly) NSString *appID;
 
+/** @property auth
+    @brief The FIRAuth instance used in the request.
+ */
 @property(nonatomic, weak, readonly, nullable) FIRAuth *auth;
 
 /** @property heartbeatLogger
@@ -69,6 +72,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID;
 
+/** @fn initWithAPIKey:appID:
+    @brief Convenience initializer.
+    @param APIKey The API key to be used in the request.
+ @param appID The Firebase app ID to be passed in the request header.
+ @param auth The FIRAuth instance used in the request.
+ */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
                                    auth:(nullable FIRAuth *)auth;
@@ -76,13 +85,20 @@ NS_ASSUME_NONNULL_BEGIN
 /** @fn initWithAPIKey:appID:heartbeatLogger:
     @brief Designated initializer.
     @param APIKey The API key to be used in the request.
-    @param appID The Firebase app ID to be passed in the request header.
+ @param appID The Firebase app ID to be passed in the request header.
     @param heartbeatLogger The heartbeat logger used to add heartbeats to the request header.
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
                         heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger;
 
+/** @fn initWithAPIKey:appID:heartbeatLogger:
+    @brief Designated initializer.
+    @param APIKey The API key to be used in the request.
+ @param appID The Firebase app ID to be passed in the request header.
+ @param auth The FIRAuth instance used in the request.
+    @param heartbeatLogger The heartbeat logger used to add heartbeats to the request header.
+ */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
                                    auth:(nullable FIRAuth *)auth

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -67,9 +67,11 @@ NS_ASSUME_NONNULL_BEGIN
     @param APIKey The API key to be used in the request.
     @param appID The Firebase app ID to be passed in the request header.
  */
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID;
+
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                                   auth:(FIRAuth *)auth;
+                                   auth:(nullable FIRAuth *)auth;
 
 /** @fn initWithAPIKey:appID:heartbeatLogger:
     @brief Designated initializer.
@@ -79,7 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                                   auth:(FIRAuth *)auth
+                        heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger;
+
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID
+                                   auth:(nullable FIRAuth *)auth
                         heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h"
 
 @protocol FIRHeartbeatLoggerProtocol;
 
@@ -36,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
     @brief The Firebase appID used in the request.
  */
 @property(nonatomic, copy, readonly) NSString *appID;
+
+@property(nonatomic, strong, readonly) FIRAuth *auth;
 
 /** @property heartbeatLogger
     @brief The heartbeat logger used to add heartbeats to the corresponding request's header.
@@ -64,7 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
     @param APIKey The API key to be used in the request.
     @param appID The Firebase app ID to be passed in the request header.
  */
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID;
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID
+                                   auth:(FIRAuth *)auth;
 
 /** @fn initWithAPIKey:appID:heartbeatLogger:
     @brief Designated initializer.
@@ -74,6 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
+                                   auth:(FIRAuth *)auth
                         heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger
     NS_DESIGNATED_INITIALIZER;
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, readonly) NSString *appID;
 
-@property(nonatomic, readonly, nullable) FIRAuth *auth;
+@property(nonatomic, weak, readonly, nullable) FIRAuth *auth;
 
 /** @property heartbeatLogger
     @brief The heartbeat logger used to add heartbeats to the corresponding request's header.

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -22,17 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAuthRequestConfiguration
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID {
-  return [self initWithAPIKey:APIKey appID:appID heartbeatLogger:nil];
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID
+                                   auth:(FIRAuth *)auth {
+  return [self initWithAPIKey:APIKey appID:appID auth:auth heartbeatLogger:nil];
 }
 
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
+                                   auth:(FIRAuth *)auth
                         heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger {
   self = [super init];
   if (self) {
     _APIKey = [APIKey copy];
     _appID = [appID copy];
+    _auth = auth;
     _heartbeatLogger = heartbeatLogger;
   }
   return self;

--- a/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthRequestConfiguration.m
@@ -22,15 +22,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAuthRequestConfiguration
 
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey appID:(NSString *)appID {
+  return [self initWithAPIKey:APIKey appID:appID auth:nil heartbeatLogger:nil];
+}
+
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                                   auth:(FIRAuth *)auth {
+                                   auth:(nullable FIRAuth *)auth {
   return [self initWithAPIKey:APIKey appID:appID auth:auth heartbeatLogger:nil];
 }
 
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey
                                   appID:(NSString *)appID
-                                   auth:(FIRAuth *)auth
+                        heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger {
+  return [self initWithAPIKey:APIKey appID:appID auth:nil heartbeatLogger:heartbeatLogger];
+}
+
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+                                  appID:(NSString *)appID
+                                   auth:(nullable FIRAuth *)auth
                         heartbeatLogger:(nullable id<FIRHeartbeatLoggerProtocol>)heartbeatLogger {
   self = [super init];
   if (self) {

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
@@ -58,7 +58,7 @@ static NSString *kIdentityPlatformStagingAPIHost =
     // Automatically set the tenant ID. If the request is initialized before FIRAuth is configured,
     // set tenant ID to nil.
     @try {
-      _tenantID = [FIRAuth auth].tenantID;
+      _tenantID = [self requestConfiguration].auth.tenantID;
     } @catch (NSException *e) {
       _tenantID = nil;
     }

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h
@@ -25,7 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSString *MFAPendingCredential;
 
 - (instancetype)initWithMFAPendingCredential:(NSString *_Nullable)MFAPendingCredential
-                                       hints:(NSArray<FIRMultiFactorInfo *> *)hints;
+                                       hints:(NSArray<FIRMultiFactorInfo *> *)hints
+                                        auth:(FIRAuth *)auth;
 
 @end
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
@@ -39,12 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRMultiFactorResolver
 
 - (instancetype)initWithMFAPendingCredential:(NSString *_Nullable)MFAPendingCredential
-                                       hints:(NSArray<FIRMultiFactorInfo *> *)hints {
+                                       hints:(NSArray<FIRMultiFactorInfo *> *)hints
+                                        auth:(FIRAuth *)auth {
   self = [super init];
   if (self) {
     _MFAPendingCredential = MFAPendingCredential;
     _hints = hints;
-    _auth = [FIRAuth auth];
+    _auth = auth;
     _session = [[FIRMultiFactorSession alloc] init];
     _session.MFAPendingCredential = MFAPendingCredential;
   }

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -377,6 +377,7 @@ static void callInMainThreadWithAuthDataResultAndError(
     // The `heartbeatLogger` will be set later via a property update.
     _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey
                                                                           appID:appID
+                                                                           auth:_auth
                                                                 heartbeatLogger:nil];
 #if TARGET_OS_IOS
     _multiFactor = multiFactor ?: [[FIRMultiFactor alloc] init];

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
@@ -15,8 +15,8 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorInfo.h"
-
 #import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
 
 @class FIRAuthCredential;
@@ -489,9 +489,10 @@ NS_ASSUME_NONNULL_BEGIN
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeSecondFactorRequired code.
     @return The NSError instance associated with the given FIRAuthError.
  */
-+ (NSError *)secondFactorRequiredErrorWithPendingCredential:(NSString *)MFAPendingCredential
-                                                      hints:(NSArray<FIRMultiFactorInfo *> *)
-                                                                multiFactorInfo;
++ (NSError *)
+    secondFactorRequiredErrorWithPendingCredential:(NSString *)MFAPendingCredential
+                                             hints:(NSArray<FIRMultiFactorInfo *> *)multiFactorInfo
+                                              auth:(FIRAuth *)auth;
 #endif
 
 /** @fn appNotVerifiedErrorWithMessage:

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -1311,12 +1311,14 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
 
 #if TARGET_OS_IOS
 + (NSError *)secondFactorRequiredErrorWithPendingCredential:(NSString *)MFAPendingCredential
-                                                      hints:(NSArray<FIRMultiFactorInfo *> *)hints {
+                                                      hints:(NSArray<FIRMultiFactorInfo *> *)hints
+                                                       auth:(FIRAuth *)auth {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   if (MFAPendingCredential && hints) {
     FIRMultiFactorResolver *resolver =
         [[FIRMultiFactorResolver alloc] initWithMFAPendingCredential:MFAPendingCredential
-                                                               hints:hints];
+                                                               hints:hints
+                                                                auth:auth];
     userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey] = resolver;
   }
   return [self errorWithCode:FIRAuthInternalErrorCodeSecondFactorRequired userInfo:userInfo];

--- a/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h"
+#import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"
 
 /** @var kEndpoint
     @brief The endpoint for the requests.
@@ -156,6 +157,27 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
                                  kEmulatorHostAndPort, kEndpoint, kAPIKey];
 
   XCTAssertEqualObjects(expectedURL, request.requestURL.absoluteString);
+}
+
+/** @fn testExpectedTenantIDWithNonDefaultFIRApp
+    @brief Tests the request correctly populated the tenant ID from a non default app.
+ */
+- (void)testExpectedTenantIDWithNonDefaultFIRApp {
+  FIRApp *nonDefautlApp = [FIRApp appForAuthUnitTestsWithName:@"nonDefautlApp"];
+  FIRAuth *nonDefaultAuth = [FIRAuth authWithApp:nonDefautlApp];
+  nonDefaultAuth.tenantID = @"tenant-id";
+  FIRAuthRequestConfiguration *requestConfiguration =
+      [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey
+                                                    appID:kFirebaseAppID
+                                                     auth:nonDefaultAuth];
+  requestConfiguration.emulatorHostAndPort = kEmulatorHostAndPort;
+  FIRIdentityToolkitRequest *request =
+      [[FIRIdentityToolkitRequest alloc] initWithEndpoint:kEndpoint
+                                     requestConfiguration:requestConfiguration
+                                      useIdentityPlatform:YES
+                                               useStaging:NO];
+
+  XCTAssertEqualObjects(@"tenant-id", request.tenantID);
 }
 
 @end

--- a/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRIdentityToolkitRequestTests.m
@@ -163,8 +163,8 @@ static NSString *const kEmulatorHostAndPort = @"emulatorhost:12345";
     @brief Tests the request correctly populated the tenant ID from a non default app.
  */
 - (void)testExpectedTenantIDWithNonDefaultFIRApp {
-  FIRApp *nonDefautlApp = [FIRApp appForAuthUnitTestsWithName:@"nonDefautlApp"];
-  FIRAuth *nonDefaultAuth = [FIRAuth authWithApp:nonDefautlApp];
+  FIRApp *nonDefaultApp = [FIRApp appForAuthUnitTestsWithName:@"nonDefaultApp"];
+  FIRAuth *nonDefaultAuth = [FIRAuth authWithApp:nonDefaultApp];
   nonDefaultAuth.tenantID = @"tenant-id";
   FIRAuthRequestConfiguration *requestConfiguration =
       [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kAPIKey

--- a/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
@@ -17,6 +17,9 @@
 #import <XCTest/XCTest.h>
 
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorInfo.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorResolver.h"
 #import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"
 
 /** @class FIRMultiFactorResolverTests

--- a/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+#if TARGET_OS_IOS
+
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorInfo.h"
@@ -52,3 +54,5 @@
 }
 
 @end
+
+#endif

--- a/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
@@ -37,7 +37,7 @@
 
   FIRApp *app = [FIRApp appForAuthUnitTestsWithName:@"app"];
   FIRAuth *auth = [FIRAuth authWithApp:app];
-    auth.tenantID = @"tenant-id";
+  auth.tenantID = @"tenant-id";
 
   FIRMultiFactorResolver *resolver =
       [[FIRMultiFactorResolver alloc] initWithMFAPendingCredential:fakeMFAPendingCredential

--- a/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRMultiFactorResolverTests.m
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
+#import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"
+
+/** @class FIRMultiFactorResolverTests
+    @brief Tests for @c FIRMultiFactorResolver.
+ */
+@interface FIRMultiFactorResolverTests : XCTestCase
+
+@end
+
+@implementation FIRMultiFactorResolverTests
+
+/** @fn testMultifactorResolverCreation
+    @brief Tests succuessful creation of a @c FIRMultiFactorResolver object.
+ */
+- (void)testMultifactorResolverCreation {
+  NSString *fakeMFAPendingCredential = @"fakeMFAPendingCredential";
+  NSArray<FIRMultiFactorInfo *> *fakeHints = @[];
+
+  FIRApp *app = [FIRApp appForAuthUnitTestsWithName:@"app"];
+  FIRAuth *auth = [FIRAuth authWithApp:app];
+    auth.tenantID = @"tenant-id";
+
+  FIRMultiFactorResolver *resolver =
+      [[FIRMultiFactorResolver alloc] initWithMFAPendingCredential:fakeMFAPendingCredential
+                                                             hints:fakeHints
+                                                              auth:auth];
+
+  XCTAssertEqualObjects(resolver.auth, auth);
+  XCTAssertEqualObjects(resolver.hints, fakeHints);
+}
+
+@end


### PR DESCRIPTION
Pass auth instance in request configure and use it to:
1. retrieve the associated tenant ID for requests https://github.com/firebase/firebase-ios-sdk/issues/10748
2. store the associated auth instance in MFA resolver https://github.com/firebase/firebase-ios-sdk/issues/10690

Fix #10748 
Fix #10690