### PR TITLE
[SPI] Set "Google" as the author on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 external_links:
   documentation: "https://firebase.google.com/docs/ios/setup"
 metadata:
-  authors: "Google, Inc."
+  authors: "Google"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,5 @@
 version: 1
 external_links:
   documentation: "https://firebase.google.com/docs/ios/setup"
+metadata:
+  authors: "Google, Inc."


### PR DESCRIPTION
Updated the [Swift Package Index](https://swiftpackageindex.com) manifest file (.spi.yml) to specify "Google, Inc." as the [authors](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.15.0/documentation/spimanifest/manifest/metadata-swift.struct/authors) of the [package](https://swiftpackageindex.com/firebase/firebase-ios-sdk). This matches the authors specified in our [podspecs](https://github.com/firebase/firebase-ios-sdk/blob/6d1e7f5fae50b8a0f2bfc753cf59c835faa0a987/FirebaseCore.podspec#L12).

Testing: Validated the manifest file using the [validate-spi-manifest](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.15.0/documentation/spimanifest/validation) tool.

#no-changelog
