### PR TITLE
Feature: Add animations to @FirestoreQuery

### DIFF
--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsAnimationView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsAnimationView.swift
@@ -1,0 +1,69 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import FirebaseFirestoreSwift
+
+/// This view demostrates how to use the ``FirestoreQuery`` property wrapper,
+/// using the `animation` parameter to make sure list items are animated when
+/// being added or removed.
+struct FavouriteFruitsAnimationView: View {
+  @FirestoreQuery(
+    collectionPath: "fruits",
+    predicates: [
+      .where("isFavourite", isEqualTo: true),
+    ],
+    animation: .default
+  ) fileprivate var fruitResults: Result<[Fruit], Error>
+
+  @State var showOnlyFavourites = true
+
+  var body: some View {
+    if case let .success(fruits) = fruitResults {
+      List(fruits) { fruit in
+        Text(fruit.name)
+      }
+      .navigationTitle("Fruits")
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Button(action: toggleFilter) {
+            Image(systemName: showOnlyFavourites
+              ? "line.3.horizontal.decrease.circle.fill"
+              : "line.3.horizontal.decrease.circle")
+          }
+        }
+      }
+    } else if case let .failure(error) = fruitResults {
+      // Handle error
+      Text("Couldn't map data: \(error.localizedDescription)")
+    }
+  }
+
+  func toggleFilter() {
+    showOnlyFavourites.toggle()
+    if showOnlyFavourites {
+      $fruitResults.predicates = [
+        .whereField("isFavourite", isEqualTo: true),
+      ]
+    } else {
+      $fruitResults.predicates = []
+    }
+  }
+}
+
+struct FavouriteFruitsView_Previews: PreviewProvider {
+  static var previews: some View {
+    FavouriteFruitsView()
+  }
+}

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
@@ -36,7 +36,6 @@ struct FavouriteFruitsMappingErrorView: View {
       List(fruits) { fruit in
         Text(fruit.name)
       }
-      .animation(.default, value: fruits)
       .navigationTitle("Mapping failure")
 
     case let .failure(error):

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
@@ -20,6 +20,9 @@ private struct Fruit: Codable, Identifiable, Equatable {
   var name: String
 }
 
+/// This view demonstrates how to use the ``FirestoreQuery`` property wrapper's
+/// error handling. When any of the documents can't be mapped, this view will
+/// just show an error message.
 struct FavouriteFruitsMappingErrorView: View {
   @FirestoreQuery(
     collectionPath: "mappingFailure",

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView.swift
@@ -23,7 +23,8 @@ private struct Fruit: Codable, Identifiable, Equatable {
 struct FavouriteFruitsMappingErrorView: View {
   @FirestoreQuery(
     collectionPath: "mappingFailure",
-    decodingFailureStrategy: .raise
+    decodingFailureStrategy: .raise,
+    animation: .default
   ) private var fruitResults: Result<[Fruit], Error>
 
   var body: some View {

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
@@ -20,6 +20,9 @@ private struct Fruit: Codable, Identifiable, Equatable {
   var name: String
 }
 
+/// This view demonstrates how to use the ``FirestoreQuery`` property wrapper's
+/// error handling. When any of the documents can't be mapped, this view will
+/// show all items that could be mapped, and a friendly error message.
 struct FavouriteFruitsMappingErrorView2: View {
   @FirestoreQuery(
     collectionPath: "mappingFailure",

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
@@ -45,7 +45,6 @@ struct FavouriteFruitsMappingErrorView2: View {
         .background(Color.red)
       }
     }
-    .animation(.default, value: fruits)
     .navigationTitle("Mapping failure")
     .ignoresSafeArea(edges: .bottom)
   }

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsMappingErrorView2.swift
@@ -23,7 +23,8 @@ private struct Fruit: Codable, Identifiable, Equatable {
 struct FavouriteFruitsMappingErrorView2: View {
   @FirestoreQuery(
     collectionPath: "mappingFailure",
-    decodingFailureStrategy: .ignore
+    decodingFailureStrategy: .ignore,
+    animation: .default
   ) private var fruits: [Fruit]
 
   var body: some View {

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
@@ -26,7 +26,8 @@ struct FavouriteFruitsView: View {
     collectionPath: "fruits",
     predicates: [
       .where("isFavourite", isEqualTo: true),
-    ]
+    ],
+    animation: .default
   ) fileprivate var fruitResults: Result<[Fruit], Error>
 
   @State var showOnlyFavourites = true

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
@@ -21,6 +21,7 @@ private struct Fruit: Codable, Identifiable, Equatable {
   var isFavourite: Bool
 }
 
+/// This view demonstrates how to use the `FirestoreQuery` property wrapper.
 struct FavouriteFruitsView: View {
   @FirestoreQuery(
     collectionPath: "fruits",

--- a/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/FavouriteFruitsView.swift
@@ -27,8 +27,7 @@ struct FavouriteFruitsView: View {
     collectionPath: "fruits",
     predicates: [
       .where("isFavourite", isEqualTo: true),
-    ],
-    animation: .default
+    ]
   ) fileprivate var fruitResults: Result<[Fruit], Error>
 
   @State var showOnlyFavourites = true

--- a/Example/FirestoreSample/FirestoreSample/Views/MenuView.swift
+++ b/Example/FirestoreSample/FirestoreSample/Views/MenuView.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
@@ -129,7 +129,7 @@ public struct FirestoreQuery<T>: DynamicProperty {
 
     /// If any errors occurred, they will be exposed here as well.
     public var error: Error?
-      
+
     /// The type of animation to apply when updating the view. If this is ommitted then no animations are fired.
     public var animation: Animation?
   }

--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
@@ -124,11 +124,14 @@ public struct FirestoreQuery<T>: DynamicProperty {
     /// The query's predicates.
     public var predicates: [QueryPredicate]
 
-    // The strategy to use in case there was a problem during the decoding phase.
+    /// The strategy to use in case there was a problem during the decoding phase.
     public var decodingFailureStrategy: DecodingFailureStrategy = .raise
 
     /// If any errors occurred, they will be exposed here as well.
     public var error: Error?
+      
+    /// The type of animation to apply when updating the view. If this is ommitted then no animations are fired.
+    public var animation: Animation?
   }
 
   /// The results of the query.
@@ -157,12 +160,14 @@ public struct FirestoreQuery<T>: DynamicProperty {
   ///   - decodingFailureStrategy: The strategy to use when there is a failure
   ///     during the decoding phase. Defaults to `DecodingFailureStrategy.raise`.
   public init<U: Decodable>(collectionPath: String, predicates: [QueryPredicate] = [],
-                            decodingFailureStrategy: DecodingFailureStrategy = .raise)
+                            decodingFailureStrategy: DecodingFailureStrategy = .raise,
+                            animation: Animation? = nil)
     where T == [U] {
     let configuration = Configuration(
       path: collectionPath,
       predicates: predicates,
-      decodingFailureStrategy: decodingFailureStrategy
+      decodingFailureStrategy: decodingFailureStrategy,
+      animation: animation
     )
 
     _firestoreQueryObservable =
@@ -177,12 +182,14 @@ public struct FirestoreQuery<T>: DynamicProperty {
   ///   - decodingFailureStrategy: The strategy to use when there is a failure
   ///     during the decoding phase. Defaults to `DecodingFailureStrategy.raise`.
   public init<U: Decodable>(collectionPath: String, predicates: [QueryPredicate] = [],
-                            decodingFailureStrategy: DecodingFailureStrategy = .raise)
+                            decodingFailureStrategy: DecodingFailureStrategy = .raise,
+                            animation: Animation? = nil)
     where T == Result<[U], Error> {
     let configuration = Configuration(
       path: collectionPath,
       predicates: predicates,
-      decodingFailureStrategy: decodingFailureStrategy
+      decodingFailureStrategy: decodingFailureStrategy,
+      animation: animation
     )
 
     _firestoreQueryObservable =

--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
@@ -159,6 +159,7 @@ public struct FirestoreQuery<T>: DynamicProperty {
   ///     filter for the fetched results.
   ///   - decodingFailureStrategy: The strategy to use when there is a failure
   ///     during the decoding phase. Defaults to `DecodingFailureStrategy.raise`.
+  ///   - animation: The optional animation to apply to the transaction.
   public init<U: Decodable>(collectionPath: String, predicates: [QueryPredicate] = [],
                             decodingFailureStrategy: DecodingFailureStrategy = .raise,
                             animation: Animation? = nil)
@@ -181,6 +182,7 @@ public struct FirestoreQuery<T>: DynamicProperty {
   ///     filter for the fetched results.
   ///   - decodingFailureStrategy: The strategy to use when there is a failure
   ///     during the decoding phase. Defaults to `DecodingFailureStrategy.raise`.
+  ///   - animation: The optional animation to apply to the transaction.
   public init<U: Decodable>(collectionPath: String, predicates: [QueryPredicate] = [],
                             decodingFailureStrategy: DecodingFailureStrategy = .raise,
                             animation: Animation? = nil)

--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQueryObservable.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQueryObservable.swift
@@ -36,7 +36,7 @@ internal class FirestoreQueryObservable<T>: ObservableObject {
       setupListener()
     }
   }
-    
+
   private func set(items: T) {
     guard let animation = configuration.animation else {
       self.items = items
@@ -172,7 +172,7 @@ internal class FirestoreQueryObservable<T>: ObservableObject {
       self.listener = query.addSnapshotListener(handler)
     }
   }
-    
+
   private func setProjectedError(_ error: Error?) {
     shouldUpdateListener = false
     configuration.error = error
@@ -182,11 +182,11 @@ internal class FirestoreQueryObservable<T>: ObservableObject {
   private func projectError(_ error: Error?) {
     guard let animation = configuration.animation else {
       setProjectedError(error)
-        return
-      }
-      withAnimation(animation) {
-        setProjectedError(error)
-      }
+      return
+    }
+    withAnimation(animation) {
+      setProjectedError(error)
+    }
   }
 
   private func removeListener() {


### PR DESCRIPTION
### Features

- Adds a SwiftUI `Animation` parameter to the FirebaseQuery initializer.
- If animation is not `nil` then setting the data to the published value will be executed inside of a `withAnimation` block (with the given `Animation`)

### Description

1. **Use case:** Animate the data updates provided by the `@FirestoreQuery` property wrapper.
2. **Current implementation:** Unless I'm missing something, `@FirebaseQuery` doesn't animate its published changes.
3. **Proposed solution:** Add an `Animation` parameter to the `FirestoreQueryObservable` initializer, store it in the `FirestoreQuery.Configuration`, and conditionally invoke a `withAnimation` block when setting the data.

### API Proposal

1. First, add an `Animation` object to the `FirestoreQuery.Configuration`
2. Add an optional `Animation` parameter to the `FirestoreQuery`'s initializer
3. Add a `private` method to update the `items` instance memory, with a conditional animation block (based on the configuration)
4. Update all of the setter expressions (setting the `items` value) with this new `set(items:)` func.
5. Also add conditional animation logic to the error setter to animate errors on screen.

### Firebase Product(s)

Firestore

### Related Feature Requests

This fixes #10810