### PR TITLE
Remove Fetch Duplicate error and fix API misuse error

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -67,9 +67,6 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeInternalError = 500;
 static NSInteger const kRCNFetchResponseHTTPStatusCodeServiceUnavailable = 503;
 static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
 
-// Deprecated error code previously from FirebaseCore
-static const NSInteger sFIRErrorCodeConfigFailed = -114;
-
 #pragma mark - RCNConfig
 
 @implementation RCNConfigFetch {

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -166,16 +166,9 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
       } else {
         FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000053",
                     @"A fetch is already in progress. Ignoring duplicate request.");
-        NSError *error =
-            [NSError errorWithDomain:FIRRemoteConfigErrorDomain
-                                code:sFIRErrorCodeConfigFailed
-                            userInfo:@{
-                              NSLocalizedDescriptionKey :
-                                  @"FetchError: Duplicate request while the previous one is pending"
-                            }];
         return [strongSelf reportCompletionOnHandler:completionHandler
                                           withStatus:FIRRemoteConfigFetchStatusFailure
-                                           withError:error];
+                                           withError:nil];
       }
     }
 
@@ -236,16 +229,9 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
       } else {
         FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000053",
                     @"A fetch is already in progress. Ignoring duplicate request.");
-        NSError *error =
-            [NSError errorWithDomain:FIRRemoteConfigErrorDomain
-                                code:sFIRErrorCodeConfigFailed
-                            userInfo:@{
-                              NSLocalizedDescriptionKey :
-                                  @"FetchError: Duplicate request while the previous one is pending"
-                            }];
         return [strongSelf reportCompletionWithStatus:FIRRemoteConfigFetchStatusFailure
                                            withUpdate:nil
-                                            withError:error
+                                            withError:nil
                                     completionHandler:nil
                               updateCompletionHandler:completionHandler];
       }

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -591,9 +591,9 @@ static NSInteger const gMaxRetries = 7;
     /// on success reset retry parameters
     _remainingRetryCount = gMaxRetries;
     [self->_settings setRealtimeRetryCount:0];
-
-    completionHandler(NSURLSessionResponseAllow);
   }
+
+  completionHandler(NSURLSessionResponseAllow);
 }
 
 /// Delegate to handle data task completion


### PR DESCRIPTION
Fix Fetch duplicate error by removing error and leaving a log, moving the completionHandler to the end of didReceiveMessage, and removing unused error code that was breaking a linting test

https://b.corp.google.com/issues/267714994
https://b.corp.google.com/issues/268242388