### PR TITLE
[AppCheck] Fix unused isTokenAutoRefreshEnabled ivar warning

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -31,13 +31,13 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 @property(nonatomic, readonly) NSUserDefaults *userDefaults;
 @property(nonatomic, readonly) NSBundle *mainBundle;
 @property(nonatomic, readonly) NSString *userDefaultKey;
-
 @property(nonatomic, nullable) NSNumber *isTokenAutoRefreshEnabledNumber;
+
 @end
 
 @implementation FIRAppCheckSettings
 
-@synthesize isTokenAutoRefreshEnabled = _isTokenAutoRefreshEnabled;
+@dynamic isTokenAutoRefreshEnabled;
 
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults


### PR DESCRIPTION
Stopped synthesizing a backing instance variable for the `isTokenAutoRefreshEnabled` property in `FIRAppCheckSettings` because it is unused, resulting in a warning when `-Wunused-property-ivar` is enabled. Replaced `@synthesize` with `@dynamic`, which resolves the following error when building in google3 (where this warning is treated as an error):
> FIRAppCheckSettings.m:92:1: error: ivar '_isTokenAutoRefreshEnabled' which backs the property is not referenced in this property's accessor [-Werror,-Wunused-property-ivar]

<details>
<summary>Details</summary>

We are providing the `- (BOOL)isTokenAutoRefreshEnabled` and `- (void)setIsTokenAutoRefreshEnabled:` implementations directly and they are indirectly backed by the `isTokenAutoRefreshEnabledNumber` property.

> You use the `@dynamic` keyword to tell the compiler that you will **fulfill the API contract implied by a property either by providing method implementations directly** or at runtime using other mechanisms such as dynamic loading of code or dynamic method resolution.

This is similar in concept to a [Computed Property](https://docs.swift.org/swift-book/LanguageGuide/Properties.html) in Swift. See the archived [Objective-C Programming Language - Declared Properties](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocProperties.html#//apple_ref/doc/uid/TP30001163-CH17) documentation for further details.

</details>

#no-changelog