### PR TITLE
[auth-swift] Depend on `CoreExtension` rather than including its sources

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -42,7 +42,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.source_files = [
     'FirebaseAuth/Sources/Swift/**/*.swift',
     source + '**/*.[mh]',
-    'FirebaseCore/Extension/*.h',
     'FirebaseAuth/Interop/*.h',
   ]
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
@@ -50,7 +49,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
   # All headers except the ones in the `Public` should be private.
   s.private_header_files = Dir['FirebaseAuth/Sources/**/*.h']
     .reject{ |f| f['FirebaseAuth/Sources/Public/'] } + [
-      'FirebaseCore/Extension/*.h',
       'FirebaseAuth/Interop/*.h'
     ]
 
@@ -69,6 +67,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseCore', '~> 10.0'
+  s.dependency 'FirebaseCoreExtension', '~> 10.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.8'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
   s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import "FirebaseAuth/Interop/FIRAuthInterop.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h"
-#import "FirebaseCore/Extension/FIRLogger.h"
+@import FirebaseCoreExtension;
 
 @class FIRAuthRequestConfiguration;
 @class FIRAuthURLPresenter;

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -18,8 +18,7 @@ import Foundation
 // When building for CocoaPods, non-public headers are exposed to Swift via a
 // private module map.
 #if COCOAPODS
-  // TODO: Prefix with `@_implementationOnly` after port.
-  import FirebaseAuth_Private
+  @_implementationOnly import FirebaseAuth_Private
 #endif // COCOAPODS
 
 /**

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
@@ -14,12 +14,8 @@
 
 import Foundation
 
-#if COCOAPODS
-  // TODO: Prefix with `@_implementationOnly` after port.
-  import FirebaseAuth_Private
-#else
-  @_implementationOnly import FirebaseCoreExtension
-#endif
+// TODO: Prefix with `@_implementationOnly` after port.
+import FirebaseCoreExtension
 
 /** @class FIRAuthRequestConfiguration
    @brief Defines configurations to be added to a request to Firebase Auth's backend.


### PR DESCRIPTION
#no-changelog