### PR TITLE
[auth-swift] Resolve missing implementation warning

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -175,11 +175,6 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
  */
 @interface FIRAuthBackend : NSObject
 
-// TODO: should be fileprivate after full port.
-+ (nullable NSError *)clientErrorWithServerErrorMessage:(NSString *)serverErrorMessage
-                                        errorDictionary:(NSDictionary *)errorDictionary
-                                               response:(id<FIRAuthRPCResponse>)response;
-
 /** @fn authUserAgent
     @brief Retrieves the Firebase Auth user agent.
     @return The Firebase Auth user agent.


### PR DESCRIPTION
### Context
Resolves warning in CP and SPM builds. Removing didn't break the build so I think this is fine.
```
/Users/nickcooke/Developer/firebase-ios-sdk/FirebaseAuth/Sources/Backend/FIRAuthBackend.m:464:17: warning: method definition for 'clientErrorWithServerErrorMessage:errorDictionary:response:' not found [-Wincomplete-implementation]
@implementation FIRAuthBackend
                ^
/Users/nickcooke/Developer/firebase-ios-sdk/FirebaseAuth/Sources/Backend/FIRAuthBackend.h:179:1: note: method 'clientErrorWithServerErrorMessage:errorDictionary:response:' declared here
+ (nullable NSError *)clientErrorWithServerErrorMessage:(NSString *)serverErrorMessage
^
1 warning generated.
Build complete! (31.62s)
```

#no-changelog