### PR TITLE
Return Server produced error if Http status code is 403 

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -36,10 +36,6 @@ static NSString *const kServerURLKey = @"key=";
 static NSString *const kEnableRealtimeURL =
     @"https://console.developers.google.com/apis/api/firebaseremoteconfigrealtime.googleapis.com/"
     @"overview?project=";
-static NSString *const kApiDisabledErrorMessage =
-    @"The Remote Config Realtime API is disabled. It must be enabled in the Google Cloud Console. "
-    @"If you enabled this API recently, wait a few minutes for the action to propagate to our "
-    @"systems and retry. You can enable the API by following this URL: %@";
 
 /// Header names
 static NSString *const kHTTPMethodPost = @"POST";  ///< HTTP request method config fetch using
@@ -542,6 +538,8 @@ static NSInteger const gMaxRetries = 7;
   NSError *dataError;
   NSString *strData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
+  /// If response data contains the API enablement link, return the entire message to the user in
+  /// the form of a error.
   if ([strData containsString:kEnableRealtimeURL]) {
     NSError *error = [NSError errorWithDomain:FIRRemoteConfigUpdateErrorDomain
                                          code:FIRRemoteConfigUpdateErrorStreamError

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -543,13 +543,9 @@ static NSInteger const gMaxRetries = 7;
   NSString *strData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
   if ([strData containsString:kEnableRealtimeURL]) {
-    NSError *error = [NSError
-        errorWithDomain:FIRRemoteConfigUpdateErrorDomain
-                   code:FIRRemoteConfigUpdateErrorStreamError
-               userInfo:@{
-                 NSLocalizedDescriptionKey :
-                     strData
-               }];
+    NSError *error = [NSError errorWithDomain:FIRRemoteConfigUpdateErrorDomain
+                                         code:FIRRemoteConfigUpdateErrorStreamError
+                                     userInfo:@{NSLocalizedDescriptionKey : strData}];
     FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. Error: %@",
                 error);
     [self propogateErrors:error];

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -544,8 +544,7 @@ static NSInteger const gMaxRetries = 7;
     NSError *error = [NSError errorWithDomain:FIRRemoteConfigUpdateErrorDomain
                                          code:FIRRemoteConfigUpdateErrorStreamError
                                      userInfo:@{NSLocalizedDescriptionKey : strData}];
-    FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. Error: %@",
-                error);
+    FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. %@", error);
     [self propogateErrors:error];
     return;
   }
@@ -603,7 +602,9 @@ static NSInteger const gMaxRetries = 7;
                  }];
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. Error: %@",
                   error);
-      [self propogateErrors:error];
+      if (statusCode != 403) {
+        [self propogateErrors:error];
+      }
     }
   } else {
     /// on success reset retry parameters

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -538,7 +538,7 @@ static NSInteger const gMaxRetries = 7;
 
   /// If response data contains the API enablement link, return the entire message to the user in
   /// the form of a error.
-  if ([strData containsString:kEnableRealtimeURL]) {
+  if ([strData containsString:kServerForbiddenStatusCode]) {
     NSError *error = [NSError errorWithDomain:FIRRemoteConfigUpdateErrorDomain
                                          code:FIRRemoteConfigUpdateErrorStreamError
                                      userInfo:@{NSLocalizedDescriptionKey : strData}];
@@ -582,6 +582,11 @@ static NSInteger const gMaxRetries = 7;
   NSHTTPURLResponse *_httpURLResponse = (NSHTTPURLResponse *)response;
   NSInteger statusCode = [_httpURLResponse statusCode];
 
+  if (statusCode == 403) {
+    completionHandler(NSURLSessionResponseAllow);
+    return;
+  }
+
   if (statusCode != kRCNFetchResponseHTTPStatusOk) {
     [self->_settings updateRealtimeExponentialBackoffTime];
     [self pauseRealtimeStream];
@@ -600,9 +605,6 @@ static NSInteger const gMaxRetries = 7;
                  }];
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. Error: %@",
                   error);
-      if (statusCode != 403) {
-        [self propogateErrors:error];
-      }
     }
   } else {
     /// on success reset retry parameters

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -543,14 +543,12 @@ static NSInteger const gMaxRetries = 7;
   NSString *strData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
   if ([strData containsString:kEnableRealtimeURL]) {
-    NSString *enableRealtimeUrlLink =
-        [kEnableRealtimeURL stringByAppendingString:[self->_options GCMSenderID]];
     NSError *error = [NSError
         errorWithDomain:FIRRemoteConfigUpdateErrorDomain
                    code:FIRRemoteConfigUpdateErrorStreamError
                userInfo:@{
                  NSLocalizedDescriptionKey :
-                     [NSString stringWithFormat:kApiDisabledErrorMessage, enableRealtimeUrlLink]
+                     strData
                }];
     FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000021", @"Cannot establish connection. Error: %@",
                 error);

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -33,9 +33,7 @@ static NSString *const kServerURLQuery = @":streamFetchInvalidations?";
 static NSString *const kServerURLKey = @"key=";
 
 /// Realtime API enablement
-static NSString *const kEnableRealtimeURL =
-    @"https://console.developers.google.com/apis/api/firebaseremoteconfigrealtime.googleapis.com/"
-    @"overview?project=";
+static NSString *const kServerForbiddenStatusCode = @"\"code\": 403";
 
 /// Header names
 static NSString *const kHTTPMethodPost = @"POST";  ///< HTTP request method config fetch using


### PR DESCRIPTION
https://buganizer.corp.google.com/issues/268398841
Pass back server error if it is the 403 API enablement response. didReceiveResponse only has statusCode response while didReceiveData has the actual error message. So in order to know if the error message is the API enablement one, I check if the URL in is the data response. 