### PR TITLE
[Release] Prepare CHANGELOGs for 10.6.0 release

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.6.0
 - [added] Added dependency on Firebase Sessions SDK to power future metrics and debugging features in Crashlytics
 
 # 10.4.0

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.6.0
 - [fixed] Fixed bug where testers were sent to the wrong URL when signing in (#10772).
 
 # 10.2.0

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.6.0
 - [added] Added dependency on Firebase Sessions SDK to power future metrics and debugging features in Performance Monitoring.
 - [changed] Changed definition of sessions, as Performance Monitoring now depends on the new Firebase Sessions SDK.
 

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# Unreleased
+# 10.6.0
 - [fixed] Fix a potential high memory usage issue.
 
 # 10.5.0


### PR DESCRIPTION
Updated the `Unreleased` CHANGELOG entries to `10.6.0` for the upcoming M128 release.