### PR TITLE
Revert "Disable watchOS pod lib lint tests (#10315)"

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -27,7 +27,7 @@ jobs:
       POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -166,8 +166,8 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        # The macos and tvos tests can hang.
-        target: [ios, tvos --skip-tests, macos --skip-tests]
+        # The macos and tvos tests can hang, and watchOS doesn't have tests.
+        target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
         flags: [
           '--use-static-frameworks'
         ]

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos --skip-tests]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -147,7 +147,8 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        # Disable watchos because it does not support XCTest.
+        target: [ios, tvos, macos, watchos --skip-tests]
         flags: [
           '--use-static-frameworks'
         ]

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -119,7 +119,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos --skip-tests] # skipping tests on mac because of keychain access
+        target: [ios, tvos, macos --skip-tests, watchos --skip-tests] # skipping tests on mac because of keychain access
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -171,7 +171,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos --skip-tests]
+        target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
         flags: [
           '--use-modular-headers'
         ]

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -59,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
         podspec: [FirebaseRemoteConfig.podspec, FirebaseRemoteConfigSwift.podspec --skip-tests]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos --skip-tests]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -131,7 +131,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -147,7 +147,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     needs: pod-lib-lint
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix #10316

Now that CocoaPods is fixed with the release of 1.12.0, restore watchos CI