### PR TITLE
[Firestore] Programmatically link un-linked symbols

### DIFF
--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -545,6 +545,17 @@ NS_ASSUME_NONNULL_BEGIN
   _firestore->Terminate(MakeCallback(completion));
 }
 
+#pragma mark - Force Link Unreferenced Symbols
+
+extern void FSTIncludeFSTFirestoreComponent(void);
+
+/// This method forces the linker to include all the Analytics categories without requiring app
+/// developers to include the '-ObjC' linker flag in their projects. DO NOT CALL THIS METHOD.
++ (void)notCalled {
+  NSAssert(NO, @"+notCalled should never be called");
+  FSTIncludeFSTFirestoreComponent();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -176,4 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/// This function forces the linker to include `FSTFirestoreComponent`. See `+[FIRFirestore notCalled]`.
+void FSTIncludeFSTFirestoreComponent(void) {}
+
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -176,7 +176,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/// This function forces the linker to include `FSTFirestoreComponent`. See `+[FIRFirestore notCalled]`.
-void FSTIncludeFSTFirestoreComponent(void) {}
+/// This function forces the linker to include `FSTFirestoreComponent`. See `+[FIRFirestore
+/// notCalled]`.
+void FSTIncludeFSTFirestoreComponent(void) {
+}
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### Context
- Some Objective-C symbols within Firestore are unreferenced and therefore aren't linked when using Firestore binary distro.  What this means is that clients would need to use the -ObjC linker flag to force link these symbols. This PR forces the linking to link via a trick C function–– avoiding the need for clients to pass the -ObjC linker flag.
- [x] Create CI workflow for testing regressions that introduce un-linked symbols. See https://github.com/firebase/firebase-ios-sdk/pull/10901

cc: @peterfriese 

#no-changelog