### PR TITLE
[Infra] Add workflow for detecting unlinked Firestore symbols

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -1,79 +1,79 @@
-name: spm
+# name: spm
 
-on:
-  pull_request:
-    paths:
-    - '.github/workflows/spm.yml'
-    - 'Package.swift'
-    - '.swiftpm/*'
-    - 'scripts/build.sh'
-    - 'SwiftPMTests/*'
-    - 'SwiftPM-PlatformExclude'
-    - 'Gemfile*'
-  schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
-    - cron:  '0 8 * * *'
+# on:
+#   pull_request:
+#     paths:
+#     - '.github/workflows/spm.yml'
+#     - 'Package.swift'
+#     - '.swiftpm/*'
+#     - 'scripts/build.sh'
+#     - 'SwiftPMTests/*'
+#     - 'SwiftPM-PlatformExclude'
+#     - 'Gemfile*'
+#   schedule:
+#     # Run every day at 12am (PST) - cron uses UTC times
+#     - cron:  '0 8 * * *'
 
-# This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
-# because each platform takes 15-20 minutes after adding Firestore.
+# # This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
+# # because each platform takes 15-20 minutes after adding Firestore.
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+# concurrency:
+#     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#     cancel-in-progress: true
 
-jobs:
-  swift-build-run:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: Functions Integration Test Server
-      run: FirebaseFunctions/Backend/start.sh synchronous
-    - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
+# jobs:
+#   swift-build-run:
+#     # Don't run on private repo unless it is a PR.
+#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+#     runs-on: macos-12
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+#       with:
+#         cache_key: ${{ matrix.os }}
+#     - name: Initialize xcodebuild
+#       run: scripts/setup_spm_tests.sh
+#     - name: Functions Integration Test Server
+#       run: FirebaseFunctions/Backend/start.sh synchronous
+#     - name: iOS Unit Tests
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 
-  # Test iOS Device build since some Firestore dependencies build different files.
-  iOS-Device:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: iOS Device and Test Build
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+#   # Test iOS Device build since some Firestore dependencies build different files.
+#   iOS-Device:
+#     # Don't run on private repo unless it is a PR.
+#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+#     runs-on: macos-12
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+#       with:
+#         cache_key: ${{ matrix.os }}
+#     - name: Initialize xcodebuild
+#       run: scripts/setup_spm_tests.sh
+#     - name: iOS Device and Test Build
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
 
-  platforms:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+#   platforms:
+#     # Don't run on private repo unless it is a PR.
+#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    runs-on: macos-12
-    strategy:
-      matrix:
-        target: [tvOS, macOS, catalyst]
-        # Full set of Firebase-Package tests only run on iOS.
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: Objc Import Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
-    - name: Swift Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
-    - name: Version Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
-    - name: Analytics Build Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
+#     runs-on: macos-12
+#     strategy:
+#       matrix:
+#         target: [tvOS, macOS, catalyst]
+#         # Full set of Firebase-Package tests only run on iOS.
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+#       with:
+#         cache_key: ${{ matrix.os }}
+#     - name: Initialize xcodebuild
+#       run: scripts/setup_spm_tests.sh
+#     - name: Objc Import Tests
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
+#     - name: Swift Tests
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
+#     - name: Version Tests
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
+#     - name: Analytics Build Tests
+#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -1,79 +1,79 @@
-# name: spm
+name: spm
 
-# on:
-#   pull_request:
-#     paths:
-#     - '.github/workflows/spm.yml'
-#     - 'Package.swift'
-#     - '.swiftpm/*'
-#     - 'scripts/build.sh'
-#     - 'SwiftPMTests/*'
-#     - 'SwiftPM-PlatformExclude'
-#     - 'Gemfile*'
-#   schedule:
-#     # Run every day at 12am (PST) - cron uses UTC times
-#     - cron:  '0 8 * * *'
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/spm.yml'
+    - 'Package.swift'
+    - '.swiftpm/*'
+    - 'scripts/build.sh'
+    - 'SwiftPMTests/*'
+    - 'SwiftPM-PlatformExclude'
+    - 'Gemfile*'
+  schedule:
+    # Run every day at 12am (PST) - cron uses UTC times
+    - cron:  '0 8 * * *'
 
-# # This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
-# # because each platform takes 15-20 minutes after adding Firestore.
+# This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
+# because each platform takes 15-20 minutes after adding Firestore.
 
-# concurrency:
-#     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-#     cancel-in-progress: true
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
-# jobs:
-#   swift-build-run:
-#     # Don't run on private repo unless it is a PR.
-#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-#     runs-on: macos-12
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-#       with:
-#         cache_key: ${{ matrix.os }}
-#     - name: Initialize xcodebuild
-#       run: scripts/setup_spm_tests.sh
-#     - name: Functions Integration Test Server
-#       run: FirebaseFunctions/Backend/start.sh synchronous
-#     - name: iOS Unit Tests
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
+jobs:
+  swift-build-run:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: Functions Integration Test Server
+      run: FirebaseFunctions/Backend/start.sh synchronous
+    - name: iOS Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 
-#   # Test iOS Device build since some Firestore dependencies build different files.
-#   iOS-Device:
-#     # Don't run on private repo unless it is a PR.
-#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-#     runs-on: macos-12
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-#       with:
-#         cache_key: ${{ matrix.os }}
-#     - name: Initialize xcodebuild
-#       run: scripts/setup_spm_tests.sh
-#     - name: iOS Device and Test Build
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+  # Test iOS Device build since some Firestore dependencies build different files.
+  iOS-Device:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: iOS Device and Test Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
 
-#   platforms:
-#     # Don't run on private repo unless it is a PR.
-#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  platforms:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-#     runs-on: macos-12
-#     strategy:
-#       matrix:
-#         target: [tvOS, macOS, catalyst]
-#         # Full set of Firebase-Package tests only run on iOS.
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-#       with:
-#         cache_key: ${{ matrix.os }}
-#     - name: Initialize xcodebuild
-#       run: scripts/setup_spm_tests.sh
-#     - name: Objc Import Tests
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
-#     - name: Swift Tests
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
-#     - name: Version Tests
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
-#     - name: Analytics Build Tests
-#       run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
+    runs-on: macos-12
+    strategy:
+      matrix:
+        target: [tvOS, macOS, catalyst]
+        # Full set of Firebase-Package tests only run on iOS.
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: Objc Import Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
+    - name: Swift Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
+    - name: Version Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
+    - name: Analytics Build Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -3,445 +3,445 @@ name: zip
 on:
   pull_request:
     paths:
-      - "ReleaseTooling/Sources/**"
-      - ".github/workflows/zip.yml"
-      - "scripts/build_non_firebase_sdks.sh"
-      - "Gemfile*"
-      # Don't run based on any markdown only changes.
-      - "!ReleaseTooling/*.md"
+    - 'ReleaseTooling/Sources/**'
+    - '.github/workflows/zip.yml'
+    - 'scripts/build_non_firebase_sdks.sh'
+    - 'Gemfile*'
+    # Don't run based on any markdown only changes.
+    - '!ReleaseTooling/*.md'
   schedule:
     # Run every day at 8pm(PST) - cron uses UTC times
-    - cron: "0 4 * * *"
+    - cron:  '0 4 * * *'
 
   workflow_dispatch:
     inputs:
       custom_spec_repos:
-        description: "Custom Podspec repos"
+        description: 'Custom Podspec repos'
         required: true
-        default: "https://github.com/firebase/SpecsStaging.git"
+        default: 'https://github.com/firebase/SpecsStaging.git'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  # package-release:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - name: Xcode 13.3.1
-  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p release_zip_dir
-  #        sh -x scripts/build_zip.sh release_zip_dir \
-  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
-  #   - uses: actions/upload-artifact@v1
-  #     with:
-  #       name: Firebase-release-zip-zip
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: release_zip_dir
+  package-release:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Xcode 13.3.1
+      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p release_zip_dir
+         sh -x scripts/build_zip.sh release_zip_dir \
+           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
+    - uses: actions/upload-artifact@v1
+      with:
+        name: Firebase-release-zip-zip
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: release_zip_dir
 
-  # build:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Xcode 13.3.1
-  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-  #   - name: Build
-  #     run: |
-  #       cd ReleaseTooling
-  #       swift build -v
+  build:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Xcode 13.3.1
+      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+    - name: Build
+      run: |
+        cd ReleaseTooling
+        swift build -v
 
-  # package-head:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: build
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - name: Xcode 13.3.1
-  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p zip_output_dir
-  #        sh -x scripts/build_zip.sh \
-  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-  #          build-head
-  #   - uses: actions/upload-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: zip_output_dir
+  package-head:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Xcode 13.3.1
+      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p zip_output_dir
+         sh -x scripts/build_zip.sh \
+           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+           build-head
+    - uses: actions/upload-artifact@v1
+      with:
+        name: Firebase-actions-dir
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: zip_output_dir
 
-  # quickstart_framework_abtesting:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "ABTesting"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh abtesting
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_abtesting
-  #       path: quickstart-ios/
+  quickstart_framework_abtesting:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "ABTesting"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh abtesting
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_abtesting
+        path: quickstart-ios/
 
-  # quickstart_framework_auth:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK:  "Authentication"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Swift Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-  #       quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh authentiation
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_auth
-  #       path: quickstart-ios/
+  quickstart_framework_auth:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK:  "Authentication"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Swift Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh authentiation
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_auth
+        path: quickstart-ios/
 
-  # quickstart_framework_config:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Config"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Swift Quickstart
+  quickstart_framework_config:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Config"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Swift Quickstart
 
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh config
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_config
-  #       path: quickstart-ios/
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh config
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_config
+        path: quickstart-ios/
 
-  # quickstart_framework_crashlytics:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Crashlytics"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: |
-  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Setup swift quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: |
-  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Test Swift Quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh crashlytics
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_crashlytics
-  #       path: quickstart-ios/
+  quickstart_framework_crashlytics:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Crashlytics"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: |
+              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Setup swift quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: |
+    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Test Swift Quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh crashlytics
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_crashlytics
+        path: quickstart-ios/
 
-  # quickstart_framework_database:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Database"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh database
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts database
-  #       path: quickstart-ios/
+  quickstart_framework_database:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Database"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh database
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts database
+        path: quickstart-ios/
 
-  # quickstart_framework_dynamiclinks:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "DynamicLinks"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Objc Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup Swift Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Update Environment Variable For DynamicLinks
-  #     run: |
-  #       sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
-  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
-  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
-  #       quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Objc Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh dynamiclinks
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_dynamiclinks
-  #       path: quickstart-ios/
+  quickstart_framework_dynamiclinks:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "DynamicLinks"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Objc Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup Swift Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Update Environment Variable For DynamicLinks
+      run: |
+        sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
+        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
+        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
+        quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
+    - name: Test Objc Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh dynamiclinks
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_dynamiclinks
+        path: quickstart-ios/
 
-  # quickstart_framework_firestore:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Firestore"
-  #   runs-on: macos-12
-  #   steps:
-  #     # Xcode 14 fails to build FirebaseAuthUI because it includes Resources. See #9886.
-  #   - name: Xcode 13.3.1
-  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh firestore
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_firestore
-  #       path: quickstart-ios/
+  quickstart_framework_firestore:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Firestore"
+    runs-on: macos-12
+    steps:
+      # Xcode 14 fails to build FirebaseAuthUI because it includes Resources. See #9886.
+    - name: Xcode 13.3.1
+      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh firestore
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_firestore
+        path: quickstart-ios/
 
   check_framework_firestore_symbols:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       FRAMEWORK_DIR: "Firebase-actions-dir"
     runs-on: macos-12
@@ -449,19 +449,19 @@ jobs:
       - name: Xcode 13.3.1
         run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
       - uses: actions/checkout@v3
-      # - name: Get framework dir
-      #   uses: actions/download-artifact@v1
-      #   with:
-      #     name: Firebase-actions-dir
+      - name: Get framework dir
+        uses: actions/download-artifact@v1
+        with:
+          name: Firebase-actions-dir
       - uses: ruby/setup-ruby@v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
       - name: Install xcpretty
         run: gem install xcpretty
-      # - name: Move frameworks
-      #   run: |
-      #     mkdir -p "${HOME}"/ios_frameworks/
-      #     find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      - name: Move frameworks
+        run: |
+          mkdir -p "${HOME}"/ios_frameworks/
+          find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
       - uses: actions/checkout@v3
       - name: Check linked Firestore.xcframework for unlinked symbols.
         run: |
@@ -469,152 +469,152 @@ jobs:
             $(pwd) \
             "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestore.xcframework
 
-  # quickstart_framework_inappmessaging:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "InAppMessaging"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh inappmessaging
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_ihappmessaging
-  #       path: quickstart-ios/
+  quickstart_framework_inappmessaging:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "InAppMessaging"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh inappmessaging
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_ihappmessaging
+        path: quickstart-ios/
 
-  # quickstart_framework_messaging:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Messaging"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh messaging
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_messaging
-  #       path: quickstart-ios/
+  quickstart_framework_messaging:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Messaging"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh messaging
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_messaging
+        path: quickstart-ios/
 
-  # quickstart_framework_storage:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     SDK: "Storage"
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v3
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh storage
-  #   - uses: actions/upload-artifact@v2
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_storage
-  #       path: quickstart-ios/
+  quickstart_framework_storage:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      SDK: "Storage"
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get framework dir
+      uses: actions/download-artifact@v1
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v3
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh storage
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_storage
+        path: quickstart-ios/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -456,6 +456,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
+      - name: Install xcpretty
+        run: gem install xcpretty
       # - name: Move frameworks
       #   run: |
       #     mkdir -p "${HOME}"/ios_frameworks/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -438,6 +438,35 @@ jobs:
         name: quickstart_artifacts_firestore
         path: quickstart-ios/
 
+  check_framework_firestore_symbols:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+    runs-on: macos-12
+    steps:
+      - name: Xcode 13.3.1
+        run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+      - uses: actions/checkout@v3
+      - name: Get framework dir
+        uses: actions/download-artifact@v1
+        with:
+          name: Firebase-actions-dir
+      - uses: ruby/setup-ruby@v1
+      - name: Setup Bundler
+        run: ./scripts/setup_bundler.sh
+      - name: Move frameworks
+        run: |
+          mkdir -p "${HOME}"/ios_frameworks/
+          find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      - uses: actions/checkout@v3
+      - name: Setup quickstart
+        run: |
+          scripts/check_firestore_symbols.sh \
+            $(pwd) \
+            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestore.xcframework
+
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -461,7 +461,7 @@ jobs:
           mkdir -p "${HOME}"/ios_frameworks/
           find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
       - uses: actions/checkout@v3
-      - name: Setup quickstart
+      - name: Check linked Firestore.xcframework for unlinked symbols.
         run: |
           scripts/check_firestore_symbols.sh \
             $(pwd) \

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -3,445 +3,445 @@ name: zip
 on:
   pull_request:
     paths:
-    - 'ReleaseTooling/Sources/**'
-    - '.github/workflows/zip.yml'
-    - 'scripts/build_non_firebase_sdks.sh'
-    - 'Gemfile*'
-    # Don't run based on any markdown only changes.
-    - '!ReleaseTooling/*.md'
+      - "ReleaseTooling/Sources/**"
+      - ".github/workflows/zip.yml"
+      - "scripts/build_non_firebase_sdks.sh"
+      - "Gemfile*"
+      # Don't run based on any markdown only changes.
+      - "!ReleaseTooling/*.md"
   schedule:
     # Run every day at 8pm(PST) - cron uses UTC times
-    - cron:  '0 4 * * *'
+    - cron: "0 4 * * *"
 
   workflow_dispatch:
     inputs:
       custom_spec_repos:
-        description: 'Custom Podspec repos'
+        description: "Custom Podspec repos"
         required: true
-        default: 'https://github.com/firebase/SpecsStaging.git'
+        default: "https://github.com/firebase/SpecsStaging.git"
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  package-release:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Xcode 13.3.1
-      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p release_zip_dir
-         sh -x scripts/build_zip.sh release_zip_dir \
-           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
-    - uses: actions/upload-artifact@v1
-      with:
-        name: Firebase-release-zip-zip
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: release_zip_dir
+  # package-release:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Xcode 13.3.1
+  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p release_zip_dir
+  #        sh -x scripts/build_zip.sh release_zip_dir \
+  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
+  #   - uses: actions/upload-artifact@v1
+  #     with:
+  #       name: Firebase-release-zip-zip
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: release_zip_dir
 
-  build:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Xcode 13.3.1
-      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-    - name: Build
-      run: |
-        cd ReleaseTooling
-        swift build -v
+  # build:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Xcode 13.3.1
+  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+  #   - name: Build
+  #     run: |
+  #       cd ReleaseTooling
+  #       swift build -v
 
-  package-head:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: build
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Xcode 13.3.1
-      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh \
-           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-           build-head
-    - uses: actions/upload-artifact@v1
-      with:
-        name: Firebase-actions-dir
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: zip_output_dir
+  # package-head:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: build
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Xcode 13.3.1
+  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p zip_output_dir
+  #        sh -x scripts/build_zip.sh \
+  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+  #          build-head
+  #   - uses: actions/upload-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: zip_output_dir
 
-  quickstart_framework_abtesting:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "ABTesting"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh abtesting
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_abtesting
-        path: quickstart-ios/
+  # quickstart_framework_abtesting:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "ABTesting"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh abtesting
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_abtesting
+  #       path: quickstart-ios/
 
-  quickstart_framework_auth:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK:  "Authentication"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh authentiation
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_auth
-        path: quickstart-ios/
+  # quickstart_framework_auth:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK:  "Authentication"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Swift Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+  #       quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh authentiation
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_auth
+  #       path: quickstart-ios/
 
-  quickstart_framework_config:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Config"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Swift Quickstart
+  # quickstart_framework_config:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Config"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Swift Quickstart
 
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh config
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_config
-        path: quickstart-ios/
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh config
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_config
+  #       path: quickstart-ios/
 
-  quickstart_framework_crashlytics:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Crashlytics"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: |
-              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Setup swift quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: |
-    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Test Swift Quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh crashlytics
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_crashlytics
-        path: quickstart-ios/
+  # quickstart_framework_crashlytics:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Crashlytics"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: |
+  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Setup swift quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: |
+  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Test Swift Quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh crashlytics
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_crashlytics
+  #       path: quickstart-ios/
 
-  quickstart_framework_database:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Database"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh database
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts database
-        path: quickstart-ios/
+  # quickstart_framework_database:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Database"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh database
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts database
+  #       path: quickstart-ios/
 
-  quickstart_framework_dynamiclinks:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "DynamicLinks"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Objc Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Update Environment Variable For DynamicLinks
-      run: |
-        sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
-        quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
-    - name: Test Objc Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh dynamiclinks
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_dynamiclinks
-        path: quickstart-ios/
+  # quickstart_framework_dynamiclinks:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "DynamicLinks"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Objc Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup Swift Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Update Environment Variable For DynamicLinks
+  #     run: |
+  #       sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
+  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
+  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
+  #       quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Objc Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh dynamiclinks
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_dynamiclinks
+  #       path: quickstart-ios/
 
-  quickstart_framework_firestore:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Firestore"
-    runs-on: macos-12
-    steps:
-      # Xcode 14 fails to build FirebaseAuthUI because it includes Resources. See #9886.
-    - name: Xcode 13.3.1
-      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh firestore
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_firestore
-        path: quickstart-ios/
+  # quickstart_framework_firestore:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Firestore"
+  #   runs-on: macos-12
+  #   steps:
+  #     # Xcode 14 fails to build FirebaseAuthUI because it includes Resources. See #9886.
+  #   - name: Xcode 13.3.1
+  #     run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh firestore
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_firestore
+  #       path: quickstart-ios/
 
   check_framework_firestore_symbols:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       FRAMEWORK_DIR: "Firebase-actions-dir"
     runs-on: macos-12
@@ -449,17 +449,17 @@ jobs:
       - name: Xcode 13.3.1
         run: sudo xcode-select -s /Applications/Xcode_13.3.1.app/Contents/Developer
       - uses: actions/checkout@v3
-      - name: Get framework dir
-        uses: actions/download-artifact@v1
-        with:
-          name: Firebase-actions-dir
+      # - name: Get framework dir
+      #   uses: actions/download-artifact@v1
+      #   with:
+      #     name: Firebase-actions-dir
       - uses: ruby/setup-ruby@v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
-      - name: Move frameworks
-        run: |
-          mkdir -p "${HOME}"/ios_frameworks/
-          find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      # - name: Move frameworks
+      #   run: |
+      #     mkdir -p "${HOME}"/ios_frameworks/
+      #     find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
       - uses: actions/checkout@v3
       - name: Check linked Firestore.xcframework for unlinked symbols.
         run: |
@@ -467,152 +467,152 @@ jobs:
             $(pwd) \
             "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestore.xcframework
 
-  quickstart_framework_inappmessaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "InAppMessaging"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh inappmessaging
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_ihappmessaging
-        path: quickstart-ios/
+  # quickstart_framework_inappmessaging:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "InAppMessaging"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh inappmessaging
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_ihappmessaging
+  #       path: quickstart-ios/
 
-  quickstart_framework_messaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Messaging"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh messaging
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_messaging
-        path: quickstart-ios/
+  # quickstart_framework_messaging:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Messaging"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh messaging
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_messaging
+  #       path: quickstart-ios/
 
-  quickstart_framework_storage:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_DIR: "Firebase-actions-dir"
-      SDK: "Storage"
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - name: Get framework dir
-      uses: actions/download-artifact@v1
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v3
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh storage
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_storage
-        path: quickstart-ios/
+  # quickstart_framework_storage:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FRAMEWORK_DIR: "Firebase-actions-dir"
+  #     SDK: "Storage"
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v3
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh storage
+  #   - uses: actions/upload-artifact@v2
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_storage
+  #       path: quickstart-ios/

--- a/Package.swift
+++ b/Package.swift
@@ -1371,20 +1371,20 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
   // FirebaseFirestoreTarget definition matches below definition.
   if let firestoreTargetIndex = package.targets
     .firstIndex(where: { $0.name == "FirebaseFirestoreTarget" }) {
-      package.targets[firestoreTargetIndex] = .target(
-        name: "FirebaseFirestoreTarget",
-        dependencies: [
-          .target(
-              name: "FirebaseFirestore",
-              condition: .when(platforms: [.iOS, .tvOS, .macOS])
-          ),
-          .product(name: "abseil", package: "abseil"),
-          .product(name: "gRPC-cpp", package: "gRPC"),
-          .product(name: "nanopb", package: "nanopb"),
-          "FirebaseCore",
-          "leveldb"
-        ],
-        path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
-      )
-    }
+    package.targets[firestoreTargetIndex] = .target(
+      name: "FirebaseFirestoreTarget",
+      dependencies: [
+        .target(
+          name: "FirebaseFirestore",
+          condition: .when(platforms: [.iOS, .tvOS, .macOS])
+        ),
+        .product(name: "abseil", package: "abseil"),
+        .product(name: "gRPC-cpp", package: "gRPC"),
+        .product(name: "nanopb", package: "nanopb"),
+        "FirebaseCore",
+        "leveldb",
+      ],
+      path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
+    )
+  }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1366,4 +1366,25 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
       path: "FirebaseFirestore.xcframework"
     )
   }
+
+  // TODO(ncooke3): Below re-defining is not needed when original
+  // FirebaseFirestoreTarget definition matches below definition.
+  if let firestoreTargetIndex = package.targets
+    .firstIndex(where: { $0.name == "FirebaseFirestoreTarget" }) {
+      package.targets[firestoreTargetIndex] = .target(
+        name: "FirebaseFirestoreTarget",
+        dependencies: [
+          .target(
+              name: "FirebaseFirestore",
+              condition: .when(platforms: [.iOS, .tvOS, .macOS])
+          ),
+          .product(name: "abseil", package: "abseil"),
+          .product(name: "gRPC-cpp", package: "gRPC"),
+          .product(name: "nanopb", package: "nanopb"),
+          "FirebaseCore",
+          "leveldb"
+        ],
+        path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
+      )
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1355,3 +1355,15 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREME
     )
   }
 }
+
+// This is set when running `scripts/check_firestore_symbols.sh`.
+if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != nil {
+  if let firestoreIndex = package.targets
+    .firstIndex(where: { $0.name == "FirebaseFirestore" }) {
+    package.targets[firestoreIndex] = .binaryTarget(
+      name: "FirebaseFirestore",
+      // The `xcframework` should be moved to the root of the repo.
+      path: "FirebaseFirestore.xcframework"
+    )
+  }
+}

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -36,6 +36,12 @@
 
 set -euo pipefail
 
+echo "About to call xcpretty"
+xcpretty --help
+echo "Called xcpretty"
+
+exit 1
+
 if [[ $# -ne 2 ]]; then
     echo "Usage: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>"
     exit 1

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DESCRIPTION: This script identifies Objective-C symbols within the
+# `FirebaseFirestore.xcframework` that are not automatically linked when used
+# in a client target. Because the `FirebaseFirestore.xcframework` should
+# function without clients needing to pass the `-ObjC`, this script catches
+# potential regressions that break that requirement.
+#
+# USAGE: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>
+
+if [ $# -ne 2 ]; then
+    echo "Usage: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>"
+    exit 1
+fi
+
+# Check if the given repo path is valid.
+FIREBASE_REPO_PATH=$1
+
+if [[ "$FIREBASE_REPO_PATH" != /* ]]; then
+   echo "The given path should be an absolute path."
+   exit 1
+fi
+
+if [ ! -d $FIREBASE_REPO_PATH ]; then
+    echo "The given repo does not exist: $FIREBASE_REPO_PATH"
+    exit 1
+fi
+
+# Check if the given xcframework path is valid.
+FIRESTORE_XCFRAMEWORK_PATH=$2
+
+if [ "$(basename $FIRESTORE_XCFRAMEWORK_PATH)" != 'FirebaseFirestore.xcframework' ]; then
+  echo "The given xcframework is not a FirebaseFirestore.xcframework."
+  exit 1
+fi
+
+if [ ! -d $FIRESTORE_XCFRAMEWORK_PATH ]; then
+    echo "The given xcframework does not exist: $FIRESTORE_XCFRAMEWORK_PATH"
+    exit 1
+fi
+
+# Copy the given Firestore framework to the root of the given Firebase repo.
+# This script uses an env var that will alter the repo's `Package.swift` to
+# pick up the copied Firestore framework. See
+# `FIREBASECI_USE_LOCAL_FIRESTORE_ZIP` in Firebase's `Package.swift` for more.
+cp -r $FIRESTORE_XCFRAMEWORK_PATH $FIREBASE_REPO_PATH
+
+# Create a temporary directory for the test package. The test package defines an
+# executable and has the following directory structure:
+#
+#       TestPkg
+#       ├── Package.swift
+#       └── Sources
+#           └── TestPkg
+#               └── main.swift
+TEST_PKG_ROOT=$(mktemp -d -t TestPkg)
+echo "Test package root: $TEST_PKG_ROOT"
+
+# Create the package's subdirectories.
+mkdir -p $TEST_PKG_ROOT/Sources/TestPkg
+
+# Generate the package's `Package.swift`.
+# TODO(ncooke3): Make package path an argument.
+cat > $TEST_PKG_ROOT/Package.swift <<- EOM
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TestPkg",
+    platforms: [.macOS(.v10_13)],
+    dependencies: [
+        .package(path: "${FIREBASE_REPO_PATH}")
+    ],
+    targets: [
+    .executableTarget(
+        name: "TestPkg",
+        dependencies: [
+            .product(
+                name: "FirebaseFirestore",
+                package: "firebase-ios-sdk"
+            )
+        ]
+    )
+    ]
+)
+EOM
+
+# Generate the package's `main.swift`.
+cat > $TEST_PKG_ROOT/Sources/TestPkg/main.swift <<- EOM
+import FirebaseFirestore
+
+let db = Firestore.firestore()
+EOM
+
+# Change to the test package's root directory in order to build the package.
+cd $TEST_PKG_ROOT
+
+# Build the test package *without* the `-ObjC` linker flag, and dump the
+# resulting executable file's Objective-C symbols into a text file.
+echo "Building test package without -ObjC linker flag..."
+FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
+xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
+      -derivedDataPath '~/Library/Developer/Xcode/DerivedData/TestPkg'
+
+nm ~/Library/Developer/Xcode/DerivedData/TestPkg/Build/Products/Debug/TestPkg \
+      | grep -o "[-+]\[.*\]" > objc_symbols_without_linker_flag.txt
+
+# Build the test package *with* the -ObjC linker flag, and dump the
+# resulting executable file's Objective-C symbols into a text file.
+echo "Building test package with -ObjC linker flag..."
+FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
+xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
+      -derivedDataPath '~/Library/Developer/Xcode/DerivedData/TestPkg-ObjC' \
+      OTHER_LDFLAGS='-ObjC'
+
+nm ~/Library/Developer/Xcode/DerivedData/TestPkg-ObjC/Build/Products/Debug/TestPkg \
+      | grep -o "[-+]\[.*\]" > objc_symbols_with_linker_flag.txt
+
+# Compare the two text files to see if the -ObjC linker flag has any effect.
+DIFF=$(diff objc_symbols_without_linker_flag.txt objc_symbols_with_linker_flag.txt)
+if [ "$DIFF" != "" ]; then
+    echo "Failure: Unlinked Objective-C symbols have been detected:"
+    echo "$DIFF"
+    exit 1
+else
+    echo "Success: No unlinked Objective-C symbols have been detected."
+    exit 0
+fi

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -114,7 +114,8 @@ cd $TEST_PKG_ROOT
 echo "Building test package without -ObjC linker flag..."
 FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
 xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
-      -derivedDataPath '~/Library/Developer/Xcode/DerivedData/TestPkg'
+      -derivedDataPath '~/Library/Developer/Xcode/DerivedData/TestPkg' \
+      || exit 1
 
 nm ~/Library/Developer/Xcode/DerivedData/TestPkg/Build/Products/Debug/TestPkg \
       | grep -o "[-+]\[.*\]" > objc_symbols_without_linker_flag.txt
@@ -125,7 +126,8 @@ echo "Building test package with -ObjC linker flag..."
 FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
 xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
       -derivedDataPath '~/Library/Developer/Xcode/DerivedData/TestPkg-ObjC' \
-      OTHER_LDFLAGS='-ObjC'
+      OTHER_LDFLAGS='-ObjC' \
+      || exit 1
 
 nm ~/Library/Developer/Xcode/DerivedData/TestPkg-ObjC/Build/Products/Debug/TestPkg \
       | grep -o "[-+]\[.*\]" > objc_symbols_with_linker_flag.txt

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -34,6 +34,8 @@
 #
 # USAGE: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>
 
+set -euo pipefail
+
 if [[ $# -ne 2 ]]; then
     echo "Usage: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>"
     exit 1
@@ -127,7 +129,7 @@ echo "Building test package without -ObjC linker flag..."
 FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
 xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
       -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/TestPkg" \
-      || exit 1
+      | xcpretty
 
 nm ~/Library/Developer/Xcode/DerivedData/TestPkg/Build/Products/Debug/TestPkg \
       | grep -o "[-+]\[.*\]" > objc_symbols_without_linker_flag.txt
@@ -139,7 +141,7 @@ FIREBASECI_USE_LOCAL_FIRESTORE_ZIP=1 \
 xcodebuild -scheme 'TestPkg' -destination 'generic/platform=macOS' \
       -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/TestPkg-ObjC" \
       OTHER_LDFLAGS='-ObjC' \
-      || exit 1
+      | xcpretty
 
 nm ~/Library/Developer/Xcode/DerivedData/TestPkg-ObjC/Build/Products/Debug/TestPkg \
       | grep -o "[-+]\[.*\]" > objc_symbols_with_linker_flag.txt

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -20,6 +20,18 @@
 # function without clients needing to pass the `-ObjC`, this script catches
 # potential regressions that break that requirement.
 #
+# DEPENDENCIES: This script depends on the given Firebase repo's `Package.swift`
+# using the `FIREBASECI_USE_LOCAL_FIRESTORE_ZIP` env var to swap the Firestore
+# target definition out to instead reference a *local* binary using the
+# `.binaryTarget(path:)` API.
+#
+# DESIGN: This script creates an executable package that depends on Firestore
+# via a local binary SPM target. The package is built twice, once with the
+# -ObjC flag and once without. The linked Objective-C symbols are then
+# stripped from each build's resulting executable. The symbols are then diffed
+# to determine if there exists symbols that were only linked due to the -ObjC
+# flag.
+#
 # USAGE: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>
 
 if [ $# -ne 2 ]; then

--- a/scripts/check_firestore_symbols.sh
+++ b/scripts/check_firestore_symbols.sh
@@ -36,12 +36,6 @@
 
 set -euo pipefail
 
-echo "About to call xcpretty"
-xcpretty --help
-echo "Called xcpretty"
-
-exit 1
-
 if [[ $# -ne 2 ]]; then
     echo "Usage: ./check_firestore_symbols.sh <PATH_TO_FIREBASE_REPO> <PATH_TO_FIRESTORE_XCFRAMEWORK>"
     exit 1


### PR DESCRIPTION
### Context
- Creates a workflow job to test for regressions within the `FirebaseFirestore.xcframework` where an unreferenced symbol is introduced.
- Tried writing in Swift but running xcodebuild via `Process` became a flaky headache.
- Unblocks #10896 

### Testing Plan
- As long as #10896 isn't merged, Firestore contains unlinked symbols. This workflow should pick them up and cause a failure. Once this PR is merged, I will rebase `#10896` on top of `master` and re-run CI. `#10896` should fix the failures. 
- There are some additional edge cases that I will introduce in a separate PR for the purpose of testing against this workflow.

#no-changelog