### PR TITLE
Reorganize OR query test

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -1051,8 +1051,7 @@
 - (void)testMultipleInOps {
   // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
-            "Skip this test if running against production because order-by-equality is not "
-            "supported yet.");
+            "Skip this test if running against production because it's not yet supported.");
 
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @0},

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -913,49 +913,16 @@
   ]];
   [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter4] matchesResult:@[ @"doc3" ]];
 
-  // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
-  FIRFilter *filter5 = [FIRFilter orFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
-                                                                  isGreaterThan:@0]
-  ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter5] queryLimitedTo:2]
-                     matchesResult:@[ @"doc1", @"doc2" ]];
-
-  // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
-  // Note: The public query API does not allow implicit ordering when limitToLast is used.
-  FIRFilter *filter6 = [FIRFilter orFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
-                                                                  isGreaterThan:@0]
-  ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter6] queryLimitedToLast:2]
-                                       queryOrderedByField:@"b"]
-                     matchesResult:@[ @"doc3", @"doc4" ]];
-
-  // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
-  FIRFilter *filter7 = [FIRFilter orFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
-  ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter7] queryLimitedTo:1]
-                                       queryOrderedByField:@"a"]
-                     matchesResult:@[ @"doc5" ]];
-
-  // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
-  FIRFilter *filter8 = [FIRFilter orFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
-  ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter8] queryLimitedToLast:1]
-                                       queryOrderedByField:@"a"]
-                     matchesResult:@[ @"doc2" ]];
-
   // Test with limits without orderBy (the __name__ ordering is the tie breaker).
-  FIRFilter *filter9 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter5 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
   ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter9] queryLimitedTo:1]
+  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter5] queryLimitedTo:1]
                      matchesResult:@[ @"doc2" ]];
 }
 
 - (void)testOrQueriesWithCompositeIndexes {
+  // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test if running against production because order-by-equality is not "
             "supported yet.");
@@ -969,12 +936,46 @@
   }];
 
   // with one inequality: a>2 || b==1.
-  FIRFilter *filter = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter1 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isGreaterThan:@2], [FIRFilter filterWhereField:@"b"
                                                                           isEqualTo:@1]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter1]
                      matchesResult:@[ @"doc5", @"doc2", @"doc3" ]];
+
+  // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
+  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
+    [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
+                                                                  isGreaterThan:@0]
+  ]];
+  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter2] queryLimitedTo:2]
+                     matchesResult:@[ @"doc1", @"doc2" ]];
+
+  // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
+  // Note: The public query API does not allow implicit ordering when limitToLast is used.
+  FIRFilter *filter3 = [FIRFilter orFilterWithFilters:@[
+    [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
+                                                                  isGreaterThan:@0]
+  ]];
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter3] queryLimitedToLast:2]
+                                       queryOrderedByField:@"b"]
+                     matchesResult:@[ @"doc3", @"doc4" ]];
+
+  // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
+  FIRFilter *filter4 = [FIRFilter orFilterWithFilters:@[
+    [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
+  ]];
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter4] queryLimitedTo:1]
+                                       queryOrderedByField:@"a"]
+                     matchesResult:@[ @"doc5" ]];
+
+  // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
+  FIRFilter *filter5 = [FIRFilter orFilterWithFilters:@[
+    [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
+  ]];
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter5] queryLimitedToLast:1]
+                                       queryOrderedByField:@"a"]
+                     matchesResult:@[ @"doc2" ]];
 }
 
 - (void)testOrQueriesWithIn {
@@ -996,9 +997,10 @@
 }
 
 - (void)testOrQueriesWithNotIn {
+  // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
-            "Skip this test if running against production because order-by-equality is not "
-            "supported yet.");
+            "Skip this test if running against production because it results in a 'missing index' "
+            "error. The Firestore Emulator, however, does serve these queries");
 
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @0},
@@ -1047,6 +1049,7 @@
 }
 
 - (void)testMultipleInOps {
+  // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test if running against production because order-by-equality is not "
             "supported yet.");
@@ -1065,8 +1068,8 @@
     [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"b"
                                                                                in:@[ @0, @2 ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter1] queryOrderedByField:@"a"]
-                     matchesResult:@[ @"doc1", @"doc6", @"doc3" ]];
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter1]
+                     matchesResult:@[ @"doc1", @"doc3", @"doc6" ]];
 
   // Two IN operations on the same field with disjunction.
   // a IN [0,3] || a IN [0,2] should union them (similar to: a IN [0,2,3]).
@@ -1079,6 +1082,7 @@
 }
 
 - (void)testUsingInWithArrayContainsAny {
+  // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test if running against production because it's not yet supported.");
 
@@ -1151,6 +1155,7 @@
 }
 
 - (void)testOrderByEquality {
+  // TODO(orquery): Enable this test against production when possible.
   XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test if running against production because order-by-equality is not "
             "supported yet.");

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -881,16 +881,8 @@
   [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter1]
                      matchesResult:@[ @"doc1", @"doc2", @"doc4", @"doc5" ]];
 
-  // with one inequality: a>2 || b==1.
-  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" isGreaterThan:@2], [FIRFilter filterWhereField:@"b"
-                                                                          isEqualTo:@1]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2]
-                     matchesResult:@[ @"doc5", @"doc2", @"doc3" ]];
-
   // (a==1 && b==0) || (a==3 && b==2)
-  FIRFilter *filter3 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter andFilterWithFilters:@[
       [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b" isEqualTo:@0]
     ]],
@@ -898,20 +890,20 @@
       [FIRFilter filterWhereField:@"a" isEqualTo:@3], [FIRFilter filterWhereField:@"b" isEqualTo:@2]
     ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter3]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2]
                      matchesResult:@[ @"doc1", @"doc3" ]];
 
   // a==1 && (b==0 || b==3).
-  FIRFilter *filter4 = [FIRFilter andFilterWithFilters:@[
+  FIRFilter *filter3 = [FIRFilter andFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter orFilterWithFilters:@[
       [FIRFilter filterWhereField:@"b" isEqualTo:@0], [FIRFilter filterWhereField:@"b" isEqualTo:@3]
     ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter4]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter3]
                      matchesResult:@[ @"doc1", @"doc4" ]];
 
   // (a==2 || b==2) && (a==3 || b==3)
-  FIRFilter *filter5 = [FIRFilter andFilterWithFilters:@[
+  FIRFilter *filter4 = [FIRFilter andFilterWithFilters:@[
     [FIRFilter orFilterWithFilters:@[
       [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@2]
     ]],
@@ -919,51 +911,73 @@
       [FIRFilter filterWhereField:@"a" isEqualTo:@3], [FIRFilter filterWhereField:@"b" isEqualTo:@3]
     ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter5] matchesResult:@[ @"doc3" ]];
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter4] matchesResult:@[ @"doc3" ]];
 
   // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
-  FIRFilter *filter6 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter5 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
                                                                   isGreaterThan:@0]
   ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter6] queryLimitedTo:2]
+  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter5] queryLimitedTo:2]
                      matchesResult:@[ @"doc1", @"doc2" ]];
 
   // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
   // Note: The public query API does not allow implicit ordering when limitToLast is used.
-  FIRFilter *filter7 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter6 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@1], [FIRFilter filterWhereField:@"b"
                                                                   isGreaterThan:@0]
   ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter7] queryLimitedToLast:2]
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter6] queryLimitedToLast:2]
                                        queryOrderedByField:@"b"]
                      matchesResult:@[ @"doc3", @"doc4" ]];
 
   // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
-  FIRFilter *filter8 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter7 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
   ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter8] queryLimitedTo:1]
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter7] queryLimitedTo:1]
                                        queryOrderedByField:@"a"]
                      matchesResult:@[ @"doc5" ]];
 
   // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
-  FIRFilter *filter9 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter8 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
   ]];
-  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter9] queryLimitedToLast:1]
+  [self checkOnlineAndOfflineQuery:[[[collRef queryWhereFilter:filter8] queryLimitedToLast:1]
                                        queryOrderedByField:@"a"]
                      matchesResult:@[ @"doc2" ]];
 
   // Test with limits without orderBy (the __name__ ordering is the tie breaker).
-  FIRFilter *filter10 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter9 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" isEqualTo:@1]
   ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter10] queryLimitedTo:1]
+  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter9] queryLimitedTo:1]
                      matchesResult:@[ @"doc2" ]];
 }
 
-- (void)testOrQueriesWithInAndNotIn {
+- (void)testOrQueriesWithCompositeIndexes {
+  XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test if running against production because order-by-equality is not "
+            "supported yet.");
+
+  FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
+    @"doc1" : @{@"a" : @1, @"b" : @0},
+    @"doc2" : @{@"a" : @2, @"b" : @1},
+    @"doc3" : @{@"a" : @3, @"b" : @2},
+    @"doc4" : @{@"a" : @1, @"b" : @3},
+    @"doc5" : @{@"a" : @1, @"b" : @1}
+  }];
+
+  // with one inequality: a>2 || b==1.
+  FIRFilter *filter = [FIRFilter orFilterWithFilters:@[
+    [FIRFilter filterWhereField:@"a" isGreaterThan:@2], [FIRFilter filterWhereField:@"b"
+                                                                          isEqualTo:@1]
+  ]];
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter]
+                     matchesResult:@[ @"doc5", @"doc2", @"doc3" ]];
+}
+
+- (void)testOrQueriesWithIn {
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @0},
     @"doc2" : @{@"b" : @1},
@@ -974,19 +988,34 @@
   }];
 
   // a==2 || b in [2,3]
-  FIRFilter *filter1 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b" in:@[ @2, @3 ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter1]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter]
                      matchesResult:@[ @"doc3", @"doc4", @"doc6" ]];
+}
+
+- (void)testOrQueriesWithNotIn {
+  XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test if running against production because order-by-equality is not "
+            "supported yet.");
+
+  FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
+    @"doc1" : @{@"a" : @1, @"b" : @0},
+    @"doc2" : @{@"b" : @1},
+    @"doc3" : @{@"a" : @3, @"b" : @2},
+    @"doc4" : @{@"a" : @1, @"b" : @3},
+    @"doc5" : @{@"a" : @1},
+    @"doc6" : @{@"a" : @2}
+  }];
 
   // a==2 || b not-in [2,3]
   // Has implicit orderBy b.
-  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" isEqualTo:@2], [FIRFilter filterWhereField:@"b"
                                                                           notIn:@[ @2, @3 ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter]
                      matchesResult:@[ @"doc1", @"doc2" ]];
 }
 
@@ -1018,6 +1047,10 @@
 }
 
 - (void)testMultipleInOps {
+  XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test if running against production because order-by-equality is not "
+            "supported yet.");
+
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @0},
     @"doc2" : @{@"b" : @1},
@@ -1035,63 +1068,20 @@
   [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter1] queryOrderedByField:@"a"]
                      matchesResult:@[ @"doc1", @"doc6", @"doc3" ]];
 
-  // Two IN operations on different fields with conjunction.
-  FIRFilter *filter2 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"b"
-                                                                               in:@[ @0, @2 ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[[collRef queryWhereFilter:filter2] queryOrderedByField:@"a"]
-                     matchesResult:@[ @"doc3" ]];
-
-  // Two IN operations on the same field.
-  // a IN [1,2,3] && a IN [0,1,4] should result in "a==1".
-  FIRFilter *filter3 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @1, @2, @3 ]],
-    [FIRFilter filterWhereField:@"a" in:@[ @0, @1, @4 ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter3]
-                     matchesResult:@[ @"doc1", @"doc4", @"doc5" ]];
-
-  // a IN [2,3] && a IN [0,1,4] is never true and so the result should be an empty set.
-  FIRFilter *filter4 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"a"
-                                                                               in:@[ @0, @1, @4 ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter4] matchesResult:@[]];
-
+  // Two IN operations on the same field with disjunction.
   // a IN [0,3] || a IN [0,2] should union them (similar to: a IN [0,2,3]).
-  FIRFilter *filter5 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter filterWhereField:@"a" in:@[ @0, @3 ]], [FIRFilter filterWhereField:@"a"
                                                                                in:@[ @0, @2 ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter5]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2]
                      matchesResult:@[ @"doc3", @"doc6" ]];
-
-  // Nested composite filter on the same field.
-  FIRFilter *filter6 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @1, @3 ]], [FIRFilter orFilterWithFilters:@[
-      [FIRFilter filterWhereField:@"a" in:@[ @0, @2 ]], [FIRFilter andFilterWithFilters:@[
-        [FIRFilter filterWhereField:@"b" isGreaterThanOrEqualTo:@1],
-        [FIRFilter filterWhereField:@"a" in:@[ @1, @3 ]]
-      ]]
-    ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter6]
-                     matchesResult:@[ @"doc3", @"doc4" ]];
-
-  // Nested composite filter on different fields.
-  FIRFilter *filter7 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"b" in:@[ @0, @3 ]], [FIRFilter orFilterWithFilters:@[
-      [FIRFilter filterWhereField:@"b" in:@[ @1 ]], [FIRFilter andFilterWithFilters:@[
-        [FIRFilter filterWhereField:@"b" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"a"
-                                                                                   in:@[ @1, @3 ]]
-      ]]
-    ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter7] matchesResult:@[ @"doc4" ]];
 }
 
-- (void)testUseInWithArrayContainsAny {
+- (void)testUsingInWithArrayContainsAny {
+  XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test if running against production because it's not yet supported.");
+
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @[ @0 ]},
     @"doc2" : @{@"b" : @[ @1 ]},
@@ -1108,30 +1098,15 @@
   [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter1]
                      matchesResult:@[ @"doc1", @"doc3", @"doc4", @"doc6" ]];
 
-  FIRFilter *filter2 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"b"
-                                                                 arrayContainsAny:@[ @0, @7 ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2] matchesResult:@[ @"doc3" ]];
-
-  FIRFilter *filter3 = [FIRFilter orFilterWithFilters:@[
+  FIRFilter *filter2 = [FIRFilter orFilterWithFilters:@[
     [FIRFilter andFilterWithFilters:@[
       [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter filterWhereField:@"c"
                                                                           isEqualTo:@10]
     ]],
     [FIRFilter filterWhereField:@"b" arrayContainsAny:@[ @0, @7 ]]
   ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter3]
+  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter2]
                      matchesResult:@[ @"doc1", @"doc3", @"doc4" ]];
-
-  FIRFilter *filter4 = [FIRFilter andFilterWithFilters:@[
-    [FIRFilter filterWhereField:@"a" in:@[ @2, @3 ]], [FIRFilter orFilterWithFilters:@[
-      [FIRFilter filterWhereField:@"b" arrayContainsAny:@[ @0, @7 ]],
-      [FIRFilter filterWhereField:@"c" isEqualTo:@20]
-    ]]
-  ]];
-  [self checkOnlineAndOfflineQuery:[collRef queryWhereFilter:filter4]
-                     matchesResult:@[ @"doc3", @"doc6" ]];
 }
 
 - (void)testUseInWithArrayContains {
@@ -1176,6 +1151,10 @@
 }
 
 - (void)testOrderByEquality {
+  XCTSkipIf(![FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test if running against production because order-by-equality is not "
+            "supported yet.");
+
   FIRCollectionReference *collRef = [self collectionRefWithDocuments:@{
     @"doc1" : @{@"a" : @1, @"b" : @[ @0 ]},
     @"doc2" : @{@"b" : @[ @1 ]},

--- a/Firestore/Swift/Tests/Integration/QueryIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/QueryIntegrationTests.swift
@@ -97,55 +97,20 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     checkOnlineAndOfflineQuery(collRef.whereFilter(filter4),
                                matchesResult: ["doc3"])
 
-    // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
-    let filter5 = Filter.orFilter(
-      [Filter.whereField("a", isEqualTo: 1),
-       Filter.whereField("b", isGreaterThan: 0)]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5).limit(to: 2),
-                               matchesResult: ["doc1", "doc2"])
-
-    // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
-    // Note: The public query API does not allow implicit ordering when limitToLast is used.
-    let filter6 = Filter.orFilter(
-      [Filter.whereField("a", isEqualTo: 1),
-       Filter.whereField("b", isGreaterThan: 0)]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter6)
-      .limit(toLast: 2)
-      .order(by: "b"),
-      matchesResult: ["doc3", "doc4"])
-
-    // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
-    let filter7 = Filter.orFilter(
-      [Filter.whereField("a", isEqualTo: 2),
-       Filter.whereField("b", isEqualTo: 1)]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter7).limit(to: 1)
-      .order(by: "a"),
-      matchesResult: ["doc5"])
-
-    // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
-    let filter8 = Filter.orFilter(
-      [Filter.whereField("a", isEqualTo: 2),
-       Filter.whereField("b", isEqualTo: 1)]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter8).limit(toLast: 1)
-      .order(by: "a"),
-      matchesResult: ["doc2"])
-
     // Test with limits without orderBy (the __name__ ordering is the tie breaker).
-    let filter9 = Filter.orFilter(
+    let filter5 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", isEqualTo: 1)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter9).limit(to: 1),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5).limit(to: 1),
                                matchesResult: ["doc2"])
   }
 
   func testOrQueriesWithCompositeIndexes() throws {
+    // TODO(orquery): Enable this test against production when possible.
     try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
-                  "Skip this test if running against production because it results in a 'missing index' error. The Firestore Emulator, however, does serve these queries.")
+                  "Skip this test if running against production because it results in" +
+                    "a 'missing index' error. The Firestore Emulator, however, does serve these queries.")
 
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": 0],
@@ -156,12 +121,49 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     )
 
     // with one inequality: a>2 || b==1.
-    let filter = Filter.orFilter(
+    let filter1 = Filter.orFilter(
       [Filter.whereField("a", isGreaterThan: 2),
        Filter.whereField("b", isEqualTo: 1)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter1),
                                matchesResult: ["doc5", "doc2", "doc3"])
+
+    // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
+    let filter2 = Filter.orFilter(
+      [Filter.whereField("a", isEqualTo: 1),
+       Filter.whereField("b", isGreaterThan: 0)]
+    )
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2).limit(to: 2),
+                               matchesResult: ["doc1", "doc2"])
+
+    // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
+    // Note: The public query API does not allow implicit ordering when limitToLast is used.
+    let filter3 = Filter.orFilter(
+      [Filter.whereField("a", isEqualTo: 1),
+       Filter.whereField("b", isGreaterThan: 0)]
+    )
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter3)
+      .limit(toLast: 2)
+      .order(by: "b"),
+      matchesResult: ["doc3", "doc4"])
+
+    // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
+    let filter4 = Filter.orFilter(
+      [Filter.whereField("a", isEqualTo: 2),
+       Filter.whereField("b", isEqualTo: 1)]
+    )
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter4).limit(to: 1)
+      .order(by: "a"),
+      matchesResult: ["doc5"])
+
+    // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
+    let filter5 = Filter.orFilter(
+      [Filter.whereField("a", isEqualTo: 2),
+       Filter.whereField("b", isEqualTo: 1)]
+    )
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5).limit(toLast: 1)
+      .order(by: "a"),
+      matchesResult: ["doc2"])
   }
 
   func testOrQueriesWithIn() throws {
@@ -184,8 +186,10 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testOrQueriesWithNotIn() throws {
+    // TODO(orquery): Enable this test against production when possible.
     try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
-                  "Skip this test if running against production because it results in a 'missing index' error. The Firestore Emulator, however, does serve these queries")
+                  "Skip this test if running against production because it results in " +
+                    "a 'missing index' error. The Firestore Emulator, however, does serve these queries")
 
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": 0],
@@ -234,6 +238,7 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testMultipleInOps() throws {
+    // TODO(orquery): Enable this test against production when possible.
     try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
                   "Skip this test if running against production because it's not yet supported.")
 
@@ -265,6 +270,7 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testUsingInWithArrayContainsAny() throws {
+    // TODO(orquery): Enable this test against production when possible.
     try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
                   "Skip this test if running against production because it's not yet supported.")
 
@@ -341,6 +347,7 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testOrderByEquality() throws {
+    // TODO(orquery): Enable this test against production when possible.
     try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
                   "Skip this test if running against production because order-by-equality is not supported yet.")
 

--- a/Firestore/Swift/Tests/Integration/QueryIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/QueryIntegrationTests.swift
@@ -58,16 +58,8 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     checkOnlineAndOfflineQuery(collRef.whereFilter(filter1),
                                matchesResult: ["doc1", "doc2", "doc4", "doc5"])
 
-    // with one inequality: a>2 || b==1.
-    let filter2 = Filter.orFilter(
-      [Filter.whereField("a", isGreaterThan: 2),
-       Filter.whereField("b", isEqualTo: 1)]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
-                               matchesResult: ["doc5", "doc2", "doc3"])
-
     // (a==1 && b==0) || (a==3 && b==2)
-    let filter3 = Filter.orFilter(
+    let filter2 = Filter.orFilter(
       [Filter.andFilter(
         [Filter.whereField("a", isEqualTo: 1),
          Filter.whereField("b", isEqualTo: 0)]
@@ -77,22 +69,22 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
          Filter.whereField("b", isEqualTo: 2)]
       )]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter3),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
                                matchesResult: ["doc1", "doc3"])
 
     // a==1 && (b==0 || b==3).
-    let filter4 = Filter.andFilter(
+    let filter3 = Filter.andFilter(
       [Filter.whereField("a", isEqualTo: 1),
        Filter.orFilter(
          [Filter.whereField("b", isEqualTo: 0),
           Filter.whereField("b", isEqualTo: 3)]
        )]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter4),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter3),
                                matchesResult: ["doc1", "doc4"])
 
     // (a==2 || b==2) && (a==3 || b==3)
-    let filter5 = Filter.andFilter(
+    let filter4 = Filter.andFilter(
       [Filter.orFilter(
         [Filter.whereField("a", isEqualTo: 2),
          Filter.whereField("b", isEqualTo: 2)]
@@ -102,56 +94,77 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
          Filter.whereField("b", isEqualTo: 3)]
       )]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter4),
                                matchesResult: ["doc3"])
 
     // Test with limits (implicit order by ASC): (a==1) || (b > 0) LIMIT 2
-    let filter6 = Filter.orFilter(
+    let filter5 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 1),
        Filter.whereField("b", isGreaterThan: 0)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter6).limit(to: 2),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5).limit(to: 2),
                                matchesResult: ["doc1", "doc2"])
 
     // Test with limits (explicit order by): (a==1) || (b > 0) LIMIT_TO_LAST 2
     // Note: The public query API does not allow implicit ordering when limitToLast is used.
-    let filter7 = Filter.orFilter(
+    let filter6 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 1),
        Filter.whereField("b", isGreaterThan: 0)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter7)
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter6)
       .limit(toLast: 2)
       .order(by: "b"),
       matchesResult: ["doc3", "doc4"])
 
     // Test with limits (explicit order by ASC): (a==2) || (b == 1) ORDER BY a LIMIT 1
-    let filter8 = Filter.orFilter(
+    let filter7 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", isEqualTo: 1)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter8).limit(to: 1)
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter7).limit(to: 1)
       .order(by: "a"),
       matchesResult: ["doc5"])
 
     // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
-    let filter9 = Filter.orFilter(
+    let filter8 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", isEqualTo: 1)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter9).limit(toLast: 1)
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter8).limit(toLast: 1)
       .order(by: "a"),
       matchesResult: ["doc2"])
 
     // Test with limits without orderBy (the __name__ ordering is the tie breaker).
-    let filter10 = Filter.orFilter(
+    let filter9 = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", isEqualTo: 1)]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter10).limit(to: 1),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter9).limit(to: 1),
                                matchesResult: ["doc2"])
   }
 
-  func testOrQueriesWithInAndNotIn() throws {
+  func testOrQueriesWithCompositeIndexes() throws {
+    try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
+                  "Skip this test if running against production because it results in a 'missing index' error. The Firestore Emulator, however, does serve these queries.")
+
+    let collRef = collectionRef(
+      withDocuments: ["doc1": ["a": 1, "b": 0],
+                      "doc2": ["a": 2, "b": 1],
+                      "doc3": ["a": 3, "b": 2],
+                      "doc4": ["a": 1, "b": 3],
+                      "doc5": ["a": 1, "b": 1]]
+    )
+
+    // with one inequality: a>2 || b==1.
+    let filter = Filter.orFilter(
+      [Filter.whereField("a", isGreaterThan: 2),
+       Filter.whereField("b", isEqualTo: 1)]
+    )
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter),
+                               matchesResult: ["doc5", "doc2", "doc3"])
+  }
+
+  func testOrQueriesWithIn() throws {
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": 0],
                       "doc2": ["b": 1],
@@ -162,20 +175,34 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     )
 
     // a==2 || b in [2,3]
-    let filter1 = Filter.orFilter(
+    let filter = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", in: [2, 3])]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter1),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter),
                                matchesResult: ["doc3", "doc4", "doc6"])
+  }
+
+  func testOrQueriesWithNotIn() throws {
+    try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
+                  "Skip this test if running against production because it results in a 'missing index' error. The Firestore Emulator, however, does serve these queries")
+
+    let collRef = collectionRef(
+      withDocuments: ["doc1": ["a": 1, "b": 0],
+                      "doc2": ["b": 1],
+                      "doc3": ["a": 3, "b": 2],
+                      "doc4": ["a": 1, "b": 3],
+                      "doc5": ["a": 1],
+                      "doc6": ["a": 2]]
+    )
 
     // a==2 || b not-in [2,3]
     // Has implicit orderBy b.
-    let filter2 = Filter.orFilter(
+    let filter = Filter.orFilter(
       [Filter.whereField("a", isEqualTo: 2),
        Filter.whereField("b", notIn: [2, 3])]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter),
                                matchesResult: ["doc1", "doc2"])
   }
 
@@ -207,6 +234,9 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testMultipleInOps() throws {
+    try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
+                  "Skip this test if running against production because it's not yet supported.")
+
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": 0],
                       "doc2": ["b": 1],
@@ -224,69 +254,20 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     checkOnlineAndOfflineQuery(collRef.whereFilter(filter1).order(by: "a"),
                                matchesResult: ["doc1", "doc6", "doc3"])
 
-    // Two IN operations on different fields with conjunction.
-    let filter2 = Filter.andFilter(
-      [Filter.whereField("a", in: [2, 3]),
-       Filter.whereField("b", in: [0, 2])]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2).order(by: "a"),
-                               matchesResult: ["doc3"])
-
-    // Two IN operations on the same field.
-    // a IN [1,2,3] && a IN [0,1,4] should result in "a==1".
-    let filter3 = Filter.andFilter(
-      [Filter.whereField("a", in: [1, 2, 3]),
-       Filter.whereField("a", in: [0, 1, 4])]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter3),
-                               matchesResult: ["doc1", "doc4", "doc5"])
-
-    // a IN [2,3] && a IN [0,1,4] is never true and so the result should be an empty set.
-    let filter4 = Filter.andFilter(
-      [Filter.whereField("a", in: [2, 3]),
-       Filter.whereField("a", in: [0, 1, 4])]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter4),
-                               matchesResult: [])
-
+    // Two IN operations on same fields with disjunction.
     // a IN [0,3] || a IN [0,2] should union them (similar to: a IN [0,2,3]).
-    let filter5 = Filter.orFilter(
+    let filter2 = Filter.orFilter(
       [Filter.whereField("a", in: [0, 3]),
        Filter.whereField("a", in: [0, 2])]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter5),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
                                matchesResult: ["doc3", "doc6"])
-
-    // Nested composite filter on the same field.
-    let filter6 = Filter.andFilter(
-      [Filter.whereField("a", in: [1, 3]),
-       Filter.orFilter(
-         [Filter.whereField("a", in: [0, 2]),
-          Filter.andFilter(
-            [Filter.whereField("b", isGreaterOrEqualTo: 1),
-             Filter.whereField("a", in: [1, 3])]
-          )]
-       )]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter6),
-                               matchesResult: ["doc3", "doc4"])
-
-    // Nested composite filter on different fields.
-    let filter7 = Filter.andFilter(
-      [Filter.whereField("b", in: [0, 3]),
-       Filter.orFilter(
-         [Filter.whereField("b", in: [1]),
-          Filter.andFilter(
-            [Filter.whereField("b", in: [2, 3]),
-             Filter.whereField("a", in: [1, 3])]
-          )]
-       )]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter7),
-                               matchesResult: ["doc4"])
   }
 
-  func testUseInWithArrayContainsAny() throws {
+  func testUsingInWithArrayContainsAny() throws {
+    try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
+                  "Skip this test if running against production because it's not yet supported.")
+
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": [0]],
                       "doc2": ["b": [1]],
@@ -303,32 +284,15 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
     checkOnlineAndOfflineQuery(collRef.whereFilter(filter1),
                                matchesResult: ["doc1", "doc3", "doc4", "doc6"])
 
-    let filter2 = Filter.andFilter(
-      [Filter.whereField("a", in: [2, 3]),
-       Filter.whereField("b", arrayContainsAny: [0, 7])]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
-                               matchesResult: ["doc3"])
-
-    let filter3 = Filter.orFilter(
+    let filter2 = Filter.orFilter(
       [Filter.andFilter(
         [Filter.whereField("a", in: [2, 3]),
          Filter.whereField("c", isEqualTo: 10)]
       ),
       Filter.whereField("b", arrayContainsAny: [0, 7])]
     )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter3),
+    checkOnlineAndOfflineQuery(collRef.whereFilter(filter2),
                                matchesResult: ["doc1", "doc3", "doc4"])
-
-    let filter4 = Filter.andFilter(
-      [Filter.whereField("a", in: [2, 3]),
-       Filter.orFilter(
-         [Filter.whereField("b", arrayContainsAny: [0, 7]),
-          Filter.whereField("c", isEqualTo: 20)]
-       )]
-    )
-    checkOnlineAndOfflineQuery(collRef.whereFilter(filter4),
-                               matchesResult: ["doc3", "doc6"])
   }
 
   func testUseInWithArrayContains() throws {
@@ -377,6 +341,9 @@ class QueryIntegrationTests: FSTIntegrationTestCase {
   }
 
   func testOrderByEquality() throws {
+    try XCTSkipIf(!FSTIntegrationTestCase.isRunningAgainstEmulator(),
+                  "Skip this test if running against production because order-by-equality is not supported yet.")
+
     let collRef = collectionRef(
       withDocuments: ["doc1": ["a": 1, "b": [0]],
                       "doc2": ["b": [1]],


### PR DESCRIPTION
#no-changelog