### PR TITLE
[auth-swift] Type safety and naming

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -77,7 +77,7 @@ public class AuthBackendRPCIssuerImplementation: NSObject, AuthBackendRPCIssuer 
   class func setDefaultBackendImplementationWithRPCIssuer(issuer: AuthBackendRPCIssuer?) {
     let defaultImplementation = AuthBackendRPCImplementation()
     if let issuer = issuer {
-      defaultImplementation.RPCIssuer = issuer
+      defaultImplementation.rpcIssuer = issuer
     }
     gBackendImplementation = defaultImplementation
   }
@@ -145,9 +145,9 @@ protocol AuthBackendImplementation {
 }
 
 private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation {
-  var RPCIssuer: AuthBackendRPCIssuer
+  var rpcIssuer: AuthBackendRPCIssuer
   override init() {
-    RPCIssuer = AuthBackendRPCIssuerImplementation()
+    rpcIssuer = AuthBackendRPCIssuerImplementation()
   }
 
   /** @fn postWithRequest:response:callback:
@@ -281,7 +281,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
         return
       }
     }
-    RPCIssuer
+    rpcIssuer
       .asyncPostToURL(withRequest: request, body: bodyData, contentType: "application/json") {
         data, error in
         // If there is an error with no body data at all, then this must be a
@@ -297,12 +297,12 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
         }
         // Try to decode the HTTP response data which may contain either a
         // successful response or error message.
-        var dictionary: [String: Any]
+        var dictionary: [String: AnyHashable]
         do {
           let rawDecode = try JSONSerialization.jsonObject(with: data,
                                                            options: JSONSerialization.ReadingOptions
                                                              .mutableLeaves)
-          guard let decodedDictionary = rawDecode as? [String: Any] else {
+          guard let decodedDictionary = rawDecode as? [String: AnyHashable] else {
             if error != nil {
               callback(AuthErrorUtils.unexpectedErrorResponse(deserializedResponse: rawDecode,
                                                               underlyingError: error))
@@ -334,7 +334,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
         // case where we have an error with successfully decoded error details
         // first:
         if error != nil {
-          if let errorDictionary = dictionary["error"] as? [String: Any] {
+          if let errorDictionary = dictionary["error"] as? [String: AnyHashable] {
             if let errorMessage = errorDictionary["message"] as? String {
               if let clientError = AuthBackendRPCImplementation.clientError(
                 withServerErrorMessage: errorMessage,

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRPCRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRPCRequest.swift
@@ -40,7 +40,8 @@ import Foundation
       @param error An out field for an error which occurred constructing the request.
       @return The HTTP body data representing the request before any encoding, or nil for error.
    */
-  @objc(unencodedHTTPRequestBodyWithError:) func unencodedHTTPRequestBody() throws -> Any
+  @objc(unencodedHTTPRequestBodyWithError:)
+  func unencodedHTTPRequestBody() throws -> [String: AnyHashable]
 
   /** @fn requestConfiguration
       @brief Obtains the request configurations if available.

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRPCResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRPCResponse.swift
@@ -24,7 +24,7 @@ import Foundation
       @param error An out field for an error which occurred constructing the request.
       @return Whether the operation was successful or not.
    */
-  @objc(setWithDictionary:error:) func setFields(dictionary: [String: Any]) throws
+  @objc(setWithDictionary:error:) func setFields(dictionary: [String: AnyHashable]) throws
 
   /** @fn clientErrorWithshortErrorMessage:detailErrorMessage
       @brief This optional method allows response classes to create client errors given a short error

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
@@ -115,8 +115,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kCreateAuthURIEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [
       kIdentifierKey: identifier,
       kContinueURIKey: continueURI,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
@@ -50,7 +50,7 @@ import Foundation
    */
   @objc public var signinMethods: [String]?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     providerID = dictionary["providerId"] as? String
     authURI = dictionary["authUri"] as? String
     registered = dictionary["registered"] as? Bool ?? false

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountRequest.swift
@@ -55,7 +55,7 @@ private let kLocalIDKey = "localId"
     super.init(endpoint: kDeleteAccountEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     [
       kIDTokenKey: accessToken,
       kLocalIDKey: localID,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
@@ -19,5 +19,5 @@ import Foundation
     @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/deleteAccount
  */
 @objc(FIRDeleteAccountResponse) public class DeleteAccountResponse: NSObject, AuthRPCResponse {
-  public func setFields(dictionary: [String: Any]) throws {}
+  public func setFields(dictionary: [String: AnyHashable]) throws {}
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInRequest.swift
@@ -71,8 +71,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kEmailLinkSigninEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [
       kEmailKey: email,
       kOOBCodeKey: oobCode,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -54,7 +54,7 @@ import Foundation
    */
   @objc public var MFAInfo: [AuthProtoMFAEnrollment]?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
     IDToken = dictionary["idToken"] as? String
     isNewUser = dictionary["isNewUser"] as? Bool ?? false
@@ -64,7 +64,7 @@ import Foundation
       .flatMap { Date(timeIntervalSinceNow: ($0 as NSString).doubleValue)
       }
 
-    if let mfaInfoArray = dictionary["mfaInfo"] as? [[String: Any]] {
+    if let mfaInfoArray = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
       var mfaInfo: [AuthProtoMFAEnrollment] = []
       for entry in mfaInfoArray {
         let enrollment = AuthProtoMFAEnrollment(dictionary: entry)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
@@ -51,7 +51,7 @@ private let kIDTokenKey = "idToken"
     super.init(endpoint: kGetAccountInfoEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     return [kIDTokenKey: accessToken]
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
@@ -171,7 +171,7 @@ public class GetAccountInfoResponseProviderUserInfo: NSObject {
     emailVerified = dictionary["emailVerified"] as? Bool ?? false
     passwordHash = dictionary["passwordHash"] as? String
     phoneNumber = dictionary["phoneNumber"] as? String
-    if let MFAEnrollmentData = dictionary["mfaInfo"] as? [[String: Any]] {
+    if let MFAEnrollmentData = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
       MFAEnrollments = MFAEnrollmentData.map { AuthProtoMFAEnrollment(dictionary: $0)
       }
     } else {
@@ -189,8 +189,8 @@ public class GetAccountInfoResponseProviderUserInfo: NSObject {
    @brief The requested users' profiles.
    */
   @objc public var users: [GetAccountInfoResponseUser]?
-  public func setFields(dictionary: [String: Any]) throws {
-    guard let usersData = dictionary["users"] as? [[String: Any]] else {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
+    guard let usersData = dictionary["users"] as? [[String: AnyHashable]] else {
       throw AuthErrorUtils.unexpectedResponse(deserializedResponse: dictionary)
     }
     guard usersData.count == 1 else {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -284,8 +284,8 @@ public class GetOOBConfirmationCodeRequest: IdentityToolkitRequest,
          requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [
       kRequestTypeKey: requestType.value,
     ]
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeResponse.swift
@@ -20,7 +20,7 @@ private let kOOBCodeKey = "oobCode"
   AuthRPCResponse {
   @objc public var OOBCode: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     OOBCode = dictionary[kOOBCodeKey] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
@@ -30,7 +30,7 @@ private let kGetProjectConfigEndPoint = "getProjectConfig"
     super.init(endpoint: kGetProjectConfigEndPoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     // XXX TODO: Probably nicer to throw, but what should we throw?
     fatalError()
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigResponse.swift
@@ -26,7 +26,7 @@ import Foundation
    */
   @objc public var authorizedDomains: [String]?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     projectID = dictionary["projectId"] as? String
     if let authorizedDomains = dictionary["authorizedDomains"] as? String,
        let data = authorizedDomains.data(using: .utf8) {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
@@ -49,8 +49,8 @@ public class FinalizeMFAEnrollmentRequest: IdentityToolkitRequest,
     )
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [:]
     if let IDToken = IDToken {
       body["idToken"] = IDToken
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentResponse.swift
@@ -19,7 +19,7 @@ import Foundation
   @objc public var IDToken: String?
   @objc public var refreshToken: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     IDToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
@@ -44,8 +44,8 @@ private let kTenantIDKey = "tenantId"
     )
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [:]
     if let IDToken = IDToken {
       body["idToken"] = IDToken
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentResponse.swift
@@ -16,8 +16,8 @@ import Foundation
 
 @objc(FIRStartMFAEnrollmentResponse) public class StartMFAEnrollmentResponse: NSObject,
   AuthRPCResponse {
-  public func setFields(dictionary: [String: Any]) throws {
-    if let data = dictionary["phoneSessionInfo"] as? [String: Any] {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
+    if let data = dictionary["phoneSessionInfo"] as? [String: AnyHashable] {
       enrollmentResponse = AuthProtoStartMFAPhoneResponseInfo(dictionary: data)
     } else {
       fatalError()

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
@@ -42,8 +42,8 @@ private let kTenantIDKey = "tenantId"
                useStaging: false)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [:]
     if let MFAPendingCredential = MFAPendingCredential {
       body["mfaPendingCredential"] = MFAPendingCredential
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInResponse.swift
@@ -19,7 +19,7 @@ import Foundation
   @objc public var IDToken: String?
   @objc public var refreshToken: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     IDToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
@@ -46,8 +46,8 @@ private let kTenantIDKey = "tenantId"
     )
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [:]
     if let MFAPendingCredential = MFAPendingCredential {
       body["mfaPendingCredential"] = MFAPendingCredential
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInResponse.swift
@@ -17,8 +17,8 @@ import Foundation
 @objc(FIRStartMFASignInResponse) public class StartMFASignInResponse: NSObject, AuthRPCResponse {
   var responseInfo: AuthProtoStartMFAPhoneResponseInfo?
 
-  public func setFields(dictionary: [String: Any]) throws {
-    if let data = dictionary["phoneResponseInfo"] as? [String: Any] {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
+    if let data = dictionary["phoneResponseInfo"] as? [String: AnyHashable] {
       responseInfo = AuthProtoStartMFAPhoneResponseInfo(dictionary: data)
     } else {
       fatalError()

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
@@ -38,8 +38,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kWithdrawMFAEndPoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
     if let IDToken = IDToken {
       postBody["idToken"] = IDToken
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFAResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFAResponse.swift
@@ -18,7 +18,7 @@ import Foundation
   @objc public var IDToken: String?
   @objc public var refreshToken: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     IDToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProto.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProto.swift
@@ -15,6 +15,6 @@
 import Foundation
 
 @objc(FIRAuthProto) public protocol AuthProto: NSObjectProtocol {
-  @objc init(dictionary: [String: Any])
-  @objc optional var dictionary: [String: Any] { get }
+  @objc init(dictionary: [String: AnyHashable])
+  @objc optional var dictionary: [String: AnyHashable] { get }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
@@ -25,7 +25,7 @@ import Foundation
 
   public var dictionary: [String: Any]
 
-  public required init(dictionary: [String: Any]) {
+  public required init(dictionary: [String: AnyHashable]) {
     self.dictionary = dictionary
     phoneInfo = dictionary["phoneInfo"] as? String
     MFAEnrollmentID = dictionary["mfaEnrollmentId"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneRequestInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneRequestInfo.swift
@@ -17,7 +17,7 @@ import Foundation
 @objc(FIRAuthProtoFinalizeMFAPhoneRequestInfo)
 public class AuthProtoFinalizeMFAPhoneRequestInfo: NSObject,
   AuthProto {
-  public required init(dictionary: [String: Any]) {
+  public required init(dictionary: [String: AnyHashable]) {
     fatalError()
   }
 
@@ -28,8 +28,8 @@ public class AuthProtoFinalizeMFAPhoneRequestInfo: NSObject,
     code = verificationCode
   }
 
-  public var dictionary: [String: Any] {
-    var dict: [String: Any] = [:]
+  public var dictionary: [String: AnyHashable] {
+    var dict: [String: AnyHashable] = [:]
     if let sessionInfo = sessionInfo {
       dict["sessionInfo"] = sessionInfo
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneResponseInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneResponseInfo.swift
@@ -17,7 +17,7 @@ import Foundation
 public class AuthProtoFinalizeMFAPhoneResponseInfo: NSObject, AuthProto {
   var phoneNumber: String?
 
-  public required init(dictionary: [String: Any]) {
+  public required init(dictionary: [String: AnyHashable]) {
     phoneNumber = dictionary["phoneNumber"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoStartMFAPhoneRequestInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoStartMFAPhoneRequestInfo.swift
@@ -35,7 +35,7 @@ private let kSecretKey = "iosSecret"
 private let kreCAPTCHATokenKey = "recaptchaToken"
 
 class AuthProtoStartMFAPhoneRequestInfo: NSObject, AuthProto {
-  required init(dictionary: [String: Any]) {
+  required init(dictionary: [String: AnyHashable]) {
     fatalError()
   }
 
@@ -48,8 +48,8 @@ class AuthProtoStartMFAPhoneRequestInfo: NSObject, AuthProto {
     self.reCAPTCHAToken = reCAPTCHAToken
   }
 
-  var dictionary: [String: Any] {
-    var dict: [String: Any] = [:]
+  var dictionary: [String: AnyHashable] {
+    var dict: [String: AnyHashable] = [:]
     if let phoneNumber = phoneNumber {
       dict[kPhoneNumberKey] = phoneNumber
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoStartMFAPhoneResponseInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoStartMFAPhoneResponseInfo.swift
@@ -17,7 +17,7 @@ import Foundation
 class AuthProtoStartMFAPhoneResponseInfo: NSObject, AuthProto {
   var sessionInfo: String?
 
-  required init(dictionary: [String: Any]) {
+  required init(dictionary: [String: AnyHashable]) {
     sessionInfo = dictionary["sessionInfo"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordRequest.swift
@@ -64,8 +64,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kResetPasswordEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
 
     postBody[kOOBCodeKey] = oobCode
     if let updatedPassword {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordResponse.swift
@@ -40,7 +40,7 @@ import Foundation
    */
   @objc public var requestType: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
     requestType = dictionary["requestType"] as? String
     verifiedEmail = dictionary["newEmail"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -161,8 +161,8 @@ private var gAPIHost = "securetoken.googleapis.com"
 
   var containsPostBody: Bool { true }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [
       kGrantTypeKey: grantType.value,
     ]
     if let scope = scope {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenResponse.swift
@@ -39,7 +39,7 @@ private let kIDTokenKey = "id_token"
 
   var expectedKind: String? { nil }
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     refreshToken = dictionary[kRefreshTokenKey] as? String
     self.accessToken = dictionary[kAccessTokenKey] as? String
     IDToken = dictionary[kIDTokenKey] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenRequest.swift
@@ -79,8 +79,8 @@ public class SendVerificationCodeRequest: IdentityToolkitRequest,
     )
   }
 
-  @objc public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  @objc public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
     postBody[kPhoneNumberKey] = phoneNumber
     if let receipt = appCredential?.receipt {
       postBody[kReceiptKey] = receipt

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenResponse.swift
@@ -18,7 +18,7 @@ import Foundation
   AuthRPCResponse {
   @objc public var verificationID: String?
 
-  @objc public func setFields(dictionary: [String: Any]) throws {
+  @objc public func setFields(dictionary: [String: AnyHashable]) throws {
     verificationID = dictionary["sessionInfo"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
@@ -204,8 +204,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kSetAccountInfoEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
     if let accessToken {
       postBody[kIDTokenKey] = accessToken
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
@@ -85,7 +85,7 @@ public class SetAccountInfoResponseProviderUserInfo: NSObject {
    */
   @objc public var refreshToken: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
     displayName = dictionary["displayName"] as? String
     IDToken = dictionary["idToken"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterRequest.swift
@@ -102,8 +102,8 @@ public class SignInWithGameCenterRequest: IdentityToolkitRequest,
     )
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [
       "playerId": playerID,
       "publicKeyUrl": publicKeyURL.absoluteString,
       "signature": signature.base64URLEncodedString(),

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterResponse.swift
@@ -26,7 +26,7 @@ import Foundation
   @objc public var isNewUser: Bool = false
   @objc public var displayName: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     IDToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
     localID = dictionary["localId"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
@@ -90,8 +90,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kSignupNewUserEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
     if let email {
       postBody[kEmailKey] = email
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserResponse.swift
@@ -32,7 +32,7 @@ import Foundation
    */
   @objc public var refreshToken: String?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     IDToken = dictionary["idToken"] as? String
     if let approximateExpirationDate = dictionary["expiresIn"] as? String {
       self

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
@@ -184,7 +184,7 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kVerifyAssertionEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     var components = URLComponents()
     var queryItems: [URLQueryItem] = [URLQueryItem(name: kProviderIDKey, value: providerID)]
     if let providerIDToken = providerIDToken {
@@ -212,7 +212,7 @@ private let kTenantIDKey = "tenantId"
 
     components.queryItems = queryItems
 
-    var body: [String: Any] = [
+    var body: [String: AnyHashable] = [
       kRequestURIKey: requestURI ?? "http://localhost", // Unused by server, but required
     ]
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -203,7 +203,7 @@ import Foundation
 
   @objc public var MFAInfo: [AuthProtoMFAEnrollment]?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     federatedID = dictionary["federatedId"] as? String
     providerID = dictionary["providerId"] as? String
     localID = dictionary["localId"] as? String
@@ -264,7 +264,7 @@ import Foundation
     oauthSecretToken = dictionary["oauthTokenSecret"] as? String
     pendingToken = dictionary["pendingToken"] as? String
 
-    if let mfaInfoDicts = dictionary["mfaInfo"] as? [[String: Any]] {
+    if let mfaInfoDicts = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
       MFAInfo = mfaInfoDicts.map {
         AuthProtoMFAEnrollment(dictionary: $0)
       }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenRequest.swift
@@ -51,8 +51,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kVerifyCustomTokenEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [
       kTokenKey: token,
     ]
     if returnSecureToken {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenResponse.swift
@@ -41,7 +41,7 @@ import Foundation
    */
   @objc public var isNewUser: Bool = false
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     idToken = dictionary["idToken"] as? String
     if let dateString = dictionary["expiresIn"] as? NSString {
       approximateExpirationDate = Date(timeIntervalSinceNow: dateString.doubleValue)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
@@ -104,8 +104,8 @@ private let kTenantIDKey = "tenantId"
     super.init(endpoint: kVerifyPasswordEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var body: [String: Any] = [
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var body: [String: AnyHashable] = [
       kEmailKey: email,
       kPasswordKey: password,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
@@ -64,7 +64,7 @@ import Foundation
 
   @objc public var MFAInfo: [AuthProtoMFAEnrollment]?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     localID = dictionary["localId"] as? String
     email = dictionary["email"] as? String
     displayName = dictionary["displayName"] as? String
@@ -76,7 +76,7 @@ import Foundation
     refreshToken = dictionary["refreshToken"] as? String
     photoURL = (dictionary["photoUrl"] as? String).flatMap { URL(string: $0) }
 
-    if let mfaInfo = dictionary["mfaInfo"] as? [[String: Any]] {
+    if let mfaInfo = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
       MFAInfo = mfaInfo.map { AuthProtoMFAEnrollment(dictionary: $0) }
     }
     MFAPendingCredential = dictionary["mfaPendingCredential"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
@@ -146,8 +146,8 @@ extension AuthOperationType {
     super.init(endpoint: kVerifyPhoneNumberEndPoint, requestConfiguration: requestConfiguration)
   }
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody: [String: Any] = [:]
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody: [String: AnyHashable] = [:]
     if let verificationID {
       postBody[kVerificationIDKey] = verificationID
     }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberResponse.swift
@@ -59,7 +59,7 @@ import Foundation
     nil
   }
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     idToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
     isNewUser = (dictionary["isNewUser"] as? Bool) ?? false

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
@@ -30,8 +30,8 @@ public class VerifyClientRequest: IdentityToolkitRequest, AuthRPCRequest {
    */
   @objc public var response: AuthRPCResponse = VerifyClientResponse()
 
-  public func unencodedHTTPRequestBody() throws -> Any {
-    var postBody = [String: Any]()
+  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+    var postBody = [String: AnyHashable]()
     if let appToken = appToken {
       postBody[Self.appTokenKey] = appToken
     }

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientResponse.swift
@@ -22,7 +22,7 @@ public class VerifyClientResponse: NSObject, AuthRPCResponse {
   /// The date after which delivery of the silent push notification is considered to have failed.
   @objc public private(set) var suggestedTimeOutDate: Date?
 
-  public func setFields(dictionary: [String: Any]) throws {
+  public func setFields(dictionary: [String: AnyHashable]) throws {
     receipt = dictionary["receipt"] as? String
     let suggestedTimeout = dictionary["suggestedTimeout"]
     if let string = suggestedTimeout as? String,

--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -109,7 +109,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(withData: nil, error: responseError)
+    try rpcIssuer?.respond(withData: nil, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -145,7 +145,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     }
     let data = "<html><body>An error occurred.</body></html>".data(using: .utf8)
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(withData: data, error: responseError)
+    try rpcIssuer?.respond(withData: data, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -185,7 +185,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let data = "<xml>Some non-JSON value.</xml>".data(using: .utf8)
-    try RPCIssuer?.respond(withData: data, error: nil)
+    try rpcIssuer?.respond(withData: data, error: nil)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -230,7 +230,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     // this array later in the test.
     let data = "[]".data(using: .utf8)
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(withData: data, error: responseError)
+    try rpcIssuer?.respond(withData: data, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -276,7 +276,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     // successfully decode this value, however, we do return it in the error results. We check for
     // this array later in the test.
     let data = "[]".data(using: .utf8)
-    try RPCIssuer?.respond(withData: data, error: nil)
+    try rpcIssuer?.respond(withData: data, error: nil)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -315,7 +315,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(serverErrorMessage: kErrorMessageCaptchaRequired, error: responseError)
+    try rpcIssuer?.respond(serverErrorMessage: kErrorMessageCaptchaRequired, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -357,7 +357,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(
+    try rpcIssuer?.respond(
       serverErrorMessage: kErrorMessageCaptchaCheckFailed,
       error: responseError
     )
@@ -390,7 +390,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(serverErrorMessage: kErrorMessageCaptchaRequiredInvalidPassword,
+    try rpcIssuer?.respond(serverErrorMessage: kErrorMessageCaptchaRequiredInvalidPassword,
                            error: responseError)
 
     XCTAssert(callbackInvoked)
@@ -436,7 +436,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     // We need to return a valid "error" response here, but we are going to intentionally use a bogus
     // error message.
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(serverErrorMessage: kUnknownServerErrorMessage, error: responseError)
+    try rpcIssuer?.respond(serverErrorMessage: kUnknownServerErrorMessage, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -478,7 +478,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcError = error as? NSError
     }
     let responseError = NSError(domain: kFakeErrorDomain, code: kFakeErrorCode)
-    try RPCIssuer?.respond(withJSON: [:], error: responseError)
+    try rpcIssuer?.respond(withJSON: [:], error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -520,7 +520,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     let kFakeUserDisabledCustomErrorMessage = "The user has been disabled."
     let customErrorMessage = "\(kUserDisabledErrorMessage)" +
       "\(kServerErrorDetailMarker)\(kFakeUserDisabledCustomErrorMessage)"
-    try RPCIssuer?.respond(serverErrorMessage: customErrorMessage, error: responseError)
+    try rpcIssuer?.respond(serverErrorMessage: customErrorMessage, error: responseError)
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -550,7 +550,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       rpcResponse = response as? FakeResponse
       rpcError = error as? NSError
     }
-    try RPCIssuer?.respond(withJSON: [:])
+    try rpcIssuer?.respond(withJSON: [:])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
@@ -587,7 +587,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     // It doesn't matter what we respond with here, as long as it's not an error response. The fake
     // response will deterministicly simulate a decoding error regardless of the response value it was
     // given.
-    try RPCIssuer?.respond(withJSON: [kTestKey: kTestValue])
+    try rpcIssuer?.respond(withJSON: [kTestKey: kTestValue])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcError)
@@ -645,7 +645,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     let expectedHeader = FIRHeaderValueFromHeartbeatsPayload(
       HeartbeatLoggingTestUtils.nonEmptyHeartbeatsPayload
     )
-    let completeRequest = try XCTUnwrap(RPCIssuer?.completeRequest)
+    let completeRequest = try XCTUnwrap(rpcIssuer?.completeRequest)
     let headerValue = completeRequest.value(forHTTPHeaderField: "X-Firebase-Client")
     XCTAssertEqual(headerValue, expectedHeader)
   }
@@ -674,7 +674,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     }
 
     // Then
-    let completeRequest = try XCTUnwrap(RPCIssuer?.completeRequest)
+    let completeRequest = try XCTUnwrap(rpcIssuer?.completeRequest)
     XCTAssertNil(completeRequest.value(forHTTPHeaderField: "X-Firebase-Client"))
   }
 
@@ -688,7 +688,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       return try! XCTUnwrap(URL(string: kFakeRequestURL))
     }
 
-    func unencodedHTTPRequestBody() throws -> Any {
+    func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
       if let encodingError {
         throw encodingError
       }
@@ -737,12 +737,12 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
   private class FakeResponse: NSObject, AuthRPCResponse {
     let decodingError: NSError?
-    var receivedDictionary: [String: Any] = [:]
+    var receivedDictionary: [String: AnyHashable] = [:]
     init(withDecodingError error: NSError? = nil) {
       decodingError = error
     }
 
-    func setFields(dictionary: [String: Any]) throws {
+    func setFields(dictionary: [String: AnyHashable]) throws {
       if let decodingError {
         throw decodingError
       }

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -79,7 +79,7 @@ class AuthTests: RPCBaseTests {
     let allSignInMethods = ["emailLink", "facebook.com"]
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer in `fetchSignInMethods`.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer in `fetchSignInMethods`.
     let group = createGroup()
 
     AuthTests.auth?.fetchSignInMethods(forEmail: kEmail) { signInMethods, error in
@@ -91,14 +91,14 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? CreateAuthURIRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? CreateAuthURIRequest)
     XCTAssertEqual(request.identifier, kEmail)
     XCTAssertEqual(request.endpoint, "createAuthUri")
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["signinMethods": allSignInMethods])
+    try rpcIssuer?.respond(withJSON: ["signinMethods": allSignInMethods])
 
     waitForExpectations(timeout: 5)
   }
@@ -120,7 +120,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     let message = "TOO_MANY_ATTEMPTS_TRY_LATER"
-    try RPCIssuer?.respond(serverErrorMessage: message)
+    try rpcIssuer?.respond(serverErrorMessage: message)
 
     waitForExpectations(timeout: 5)
   }
@@ -147,7 +147,7 @@ class AuthTests: RPCBaseTests {
     setFakeGetAccountProvider()
     setFakeSecureTokenService()
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -166,14 +166,14 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? EmailLinkSignInRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? EmailLinkSignInRequest)
     XCTAssertEqual(request.email, kEmail)
     XCTAssertEqual(request.oobCode, fakeCode)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["idToken": kAccessToken,
+    try rpcIssuer?.respond(withJSON: ["idToken": kAccessToken,
                                       "email": kEmail,
                                       "isNewUser": true,
                                       "refreshToken": kRefreshToken])
@@ -188,7 +188,7 @@ class AuthTests: RPCBaseTests {
   func testSignInWithEmailLinkFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -202,7 +202,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -217,7 +217,7 @@ class AuthTests: RPCBaseTests {
     setFakeGetAccountProvider()
     setFakeSecureTokenService()
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -242,15 +242,15 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? VerifyPasswordRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? VerifyPasswordRequest)
     XCTAssertEqual(request.email, kEmail)
     XCTAssertEqual(request.password, kFakePassword)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertTrue(request.returnSecureToken)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["idToken": kAccessToken,
+    try rpcIssuer?.respond(withJSON: ["idToken": kAccessToken,
                                       "email": kEmail,
                                       "isNewUser": true,
                                       "refreshToken": kRefreshToken])
@@ -265,7 +265,7 @@ class AuthTests: RPCBaseTests {
   func testSignInWithEmailPasswordFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -280,7 +280,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_PASSWORD")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_PASSWORD")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -292,7 +292,7 @@ class AuthTests: RPCBaseTests {
   func testResetPasswordSuccess() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -305,14 +305,14 @@ class AuthTests: RPCBaseTests {
       }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? ResetPasswordRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? ResetPasswordRequest)
     XCTAssertEqual(request.oobCode, kFakeOobCode)
     XCTAssertEqual(request.updatedPassword, kFakePassword)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: [:])
+    try rpcIssuer?.respond(withJSON: [:])
 
     waitForExpectations(timeout: 10)
   }
@@ -324,7 +324,7 @@ class AuthTests: RPCBaseTests {
   func testResetPasswordFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -339,7 +339,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -352,7 +352,7 @@ class AuthTests: RPCBaseTests {
     let verifyEmailRequestType = "VERIFY_EMAIL"
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -366,13 +366,13 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? ResetPasswordRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? ResetPasswordRequest)
     XCTAssertEqual(request.oobCode, kFakeOobCode)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["email": kEmail,
+    try rpcIssuer?.respond(withJSON: ["email": kEmail,
                                       "requestType": verifyEmailRequestType,
                                       "newEmail": kNewEmail])
     waitForExpectations(timeout: 10)
@@ -384,7 +384,7 @@ class AuthTests: RPCBaseTests {
   func testCheckActionCodeFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -398,7 +398,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "EXPIRED_OOB_CODE")
+    try rpcIssuer?.respond(serverErrorMessage: "EXPIRED_OOB_CODE")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -409,7 +409,7 @@ class AuthTests: RPCBaseTests {
   func testApplyActionCodeSuccess() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -421,12 +421,12 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? SetAccountInfoRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? SetAccountInfoRequest)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: [:])
+    try rpcIssuer?.respond(withJSON: [:])
     waitForExpectations(timeout: 10)
   }
 
@@ -436,7 +436,7 @@ class AuthTests: RPCBaseTests {
   func testApplyActionCodeFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -450,7 +450,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -461,7 +461,7 @@ class AuthTests: RPCBaseTests {
   func testVerifyPasswordResetCodeSuccess() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -474,13 +474,13 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? ResetPasswordRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? ResetPasswordRequest)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertEqual(request.oobCode, kFakeOobCode)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["email": kEmail])
+    try rpcIssuer?.respond(withJSON: ["email": kEmail])
     waitForExpectations(timeout: 10)
   }
 
@@ -490,7 +490,7 @@ class AuthTests: RPCBaseTests {
   func testVerifyPasswordResetCodeFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -505,7 +505,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_OOB_CODE")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -520,7 +520,7 @@ class AuthTests: RPCBaseTests {
     setFakeSecureTokenService()
     setFakeGetAccountProviderAnonymous()
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -541,15 +541,15 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? SignUpNewUserRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? SignUpNewUserRequest)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertNil(request.email)
     XCTAssertNil(request.password)
     XCTAssertTrue(request.returnSecureToken)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["idToken": kAccessToken,
+    try rpcIssuer?.respond(withJSON: ["idToken": kAccessToken,
                                       "email": kEmail,
                                       "isNewUser": true,
                                       "refreshToken": kRefreshToken])
@@ -563,7 +563,7 @@ class AuthTests: RPCBaseTests {
   func testSignInAnonymouslyFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -578,7 +578,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "OPERATION_NOT_ALLOWED")
+    try rpcIssuer?.respond(serverErrorMessage: "OPERATION_NOT_ALLOWED")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -591,7 +591,7 @@ class AuthTests: RPCBaseTests {
     setFakeSecureTokenService()
     setFakeGetAccountProvider()
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -612,14 +612,14 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? VerifyCustomTokenRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? VerifyCustomTokenRequest)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertEqual(request.token, kCustomToken)
     XCTAssertTrue(request.returnSecureToken)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["idToken": kAccessToken,
+    try rpcIssuer?.respond(withJSON: ["idToken": kAccessToken,
                                       "email": kEmail,
                                       "isNewUser": false,
                                       "refreshToken": kRefreshToken])
@@ -633,7 +633,7 @@ class AuthTests: RPCBaseTests {
   func testSignInWithCustomTokenFailure() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -648,7 +648,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "INVALID_CUSTOM_TOKEN")
+    try rpcIssuer?.respond(serverErrorMessage: "INVALID_CUSTOM_TOKEN")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -661,7 +661,7 @@ class AuthTests: RPCBaseTests {
     setFakeSecureTokenService()
     setFakeGetAccountProvider()
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -682,15 +682,15 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? SignUpNewUserRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? SignUpNewUserRequest)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertEqual(request.email, kEmail)
     XCTAssertEqual(request.password, kFakePassword)
     XCTAssertTrue(request.returnSecureToken)
 
     // 3. Send the response from the fake backend.
-    try RPCIssuer?.respond(withJSON: ["idToken": kAccessToken,
+    try rpcIssuer?.respond(withJSON: ["idToken": kAccessToken,
                                       "email": kEmail,
                                       "isNewUser": true,
                                       "refreshToken": kRefreshToken])
@@ -705,7 +705,7 @@ class AuthTests: RPCBaseTests {
     let expectation = self.expectation(description: #function)
     let reason = "The password must be 6 characters long or more."
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
 
     try AuthTests.auth?.signOut()
@@ -720,7 +720,7 @@ class AuthTests: RPCBaseTests {
     group.wait()
 
     // 2. Send the response from the fake backend.
-    try RPCIssuer?.respond(serverErrorMessage: "WEAK_PASSWORD")
+    try rpcIssuer?.respond(serverErrorMessage: "WEAK_PASSWORD")
     waitForExpectations(timeout: 10)
     XCTAssertNil(AuthTests.auth?.currentUser)
   }
@@ -765,7 +765,7 @@ class AuthTests: RPCBaseTests {
   func testSendPasswordResetEmailSuccess() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer in `fetchSignInMethods`.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer in `fetchSignInMethods`.
     let group = createGroup()
 
     AuthTests.auth?.sendPasswordReset(withEmail: kEmail) { error in
@@ -776,13 +776,13 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? GetOOBConfirmationCodeRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? GetOOBConfirmationCodeRequest)
     XCTAssertEqual(request.email, kEmail)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
 
     // 3. Send the response from the fake backend.
-    _ = try RPCIssuer?.respond(withJSON: [:])
+    _ = try rpcIssuer?.respond(withJSON: [:])
 
     waitForExpectations(timeout: 5)
   }
@@ -803,7 +803,7 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    try RPCIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
+    try rpcIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
 
     waitForExpectations(timeout: 5)
   }
@@ -814,7 +814,7 @@ class AuthTests: RPCBaseTests {
   func testSendSignInLinkToEmailSuccess() throws {
     let expectation = self.expectation(description: #function)
 
-    // 1. Create a group to synchronize request creation by the fake RPCIssuer in `fetchSignInMethods`.
+    // 1. Create a group to synchronize request creation by the fake rpcIssuer in `fetchSignInMethods`.
     let group = createGroup()
 
     AuthTests.auth?.sendSignInLink(toEmail: kEmail,
@@ -826,15 +826,15 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    // 2. After the fake RPCIssuer leaves the group, validate the created Request instance.
-    let request = try XCTUnwrap(RPCIssuer?.request as? GetOOBConfirmationCodeRequest)
+    // 2. After the fake rpcIssuer leaves the group, validate the created Request instance.
+    let request = try XCTUnwrap(rpcIssuer?.request as? GetOOBConfirmationCodeRequest)
     XCTAssertEqual(request.email, kEmail)
     XCTAssertEqual(request.APIKey, AuthTests.kFakeAPIKey)
     XCTAssertEqual(request.continueURL, kContinueURL)
     XCTAssertTrue(request.handleCodeInApp)
 
     // 3. Send the response from the fake backend.
-    _ = try RPCIssuer?.respond(withJSON: [:])
+    _ = try rpcIssuer?.respond(withJSON: [:])
 
     waitForExpectations(timeout: 5)
   }
@@ -856,7 +856,7 @@ class AuthTests: RPCBaseTests {
     }
     group.wait()
 
-    try RPCIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
+    try rpcIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
     waitForExpectations(timeout: 5)
   }
 
@@ -882,7 +882,7 @@ class AuthTests: RPCBaseTests {
 //    }
 //    group.wait()
 //
-//    try RPCIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
+//    try rpcIssuer?.respond(underlyingErrorMessage: "ipRefererBlocked")
 //    waitForExpectations(timeout: 5)
 //  }
 //  - (void)testUpdateCurrentUserFailure {
@@ -932,7 +932,7 @@ class AuthTests: RPCBaseTests {
   }
 
   private func setFakeSecureTokenService() {
-    RPCIssuer?.fakeSecureTokenServiceJSON = ["access_token": kAccessToken]
+    rpcIssuer?.fakeSecureTokenServiceJSON = ["access_token": kAccessToken]
   }
 
   private func setFakeGetAccountProvider() {
@@ -950,7 +950,7 @@ class AuthTests: RPCBaseTests {
     let kEmailVerifiedKey = "emailVerified"
     let kLocalIDKey = "localId"
 
-    RPCIssuer?.fakeGetAccountProviderJSON = [[
+    rpcIssuer?.fakeGetAccountProviderJSON = [[
       kProviderUserInfoKey: [[
         kProviderIDkey: kTestProviderID,
         kDisplayNameKey: kDisplayName,
@@ -972,7 +972,7 @@ class AuthTests: RPCBaseTests {
     let kTestPasswordHash = "testPasswordHash"
     let kLocalIDKey = "localId"
 
-    RPCIssuer?.fakeGetAccountProviderJSON = [[
+    rpcIssuer?.fakeGetAccountProviderJSON = [[
       kLocalIDKey: kLocalID,
       kPasswordHashKey: kTestPasswordHash,
     ]]
@@ -980,7 +980,7 @@ class AuthTests: RPCBaseTests {
 
   private func createGroup() -> DispatchGroup {
     let group = DispatchGroup()
-    RPCIssuer?.group = group
+    rpcIssuer?.group = group
     group.enter()
     return group
   }

--- a/FirebaseAuth/Tests/Unit/CreateAuthURITests.swift
+++ b/FirebaseAuth/Tests/Unit/CreateAuthURITests.swift
@@ -80,7 +80,7 @@ class CreateAuthURITests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [kAuthUriKey: kTestAuthUri])
+    _ = try rpcIssuer?.respond(withJSON: [kAuthUriKey: kTestAuthUri])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcError)
@@ -101,11 +101,11 @@ class CreateAuthURITests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    XCTAssertEqual(RPCIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
-    XCTAssertEqual(RPCIssuer?.decodedRequest?["identifier"] as? String, kTestIdentifier)
-    XCTAssertEqual(RPCIssuer?.decodedRequest?["continueUri"] as? String, kTestContinueURI)
+    XCTAssertEqual(rpcIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
+    XCTAssertEqual(rpcIssuer?.decodedRequest?["identifier"] as? String, kTestIdentifier)
+    XCTAssertEqual(rpcIssuer?.decodedRequest?["continueUri"] as? String, kTestContinueURI)
 
-    _ = try RPCIssuer?
+    _ = try rpcIssuer?
       .respond(withJSON: ["kind": kTestExpectedKind,
                           "allProviders": [kTestProviderID1, kTestProviderID2]])
 

--- a/FirebaseAuth/Tests/Unit/DeleteAccountTests.swift
+++ b/FirebaseAuth/Tests/Unit/DeleteAccountTests.swift
@@ -73,7 +73,7 @@ class DeleteAccountTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [:])
+    _ = try rpcIssuer?.respond(withJSON: [:])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcError)

--- a/FirebaseAuth/Tests/Unit/EmailLinkSignInTests.swift
+++ b/FirebaseAuth/Tests/Unit/EmailLinkSignInTests.swift
@@ -56,8 +56,8 @@ class EmailLinkSignInTests: RPCBaseTests {
     AuthBackend.post(withRequest: makeEmailLinkSignInRequest()) { response, error in
       XCTFail("No explicit response from the fake backend.")
     }
-    XCTAssertEqual(RPCIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
-    guard let requestDictionary = RPCIssuer?.decodedRequest as? [AnyHashable: String] else {
+    XCTAssertEqual(rpcIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
+    guard let requestDictionary = rpcIssuer?.decodedRequest as? [AnyHashable: String] else {
       XCTFail("decodedRequest is not a dictionary")
       return
     }
@@ -76,8 +76,8 @@ class EmailLinkSignInTests: RPCBaseTests {
     AuthBackend.post(withRequest: request) { response, error in
       XCTFail("No explicit response from the fake backend.")
     }
-    XCTAssertEqual(RPCIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
-    guard let requestDictionary = RPCIssuer?.decodedRequest as? [AnyHashable: String] else {
+    XCTAssertEqual(rpcIssuer?.requestURL?.absoluteString, kExpectedAPIURL)
+    guard let requestDictionary = rpcIssuer?.decodedRequest as? [AnyHashable: String] else {
       XCTFail("decodedRequest is not a dictionary")
       return
     }
@@ -114,7 +114,7 @@ class EmailLinkSignInTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    try RPCIssuer?.respond(withJSON: ["idToken": kTestIDTokenResponse,
+    try rpcIssuer?.respond(withJSON: ["idToken": kTestIDTokenResponse,
                                       "email": kTestEmailResponse,
                                       "isNewUser": true,
                                       "expiresIn": "\(kTestTokenExpirationTimeInterval)",

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -321,7 +321,7 @@ static const NSTimeInterval kWaitInterval = .5;
 }
 
 - (void)tearDown {
-  [FIRAuthBackend2 setDefaultBackendImplementationWithRPCIssuer:nil];
+  [FIRAuthBackend2 setDefaultBackendImplementationWithrpcIssuer:nil];
   [[FIRAuthDispatcher sharedInstance] setDispatchAfterImplementation:nil];
 
 #if TARGET_OS_IOS

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -279,7 +279,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 - (void)tearDown {
-  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [FIRAuthBackend setDefaultBackendImplementationWithrpcIssuer:nil];
   [super tearDown];
 }
 

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -419,7 +419,7 @@ static NSString *const kFakeWebSignInUserInteractionFailureReason = @"fake_reaso
 }
 
 - (void)tearDown {
-  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [FIRAuthBackend setDefaultBackendImplementationWithrpcIssuer:nil];
   [super tearDown];
 }
 

--- a/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
@@ -17,11 +17,11 @@ import XCTest
 
 @testable import FirebaseAuth
 
-/** @class FIRFakeBackendRPCIssuer
-    @brief An implementation of @c FIRAuthBackendRPCIssuer which is used to test backend request,
+/** @class FIRFakeBackendrpcIssuer
+    @brief An implementation of @c FIRAuthBackendrpcIssuer which is used to test backend request,
         response, and glue logic.
  */
-class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
+class FakeBackendrpcIssuer: NSObject, AuthBackendRPCIssuer {
   /** @property requestURL
       @brief The URL which was requested.
    */

--- a/FirebaseAuth/Tests/Unit/GetAccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Unit/GetAccountInfoTests.swift
@@ -101,7 +101,7 @@ class GetAccountInfoTests: RPCBaseTests {
       kPasswordHashKey: kTestPasswordHash,
     ]]
 
-    _ = try RPCIssuer?.respond(withJSON: ["users": usersIn])
+    _ = try rpcIssuer?.respond(withJSON: ["users": usersIn])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcError)

--- a/FirebaseAuth/Tests/Unit/GetOOBConfirmationCode.swift
+++ b/FirebaseAuth/Tests/Unit/GetOOBConfirmationCode.swift
@@ -165,7 +165,7 @@ class GetOOBConfirmationCodeTests: RPCBaseTests {
         rpcError = error as? NSError
       }
 
-      _ = try RPCIssuer?.respond(withJSON: [kOOBCodeKey: kTestOOBCode])
+      _ = try rpcIssuer?.respond(withJSON: [kOOBCodeKey: kTestOOBCode])
 
       XCTAssert(callbackInvoked)
       XCTAssertNil(rpcError)
@@ -195,7 +195,7 @@ class GetOOBConfirmationCodeTests: RPCBaseTests {
         rpcError = error as? NSError
       }
 
-      _ = try RPCIssuer?.respond(withJSON: [:])
+      _ = try rpcIssuer?.respond(withJSON: [:])
 
       XCTAssert(callbackInvoked)
       XCTAssertNil(rpcError)

--- a/FirebaseAuth/Tests/Unit/GetProjectConfigTests.swift
+++ b/FirebaseAuth/Tests/Unit/GetProjectConfigTests.swift
@@ -64,7 +64,7 @@ class GetProjectConfigTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: ["projectId": kTestProjectID,
+    _ = try rpcIssuer?.respond(withJSON: ["projectId": kTestProjectID,
                                           "authorizedDomains": [kTestDomain1, kTestDomain2]])
 
     XCTAssert(callbackInvoked)

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -225,10 +225,10 @@ import FirebaseCore
       // Use fake authURLPresenter so we can test the parameters that get sent to it.
       OAuthProviderTests.auth?.authURLPresenter = FakePresenter()
 
-      // 1. Create a group to synchronize request creation by the fake RPCIssuer in `fetchSignInMethods`.
+      // 1. Create a group to synchronize request creation by the fake rpcIssuer in `fetchSignInMethods`.
       let group = DispatchGroup()
       if !OAuthProviderTests.testEmulator {
-        RPCIssuer?.group = group
+        rpcIssuer?.group = group
         group.enter()
       }
 
@@ -382,16 +382,16 @@ import FirebaseCore
         expectation.fulfill()
       }
       if !OAuthProviderTests.testEmulator {
-        // 3. Wait for fake RPCIssuer to leave the group.
+        // 3. Wait for fake rpcIssuer to leave the group.
         group.wait()
 
-        // 4. After the fake RPCIssuer leaves the group, validate the created Request instance.
-        let request = try XCTUnwrap(RPCIssuer?.request as? GetProjectConfigRequest)
+        // 4. After the fake rpcIssuer leaves the group, validate the created Request instance.
+        let request = try XCTUnwrap(rpcIssuer?.request as? GetProjectConfigRequest)
         XCTAssertEqual(request.endpoint, "getProjectConfig")
         XCTAssertEqual(request.APIKey, OAuthProviderTests.kFakeAPIKey)
 
         // 5. Send the response from the fake backend.
-        _ = try RPCIssuer?
+        _ = try rpcIssuer?
           .respond(withJSON: ["authorizedDomains": [OAuthProviderTests.kFakeAuthorizedDomain]])
       }
       waitForExpectations(timeout: 105)

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -33,17 +33,17 @@ class RPCBaseTests: XCTestCase {
    */
   let kTestIdentifier = "Identifier"
 
-  var RPCIssuer: FakeBackendRPCIssuer?
+  var rpcIssuer: FakeBackendrpcIssuer?
   var rpcImplementation: AuthBackendImplementation?
 
   override func setUp() {
-    RPCIssuer = FakeBackendRPCIssuer()
-    AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: RPCIssuer)
+    rpcIssuer = FakeBackendrpcIssuer()
+    AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: rpcIssuer)
     rpcImplementation = AuthBackend.implementation()
   }
 
   override func tearDown() {
-    RPCIssuer = nil
+    rpcIssuer = nil
     AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: nil)
   }
 
@@ -54,11 +54,11 @@ class RPCBaseTests: XCTestCase {
                                        expected: String,
                                        key: String,
                                        value: String?,
-                                       checkPostBody: Bool = false) throws -> FakeBackendRPCIssuer {
+                                       checkPostBody: Bool = false) throws -> FakeBackendrpcIssuer {
     AuthBackend.post(withRequest: request) { response, error in
       XCTFail("No explicit response from the fake backend.")
     }
-    let rpcIssuer = try XCTUnwrap(RPCIssuer)
+    let rpcIssuer = try XCTUnwrap(rpcIssuer)
     XCTAssertEqual(rpcIssuer.requestURL?.absoluteString, expected)
     if checkPostBody,
        let containsPostBody = request.containsPostBody?() {
@@ -93,11 +93,11 @@ class RPCBaseTests: XCTestCase {
     }
 
     if let json = json {
-      _ = try RPCIssuer?.respond(withJSON: json)
+      _ = try rpcIssuer?.respond(withJSON: json)
     } else if let reason = reason {
-      _ = try RPCIssuer?.respond(underlyingErrorMessage: reason, message: message)
+      _ = try rpcIssuer?.respond(underlyingErrorMessage: reason, message: message)
     } else {
-      _ = try RPCIssuer?.respond(serverErrorMessage: message)
+      _ = try rpcIssuer?.respond(serverErrorMessage: message)
     }
 
     XCTAssert(callbackInvoked)

--- a/FirebaseAuth/Tests/Unit/ResetPasswordTests.swift
+++ b/FirebaseAuth/Tests/Unit/ResetPasswordTests.swift
@@ -86,7 +86,7 @@ class ResetPasswordTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: ["email": kTestEmail,
+    _ = try rpcIssuer?.respond(withJSON: ["email": kTestEmail,
                                           "requestType": kExpectedResetPasswordRequestType])
 
     XCTAssert(callbackInvoked)

--- a/FirebaseAuth/Tests/Unit/SendVerificationCodeTests.swift
+++ b/FirebaseAuth/Tests/Unit/SendVerificationCodeTests.swift
@@ -93,7 +93,7 @@ class SendVerificationCodeTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [kVerificationIDKey: kFakeVerificationID])
+    _ = try rpcIssuer?.respond(withJSON: [kVerificationIDKey: kFakeVerificationID])
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcError)

--- a/FirebaseAuth/Tests/Unit/SetAccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Unit/SetAccountInfoTests.swift
@@ -214,7 +214,7 @@ class SetAccountInfoTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [kProviderUserInfoKey: [[kPhotoUrlKey: kTestPhotoURL]],
+    _ = try rpcIssuer?.respond(withJSON: [kProviderUserInfoKey: [[kPhotoUrlKey: kTestPhotoURL]],
                                           kIDTokenKey: kTestIDToken,
                                           kExpiresInKey: kTestExpiresIn,
                                           kRefreshTokenKey: kTestRefreshToken])

--- a/FirebaseAuth/Tests/Unit/SignInWithGameCenterTests.swift
+++ b/FirebaseAuth/Tests/Unit/SignInWithGameCenterTests.swift
@@ -95,7 +95,7 @@ class SignInWithGameCenterTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       "idToken": kIDToken,
       "refreshToken": kRefreshToken,
       "localId": kLocalID,

--- a/FirebaseAuth/Tests/Unit/SignUpNewUserTests.swift
+++ b/FirebaseAuth/Tests/Unit/SignUpNewUserTests.swift
@@ -83,7 +83,7 @@ class SignUpNewUserTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kIDTokenKey: kTestIDToken,
       kExpiresInKey: kTestExpiresIn,
       kRefreshTokenKey: kTestRefreshToken,

--- a/FirebaseAuth/Tests/Unit/VerifyAssertionTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyAssertionTests.swift
@@ -164,7 +164,7 @@ class VerifyAssertionTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kProviderIDKey: kTestProviderID,
       kIDTokenKey: kTestIDToken,
       kExpiresInKey: kTestExpiresIn,
@@ -205,7 +205,7 @@ class VerifyAssertionTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kProviderIDKey: kTestProviderID,
       kIDTokenKey: kTestIDToken,
       kExpiresInKey: kTestExpiresIn,

--- a/FirebaseAuth/Tests/Unit/VerifyClientTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyClientTests.swift
@@ -73,7 +73,7 @@ class VerifyClientTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kReceiptKey: kFakeReceipt,
       kSuggestedTimeOutKey: kFakeSuggestedTimeout,
     ])

--- a/FirebaseAuth/Tests/Unit/VerifyCustomTokenTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyCustomTokenTests.swift
@@ -107,7 +107,7 @@ class VerifyCustomTokenTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kIDTokenKey: kTestIDToken,
       kExpiresInKey: kTestExpiresIn,
       kRefreshTokenKey: kTestRefreshToken,

--- a/FirebaseAuth/Tests/Unit/VerifyPasswordTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyPasswordTests.swift
@@ -160,7 +160,7 @@ class VerifyPasswordTests: RPCBaseTests {
       rpcError = error as? NSError
     }
 
-    _ = try RPCIssuer?.respond(withJSON: [
+    _ = try rpcIssuer?.respond(withJSON: [
       kLocalIDKey: kTestLocalID,
       kEmailKey: kTestEmail,
       kDisplayNameKey: kTestDisplayName,

--- a/FirebaseAuth/Tests/Unit/VerifyPhoneNumberTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyPhoneNumberTests.swift
@@ -115,7 +115,7 @@ import XCTest
         rpcError = error as? NSError
       }
 
-      _ = try RPCIssuer?.respond(withJSON: [
+      _ = try rpcIssuer?.respond(withJSON: [
         "idToken": kTestIDToken,
         "refreshToken": kTestRefreshToken,
         "localId": kTestLocalID,
@@ -147,7 +147,7 @@ import XCTest
           rpcError = error as? NSError
         }
 
-      _ = try RPCIssuer?.respond(withJSON: [
+      _ = try rpcIssuer?.respond(withJSON: [
         "temporaryProof": kTemporaryProof,
         "phoneNumber": kPhoneNumber,
       ])


### PR DESCRIPTION
Tighten up type safety on RPC dictionaries
Rename `RPCIssuer` to `rpcIssuer`

#no-changelog