### PR TITLE
Provide server errors via the NSUnderlyingErrorKey

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [added] Provide server errors via the `NSUnderlyingErrorKey`.
+
 # 10.5.0
 - [added] Added Storage API to limit upload chunk size. (#10137)
 - [fixed] Run `pod update` or `File -> Packages -> Update to latest Packages` to update the `GTMSessionFetcher` dependency to at least version `3.1.0`.

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -58,6 +58,7 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     errorDictionary["ResponseErrorDomain"] = serverError.domain
     errorDictionary["ResponseErrorCode"] = serverError.code
     errorDictionary["bucket"] = ref.path.bucket
+    errorDictionary[NSUnderlyingErrorKey] = serverError
 
     if let object = ref.path.object {
       errorDictionary["object"] = object

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -137,8 +137,11 @@ import XCTest
       do {
         _ = try await ref.putFileAsync(from: fileURL)
         XCTFail("Unexpected success from putFile of a directory")
-      } catch StorageError.unknown {
-        XCTAssertTrue(true)
+      } catch let StorageError.unknown(reason) {
+        XCTAssertTrue(reason.starts(with: "File at URL:"))
+        XCTAssertTrue(reason.hasSuffix(
+          "is not reachable. Ensure file URL is not a directory, symbolic link, or invalid url."
+        ))
       } catch {
         XCTFail("error failed to convert to StorageError.unknown")
       }

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -55,7 +55,12 @@ import XCTest
         _ = try await ref.delete()
       } catch {
         caughtError = true
-        XCTAssertEqual((error as NSError).code, StorageErrorCode.objectNotFound.rawValue)
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.code, StorageErrorCode.objectNotFound.rawValue)
+        XCTAssertEqual(nsError.userInfo["ResponseErrorCode"] as? Int, 404)
+        let underlyingError = try XCTUnwrap(nsError.userInfo[NSUnderlyingErrorKey] as? NSError)
+        XCTAssertEqual(underlyingError.code, 404)
+        XCTAssertEqual(underlyingError.domain, "com.google.HTTPStatus")
       }
       XCTAssertTrue(caughtError)
     }


### PR DESCRIPTION
Historically, FirebaseStorage deconstructs and reconstructs underlying server errors into a different format. With this PR, we also provide the original underlying error via the more standard `NSUnderlyingErrorKey`.

Also add three types of tests:

- Test existing server error reconstruction
- Server error via `NSUnderlyingErrorKey`
- Demonstrate showing the reason for an `.unknown` Swift error (not from server) to help clarify #10889

A more complete solution to #10889 can be addressed with a small breaking change in the next major release.