### PR TITLE
Avoid deeply nested timestamps that can cause stack overflow.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [feature] Add support for disjunctions in queries (`OR` queries).
+- [fixed] Fixed stack overflow caused by deeply nested server timestamps.
 
 # 10.6.0
 - [fixed] Fix a potential high memory usage issue.

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/test/unit/local/local_store_test.h"
 
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -34,10 +35,14 @@
 #include "Firestore/core/src/model/document.h"
 #include "Firestore/core/src/model/document_key.h"
 #include "Firestore/core/src/model/field_index.h"
+#include "Firestore/core/src/model/field_mask.h"
+#include "Firestore/core/src/model/field_path.h"
+#include "Firestore/core/src/model/field_transform.h"
 #include "Firestore/core/src/model/mutable_document.h"
 #include "Firestore/core/src/model/mutation.h"
 #include "Firestore/core/src/model/mutation_batch_result.h"
 #include "Firestore/core/src/model/patch_mutation.h"
+#include "Firestore/core/src/model/server_timestamp_util.h"
 #include "Firestore/core/src/model/set_mutation.h"
 #include "Firestore/core/src/model/transform_operation.h"
 #include "Firestore/core/src/remote/existence_filter.h"
@@ -92,6 +97,7 @@ using testutil::Key;
 using testutil::Map;
 using testutil::OverlayTypeMap;
 using testutil::Query;
+using testutil::ServerTimestamp;
 using testutil::UnknownDoc;
 using testutil::UpdateRemoteEvent;
 using testutil::UpdateRemoteEventWithLimboTargets;
@@ -1682,6 +1688,24 @@ TEST_P(LocalStoreTest, PatchMutationLeadsToPatchOverlay) {
   FSTAssertOverlaysRead(0, 1);
   FSTAssertOverlayTypes(
       OverlayTypeMap({{Key("foo/baz"), model::Mutation::Type::Patch}}));
+}
+
+TEST_P(LocalStoreTest, DeeplyNestedTimestampDoesNotCauseStackOverflow) {
+  Timestamp timestamp = Timestamp::Now();
+  Message<_google_firestore_v1_Value> initialServerTimestamp =
+      model::EncodeServerTimestamp(timestamp, absl::nullopt);
+  model::FieldPath path = model::FieldPath::FromDotSeparatedString("timestamp");
+  auto makeDeeplyNestedTimestamp = [&]() {
+    for (int i = 0; i < 1000; ++i) {
+      WriteMutation(testutil::MergeMutation(
+          "foo/bar",
+          Map("timestamp",
+              model::EncodeServerTimestamp(timestamp, *initialServerTimestamp)),
+          {path}, {ServerTimestamp("timestamp")}));
+    }
+  };
+  std::thread t(makeDeeplyNestedTimestamp);
+  EXPECT_NO_FATAL_FAILURE(t.join());
 }
 
 }  // namespace local


### PR DESCRIPTION
This is porting the fix from https://github.com/firebase/firebase-android-sdk/pull/4715 which prevents deeply nested timestamps and fixes a potential stack overflow error.

This may also be the root cause of #10469.