### PR TITLE
[auth-swift] Restore integration tests

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -38,49 +38,45 @@ jobs:
     - name: Build and test
       run: |
          scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} --allow-warnings
-
 #TODO: Restore warnings check
 #        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }}
 
-# Disable until sample app is written in Swift with @testable
-  # integration-tests:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-  #     POD_LIB_LINT_ONLY: 1
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Prereqs
-  #     run: scripts/install_prereqs.sh Auth iOS
-  #   - name: Install Secrets
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
-  #         FirebaseAuth/Tests/Sample/ApiTests/AuthCredentials.h "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Application.plist.gpg \
-  #         FirebaseAuth/Tests/Sample/Sample/Application.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
-  #         FirebaseAuth/Tests/Sample/Sample/AuthCredentials.h "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
-  #         FirebaseAuth/Tests/Sample/Sample/GoogleService-Info.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
-  #         FirebaseAuth/Tests/Sample/Sample/GoogleService-Info_multi.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
-  #         FirebaseAuth/Tests/Sample/Sample/Sample.entitlements "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
-  #         FirebaseAuth/Tests/Sample/SwiftApiTests/Credentials.swift "$plist_secret"
-
-  #   - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Auth iOS)
+  integration-tests:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
+      POD_LIB_LINT_ONLY: 1
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Prereqs
+      run: scripts/install_prereqs.sh Auth iOS
+    - name: Install Secrets
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
+          FirebaseAuth/Tests/Sample/ApiTests/AuthCredentials.h "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Application.plist.gpg \
+          FirebaseAuth/Tests/Sample/Sample/Application.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
+          FirebaseAuth/Tests/Sample/Sample/AuthCredentials.h "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
+          FirebaseAuth/Tests/Sample/Sample/GoogleService-Info.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
+          FirebaseAuth/Tests/Sample/Sample/GoogleService-Info_multi.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
+          FirebaseAuth/Tests/Sample/Sample/Sample.entitlements "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
+          FirebaseAuth/Tests/Sample/SwiftApiTests/Credentials.swift "$plist_secret"
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Auth iOS)
 
   # Disable until mixed language support is available or Auth is fully in Swift
   # spm:

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -26,7 +26,6 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULSceneDelegateSwizzler.h>
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FirebaseAuth.h"
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth-Swift.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -305,8 +305,7 @@ NS_SWIFT_NAME(Auth)
 /** @property mainBundle
     @brief Allow tests to swap in an alternate mainBundle.
  */
-@property(nonatomic, strong)
-    NSArray<NSDictionary<NSString *, NSArray<NSString *> *> *> *mainBundleUrlTypes;
+@property(nonatomic, strong) NSArray<NSDictionary<NSString *, id> *> *mainBundleUrlTypes;
 
 /** @property notificationManager
     @brief The manager for remote notifications used by phone number auth.

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -26,7 +26,7 @@
     /** @fn
         @brief Creates an `AuthCredential` for a Game Center sign in.
      */
-    open class func getCredential(completion: @escaping (AuthCredential?, Error?) -> Void) {
+    @objc public class func getCredential(completion: @escaping (AuthCredential?, Error?) -> Void) {
       /**
        Linking GameKit.framework without using it on macOS results in App Store rejection.
        Thus we don't link GameKit.framework to our SDK directly. `optionalLocalPlayer` is used for

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -45,7 +45,7 @@ import Foundation
 
   @objc override func prepare(_ request: VerifyAssertionRequest) {
     request.providerIDToken = IDToken
-    request.accessToken = accessToken
+    request.providerAccessToken = accessToken
   }
 
   static var supportsSecureCoding = true

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -24,12 +24,12 @@ import CommonCrypto
   /** @property scopes
       @brief Array used to configure the OAuth scopes.
    */
-  @objc public let scopes: [String]
+  @objc public var scopes: [String]
 
   /** @property customParameters
       @brief Dictionary used to configure the OAuth custom parameters.
    */
-  @objc public let customParameters: [String: String]
+  @objc public var customParameters: [String: String]
 
   /** @property providerID
       @brief The provider ID indicating the specific OAuth provider this OAuthProvider instance

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -159,7 +159,7 @@ private var gAPIHost = "securetoken.googleapis.com"
     return URL(string: urlString)!
   }
 
-  var containsPostBody: Bool { true }
+  public func containsPostBody() -> Bool { true }
 
   public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     var postBody: [String: AnyHashable] = [

--- a/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
+++ b/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
@@ -23,7 +23,10 @@ import Foundation
   @objc public var providerID: String?
   @objc public var profile: [String: Any]?
   @objc public var username: String?
-  @objc public var isNewUser: Bool = false
+  @objc public var newUser: Bool
+  @objc public var isNewUser: Bool {
+    return newUser
+  }
 
   @objc public static func userInfo(verifyAssertionResponse: VerifyAssertionResponse)
     -> AdditionalUserInfo {
@@ -33,12 +36,13 @@ import Foundation
                               isNewUser: verifyAssertionResponse.isNewUser)
   }
 
+  // TODO: this init should not be public
   @objc public init(providerID: String?, profile: [String: Any]?, username: String?,
                     isNewUser: Bool) {
     self.providerID = providerID
     self.profile = profile
     self.username = username
-    self.isNewUser = isNewUser
+    newUser = isNewUser
   }
 
   public static var supportsSecureCoding: Bool {
@@ -62,9 +66,9 @@ import Foundation
       of: NSNumber.self,
       forKey: AdditionalUserInfo.newUserKey
     ) {
-      isNewUser = newUser.boolValue
+      self.newUser = newUser.boolValue
     } else {
-      isNewUser = false
+      newUser = false
     }
   }
 

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -54,14 +54,16 @@ import Foundation
    NSError object returned. This is the updated auth credential the developer should use for
    recovery if applicable.
    */
-  @objc public static let userInfoUpdatedCredentialKey: String = "FIRAuthErrorUserInfoUpdatedCredentialKey"
+  @objc public static let userInfoUpdatedCredentialKey: String =
+    "FIRAuthErrorUserInfoUpdatedCredentialKey"
 
   /**
    @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
    returned when 2FA is required for sign-incompletion.
    */
   @objc(FIRAuthErrorUserInfoMultiFactorResolverKey)
-  public static let userInfoMultiFactorResolverKey: String = "FIRAuthErrorUserInfoMultiFactorResolverKey"
+  public static let userInfoMultiFactorResolverKey: String =
+    "FIRAuthErrorUserInfoMultiFactorResolverKey"
 }
 
 @objc(FIRAuthErrorCode) public enum AuthErrorCode: Int {

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -31,11 +31,12 @@ import Foundation
  + `FIRAuthErrorCodeInvalidUserToken`
  + `FIRAuthErrorCodeUserDisabled`
  */
-@objc(FIRAuthErrors) public class AuthErrors: NSObject {
-  @objc(FIRAuthErrorDomain) public static var AuthErrorDomain: String = "FIRAuthErrorDomain"
 
-  @objc(FIRAuthErrorUserInfoNameKey) static var AuthErrorUserInfoNameKey: String =
-    "FIRAuthErrorUserInfoNameKey"
+// TODO: Keep the original global strings as deprecated, at least for CocoaPods, like we do in Storage.
+@objc(FIRAuthErrors) public class AuthErrors: NSObject {
+  @objc public static let domain: String = "FIRAuthErrorDomain"
+
+  @objc public static let userInfoNameKey: String = "FIRAuthErrorUserInfoNameKey"
 
   /**
    @brief Errors with one of the following three codes:
@@ -46,26 +47,21 @@ import Foundation
    associated with this key is an NSString of the email address of the account that already
    exists.
    */
-  @objc(FIRAuthErrorUserInfoEmailKey)
-  public static let AuthErrorUserInfoEmailKey: String =
-    "FIRAuthErrorUserInfoEmailKey"
+  @objc public static let userInfoEmailKey: String = "FIRAuthErrorUserInfoEmailKey"
 
   /**
    @brief The key used to read the updated Auth credential from the userInfo dictionary of the
    NSError object returned. This is the updated auth credential the developer should use for
    recovery if applicable.
    */
-  @objc(FIRAuthErrorUserInfoUpdatedCredentialKey)
-  public static let AuthErrorUserInfoUpdatedCredentialKey: String =
-    "FIRAuthErrorUserInfoUpdatedCredentialKey"
+  @objc public static let userInfoUpdatedCredentialKey: String = "FIRAuthErrorUserInfoUpdatedCredentialKey"
 
   /**
    @brief The key used to read the MFA resolver from the userInfo dictionary of the NSError object
    returned when 2FA is required for sign-incompletion.
    */
   @objc(FIRAuthErrorUserInfoMultiFactorResolverKey)
-  static let AuthErrorUserInfoMultiFactorResolverKey: String =
-    "FIRAuthErrorUserInfoMultiFactorResolverKey"
+  public static let userInfoMultiFactorResolverKey: String = "FIRAuthErrorUserInfoMultiFactorResolverKey"
 }
 
 @objc(FIRAuthErrorCode) public enum AuthErrorCode: Int {

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
@@ -33,7 +33,7 @@ typealias FIRFetchAuthDomainCallback = (String?, Error?) -> Void
   }
 
   @objc public static func isCallbackSchemeRegistered(forCustomURLScheme scheme: String,
-                                                      urlTypes: [[String: [String]]]?) -> Bool {
+                                                      urlTypes: [[String: Any]]?) -> Bool {
     let expectedCustomScheme = scheme.lowercased()
     guard let urlTypes = urlTypes else {
       return false
@@ -42,9 +42,11 @@ typealias FIRFetchAuthDomainCallback = (String?, Error?) -> Void
       guard let urlTypeSchemes = urlType["CFBundleURLSchemes"] else {
         continue
       }
-      for urlTypeScheme in urlTypeSchemes {
-        if urlTypeScheme.lowercased() == expectedCustomScheme {
-          return true
+      if let schemes = urlTypeSchemes as? [String] {
+        for urlTypeScheme in schemes {
+          if urlTypeScheme.lowercased() == expectedCustomScheme {
+            return true
+          }
         }
       }
     }

--- a/FirebaseAuth/Tests/Sample/ApiTests/AccountInfoTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/AccountInfoTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+@import FirebaseAuth;
+
 #import "FIRAuthApiTestsBase.h"
 
 /** The testing email address for testCreateAccountWithEmailAndPassword. */

--- a/FirebaseAuth/Tests/Sample/ApiTests/CustomAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/CustomAuthTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+@import FirebaseAuth;
+
 #import "FIRAuthApiTestsBase.h"
 
 /** The user name string for Custom Auth testing account. */

--- a/FirebaseAuth/Tests/Sample/ApiTests/FacebookAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/FacebookAuthTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+@import FirebaseAuth;
+
 #import "FIRAuthApiTestsBase.h"
 
 /** Facebook app access token that will be used for Facebook Graph API, which is different from

--- a/FirebaseAuth/Tests/Sample/ApiTests/GoogleAuthTests.m
+++ b/FirebaseAuth/Tests/Sample/ApiTests/GoogleAuthTests.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+@import FirebaseAuth;
+
 #import "FIRAuthApiTestsBase.h"
 
 static NSString *kGoogleClientID = KGOOGLE_CLIENT_ID;

--- a/FirebaseAuth/Tests/Sample/AuthSample.xcodeproj/project.pbxproj
+++ b/FirebaseAuth/Tests/Sample/AuthSample.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		DED400C2243E571500BF6D56 /* BYOAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DED400BC243E571500BF6D56 /* BYOAuthTests.m */; };
 		DED400C3243E571500BF6D56 /* FIRAuthE2eTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DED400BE243E571500BF6D56 /* FIRAuthE2eTests.m */; };
 		DED400C4243E571500BF6D56 /* FIRAuthE2eTestsBase.m in Sources */ = {isa = PBXBuildFile; fileRef = DED400BF243E571500BF6D56 /* FIRAuthE2eTestsBase.m */; };
-		DEF68E952799B9970064CC92 /* SwiftAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF68E942799B9970064CC92 /* SwiftAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -181,7 +180,6 @@
 		DED400BD243E571500BF6D56 /* FIRAuthE2eTestsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FIRAuthE2eTestsBase.h; sourceTree = "<group>"; };
 		DED400BE243E571500BF6D56 /* FIRAuthE2eTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthE2eTests.m; sourceTree = "<group>"; };
 		DED400BF243E571500BF6D56 /* FIRAuthE2eTestsBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthE2eTestsBase.m; sourceTree = "<group>"; };
-		DEF68E942799B9970064CC92 /* SwiftAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -354,7 +352,6 @@
 				DE1865B3245C92A600F8AD70 /* GoogleTests.swift */,
 				DE1865B5245C95DA00F8AD70 /* Credentials.swift */,
 				DE1865B7245CC6FC00F8AD70 /* FacebookTests.swift */,
-				DEF68E942799B9970064CC92 /* SwiftAPI.swift */,
 			);
 			path = SwiftApiTests;
 			sourceTree = "<group>";
@@ -584,7 +581,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DEF68E952799B9970064CC92 /* SwiftAPI.swift in Sources */,
 				DE1865B4245C92A600F8AD70 /* GoogleTests.swift in Sources */,
 				DE1865AE245B8A1400F8AD70 /* AnonymousTests.swift in Sources */,
 				DE1865B8245CC6FC00F8AD70 /* FacebookTests.swift in Sources */,

--- a/FirebaseAuth/Tests/Sample/Podfile
+++ b/FirebaseAuth/Tests/Sample/Podfile
@@ -12,6 +12,7 @@ target 'AuthSample' do
   platform :ios, '11.0'
   pod 'FirebaseCore', :path => '../../../'
   pod 'FirebaseCoreInternal', :path => '../../../'
+  pod 'FirebaseCoreExtension', :path => '../../../'
   pod 'FirebaseAuth', :path => '../../../', :testspecs => ['unit']
   pod 'FirebaseInstallations', :path => '../../..'
   pod 'FBSDKLoginKit', '< 13'

--- a/FirebaseAuth/Tests/Sample/Sample/FacebookAuthProvider.m
+++ b/FirebaseAuth/Tests/Sample/Sample/FacebookAuthProvider.m
@@ -19,7 +19,7 @@
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>
 
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
+@import FirebaseAuth;
 #import "ApplicationDelegate.h"
 #import "AuthCredentials.h"
 

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+App.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+App.m
@@ -17,12 +17,10 @@
 #import "MainViewController+App.h"
 
 #import "AppManager.h"
-#import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h"
-#import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.h"
+@import FirebaseAuth;
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 #import "MainViewController+Internal.h"
-#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthBackend.h"
 #import <FirebaseCore/FIRApp.h>
 
 static NSString *const kTokenRefreshErrorAlertTitle = @"Get Token Error";
@@ -145,7 +143,7 @@ static NSString *const kTokenRefreshedAlertTitle = @"Token";
     [[FIRVerifyClientRequest alloc] initWithAppToken:token.string
                                            isSandbox:token.type == FIRAuthAPNSTokenTypeSandbox
                                 requestConfiguration:[AppManager auth].requestConfiguration];
-    [FIRAuthBackend verifyClient:request callback:^(FIRVerifyClientResponse *_Nullable response,
+    [FIRAuthBackend2 postWithRequest:request callback:^(FIRVerifyClientResponse *_Nullable response,
                                                     NSError *_Nullable error) {
       if (error) {
         [self logFailure:@"Verify iOS client failed." error:error];
@@ -168,7 +166,7 @@ static NSString *const kTokenRefreshedAlertTitle = @"Token";
                                                       reCAPTCHAToken:nil
                                                 requestConfiguration:
          [AppManager auth].requestConfiguration];
-         [FIRAuthBackend sendVerificationCode:request
+         [FIRAuthBackend2 postWithRequest:request
                                      callback:^(FIRSendVerificationCodeResponse *_Nullable response,
                                                 NSError *_Nullable error) {
            if (error) {

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
@@ -17,12 +17,10 @@
 #import "MainViewController+Email.h"
 
 #import "AppManager.h"
-#import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
+@import FirebaseAuth;
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey;
 
 typedef void (^ShowEmailDialogCompletion)(FIRAuthCredential *credential);
 
@@ -125,7 +123,7 @@ typedef void (^ShowEmailDialogCompletion)(FIRAuthCredential *credential);
             [self hideSpinner:^{
               if (error) {
                 if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
-                  FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+                  FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrors.FIRAuthErrorUserInfoMultiFactorResolverKey];
                   NSMutableString *displayNameString = [NSMutableString string];
                   for (FIRMultiFactorInfo *tmpFactorInfo in resolver.hints) {
                     [displayNameString appendString:tmpFactorInfo.displayName];

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.h
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.h
@@ -19,7 +19,6 @@
 
 #import "MainViewController.h"
 
-#import <FirebaseAuth/FIRGameCenterAuthProvider.h>
 #import "StaticContentTableViewManager.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Google.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Google.m
@@ -19,13 +19,10 @@
 #import "AppManager.h"
 #import "AuthProviders.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
-#import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
 #import "MainViewController+Internal.h"
 @import FirebaseAuth;
 
 NS_ASSUME_NONNULL_BEGIN
-
-extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey;
 
 @implementation MainViewController (Google)
 
@@ -37,7 +34,7 @@ extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey;
     [StaticContentTableViewCell cellWithTitle:@"Link with Google"
                                       action:^{ [weakSelf linkWithGoogle]; }],
     [StaticContentTableViewCell cellWithTitle:@"Unlink from Google"
-                                      action:^{ [weakSelf unlinkFromProvider:FIRGoogleAuthProvider.string completion:nil]; }],
+                                      action:^{ [weakSelf unlinkFromProvider:FIRGoogleAuthProvider.id completion:nil]; }],
     [StaticContentTableViewCell cellWithTitle:@"Reauthenticate Google"
                                       action:^{ [weakSelf reauthenticateGoogle]; }],
     ]];
@@ -56,7 +53,7 @@ extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey;
                                               NSError *_Nullable error) {
        if (error) {
          if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
-           FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+           FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrors.FIRAuthErrorUserInfoMultiFactorResolverKey];
            NSMutableString *displayNameString = [NSMutableString string];
            for (FIRMultiFactorInfo *tmpFactorInfo in resolver.hints) {
              [displayNameString appendString:tmpFactorInfo.displayName];

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+MultiFactor.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+MultiFactor.m
@@ -18,8 +18,7 @@
 
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+@import FirebaseAuth;
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+OAuth.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+OAuth.m
@@ -21,7 +21,7 @@
 #import <AuthenticationServices/AuthenticationServices.h>
 
 #import "AppManager.h"
-#import <FirebaseAuth/FIROAuthProvider.h>
+@import FirebaseAuth;
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Phone.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Phone.m
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
                       // provided credential.
                       [self showSpinner:^{
                         FIRPhoneAuthCredential *credential =
-                        error.userInfo[FIRAuthErrorUserInfoUpdatedCredentialKey];
+                        error.userInfo[FIRAuthErrors.userInfoUpdatedCredentialKey];
                         [[AppManager auth] signInWithCredential:credential
                                                     completion:^(FIRAuthDataResult *_Nullable result,
                                                                  NSError *_Nullable error) {

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController.m
@@ -52,8 +52,6 @@ static NSString *const kSwitchToInMemoryUserTitle = @"Switch to in memory user";
 
 static NSString *const kNewOrExistingUserToggleTitle = @"New or Existing User Toggle";
 
-extern NSString *const FIRAuthErrorUserInfoMultiFactorResolverKey;
-
 typedef void (^FIRTokenCallback)(NSString *_Nullable token, NSError *_Nullable error);
 
 @implementation MainViewController {
@@ -82,7 +80,7 @@ typedef void (^FIRTokenCallback)(NSString *_Nullable token, NSError *_Nullable e
     _actionCodeContinueURL = [NSURL URLWithString:KCONTINUE_URL];
     _authStateDidChangeListeners = [NSMutableArray array];
     _IDTokenDidChangeListeners = [NSMutableArray array];
-    _googleOAuthProvider = [FIROAuthProvider providerWithProviderID:FIRGoogleAuthProvider.string];
+    _googleOAuthProvider = [FIROAuthProvider providerWithProviderID:FIRGoogleAuthProvider.id];
     _microsoftOAuthProvider = [FIROAuthProvider providerWithProviderID:@"microsoft.com"];
     _twitterOAuthProvider = [FIROAuthProvider providerWithProviderID:@"twitter.com"];
     _linkedinOAuthProvider = [FIROAuthProvider providerWithProviderID:@"linkedin.com"];
@@ -319,7 +317,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                                NSError *_Nullable error) {
         if (error) {
           if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
-            FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+            FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrors.FIRAuthErrorUserInfoMultiFactorResolverKey];
             NSMutableString *displayNameString = [NSMutableString string];
             for (FIRMultiFactorInfo *tmpFactorInfo in resolver.hints) {
               [displayNameString appendString:tmpFactorInfo.displayName];
@@ -420,7 +418,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                                NSError *_Nullable error) {
         if (error) {
           if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
-            FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+            FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrors.FIRAuthErrorUserInfoMultiFactorResolverKey];
             NSMutableString *displayNameString = [NSMutableString string];
             for (FIRMultiFactorInfo *tmpFactorInfo in resolver.hints) {
               [displayNameString appendString:tmpFactorInfo.displayName];
@@ -552,7 +550,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                                    (long)error.code,
                                                    error.localizedDescription];
     if (error.code == FIRAuthErrorCodeAccountExistsWithDifferentCredential) {
-      NSString *errorEmail = error.userInfo[FIRAuthErrorUserInfoEmailKey];
+      NSString *errorEmail = error.userInfo[FIRAuthErrors.userInfoEmailKey];
       resultsTitle = [NSString stringWithFormat:@"Existing email : %@", errorEmail];
     }
     [self showMessagePromptWithTitle:resultsTitle

--- a/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
@@ -32,12 +32,12 @@
 /** @var kIdentityToolkitRequestClassName
     @brief The class name of Identity Toolkit requests.
  */
-static NSString *const kIdentityToolkitRequestClassName = @"FIRIdentityToolkitRequest";
+static NSString *const kIdentityToolkitRequestClassName = @"IdentityToolkitRequest";
 
 /** @var kSecureTokenRequestClassName
     @brief The class name of Secure Token Service requests.
  */
-static NSString *const kSecureTokenRequestClassName = @"FIRSecureTokenRequest";
+static NSString *const kSecureTokenRequestClassName = @"SecureTokenRequest";
 
 /** @var kIdentityToolkitSandboxHost
     @brief The host of Identity Toolkit sandbox server.
@@ -116,6 +116,8 @@ static NSString *truncatedString(NSString *string, NSUInteger length) {
 - (IBAction)done:(id)sender {
   [self dismissViewControllerAnimated:YES completion:nil];
 }
+
+// TODO: This reliance on `NSClassFromString` crashes with the Swift implementation.
 
 - (void)setUpAPIHosts {
   if (gAPIHosts) {

--- a/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
@@ -20,8 +20,7 @@
 
 #import "AppManager.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
-#import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h"
-#import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.h"
+@import FirebaseAuth;
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h"
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIROptions.h>

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -79,7 +79,7 @@ class AccountInfoTests: TestsBase {
   func testUpdatingUsersEmailAsync() async throws {
     let auth = Auth.auth()
     do {
-      let _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
+      _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
 
       XCTFail("Did not get error for recreating a user")
     } catch {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -79,7 +79,7 @@ class AccountInfoTests: TestsBase {
   func testUpdatingUsersEmailAsync() async throws {
     let auth = Auth.auth()
     do {
-      let user = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
+      let _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
 
       XCTFail("Did not get error for recreating a user")
     } catch {

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -37,18 +37,18 @@ class GoogleTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testSignInWithGoogleAsync() async throws {
-      let auth = Auth.auth()
-      let userInfoDict = try await getGoogleAccessTokenAsync()
-      let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
-      let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
-      let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
-                                                     accessToken: googleAccessToken)
-      _ = try await auth.signIn(with: credential)
-    }
-  #endif
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testSignInWithGoogleAsync() async throws {
+    let auth = Auth.auth()
+    let userInfoDict = try await getGoogleAccessTokenAsync()
+    let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
+    let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
+    let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
+                                                   accessToken: googleAccessToken)
+    _ = try await auth.signIn(with: credential)
+    let displayName = try XCTUnwrap(auth.currentUser?.displayName)
+    XCTAssertEqual(displayName, "apitests ios");
+  }
 
   /// ** Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
   // * access token. Returns a dictionary that constains "access_token", "token_type", "expires_in" and

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -30,7 +30,7 @@ class GoogleTests: TestsBase {
     let expectation = self.expectation(description: "Signing in with Google finished.")
     auth.signIn(with: credential) { result, error in
       if let error = error {
-        print("Signing in with Google had error: \(error)")
+        XCTFail("Signing in with Google had error: \(error)")
       }
       expectation.fulfill()
     }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -47,7 +47,7 @@ class GoogleTests: TestsBase {
                                                    accessToken: googleAccessToken)
     _ = try await auth.signIn(with: credential)
     let displayName = try XCTUnwrap(auth.currentUser?.displayName)
-    XCTAssertEqual(displayName, "apitests ios");
+    XCTAssertEqual(displayName, "apitests ios")
   }
 
   /// ** Sends http request to Google OAuth2 token server to use refresh token to exchange for Google

--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -46,7 +46,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     }
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -81,7 +81,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     }
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -113,7 +113,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.networkError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -149,7 +149,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -189,7 +189,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -234,7 +234,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -280,7 +280,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -319,7 +319,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -364,7 +364,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.captchaCheckFailed.rawValue)
   }
 
@@ -395,7 +395,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -440,7 +440,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -482,7 +482,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)
@@ -524,7 +524,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
 
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.userDisabled.rawValue)
 
     let customMessage = try XCTUnwrap(rpcError?.userInfo[NSLocalizedDescriptionKey] as? String)
@@ -555,7 +555,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
     XCTAssert(callbackInvoked)
     XCTAssertNil(rpcResponse)
 
-    XCTAssertEqual(rpcError?.domain, AuthErrors.AuthErrorDomain)
+    XCTAssertEqual(rpcError?.domain, AuthErrors.domain)
     XCTAssertEqual(rpcError?.code, AuthErrorCode.internalError.rawValue)
 
     let underlyingError = try XCTUnwrap(rpcError?.userInfo[NSUnderlyingErrorKey] as? NSError)

--- a/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
@@ -17,8 +17,8 @@ import XCTest
 
 @testable import FirebaseAuth
 
-/** @class FIRFakeBackendRPCIssuer
-    @brief An implementation of @c FIRAuthBackendrpcIssuer which is used to test backend request,
+/** @class FakeBackendRPCIssuer
+    @brief An implementation of @c AuthBackendRPCIssuer which is used to test backend request,
         response, and glue logic.
  */
 class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {

--- a/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/FakeBackendRPCIssuer.swift
@@ -17,11 +17,11 @@ import XCTest
 
 @testable import FirebaseAuth
 
-/** @class FIRFakeBackendrpcIssuer
+/** @class FIRFakeBackendRPCIssuer
     @brief An implementation of @c FIRAuthBackendrpcIssuer which is used to test backend request,
         response, and glue logic.
  */
-class FakeBackendrpcIssuer: NSObject, AuthBackendRPCIssuer {
+class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
   /** @property requestURL
       @brief The URL which was requested.
    */

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -33,11 +33,11 @@ class RPCBaseTests: XCTestCase {
    */
   let kTestIdentifier = "Identifier"
 
-  var rpcIssuer: FakeBackendrpcIssuer?
+  var rpcIssuer: FakeBackendRPCIssuer?
   var rpcImplementation: AuthBackendImplementation?
 
   override func setUp() {
-    rpcIssuer = FakeBackendrpcIssuer()
+    rpcIssuer = FakeBackendRPCIssuer()
     AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: rpcIssuer)
     rpcImplementation = AuthBackend.implementation()
   }
@@ -54,7 +54,7 @@ class RPCBaseTests: XCTestCase {
                                        expected: String,
                                        key: String,
                                        value: String?,
-                                       checkPostBody: Bool = false) throws -> FakeBackendrpcIssuer {
+                                       checkPostBody: Bool = false) throws -> FakeBackendRPCIssuer {
     AuthBackend.post(withRequest: request) { response, error in
       XCTFail("No explicit response from the fake backend.")
     }

--- a/FirebaseAuth/Tests/Unit/VerifyPhoneNumberTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyPhoneNumberTests.swift
@@ -155,8 +155,7 @@ import XCTest
       XCTAssert(callbackInvoked)
       XCTAssertNil(rpcResponse)
       let credential = try XCTUnwrap(rpcError?
-        .userInfo[AuthErrors.AuthErrorUserInfoUpdatedCredentialKey]
-        as? PhoneAuthCredential)
+        .userInfo[AuthErrors.userInfoUpdatedCredentialKey] as? PhoneAuthCredential)
       XCTAssertEqual(credential.temporaryProof, kTemporaryProof)
       XCTAssertEqual(credential.phoneNumber, kPhoneNumber)
     }


### PR DESCRIPTION
Since so much extra stuff is `public` while transitioning, it's possible to run the existing ObjC integration tests, including the internal API tests that will eventually need to be ported to Swift.

For now, the integration tests will be an extra set of tests as we move to a Swift implementation, and this PR fixes a few errors in the transition.

#no-changelog