### PR TITLE
Fixing threading-related hang during initialization in urgent mode

### DIFF
--- a/Crashlytics/UnitTests/Data/GoogleService-Info.plist
+++ b/Crashlytics/UnitTests/Data/GoogleService-Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>ATestTestTestTestTestTestTestTestTest00</string>
+	<key>PROJECT_ID</key>
+	<string>test-1aaaa</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:632950151350:ios:d5b0d08d4f00f4b1</string>
+</dict>
+</plist>

--- a/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
@@ -74,11 +74,12 @@ NSString *const TestFIID = @"TestFIID";
 
 - (void)tearDown {
   self.uploader = nil;
+  [FIRApp resetApps];
 
   [super tearDown];
 }
 
-- (void)setupUploaderWithInstallations:(FIRMockInstallations *)installations {
+- (void)setupUploaderWithInstallations:(FIRInstallations *)installations {
   // Allow nil values only in tests
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -95,11 +96,20 @@ NSString *const TestFIID = @"TestFIID";
   self.uploader = [[FIRCLSReportUploader alloc] initWithManagerData:self.managerData];
 }
 
+- (NSString *)resourcePath {
+  return [[NSBundle bundleForClass:[self class]] resourcePath];
+}
+
+- (FIRCLSInternalReport *)createReport {
+  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:[self packagePath]];
+  self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
+  return report;
+}
+
 #pragma mark - Tests
 
 - (void)testPrepareReport {
-  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:[self packagePath]];
-  self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
+  FIRCLSInternalReport *report = [self createReport];
 
   XCTAssertNil(self.uploader.fiid);
 
@@ -115,9 +125,64 @@ NSString *const TestFIID = @"TestFIID";
       [self.fileManager.moveItemAtPath_destDir containsString:self.fileManager.preparedPath]);
 }
 
+- (void)testPrepareReportOnMainThread {
+  NSString *pathToPlist =
+      [[self resourcePath] stringByAppendingPathComponent:@"GoogleService-Info.plist"];
+  FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:pathToPlist];
+
+  [FIRApp configureWithName:@"__FIRAPP_DEFAULT" options:options];
+  XCTAssertNotNil([FIRApp defaultApp], @"configureWithName must have been initialized");
+
+  FIRInstallations *installations = [FIRInstallations installationsWithApp:[FIRApp defaultApp]];
+  FIRCLSInternalReport *report = [self createReport];
+  [self setupUploaderWithInstallations:installations];
+
+  /*
+   if a report is urgent report will be processed on the Main Thread
+   otherwise, it will be dispatched to a NSOperationQueue (see `FIRCLSExistingReportManager.m:230`)
+
+   This test checks if `prepareAndSubmitReport` finishes in a reasonable time.
+   */
+
+  NSOperationQueue *queue = [NSOperationQueue new];
+
+  // target call will block the main thread, so we need a background thread
+  // that will wait on a semaphore for a timeout
+  dispatch_semaphore_t backgroundWaiter = dispatch_semaphore_create(0);
+  [queue addOperationWithBlock:^{
+    intptr_t result = dispatch_semaphore_wait(backgroundWaiter,
+                                              dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
+    BOOL exitBecauseOfTimeout = result != 0;
+    NSAssert(exitBecauseOfTimeout == false, @"Main Thread was blocked for more than 1 second");
+  }];
+
+  // Urgent (on the Main thread)
+  [self.uploader prepareAndSubmitReport:report
+                    dataCollectionToken:FIRCLSDataCollectionToken.validToken
+                               asUrgent:NO
+                         withProcessing:YES];
+  dispatch_semaphore_signal(backgroundWaiter);
+
+  // Not urgent (on a background thread)
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"wait for a preparation to complete"];
+
+  [queue addOperationWithBlock:^{
+    [self.uploader prepareAndSubmitReport:report
+                      dataCollectionToken:FIRCLSDataCollectionToken.validToken
+                                 asUrgent:NO
+                           withProcessing:YES];
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *_Nullable error) {
+                                 XCTAssertNil(error, @"expectations failed: %@", error);
+                               }];
+}
+
 - (void)test_NilFIID_DoesNotCrash {
-  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:[self packagePath]];
-  self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
+  FIRCLSInternalReport *report = [self createReport];
 
   self.mockInstallations = [[FIRMockInstallations alloc]
       initWithError:[NSError errorWithDomain:@"TestDomain" code:-1 userInfo:nil]];


### PR DESCRIPTION
This commit fixes a threading issue in the FIRCLSInstallIdentifierModel class that caused a 10-second hang during Crashlytics initialization in urgent mode. The issue was caused by a semaphore that was waiting for a completion handler to unblock it, but the completion handler was waiting for the main thread to call dispatch_async, resulting in a deadlock. To solve this problem, the code was updated to use a runloop spinning mechanism instead of the semaphore when running on the main thread. This allows dispatch_async to notify the thread to resume execution without blocking it.

Changes include:
- Introducing a check for the main thread before using a semaphore
- Using a run loop to handle main thread execution
- Adding a test case for report preparation on the main thread
- Adding a GoogleService-Info.plist file for support initialization of the FIRApp.defaultApp in the unit tests