### PR TITLE
[auth-swift] Prep for keychain dependency injection (pt. 1)

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -437,6 +437,7 @@ static NSString *const kMissingPasswordReason = @"Missing Password";
                                                                            auth:self
                                                                 heartbeatLogger:heartbeatLogger];
     _firebaseAppName = [appName copy];
+    _firebaseAppId = [appID copy];
 #if TARGET_OS_IOS
     _settings = [[FIRAuthSettings alloc] init];
 
@@ -458,7 +459,7 @@ static NSString *const kMissingPasswordReason = @"Missing Password";
     if (!strongSelf) {
       return;
     }
-    NSString *keychainServiceName = [[self class] keychainServiceNameForApp:self.app];
+    NSString *keychainServiceName = [FIRAuth keychainServiceNameForAppID:strongSelf.firebaseAppId];
     if (keychainServiceName) {
       strongSelf->_keychainServices =
           [[FIRAuthKeychainServices alloc] initWithService:keychainServiceName];
@@ -1768,8 +1769,8 @@ typedef void (^FIRSignupNewUserCallback)(FIRSignUpNewUserResponse *_Nullable res
   return NO;
 }
 
-+ (NSString *)keychainServiceNameForApp:(FIRApp *)app {
-  return [@"firebase_auth_" stringByAppendingString:app.options.googleAppID];;
++ (NSString *)keychainServiceNameForAppID:(NSString *)appID {
+  return [@"firebase_auth_" stringByAppendingString:appID];
 }
 
 /** @fn scheduleAutoTokenRefreshWithDelay:
@@ -2127,7 +2128,7 @@ typedef void (^FIRSignupNewUserCallback)(FIRSignUpNewUserResponse *_Nullable res
 - (void)appWillBeDeleted:(nonnull FIRApp *)app {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     // This doesn't stop any request already issued, see b/27704535 .
-    NSString *keychainServiceName = [[self class] keychainServiceNameForApp:app];
+    NSString *keychainServiceName = [FIRAuth keychainServiceNameForAppID:app.options.googleAppID];
     if (keychainServiceName) {
       FIRAuthKeychainServices *keychain =
           [[FIRAuthKeychainServices alloc] initWithService:keychainServiceName];

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -47,16 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #endif  // TARGET_OS_IOS
 
-/** @fn initWithAPIKey:appName:
-    @brief Designated initializer.
-    @param APIKey The Google Developers Console API key for making requests from your app.
-    @param appName The name property of the previously created @c FIRApp instance.
-    @param appID The app ID of the Firebase application.
- */
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
-                                appName:(NSString *)appName
-                                  appID:(NSString *)appID;
-
 /** @fn getUserID
     @brief Gets the identifier of the current user, if any.
     @return The identifier of the current user, or nil if there is no current user.

--- a/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
@@ -24,7 +24,6 @@
 
 @interface FIRAuth (Test)
 @property(nonatomic, strong, nullable) FIRAuthStoredUserManager *storedUserManager;
-+ (NSString *)keychainServiceNameForAppName:(NSString *)appName;
 @end
 
 @interface UseUserAccessGroupTests : XCTestCase
@@ -39,7 +38,6 @@
 
 - (void)testUseUserAccessGroup {
   id classMock = OCMClassMock([FIRAuth class]);
-  OCMStub([classMock keychainServiceNameForAppName:OCMOCK_ANY]).andReturn(nil);
   FIRAuthStoredUserManager *myManager =
       [[FIRAuthStoredUserManager alloc] initWithServiceName:@"MyService"];
   [myManager setStoredUserAccessGroup:@"MyGroup" error:nil];


### PR DESCRIPTION
### Context
- Precursor to making Auth SDK more dependency injection friendly. The goal is to provide an Auth initializer that accepts a passed in keychain storage instance. In order to get there, I need to do some refactoring and am breaking it up into small PRs so the approach is more reviewable.
- This should be a no-op and not change behavior.

#no-changelog