### PR TITLE
Firestore: defer copying bloom filter bytes until the bloom filter is actually needed

### DIFF
--- a/Firestore/core/src/nanopb/fields_array.h
+++ b/Firestore/core/src/nanopb/fields_array.h
@@ -227,6 +227,21 @@ inline const pb_field_t* FieldsArray<
   return google_firestore_v1_StructuredAggregationQuery_Aggregation_Count_fields;
 }
 
+template <>
+inline const pb_field_t* FieldsArray<google_firestore_v1_ExistenceFilter>() {
+  return google_firestore_v1_ExistenceFilter_fields;
+}
+
+template <>
+inline const pb_field_t* FieldsArray<google_firestore_v1_BloomFilter>() {
+  return google_firestore_v1_BloomFilter_fields;
+}
+
+template <>
+inline const pb_field_t* FieldsArray<google_firestore_v1_BitSequence>() {
+  return google_firestore_v1_BitSequence_fields;
+}
+
 }  // namespace nanopb
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/remote/remote_objc_bridge.cc
+++ b/Firestore/core/src/remote/remote_objc_bridge.cc
@@ -105,8 +105,8 @@ WatchStreamSerializer::ParseResponse(Reader* reader) const {
 
 std::unique_ptr<WatchChange> WatchStreamSerializer::DecodeWatchChange(
     nanopb::Reader* reader,
-    google_firestore_v1_ListenResponse& response) const {
-  return serializer_.DecodeWatchChange(reader->context(), response);
+    nanopb::Message<google_firestore_v1_ListenResponse>&& response) const {
+  return serializer_.DecodeWatchChange(reader->context(), std::move(response));
 }
 
 SnapshotVersion WatchStreamSerializer::DecodeSnapshotVersion(

--- a/Firestore/core/src/remote/remote_objc_bridge.h
+++ b/Firestore/core/src/remote/remote_objc_bridge.h
@@ -80,7 +80,7 @@ class WatchStreamSerializer {
    */
   std::unique_ptr<WatchChange> DecodeWatchChange(
       nanopb::Reader* reader,
-      google_firestore_v1_ListenResponse& response) const;
+      nanopb::Message<google_firestore_v1_ListenResponse>&& response) const;
   model::SnapshotVersion DecodeSnapshotVersion(
       nanopb::Reader* reader,
       const google_firestore_v1_ListenResponse& response) const;

--- a/Firestore/core/src/remote/serializer.h
+++ b/Firestore/core/src/remote/serializer.h
@@ -210,7 +210,7 @@ class Serializer {
    */
   std::unique_ptr<remote::WatchChange> DecodeWatchChange(
       util::ReadContext* context,
-      google_firestore_v1_ListenResponse& watch_change) const;
+      nanopb::Message<google_firestore_v1_ListenResponse>&& watch_change) const;
 
   model::SnapshotVersion DecodeVersionFromListenResponse(
       util::ReadContext* context,
@@ -339,10 +339,10 @@ class Serializer {
       const google_firestore_v1_DocumentRemove& change) const;
   std::unique_ptr<remote::WatchChange> DecodeExistenceFilterWatchChange(
       util::ReadContext* context,
-      const google_firestore_v1_ExistenceFilter& filter) const;
+      nanopb::Message<google_firestore_v1_ExistenceFilter>&& filter) const;
 
   ExistenceFilter DecodeExistenceFilter(
-      const google_firestore_v1_ExistenceFilter& filter) const;
+      nanopb::Message<google_firestore_v1_ExistenceFilter>&& filter) const;
 
   model::DatabaseId database_id_;
   // TODO(varconst): Android caches the result of calling `EncodeDatabaseName`

--- a/Firestore/core/src/remote/watch_stream.cc
+++ b/Firestore/core/src/remote/watch_stream.cc
@@ -104,8 +104,9 @@ Status WatchStream::NotifyStreamResponse(const grpc::ByteBuffer& message) {
   // A successful response means the stream is healthy.
   backoff_.Reset();
 
-  auto watch_change = watch_serializer_.DecodeWatchChange(&reader, *response);
   auto version = watch_serializer_.DecodeSnapshotVersion(&reader, *response);
+  auto watch_change =
+      watch_serializer_.DecodeWatchChange(&reader, std::move(response));
   if (!reader.ok()) {
     return reader.status();
   }


### PR DESCRIPTION
This is a temporary PR that will eventually be closed without merging. It shows one way that the bloom filter bytes could potentially avoid the expensive copy of the bloom filter bytes until the bloom filter is actually needed. See https://github.com/firebase/firebase-ios-sdk/pull/10953#discussion_r1143636462 for details.

#no-changelog