### PR TITLE
Turn off flaky Crashlytics tests

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -136,6 +136,8 @@
 
 #pragma mark - Tests
 
+// This test has been disabled due to a flake
+#if FIRCLS_FLAKY_TESTS_ENABLED
 - (void)testNoReports {
   [self.existingReportManager collectExistingReports];
 
@@ -147,6 +149,7 @@
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
+#endif
 
 - (void)testReportNoEvents {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:NO];

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -149,7 +149,6 @@
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
-#endif
 
 - (void)testReportNoEvents {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:NO];
@@ -165,6 +164,7 @@
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
+#endif
 
 - (void)testUnsentReportsUnderLimit {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -307,6 +307,8 @@
   [self waitForPromise:[self startReportManagerWithDataCollectionEnabled:YES] withTimeout:4];
 }
 
+// This test has been disabled due to a flake
+#if FIRCLS_FLAKY_TESTS_ENABLED
 - (void)testExistingUnimportantReportOnStartWithDataCollectionDisabled {
   // create a report and put it in place
   [self createActiveReport];
@@ -319,6 +321,7 @@
   XCTAssertEqual([self.prepareAndSubmitReportArray count], 0);
   XCTAssertEqual([self.uploadReportArray count], 0);
 }
+#endif
 
 - (void)testExistingReportOnStart {
   // create a report and put it in place

--- a/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
@@ -98,8 +98,7 @@ NSString *const TestFIID = @"TestFIID";
 #pragma mark - Tests
 
 - (void)testPrepareReport {
-  NSString *path = [self.fileManager.activePath stringByAppendingPathComponent:@"pkg_uuid"];
-  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:path];
+  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:[self packagePath]];
   self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
 
   XCTAssertNil(self.uploader.fiid);
@@ -117,8 +116,7 @@ NSString *const TestFIID = @"TestFIID";
 }
 
 - (void)test_NilFIID_DoesNotCrash {
-  NSString *path = [self.fileManager.activePath stringByAppendingPathComponent:@"pkg_uuid"];
-  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:path];
+  FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:[self packagePath]];
   self.fileManager.moveItemAtPathResult = [NSNumber numberWithInt:1];
 
   self.mockInstallations = [[FIRMockInstallations alloc]


### PR DESCRIPTION
2 different flaky tests are disabled in this PR. A task has been filed for the Crashlytics team to fix this:

 - https://github.com/firebase/firebase-ios-sdk/actions/runs/4485746539/jobs/7889007887
 - https://github.com/firebase/firebase-ios-sdk/actions/runs/4319822264/jobs/7539418159

This should also fix https://github.com/firebase/firebase-ios-sdk/issues/10873