### PR TITLE
[auth-swift] Migrate usage of `FIRAuthKeychainServices` to `id<FIRAuthSorage>`

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -337,7 +337,7 @@ static NSString *const kMissingPasswordReason = @"Missing Password";
   /** @var _keychainServices
       @brief The keychain service.
    */
-  FIRAuthKeychainServices *_keychainServices;
+  id<FIRAuthStorage> _keychainServices;
 
   /** @var _lastNotifiedUserToken
       @brief The user access (ID) token used last time for posting auth state changed notification.

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h
@@ -20,7 +20,7 @@
 #import <Foundation/Foundation.h>
 
 @class FIRAuthAppCredential;
-@class FIRAuthKeychainServices;
+@protocol FIRAuthStorage;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -56,7 +56,7 @@ typedef void (^FIRAuthAppCredentialCallback)(FIRAuthAppCredential *credential);
     @param keychain The iOS Keychain storage to back up the app credential with.
     @return The initialized instance.
  */
-- (instancetype)initWithKeychain:(FIRAuthKeychainServices *)keychain NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithKeychain:(id<FIRAuthStorage>)keychain NS_DESIGNATED_INITIALIZER;
 
 /** @fn didStartVerificationWithReceipt:timeout:callback:
     @brief Notifies that the app verification process has started.

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
@@ -47,7 +47,7 @@ static const NSUInteger kMaximumNumberOfPendingReceipts = 32;
   /** @var _keychainServices
       @brief The keychain for app credentials to load from and to save to.
    */
-  FIRAuthKeychainServices *_keychainServices;
+  id<FIRAuthStorage> _keychainServices;
 
   /** @var _pendingReceipts
       @brief A list of pending receipts sorted in the order they were recorded.
@@ -60,7 +60,7 @@ static const NSUInteger kMaximumNumberOfPendingReceipts = 32;
   NSMutableDictionary<NSString *, FIRAuthAppCredentialCallback> *_callbacksByReceipt;
 }
 
-- (instancetype)initWithKeychain:(FIRAuthKeychainServices *)keychain {
+- (instancetype)initWithKeychain:(id<FIRAuthStorage>)keychain {
   self = [super init];
   if (self) {
     _keychainServices = keychain;


### PR DESCRIPTION
### Context
- Generalize existing initializers that accept keychain wrapper types

#no-changelog