### PR TITLE
[auth-swift] Move keychain intitialization code into intializer

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -447,10 +447,9 @@ static NSString *const kMissingPasswordReason = @"Missing Password";
 
     NSString *keychainServiceName = [FIRAuth keychainServiceNameForAppID:_firebaseAppId];
     if (keychainServiceName) {
-        _keychainServices =
-            [[FIRAuthKeychainServices alloc] initWithService:keychainServiceName];
-        _storedUserManager =
-            [[FIRAuthStoredUserManager alloc] initWithServiceName:keychainServiceName];
+      _keychainServices = [[FIRAuthKeychainServices alloc] initWithService:keychainServiceName];
+      _storedUserManager =
+          [[FIRAuthStoredUserManager alloc] initWithServiceName:keychainServiceName];
     }
     [self protectedDataInitialization];
   }


### PR DESCRIPTION
### Context
- Auth's keychain storage instances are initialized via a helper method called
  from the Auth designated initializer. Moving the keychain initialization code
  into the intializer should be safe as the initializing the keychain accessor
  types have no side effect.

#no-changelog
