### PR TITLE
Verify MLKit integration with Firebase 10.x

### DIFF
--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -34,7 +34,8 @@ target 'SymbolCollisionTest' do
     # Google Pods depending on a Firebase or GDT major version
 
     # TODO(v10): Uncomment when MLKit updates to Firebase 10 and GTMSessionFetcher 2.x
-#    pod 'GoogleMLKit'
+    pod 'GoogleMLKit'
+    pod 'GoogleMLKit/TextRecognition'
 
   # Other Google Pods
     pod 'ARCore'

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -33,9 +33,9 @@ target 'SymbolCollisionTest' do
 
     # Google Pods depending on a Firebase or GDT major version
 
-    # TODO(v10): Uncomment when MLKit updates to Firebase 10 and GTMSessionFetcher 2.x
-    pod 'GoogleMLKit'
-    pod 'GoogleMLKit/TextRecognition'
+    # MLKit is incompatible with ARCore.
+    # duplicate symbol 'farmhashte::Fingerprint64WithSeeds. See #11003.
+    # pod 'GoogleMLKit'
 
   # Other Google Pods
     pod 'ARCore'


### PR DESCRIPTION
MLKit 4.0.0 is compatible with Firebase 10.x. Restore the integration testing and disable it again when discovering MLKit is incompatible with ARCore.

Fix #10359