### PR TITLE
[auth-swift] Use stored keychain service at app cleanup

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -2116,14 +2116,8 @@ typedef void (^FIRSignupNewUserCallback)(FIRSignUpNewUserResponse *_Nullable res
 
 - (void)appWillBeDeleted:(nonnull FIRApp *)app {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
-    // This doesn't stop any request already issued, see b/27704535 .
-    NSString *keychainServiceName = [FIRAuth keychainServiceNameForAppID:app.options.googleAppID];
-    if (keychainServiceName) {
-      FIRAuthKeychainServices *keychain =
-          [[FIRAuthKeychainServices alloc] initWithService:keychainServiceName];
-      NSString *userKey = [NSString stringWithFormat:kUserKey, app.name];
-      [keychain removeDataForKey:userKey error:NULL];
-    }
+    NSString *userKey = [NSString stringWithFormat:kUserKey, app.name];
+    [_keychainServices removeDataForKey:userKey error:NULL];
     dispatch_async(dispatch_get_main_queue(), ^{
       // TODO: Move over to fire an event instead, once ready.
       [[NSNotificationCenter defaultCenter] postNotificationName:FIRAuthStateDidChangeNotification

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -2117,7 +2117,7 @@ typedef void (^FIRSignupNewUserCallback)(FIRSignUpNewUserResponse *_Nullable res
 - (void)appWillBeDeleted:(nonnull FIRApp *)app {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     NSString *userKey = [NSString stringWithFormat:kUserKey, app.name];
-    [_keychainServices removeDataForKey:userKey error:NULL];
+    [self->_keychainServices removeDataForKey:userKey error:NULL];
     dispatch_async(dispatch_get_main_queue(), ^{
       // TODO: Move over to fire an event instead, once ready.
       [[NSNotificationCenter defaultCenter] postNotificationName:FIRAuthStateDidChangeNotification


### PR DESCRIPTION
### Context
- Auth conforms to Core's library component protocol and implements the `appWillBeDeleted:` API.
- The implementation removes the Auth's instances stored info from the keychain.
- If we are injecting the keychain instance into Auth, we ideally are using the the injected version at cleanup time–– instead of creating this new one for cleanup purposes.
#no-changelog