### PR TITLE
[Infra] Print state of invalid assertion to help identify cause of flake

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -177,7 +177,8 @@
   [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
 
   // Reports with events should be kept if there's less than MAX_UNSENT_REPORTS reports
-  XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports);
+  XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports,
+                 @"Contents of active path: %@", [self contentsOfActivePath]);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, FIRCLSMaxUnsentReports);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count,
                  FIRCLSMaxUnsentReports);
@@ -208,7 +209,8 @@
   [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
 
   // Remove any reports over the limit, starting with the oldest
-  XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports);
+  XCTAssertEqual([[self contentsOfActivePath] count], FIRCLSMaxUnsentReports,
+                 @"Contents of active path: %@", [self contentsOfActivePath]);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, FIRCLSMaxUnsentReports);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count,
                  FIRCLSMaxUnsentReports);


### PR DESCRIPTION
### Context
- Nightlies reporting more Crashlytics flakes from over the weekend (#11012). 
- Could not reproduce but adding some logging to better understand the failures.

#no-changelog