### PR TITLE
[Infra] Remove test artifact directory in test set up

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -54,6 +54,11 @@
 
   self.fileManager = [[FIRCLSTempMockFileManager alloc] init];
 
+  // Cleanup potential artifacts from other test files.
+  if ([[NSFileManager defaultManager] fileExistsAtPath:[self.fileManager rootPath]]) {
+    assert([self.fileManager removeItemAtPath:[self.fileManager rootPath]]);
+  }
+
   // Allow nil values only in tests
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"


### PR DESCRIPTION
### Context
- A potential hint–– the last three times a test from this file failed in CI, it was the first test run in the file. This may mean another test is leaving some state behind. I'm proposing we copy some of the `tearDown` code into the `setUp` code to enforce a clean artifact directory.
  - https://github.com/firebase/firebase-ios-sdk/actions/runs/4485746539/jobs/7889007887#step:5:972
  - https://github.com/firebase/firebase-ios-sdk/actions/runs/4528004614/jobs/7974385037#step:5:454
  - https://github.com/firebase/firebase-ios-sdk/actions/runs/4528004614/jobs/7974385037#step:5:997

#no-changelog