### PR TITLE
[Infra] Re-enable tests disabled in #10995

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -141,8 +141,6 @@
 
 #pragma mark - Tests
 
-// This test has been disabled due to a flake
-#if FIRCLS_FLAKY_TESTS_ENABLED
 - (void)testNoReports {
   [self.existingReportManager collectExistingReports];
 
@@ -169,7 +167,6 @@
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
 }
-#endif
 
 - (void)testUnsentReportsUnderLimit {
   [self createActiveReportWithID:@"report_A" time:12312 withEvents:YES];

--- a/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m
@@ -147,7 +147,8 @@
   [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
 
   // Reports without events should be deleted
-  XCTAssertEqual([[self contentsOfActivePath] count], 0);
+  XCTAssertEqual([[self contentsOfActivePath] count], 0, @"Contents of active path: %@",
+                 [self contentsOfActivePath]);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, 0);
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);
@@ -162,7 +163,8 @@
   [self.existingReportManager.operationQueue waitUntilAllOperationsAreFinished];
 
   // Reports without events should be deleted
-  XCTAssertEqual([[self contentsOfActivePath] count], 0);
+  XCTAssertEqual([[self contentsOfActivePath] count], 0, @"Contents of active path: %@",
+                 [self contentsOfActivePath]);
   XCTAssertEqual(self.existingReportManager.unsentReportsCount, 0);
   XCTAssertEqual(self.existingReportManager.newestUnsentReport, nil);
   XCTAssertEqual(self.existingReportManager.existingUnemptyActiveReportPaths.count, 0);

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -307,8 +307,6 @@
   [self waitForPromise:[self startReportManagerWithDataCollectionEnabled:YES] withTimeout:4];
 }
 
-// This test has been disabled due to a flake
-#if FIRCLS_FLAKY_TESTS_ENABLED
 - (void)testExistingUnimportantReportOnStartWithDataCollectionDisabled {
   // create a report and put it in place
   [self createActiveReport];
@@ -321,7 +319,6 @@
   XCTAssertEqual([self.prepareAndSubmitReportArray count], 0);
   XCTAssertEqual([self.uploadReportArray count], 0);
 }
-#endif
 
 - (void)testExistingReportOnStart {
   // create a report and put it in place


### PR DESCRIPTION
### Context
- Test results after #11021 looked promising for the `Crashlytics/UnitTests/FIRCLSExistingReportManagerTests.m` file. This PR reverts the tests disabled in https://github.com/firebase/firebase-ios-sdk/pull/10995 and adds debug logging to the re-enabled tests in `FIRCLSExistingReportManagerTests.m`.

#no-changelog