### PR TITLE
[auth-swift] Make request components for deterministic to avoid test flakes

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
@@ -247,7 +247,7 @@ private let kLastNameKey = "lastName"
       }
       let userDict = [kNameKey: nameDict]
       do {
-        let userJson = try JSONSerialization.data(withJSONObject: userDict)
+        let userJson = try JSONEncoder().encode(userDict)
         let jsonString = String(data: userJson, encoding: .utf8)
         queryItems.append(URLQueryItem(name: kUserKey, value: jsonString))
       } catch {

--- a/FirebaseAuth/Tests/Unit/VerifyAssertionTests.swift
+++ b/FirebaseAuth/Tests/Unit/VerifyAssertionTests.swift
@@ -98,8 +98,6 @@ class VerifyAssertionTests: RPCBaseTests {
     // The name fields may be sorted either way.
     let userJSON = "{\"name\":{\"firstName\":\"\(kFakeGivenName)\"," +
       "\"lastName\":\"\(kFakeFamilyName)\"}}"
-    let userJSONAlt = "{\"name\":{\"lastName\":\"\(kFakeFamilyName)\"," +
-      "\"firstName\":\"\(kFakeGivenName)\"}}"
 
     let issuer = try checkRequest(
       request: request,
@@ -117,19 +115,8 @@ class VerifyAssertionTests: RPCBaseTests {
       URLQueryItem(name: "user", value: userJSON),
     ]
 
-    var componentsAlt = URLComponents()
-    componentsAlt.queryItems = [
-      URLQueryItem(name: kProviderIDKey, value: kTestProviderID),
-      URLQueryItem(name: kProviderIDTokenKey, value: kTestProviderIDToken),
-      URLQueryItem(name: kProviderAccessTokenKey, value: kTestProviderAccessToken),
-      URLQueryItem(name: kProviderOAuthTokenSecretKey, value: kTestProviderOAuthTokenSecret),
-      URLQueryItem(name: kInputEmailKey, value: kTestInputEmail),
-      URLQueryItem(name: "user", value: userJSONAlt),
-    ]
-
     let requestDictionary = try XCTUnwrap(issuer.decodedRequest as? [String: AnyHashable])
-    let postBody = try XCTUnwrap(requestDictionary[kPostBodyKey] as? String)
-    XCTAssertTrue(postBody == components.query || postBody == componentsAlt.query)
+    XCTAssertEqual(requestDictionary[kPostBodyKey], components.query)
     XCTAssertTrue(try XCTUnwrap(requestDictionary[kReturnSecureTokenKey] as? Bool))
     XCTAssertFalse(try XCTUnwrap(requestDictionary[kAutoCreateKey] as? Bool))
   }


### PR DESCRIPTION
### Context
- I was seeing non-deterministic flakes locally and tracked it down to the `testVerifyAssertionRequestOptionalFields` test method. They were more reproducible when I ran the mentioned test 100-1000 times. The issue is that the test specifies a hardcoded JSON string to compare the firstname/lastname request component, but the implementation dynamically creates the JSON string via the `JSONSerialization.data(withJSONObject:)` API. This API seems to create a JSON string without preserving the given dictionary's given order. While the order doesn't matter in practice, it eliminates the flakes as the hardcoded test string will always match. Interestingly, using `JSONEncoder().encode(_:)` seems to preserve the order as I wasn't able to reproduce when re-running 1k times.

#no-changelog