### PR TITLE
Scripts cleanup: remove python `six` usage and get `ruby` from `PATH`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: 3.11
 
     - name: Cache Mint packages
       uses: actions/cache@v3

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: 3.11
 
     - name: Setup check
       run:  scripts/setup_check.sh

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Check out firebase-cpp-sdk
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,3 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.12.0'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
-

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.12.0'
 gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '8.4.5'
+

--- a/scripts/lib/checker.py
+++ b/scripts/lib/checker.py
@@ -55,9 +55,8 @@ class Result(object):
   def __init__(self, num_errors, output):
     self.errors = num_errors
     self.output = (output
-      if isinstance(output, str)
-      else output.decode('utf8', errors='replace')
-    )
+                   if isinstance(output, str)
+                   else output.decode('utf8', errors='replace'))
 
   @staticmethod
   def from_list(errors):

--- a/scripts/lib/checker.py
+++ b/scripts/lib/checker.py
@@ -16,7 +16,6 @@ from __future__ import division
 
 import math
 import multiprocessing.pool
-import six
 import sys
 import threading
 
@@ -55,7 +54,9 @@ class Result(object):
 
   def __init__(self, num_errors, output):
     self.errors = num_errors
-    self.output = six.ensure_text(output)
+    self.output = (output
+      if isinstance(output, str)
+      else output.decode('utf8', errors='replace')
 
   @staticmethod
   def from_list(errors):

--- a/scripts/lib/checker.py
+++ b/scripts/lib/checker.py
@@ -57,6 +57,7 @@ class Result(object):
     self.output = (output
       if isinstance(output, str)
       else output.decode('utf8', errors='replace')
+    )
 
   @staticmethod
   def from_list(errors):

--- a/scripts/lib/git.py
+++ b/scripts/lib/git.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import six
 import subprocess
 
 from lib import command_trace
@@ -105,7 +104,7 @@ def find_lines_matching(pattern, sources=None):
     proc.terminate()
     proc.wait()
 
-  return six.ensure_text(b''.join(result))
+  return b''.join(result).decode('utf8', errors='replace')
 
 
 def make_patterns(dirs):
@@ -135,11 +134,11 @@ def is_within_repo():
 def get_repo_root():
   """Returns the absolute path to the root of the current git repo."""
   command = ['git', 'rev-parse', '--show-toplevel']
-  return six.ensure_text(subprocess.check_output(command).rstrip())
+  return subprocess.check_output(command, text=True, errors='replace').rstrip())
 
 
 def _null_split_output(command):
   """Runs the given command and splits its output on the null byte."""
   command_trace.log(command)
-  result = six.ensure_text(subprocess.check_output(command))
+  result = subprocess.check_output(command, text=True, errors='replace')
   return [name for name in result.rstrip().split('\0') if name]

--- a/scripts/lib/git.py
+++ b/scripts/lib/git.py
@@ -134,7 +134,7 @@ def is_within_repo():
 def get_repo_root():
   """Returns the absolute path to the root of the current git repo."""
   command = ['git', 'rev-parse', '--show-toplevel']
-  return subprocess.check_output(command, text=True, errors='replace').rstrip())
+  return subprocess.check_output(command, text=True, errors='replace').rstrip()
 
 
 def _null_split_output(command):

--- a/scripts/make_release_notes.py
+++ b/scripts/make_release_notes.py
@@ -76,11 +76,8 @@ def main():
 
 
 def find_local_repo():
-  url = subprocess.check_output(
-    ['git', 'config', '--get', 'remote.origin.url'],
-    text=True,
-    errors='replace',
-  )
+  url = subprocess.check_output(['git', 'config', '--get', 'remote.origin.url'],
+                                text=True, errors='replace')
 
   # ssh or https style URL
   m = re.match(r'^(?:git@github\.com:|https://github\.com/)(.*)\.git$', url)

--- a/scripts/make_release_notes.py
+++ b/scripts/make_release_notes.py
@@ -22,8 +22,6 @@ import re
 import subprocess
 import string
 
-import six
-
 NO_HEADING = 'PRODUCT HAS NO HEADING'
 
 
@@ -78,8 +76,11 @@ def main():
 
 
 def find_local_repo():
-  url = six.ensure_text(
-      subprocess.check_output(['git', 'config', '--get', 'remote.origin.url']))
+  url = subprocess.check_output(
+    ['git', 'config', '--get', 'remote.origin.url'],
+    text=True,
+    errors='replace',
+  )
 
   # ssh or https style URL
   m = re.match(r'^(?:git@github\.com:|https://github\.com/)(.*)\.git$', url)

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Copyright 2018 Google
 #


### PR DESCRIPTION
This PR makes the scripts easier to run.

The first change is to `scripts/sync_project.rb` to look up the `ruby` interpreter in the `PATH` rather than hardcoding `/usr/bin/ruby`. For me, personally, this fixed a bug where I wanted it to use `ruby` from homebrew rather than the system `ruby` interpreter.

The second change is to remove the usage of the `six` library from Python scripts. Since everyone should be using Python 3 by now, there is no need for `six`. Also, this removes the requirement that people install this dependency on their local machines and make the scripts usable from a "vanilla" Python distribution.

The third change is to upgrade the Python version used in the GitHub Actions workflows from 3.6/3.7 to the latest, 3.11.