### PR TITLE
[SPM] Require Xcode 13.3+ (Swift 5.6)

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 10.8.0
+- [changed] The Firebase Swift package now requires the Swift 5.6 toolchain (Xcode 13.3) to build.
+
 # Firebase 10.4.0
 - Deprecate `androidClientID` and `trackingID` from FirebaseOptions. (#10520)
 

--- a/Package.swift
+++ b/Package.swift
@@ -1395,7 +1395,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
 
   // Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement so that the
   // release process can defer publishing the GoogleAppMeasurement tag until after testing.
-  if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] == "true" {
+  if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] != nil {
     return .package(url: appMeasurementURL, branch: "main")
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1390,21 +1390,12 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
 
 // MARK: - Helper Functions
 
-/// Returns  `true` if running in a GitHub Action (Continous Integration).
-func runningInGitHubAction() -> Bool {
-  if let gitHubAction = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] {
-    return gitHubAction == "true"
-  }
-
-  return false
-}
-
 func googleAppMeasurementDependency() -> Package.Dependency {
   let appMeasurementURL = "https://github.com/google/GoogleAppMeasurement.git"
 
   // Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement so that the
-  // release process can defer publish the GoogleAppMeasurement tag until after testing.
-  if runningInGitHubAction() {
+  // release process can defer publishing the GoogleAppMeasurement tag until after testing.
+  if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] == "true" {
     return .package(url: appMeasurementURL, branch: "main")
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -203,7 +203,7 @@ let package = Package(
         // TODO: - Add support for cflags cSetting so that we can set the -fno-autolink option
       ],
       linkerSettings: [
-        .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+        .linkedFramework("UIKit", .when(platforms: [.iOS, .macCatalyst, .tvOS])),
         .linkedFramework("AppKit", .when(platforms: [.macOS])),
       ]
     ),
@@ -282,17 +282,20 @@ let package = Package(
     .target(
       name: "FirebaseAnalyticsTarget",
       dependencies: [.target(name: "FirebaseAnalyticsWrapper",
-                             condition: .when(platforms: [.iOS, .macOS, .tvOS]))],
+                             condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseAnalyticsWrap"
     ),
 
     .target(
       name: "FirebaseAnalyticsWrapper",
       dependencies: [
-        .target(name: "FirebaseAnalytics", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
+        .target(
+          name: "FirebaseAnalytics",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
         .product(name: "GoogleAppMeasurement",
                  package: "GoogleAppMeasurement",
-                 condition: .when(platforms: [.iOS, .macOS, .tvOS])),
+                 condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])),
         "FirebaseCore",
         "FirebaseInstallations",
         .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
@@ -317,7 +320,7 @@ let package = Package(
     .target(
       name: "FirebaseAnalyticsSwiftTarget",
       dependencies: [.target(name: "FirebaseAnalyticsSwift",
-                             condition: .when(platforms: [.iOS, .macOS, .tvOS]))],
+                             condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseAnalyticsSwiftWrap"
     ),
     .target(
@@ -329,16 +332,19 @@ let package = Package(
     .target(
       name: "FirebaseAnalyticsWithoutAdIdSupportTarget",
       dependencies: [.target(name: "FirebaseAnalyticsWithoutAdIdSupportWrapper",
-                             condition: .when(platforms: [.iOS, .macOS, .tvOS]))],
+                             condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseAnalyticsWithoutAdIdSupportWrap"
     ),
     .target(
       name: "FirebaseAnalyticsWithoutAdIdSupportWrapper",
       dependencies: [
-        .target(name: "FirebaseAnalytics", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
+        .target(
+          name: "FirebaseAnalytics",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
         .product(name: "GoogleAppMeasurementWithoutAdIdSupport",
                  package: "GoogleAppMeasurement",
-                 condition: .when(platforms: [.iOS])),
+                 condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])),
         "FirebaseCore",
         "FirebaseInstallations",
         .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
@@ -1098,7 +1104,10 @@ let package = Package(
       ],
       linkerSettings: [
         .linkedFramework("Security"),
-        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
+        .linkedFramework(
+          "SystemConfiguration",
+          .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
       ]
     ),
     // The Sessions SDK is Swift-first with Objective-C code to support
@@ -1131,7 +1140,10 @@ let package = Package(
       ],
       linkerSettings: [
         .linkedFramework("Security"),
-        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
+        .linkedFramework(
+          "SystemConfiguration",
+          .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
       ]
     ),
     .testTarget(
@@ -1271,7 +1283,10 @@ let package = Package(
               .headerSearchPath("../.."),
             ],
             linkerSettings: [
-              .linkedFramework("DeviceCheck", .when(platforms: [.iOS, .macOS, .tvOS])),
+              .linkedFramework(
+                "DeviceCheck",
+                .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+              ),
             ]),
     // Internal headers only for consuming from Swift.
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let firebaseVersion = "10.8.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v11), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v7)],
+  platforms: [.iOS(.v11), .macCatalyst(.v13), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 
@@ -136,66 +136,49 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      name: "Promises",
       url: "https://github.com/google/promises.git",
       "2.1.0" ..< "3.0.0"
     ),
     .package(
-      name: "SwiftProtobuf",
       url: "https://github.com/apple/swift-protobuf.git",
       "1.19.0" ..< "2.0.0"
     ),
+    googleAppMeasurementDependency(),
     .package(
-      name: "GoogleAppMeasurement",
-      url: "https://github.com/google/GoogleAppMeasurement.git",
-      // Note that CI changes the version to the head of main for CI.
-      // See scripts/setup_spm_tests.sh.
-      .exact("10.6.0")
-    ),
-    .package(
-      name: "GoogleDataTransport",
       url: "https://github.com/google/GoogleDataTransport.git",
       "9.2.0" ..< "10.0.0"
     ),
     .package(
-      name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
       "7.10.0" ..< "8.0.0"
     ),
     .package(
-      name: "GTMSessionFetcher",
       url: "https://github.com/google/gtm-session-fetcher.git",
       "2.1.0" ..< "4.0.0"
     ),
     .package(
-      name: "nanopb",
       url: "https://github.com/firebase/nanopb.git",
       "2.30909.0" ..< "2.30910.0"
     ),
     .package(
-      name: "abseil",
       url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
       "0.20220203.1" ..< "0.20220204.0"
     ),
     .package(
-      name: "gRPC",
       url: "https://github.com/grpc/grpc-ios.git",
       "1.44.0-grpc" ..< "1.45.0-grpc"
     ),
     .package(
-      name: "OCMock",
       url: "https://github.com/erikdoe/ocmock.git",
-      .revision("c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110")
+      revision: "c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110"
     ),
     .package(
-      name: "leveldb",
       url: "https://github.com/firebase/leveldb.git",
       "1.22.2" ..< "1.23.0"
     ),
     .package(
-      name: "GCDWebServer",
       url: "https://github.com/SlaunchaMan/GCDWebServer.git",
-      .revision("935e2736044e71e5341663c3cc9a335ba6867a2b")
+      revision: "935e2736044e71e5341663c3cc9a335ba6867a2b"
     ),
   ],
   targets: [
@@ -230,7 +213,7 @@ let package = Package(
         "FirebaseCore",
         "SharedTestUtilities",
         "HeartbeatLoggingTestUtils",
-        "OCMock",
+        .product(name: "OCMock", package: "ocmock"),
       ],
       path: "FirebaseCore/Tests/Unit",
       exclude: ["Resources/GoogleService-Info.plist"],
@@ -288,7 +271,7 @@ let package = Package(
     ),
     .testTarget(
       name: "ABTestingUnit",
-      dependencies: ["FirebaseABTesting", "OCMock"],
+      dependencies: ["FirebaseABTesting", .product(name: "OCMock", package: "ocmock")],
       path: "FirebaseABTesting/Tests/Unit",
       resources: [.process("Resources")],
       cSettings: [
@@ -408,7 +391,7 @@ let package = Package(
     ),
     .testTarget(
       name: "AppDistributionUnit",
-      dependencies: ["FirebaseAppDistribution", "OCMock"],
+      dependencies: ["FirebaseAppDistribution", .product(name: "OCMock", package: "ocmock")],
       path: "FirebaseAppDistribution/Tests/Unit",
       exclude: ["Swift/"],
       resources: [.process("Resources")],
@@ -431,7 +414,7 @@ let package = Package(
         "FirebaseCore",
         .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
-        .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
+        .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
       ],
       path: "FirebaseAuth/Sources",
       publicHeadersPath: "Public",
@@ -457,7 +440,11 @@ let package = Package(
     ),
     .testTarget(
       name: "AuthUnit",
-      dependencies: ["FirebaseAuth", "OCMock", "HeartbeatLoggingTestUtils"],
+      dependencies: [
+        "FirebaseAuth",
+        "HeartbeatLoggingTestUtils",
+        .product(name: "OCMock", package: "ocmock"),
+      ],
       path: "FirebaseAuth/Tests/Unit",
       exclude: [
         "FIRAuthKeychainServicesTests.m", // TODO: figure out SPM keychain testing
@@ -532,7 +519,7 @@ let package = Package(
     ),
     .testTarget(
       name: "FirebaseCrashlyticsUnit",
-      dependencies: ["FirebaseCrashlytics", "OCMock"],
+      dependencies: ["FirebaseCrashlytics", .product(name: "OCMock", package: "ocmock")],
       path: "Crashlytics/UnitTests",
       resources: [
         .copy("FIRCLSMachO/machO_data"),
@@ -573,7 +560,11 @@ let package = Package(
     ),
     .testTarget(
       name: "DatabaseUnit",
-      dependencies: ["FirebaseDatabase", "OCMock", "SharedTestUtilities"],
+      dependencies: [
+        "FirebaseDatabase",
+        "SharedTestUtilities",
+        .product(name: "OCMock", package: "ocmock"),
+      ],
       path: "FirebaseDatabase/Tests/",
       exclude: [
         // Disable Swift tests as mixed targets are not supported (Xcode 12.4).
@@ -651,8 +642,8 @@ let package = Package(
         "FirebaseCore",
         "leveldb",
         .product(name: "nanopb", package: "nanopb"),
-        .product(name: "abseil", package: "abseil"),
-        .product(name: "gRPC-cpp", package: "gRPC"),
+        .product(name: "abseil", package: "abseil-cpp-SwiftPM"),
+        .product(name: "gRPC-cpp", package: "grpc-ios"),
       ],
       path: "Firestore",
       exclude: [
@@ -757,7 +748,7 @@ let package = Package(
         "FirebaseCoreExtension",
         "FirebaseMessagingInterop",
         "FirebaseSharedSwift",
-        .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
+        .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
       ],
       path: "FirebaseFunctions/Sources"
     ),
@@ -875,7 +866,7 @@ let package = Package(
         "FirebaseInstallations",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULLogger", package: "GoogleUtilities"),
-        "SwiftProtobuf",
+        .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       ],
       path: "FirebaseMLModelDownloader/Sources",
       exclude: [
@@ -926,7 +917,11 @@ let package = Package(
     ),
     .testTarget(
       name: "MessagingUnit",
-      dependencies: ["FirebaseMessaging", "SharedTestUtilities", "OCMock"],
+      dependencies: [
+        "FirebaseMessaging",
+        "SharedTestUtilities",
+        .product(name: "OCMock", package: "ocmock"),
+      ],
       path: "FirebaseMessaging/Tests/UnitTests",
       exclude: [
         "FIRMessagingContextManagerServiceTest.m", // TODO: Adapt its NSBundle usage to SPM.
@@ -975,9 +970,9 @@ let package = Package(
       name: "PerformanceUnit",
       dependencies: [
         "FirebasePerformanceTarget",
-        "OCMock",
         "SharedTestUtilities",
         "GCDWebServer",
+        .product(name: "OCMock", package: "ocmock"),
       ],
       path: "FirebasePerformance/Tests/Unit",
       resources: [
@@ -1000,7 +995,7 @@ let package = Package(
                      "FirebaseAuthInterop",
                      "FirebaseMessagingInterop",
                      "GoogleDataTransport",
-                     "OCMock"],
+                     .product(name: "OCMock", package: "ocmock")],
       path: "SharedTestUtilities",
       publicHeadersPath: "./",
       cSettings: [
@@ -1026,7 +1021,7 @@ let package = Package(
     ),
     .testTarget(
       name: "RemoteConfigUnit",
-      dependencies: ["FirebaseRemoteConfig", "OCMock"],
+      dependencies: ["FirebaseRemoteConfig", .product(name: "OCMock", package: "ocmock")],
       path: "FirebaseRemoteConfig/Tests/Unit",
       exclude: [
         // Need to be evaluated/ported to RC V2.
@@ -1072,7 +1067,7 @@ let package = Package(
     ),
     .target(
       name: "RemoteConfigFakeConsoleObjC",
-      dependencies: ["OCMock"],
+      dependencies: [.product(name: "OCMock", package: "ocmock")],
       path: "FirebaseRemoteConfigSwift/Tests/ObjC",
       publicHeadersPath: ".",
       cSettings: [
@@ -1154,7 +1149,7 @@ let package = Package(
         "FirebaseAuthInterop",
         "FirebaseCore",
         "FirebaseCoreExtension",
-        .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
+        .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
       ],
       path: "FirebaseStorage/Sources"
     ),
@@ -1294,9 +1289,9 @@ let package = Package(
       name: "AppCheckUnit",
       dependencies: [
         "FirebaseAppCheck",
-        "OCMock",
         "SharedTestUtilities",
         "HeartbeatLoggingTestUtils",
+        .product(name: "OCMock", package: "ocmock"),
       ],
       path: "FirebaseAppCheck/Tests",
       exclude: [
@@ -1345,17 +1340,6 @@ let package = Package(
   cxxLanguageStandard: CXXLanguageStandard.gnucxx14
 )
 
-if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] != nil {
-  if let GoogleAppMeasurementIndex = package.dependencies
-    .firstIndex(where: { $0.name == "GoogleAppMeasurement" }) {
-    package.dependencies[GoogleAppMeasurementIndex] = .package(
-      name: "GoogleAppMeasurement",
-      url: "https://github.com/google/GoogleAppMeasurement.git",
-      .branch("main")
-    )
-  }
-}
-
 // This is set when running `scripts/check_firestore_symbols.sh`.
 if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != nil {
   if let firestoreIndex = package.targets
@@ -1378,8 +1362,8 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
           name: "FirebaseFirestore",
           condition: .when(platforms: [.iOS, .tvOS, .macOS])
         ),
-        .product(name: "abseil", package: "abseil"),
-        .product(name: "gRPC-cpp", package: "gRPC"),
+        .product(name: "abseil", package: "abseil-cpp-SwiftPM"),
+        .product(name: "gRPC-cpp", package: "grpc-ios"),
         .product(name: "nanopb", package: "nanopb"),
         "FirebaseCore",
         "leveldb",
@@ -1387,4 +1371,17 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
       path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
     )
   }
+}
+
+// MARK: - Helper Functions
+
+func googleAppMeasurementDependency() -> Package.Dependency {
+  let gitURL = "https://github.com/google/GoogleAppMeasurement.git"
+
+  // Use head of main for CI; see scripts/setup_spm_tests.sh.
+  if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] != nil {
+    return .package(url: gitURL, branch: "main")
+  }
+
+  return .package(url: gitURL, exact: "10.6.0")
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1395,7 +1395,7 @@ func runningInGitHubAction() -> Bool {
   if let gitHubAction = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] {
     return gitHubAction == "true"
   }
-  
+
   return false
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1390,13 +1390,23 @@ if ProcessInfo.processInfo.environment["FIREBASECI_USE_LOCAL_FIRESTORE_ZIP"] != 
 
 // MARK: - Helper Functions
 
-func googleAppMeasurementDependency() -> Package.Dependency {
-  let gitURL = "https://github.com/google/GoogleAppMeasurement.git"
+/// Returns  `true` if running in a GitHub Action (Continous Integration).
+func runningInGitHubAction() -> Bool {
+  if let gitHubAction = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] {
+    return gitHubAction == "true"
+  }
+  
+  return false
+}
 
-  // Use head of main for CI; see scripts/setup_spm_tests.sh.
-  if ProcessInfo.processInfo.environment["FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT"] != nil {
-    return .package(url: gitURL, branch: "main")
+func googleAppMeasurementDependency() -> Package.Dependency {
+  let appMeasurementURL = "https://github.com/google/GoogleAppMeasurement.git"
+
+  // Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement so that the
+  // release process can defer publish the GoogleAppMeasurement tag until after testing.
+  if runningInGitHubAction() {
+    return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: gitURL, exact: "10.8.0")
+  return .package(url: appMeasurementURL, exact: "10.8.0")
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -171,7 +171,7 @@ watchos_flags=(
 )
 catalyst_flags=(
   ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES -sdk macosx
-  -destination platform="macOS,variant=Mac Catalyst" TARGETED_DEVICE_FAMILY=2
+  -destination platform="macOS,variant=Mac Catalyst,arch=x86_64" TARGETED_DEVICE_FAMILY=2
   CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 )
 

--- a/scripts/setup_spm_tests.sh
+++ b/scripts/setup_spm_tests.sh
@@ -15,13 +15,6 @@
 # limitations under the License.
 
 
-# Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement
-# so that the release process can defer publish the GoogleAppMeasurement tag
-# until after testing.
-
-export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
-
-
 # Move schemes into place to run Swift Package Manager tests
 # These cannot be stored in the correct location because they cause
 # clutter for SDK clients.

--- a/scripts/setup_spm_tests.sh
+++ b/scripts/setup_spm_tests.sh
@@ -15,16 +15,13 @@
 # limitations under the License.
 
 
-# Point SPM to the tip of main of https://github.com/google/GoogleAppMeasurement
+# Point SPM CI to the tip of main of https://github.com/google/GoogleAppMeasurement
 # so that the release process can defer publishing the GoogleAppMeasurement tag
 # until after testing.
-#
-# Note: This only applies when invoking SPM tooling from the CLI. To open
-# Package.swift in Xcode with this environment variable, run:
-#   open --env FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=true Package.swift
-# Ensure that Xcode is not open or running when using the above command.
 
-export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
+# For example: Change `exact: "8.3.1"` to `branch: "main"`
+
+sed -i '' ''s#exact:[[:space:]]*"[0-9.]*"#branch: "main"#'' Package.swift
 
 
 # Move schemes into place to run Swift Package Manager tests

--- a/scripts/setup_spm_tests.sh
+++ b/scripts/setup_spm_tests.sh
@@ -21,7 +21,7 @@
 
 # For example: Change `exact: "8.3.1"` to `branch: "main"`
 
-sed -i '' ''s#exact:[[:space:]]*"[0-9.]*"#branch: "main"#'' Package.swift
+sed -i '' 's#exact:[[:space:]]*"[0-9.]*"#branch: "main"#' Package.swift
 
 
 # Move schemes into place to run Swift Package Manager tests

--- a/scripts/setup_spm_tests.sh
+++ b/scripts/setup_spm_tests.sh
@@ -19,9 +19,7 @@
 # so that the release process can defer publish the GoogleAppMeasurement tag
 # until after testing.
 
-# For example: Change `.exact("8.3.1")` to `.branch("main")`
-
-sed -i '' 's#exact("[0-9.]*#branch("main#' Package.swift
+export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
 
 
 # Move schemes into place to run Swift Package Manager tests

--- a/scripts/setup_spm_tests.sh
+++ b/scripts/setup_spm_tests.sh
@@ -15,6 +15,18 @@
 # limitations under the License.
 
 
+# Point SPM to the tip of main of https://github.com/google/GoogleAppMeasurement
+# so that the release process can defer publishing the GoogleAppMeasurement tag
+# until after testing.
+#
+# Note: This only applies when invoking SPM tooling from the CLI. To open
+# Package.swift in Xcode with this environment variable, run:
+#   open --env FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=true Package.swift
+# Ensure that Xcode is not open or running when using the above command.
+
+export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
+
+
 # Move schemes into place to run Swift Package Manager tests
 # These cannot be stored in the correct location because they cause
 # clutter for SDK clients.


### PR DESCRIPTION
Increased `swift-tools-version` to `5.6` in `Package.swift` to declare that that the Swift 5.6 toolchain (included in Xcode 13.3) is the minimum version required to build the Firebase package.

Replaced uses of initializers / methods / enums that were deprecated in SPM 5.6.

Note: Xcode 13.3.1+ has been the minimum supported since [Firebase 9.0](https://firebase.google.com/support/release-notes/ios#version_900_-_may_3_2022) but this enforces Xcode 13.3+ in `Package.swift`. However, this does not enforce Xcode 13.3<b>.1</b> specifically since the Swift toolchain version did not change between Xcode 13.3 and 13.3.1.
