### PR TITLE
Fix App Quality Sessions field for Bundle Short Version

### DIFF
--- a/FirebaseSessions/Sources/ApplicationInfo.swift
+++ b/FirebaseSessions/Sources/ApplicationInfo.swift
@@ -107,11 +107,11 @@ class ApplicationInfo: ApplicationInfoProtocol {
   }
 
   var appBuildVersion: String {
-    return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
   }
 
   var appDisplayVersion: String {
-    return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+    return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
   }
 
   var osBuildVersion: String {


### PR DESCRIPTION
We had the fields mixed up:

<img width="621" alt="Screenshot 2023-03-30 at 4 43 50 PM" src="https://user-images.githubusercontent.com/555046/228959740-6d94aae3-348c-441d-9025-c208a7f14d54.png">
