### PR TITLE
Fix successful typo

### DIFF
--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -93,7 +93,7 @@ static exception_mask_t FIRCLSMachExceptionMask(void) {
   // is a confirmed kernel bug.  Lacking access to EXC_CRASH means we must use signal handlers to
   // cover all types of crashes.
   // EXC_GUARD is relatively new, and isn't available on all OS versions. You have to be careful,
-  // becuase you cannot succesfully register hanlders if there are any unrecognized masks. We've
+  // because you cannot successfully register hanlders if there are any unrecognized masks. We've
   // dropped support for old OS versions that didn't have EXC_GUARD (iOS 5 and below, macOS 10.6 and
   // below) so we always add it now
 

--- a/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
@@ -166,7 +166,7 @@ static NSString *const kCredentialTooOldErrorMessage = @"CREDENTIAL_TOO_OLD_LOGI
 }
 
 /** @fn testSuccessfulDeleteAccount
-    @brief This test simulates a completed succesful deleteAccount operation.
+    @brief This test simulates a completed successful deleteAccount operation.
  */
 - (void)testSuccessfulDeleteAccountResponse {
   FIRDeleteAccountRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
@@ -159,7 +159,7 @@ static const BOOL kFakeIsNewUSerFlag = YES;
 }
 
 /** @fn testSuccessfulEmailLinkSignInResponse
-    @brief Tests a succesful email link sign-in response.
+    @brief Tests a successful email link sign-in response.
  */
 - (void)testSuccessfulEmailLinkSignInResponse {
   FIREmailLinkSignInRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIRRevokeTokenResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRRevokeTokenResponseTests.m
@@ -88,7 +88,7 @@ static NSString *const kExpectedAPIURL =
 }
 
 /** @fn testSuccessfulRevokeTokenResponse
-    @brief Tests a succesful attempt of the token revocation flow.
+    @brief Tests a successful attempt of the token revocation flow.
  */
 - (void)testSuccessfulResponse {
   FIRRevokeTokenRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
@@ -251,7 +251,7 @@ static NSString *const kCaptchaCheckFailedErrorMessage = @"CAPTCHA_CHECK_FAILED"
 }
 
 /** @fn testSuccessfulSendVerificationCodeResponse
-    @brief Tests a succesful to send a verification code.
+    @brief Tests a successful to send a verification code.
  */
 - (void)testSuccessfulSendVerificationCodeResponse {
   FIRAuthAppCredential *credential = [[FIRAuthAppCredential alloc] initWithReceipt:kTestReceipt

--- a/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
@@ -163,7 +163,7 @@ static NSString *const kInvalidAppCredentialErrorMessage = @"INVALID_APP_CREDENT
 }
 
 /** @fn testSuccessfulVerifyClientResponse
-    @brief Tests a succesful attempt of the verify password flow.
+    @brief Tests a successful attempt of the verify password flow.
  */
 - (void)testSuccessfulVerifyPasswordResponse {
   FIRVerifyClientRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
@@ -436,7 +436,7 @@ static const double kAllowedTimeDifference = 0.1;
 }
 
 /** @fn testSuccessfulVerifyPasswordResponse
-    @brief Tests a succesful attempt of the verify password flow.
+    @brief Tests a successful attempt of the verify password flow.
  */
 - (void)testSuccessfulVerifyPasswordResponse {
   FIRVerifyPasswordRequest *request =

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
@@ -223,7 +223,7 @@ static const double kAllowedTimeDifference = 0.1;
 }
 
 /** @fn testSuccessfulVerifyPhoneNumberResponse
-    @brief Tests a succesful to verify phone number flow.
+    @brief Tests a successful to verify phone number flow.
  */
 - (void)testSuccessfulVerifyPhoneNumberResponse {
   FIRVerifyPhoneNumberRequest *request =
@@ -261,7 +261,7 @@ static const double kAllowedTimeDifference = 0.1;
 }
 
 /** @fn testSuccessfulVerifyPhoneNumberResponseWithTemporaryProof
-    @brief Tests a succesful to verify phone number flow with temporary proof response.
+    @brief Tests a successful to verify phone number flow with temporary proof response.
  */
 - (void)testSuccessfulVerifyPhoneNumberResponseWithTemporaryProof {
   FIRVerifyPhoneNumberRequest *request =

--- a/FirebaseMessaging/Sources/FIRMessagingPendingTopicsList.h
+++ b/FirebaseMessaging/Sources/FIRMessagingPendingTopicsList.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  topics and perform the operation safely and correctly.
  *
  *  When a topic fails to subscribe or unsubscribe due to a network error, it is considered a
- *  recoverable error, and so it remains in the current batch until it is succesfully completed.
+ *  recoverable error, and so it remains in the current batch until it is successfully completed.
  *  Topic updates are completed when they either (a) succeed, (b) are cancelled, or (c) result in an
  *  unrecoverable error. Any error outside of `NSURLErrorDomain` is considered an unrecoverable
  *  error.


### PR DESCRIPTION
succesful -> successful
becuase -> because

#no-changelog