### PR TITLE
[Auth] Remove unreachable code

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -526,54 +526,42 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
           [[FIRAuthStoredUserManager alloc] initWithServiceName:keychainServiceName];
     }
 
-    NSError *error;
     NSString *storedUserAccessGroup =
-        [strongSelf.storedUserManager getStoredUserAccessGroupWithError:&error];
-    if (!error) {
-      if (!storedUserAccessGroup) {
-        FIRUser *user;
-        if ([strongSelf getUser:&user error:&error]) {
-          strongSelf.tenantID = user.tenantID;
-          [strongSelf updateCurrentUser:user byForce:NO savingToDisk:NO error:&error];
-          self->_lastNotifiedUserToken = user.rawAccessToken;
-        } else {
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          if (error.code == FIRAuthErrorCodeKeychainError) {
-            // If there's a keychain error, assume it is due to the keychain being accessed
-            // before the device is unlocked as a result of prewarming, and listen for the
-            // UIApplicationProtectedDataDidBecomeAvailable notification.
-            [strongSelf addProtectedDataDidBecomeAvailableObserver];
-          }
-#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
-                      @"Error loading saved user when starting up: %@", error);
-        }
+        [strongSelf.storedUserManager getStoredUserAccessGroupWithError:nil];
+    if (!storedUserAccessGroup) {
+      FIRUser *user;
+      NSError *error;
+      if ([strongSelf getUser:&user error:&error]) {
+        strongSelf.tenantID = user.tenantID;
+        [strongSelf updateCurrentUser:user byForce:NO savingToDisk:NO error:&error];
+        self->_lastNotifiedUserToken = user.rawAccessToken;
       } else {
-        [strongSelf internalUseUserAccessGroup:storedUserAccessGroup error:&error];
-        if (error) {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          if (error.code == FIRAuthErrorCodeKeychainError) {
-            // If there's a keychain error, assume it is due to the keychain being accessed
-            // before the device is unlocked as a result of prewarming, and listen for the
-            // UIApplicationProtectedDataDidBecomeAvailable notification.
-            [strongSelf addProtectedDataDidBecomeAvailableObserver];
-          }
-#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-          FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
-                      @"Error loading saved user when starting up: %@", error);
+        if (error.code == FIRAuthErrorCodeKeychainError) {
+          // If there's a keychain error, assume it is due to the keychain being accessed
+          // before the device is unlocked as a result of prewarming, and listen for the
+          // UIApplicationProtectedDataDidBecomeAvailable notification.
+          [strongSelf addProtectedDataDidBecomeAvailableObserver];
         }
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
+        FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
+                    @"Error loading saved user when starting up: %@", error);
       }
     } else {
+      NSError *error;
+      [strongSelf internalUseUserAccessGroup:storedUserAccessGroup error:&error];
+      if (error) {
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-      if (error.code == FIRAuthErrorCodeKeychainError) {
-        // If there's a keychain error, assume it is due to the keychain being accessed
-        // before the device is unlocked as a result of prewarming, and listen for the
-        // UIApplicationProtectedDataDidBecomeAvailable notification.
-        [strongSelf addProtectedDataDidBecomeAvailableObserver];
-      }
+        if (error.code == FIRAuthErrorCodeKeychainError) {
+          // If there's a keychain error, assume it is due to the keychain being accessed
+          // before the device is unlocked as a result of prewarming, and listen for the
+          // UIApplicationProtectedDataDidBecomeAvailable notification.
+          [strongSelf addProtectedDataDidBecomeAvailableObserver];
+        }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
-      FIRLogError(kFIRLoggerAuth, @"I-AUT000001", @"Error loading saved user when starting up: %@",
-                  error);
+        FIRLogError(kFIRLoggerAuth, @"I-AUT000001",
+                    @"Error loading saved user when starting up: %@", error);
+      }
     }
 
 #if TARGET_OS_IOS

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -526,8 +526,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
           [[FIRAuthStoredUserManager alloc] initWithServiceName:keychainServiceName];
     }
 
-    NSString *storedUserAccessGroup =
-        [strongSelf.storedUserManager getStoredUserAccessGroupWithError:nil];
+    NSString *storedUserAccessGroup = [strongSelf.storedUserManager getStoredUserAccessGroup];
     if (!storedUserAccessGroup) {
       FIRUser *user;
       NSError *error;

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -2294,7 +2294,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 - (BOOL)internalUseUserAccessGroup:(NSString *_Nullable)accessGroup
                              error:(NSError *_Nullable *_Nullable)outError {
   BOOL success;
-  success = [self.storedUserManager setStoredUserAccessGroup:accessGroup error:outError];
+  success = [self.storedUserManager setStoredUserAccessGroup:accessGroup];
   if (!success) {
     return NO;
   }

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
@@ -53,10 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** @fn setStoredUserAccessGroup:error:
     @brief The setter of the user access group stored locally.
     @param accessGroup The access group to be set.
-    @param outError Return value for any error which occurs.
  */
-- (BOOL)setStoredUserAccessGroup:(NSString *_Nullable)accessGroup
-                           error:(NSError *_Nullable *_Nullable)outError;
+- (BOOL)setStoredUserAccessGroup:(NSString *_Nullable)accessGroup;
 
 /** @fn getStoredUserForAccessGroup:projectID:error:
     @brief The getter of the user stored locally.

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
@@ -47,9 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** @fn getStoredUserAccessGroupWithError:
     @brief Get the user access group stored locally.
-    @param outError Return value for any error which occurs.
  */
-- (nullable NSString *)getStoredUserAccessGroupWithError:(NSError *_Nullable *_Nullable)outError;
+- (nullable NSString *)getStoredUserAccessGroup;
 
 /** @fn setStoredUserAccessGroup:error:
     @brief The setter of the user access group stored locally.

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -50,7 +50,7 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
 #pragma mark - User Access Group
 
 - (NSString *_Nullable)getStoredUserAccessGroup {
-  NSData *data = [self.userDefaults dataForKey:kStoredUserAccessGroupKey error:nil];
+  NSData *data = [self.userDefaults dataForKey:kStoredUserAccessGroupKey error:NULL];
   if (data) {
     NSString *userAccessGroup = [NSString stringWithUTF8String:data.bytes];
     return userAccessGroup;

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -59,13 +59,12 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   }
 }
 
-- (BOOL)setStoredUserAccessGroup:(NSString *_Nullable)accessGroup
-                           error:(NSError *_Nullable *_Nullable)outError {
+- (BOOL)setStoredUserAccessGroup:(NSString *_Nullable)accessGroup {
   NSData *data = [accessGroup dataUsingEncoding:NSUTF8StringEncoding];
   if (!data) {
-    return [self.userDefaults removeDataForKey:kStoredUserAccessGroupKey error:outError];
+    return [self.userDefaults removeDataForKey:kStoredUserAccessGroupKey error:NULL];
   } else {
-    return [self.userDefaults setData:data forKey:kStoredUserAccessGroupKey error:outError];
+    return [self.userDefaults setData:data forKey:kStoredUserAccessGroupKey error:NULL];
   }
 }
 

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -49,8 +49,8 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
 
 #pragma mark - User Access Group
 
-- (NSString *_Nullable)getStoredUserAccessGroupWithError:(NSError *_Nullable *_Nullable)outError {
-  NSData *data = [self.userDefaults dataForKey:kStoredUserAccessGroupKey error:outError];
+- (NSString *_Nullable)getStoredUserAccessGroup {
+  NSData *data = [self.userDefaults dataForKey:kStoredUserAccessGroupKey error:nil];
   if (data) {
     NSString *userAccessGroup = [NSString stringWithUTF8String:data.bytes];
     return userAccessGroup;

--- a/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
@@ -49,7 +49,7 @@
   id partialMock = OCMPartialMock(auth);
   OCMStub([partialMock storedUserManager]).andReturn(myManager);
 
-  XCTAssertNotNil([auth.storedUserManager getStoredUserAccessGroupWithError:nil]);
+  XCTAssertNotNil([auth.storedUserManager getStoredUserAccessGroup]);
   XCTAssertTrue([auth useUserAccessGroup:@"id.com.example.group1" error:nil]);
   XCTAssertTrue([auth useUserAccessGroup:@"id.com.example.group2" error:nil]);
   XCTAssertTrue([auth useUserAccessGroup:nil error:nil]);

--- a/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
@@ -42,7 +42,7 @@
   OCMStub([classMock keychainServiceNameForAppName:OCMOCK_ANY]).andReturn(nil);
   FIRAuthStoredUserManager *myManager =
       [[FIRAuthStoredUserManager alloc] initWithServiceName:@"MyService"];
-  [myManager setStoredUserAccessGroup:@"MyGroup" error:nil];
+  [myManager setStoredUserAccessGroup:@"MyGroup"];
 
   FIRAuth *auth = [FIRAuth auth];
   XCTAssertNotNil(auth);


### PR DESCRIPTION
_I recommend viewing the diff without whitespace changes. [See nice diff.](https://github.com/firebase/firebase-ios-sdk/pull/11091/files?diff=unified&w=1)_

### Context
The outer `else` clause is unreachable and should be removed. We pass a pointer to `- [FIRAuthStoredUserManager getStoredUserAccessGroupWithError:]` but there is no resulting code path for it be populated.
<img width="955" alt="Screen Shot 2023-04-08 at 4 21 30 PM" src="https://user-images.githubusercontent.com/36927374/230741526-93b77592-82e8-4877-90f2-f255df8ef0e1.png">

The implementation of `- [FIRAuthStoredUserManager getStoredUserAccessGroupWithError:]` is pasted below. The only way for the `outError` to be populated is in the `- [FIRAuthUserDefaults dataForKey:error:]` method on line 53.
https://github.com/firebase/firebase-ios-sdk/blob/8badb28bf2727941c3e4b41fab87905de8595ca4/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m#L52-L60

But, looking at the implementation of `- [FIRAuthUserDefaults dataForKey:error:]`, no code path will populate the error.
https://github.com/firebase/firebase-ios-sdk/blob/8badb28bf2727941c3e4b41fab87905de8595ca4/FirebaseAuth/Sources/Storage/FIRAuthUserDefaults.m#L44-L50

So given that, it's safe to remove the code in the outer `else` clause as it's unreachable. This simplifies the surrounding code.

I found this while porting `FIRAuthStoredUserManager` in the `auth-swift` branch.

#no-changelog