### PR TITLE
[RemoteConfig] Expose NSUnderlyingError to client

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -515,12 +515,12 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
         // Must set lastFetchStatus before setting Fetch Error.
         strongSelf->_settings.lastFetchStatus = FIRRemoteConfigFetchStatusFailure;
         strongSelf->_settings.lastFetchError = FIRRemoteConfigErrorInternalError;
-        NSDictionary<NSErrorUserInfoKey, id> *userInfo = @{
-          NSLocalizedDescriptionKey :
-              ([error localizedDescription]
-                   ?: [NSString
-                          stringWithFormat:@"Internal Error. Status code: %ld", (long)statusCode])
-        };
+        NSMutableDictionary<NSErrorUserInfoKey, id> *userInfo = [NSMutableDictionary dictionary];
+        userInfo[NSUnderlyingErrorKey] = error;
+        userInfo[NSLocalizedDescriptionKey] =
+            error.localizedDescription
+                ?: [NSString stringWithFormat:@"Internal Error. Status code: %ld", statusCode];
+
         return [strongSelf
             reportCompletionWithStatus:FIRRemoteConfigFetchStatusFailure
                             withUpdate:nil

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -519,7 +519,8 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
         userInfo[NSUnderlyingErrorKey] = error;
         userInfo[NSLocalizedDescriptionKey] =
             error.localizedDescription
-                ?: [NSString stringWithFormat:@"Internal Error. Status code: %ld", statusCode];
+                ?: [NSString
+                       stringWithFormat:@"Internal Error. Status code: %ld", (long)statusCode];
 
         return [strongSelf
             reportCompletionWithStatus:FIRRemoteConfigFetchStatusFailure


### PR DESCRIPTION
Sometimes I still get no underlying error. This will fix it.

Fixes https://github.com/firebase/firebase-ios-sdk/issues/10454