### PR TITLE
[Tooling] Add FIR_CLANG_FORMAT_PATH env var to style.sh (#11097)

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseABTesting-197f0cb4125363b6.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseABTesting-a0406dfa65451d86.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseABTesting-f6703794173225ac.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseABTesting-08e98ef79cd15ebe.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/ABTesting-a71d17cadc209af9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/Google-Mobile-Ads-SDK-50008c143ad8f268.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/Google-Mobile-Ads-SDK-116c40997650f5d4.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/Google-Mobile-Ads-SDK-740de42758581c96.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/Google-Mobile-Ads-SDK-20493dd791701138.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/AdMob-8a654a42c33bbcc8.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/AdMob-63dab3b525b94cd9.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/AdMob-134752c6180a2a41.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalytics-e8ebe991b5743f71.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseAnalytics-aebb0844491598df.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseAnalytics-e550ea45578c421f.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseAnalytics-e874ef3f225a5943.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Analytics-2468c231ebeb7922.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Analytics-bc8101d420b896c5.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Analytics-d2b6a6b0242db786.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalyticsOnDeviceConversion-eca2f83d40e0278d.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseAnalyticsOnDeviceConversion-3f8f988326390746.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseAnalyticsOnDeviceConversion-4d066b23b7455efd.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseAnalyticsOnDeviceConversion-bf8e113bb071c6a6.zip",
   "9.0.0": "https://dl.google.com/dl/firebase/ios/carthage/9.0.0/FirebaseAnalyticsOnDeviceConversion-31aedde70a736b8a.zip",
   "9.1.0": "https://dl.google.com/dl/firebase/ios/carthage/9.1.0/FirebaseAnalyticsOnDeviceConversion-f13b5a47d1e3978d.zip",
   "9.2.0": "https://dl.google.com/dl/firebase/ios/carthage/9.2.0/FirebaseAnalyticsOnDeviceConversion-2ebf567c4d97de12.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppCheck-3ce0f074bfcd2596.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseAppCheck-78cd3282e529047c.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseAppCheck-9e7e6ba8c829f2d1.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseAppCheck-7803c5aa7f09e9fa.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppCheck-9ef1d217cf057203.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseAppCheck-fc03215d9fe45d3a.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseAppCheck-6ebe9e9539f06003.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppDistribution-79dc2b1348d9aee9.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseAppDistribution-8ac9dedb565fcc37.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseAppDistribution-e3546365e400e709.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseAppDistribution-d67388ecfb901083.zip",
   "6.31.0": "https://dl.google.com/dl/firebase/ios/carthage/6.31.0/FirebaseAppDistribution-07f6a2cf7f576a8a.zip",
   "6.32.0": "https://dl.google.com/dl/firebase/ios/carthage/6.32.0/FirebaseAppDistribution-a9c4f5db794508ca.zip",
   "6.33.0": "https://dl.google.com/dl/firebase/ios/carthage/6.33.0/FirebaseAppDistribution-448a96d2ade54581.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAuth-7e18a510d0a5b02e.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseAuth-80d882e7b6f41dc1.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseAuth-5d076d5861aa5f3b.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseAuth-edf20beb3ea27846.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Auth-0fa76ba0f7956220.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Auth-5ddd2b4351012c7a.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Auth-5e248984d78d7284.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseCrashlytics-53604573442e756b.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseCrashlytics-faded0c12b5ca6d4.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseCrashlytics-e16ca4491f76e851.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseCrashlytics-b9ef0d68832375c2.zip",
   "6.15.0": "https://dl.google.com/dl/firebase/ios/carthage/6.15.0/FirebaseCrashlytics-1c6d22d5b73c84fd.zip",
   "6.16.0": "https://dl.google.com/dl/firebase/ios/carthage/6.16.0/FirebaseCrashlytics-938e5fd0e2eab3b3.zip",
   "6.17.0": "https://dl.google.com/dl/firebase/ios/carthage/6.17.0/FirebaseCrashlytics-fa09f0c8f31ed5d9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDatabase-aea9249d81841ee1.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseDatabase-7ddcff7e9ab09b6f.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseDatabase-c91ca3f6f5855ede.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseDatabase-30ebbb3e09ae181b.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Database-1f7a820452722c7d.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Database-1f7a820452722c7d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Database-59a12d87456b3e1c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDynamicLinks-bcb5df6ec32f6684.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseDynamicLinks-75e73fe1a66fd58d.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseDynamicLinks-b84cbbce9ef9e522.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseDynamicLinks-048606765d53444f.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/DynamicLinks-6a76740211df73f5.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/DynamicLinks-6a76740211df73f5.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/DynamicLinks-6a76740211df73f5.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFirestore-46fa68ddf287f76e.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseFirestore-9309c3d7d09cec1f.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseFirestore-75a516d0c29e6c05.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseFirestore-020ac095804eeb0a.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Firestore-68fc02c229d0cc69.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Firestore-87a804ab561d91db.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Firestore-ecb3eea7bde7e8e8.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFunctions-688a38b567392fcf.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseFunctions-847bd6bbad2cca2e.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseFunctions-964106b4ea1b6863.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseFunctions-c1d474aa3e9f3132.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Functions-f4c426016dd41e38.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Functions-c6c44427c3034736.zip",
   "5.0.0": "https://dl.google.com/dl/firebase/ios/carthage/5.0.0/Functions-146f34c401bd459b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/GoogleSignIn-5cb2a2f1f74efd5e.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/GoogleSignIn-c2efebac5872431a.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/GoogleSignIn-d6619177d04c0be8.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/GoogleSignIn-23b48d262d978cc3.zip",
   "6.0.0": "https://dl.google.com/dl/firebase/ios/carthage/6.0.0/GoogleSignIn-de9c5d5e8eb6d6ea.zip",
   "6.1.0": "https://dl.google.com/dl/firebase/ios/carthage/6.1.0/GoogleSignIn-8c82f2870573a793.zip",
   "6.10.0": "https://dl.google.com/dl/firebase/ios/carthage/6.10.0/GoogleSignIn-ff3aef61c4a55b05.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseInAppMessaging-91d4dd9878a06b7e.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseInAppMessaging-7a86b20a5c45d210.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseInAppMessaging-efd56ccd27a263b7.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseInAppMessaging-368eb6ae0f05e198.zip",
   "5.10.0": "https://dl.google.com/dl/firebase/ios/carthage/5.10.0/InAppMessaging-a7a3f933362f6e95.zip",
   "5.11.0": "https://dl.google.com/dl/firebase/ios/carthage/5.11.0/InAppMessaging-fa28ce1b88fbca93.zip",
   "5.12.0": "https://dl.google.com/dl/firebase/ios/carthage/5.12.0/InAppMessaging-fa28ce1b88fbca93.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMLModelDownloader-9abf9b0e24bfb921.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseMLModelDownloader-32232af316aa173b.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseMLModelDownloader-b3b708608b720282.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseMLModelDownloader-4b76f0890fe3768f.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMLModelDownloader-8f972757fb181320.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseMLModelDownloader-058ad59fa6dc0111.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseMLModelDownloader-286479a966d2fb37.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMessaging-439a17dcc8b8172b.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseMessaging-7c95dd37771cfcaf.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseMessaging-159709b68b1e73f0.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseMessaging-3ba7b7fc7eb0ea0d.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Messaging-a22ef2b5f2f30f82.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Messaging-94fa4e090c7e9185.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Messaging-2a00a1c64a19d176.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebasePerformance-0ffe559f7554d8a5.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebasePerformance-fed2b2529213ff3c.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebasePerformance-bf2e8fda7c51f58c.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebasePerformance-9fa53b0614619644.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Performance-d8693eb892bfa05b.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Performance-0a400f9460f7a71d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Performance-f5b4002ab96523e4.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseRemoteConfig-2237eb5fcd4a4525.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseRemoteConfig-58b3a9d6d2e984a3.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseRemoteConfig-d22b71a51699e99e.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseRemoteConfig-3aac6f26a0bf5494.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/RemoteConfig-7e9635365ccd4a17.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/RemoteConfig-e7928fcb6311c439.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/RemoteConfig-9ab1ca5f360a1780.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -7,6 +7,7 @@
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseStorage-04f255ea8c3a7420.zip",
   "10.6.0": "https://dl.google.com/dl/firebase/ios/carthage/10.6.0/FirebaseStorage-b694755bafb60c47.zip",
   "10.7.0": "https://dl.google.com/dl/firebase/ios/carthage/10.7.0/FirebaseStorage-58e9306207602f8d.zip",
+  "10.8.0": "https://dl.google.com/dl/firebase/ios/carthage/10.8.0/FirebaseStorage-93b66c8a6ff5483b.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Storage-6b3e77e1a7fdbc61.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Storage-4721c35d2b90a569.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Storage-821299369b9d0fb2.zip",

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -24,14 +24,28 @@
 # Commonly
 # ./scripts/style.sh master
 
+# Set the environment variable FIR_CLANG_FORMAT_PATH to use a specific version
+# of clang-format, regardless of its order in the shell PATH.
+#
+# Example (add to ~/.bash_profile, ~/.zshrc or run in interactive shell):
+#   FIR_CLANG_FORMAT_PATH="$(brew --prefix clang-format)/bin/clang-format"
+#   export FIR_CLANG_FORMAT_PATH
+if [[ -n "$FIR_CLANG_FORMAT_PATH" ]]; then
+  clang_format_bin="$FIR_CLANG_FORMAT_PATH"
+elif ! clang_format_bin=$(command -v clang-format); then
+  echo "clang-format not found, install with 'brew install clang-format'"
+  exit 1
+fi
+
 # Strip the clang-format version output down to the major version. Examples:
 #   clang-format version 7.0.0 (tags/google/stable/2018-01-11)
 #   clang-format version google3-trunk (trunk r333779)
-version=$(clang-format --version)
+version=$("$clang_format_bin" --version)
 
 # Log the version in non-interactive use as it can be useful in travis logs.
 if [[ ! -t 1 ]]; then
-  echo "Found: $version"
+  echo "Clang-format Path: $clang_format_bin"
+  echo "Clang-format Version: $version"
 fi
 
 # Remove leading "clang-format version"
@@ -191,7 +205,7 @@ for f in $files; do
       false
     fi
   else
-    clang-format "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
+    "$clang_format_bin" "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
   fi
 
   if [[ "$test_only" == true && $? -ne 1 ]]; then


### PR DESCRIPTION
Added an environment variable to specify the path to the version of clang-format used by the style.sh script.
