### PR TITLE
[Release Tooling] Separate out dynamic content from zip README.md

### DIFF
--- a/ReleaseTooling/Template/METADATA.md
+++ b/ReleaseTooling/Template/METADATA.md
@@ -1,0 +1,14 @@
+## Dependency Graph
+
+"(~> X)" below means that the SDK requires all of the xcframeworks from X. You
+should make sure to include all of the xcframeworks from X when including the
+SDK.
+
+__INTEGRATION__
+
+## Versions
+
+The xcframeworks in this directory map to these versions of the Firebase SDKs in
+CocoaPods.
+
+__VERSIONS__

--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -88,11 +88,6 @@ frameworks and libraries listed in each Firebase framework's
 indicator that not all system libraries are being brought into your build
 automatically.
 
-"(~> X)" below means that the SDK requires all of the xcframeworks from X. You
-should make sure to include all of the xcframeworks from X when including the
-SDK.
-
-__INTEGRATION__
 # Samples
 
 You can get samples for Firebase from https://github.com/firebase/quickstart-ios:
@@ -104,10 +99,3 @@ this archive; for example, FirebaseUI. For the samples that depend on SDKs not
 included in this archive, you'll need to use CocoaPods or use the
 [ZipBuilder](https://github.com/firebase/firebase-ios-sdk/tree/master/ReleaseTooling)
 to create your own custom binary frameworks.
-
-# Versions
-
-The xcframeworks in this directory map to these versions of the Firebase SDKs in
-CocoaPods.
-
-__VERSIONS__


### PR DESCRIPTION
### Context
- The zip `README.md` has two sections that are populated each release with metadata regarding the release's dependency graph and included versions. Other than those two sections, the zip `README.md` does not change often. So, it's reasonable to break out those sections into a separate `METADATA.md` file.
- For additional context, this change is motivated by b/269421146.

#no-changelog