### PR TITLE
Updated README Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-[![Version](https://img.shields.io/cocoapods/v/Firebase.svg?style=flat)](https://cocoapods.org/pods/Firebase)
-[![License](https://img.shields.io/cocoapods/l/Firebase.svg?style=flat)](https://cocoapods.org/pods/Firebase)
-[![Platform](https://img.shields.io/cocoapods/p/Firebase.svg?style=flat)](https://cocoapods.org/pods/Firebase)
+<p align="center">
+  <a href="https://cocoapods.org/pods/Firebase">
+    <img src="https://img.shields.io/github/v/release/Firebase/firebase-ios-sdk?style=flat&label=CocoaPods"/>
+  </a>
+  <a href="https://swiftpackageindex.com/firebase/firebase-ios-sdk">
+    <img src="https://img.shields.io/github/v/release/Firebase/firebase-ios-sdk?style=flat&label=Swift%20Package%20Index&color=red"/>
+  </a>
+  <a href="https://cocoapods.org/pods/Firebase">
+    <img src="https://img.shields.io/github/license/Firebase/firebase-ios-sdk?style=flat"/>
+  </a>
+  <a href="https://swiftpackageindex.com/firebase/firebase-ios-sdk">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffirebase%2Ffirebase-ios-sdk%2Fbadge%3Ftype%3Dplatforms"/>
+  </a>
+  <a href="https://swiftpackageindex.com/firebase/firebase-ios-sdk">
+    <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffirebase%2Ffirebase-ios-sdk%2Fbadge%3Ftype%3Dswift-versions"/>
+  </a>
+</p>
 
 # Firebase Apple Open Source Development
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
   <a href="https://cocoapods.org/pods/Firebase">
     <img src="https://img.shields.io/github/license/Firebase/firebase-ios-sdk?style=flat"/>
-  </a>
+  </a><br/>
   <a href="https://swiftpackageindex.com/firebase/firebase-ios-sdk">
     <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffirebase%2Ffirebase-ios-sdk%2Fbadge%3Ftype%3Dplatforms"/>
   </a>


### PR DESCRIPTION
I noticed that the CocoaPods badges are a bit flakey/not showing. Managed to get one of them to load after a bit of refreshing, but figured it could do with some updates.

Also added a couple of the badges from Swift Package Index, as they offer great insights to what platforms and Swift versions are supported.

| Old README | New README |
|:-:|:-:|
| <img width="1015" alt="Screenshot 2023-04-13 at 10 04 24" src="https://user-images.githubusercontent.com/5754073/231713685-66a8cde6-ef18-4724-86fd-1ed59577c255.png"> | <img width="1014" alt="Screenshot 2023-04-13 at 10 13 54" src="https://user-images.githubusercontent.com/5754073/231713700-6e935626-c363-4cca-9a51-dc52ab3b2f76.png"> |

Please let me know what you think, happy to change/update as necessary.