### PR TITLE
[Release] Enable macCatalyst support for Firestore targets

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 10.8.1
+- [fixed] Swift Package Manager only release to fix a 10.8.0 Firestore issue
+  impacting macCatalyst. (#11119)
+
 # Firebase 10.8.0
 - Fix new build warnings introduced by Xcode 14.3. (#11059)
 - [changed] The Firebase Swift package now requires the Swift 5.6 toolchain (Xcode 13.3) to build.

--- a/Package.swift
+++ b/Package.swift
@@ -640,7 +640,7 @@ let package = Package(
       dependencies: [
         .target(
           name: "FirebaseFirestore",
-          condition: .when(platforms: [.iOS, .tvOS, .macOS])
+          condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
         ),
         .product(name: "abseil", package: "abseil-cpp-binary"),
         .product(name: "gRPC-C++", package: "grpc-binary"),
@@ -660,7 +660,7 @@ let package = Package(
     .target(
       name: "FirebaseFirestoreSwiftTarget",
       dependencies: [.target(name: "FirebaseFirestoreSwift",
-                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+                             condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap"
     ),
 


### PR DESCRIPTION
### Context
- SPM only change that was missed in #11066
- We recently bumped to enforce swift-tools-version 5.6, which enforces being explicit about macCatalyst support. #11046

After this merges, I'll create the release branch and cherry-pick this into it.