### PR TITLE
Analytics ObjC API coverage tests via CocoaPods and SPM

### DIFF
--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -46,4 +46,15 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
       'FirebaseAnalyticsSwift/Tests/SwiftUnit/**/*.swift',
     ]
   end
+
+    s.test_spec 'objc-api-coverage' do |objc_api_tests|
+    objc_api_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
+    objc_api_tests.source_files = [
+      'FirebaseAnalyticsSwift/Tests/ObjCAPI/*.m',
+    ]
+  end
 end

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -47,7 +47,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
     ]
   end
 
-    s.test_spec 'objc-api-coverage' do |objc_api_tests|
+  s.test_spec 'objc-api-coverage' do |objc_api_tests|
     objc_api_tests.platforms = {
       :ios => ios_deployment_target,
       :osx => osx_deployment_target,

--- a/FirebaseAnalyticsSwift/Tests/ObjCAPI/ObjCAPITests.m
+++ b/FirebaseAnalyticsSwift/Tests/ObjCAPI/ObjCAPITests.m
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseAnalyticsSwift/Tests/ObjCAPI/ObjCAPITests.m
+++ b/FirebaseAnalyticsSwift/Tests/ObjCAPI/ObjCAPITests.m
@@ -1,0 +1,182 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// MARK: This file is used to test the coverage of using Analytics APIs from Objective C.
+
+@import Foundation;
+@import XCTest;
+
+@import FirebaseAnalytics;
+
+@interface ObjCAPICoverage : XCTestCase
+@end
+
+@implementation ObjCAPICoverage
+- (NSString *)analyticsTests {
+  [FIRAnalytics logEventWithName:@"event_name" parameters:@{@"param" : @1}];
+  [FIRAnalytics setUserPropertyString:@"value" forName:@"name"];
+  [FIRAnalytics setUserID:@"userid"];
+  [FIRAnalytics setAnalyticsCollectionEnabled:YES];
+  [FIRAnalytics setSessionTimeoutInterval:360.0];
+  [FIRAnalytics resetAnalyticsData];
+  [FIRAnalytics setDefaultEventParameters:@{@"default" : @100}];
+  NSString *str = [FIRAnalytics appInstanceID];
+
+  [FIRAnalytics sessionIDWithCompletion:^(int64_t sessionID, NSError *_Nullable error){
+  }];
+  return str;
+}
+
+- (void)appDelegateTests:(NSURL *)url {
+  [FIRAnalytics handleEventsForBackgroundURLSession:@"sessionID"
+                                  completionHandler:^{
+                                  }];
+  [FIRAnalytics handleOpenURL:url];
+  [FIRAnalytics handleUserActivity:[NSUserActivity init]];
+}
+
+- (void)consentTests:(NSURL *)url {
+  [FIRAnalytics setConsent:@{
+    FIRConsentTypeAnalyticsStorage : FIRConsentStatusGranted,
+    FIRConsentTypeAdStorage : FIRConsentStatusDenied
+  }];
+}
+
+- (void)onDeviceConversionTests:(NSURL *)url {
+  [FIRAnalytics initiateOnDeviceConversionMeasurementWithEmailAddress:@"a@.a.com"];
+}
+
+- (NSArray<NSString *> *)eventNames {
+  return @[
+    kFIREventAdImpression,
+    kFIREventAddPaymentInfo,
+    kFIREventAddShippingInfo,
+    kFIREventAddToCart,
+    kFIREventAddToWishlist,
+    kFIREventAppOpen,
+    kFIREventBeginCheckout,
+    kFIREventCampaignDetails,
+    kFIREventEarnVirtualCurrency,
+    kFIREventGenerateLead,
+    kFIREventJoinGroup,
+    kFIREventLevelEnd,
+    kFIREventLevelStart,
+    kFIREventLevelUp,
+    kFIREventLogin,
+    kFIREventPostScore,
+    kFIREventPurchase,
+    kFIREventRefund,
+    kFIREventRemoveFromCart,
+    kFIREventScreenView,
+    kFIREventSearch,
+    kFIREventSelectContent,
+    kFIREventSelectItem,
+    kFIREventSelectPromotion,
+    kFIREventShare,
+    kFIREventSignUp,
+    kFIREventSpendVirtualCurrency,
+    kFIREventTutorialBegin,
+    kFIREventTutorialComplete,
+    kFIREventUnlockAchievement,
+    kFIREventViewCart,
+    kFIREventViewItem,
+    kFIREventViewItemList,
+    kFIREventViewPromotion,
+    kFIREventViewSearchResults,
+  ];
+}
+
+- (NSArray<NSString *> *)parameterNames {
+  return @[
+    kFIRParameterAchievementID,
+    kFIRParameterAdFormat,
+    kFIRParameterAdNetworkClickID,
+    kFIRParameterAdPlatform,
+    kFIRParameterAdSource,
+    kFIRParameterAdUnitName,
+    kFIRParameterAffiliation,
+    kFIRParameterCP1,
+    kFIRParameterCampaign,
+    kFIRParameterCampaignID,
+    kFIRParameterCharacter,
+    kFIRParameterContent,
+    kFIRParameterContentType,
+    kFIRParameterCoupon,
+    kFIRParameterCreativeFormat,
+    kFIRParameterCreativeName,
+    kFIRParameterCreativeSlot,
+    kFIRParameterCurrency,
+    kFIRParameterDestination,
+    kFIRParameterDiscount,
+    kFIRParameterEndDate,
+    kFIRParameterExtendSession,
+    kFIRParameterFlightNumber,
+    kFIRParameterGroupID,
+    kFIRParameterIndex,
+    kFIRParameterItemBrand,
+    kFIRParameterItemCategory,
+    kFIRParameterItemCategory2,
+    kFIRParameterItemCategory3,
+    kFIRParameterItemCategory4,
+    kFIRParameterItemCategory5,
+    kFIRParameterItemID,
+    kFIRParameterItemListID,
+    kFIRParameterItemListName,
+    kFIRParameterItemName,
+    kFIRParameterItemVariant,
+    kFIRParameterItems,
+    kFIRParameterLevel,
+    kFIRParameterLevelName,
+    kFIRParameterLocation,
+    kFIRParameterLocationID,
+    kFIRParameterMarketingTactic,
+    kFIRParameterMedium,
+    kFIRParameterMethod,
+    kFIRParameterNumberOfNights,
+    kFIRParameterNumberOfPassengers,
+    kFIRParameterNumberOfRooms,
+    kFIRParameterOrigin,
+    kFIRParameterPaymentType,
+    kFIRParameterPrice,
+    kFIRParameterPromotionID,
+    kFIRParameterPromotionName,
+    kFIRParameterQuantity,
+    kFIRParameterScore,
+    kFIRParameterScreenClass,
+    kFIRParameterScreenName,
+    kFIRParameterSearchTerm,
+    kFIRParameterShipping,
+    kFIRParameterShippingTier,
+    kFIRParameterSource,
+    kFIRParameterSourcePlatform,
+    kFIRParameterStartDate,
+    kFIRParameterSuccess,
+    kFIRParameterTax,
+    kFIRParameterTerm,
+    kFIRParameterTransactionID,
+    kFIRParameterTravelClass,
+    kFIRParameterValue,
+    kFIRParameterVirtualCurrencyName,
+  ];
+}
+
+- (NSArray<NSString *> *)userPropertyNames {
+  return @[
+    kFIRUserPropertyAllowAdPersonalizationSignals,
+    kFIRUserPropertySignUpMethod,
+  ];
+}
+@end

--- a/Package.swift
+++ b/Package.swift
@@ -333,6 +333,11 @@ let package = Package(
       dependencies: ["FirebaseAnalyticsSwift"],
       path: "FirebaseAnalyticsSwift/Tests/SwiftUnit"
     ),
+    .testTarget(
+      name: "AnalyticsObjCAPI",
+      dependencies: ["FirebaseAnalyticsSwift"],
+      path: "FirebaseAnalyticsSwift/Tests/ObjCAPI"
+    ),
 
     .target(
       name: "FirebaseAnalyticsWithoutAdIdSupportTarget",

--- a/scripts/spm_test_schemes/AnalyticsObjCAPI.xcscheme
+++ b/scripts/spm_test_schemes/AnalyticsObjCAPI.xcscheme
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AnalyticsObjCAPI"
+               BuildableName = "AnalyticsObjCAPI"
+               BlueprintName = "AnalyticsObjCAPI"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AnalyticsObjCAPI"
+            BuildableName = "AnalyticsObjCAPI"
+            BlueprintName = "AnalyticsObjCAPI"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Add build tests for the Analytics Objective C API via CocoaPods and SPM.

#no-changelog