### PR TITLE
Fix typo

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 10.8.0
 - [added] Added Firebase App Check support to Firebase Auth. (#11056)
-- [added] Added sign in with Apple token revocation support. (#9906)
+- [added] Added Sign in with Apple token revocation support. (#9906)
 
 # 10.7.0
 - [added] Added an API for developers to pass the fullName from the Sign in with Apple credential to Firebase. (#10068)


### PR DESCRIPTION
Official spelling is _Sign in with Apple_.