### PR TITLE
Remove references to deprecated CTCarrier for Sessions

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed references to deprecated CTCarrier API in FirebaseSessions. (#11144)
+
 # 10.9.0
 - [fixed] Updated upload-symbols to 3.15. Disabled dSYM uploads for Flutter
   apps building with --obfuscate and added instructions for uploading through

--- a/FirebaseSessions/Sources/ApplicationInfo.swift
+++ b/FirebaseSessions/Sources/ApplicationInfo.swift
@@ -47,9 +47,6 @@ protocol ApplicationInfoProtocol {
   /// Model of the device
   var deviceModel: String { get }
 
-  /// Validated Mobile Country Code and Mobile Network Code
-  var mccMNC: String { get }
-
   /// Network information for the application
   var networkInfo: NetworkInfoProtocol { get }
 
@@ -91,10 +88,6 @@ class ApplicationInfo: ApplicationInfoProtocol {
 
   var deviceModel: String {
     return GULAppEnvironmentUtil.deviceSimulatorModel() ?? ""
-  }
-
-  var mccMNC: String {
-    return FIRSESValidateMccMnc(networkInfo.mobileCountryCode, networkInfo.mobileNetworkCode) ?? ""
   }
 
   var networkInfo: NetworkInfoProtocol {

--- a/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
+++ b/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
@@ -62,7 +62,6 @@ class DevEventConsoleLogger: EventGDTLoggerProtocol {
             mobile_subtype: \(proto.application_info.apple_app_info.network_connection_info
       .mobile_subtype.rawValue)
           os_name: \(proto.application_info.apple_app_info.os_name.description)
-          mcc_mnc: \(proto.application_info.apple_app_info.mcc_mnc.description)
           log_environment: \(proto.application_info.log_environment)
     """
 

--- a/FirebaseSessions/Sources/NetworkInfo.swift
+++ b/FirebaseSessions/Sources/NetworkInfo.swift
@@ -26,24 +26,12 @@ import Foundation
 #endif // SWIFT_PACKAGE
 
 protocol NetworkInfoProtocol {
-  var mobileCountryCode: String? { get }
-
-  var mobileNetworkCode: String? { get }
-
   var networkType: GULNetworkType { get }
 
   var mobileSubtype: String { get }
 }
 
 class NetworkInfo: NetworkInfoProtocol {
-  var mobileCountryCode: String? {
-    return GULNetworkInfo.getNetworkMobileCountryCode()
-  }
-
-  var mobileNetworkCode: String? {
-    return GULNetworkInfo.getNetworkMobileNetworkCode()
-  }
-
   var networkType: GULNetworkType {
     return GULNetworkInfo.getNetworkType()
   }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -130,7 +130,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     switch subscriber {
     case .Performance:
       let oldString = proto.application_info.apple_app_info.mcc_mnc
-      proto.application_info.apple_app_info.mcc_mnc = makeProtoString(appInfo.mccMNC)
+      proto.application_info.apple_app_info.mcc_mnc = makeProtoString("")
       nanopb_free(oldString)
       proto.application_info.apple_app_info.network_connection_info
         .network_type = convertNetworkType(networkType: appInfo.networkInfo.networkType)

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.h
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.h
@@ -91,9 +91,6 @@ pb_size_t FIRSESGetAppleApplicationInfoTag(void);
 /// private method in GULAppEnvironmentUtil.
 NSString* _Nullable FIRSESGetSysctlEntry(const char* sysctlKey);
 
-/// Returns the validated MccMnc if it is available, or nil if the device does not support telephone
-NSString* _Nullable FIRSESValidateMccMnc(NSString* _Nullable mcc, NSString* _Nullable mnc);
-
 NS_ASSUME_NONNULL_END
 
 #endif /* FIRSESNanoPBHelpers_h */

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
@@ -182,29 +182,4 @@ NSString *_Nullable FIRSESGetSysctlEntry(const char *sysctlKey) {
   }
 }
 
-NSString *_Nullable FIRSESValidateMccMnc(NSString *_Nullable mcc, NSString *_Nullable mnc) {
-  // These are both nil if the target does not support mobile connectivity
-  if (mcc == nil && mnc == nil) {
-    return nil;
-  }
-
-  if (mcc.length != 3 || mnc.length < 2 || mnc.length > 3) {
-    return nil;
-  }
-
-  // If the resulting appended mcc + mnc contains characters that are not
-  // decimal digits, return nil
-  static NSCharacterSet *notDigits;
-  static dispatch_once_t token;
-  dispatch_once(&token, ^{
-    notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
-  });
-  NSString *mccMnc = [mcc stringByAppendingString:mnc];
-  if ([mccMnc rangeOfCharacterFromSet:notDigits].location != NSNotFound) {
-    return nil;
-  }
-
-  return mccMnc;
-}
-
 NS_ASSUME_NONNULL_END

--- a/FirebaseSessions/Tests/Unit/ApplicationInfoTests.swift
+++ b/FirebaseSessions/Tests/Unit/ApplicationInfoTests.swift
@@ -27,42 +27,6 @@ class ApplicationInfoTests: XCTestCase {
     appInfo = ApplicationInfo(appID: "testAppID", networkInfo: mockNetworkInfo)
   }
 
-  func test_mccMNC_validatesCorrectly() {
-    let expectations: [(mobileCountryCode: String, mobileNetworkCode: String, expected: String)] = [
-      ("310", "004", "310004"),
-      ("310", "01", "31001"),
-      ("001", "50", "00150"),
-    ]
-
-    expectations
-      .forEach { (mobileCountryCode: String, mobileNetworkCode: String, expected: String) in
-        mockNetworkInfo.mobileCountryCode = mobileCountryCode
-        mockNetworkInfo.mobileNetworkCode = mobileNetworkCode
-
-        XCTAssertEqual(appInfo.mccMNC, expected)
-      }
-  }
-
-  func test_mccMNC_isEmptyWhenInvalid() {
-    let expectations: [(mobileCountryCode: String?, mobileNetworkCode: String?)] = [
-      ("3100", "004"), // MCC too long
-      ("31", "01"), // MCC too short
-      ("310", "0512"), // MNC too long
-      ("L00", "003"), // MCC contains non-decimal characters
-      ("300", "00T"), // MNC contains non-decimal characters
-      (nil, nil), // Handle nils gracefully
-      (nil, "001"),
-      ("310", nil),
-    ]
-
-    expectations.forEach { (mobileCountryCode: String?, mobileNetworkCode: String?) in
-      mockNetworkInfo.mobileCountryCode = mobileCountryCode
-      mockNetworkInfo.mobileNetworkCode = mobileNetworkCode
-
-      XCTAssertEqual(appInfo.mccMNC, "")
-    }
-  }
-
   func test_LogEnvironment_hasProdAsDefault() {
     XCTAssertEqual(appInfo.environment, .prod)
   }

--- a/FirebaseSessions/Tests/Unit/Mocks/MockApplicationInfo.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockApplicationInfo.swift
@@ -34,8 +34,6 @@ class MockApplicationInfo: ApplicationInfoProtocol {
 
   var deviceModel: String = ""
 
-  var mccMNC: String = ""
-
   var environment: DevEnvironment = .prod
 
   var appBuildVersion: String = ""
@@ -52,7 +50,6 @@ class MockApplicationInfo: ApplicationInfoProtocol {
   static let testBundleID = "testBundleID"
   static let testSDKVersion = "testSDKVersion"
   static let testOSName = "ios"
-  static let testMCCMNC = "testMCCMNC"
   static let testDeviceModel = "testDeviceModel"
   static let testEnvironment: DevEnvironment = .prod
   static let testAppBuildVersion = "testAppBuildVersion"
@@ -67,7 +64,6 @@ class MockApplicationInfo: ApplicationInfoProtocol {
     bundleID = MockApplicationInfo.testBundleID
     sdkVersion = MockApplicationInfo.testSDKVersion
     osName = MockApplicationInfo.testOSName
-    mccMNC = MockApplicationInfo.testMCCMNC
     deviceModel = MockApplicationInfo.testDeviceModel
     environment = MockApplicationInfo.testEnvironment
     appBuildVersion = MockApplicationInfo.testAppBuildVersion

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -268,7 +268,7 @@ class SessionStartEventTests: XCTestCase {
       #endif
       assertEqualProtoString(
         proto.application_info.apple_app_info.mcc_mnc,
-        expected: MockApplicationInfo.testMCCMNC,
+        expected: "",
         fieldName: "mcc_mnc"
       )
     }


### PR DESCRIPTION
https://developer.apple.com/forums/thread/714876
 - Deprecated with no replacement in iOS 16.4.

Currently FirebaseSessions doesn't use this data, as it's still in development, so no customer impact.

TODO
- [x] Run tests