### PR TITLE
[Infra] Expand file extenstion in 'source' glob

### DIFF
--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -54,7 +54,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
       :tvos => tvos_deployment_target
     }
     objc_api_tests.source_files = [
-      'FirebaseAnalyticsSwift/Tests/ObjCAPI/*.m',
+      'FirebaseAnalyticsSwift/Tests/ObjCAPI/*.[hm]',
     ]
   end
 end


### PR DESCRIPTION
### Context
- AnalyticsSwift pod doesn't stage because:
```
Validating spec
 -> FirebaseAnalyticsSwift (10.9.0)
    - ERROR | [iOS] unknown: Encountered an unknown error (Unable to install the `FirebaseAnalyticsSwift` pod, because the `FirebaseAnalyticsSwift-Unit-objc-api-coverage` target in Xcode would have no sources to compile.) during validation.

[!] The `FirebaseAnalyticsSwift.podspec` specification does not validate.
```
- This fix seems to work doing a dry run staging

#no-changelog