### PR TITLE
[Infra] Use GoogleAppMeasurement HEAD when checking Firestore binary for unlinked symbols

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -444,6 +444,7 @@ jobs:
     needs: package-head
     env:
       FRAMEWORK_DIR: "Firebase-actions-dir"
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-12
     steps:
       - name: Xcode 13.3.1


### PR DESCRIPTION
### Context
- I noticed that the `zip / check_framework_firestore_symbols` workflow was silently failing during the last release cycle due to GoogleAppMeasurement not being published. I had a workaround related to pipefail that involved subshells that I learned was unnecessary. I merged #11094 hoping that it would surface these failures in the next release cycle–– and it did.
- This PR exports the GoogleAppMeasurement env var for the workflow so the `check_framework_firestore_symbols` job always uses latest HEAD of `GoogleAppMeasurement`. 

Fix #11135