### PR TITLE
[Infra] Add sample app to test building SPM distro across supported platforms

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -86,7 +86,10 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        platform: [iOS, tvOS, macOS, catalyst]
+        platform: [iOS, tvOS]
+        # TODO(Xcode 14.3): Remove above line and uncomment below array when GHA
+        # supports Ventura/Xcode 14.3.
+        # platform: [iOS, tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -81,6 +81,8 @@ jobs:
   client-app:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-12
     strategy:
       matrix:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -22,61 +22,61 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  swift-build-run:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: Functions Integration Test Server
-      run: FirebaseFunctions/Backend/start.sh synchronous
-    - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
+  # swift-build-run:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Initialize xcodebuild
+  #     run: scripts/setup_spm_tests.sh
+  #   - name: Functions Integration Test Server
+  #     run: FirebaseFunctions/Backend/start.sh synchronous
+  #   - name: iOS Unit Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 
-  # Test iOS Device build since some Firestore dependencies build different files.
-  iOS-Device:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: iOS Device and Test Build
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+  # # Test iOS Device build since some Firestore dependencies build different files.
+  # iOS-Device:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Initialize xcodebuild
+  #     run: scripts/setup_spm_tests.sh
+  #   - name: iOS Device and Test Build
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
 
-  platforms:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # platforms:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    runs-on: macos-12
-    strategy:
-      matrix:
-        target: [tvOS, macOS, catalyst]
-        # Full set of Firebase-Package tests only run on iOS.
-    steps:
-    - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - name: Initialize xcodebuild
-      run: scripts/setup_spm_tests.sh
-    - name: Objc Import Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
-    - name: Swift Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
-    - name: Version Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
-    - name: Analytics Build Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
+  #   runs-on: macos-12
+  #   strategy:
+  #     matrix:
+  #       target: [tvOS, macOS, catalyst]
+  #       # Full set of Firebase-Package tests only run on iOS.
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.os }}
+  #   - name: Initialize xcodebuild
+  #     run: scripts/setup_spm_tests.sh
+  #   - name: Objc Import Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
+  #   - name: Swift Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
+  #   - name: Version Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
+  #   - name: Analytics Build Tests
+  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
 
   client-app:
     # Don't run on private repo unless it is a PR.
@@ -97,3 +97,7 @@ jobs:
         cache_key: ${{ matrix.os }}
     - name: Build Client App –– ${{ matrix.platform }}
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild
+    - uses: actions/upload-artifact@v2
+      with:
+        name: xcodebuild_${{ matrix.platform }}.log
+        path: xcodebuild.log

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst]
+        platform: [iOS, tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        platform: [iOS, tvOS]
+        platform: [iOS]
         # TODO(Xcode 14.3): Remove above line and uncomment below array when GHA
         # supports Ventura/Xcode 14.3.
         # platform: [iOS, tvOS, macOS, catalyst]

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -97,7 +97,3 @@ jobs:
         cache_key: ${{ matrix.os }}
     - name: Build Client App –– ${{ matrix.platform }}
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild
-    - uses: actions/upload-artifact@v2
-      with:
-        name: xcodebuild_${{ matrix.platform }}.log
-        path: xcodebuild.log

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -22,64 +22,63 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # swift-build-run:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - name: Initialize xcodebuild
-  #     run: scripts/setup_spm_tests.sh
-  #   - name: Functions Integration Test Server
-  #     run: FirebaseFunctions/Backend/start.sh synchronous
-  #   - name: iOS Unit Tests
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
+  swift-build-run:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: Functions Integration Test Server
+      run: FirebaseFunctions/Backend/start.sh synchronous
+    - name: iOS Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 
-  # # Test iOS Device build since some Firestore dependencies build different files.
-  # iOS-Device:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - name: Initialize xcodebuild
-  #     run: scripts/setup_spm_tests.sh
-  #   - name: iOS Device and Test Build
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+  # Test iOS Device build since some Firestore dependencies build different files.
+  iOS-Device:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: iOS Device and Test Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
 
-  # platforms:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  platforms:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-  #   runs-on: macos-12
-  #   strategy:
-  #     matrix:
-  #       target: [tvOS, macOS, catalyst]
-  #       # Full set of Firebase-Package tests only run on iOS.
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.os }}
-  #   - name: Initialize xcodebuild
-  #     run: scripts/setup_spm_tests.sh
-  #   - name: Objc Import Tests
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
-  #   - name: Swift Tests
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
-  #   - name: Version Tests
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
-  #   - name: Analytics Build Tests
-  #     run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
+    runs-on: macos-12
+    strategy:
+      matrix:
+        target: [tvOS, macOS, catalyst]
+        # Full set of Firebase-Package tests only run on iOS.
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: Objc Import Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh objc-import-test ${{ matrix.target }} spm
+    - name: Swift Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh swift-test ${{ matrix.target }} spm
+    - name: Version Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
+    - name: Analytics Build Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
 
   client-app:
-    # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -77,3 +77,18 @@ jobs:
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh version-test ${{ matrix.target }} spm
     - name: Analytics Build Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh analytics-import-test ${{ matrix.target }} spm
+
+  client-app:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-12
+    strategy:
+      matrix:
+        target: [iOS, tvOS, macOS, catalyst]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - name: Build Client App –– ${{ matrix.platform }}
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild

--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,12 @@ let package = Package(
       name: "FirebaseAnalytics",
       targets: ["FirebaseAnalyticsTarget"]
     ),
+    // This library is not designed to be imported into client source code.
     .library(
       name: "FirebaseAnalyticsWithoutAdIdSupport",
       targets: ["FirebaseAnalyticsWithoutAdIdSupportTarget"]
     ),
+    // This library is not designed to be imported into client source code.
     .library(
       name: "FirebaseAnalyticsOnDeviceConversion",
       targets: ["FirebaseAnalyticsOnDeviceConversionTarget"]
@@ -1199,6 +1201,7 @@ let package = Package(
         "FirebaseAnalyticsSwiftTarget",
         "FirebaseAnalyticsWrapper",
         "Firebase",
+
       ],
       path: "SwiftPMTests/analytics-import-test"
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1201,7 +1201,6 @@ let package = Package(
         "FirebaseAnalyticsSwiftTarget",
         "FirebaseAnalyticsWrapper",
         "Firebase",
-
       ],
       path: "SwiftPMTests/analytics-import-test"
     ),

--- a/SwiftPMTests/ClientApp/ClientApp.xcodeproj/project.pbxproj
+++ b/SwiftPMTests/ClientApp/ClientApp.xcodeproj/project.pbxproj
@@ -1,0 +1,609 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		EA05C7DE29F08D4B00D1014F /* objc-module-import-test.m in Sources */ = {isa = PBXBuildFile; fileRef = EA05C7DD29F08D4B00D1014F /* objc-module-import-test.m */; };
+		EA05C7E029F0911400D1014F /* objc-header-import-test.m in Sources */ = {isa = PBXBuildFile; fileRef = EA05C7DF29F0911400D1014F /* objc-header-import-test.m */; };
+		EA0BC0FF29F06D5B005B8AEE /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = EA0BC0FE29F06D5B005B8AEE /* FirebaseAnalyticsOnDeviceConversion */; };
+		EA1269B429EDF98800D79E66 /* ClientApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1269B329EDF98800D79E66 /* ClientApp.swift */; };
+		EA1269B629EDF98800D79E66 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1269B529EDF98800D79E66 /* ContentView.swift */; };
+		EA1269B829EDF98A00D79E66 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA1269B729EDF98A00D79E66 /* Assets.xcassets */; };
+		EA1269BC29EDF98A00D79E66 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA1269BB29EDF98A00D79E66 /* Preview Assets.xcassets */; };
+		EA501B1129F09594009C4DBC /* objcxx-header-import-test.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA501B1029F09593009C4DBC /* objcxx-header-import-test.mm */; };
+		EA501B1329F0960B009C4DBC /* objcxx-module-import-test.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA501B1229F0960B009C4DBC /* objcxx-module-import-test.mm */; };
+		EA7DF54329EF20B9005664A7 /* swift-import-test.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7DF54229EF20B9005664A7 /* swift-import-test.swift */; };
+		EA7DF58329EF3326005664A7 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF58229EF3326005664A7 /* FirebaseAnalytics */; };
+		EA7DF58729EF3326005664A7 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF58629EF3326005664A7 /* FirebaseAnalyticsSwift */; };
+		EA7DF58929EF3326005664A7 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF58829EF3326005664A7 /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		EA7DF58B29EF3326005664A7 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF58A29EF3326005664A7 /* FirebaseAppCheck */; };
+		EA7DF58D29EF3326005664A7 /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = EA7DF58C29EF3326005664A7 /* FirebaseAppDistribution-Beta */; };
+		EA7DF58F29EF3326005664A7 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF58E29EF3326005664A7 /* FirebaseAuth */; };
+		EA7DF59129EF3326005664A7 /* FirebaseAuthCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59029EF3326005664A7 /* FirebaseAuthCombine-Community */; };
+		EA7DF59329EF3326005664A7 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59229EF3326005664A7 /* FirebaseCrashlytics */; };
+		EA7DF59529EF3326005664A7 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59429EF3326005664A7 /* FirebaseDatabase */; };
+		EA7DF59729EF3326005664A7 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59629EF3326005664A7 /* FirebaseDatabaseSwift */; };
+		EA7DF59929EF3326005664A7 /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = EA7DF59829EF3326005664A7 /* FirebaseDynamicLinks */; };
+		EA7DF59B29EF3326005664A7 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59A29EF3326005664A7 /* FirebaseFirestore */; };
+		EA7DF59D29EF3326005664A7 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59C29EF3326005664A7 /* FirebaseFirestoreCombine-Community */; };
+		EA7DF59F29EF3327005664A7 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF59E29EF3327005664A7 /* FirebaseFirestoreSwift */; };
+		EA7DF5A129EF3327005664A7 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5A029EF3327005664A7 /* FirebaseFunctions */; };
+		EA7DF5A329EF3327005664A7 /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5A229EF3327005664A7 /* FirebaseFunctionsCombine-Community */; };
+		EA7DF5A529EF3327005664A7 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, tvos, ); productRef = EA7DF5A429EF3327005664A7 /* FirebaseInAppMessaging-Beta */; };
+		EA7DF5A729EF3327005664A7 /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, maccatalyst, tvos, ); productRef = EA7DF5A629EF3327005664A7 /* FirebaseInAppMessagingSwift-Beta */; };
+		EA7DF5A929EF3327005664A7 /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5A829EF3327005664A7 /* FirebaseInstallations */; };
+		EA7DF5AB29EF3327005664A7 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5AA29EF3327005664A7 /* FirebaseMessaging */; };
+		EA7DF5AD29EF3327005664A7 /* FirebaseMLModelDownloader in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5AC29EF3327005664A7 /* FirebaseMLModelDownloader */; };
+		EA7DF5AF29EF3328005664A7 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, tvos, ); productRef = EA7DF5AE29EF3328005664A7 /* FirebasePerformance */; };
+		EA7DF5B129EF3328005664A7 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5B029EF3328005664A7 /* FirebaseRemoteConfig */; };
+		EA7DF5B329EF3328005664A7 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5B229EF3328005664A7 /* FirebaseRemoteConfigSwift */; };
+		EA7DF5B529EF3328005664A7 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5B429EF3328005664A7 /* FirebaseStorage */; };
+		EA7DF5B729EF3328005664A7 /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = EA7DF5B629EF3328005664A7 /* FirebaseStorageCombine-Community */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		EA05C7DD29F08D4B00D1014F /* objc-module-import-test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "objc-module-import-test.m"; sourceTree = "<group>"; };
+		EA05C7DF29F0911400D1014F /* objc-header-import-test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "objc-header-import-test.m"; sourceTree = "<group>"; };
+		EA1269B029EDF98800D79E66 /* ClientApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClientApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA1269B329EDF98800D79E66 /* ClientApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientApp.swift; sourceTree = "<group>"; };
+		EA1269B529EDF98800D79E66 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		EA1269B729EDF98A00D79E66 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		EA1269B929EDF98A00D79E66 /* ClientApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ClientApp.entitlements; sourceTree = "<group>"; };
+		EA1269BB29EDF98A00D79E66 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		EA501B1029F09593009C4DBC /* objcxx-header-import-test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "objcxx-header-import-test.mm"; sourceTree = "<group>"; };
+		EA501B1229F0960B009C4DBC /* objcxx-module-import-test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "objcxx-module-import-test.mm"; sourceTree = "<group>"; };
+		EA7DF54229EF20B9005664A7 /* swift-import-test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "swift-import-test.swift"; sourceTree = "<group>"; };
+		EA7DF54929EF2A92005664A7 /* firebase-ios-sdk */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "firebase-apple-sdk"; path = ../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		EA1269AD29EDF98800D79E66 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA7DF59529EF3326005664A7 /* FirebaseDatabase in Frameworks */,
+				EA7DF5A329EF3327005664A7 /* FirebaseFunctionsCombine-Community in Frameworks */,
+				EA7DF59B29EF3326005664A7 /* FirebaseFirestore in Frameworks */,
+				EA7DF58729EF3326005664A7 /* FirebaseAnalyticsSwift in Frameworks */,
+				EA0BC0FF29F06D5B005B8AEE /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
+				EA7DF58329EF3326005664A7 /* FirebaseAnalytics in Frameworks */,
+				EA7DF59F29EF3327005664A7 /* FirebaseFirestoreSwift in Frameworks */,
+				EA7DF5AD29EF3327005664A7 /* FirebaseMLModelDownloader in Frameworks */,
+				EA7DF58B29EF3326005664A7 /* FirebaseAppCheck in Frameworks */,
+				EA7DF58929EF3326005664A7 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+				EA7DF5AB29EF3327005664A7 /* FirebaseMessaging in Frameworks */,
+				EA7DF58F29EF3326005664A7 /* FirebaseAuth in Frameworks */,
+				EA7DF5B329EF3328005664A7 /* FirebaseRemoteConfigSwift in Frameworks */,
+				EA7DF59329EF3326005664A7 /* FirebaseCrashlytics in Frameworks */,
+				EA7DF5A529EF3327005664A7 /* FirebaseInAppMessaging-Beta in Frameworks */,
+				EA7DF59729EF3326005664A7 /* FirebaseDatabaseSwift in Frameworks */,
+				EA7DF5B729EF3328005664A7 /* FirebaseStorageCombine-Community in Frameworks */,
+				EA7DF5B129EF3328005664A7 /* FirebaseRemoteConfig in Frameworks */,
+				EA7DF5A129EF3327005664A7 /* FirebaseFunctions in Frameworks */,
+				EA7DF58D29EF3326005664A7 /* FirebaseAppDistribution-Beta in Frameworks */,
+				EA7DF5AF29EF3328005664A7 /* FirebasePerformance in Frameworks */,
+				EA7DF59129EF3326005664A7 /* FirebaseAuthCombine-Community in Frameworks */,
+				EA7DF5B529EF3328005664A7 /* FirebaseStorage in Frameworks */,
+				EA7DF5A729EF3327005664A7 /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
+				EA7DF59929EF3326005664A7 /* FirebaseDynamicLinks in Frameworks */,
+				EA7DF59D29EF3326005664A7 /* FirebaseFirestoreCombine-Community in Frameworks */,
+				EA7DF5A929EF3327005664A7 /* FirebaseInstallations in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		EA1269A729EDF98800D79E66 = {
+			isa = PBXGroup;
+			children = (
+				EA1269C229EDF9DD00D79E66 /* Packages */,
+				EA1269B229EDF98800D79E66 /* ClientApp */,
+				EA1269B129EDF98800D79E66 /* Products */,
+				EA1269C429EDFC1000D79E66 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		EA1269B129EDF98800D79E66 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EA1269B029EDF98800D79E66 /* ClientApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EA1269B229EDF98800D79E66 /* ClientApp */ = {
+			isa = PBXGroup;
+			children = (
+				EA1269B329EDF98800D79E66 /* ClientApp.swift */,
+				EA7DF54229EF20B9005664A7 /* swift-import-test.swift */,
+				EA05C7DD29F08D4B00D1014F /* objc-module-import-test.m */,
+				EA05C7DF29F0911400D1014F /* objc-header-import-test.m */,
+				EA501B1029F09593009C4DBC /* objcxx-header-import-test.mm */,
+				EA501B1229F0960B009C4DBC /* objcxx-module-import-test.mm */,
+				EA1269B529EDF98800D79E66 /* ContentView.swift */,
+				EA1269B729EDF98A00D79E66 /* Assets.xcassets */,
+				EA1269B929EDF98A00D79E66 /* ClientApp.entitlements */,
+				EA1269BA29EDF98A00D79E66 /* Preview Content */,
+			);
+			path = ClientApp;
+			sourceTree = "<group>";
+		};
+		EA1269BA29EDF98A00D79E66 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				EA1269BB29EDF98A00D79E66 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		EA1269C229EDF9DD00D79E66 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				EA7DF54929EF2A92005664A7 /* firebase-ios-sdk */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		EA1269C429EDFC1000D79E66 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		EA1269AF29EDF98800D79E66 /* ClientApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA1269BF29EDF98A00D79E66 /* Build configuration list for PBXNativeTarget "ClientApp" */;
+			buildPhases = (
+				EA1269AC29EDF98800D79E66 /* Sources */,
+				EA1269AD29EDF98800D79E66 /* Frameworks */,
+				EA1269AE29EDF98800D79E66 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ClientApp;
+			packageProductDependencies = (
+				EA7DF58229EF3326005664A7 /* FirebaseAnalytics */,
+				EA7DF58629EF3326005664A7 /* FirebaseAnalyticsSwift */,
+				EA7DF58829EF3326005664A7 /* FirebaseAnalyticsWithoutAdIdSupport */,
+				EA7DF58A29EF3326005664A7 /* FirebaseAppCheck */,
+				EA7DF58C29EF3326005664A7 /* FirebaseAppDistribution-Beta */,
+				EA7DF58E29EF3326005664A7 /* FirebaseAuth */,
+				EA7DF59029EF3326005664A7 /* FirebaseAuthCombine-Community */,
+				EA7DF59229EF3326005664A7 /* FirebaseCrashlytics */,
+				EA7DF59429EF3326005664A7 /* FirebaseDatabase */,
+				EA7DF59629EF3326005664A7 /* FirebaseDatabaseSwift */,
+				EA7DF59829EF3326005664A7 /* FirebaseDynamicLinks */,
+				EA7DF59A29EF3326005664A7 /* FirebaseFirestore */,
+				EA7DF59C29EF3326005664A7 /* FirebaseFirestoreCombine-Community */,
+				EA7DF59E29EF3327005664A7 /* FirebaseFirestoreSwift */,
+				EA7DF5A029EF3327005664A7 /* FirebaseFunctions */,
+				EA7DF5A229EF3327005664A7 /* FirebaseFunctionsCombine-Community */,
+				EA7DF5A429EF3327005664A7 /* FirebaseInAppMessaging-Beta */,
+				EA7DF5A629EF3327005664A7 /* FirebaseInAppMessagingSwift-Beta */,
+				EA7DF5A829EF3327005664A7 /* FirebaseInstallations */,
+				EA7DF5AA29EF3327005664A7 /* FirebaseMessaging */,
+				EA7DF5AC29EF3327005664A7 /* FirebaseMLModelDownloader */,
+				EA7DF5AE29EF3328005664A7 /* FirebasePerformance */,
+				EA7DF5B029EF3328005664A7 /* FirebaseRemoteConfig */,
+				EA7DF5B229EF3328005664A7 /* FirebaseRemoteConfigSwift */,
+				EA7DF5B429EF3328005664A7 /* FirebaseStorage */,
+				EA7DF5B629EF3328005664A7 /* FirebaseStorageCombine-Community */,
+				EA0BC0FE29F06D5B005B8AEE /* FirebaseAnalyticsOnDeviceConversion */,
+			);
+			productName = ClientApp;
+			productReference = EA1269B029EDF98800D79E66 /* ClientApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EA1269A829EDF98800D79E66 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					EA1269AF29EDF98800D79E66 = {
+						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1430;
+					};
+				};
+			};
+			buildConfigurationList = EA1269AB29EDF98800D79E66 /* Build configuration list for PBXProject "ClientApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EA1269A729EDF98800D79E66;
+			packageReferences = (
+			);
+			productRefGroup = EA1269B129EDF98800D79E66 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EA1269AF29EDF98800D79E66 /* ClientApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EA1269AE29EDF98800D79E66 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA1269BC29EDF98A00D79E66 /* Preview Assets.xcassets in Resources */,
+				EA1269B829EDF98A00D79E66 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EA1269AC29EDF98800D79E66 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA1269B629EDF98800D79E66 /* ContentView.swift in Sources */,
+				EA501B1329F0960B009C4DBC /* objcxx-module-import-test.mm in Sources */,
+				EA05C7DE29F08D4B00D1014F /* objc-module-import-test.m in Sources */,
+				EA7DF54329EF20B9005664A7 /* swift-import-test.swift in Sources */,
+				EA05C7E029F0911400D1014F /* objc-header-import-test.m in Sources */,
+				EA1269B429EDF98800D79E66 /* ClientApp.swift in Sources */,
+				EA501B1129F09594009C4DBC /* objcxx-header-import-test.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		EA1269BD29EDF98A00D79E66 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		EA1269BE29EDF98A00D79E66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		EA1269C029EDF98A00D79E66 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = ClientApp/ClientApp.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ClientApp/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MARKETING_VERSION = 1.0;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fcxx-modules",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.ClientApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+			};
+			name = Debug;
+		};
+		EA1269C129EDF98A00D79E66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = ClientApp/ClientApp.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ClientApp/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MARKETING_VERSION = 1.0;
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fcxx-modules",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.ClientApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		EA1269AB29EDF98800D79E66 /* Build configuration list for PBXProject "ClientApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA1269BD29EDF98A00D79E66 /* Debug */,
+				EA1269BE29EDF98A00D79E66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EA1269BF29EDF98A00D79E66 /* Build configuration list for PBXNativeTarget "ClientApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA1269C029EDF98A00D79E66 /* Debug */,
+				EA1269C129EDF98A00D79E66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EA0BC0FE29F06D5B005B8AEE /* FirebaseAnalyticsOnDeviceConversion */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAnalyticsOnDeviceConversion;
+		};
+		EA7DF58229EF3326005664A7 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAnalytics;
+		};
+		EA7DF58629EF3326005664A7 /* FirebaseAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAnalyticsSwift;
+		};
+		EA7DF58829EF3326005664A7 /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		EA7DF58A29EF3326005664A7 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAppCheck;
+		};
+		EA7DF58C29EF3326005664A7 /* FirebaseAppDistribution-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseAppDistribution-Beta";
+		};
+		EA7DF58E29EF3326005664A7 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAuth;
+		};
+		EA7DF59029EF3326005664A7 /* FirebaseAuthCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseAuthCombine-Community";
+		};
+		EA7DF59229EF3326005664A7 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseCrashlytics;
+		};
+		EA7DF59429EF3326005664A7 /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseDatabase;
+		};
+		EA7DF59629EF3326005664A7 /* FirebaseDatabaseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseDatabaseSwift;
+		};
+		EA7DF59829EF3326005664A7 /* FirebaseDynamicLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseDynamicLinks;
+		};
+		EA7DF59A29EF3326005664A7 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseFirestore;
+		};
+		EA7DF59C29EF3326005664A7 /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		EA7DF59E29EF3327005664A7 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseFirestoreSwift;
+		};
+		EA7DF5A029EF3327005664A7 /* FirebaseFunctions */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseFunctions;
+		};
+		EA7DF5A229EF3327005664A7 /* FirebaseFunctionsCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseFunctionsCombine-Community";
+		};
+		EA7DF5A429EF3327005664A7 /* FirebaseInAppMessaging-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseInAppMessaging-Beta";
+		};
+		EA7DF5A629EF3327005664A7 /* FirebaseInAppMessagingSwift-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseInAppMessagingSwift-Beta";
+		};
+		EA7DF5A829EF3327005664A7 /* FirebaseInstallations */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseInstallations;
+		};
+		EA7DF5AA29EF3327005664A7 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseMessaging;
+		};
+		EA7DF5AC29EF3327005664A7 /* FirebaseMLModelDownloader */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseMLModelDownloader;
+		};
+		EA7DF5AE29EF3328005664A7 /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebasePerformance;
+		};
+		EA7DF5B029EF3328005664A7 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseRemoteConfig;
+		};
+		EA7DF5B229EF3328005664A7 /* FirebaseRemoteConfigSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseRemoteConfigSwift;
+		};
+		EA7DF5B429EF3328005664A7 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseStorage;
+		};
+		EA7DF5B629EF3328005664A7 /* FirebaseStorageCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "FirebaseStorageCombine-Community";
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = EA1269A829EDF98800D79E66 /* Project object */;
+}

--- a/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/Contents.json
+++ b/SwiftPMTests/ClientApp/ClientApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/ClientApp.entitlements
+++ b/SwiftPMTests/ClientApp/ClientApp/ClientApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/SwiftPMTests/ClientApp/ClientApp/ClientApp.swift
+++ b/SwiftPMTests/ClientApp/ClientApp/ClientApp.swift
@@ -16,9 +16,9 @@ import SwiftUI
 
 @main
 struct ClientApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
     }
+  }
 }

--- a/SwiftPMTests/ClientApp/ClientApp/ClientApp.swift
+++ b/SwiftPMTests/ClientApp/ClientApp/ClientApp.swift
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+@main
+struct ClientApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/ContentView.swift
+++ b/SwiftPMTests/ClientApp/ClientApp/ContentView.swift
@@ -1,0 +1,33 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/ContentView.swift
+++ b/SwiftPMTests/ClientApp/ClientApp/ContentView.swift
@@ -15,19 +15,19 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
-        }
-        .padding()
+  var body: some View {
+    VStack {
+      Image(systemName: "globe")
+        .imageScale(.large)
+        .foregroundColor(.accentColor)
+      Text("Hello, world!")
     }
+    .padding()
+  }
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
+  static var previews: some View {
+    ContentView()
+  }
 }

--- a/SwiftPMTests/ClientApp/ClientApp/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SwiftPMTests/ClientApp/ClientApp/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftPMTests/ClientApp/ClientApp/objc-header-import-test.m
+++ b/SwiftPMTests/ClientApp/ClientApp/objc-header-import-test.m
@@ -17,43 +17,43 @@
 
 // ‼️ NOTE: Changes should also be reflected in `objcxx-header-import-test.m`.
 
-#import "Firebase.h"
 #import <Firebase.h>
-#import "FirebaseABTesting/FirebaseABTesting.h"
 #import <FirebaseABTesting/FirebaseABTesting.h>
-#import "FirebaseAnalytics/FirebaseAnalytics.h"
 #import <FirebaseAnalytics/FirebaseAnalytics.h>
-#import "FirebaseAppCheck/FirebaseAppCheck.h"
 #import <FirebaseAppCheck/FirebaseAppCheck.h>
+#import "Firebase.h"
+#import "FirebaseABTesting/FirebaseABTesting.h"
+#import "FirebaseAnalytics/FirebaseAnalytics.h"
+#import "FirebaseAppCheck/FirebaseAppCheck.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
 #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
 #endif
-#import "FirebaseAuth/FirebaseAuth.h"
 #import <FirebaseAuth/FirebaseAuth.h>
-#import "FirebaseCore/FirebaseCore.h"
 #import <FirebaseCore/FirebaseCore.h>
-#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
 #import <FirebaseCrashlytics/FirebaseCrashlytics.h>
-#import "FirebaseDatabase/FirebaseDatabase.h"
 #import <FirebaseDatabase/FirebaseDatabase.h>
+#import "FirebaseAuth/FirebaseAuth.h"
+#import "FirebaseCore/FirebaseCore.h"
+#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
+#import "FirebaseDatabase/FirebaseDatabase.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
 #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
 #endif
-#import "FirebaseFirestore/FirebaseFirestore.h"
 #import <FirebaseFirestore/FirebaseFirestore.h>
+#import "FirebaseFirestore/FirebaseFirestore.h"
 #if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
-#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
 #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
+#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
 #endif
-#import "FirebaseInstallations/FirebaseInstallations.h"
 #import <FirebaseInstallations/FirebaseInstallations.h>
-#import "FirebaseMessaging/FirebaseMessaging.h"
 #import <FirebaseMessaging/FirebaseMessaging.h>
+#import "FirebaseInstallations/FirebaseInstallations.h"
+#import "FirebaseMessaging/FirebaseMessaging.h"
 #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
-#import "FirebasePerformance/FirebasePerformance.h"
 #import <FirebasePerformance/FirebasePerformance.h>
+#import "FirebasePerformance/FirebasePerformance.h"
 #endif
-#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"
 #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"

--- a/SwiftPMTests/ClientApp/ClientApp/objc-header-import-test.m
+++ b/SwiftPMTests/ClientApp/ClientApp/objc-header-import-test.m
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file imports all Firebase products that vend an umbrella header.
+// Products implemented in Swift are therefore omitted.
+
+// ‼️ NOTE: Changes should also be reflected in `objcxx-header-import-test.m`.
+
+#import "Firebase.h"
+#import <Firebase.h>
+#import "FirebaseABTesting/FirebaseABTesting.h"
+#import <FirebaseABTesting/FirebaseABTesting.h>
+#import "FirebaseAnalytics/FirebaseAnalytics.h"
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
+#import "FirebaseAppCheck/FirebaseAppCheck.h"
+#import <FirebaseAppCheck/FirebaseAppCheck.h>
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
+#import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+#endif
+#import "FirebaseAuth/FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
+#import "FirebaseCore/FirebaseCore.h"
+#import <FirebaseCore/FirebaseCore.h>
+#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
+#import <FirebaseCrashlytics/FirebaseCrashlytics.h>
+#import "FirebaseDatabase/FirebaseDatabase.h"
+#import <FirebaseDatabase/FirebaseDatabase.h>
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
+#import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+#endif
+#import "FirebaseFirestore/FirebaseFirestore.h"
+#import <FirebaseFirestore/FirebaseFirestore.h>
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
+#import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
+#endif
+#import "FirebaseInstallations/FirebaseInstallations.h"
+#import <FirebaseInstallations/FirebaseInstallations.h>
+#import "FirebaseMessaging/FirebaseMessaging.h"
+#import <FirebaseMessaging/FirebaseMessaging.h>
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+#import "FirebasePerformance/FirebasePerformance.h"
+#import <FirebasePerformance/FirebasePerformance.h>
+#endif
+#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"
+#import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>

--- a/SwiftPMTests/ClientApp/ClientApp/objc-module-import-test.m
+++ b/SwiftPMTests/ClientApp/ClientApp/objc-module-import-test.m
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ‼️ NOTE: Changes should also be reflected in `objcxx-module-import-test.m`.
+
+@import Firebase;
+@import FirebaseABTesting;
+@import FirebaseAnalytics;
+@import FirebaseAppCheck;
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+@import FirebaseAppDistribution;
+#endif
+@import FirebaseAuth;
+@import FirebaseCore;
+@import FirebaseCrashlytics;
+@import FirebaseDatabase;
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+@import FirebaseDynamicLinks;
+#endif
+@import FirebaseFirestore;
+@import FirebaseFunctions;
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+@import FirebaseInAppMessaging;
+#endif
+@import FirebaseInstallations;
+@import FirebaseMessaging;
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+@import FirebasePerformance;
+#endif
+@import FirebaseRemoteConfig;
+@import FirebaseStorage;

--- a/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
+++ b/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
@@ -17,43 +17,43 @@
 
 // ‼️ Changes should also be reflected in `objc-header-import-test.m`.
 
-#import "Firebase.h"
 #import <Firebase.h>
-#import "FirebaseABTesting/FirebaseABTesting.h"
 #import <FirebaseABTesting/FirebaseABTesting.h>
-#import "FirebaseAnalytics/FirebaseAnalytics.h"
 #import <FirebaseAnalytics/FirebaseAnalytics.h>
-#import "FirebaseAppCheck/FirebaseAppCheck.h"
 #import <FirebaseAppCheck/FirebaseAppCheck.h>
+#import "Firebase.h"
+#import "FirebaseABTesting/FirebaseABTesting.h"
+#import "FirebaseAnalytics/FirebaseAnalytics.h"
+#import "FirebaseAppCheck/FirebaseAppCheck.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
 #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
 #endif
-#import "FirebaseAuth/FirebaseAuth.h"
 #import <FirebaseAuth/FirebaseAuth.h>
-#import "FirebaseCore/FirebaseCore.h"
 #import <FirebaseCore/FirebaseCore.h>
-#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
 #import <FirebaseCrashlytics/FirebaseCrashlytics.h>
-#import "FirebaseDatabase/FirebaseDatabase.h"
 #import <FirebaseDatabase/FirebaseDatabase.h>
+#import "FirebaseAuth/FirebaseAuth.h"
+#import "FirebaseCore/FirebaseCore.h"
+#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
+#import "FirebaseDatabase/FirebaseDatabase.h"
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
 #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
 #endif
-#import "FirebaseFirestore/FirebaseFirestore.h"
 #import <FirebaseFirestore/FirebaseFirestore.h>
+#import "FirebaseFirestore/FirebaseFirestore.h"
 #if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
-#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
 #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
+#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
 #endif
-#import "FirebaseInstallations/FirebaseInstallations.h"
 #import <FirebaseInstallations/FirebaseInstallations.h>
-#import "FirebaseMessaging/FirebaseMessaging.h"
 #import <FirebaseMessaging/FirebaseMessaging.h>
+#import "FirebaseInstallations/FirebaseInstallations.h"
+#import "FirebaseMessaging/FirebaseMessaging.h"
 #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
-#import "FirebasePerformance/FirebasePerformance.h"
 #import <FirebasePerformance/FirebasePerformance.h>
+#import "FirebasePerformance/FirebasePerformance.h"
 #endif
-#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"
 #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"

--- a/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
+++ b/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
@@ -17,43 +17,44 @@
 
 // ‼️ Changes should also be reflected in `objc-header-import-test.m`.
 
-#import <Firebase.h>
-#import <FirebaseABTesting/FirebaseABTesting.h>
-#import <FirebaseAnalytics/FirebaseAnalytics.h>
-#import <FirebaseAppCheck/FirebaseAppCheck.h>
-#import "Firebase.h"
-#import "FirebaseABTesting/FirebaseABTesting.h"
-#import "FirebaseAnalytics/FirebaseAnalytics.h"
-#import "FirebaseAppCheck/FirebaseAppCheck.h"
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import <FirebaseAppDistribution/FirebaseAppDistribution.h>
-#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
-#endif
-#import <FirebaseAuth/FirebaseAuth.h>
-#import <FirebaseCore/FirebaseCore.h>
-#import <FirebaseCrashlytics/FirebaseCrashlytics.h>
-#import <FirebaseDatabase/FirebaseDatabase.h>
-#import "FirebaseAuth/FirebaseAuth.h"
-#import "FirebaseCore/FirebaseCore.h"
-#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
-#import "FirebaseDatabase/FirebaseDatabase.h"
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-#import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
-#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
-#endif
-#import <FirebaseFirestore/FirebaseFirestore.h>
-#import "FirebaseFirestore/FirebaseFirestore.h"
-#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
-#import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
-#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
-#endif
-#import <FirebaseInstallations/FirebaseInstallations.h>
-#import <FirebaseMessaging/FirebaseMessaging.h>
-#import "FirebaseInstallations/FirebaseInstallations.h"
-#import "FirebaseMessaging/FirebaseMessaging.h"
-#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
-#import <FirebasePerformance/FirebasePerformance.h>
-#import "FirebasePerformance/FirebasePerformance.h"
-#endif
-#import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"
+// TODO(Xcode 14.3): Re-enable contest when GHA supports Xcode 14.3.
+// #import <Firebase.h>
+// #import <FirebaseABTesting/FirebaseABTesting.h>
+// #import <FirebaseAnalytics/FirebaseAnalytics.h>
+// #import <FirebaseAppCheck/FirebaseAppCheck.h>
+// #import "Firebase.h"
+// #import "FirebaseABTesting/FirebaseABTesting.h"
+// #import "FirebaseAnalytics/FirebaseAnalytics.h"
+// #import "FirebaseAppCheck/FirebaseAppCheck.h"
+// #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+// #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+// #import "FirebaseAppDistribution/FirebaseAppDistribution.h"
+// #endif
+// #import <FirebaseAuth/FirebaseAuth.h>
+// #import <FirebaseCore/FirebaseCore.h>
+// #import <FirebaseCrashlytics/FirebaseCrashlytics.h>
+// #import <FirebaseDatabase/FirebaseDatabase.h>
+// #import "FirebaseAuth/FirebaseAuth.h"
+// #import "FirebaseCore/FirebaseCore.h"
+// #import "FirebaseCrashlytics/FirebaseCrashlytics.h"
+// #import "FirebaseDatabase/FirebaseDatabase.h"
+// #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+// #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+// #import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
+// #endif
+// #import <FirebaseFirestore/FirebaseFirestore.h>
+// #import "FirebaseFirestore/FirebaseFirestore.h"
+// #if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+// #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
+// #import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
+// #endif
+// #import <FirebaseInstallations/FirebaseInstallations.h>
+// #import <FirebaseMessaging/FirebaseMessaging.h>
+// #import "FirebaseInstallations/FirebaseInstallations.h"
+// #import "FirebaseMessaging/FirebaseMessaging.h"
+// #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+// #import <FirebasePerformance/FirebasePerformance.h>
+// #import "FirebasePerformance/FirebasePerformance.h"
+// #endif
+// #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+// #import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"

--- a/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
+++ b/SwiftPMTests/ClientApp/ClientApp/objcxx-header-import-test.mm
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file imports all Firebase products that vend an umbrella header.
+// Products implemented in Swift are therefore omitted.
+
+// ‼️ Changes should also be reflected in `objc-header-import-test.m`.
+
+#import "Firebase.h"
+#import <Firebase.h>
+#import "FirebaseABTesting/FirebaseABTesting.h"
+#import <FirebaseABTesting/FirebaseABTesting.h>
+#import "FirebaseAnalytics/FirebaseAnalytics.h"
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
+#import "FirebaseAppCheck/FirebaseAppCheck.h"
+#import <FirebaseAppCheck/FirebaseAppCheck.h>
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#import "FirebaseAppDistribution/FirebaseAppDistribution.h"
+#import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+#endif
+#import "FirebaseAuth/FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
+#import "FirebaseCore/FirebaseCore.h"
+#import <FirebaseCore/FirebaseCore.h>
+#import "FirebaseCrashlytics/FirebaseCrashlytics.h"
+#import <FirebaseCrashlytics/FirebaseCrashlytics.h>
+#import "FirebaseDatabase/FirebaseDatabase.h"
+#import <FirebaseDatabase/FirebaseDatabase.h>
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#import "FirebaseDynamicLinks/FirebaseDynamicLinks.h"
+#import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+#endif
+#import "FirebaseFirestore/FirebaseFirestore.h"
+#import <FirebaseFirestore/FirebaseFirestore.h>
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+#import "FirebaseInAppMessaging/FirebaseInAppMessaging.h"
+#import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
+#endif
+#import "FirebaseInstallations/FirebaseInstallations.h"
+#import <FirebaseInstallations/FirebaseInstallations.h>
+#import "FirebaseMessaging/FirebaseMessaging.h"
+#import <FirebaseMessaging/FirebaseMessaging.h>
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+#import "FirebasePerformance/FirebasePerformance.h"
+#import <FirebasePerformance/FirebasePerformance.h>
+#endif
+#import "FirebaseRemoteConfig/FirebaseRemoteConfig.h"
+#import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>

--- a/SwiftPMTests/ClientApp/ClientApp/objcxx-module-import-test.mm
+++ b/SwiftPMTests/ClientApp/ClientApp/objcxx-module-import-test.mm
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ‼️ NOTE: Changes should also be reflected in `objc-module-import-test.m`.
+
+@import Firebase;
+@import FirebaseABTesting;
+@import FirebaseAnalytics;
+@import FirebaseAppCheck;
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+@import FirebaseAppDistribution;
+#endif
+@import FirebaseAuth;
+@import FirebaseCore;
+@import FirebaseCrashlytics;
+@import FirebaseDatabase;
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+@import FirebaseDynamicLinks;
+#endif
+@import FirebaseFirestore;
+@import FirebaseFunctions;
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+@import FirebaseInAppMessaging;
+#endif
+@import FirebaseInstallations;
+@import FirebaseMessaging;
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+@import FirebasePerformance;
+#endif
+@import FirebaseRemoteConfig;
+@import FirebaseStorage;

--- a/SwiftPMTests/ClientApp/ClientApp/objcxx-module-import-test.mm
+++ b/SwiftPMTests/ClientApp/ClientApp/objcxx-module-import-test.mm
@@ -14,29 +14,30 @@
 
 // ‼️ NOTE: Changes should also be reflected in `objc-module-import-test.m`.
 
-@import Firebase;
-@import FirebaseABTesting;
-@import FirebaseAnalytics;
-@import FirebaseAppCheck;
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-@import FirebaseAppDistribution;
-#endif
-@import FirebaseAuth;
-@import FirebaseCore;
-@import FirebaseCrashlytics;
-@import FirebaseDatabase;
-#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-@import FirebaseDynamicLinks;
-#endif
-@import FirebaseFirestore;
-@import FirebaseFunctions;
-#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
-@import FirebaseInAppMessaging;
-#endif
-@import FirebaseInstallations;
-@import FirebaseMessaging;
-#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
-@import FirebasePerformance;
-#endif
-@import FirebaseRemoteConfig;
-@import FirebaseStorage;
+// TODO(Xcode 14.3): Re-enable contest when GHA supports Xcode 14.3.
+// @import Firebase;
+// @import FirebaseABTesting;
+// @import FirebaseAnalytics;
+// @import FirebaseAppCheck;
+// #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+// @import FirebaseAppDistribution;
+// #endif
+// @import FirebaseAuth;
+// @import FirebaseCore;
+// @import FirebaseCrashlytics;
+// @import FirebaseDatabase;
+// #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+// @import FirebaseDynamicLinks;
+// #endif
+// @import FirebaseFirestore;
+// @import FirebaseFunctions;
+// #if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
+// @import FirebaseInAppMessaging;
+// #endif
+// @import FirebaseInstallations;
+// @import FirebaseMessaging;
+// #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_TV
+// @import FirebasePerformance;
+// #endif
+// @import FirebaseRemoteConfig;
+// @import FirebaseStorage;

--- a/SwiftPMTests/ClientApp/ClientApp/swift-import-test.swift
+++ b/SwiftPMTests/ClientApp/ClientApp/swift-import-test.swift
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ‼️ Changes should also be reflected in the ObjC/ObjC++ files if applicable.
+
+import Firebase
+// NOTE(ncooke3): `FirebaseABTesting` is not listed as a library.
+import FirebaseABTesting
+import FirebaseAnalytics
+import FirebaseAnalyticsSwift
+import FirebaseAppCheck
+#if os(iOS) && !targetEnvironment(macCatalyst)
+  import FirebaseAppDistribution
+#endif
+import FirebaseAuth
+import FirebaseAuthCombineSwift
+import FirebaseCore
+import FirebaseCrashlytics
+import FirebaseDatabase
+import FirebaseDatabaseSwift
+#if os(iOS) && !targetEnvironment(macCatalyst)
+  import FirebaseDynamicLinks
+#endif
+import FirebaseFirestore
+import FirebaseFirestoreCombineSwift
+import FirebaseFirestoreSwift
+import FirebaseFunctions
+import FirebaseFunctionsCombineSwift
+#if (os(iOS) || os(tvOS)) && !targetEnvironment(macCatalyst)
+  import FirebaseInAppMessaging
+  import FirebaseInAppMessagingSwift
+#endif
+import FirebaseInstallations
+import FirebaseMessaging
+import FirebaseMLModelDownloader
+#if (os(iOS) && !targetEnvironment(macCatalyst)) || os(tvOS)
+  import FirebasePerformance
+#endif
+import FirebaseRemoteConfig
+import FirebaseRemoteConfigSwift
+import FirebaseStorage
+import FirebaseStorageCombineSwift

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,10 +108,11 @@ source scripts/check_secrets.sh
 function RunXcodebuild() {
   echo xcodebuild "$@"
 
-  xcpretty_cmd=(xcpretty)
+  # xcpretty_cmd=(xcpretty)
 
   result=0
-  xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+  # xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+  xcodebuild "$@" | tee xcodebuild.log || result=$?
 
   if [[ $result == 65 ]]; then
     ExportLogs "$@"
@@ -120,7 +121,9 @@ function RunXcodebuild() {
     sleep 5
 
     result=0
-    xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+    # xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
+    xcodebuild "$@" | tee xcodebuild.log || result=$?
+
   fi
 
   if [[ $result != 0 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,11 +108,10 @@ source scripts/check_secrets.sh
 function RunXcodebuild() {
   echo xcodebuild "$@"
 
-  # xcpretty_cmd=(xcpretty)
+  xcpretty_cmd=(xcpretty)
 
   result=0
-  # xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
-  xcodebuild "$@" | tee xcodebuild.log || result=$?
+  xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
 
   if [[ $result == 65 ]]; then
     ExportLogs "$@"
@@ -121,9 +120,7 @@ function RunXcodebuild() {
     sleep 5
 
     result=0
-    # xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
-    xcodebuild "$@" | tee xcodebuild.log || result=$?
-
+    xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}" || result=$?
   fi
 
   if [[ $result != 0 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -698,6 +698,14 @@ case "$product-$platform-$method" in
       build
     ;;
 
+  SwiftPMClientApp-*-xcodebuild)
+    RunXcodebuild \
+      -project 'SwiftPMTests/ClientApp/ClientApp.xcodeproj' \
+      -scheme "ClientApp" \
+      "${xcb_flags[@]}" \
+      build
+    ;;
+
   *)
 
     echo "Don't know how to build this product-platform-method combination" 1>&2


### PR DESCRIPTION
### Context
- Add "client" sample app that imports all applicable product in a Swift, Obj-C, and Obj-C++ context.
- Add corresponding multi-platform `spm / client-app` job to test that app builds from the branch's HEAD package state.
- Checked and verified that this would have caught the issue that required 10.8.1 release.
- This also surfaced some other warnings and discrepancies that can now be addressed in subsequent PRs.
- Theres's currently a bug in Xcode versions under 14.3 that will affect this job running on some platforms. The build error looks like:
  
  >  Showing All Messages
/Users/nickcooke/Library/Developer/Xcode/DerivedData/ClientApp-ftiilcvpyjwxxieryciqmiulqnea/SourcePackages/artifacts/googleappmeasurement/GoogleAppMeasurementOnDeviceConversion.xcframework:1:1: While building for macOS, no library for this platform was found in '/Users/nickcooke/Library/Developer/Xcode/DerivedData/ClientApp-ftiilcvpyjwxxieryciqmiulqnea/SourcePackages/artifacts/googleappmeasurement/GoogleAppMeasurementOnDeviceConversion.xcframework'.

  Any idea of a workaround we could do for `GoogleAppMeasurementOnDeviceConversion` that would let us run on earlier Xcodes? I tried editing the `GoogleAppMeasurementOnDeviceConversion` to use the `condition(when: [.iOS])` but that didn't work. 
 
  The relevant fix introduced in Xcode 14.3 was:

  > Fixed: Conditional target dependencies (SE-0273) in packages are now correctly applied to binary targets and leads to top-level targets being filtered out from builds of root packages. (85762201)"

  GitHub Actions doesn't support 14.3 yet so I'm expecting some platforms like Catalyst to fail to build. I will disable those platforms and add a comment to re-enable when GHA supports Xcode 14.3.

  The only other workaround I could think of to get all platforms running on our minimum supported Xcode is to add dummy xcframework slices for `mac` and `maccatalyst` to `(Analytics|GoogleAppMeasurement)OnDeviceConversion` products. And issue a [warning like Performance](https://github.com/firebase/firebase-ios-sdk/blob/767d7c28f4d3984226d3b6177e6a6c538926f89c/SwiftPM-PlatformExclude/FirebasePerformanceWrap/include/dummy.h#L20). Thoughts? @paulb777 @andrewheard 

---

There was also another issue where ObjC++ files could not import the headers/modules of binary targets. This seems to be an Xcode 14.2 issue that was resolved in Xcode 14.3 (however I can't find corresponding release note). 

---

_Decision: Recommend 14.3 for ObjC++ use and to workaround GoogleAppMeasurement issue._