### PR TITLE
Add `@discardableResult` to async `addDocument`

### DIFF
--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -25,6 +25,7 @@ import Foundation
     /// - Parameter data: A `Dictionary` containing the data for the new document.
     /// - Throws: `Error` if the backend rejected the write.
     /// - Returns: A `DocumentReference` pointing to the newly created document.
+    @discardableResult
     func addDocument(data: [String: Any]) async throws -> DocumentReference {
       return try await withCheckedThrowingContinuation { continuation in
         var document: DocumentReference?


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-ios-sdk/issues/10640

I would like to propose a Pull Request to add the `@discardableResult` attribute to the async `addDocument` method in CollectionReference. This change would be consistent with the similar change made in PR #10661.
