### PR TITLE
Firestore Spec Tests: Port JS PR 7257 (use strings for `targetPurpose`)

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -327,6 +327,20 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
   return Version(version.longLongValue);
 }
 
+- (QueryPurpose)parseQueryPurpose:(NSNumber *)value {
+  switch ([value intValue]) {
+    case 0:
+      return QueryPurpose::Listen;
+    case 1:
+      return QueryPurpose::ExistenceFilterMismatch;
+    case 3:
+      return QueryPurpose::LimboResolution;
+    default:
+      XCTFail(@"unknown query purpose value: %@", value);
+      return QueryPurpose::Listen;
+  }
+}
+
 - (DocumentViewChange)parseChange:(NSDictionary *)jsonDoc ofType:(DocumentViewChange::Type)type {
   NSNumber *version = jsonDoc[@"version"];
   NSDictionary *options = jsonDoc[@"options"];
@@ -781,7 +795,7 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
 
               QueryPurpose purpose = QueryPurpose::Listen;
               if ([queryData objectForKey:@"targetPurpose"] != nil) {
-                purpose = static_cast<QueryPurpose>([queryData[@"targetPurpose"] intValue]);
+                purpose = [self parseQueryPurpose:queryData[@"targetPurpose"]];
               }
 
               TargetData target_data(query.ToTarget(), targetID, 0, purpose);

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -327,18 +327,18 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
   return Version(version.longLongValue);
 }
 
-- (QueryPurpose)parseQueryPurpose:(NSNumber *)value {
-  switch ([value intValue]) {
-    case 0:
-      return QueryPurpose::Listen;
-    case 1:
-      return QueryPurpose::ExistenceFilterMismatch;
-    case 3:
-      return QueryPurpose::LimboResolution;
-    default:
-      XCTFail(@"unknown query purpose value: %@", value);
-      return QueryPurpose::Listen;
+- (QueryPurpose)parseQueryPurpose:(NSString *)value {
+  if ([value isEqualToString:@"TargetPurposeListen"]) {
+    return QueryPurpose::Listen;
   }
+  if ([value isEqualToString:@"TargetPurposeExistenceFilterMismatch"]) {
+    return QueryPurpose::ExistenceFilterMismatch;
+  }
+  if ([value isEqualToString:@"TargetPurposeLimboResolution"]) {
+    return QueryPurpose::LimboResolution;
+  }
+  XCTFail(@"unknown query purpose value: %@", value);
+  return QueryPurpose::Listen;
 }
 
 - (DocumentViewChange)parseChange:(NSDictionary *)jsonDoc ofType:(DocumentViewChange::Type)type {

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -465,13 +465,12 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
   }
 }
 
-- (void)doWatchFilter:(NSArray *)watchFilter {
-  NSArray<NSNumber *> *targets = watchFilter[0];
+- (void)doWatchFilter:(NSDictionary *)watchFilter {
+  NSArray<NSString *> *keys = watchFilter[@"keys"];
+  NSArray<NSNumber *> *targets = watchFilter[@"targetIds"];
   HARD_ASSERT(targets.count == 1, "ExistenceFilters currently support exactly one target only.");
 
-  int keyCount = watchFilter.count == 0 ? 0 : (int)watchFilter.count - 1;
-
-  ExistenceFilter filter{keyCount};
+  ExistenceFilter filter{static_cast<int>(keys.count)};
   ExistenceFilterWatchChange change{filter, targets[0].intValue};
   [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
 }

--- a/Firestore/Example/Tests/SpecTests/json/bundle_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/bundle_spec_test.json
@@ -1179,7 +1179,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/bundle_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/bundle_spec_test.json
@@ -1179,7 +1179,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -132,12 +132,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -366,13 +368,15 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1",
+            "collection/2"
           ],
-          "collection/1",
-          "collection/2"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchEntity": {
@@ -729,11 +733,13 @@
         }
       },
       {
-        "watchFilter": [
-          [
+        "watchFilter": {
+          "keys": [
+          ],
+          "targetIds": [
             2
           ]
-        ]
+        }
       },
       {
         "watchRemove": {
@@ -910,12 +916,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -1203,12 +1211,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -1313,12 +1323,14 @@
         }
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -1489,12 +1501,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -1846,12 +1860,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {
@@ -2149,11 +2165,13 @@
         ]
       },
       {
-        "watchFilter": [
-          [
+        "watchFilter": {
+          "keys": [
+          ],
+          "targetIds": [
             2
           ]
-        ]
+        }
       },
       {
         "watchSnapshot": {
@@ -2265,12 +2283,14 @@
         ]
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/1"
           ],
-          "collection/1"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {

--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -1,4 +1,4190 @@
 {
+  "Bloom filter can process special characters in document name": {
+    "describeName": "Existence Filters:",
+    "itName": "Bloom filter can process special characters in document name",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/ÀÒ∑",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/À∑Ò",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/ÀÒ∑",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/À∑Ò",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "IIAAIIAIIAAIIAIIAA==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/ÀÒ∑"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/À∑Ò"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/À∑Ò"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Bloom filter fills in default values for undefined padding and hashCount": {
+    "describeName": "Existence Filters:",
+    "itName": "Bloom filter fills in default values for undefined padding and hashCount",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AhAAApAAAIAEBIAABA=="
+            }
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 1
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Bloom filter is handled at global snapshot": {
+    "describeName": "Existence Filters:",
+    "itName": "Bloom filter is handled at global snapshot",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AhAAApAAAIAEBIAABA==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Bloom filter limbo resolution is denied": {
+    "describeName": "Existence Filters:",
+    "itName": "Bloom filter limbo resolution is denied",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AhAAApAAAIAEBIAABA==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "cause": {
+            "code": 7
+          },
+          "targetIds": [
+            1
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Bloom filter with large size works as expected": {
+    "describeName": "Existence Filters:",
+    "itName": "Bloom filter with large size works as expected",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/doc0",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc2",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc3",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc4",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc5",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc6",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc7",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc8",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc9",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc10",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc11",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc12",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc13",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc14",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc15",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc16",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc17",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc18",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc19",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc20",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc21",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc22",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc23",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc24",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc25",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc26",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc27",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc28",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc29",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc30",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc31",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc32",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc33",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc34",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc35",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc36",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc37",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc38",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc39",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc40",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc41",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc42",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc43",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc44",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc45",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc46",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc47",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc48",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc49",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc50",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc51",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc52",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc53",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc54",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc55",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc56",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc57",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc58",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc59",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc60",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc61",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc62",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc63",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc64",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc65",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc66",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc67",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc68",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc69",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc70",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc71",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc72",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc73",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc74",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc75",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc76",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc77",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc78",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc79",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc80",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc81",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc82",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc83",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc84",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc85",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc86",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc87",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc88",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc89",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc90",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc91",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc92",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc93",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc94",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc95",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc96",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc97",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc98",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/doc99",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/doc0",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc4",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc5",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc6",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc7",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc8",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc9",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc10",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc11",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc12",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc13",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc14",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc15",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc16",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc17",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc18",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc19",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc20",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc21",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc22",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc23",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc24",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc25",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc26",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc27",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc28",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc29",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc30",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc31",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc32",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc33",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc34",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc35",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc36",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc37",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc38",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc39",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc40",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc41",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc42",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc43",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc44",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc45",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc46",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc47",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc48",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc49",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc50",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc51",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc52",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc53",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc54",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc55",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc56",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc57",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc58",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc59",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc60",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc61",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc62",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc63",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc64",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc65",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc66",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc67",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc68",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc69",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc70",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc71",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc72",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc73",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc74",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc75",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc76",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc77",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc78",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc79",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc80",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc81",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc82",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc83",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc84",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc85",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc86",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc87",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc88",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc89",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc90",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc91",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc92",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc93",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc94",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc95",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc96",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc97",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc98",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/doc99",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "+9oMQXUptl274DOaET8sfebQ4aCu0Roiddbja3z8TfadKuyPV/9XWV5Ksv+vywRXTfZSNIn8z+xk/oq1+cbOPepeNvbXVOF6H92fCOAz/KiS3Mcw338R9tXE3Y7QB1L2kbvbvVHW3Kn/k3Vx8k9Oa19eWX6RYE97Q+oCcVU=",
+              "padding": 0
+            },
+            "hashCount": 16
+          },
+          "keys": [
+            "collection/doc0",
+            "collection/doc1",
+            "collection/doc2",
+            "collection/doc3",
+            "collection/doc4",
+            "collection/doc5",
+            "collection/doc6",
+            "collection/doc7",
+            "collection/doc8",
+            "collection/doc9",
+            "collection/doc10",
+            "collection/doc11",
+            "collection/doc12",
+            "collection/doc13",
+            "collection/doc14",
+            "collection/doc15",
+            "collection/doc16",
+            "collection/doc17",
+            "collection/doc18",
+            "collection/doc19",
+            "collection/doc20",
+            "collection/doc21",
+            "collection/doc22",
+            "collection/doc23",
+            "collection/doc24",
+            "collection/doc25",
+            "collection/doc26",
+            "collection/doc27",
+            "collection/doc28",
+            "collection/doc29",
+            "collection/doc30",
+            "collection/doc31",
+            "collection/doc32",
+            "collection/doc33",
+            "collection/doc34",
+            "collection/doc35",
+            "collection/doc36",
+            "collection/doc37",
+            "collection/doc38",
+            "collection/doc39",
+            "collection/doc40",
+            "collection/doc41",
+            "collection/doc42",
+            "collection/doc43",
+            "collection/doc44",
+            "collection/doc45",
+            "collection/doc46",
+            "collection/doc47",
+            "collection/doc48",
+            "collection/doc49"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/doc50",
+            "collection/doc51",
+            "collection/doc52",
+            "collection/doc53",
+            "collection/doc54",
+            "collection/doc55",
+            "collection/doc56",
+            "collection/doc57",
+            "collection/doc58",
+            "collection/doc59",
+            "collection/doc60",
+            "collection/doc61",
+            "collection/doc62",
+            "collection/doc63",
+            "collection/doc64",
+            "collection/doc65",
+            "collection/doc66",
+            "collection/doc67",
+            "collection/doc68",
+            "collection/doc69",
+            "collection/doc70",
+            "collection/doc71",
+            "collection/doc72",
+            "collection/doc73",
+            "collection/doc74",
+            "collection/doc75",
+            "collection/doc76",
+            "collection/doc77",
+            "collection/doc78",
+            "collection/doc79",
+            "collection/doc80",
+            "collection/doc81",
+            "collection/doc82",
+            "collection/doc83",
+            "collection/doc84",
+            "collection/doc85",
+            "collection/doc86",
+            "collection/doc87",
+            "collection/doc88",
+            "collection/doc89",
+            "collection/doc90",
+            "collection/doc91",
+            "collection/doc92",
+            "collection/doc93",
+            "collection/doc94",
+            "collection/doc95",
+            "collection/doc96",
+            "collection/doc97",
+            "collection/doc98",
+            "collection/doc99"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc50"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "11": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc55"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "13": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc56"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "15": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc57"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "17": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc58"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "19": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc59"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "21": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc60"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "23": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc61"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "25": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc62"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "27": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc63"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "29": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc64"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc51"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "31": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc65"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "33": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc66"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "35": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc67"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "37": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc68"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "39": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc69"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "41": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc70"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "43": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc71"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "45": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc72"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "47": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc73"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "49": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc74"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "5": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc52"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "51": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc75"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "53": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc76"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "55": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc77"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "57": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc78"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "59": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc79"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "61": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc80"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "63": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc81"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "65": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc82"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "67": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc83"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "69": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc84"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "7": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc53"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "71": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc85"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "73": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc86"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "75": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc87"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "77": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc88"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "79": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc89"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "81": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc90"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "83": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc91"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "85": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc92"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "87": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc93"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "89": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc94"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "9": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc54"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "91": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc95"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "93": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc96"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "95": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc97"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "97": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc98"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "99": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc99"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            }
+          }
+        }
+      }
+    ]
+  },
   "Existence filter clears resume token": {
     "describeName": "Existence Filters:",
     "itName": "Existence filter clears resume token",
@@ -1026,7 +5212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -1611,7 +5797,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -1970,7 +6156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -2326,6 +6512,1593 @@
               ],
               "resumeToken": "",
               "targetPurpose": 1
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Full re-query is skipped when bloom filter can identify documents deleted": {
+    "describeName": "Existence Filters:",
+    "itName": "Full re-query is skipped when bloom filter can identify documents deleted",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AhAAApAAAIAEBIAABA==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Full re-query is triggered when bloom filter bitmap is invalid": {
+    "describeName": "Existence Filters:",
+    "itName": "Full re-query is triggered when bloom filter bitmap is invalid",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "INVALID_BASE_64",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 1
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Full re-query is triggered when bloom filter can not identify documents deleted": {
+    "describeName": "Existence Filters:",
+    "itName": "Full re-query is triggered when bloom filter can not identify documents deleted",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AxBIApBIAIAWBoCQBA==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 2
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Full re-query is triggered when bloom filter hashCount is invalid": {
+    "describeName": "Existence Filters:",
+    "itName": "Full re-query is triggered when bloom filter hashCount is invalid",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "AhAAApAAAIAEBIAABA==",
+              "padding": 4
+            },
+            "hashCount": -1
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 1
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Full re-query is triggered when bloom filter is empty": {
+    "describeName": "Existence Filters:",
+    "itName": "Full re-query is triggered when bloom filter is empty",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "",
+              "padding": 0
+            },
+            "hashCount": 0
+          },
+          "keys": [
+            "collection/a"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 1
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Same documents can have different bloom filters": {
+    "describeName": "Existence Filters:",
+    "itName": "Same documents can have different bloom filters",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+              [
+                "v",
+                "<=",
+                2
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      "<=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "v",
+                  "<=",
+                  2
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+              [
+                "v",
+                ">=",
+                2
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 4
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "v",
+                  ">=",
+                  2
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      "<=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      ">=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "v",
+                  ">=",
+                  2
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "CQ==",
+              "padding": 3
+            },
+            "hashCount": 2
+          },
+          "keys": [
+            "collection/b"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "v",
+                  "<=",
+                  2
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      "<=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      ">=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "CA==",
+              "padding": 4
+            },
+            "hashCount": 1
+          },
+          "keys": [
+            "collection/b"
+          ],
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "v",
+                  ">=",
+                  2
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a",
+            "collection/c"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      "<=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "v",
+                      ">=",
+                      2
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
             }
           }
         }

--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -185,7 +185,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -385,7 +385,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -613,7 +613,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -818,7 +818,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3529,7 +3529,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "11": {
               "queries": [
@@ -3542,7 +3542,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "13": {
               "queries": [
@@ -3555,7 +3555,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "15": {
               "queries": [
@@ -3568,7 +3568,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "17": {
               "queries": [
@@ -3581,7 +3581,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "19": {
               "queries": [
@@ -3594,7 +3594,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3619,7 +3619,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "23": {
               "queries": [
@@ -3632,7 +3632,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "25": {
               "queries": [
@@ -3645,7 +3645,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "27": {
               "queries": [
@@ -3658,7 +3658,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "29": {
               "queries": [
@@ -3671,7 +3671,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "3": {
               "queries": [
@@ -3684,7 +3684,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "31": {
               "queries": [
@@ -3697,7 +3697,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "33": {
               "queries": [
@@ -3710,7 +3710,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "35": {
               "queries": [
@@ -3723,7 +3723,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "37": {
               "queries": [
@@ -3736,7 +3736,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "39": {
               "queries": [
@@ -3749,7 +3749,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "41": {
               "queries": [
@@ -3762,7 +3762,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "43": {
               "queries": [
@@ -3775,7 +3775,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "45": {
               "queries": [
@@ -3788,7 +3788,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "47": {
               "queries": [
@@ -3801,7 +3801,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "49": {
               "queries": [
@@ -3814,7 +3814,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "5": {
               "queries": [
@@ -3827,7 +3827,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "51": {
               "queries": [
@@ -3840,7 +3840,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "53": {
               "queries": [
@@ -3853,7 +3853,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "55": {
               "queries": [
@@ -3866,7 +3866,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "57": {
               "queries": [
@@ -3879,7 +3879,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "59": {
               "queries": [
@@ -3892,7 +3892,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "61": {
               "queries": [
@@ -3905,7 +3905,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "63": {
               "queries": [
@@ -3918,7 +3918,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "65": {
               "queries": [
@@ -3931,7 +3931,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "67": {
               "queries": [
@@ -3944,7 +3944,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "69": {
               "queries": [
@@ -3957,7 +3957,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -3970,7 +3970,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "71": {
               "queries": [
@@ -3983,7 +3983,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "73": {
               "queries": [
@@ -3996,7 +3996,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "75": {
               "queries": [
@@ -4009,7 +4009,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "77": {
               "queries": [
@@ -4022,7 +4022,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "79": {
               "queries": [
@@ -4035,7 +4035,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "81": {
               "queries": [
@@ -4048,7 +4048,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "83": {
               "queries": [
@@ -4061,7 +4061,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "85": {
               "queries": [
@@ -4074,7 +4074,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "87": {
               "queries": [
@@ -4087,7 +4087,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "89": {
               "queries": [
@@ -4100,7 +4100,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "9": {
               "queries": [
@@ -4113,7 +4113,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "91": {
               "queries": [
@@ -4126,7 +4126,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "93": {
               "queries": [
@@ -4139,7 +4139,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "95": {
               "queries": [
@@ -4152,7 +4152,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "97": {
               "queries": [
@@ -4165,7 +4165,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "99": {
               "queries": [
@@ -4178,7 +4178,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4360,7 +4360,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -4632,7 +4632,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5144,7 +5144,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5212,7 +5212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5225,7 +5225,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5282,7 +5282,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5729,7 +5729,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5797,7 +5797,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5810,7 +5810,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5877,7 +5877,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6088,7 +6088,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6156,7 +6156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -6169,7 +6169,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6236,7 +6236,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6511,7 +6511,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6704,7 +6704,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -6972,7 +6972,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7186,7 +7186,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": "TargetPurposeExistenceFilterMismatchBloom"
             }
           }
         }
@@ -7376,7 +7376,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7566,7 +7566,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7953,7 +7953,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8051,7 +8051,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8081,7 +8081,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -3445,11 +3445,13 @@
         ]
       },
       {
-        "watchFilter": [
-          [
+        "watchFilter": {
+          "keys": [
+          ],
+          "targetIds": [
             1
           ]
-        ]
+        }
       },
       {
         "watchCurrent": [
@@ -8201,15 +8203,16 @@
         }
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/b1",
+            "collection/b2",
+            "collection/b3"
           ],
-          "collection/b1",
-          "collection/b2",
-          "collection/b3"
-        ]
-
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -238,7 +238,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -284,7 +284,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -411,7 +411,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -495,7 +495,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -578,7 +578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -682,7 +682,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "10": {
               "queries": [
@@ -782,7 +782,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "10": {
               "queries": [
@@ -873,7 +873,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -947,7 +947,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1212,7 +1212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1258,7 +1258,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1385,7 +1385,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1469,7 +1469,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1552,7 +1552,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -1656,7 +1656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "10": {
               "queries": [
@@ -1756,7 +1756,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "10": {
               "queries": [
@@ -2055,7 +2055,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -2141,7 +2141,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -2224,7 +2224,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -2442,7 +2442,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -2862,7 +2862,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -3152,7 +3152,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -3422,7 +3422,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -3672,7 +3672,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -3965,7 +3965,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -4081,7 +4081,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -4345,7 +4345,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -4697,7 +4697,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -5082,7 +5082,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -5173,7 +5173,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -5553,7 +5553,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -5578,7 +5578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -5690,7 +5690,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -5715,7 +5715,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -5770,7 +5770,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -5890,7 +5890,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -6332,7 +6332,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -6870,7 +6870,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -7203,7 +7203,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -7288,7 +7288,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -7618,7 +7618,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -7643,7 +7643,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -7754,7 +7754,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "7": {
               "queries": [
@@ -7767,7 +7767,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -7875,7 +7875,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -7947,6 +7947,402 @@
             }
           },
           "enqueuedLimboDocs": [
+          ]
+        }
+      }
+    ]
+  },
+  "Limbo resolution throttling with bloom filter application": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with bloom filter application",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "maxConcurrentLimboResolutions": 2,
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a1"
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/a2",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a2"
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/a3",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a3"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a1"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/a2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a2"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/a3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a3"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/b1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b1"
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b2",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b2"
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b3",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b3"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchFilter": {
+          "bloomFilter": {
+            "bits": {
+              "bitmap": "yABCEAeZURNRGAkgAQ==",
+              "padding": 4
+            },
+            "hashCount": 10
+          },
+          "keys": [
+            "collection/b1",
+            "collection/b2",
+            "collection/b3"
+          ],
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/b1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b1"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b2"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b3"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a1",
+            "collection/a2"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a1"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a2"
+                }
+              ],
+              "resumeToken": "",
+              "targetPurpose": 3
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/a3"
           ]
         }
       }
@@ -8378,7 +8774,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -8404,7 +8800,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -8513,7 +8909,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -8854,7 +9250,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -8879,7 +9275,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -8970,7 +9366,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "5": {
               "queries": [
@@ -8983,7 +9379,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -9068,7 +9464,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "7": {
               "queries": [
@@ -9081,7 +9477,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -9165,7 +9561,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "9": {
               "queries": [
@@ -9178,7 +9574,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -9260,7 +9656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           },
           "enqueuedLimboDocs": [
@@ -9642,7 +10038,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -238,7 +238,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -284,7 +284,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -411,7 +411,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -495,7 +495,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -578,7 +578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -682,7 +682,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -782,7 +782,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -873,7 +873,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -947,7 +947,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1212,7 +1212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1258,7 +1258,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1385,7 +1385,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1469,7 +1469,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1552,7 +1552,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1656,7 +1656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -1756,7 +1756,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -2055,7 +2055,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2141,7 +2141,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2224,7 +2224,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2442,7 +2442,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -2862,7 +2862,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3152,7 +3152,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3422,7 +3422,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3672,7 +3672,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3965,7 +3965,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4081,7 +4081,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4345,7 +4345,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4697,7 +4697,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5082,7 +5082,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5173,7 +5173,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5553,7 +5553,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5578,7 +5578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5690,7 +5690,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5715,7 +5715,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5770,7 +5770,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5890,7 +5890,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -6332,7 +6332,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -6870,7 +6870,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -7203,7 +7203,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -7288,7 +7288,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7618,7 +7618,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -7643,7 +7643,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7754,7 +7754,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -7767,7 +7767,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7875,7 +7875,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8313,7 +8313,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8338,7 +8338,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8681,7 +8681,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -8774,7 +8774,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8787,7 +8787,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             },
             "3": {
               "queries": [
@@ -8800,7 +8800,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8896,7 +8896,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             },
             "5": {
               "queries": [
@@ -8909,7 +8909,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8978,7 +8978,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           },
           "enqueuedLimboDocs": [
@@ -9250,7 +9250,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -9275,7 +9275,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9366,7 +9366,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "5": {
               "queries": [
@@ -9379,7 +9379,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9464,7 +9464,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -9477,7 +9477,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9561,7 +9561,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "9": {
               "queries": [
@@ -9574,7 +9574,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9656,7 +9656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -10038,7 +10038,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
@@ -5611,12 +5611,14 @@
         }
       },
       {
-        "watchFilter": [
-          [
-            2
+        "watchFilter": {
+          "keys": [
+            "collection/b"
           ],
-          "collection/b"
-        ]
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchSnapshot": {

--- a/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
@@ -220,7 +220,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -4461,7 +4461,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -4488,7 +4488,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -4625,7 +4625,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -4650,7 +4650,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -4794,7 +4794,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "7": {
               "queries": [
@@ -4807,7 +4807,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -4950,7 +4950,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             }
           }
         }
@@ -5449,7 +5449,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -5713,7 +5713,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
@@ -220,7 +220,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4461,7 +4461,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4488,7 +4488,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -4625,7 +4625,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -4650,7 +4650,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4794,7 +4794,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -4807,7 +4807,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4950,7 +4950,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5449,7 +5449,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -5645,7 +5645,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5713,7 +5713,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5732,7 +5732,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5825,7 +5825,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }

--- a/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
@@ -3381,6 +3381,161 @@
       }
     ]
   },
+  "ExpectedCount in listen request should work after coming back online": {
+    "describeName": "Listens:",
+    "itName": "ExpectedCount in listen request should work after coming back online",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": false
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      }
+    ]
+  },
   "Ignores update from inactive target": {
     "describeName": "Listens:",
     "itName": "Ignores update from inactive target",
@@ -12584,6 +12739,536 @@
             ]
           }
         ]
+      }
+    ]
+  },
+  "Resuming a query should specify expectedCount that does not include pending mutations": {
+    "describeName": "Listens:",
+    "itName": "Resuming a query should specify expectedCount that does not include pending mutations",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": false
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/b",
+          {
+            "key": "b"
+          }
+        ]
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Resuming a query should specify expectedCount when adding the target": {
+    "describeName": "Listens:",
+    "itName": "Resuming a query should specify expectedCount when adding the target",
+    "tags": [
+      "no-ios",
+      "no-android"
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": false
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "createTime": 0,
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "createTime": 0,
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        }
       }
     ]
   },

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -1156,7 +1156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -1194,7 +1194,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -1156,7 +1156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [
@@ -1194,7 +1194,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "2": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/recovery_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/recovery_spec_test.json
@@ -3133,7 +3133,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -3223,7 +3223,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -3613,7 +3613,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [
@@ -3673,7 +3673,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": 3
             },
             "4": {
               "queries": [

--- a/Firestore/Example/Tests/SpecTests/json/recovery_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/recovery_spec_test.json
@@ -3133,7 +3133,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3223,7 +3223,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3613,7 +3613,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3673,7 +3673,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [


### PR DESCRIPTION
Port spec test changes from https://github.com/firebase/firebase-js-sdk/pull/7257 (Firestore: use string values for TargetPurpose enum).

For reference, here is the Android port of the same change: https://github.com/firebase/firebase-android-sdk/pull/4931

#no-changelog