### PR TITLE
Extract GACAppCheckSettings protocol from FIRAppCheckSettingsProtocol

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -68,7 +68,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 @property(nonatomic, readonly) id<FIRAppCheckProvider> appCheckProvider;
 @property(nonatomic, readonly) id<FIRAppCheckStorageProtocol> storage;
 @property(nonatomic, readonly) NSNotificationCenter *notificationCenter;
-@property(nonatomic, readonly) id<FIRAppCheckSettingsProtocol> settings;
+@property(nonatomic, readonly) id<GACAppCheckSettings> settings;
 
 @property(nonatomic, readonly, nullable) id<FIRAppCheckTokenRefresherProtocol> tokenRefresher;
 
@@ -148,7 +148,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
                         storage:(id<FIRAppCheckStorageProtocol>)storage
                  tokenRefresher:(id<FIRAppCheckTokenRefresherProtocol>)tokenRefresher
              notificationCenter:(NSNotificationCenter *)notificationCenter
-                       settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                       settings:(id<GACAppCheckSettings>)settings {
   self = [super init];
   if (self) {
     _appName = appName;

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -38,6 +38,7 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 @implementation FIRAppCheckSettings
 
 @dynamic isTokenAutoRefreshEnabled;
+@dynamic isDataCollectionDefaultEnabled;
 
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults
@@ -94,6 +95,10 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
     self.isTokenAutoRefreshEnabledNumber = @(isTokenAutoRefreshEnabled);
     [self.userDefaults setObject:self.isTokenAutoRefreshEnabledNumber forKey:self.userDefaultKey];
   }
+}
+
+- (BOOL)isDataCollectionDefaultEnabled {
+  return self.firebaseApp.dataCollectionDefaultEnabled;
 }
 
 @end

--- a/FirebaseAppCheck/Sources/Core/GACAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/Core/GACAppCheckSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,16 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseAppCheck/Sources/Core/GACAppCheckSettings.h"
-
-@class FIRApp;
-
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix;
-FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey;
+/// A collection of App Check-wide settings and parameters.
+@protocol GACAppCheckSettings <NSObject>
 
-/// Handles storing and updating the Firebase app check wide settings and parameters.
-@interface FIRAppCheckSettings : NSObject <GACAppCheckSettings>
+/// If App Check token auto-refresh is allowed.
+@property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;
 
-- (instancetype)initWithApp:(FIRApp *)firebaseApp
-                userDefault:(NSUserDefaults *)userDefaults
-                 mainBundle:(NSBundle *)mainBundle;
+/// If automatic data collection is enabled.
+@property(nonatomic, readonly, assign) BOOL isDataCollectionDefaultEnabled;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h
+++ b/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h
@@ -18,7 +18,7 @@
 
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTimer.h"
 
-@protocol FIRAppCheckSettingsProtocol;
+@protocol GACAppCheckSettings;
 @class FIRAppCheckTokenRefreshResult;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -57,12 +57,11 @@ typedef void (^FIRAppCheckTokenRefreshBlock)(FIRAppCheckTokenRefreshCompletion c
 /// @param settings An object that handles Firebase app check settings.
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
                         timerProvider:(FIRTimerProvider)timerProvider
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings
-    NS_DESIGNATED_INITIALIZER;
+                             settings:(id<GACAppCheckSettings>)settings NS_DESIGNATED_INITIALIZER;
 
 /// A convenience initializer with a timer provider returning an instance of  `FIRAppCheckTimer`.
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings;
+                             settings:(id<GACAppCheckSettings>)settings;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.m
+++ b/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
 
-#import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
+#import "FirebaseAppCheck/Sources/Core/GACAppCheckSettings.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTimer.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefreshResult.h"
 
@@ -35,7 +35,7 @@ static const double kAutoRefreshFraction = 0.5;
 
 @property(nonatomic, readonly) dispatch_queue_t refreshQueue;
 
-@property(nonatomic, readonly) id<FIRAppCheckSettingsProtocol> settings;
+@property(nonatomic, readonly) id<GACAppCheckSettings> settings;
 
 @property(nonatomic, readonly) FIRTimerProvider timerProvider;
 @property(atomic, nullable) id<FIRAppCheckTimerProtocol> timer;
@@ -52,7 +52,7 @@ static const double kAutoRefreshFraction = 0.5;
 
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
                         timerProvider:(FIRTimerProvider)timerProvider
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                             settings:(id<GACAppCheckSettings>)settings {
   self = [super init];
   if (self) {
     _refreshQueue =
@@ -65,7 +65,7 @@ static const double kAutoRefreshFraction = 0.5;
 }
 
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                             settings:(id<GACAppCheckSettings>)settings {
   return [self initWithRefreshResult:refreshResult
                        timerProvider:[FIRAppCheckTimer timerProvider]
                             settings:settings];

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -51,7 +51,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                         storage:(id<FIRAppCheckStorageProtocol>)storage
                  tokenRefresher:(id<FIRAppCheckTokenRefresherProtocol>)tokenRefresher
              notificationCenter:(NSNotificationCenter *)notificationCenter
-                       settings:(id<FIRAppCheckSettingsProtocol>)settings;
+                       settings:(id<GACAppCheckSettings>)settings;
 
 - (nullable instancetype)initWithApp:(FIRApp *)app;
 @end
@@ -62,7 +62,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 @property(nonatomic) OCMockObject<FIRAppCheckStorageProtocol> *mockStorage;
 @property(nonatomic) OCMockObject<FIRAppCheckProvider> *mockAppCheckProvider;
 @property(nonatomic) OCMockObject<FIRAppCheckTokenRefresherProtocol> *mockTokenRefresher;
-@property(nonatomic) OCMockObject<FIRAppCheckSettingsProtocol> *mockSettings;
+@property(nonatomic) OCMockObject<GACAppCheckSettings> *mockSettings;
 @property(nonatomic) NSNotificationCenter *notificationCenter;
 @property(nonatomic) FIRAppCheck<FIRAppCheckInterop> *appCheck;
 
@@ -79,7 +79,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   self.mockStorage = OCMProtocolMock(@protocol(FIRAppCheckStorageProtocol));
   self.mockAppCheckProvider = OCMProtocolMock(@protocol(FIRAppCheckProvider));
   self.mockTokenRefresher = OCMProtocolMock(@protocol(FIRAppCheckTokenRefresherProtocol));
-  self.mockSettings = OCMProtocolMock(@protocol(FIRAppCheckSettingsProtocol));
+  self.mockSettings = OCMProtocolMock(@protocol(GACAppCheckSettings));
   self.notificationCenter = [[NSNotificationCenter alloc] init];
 
   [self stubSetTokenRefreshHandler];

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTokenRefresherTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTokenRefresherTests.m
@@ -28,7 +28,7 @@
 
 @property(nonatomic) FIRFakeTimer *fakeTimer;
 
-@property(nonatomic) OCMockObject<FIRAppCheckSettingsProtocol> *mockSettings;
+@property(nonatomic) OCMockObject<GACAppCheckSettings> *mockSettings;
 
 @property(nonatomic) FIRAppCheckTokenRefreshResult *initialTokenRefreshResult;
 
@@ -37,7 +37,7 @@
 @implementation FIRAppCheckTokenRefresherTests
 
 - (void)setUp {
-  self.mockSettings = OCMProtocolMock(@protocol(FIRAppCheckSettingsProtocol));
+  self.mockSettings = OCMProtocolMock(@protocol(GACAppCheckSettings));
   self.fakeTimer = [[FIRFakeTimer alloc] init];
 
   NSDate *receivedAtDate = [NSDate date];


### PR DESCRIPTION
`FIRAppCheckSettings` implements the extracted `GACAppCheckSettings` protocol for Firebase App Check and other integrators must provide their own implementations.