### PR TITLE
Fix Xcode 14.3 RC warnings

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -39,7 +39,7 @@ static NSString *const RCNDatabaseName = @"RemoteConfig.sqlite3";
 static NSString *const RCNRemoteConfigStorageSubDirectory = @"Google/RemoteConfig";
 
 /// Remote Config database path for deprecated V0 version.
-static NSString *RemoteConfigPathForOldDatabaseV0() {
+static NSString *RemoteConfigPathForOldDatabaseV0(void) {
   NSArray *dirPaths =
       NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
   NSString *docPath = dirPaths.firstObject;
@@ -97,7 +97,7 @@ static BOOL RemoteConfigCreateFilePathIfNotExist(NSString *filePath) {
   return YES;
 }
 
-static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
+static NSArray *RemoteConfigMetadataTableColumnsInOrder(void) {
   return @[
     RCNKeyBundleIdentifier, RCNKeyNamespace, RCNKeyFetchTime, RCNKeyDigestPerNamespace,
     RCNKeyDeviceContext, RCNKeyAppContext, RCNKeySuccessFetchTime, RCNKeyFailureFetchTime,

--- a/FirebaseRemoteConfig/Sources/RCNDevice.m
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.m
@@ -33,19 +33,19 @@ static NSString *const RCNDeviceContextKeyDeviceLocale = @"device_locale";
 static NSString *const RCNDeviceContextKeyLocaleLanguage = @"locale_language";
 static NSString *const RCNDeviceContextKeyGMPProjectIdentifier = @"GMP_project_Identifier";
 
-NSString *FIRRemoteConfigAppVersion() {
+NSString *FIRRemoteConfigAppVersion(void) {
   return [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
 }
 
-NSString *FIRRemoteConfigAppBuildVersion() {
+NSString *FIRRemoteConfigAppBuildVersion(void) {
   return [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 }
 
-NSString *FIRRemoteConfigPodVersion() {
+NSString *FIRRemoteConfigPodVersion(void) {
   return FIRFirebaseVersion();
 }
 
-RCNDeviceModel FIRRemoteConfigDeviceSubtype() {
+RCNDeviceModel FIRRemoteConfigDeviceSubtype(void) {
   NSString *model = [GULAppEnvironmentUtil deviceModel];
   if ([model hasPrefix:@"iPhone"]) {
     return RCNDeviceModelPhone;
@@ -56,7 +56,7 @@ RCNDeviceModel FIRRemoteConfigDeviceSubtype() {
   return RCNDeviceModelOther;
 }
 
-NSString *FIRRemoteConfigDeviceCountry() {
+NSString *FIRRemoteConfigDeviceCountry(void) {
   return [[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] lowercaseString];
 }
 


### PR DESCRIPTION
Xcode 14.3 complains about missing void's in parameterless C-style functions

#no-changelog