### PR TITLE
Xcode 14.3 test_specs always need requires_app_host

### DIFF
--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -46,6 +46,7 @@ iOS SDK for App Distribution for Firebase.
      'FirebaseAppDistribution/Tests/Unit*/*.[mh]',
      'FirebaseAppDistribution/Tests/Unit/Swift*/*.swift',
    ]
+   unit_tests.requires_app_host = true
    unit_tests.resources = 'FirebaseAppDistribution/Tests/Unit/Resources/*'
    unit_tests.dependency 'OCMock'
   end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -96,6 +96,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
     swift_unit_tests.pod_target_xcconfig = {
       'SWIFT_OBJC_BRIDGING_HEADER' => '$(PODS_TARGET_SRCROOT)/FirebaseCore/Tests/SwiftUnit/FirebaseCore-unit-Bridging-Header.h'
     }
+    swift_unit_tests.requires_app_host = true
     swift_unit_tests.dependency 'OCMock'
     swift_unit_tests.resources = 'FirebaseCore/Tests/Unit/Resources/GoogleService-Info.plist'
   end

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -117,5 +117,6 @@ Pod::Spec.new do |s|
     unit_tests.resources = 'Crashlytics/UnitTests/Data/*',
                            'Crashlytics/UnitTests/*.clsrecord',
                            'Crashlytics/UnitTests/FIRCLSMachO/machO_data/*'
+    unit_tests.requires_app_host = true
   end
 end

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -54,6 +54,7 @@ Cloud Functions for Firebase.
     objc_tests.source_files = [
       'FirebaseFunctions/Tests/ObjCIntegration/ObjC*'
     ]
+    objc_tests.requires_app_host = true
   end
 
   s.test_spec 'integration' do |int_tests|
@@ -63,5 +64,6 @@ Cloud Functions for Firebase.
       :tvos => tvos_deployment_target
     }
     int_tests.source_files = 'FirebaseFunctions/Tests/Integration/*.swift'
+    int_tests.requires_app_host = true
   end
 end

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -70,6 +70,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
       :tvos => tvos_deployment_target
     }
     unit_tests.source_files = 'FirebaseStorage/Tests/Unit/StorageAPITests.swift'
+    unit_tests.requires_app_host = true
   end
 
   s.test_spec 'integration' do |int_tests|


### PR DESCRIPTION
Get `pod lib lint` unit tests working on Xcode 14.3