### PR TITLE
Extract GACAppCheckSettings from FIRAppCheckSettings

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -35,6 +35,7 @@
 #import "FirebaseAppCheck/Sources/Core/Storage/FIRAppCheckStorage.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefreshResult.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
 
 #import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
 #import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
@@ -67,7 +68,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 @property(nonatomic, readonly) id<FIRAppCheckProvider> appCheckProvider;
 @property(nonatomic, readonly) id<FIRAppCheckStorageProtocol> storage;
 @property(nonatomic, readonly) NSNotificationCenter *notificationCenter;
-@property(nonatomic, readonly) id<FIRAppCheckSettingsProtocol> settings;
+@property(nonatomic, readonly) id<GACAppCheckSettingsProtocol> settings;
 
 @property(nonatomic, readonly, nullable) id<FIRAppCheckTokenRefresherProtocol> tokenRefresher;
 
@@ -100,7 +101,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
     return nil;
   }
 
-  FIRAppCheckSettings *settings =
+  id<GACAppCheckSettingsProtocol> settings =
       [[FIRAppCheckSettings alloc] initWithApp:app
                                    userDefault:[NSUserDefaults standardUserDefaults]
                                     mainBundle:[NSBundle mainBundle]];
@@ -126,7 +127,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
                         storage:(id<FIRAppCheckStorageProtocol>)storage
                  tokenRefresher:(id<FIRAppCheckTokenRefresherProtocol>)tokenRefresher
              notificationCenter:(NSNotificationCenter *)notificationCenter
-                       settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                       settings:(id<GACAppCheckSettingsProtocol>)settings {
   self = [super init];
   if (self) {
     _appName = appName;

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
@@ -25,20 +25,20 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix;
 FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey;
 
-/// A collection of Firebase app check wide settings and parameters.
-@protocol FIRAppCheckSettingsProtocol <NSObject>
-
-/// If Firebase app check token auto-refresh is allowed.
-@property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;
-
-@end
-
 /// Handles storing and updating the Firebase app check wide settings and parameters.
-@interface FIRAppCheckSettings : GACAppCheckSettings <FIRAppCheckSettingsProtocol>
+@interface FIRAppCheckSettings : GACAppCheckSettings
 
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults
-                 mainBundle:(NSBundle *)mainBundle;
+                 mainBundle:(NSBundle *)mainBundle NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
+                               mainBundle:(NSBundle *)mainBundle
+    tokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+       tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
+    NS_UNAVAILABLE;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
+
 @class FIRApp;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,7 +34,7 @@ FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKe
 @end
 
 /// Handles storing and updating the Firebase app check wide settings and parameters.
-@interface FIRAppCheckSettings : NSObject <FIRAppCheckSettingsProtocol>
+@interface FIRAppCheckSettings : GACAppCheckSettings <FIRAppCheckSettingsProtocol>
 
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -53,7 +53,7 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
   @synchronized(self) {
     GACAppCheckTokenAutoRefreshPolicy policy = self.tokenAutoRefreshPolicy;
 
-    if (policy != GACAppCheckTokenAutoRefreshPolicyDefault) {
+    if (policy != GACAppCheckTokenAutoRefreshPolicyUnspecified) {
       return policy == GACAppCheckTokenAutoRefreshPolicyEnabled;
     }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -28,10 +28,6 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 @interface FIRAppCheckSettings ()
 
 @property(nonatomic, weak, readonly) FIRApp *firebaseApp;
-@property(nonatomic, readonly) NSUserDefaults *userDefaults;
-@property(nonatomic, readonly) NSBundle *mainBundle;
-@property(nonatomic, readonly) NSString *userDefaultKey;
-@property(nonatomic, nullable) NSNumber *isTokenAutoRefreshEnabledNumber;
 
 @end
 
@@ -42,40 +38,23 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults
                  mainBundle:(NSBundle *)mainBundle {
-  self = [super init];
+  self = [super initWithUserDefaults:userDefaults
+                                 mainBundle:mainBundle
+      tokenAutoRefreshPolicyUserDefaultsKey:[kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix
+                                                stringByAppendingString:firebaseApp.name]
+         tokenAutoRefreshPolicyInfoPListKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey];
   if (self) {
     _firebaseApp = firebaseApp;
-    _userDefaults = userDefaults;
-    _mainBundle = mainBundle;
-    _userDefaultKey = [kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix
-        stringByAppendingString:firebaseApp.name];
   }
   return self;
 }
 
 - (BOOL)isTokenAutoRefreshEnabled {
   @synchronized(self) {
-    if (self.isTokenAutoRefreshEnabledNumber != nil) {
-      // Return value form the in-memory cache to avoid accessing the user default or bundle when
-      // not required.
-      return self.isTokenAutoRefreshEnabledNumber.boolValue;
-    }
+    GACAppCheckTokenAutoRefreshPolicy policy = self.tokenAutoRefreshPolicy;
 
-    // Check user defaults for a value set during the previous launch.
-    NSNumber *isTokenAutoRefreshEnabledNumber =
-        [self.userDefaults objectForKey:self.userDefaultKey];
-
-    // Check Info.plist if no user defaults value found.
-    if (isTokenAutoRefreshEnabledNumber == nil) {
-      isTokenAutoRefreshEnabledNumber = [self.mainBundle
-          objectForInfoDictionaryKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey];
-    }
-
-    if (isTokenAutoRefreshEnabledNumber != nil) {
-      // Update in-memory cache.
-      self.isTokenAutoRefreshEnabledNumber = isTokenAutoRefreshEnabledNumber;
-      // Return the value.
-      return isTokenAutoRefreshEnabledNumber.boolValue;
+    if (policy != GACAppCheckTokenAutoRefreshPolicyDefault) {
+      return policy == GACAppCheckTokenAutoRefreshPolicyEnabled;
     }
 
     // Fallback to the global data collection flag.
@@ -91,8 +70,11 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 
 - (void)setIsTokenAutoRefreshEnabled:(BOOL)isTokenAutoRefreshEnabled {
   @synchronized(self) {
-    self.isTokenAutoRefreshEnabledNumber = @(isTokenAutoRefreshEnabled);
-    [self.userDefaults setObject:self.isTokenAutoRefreshEnabledNumber forKey:self.userDefaultKey];
+    if (isTokenAutoRefreshEnabled) {
+      self.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyEnabled;
+    } else {
+      self.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDisabled;
+    }
   }
 }
 

--- a/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h
+++ b/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h
@@ -18,7 +18,7 @@
 
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTimer.h"
 
-@protocol FIRAppCheckSettingsProtocol;
+@protocol GACAppCheckSettingsProtocol;
 @class FIRAppCheckTokenRefreshResult;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -57,12 +57,12 @@ typedef void (^FIRAppCheckTokenRefreshBlock)(FIRAppCheckTokenRefreshCompletion c
 /// @param settings An object that handles Firebase app check settings.
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
                         timerProvider:(FIRTimerProvider)timerProvider
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings
+                             settings:(id<GACAppCheckSettingsProtocol>)settings
     NS_DESIGNATED_INITIALIZER;
 
 /// A convenience initializer with a timer provider returning an instance of  `FIRAppCheckTimer`.
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings;
+                             settings:(id<GACAppCheckSettingsProtocol>)settings;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.m
+++ b/FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.m
@@ -16,9 +16,9 @@
 
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
 
-#import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTimer.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefreshResult.h"
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,7 +35,7 @@ static const double kAutoRefreshFraction = 0.5;
 
 @property(nonatomic, readonly) dispatch_queue_t refreshQueue;
 
-@property(nonatomic, readonly) id<FIRAppCheckSettingsProtocol> settings;
+@property(nonatomic, readonly) id<GACAppCheckSettingsProtocol> settings;
 
 @property(nonatomic, readonly) FIRTimerProvider timerProvider;
 @property(atomic, nullable) id<FIRAppCheckTimerProtocol> timer;
@@ -52,7 +52,7 @@ static const double kAutoRefreshFraction = 0.5;
 
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
                         timerProvider:(FIRTimerProvider)timerProvider
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                             settings:(id<GACAppCheckSettingsProtocol>)settings {
   self = [super init];
   if (self) {
     _refreshQueue =
@@ -65,7 +65,7 @@ static const double kAutoRefreshFraction = 0.5;
 }
 
 - (instancetype)initWithRefreshResult:(FIRAppCheckTokenRefreshResult *)refreshResult
-                             settings:(id<FIRAppCheckSettingsProtocol>)settings {
+                             settings:(id<GACAppCheckSettingsProtocol>)settings {
   return [self initWithRefreshResult:refreshResult
                        timerProvider:[FIRAppCheckTimer timerProvider]
                             settings:settings];

--- a/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
@@ -18,20 +18,32 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Policies (i.e., behavior) for the App Check token auto-refresh mechanism.
 typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
-  GACAppCheckTokenAutoRefreshPolicyDefault,
+  /// Token auto-refresh behavior is not configured; determining default behavior is delegated to
+  /// `GACAppCheckSettings` subclasses.
+  GACAppCheckTokenAutoRefreshPolicyUnspecified,
+
+  /// Token auto-refresh is explicitly enabled.
   GACAppCheckTokenAutoRefreshPolicyEnabled,
+
+  /// Token auto-refresh is explicitly disabled.
   GACAppCheckTokenAutoRefreshPolicyDisabled
 };
 
+/// A collection of App Check-wide settings and parameters.
 @protocol GACAppCheckSettingsProtocol <NSObject>
 
-@property(nonatomic, assign) GACAppCheckTokenAutoRefreshPolicy tokenAutoRefreshPolicy;
+/// If App Check token auto-refresh is enabled.
+@property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;
 
 @end
 
 /// Handles storing and updating App Check-wide settings and parameters.
 @interface GACAppCheckSettings : NSObject <GACAppCheckSettingsProtocol>
+
+/// The configured policy (i.e., behavior) for the App Check token auto-refresh mechanism.
+@property(nonatomic, assign) GACAppCheckTokenAutoRefreshPolicy tokenAutoRefreshPolicy;
 
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
                                mainBundle:(NSBundle *)mainBundle

--- a/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
@@ -45,6 +45,14 @@ typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
 /// The configured policy (i.e., behavior) for the App Check token auto-refresh mechanism.
 @property(nonatomic, assign) GACAppCheckTokenAutoRefreshPolicy tokenAutoRefreshPolicy;
 
+/// The designated initializer.
+/// - Parameters:
+///   - userDefaults: An interface to the user’s defaults database.
+///   - mainBundle: An interface to the main bundle for the executable.
+///   - tokenAutoRefreshPolicyUserDefaultsKey: The user defaults key for the token auto-refresh
+///   configuration value.
+///   - tokenAutoRefreshPolicyInfoPListKey: The Info.plist key for the token auto-refresh
+///   configuration value.
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
                                mainBundle:(NSBundle *)mainBundle
     tokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey

--- a/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
+  GACAppCheckTokenAutoRefreshPolicyDefault,
+  GACAppCheckTokenAutoRefreshPolicyEnabled,
+  GACAppCheckTokenAutoRefreshPolicyDisabled
+};
+
+@protocol GACAppCheckSettingsProtocol <NSObject>
+
+@property(nonatomic, assign) GACAppCheckTokenAutoRefreshPolicy tokenAutoRefreshPolicy;
+
+@end
+
+/// Handles storing and updating App Check-wide settings and parameters.
+@interface GACAppCheckSettings : NSObject <GACAppCheckSettingsProtocol>
+
+- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
+                               mainBundle:(NSBundle *)mainBundle
+    tokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+       tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
+    NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.m
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation GACAppCheckSettings
 
 @synthesize tokenAutoRefreshPolicy = _tokenAutoRefreshPolicy;
+@dynamic isTokenAutoRefreshEnabled;
 
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
                                mainBundle:(NSBundle *)mainBundle
@@ -45,10 +46,23 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+- (BOOL)isTokenAutoRefreshEnabled {
+  NSAssert(NO, @"The method `isTokenAutoRefreshEnabled` must be implemented in a subclass of "
+               @"GACAppCheckSettings.");
+  return NO;
+}
+
+- (void)setIsTokenAutoRefreshEnabled:(BOOL)isTokenAutoRefreshEnabled {
+  NSAssert(NO, @"The method `setIsTokenAutoRefreshEnabled:` must be implemented in a subclass of "
+               @"GACAppCheckSettings.");
+}
+
+#pragma mark - GACAppCheckSettingsProtocol
+
 - (GACAppCheckTokenAutoRefreshPolicy)tokenAutoRefreshPolicy {
   @synchronized(self) {
     // Return the in-memory cached value, when available, to avoid checking user defaults or bundle.
-    if (_tokenAutoRefreshPolicy != GACAppCheckTokenAutoRefreshPolicyDefault) {
+    if (_tokenAutoRefreshPolicy != GACAppCheckTokenAutoRefreshPolicyUnspecified) {
       return _tokenAutoRefreshPolicy;
     }
 
@@ -57,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self.userDefaults objectForKey:self.tokenAutoRefreshPolicyUserDefaultsKey]);
 
     // Check the main bundule (Info.plist) if no user defaults value was cached.
-    if (_tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyDefault) {
+    if (_tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyUnspecified) {
       _tokenAutoRefreshPolicy = GACAppCheckSettingsTokenRefreshPolicy(
           [self.mainBundle objectForInfoDictionaryKey:self.tokenAutoRefreshPolicyInfoPListKey]);
     }
@@ -68,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTokenAutoRefreshPolicy:(GACAppCheckTokenAutoRefreshPolicy)tokenAutoRefreshPolicy {
   @synchronized(self) {
-    if (tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyDefault) {
+    if (tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyUnspecified) {
       [self.userDefaults removeObjectForKey:self.tokenAutoRefreshPolicyUserDefaultsKey];
       return;
     }
@@ -80,10 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
+#pragma mark - Private
+
 GACAppCheckTokenAutoRefreshPolicy GACAppCheckSettingsTokenRefreshPolicy(
     NSNumber *_Nullable autoRefreshNumber) {
   if (autoRefreshNumber == nil) {
-    return GACAppCheckTokenAutoRefreshPolicyDefault;
+    return GACAppCheckTokenAutoRefreshPolicyUnspecified;
   }
 
   return autoRefreshNumber.boolValue ? GACAppCheckTokenAutoRefreshPolicyEnabled

--- a/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.m
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GACAppCheckSettings ()
+
+@property(nonatomic, readonly) NSUserDefaults *userDefaults;
+@property(nonatomic, readonly) NSBundle *mainBundle;
+@property(nonatomic, readonly) NSString *tokenAutoRefreshPolicyUserDefaultsKey;
+@property(nonatomic, readonly) NSString *tokenAutoRefreshPolicyInfoPListKey;
+
+@end
+
+@implementation GACAppCheckSettings
+
+@synthesize tokenAutoRefreshPolicy = _tokenAutoRefreshPolicy;
+
+- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults
+                               mainBundle:(NSBundle *)mainBundle
+    tokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+       tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey {
+  self = [super init];
+  if (self) {
+    _userDefaults = userDefaults;
+    _mainBundle = mainBundle;
+    _tokenAutoRefreshPolicyUserDefaultsKey = [tokenAutoRefreshPolicyUserDefaultsKey copy];
+    _tokenAutoRefreshPolicyInfoPListKey = [tokenAutoRefreshPolicyInfoPListKey copy];
+  }
+  return self;
+}
+
+- (GACAppCheckTokenAutoRefreshPolicy)tokenAutoRefreshPolicy {
+  @synchronized(self) {
+    // Return the in-memory cached value, when available, to avoid checking user defaults or bundle.
+    if (_tokenAutoRefreshPolicy != GACAppCheckTokenAutoRefreshPolicyDefault) {
+      return _tokenAutoRefreshPolicy;
+    }
+
+    // Check user defaults for a value set during the previous launch.
+    _tokenAutoRefreshPolicy = GACAppCheckSettingsTokenRefreshPolicy(
+        [self.userDefaults objectForKey:self.tokenAutoRefreshPolicyUserDefaultsKey]);
+
+    // Check the main bundule (Info.plist) if no user defaults value was cached.
+    if (_tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyDefault) {
+      _tokenAutoRefreshPolicy = GACAppCheckSettingsTokenRefreshPolicy(
+          [self.mainBundle objectForInfoDictionaryKey:self.tokenAutoRefreshPolicyInfoPListKey]);
+    }
+
+    return _tokenAutoRefreshPolicy;
+  }
+}
+
+- (void)setTokenAutoRefreshPolicy:(GACAppCheckTokenAutoRefreshPolicy)tokenAutoRefreshPolicy {
+  @synchronized(self) {
+    if (tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyDefault) {
+      [self.userDefaults removeObjectForKey:self.tokenAutoRefreshPolicyUserDefaultsKey];
+      return;
+    }
+
+    _tokenAutoRefreshPolicy = tokenAutoRefreshPolicy;
+    BOOL autoRefreshEnabled = tokenAutoRefreshPolicy == GACAppCheckTokenAutoRefreshPolicyEnabled;
+    [self.userDefaults setBool:autoRefreshEnabled
+                        forKey:self.tokenAutoRefreshPolicyUserDefaultsKey];
+  }
+}
+
+GACAppCheckTokenAutoRefreshPolicy GACAppCheckSettingsTokenRefreshPolicy(
+    NSNumber *_Nullable autoRefreshNumber) {
+  if (autoRefreshNumber == nil) {
+    return GACAppCheckTokenAutoRefreshPolicyDefault;
+  }
+
+  return autoRefreshNumber.boolValue ? GACAppCheckTokenAutoRefreshPolicyEnabled
+                                     : GACAppCheckTokenAutoRefreshPolicyDisabled;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
@@ -104,7 +104,7 @@
   OCMReject([self.mockApp isDataCollectionDefaultEnabled]);
 
   // 1.4. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(newFlagValue) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:newFlagValue forKey:self.userDefaultKey]);
 
   // 2. Set flag value.
   self.settings.isTokenAutoRefreshEnabled = newFlagValue;
@@ -206,7 +206,7 @@
 - (void)testSetIsTokenAutoRefreshEnabled {
   // 1. Set first time.
   // 1.1. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(YES) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:YES forKey:self.userDefaultKey]);
 
   // 1.2 Set.
   self.settings.isTokenAutoRefreshEnabled = YES;
@@ -217,13 +217,146 @@
 
   // 2. Set second time.
   // 2.1. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(NO) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:NO forKey:self.userDefaultKey]);
 
   // 2.2 Set.
   self.settings.isTokenAutoRefreshEnabled = NO;
 
   // 2.3. Check.
   XCTAssertEqual(self.settings.isTokenAutoRefreshEnabled, NO);
+  OCMVerifyAll(self.mockUserDefaults);
+}
+
+#pragma mark - GACAppCheckSettings Tests
+
+- (void)testGetTokenAutoRefreshPolicyWhenDidNotExplicitlySet {
+  // 1. Configure expectations.
+  // 1.1. Expect user defaults to be checked.
+  OCMExpect([self.mockUserDefaults objectForKey:self.userDefaultKey]).andReturn(nil);
+
+  // 1.2. Expect main bundle to be checked.
+  OCMExpect(
+      [self.bundleMock objectForInfoDictionaryKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey])
+      .andReturn(nil);
+
+  // 2. Check the flag value.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+
+  // 3. Check mocks.
+  OCMVerifyAll(self.mockUserDefaults);
+  OCMVerifyAll(self.mockApp);
+  OCMVerifyAll(self.bundleMock);
+}
+
+- (void)testGetTokenAutoRefreshPolicyWhenSetToDefault {
+  // 1. Configure expectations.
+  // 1.1. Expect user defaults to be checked.
+  OCMExpect([self.mockUserDefaults objectForKey:self.userDefaultKey]).andReturn(nil);
+
+  // 1.2. Expect main bundle to be checked.
+  OCMExpect(
+      [self.bundleMock objectForInfoDictionaryKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey])
+      .andReturn(nil);
+
+  // 1.3. Expect the user defaults value to be cleared.
+  OCMExpect([self.mockUserDefaults removeObjectForKey:self.userDefaultKey]);
+
+  // 2. Set the flag value.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDefault;
+
+  // 3. Check the flag value.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+
+  // 4. Check mocks.
+  OCMVerifyAll(self.mockUserDefaults);
+  OCMVerifyAll(self.mockApp);
+  OCMVerifyAll(self.bundleMock);
+}
+
+- (void)testGetTokenAutoRefreshPolicyWhenEnabledThisAppRun {
+  // 1. Configure expectations.
+  // 1.1. Don't expect user defaults to be checked.
+  OCMReject([self.mockUserDefaults objectForKey:self.userDefaultKey]);
+
+  // 1.2. Don't expect main bundle to be checked.
+  OCMReject(
+      [self.bundleMock objectForInfoDictionaryKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey]);
+
+  // 1.3. Expect the new value to be saved to the user defaults.
+  OCMExpect([self.mockUserDefaults setBool:YES forKey:self.userDefaultKey]);
+
+  // 2. Set flag value.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyEnabled;
+
+  // 3. Check the flag value.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyEnabled);
+
+  // 4. Check mocks.
+  OCMVerifyAll(self.mockUserDefaults);
+  OCMVerifyAll(self.mockApp);
+  OCMVerifyAll(self.bundleMock);
+}
+
+- (void)testGetTokenAutoRefreshPolicyWhenDisabledThisAppRun {
+  // 1. Configure expectations.
+  // 1.1. Don't expect user defaults to be checked.
+  OCMReject([self.mockUserDefaults objectForKey:self.userDefaultKey]);
+
+  // 1.2. Don't expect main bundle to be checked.
+  OCMReject(
+      [self.bundleMock objectForInfoDictionaryKey:kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey]);
+
+  // 1.3. Expect the new value to be saved to the user defaults.
+  OCMExpect([self.mockUserDefaults setBool:NO forKey:self.userDefaultKey]);
+
+  // 2. Set flag value.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDisabled;
+
+  // 3. Check the flag value.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDisabled);
+
+  // 4. Check mocks.
+  OCMVerifyAll(self.mockUserDefaults);
+  OCMVerifyAll(self.mockApp);
+  OCMVerifyAll(self.bundleMock);
+}
+
+- (void)testSetTokenAutoRefreshPolicyDefault {
+  // 1. Set first time.
+  // 1.1. Expect the user defaults value to be cleared.
+  OCMExpect([self.mockUserDefaults removeObjectForKey:self.userDefaultKey]);
+
+  // 1.2 Set.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDefault;
+
+  // 1.3. Check.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+  OCMVerifyAll(self.mockUserDefaults);
+}
+
+- (void)testSetTokenAutoRefreshPolicyEnabled {
+  // 1. Set first time.
+  // 1.1. Expect the new value to be saved to the user defaults.
+  OCMExpect([self.mockUserDefaults setBool:YES forKey:self.userDefaultKey]);
+
+  // 1.2 Set.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyEnabled;
+
+  // 1.3. Check.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyEnabled);
+  OCMVerifyAll(self.mockUserDefaults);
+}
+
+- (void)testSetTokenAutoRefreshPolicyDisabled {
+  // 1. Set first time.
+  // 1.1. Expect the new value to be saved to the user defaults.
+  OCMExpect([self.mockUserDefaults setBool:NO forKey:self.userDefaultKey]);
+
+  // 1.2 Set.
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDisabled;
+
+  // 1.3. Check.
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDisabled);
   OCMVerifyAll(self.mockUserDefaults);
 }
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
@@ -19,6 +19,7 @@
 #import <OCMock/OCMock.h>
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -240,7 +241,8 @@
       .andReturn(nil);
 
   // 2. Check the flag value.
-  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy,
+                 GACAppCheckTokenAutoRefreshPolicyUnspecified);
 
   // 3. Check mocks.
   OCMVerifyAll(self.mockUserDefaults);
@@ -262,10 +264,11 @@
   OCMExpect([self.mockUserDefaults removeObjectForKey:self.userDefaultKey]);
 
   // 2. Set the flag value.
-  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDefault;
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyUnspecified;
 
   // 3. Check the flag value.
-  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy,
+                 GACAppCheckTokenAutoRefreshPolicyUnspecified);
 
   // 4. Check mocks.
   OCMVerifyAll(self.mockUserDefaults);
@@ -327,10 +330,11 @@
   OCMExpect([self.mockUserDefaults removeObjectForKey:self.userDefaultKey]);
 
   // 1.2 Set.
-  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyDefault;
+  self.settings.tokenAutoRefreshPolicy = GACAppCheckTokenAutoRefreshPolicyUnspecified;
 
   // 1.3. Check.
-  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy, GACAppCheckTokenAutoRefreshPolicyDefault);
+  XCTAssertEqual(self.settings.tokenAutoRefreshPolicy,
+                 GACAppCheckTokenAutoRefreshPolicyUnspecified);
   OCMVerifyAll(self.mockUserDefaults);
 }
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -51,7 +51,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
                         storage:(id<FIRAppCheckStorageProtocol>)storage
                  tokenRefresher:(id<FIRAppCheckTokenRefresherProtocol>)tokenRefresher
              notificationCenter:(NSNotificationCenter *)notificationCenter
-                       settings:(id<FIRAppCheckSettingsProtocol>)settings;
+                       settings:(id<GACAppCheckSettingsProtocol>)settings;
 
 - (nullable instancetype)initWithApp:(FIRApp *)app;
 @end
@@ -62,7 +62,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 @property(nonatomic) OCMockObject<FIRAppCheckStorageProtocol> *mockStorage;
 @property(nonatomic) OCMockObject<FIRAppCheckProvider> *mockAppCheckProvider;
 @property(nonatomic) OCMockObject<FIRAppCheckTokenRefresherProtocol> *mockTokenRefresher;
-@property(nonatomic) OCMockObject<FIRAppCheckSettingsProtocol> *mockSettings;
+@property(nonatomic) OCMockObject<GACAppCheckSettingsProtocol> *mockSettings;
 @property(nonatomic) NSNotificationCenter *notificationCenter;
 @property(nonatomic) FIRAppCheck<FIRAppCheckInterop> *appCheck;
 
@@ -79,7 +79,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   self.mockStorage = OCMProtocolMock(@protocol(FIRAppCheckStorageProtocol));
   self.mockAppCheckProvider = OCMProtocolMock(@protocol(FIRAppCheckProvider));
   self.mockTokenRefresher = OCMProtocolMock(@protocol(FIRAppCheckTokenRefresherProtocol));
-  self.mockSettings = OCMProtocolMock(@protocol(FIRAppCheckSettingsProtocol));
+  self.mockSettings = OCMProtocolMock(@protocol(GACAppCheckSettingsProtocol));
   self.notificationCenter = [[NSNotificationCenter alloc] init];
 
   [self stubSetTokenRefreshHandler];

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTokenRefresherTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTokenRefresherTests.m
@@ -18,9 +18,9 @@
 
 #import <OCMock/OCMock.h>
 
-#import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefreshResult.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
+#import "FirebaseAppCheck/Sources/GAC/Core/GACAppCheckSettings.h"
 #import "FirebaseAppCheck/Tests/Unit/Utils/FIRFakeTimer.h"
 #import "SharedTestUtilities/Date/FIRDateTestUtils.h"
 
@@ -28,7 +28,7 @@
 
 @property(nonatomic) FIRFakeTimer *fakeTimer;
 
-@property(nonatomic) OCMockObject<FIRAppCheckSettingsProtocol> *mockSettings;
+@property(nonatomic) OCMockObject<GACAppCheckSettingsProtocol> *mockSettings;
 
 @property(nonatomic) FIRAppCheckTokenRefreshResult *initialTokenRefreshResult;
 
@@ -37,7 +37,7 @@
 @implementation FIRAppCheckTokenRefresherTests
 
 - (void)setUp {
-  self.mockSettings = OCMProtocolMock(@protocol(FIRAppCheckSettingsProtocol));
+  self.mockSettings = OCMProtocolMock(@protocol(GACAppCheckSettingsProtocol));
   self.fakeTimer = [[FIRFakeTimer alloc] init];
 
   NSDate *receivedAtDate = [NSDate date];


### PR DESCRIPTION
Extracted the non-Firebase-specific implementation details out of `FIRAppCheckSettings` into `GACAppCheckSettings`.

Added a `GACAppCheckTokenAutoRefreshPolicy` enum to represent the tri-state (`nil`/`YES`/`NO`) of auto token refresh enablement in `GACAppCheckSettings`.

This is an alternative approach to PR #11193 that makes `FIRAppCheckSettings` a subclass of `GACAppCheckSettings` to share common code.

#no-changelog