### PR TITLE
Build AppCheck without Firebase Core

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   s.source_files = [
     base_dir + 'Sources/**/*.[mh]',
     base_dir + 'Interop/*.h',
-    'FirebaseCore/Extension/*.h',
+ #   'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseAppCheck/*.h'
 
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'FirebaseCore', '~> 10.0'
+#  s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -40,8 +40,9 @@
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckHTTPError.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 /// A data object that contains all key attest data required for FAC token exchange.
@@ -136,6 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
+#ifdef TODO_SPLIT
 #if FIR_APP_ATTEST_SUPPORTED_TARGETS
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
@@ -169,6 +171,9 @@ NS_ASSUME_NONNULL_BEGIN
 #else   // FIR_APP_ATTEST_SUPPORTED_TARGETS
   return nil;
 #endif  // FIR_APP_ATTEST_SUPPORTED_TARGETS
+#else
+  return nil;
+#endif
 }
 
 #pragma mark - FIRAppCheckProvider

--- a/FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.m
+++ b/FirebaseAppCheck/Sources/Core/APIService/FIRAppCheckAPIService.m
@@ -25,8 +25,9 @@
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 #import <GoogleUtilities/GULURLSessionDataResponse.h>
 #import <GoogleUtilities/NSURLSession+GULPromises.h>
 
@@ -109,11 +110,11 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
              request.HTTPBody = body;
 
              [request setValue:self.APIKey forHTTPHeaderField:kAPIKeyHeaderKey];
-
+#ifdef TODO_SPLIT
              [request setValue:FIRHeaderValueFromHeartbeatsPayload(
                                    [self.heartbeatLogger flushHeartbeatsIntoPayload])
                  forHTTPHeaderField:kHeartbeatKey];
-
+#endif
              [request setValue:[[NSBundle mainBundle] bundleIdentifier]
                  forHTTPHeaderField:kBundleIdKey];
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -38,8 +38,9 @@
 #import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
 #import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 /// A notification with the specified name is sent to the default notification center
@@ -61,7 +62,11 @@ static const NSTimeInterval kTokenExpirationThreshold = 5 * 60;  // 5 min.
 
 static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
+#ifdef TODO_SPLIT
 @interface FIRAppCheck () <FIRLibrary, FIRAppCheckInterop>
+#else
+@interface FIRAppCheck () <FIRAppCheckInterop>
+#endif
 @property(class, nullable) id<FIRAppCheckProviderFactory> providerFactory;
 
 @property(nonatomic, readonly) NSString *appName;
@@ -80,6 +85,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 #pragma mark - FIRComponents
 
+#ifdef TODO_SPLIT
 + (void)load {
   [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self withName:@"fire-app-check"];
 }
@@ -186,7 +192,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   id<FIRAppCheckInterop> appCheck = FIR_COMPONENT(FIRAppCheckInterop, firebaseApp.container);
   return (FIRAppCheck *)appCheck;
 }
-
+#endif
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
                  completion:(void (^)(FIRAppCheckToken *_Nullable token,
                                       NSError *_Nullable error))handler {

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
@@ -16,8 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#else
+typedef NSString *const FIRLoggerService;
+#endif
 extern FIRLoggerService kFIRLoggerAppCheck;
 
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnknown;

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -16,8 +16,9 @@
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 FIRLoggerService kFIRLoggerAppCheck = @"[FirebaseAppCheck]";
@@ -49,7 +50,9 @@ NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected = @"I-FAA007002
 void FIRAppCheckDebugLog(NSString *messageCode, NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
+#ifdef TODO_SWIFT
   FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, messageCode, message, args_ptr);
+#endif
   va_end(args_ptr);
 }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -16,8 +16,9 @@
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 NSString *const kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix =
@@ -47,8 +48,10 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
     _firebaseApp = firebaseApp;
     _userDefaults = userDefaults;
     _mainBundle = mainBundle;
+#ifdef TODO_SPLIT
     _userDefaultKey = [kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix
         stringByAppendingString:firebaseApp.name];
+#endif
   }
   return self;
 }
@@ -77,7 +80,7 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
       // Return the value.
       return isTokenAutoRefreshEnabledNumber.boolValue;
     }
-
+#ifdef TODO_SPLIT
     // Fallback to the global data collection flag.
     if (self.firebaseApp) {
       return self.firebaseApp.isDataCollectionDefaultEnabled;
@@ -86,6 +89,9 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
       // case.
       return NO;
     }
+#else
+    return NO;
+#endif
   }
 }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.m
@@ -16,10 +16,12 @@
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 @implementation FIRAppCheckValidator
 
+#ifdef TODO_SPLIT
 + (NSArray<NSString *> *)tokenExchangeMissingFieldsInOptions:(FIROptions *)options {
   NSMutableArray<NSString *> *missingFields = [NSMutableArray array];
 
@@ -37,5 +39,6 @@
 
   return [missingFields copy];
 }
+#endif
 
 @end

--- a/FirebaseAppCheck/Sources/DebugProvider/API/FIRAppCheckDebugProviderAPIService.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/API/FIRAppCheckDebugProviderAPIService.m
@@ -30,9 +30,9 @@
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
-
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kContentTypeKey = @"Content-Type";

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
@@ -27,9 +27,9 @@
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h"
 #import "FirebaseAppCheck/Sources/DebugProvider/API/FIRAppCheckDebugProviderAPIService.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
-
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kDebugTokenEnvKey = @"FIRAAppCheckDebugToken";
@@ -48,7 +48,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   }
   return self;
 }
-
+#ifdef TODO_SPLIT
 - (nullable instancetype)initWithApp:(FIRApp *)app {
   NSArray<NSString *> *missingOptionsFields =
       [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
@@ -76,6 +76,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
   return [self initWithAPIService:debugAPIService];
 }
+#endif
 
 - (NSString *)currentDebugToken {
   NSString *envVariableValue = [[NSProcessInfo processInfo] environment][kDebugTokenEnvKey];

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -26,10 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(FIRApp *)app {
   FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
 
+#ifdef TODO_SPLIT
   // Print only locally generated token to avoid a valid token leak on CI.
   FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
                 @"Firebase App Check debug token: '%@'.", [provider localDebugToken]);
-
+#endif
   return provider;
 }
 

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.m
@@ -30,8 +30,9 @@
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kContentTypeKey = @"Content-Type";

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -35,9 +35,9 @@
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/API/FIRDeviceCheckAPIService.h"
 #import "FirebaseAppCheck/Sources/DeviceCheckProvider/DCDevice+FIRDeviceCheckTokenGenerator.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
-
+#ifdef TODO_SPLIT
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
+#endif
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRDeviceCheckProvider ()
@@ -74,6 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
+#ifdef TODO_SPLIT
   NSArray<NSString *> *missingOptionsFields =
       [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
@@ -100,6 +101,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                      appID:app.options.googleAppID];
 
   return [self initWithAPIService:deviceCheckAPIService];
+#else
+  return nil;
+#endif
 }
 
 #pragma mark - FIRAppCheckProvider


### PR DESCRIPTION
Scope out disambiguating AppCheck from FirebaseCore.

This PR adds enough ifdefs to successfully built AppCheck after removing the FirebaseCore dependency. 