### PR TITLE
[App Check] Split App Check Component into separate file

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck+Internal.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck+Internal.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheck ()
+
+- (nullable instancetype)initWithApp:(FIRApp *)app;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -27,6 +27,7 @@
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProviderFactory.h"
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
+#import "FirebaseAppCheck/Sources/Core/FIRAppCheck+Internal.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckToken+Internal.h"
@@ -37,8 +38,6 @@
 
 #import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
 #import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -61,7 +60,7 @@ static const NSTimeInterval kTokenExpirationThreshold = 5 * 60;  // 5 min.
 
 static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
-@interface FIRAppCheck () <FIRLibrary, FIRAppCheckInterop>
+@interface FIRAppCheck () <FIRAppCheckInterop>
 @property(class, nullable) id<FIRAppCheckProviderFactory> providerFactory;
 
 @property(nonatomic, readonly) NSString *appName;
@@ -78,28 +77,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 @implementation FIRAppCheck
 
-#pragma mark - FIRComponents
-
-+ (void)load {
-  [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self withName:@"fire-app-check"];
-}
-
-+ (NSArray<FIRComponent *> *)componentsToRegister {
-  FIRComponentCreationBlock creationBlock =
-      ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
-    *isCacheable = YES;
-    return [[FIRAppCheck alloc] initWithApp:container.app];
-  };
-
-  // Use eager instantiation timing to give a chance for FAC token to be requested before it is
-  // actually needed to avoid extra delaying dependent requests.
-  FIRComponent *appCheckProvider =
-      [FIRComponent componentWithProtocol:@protocol(FIRAppCheckInterop)
-                      instantiationTiming:FIRInstantiationTimingAlwaysEager
-                             dependencies:@[]
-                            creationBlock:creationBlock];
-  return @[ appCheckProvider ];
-}
+#pragma mark - Internal
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
   id<FIRAppCheckProviderFactory> providerFactory = [FIRAppCheck providerFactory];

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckComponent.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckComponent.m
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseAppCheck/Sources/Core/FIRAppCheck+Internal.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
+
+#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
+
+#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckComponent : NSObject <FIRLibrary>
+@end
+
+@implementation FIRAppCheckComponent
+
++ (void)load {
+  [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self withName:@"fire-app-check"];
+}
+
++ (NSArray<FIRComponent *> *)componentsToRegister {
+  FIRComponentCreationBlock creationBlock =
+      ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
+    *isCacheable = YES;
+    return [[FIRAppCheck alloc] initWithApp:container.app];
+  };
+
+  // Use eager instantiation timing to give a chance for FAC token to be requested before it is
+  // actually needed to avoid extra delaying dependent requests.
+  FIRComponent *appCheckProvider =
+      [FIRComponent componentWithProtocol:@protocol(FIRAppCheckInterop)
+                      instantiationTiming:FIRInstantiationTimingAlwaysEager
+                             dependencies:@[]
+                            creationBlock:creationBlock];
+  return @[ appCheckProvider ];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Extracted the App Check Component (`FIRLibrary`) into a separate file.

#no-changelog