### PR TITLE
Fill in os_version and app_build_version for Sessions

### DIFF
--- a/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
+++ b/FirebaseSessions/Sources/Development/DevEventConsoleLogger.swift
@@ -48,6 +48,8 @@ class DevEventConsoleLogger: EventGDTLoggerProtocol {
           session_sampling_rate: \(proto.session_data.data_collection_status.session_sampling_rate)
       application_info
         app_id: \(proto.application_info.app_id.description)
+        session_sdk_version: \(proto.application_info.session_sdk_version.description)
+        os_version: \(proto.application_info.os_version.description)
         device_model: \(proto.application_info.device_model.description)
         development_platform_name: \(proto.application_info.development_platform_name.description)
         development_platform_version: \(proto.application_info.development_platform_version
@@ -56,6 +58,7 @@ class DevEventConsoleLogger: EventGDTLoggerProtocol {
         apple_app_info
           bundle_short_version: \(proto.application_info.apple_app_info.bundle_short_version
       .description)
+          app_build_version: \(proto.application_info.apple_app_info.app_build_version.description)
           network_connection_info
             network_type: \(proto.application_info.apple_app_info.network_connection_info
       .network_type.rawValue)

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -49,6 +49,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
 
     proto.application_info.app_id = makeProtoString(appInfo.appID)
     proto.application_info.session_sdk_version = makeProtoString(appInfo.sdkVersion)
+    proto.application_info.os_version = makeProtoString(appInfo.osDisplayVersion)
     proto.application_info.log_environment = convertLogEnvironment(environment: appInfo.environment)
     proto.application_info.device_model = makeProtoString(appInfo.deviceModel)
 //    proto.application_info.development_platform_name;
@@ -58,6 +59,8 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     proto.application_info.which_platform_info = FIRSESGetAppleApplicationInfoTag()
     proto.application_info.apple_app_info
       .bundle_short_version = makeProtoString(appInfo.appDisplayVersion)
+    proto.application_info.apple_app_info
+      .app_build_version = makeProtoString(appInfo.appBuildVersion)
     proto.application_info.apple_app_info.os_name = convertOSName(osName: appInfo.osName)
 
     // Set network info to base values but don't fill them in with the real

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -105,9 +105,19 @@ class SessionStartEventTests: XCTestCase {
         fieldName: "session_sdk_version"
       )
       assertEqualProtoString(
+        proto.application_info.os_version,
+        expected: MockApplicationInfo.testOsDisplayVersion,
+        fieldName: "os_version"
+      )
+      assertEqualProtoString(
         proto.application_info.apple_app_info.bundle_short_version,
         expected: MockApplicationInfo.testAppDisplayVersion,
         fieldName: "bundle_short_version"
+      )
+      assertEqualProtoString(
+        proto.application_info.apple_app_info.app_build_version,
+        expected: MockApplicationInfo.testAppBuildVersion,
+        fieldName: "app_build_version"
       )
       assertEqualProtoString(
         proto.application_info.device_model,


### PR DESCRIPTION
Follow up on https://github.com/firebase/firebase-ios-sdk/pull/11205

#no-changelog 

```
Session Event:
  event_type: SESSION_START
  session_data
    session_id: 548c1d690b1b4de3ac908bd073971631
    first_session_id: 548c1d690b1b4de3ac908bd073971631
    session_index: 0
    event_timestamp_us: 1683218660000000
    firebase_installation_id: edv8erKRTUNDn_TDoVNgZT
    data_collection_status
      crashlytics: SDK_NOT_INSTALLED
      performance: ENABLED
      session_sampling_rate: 1.0
  application_info
    app_id: 1:1080744134505:ios:bbb8009438b93cc673dff8
    session_sdk_version: 10.10.0
    os_version: 16.2
    device_model: iOS Simulator (iPhone)
    development_platform_name: <NULL>
    development_platform_version: <NULL>
    session_sdk_version: 10.10.0
    apple_app_info
      bundle_short_version: 1.0
      app_build_version: 1
      network_connection_info
        network_type: 1
        mobile_subtype: 0
      os_name: IOS
      log_environment: PROD
```