### PR TITLE
Backward Compatible Count C++ API

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		0CEE93636BA4852D3C5EC428 /* timestamp_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = ABF6506B201131F8005F2C74 /* timestamp_test.cc */; };
 		0D124ED1B567672DD1BCEF05 /* memory_target_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2286F308EFB0534B1BDE05B9 /* memory_target_cache_test.cc */; };
 		0D2D25522A94AA8195907870 /* status.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9920B89AAC00B5BCE7 /* status.pb.cc */; };
+		0D497A561061A0FA4C4844B0 /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		0D6AE96565603226DB2E6838 /* logic_utils_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 28B45B2104E2DAFBBF86DBB7 /* logic_utils_test.cc */; };
 		0D88B4CB916A4752B08E5B42 /* query_listener_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 7C3F995E040E9E9C5E8514BB /* query_listener_test.cc */; };
 		0DAA255C2FEB387895ADEE12 /* bits_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380D01201BC69F00D97691 /* bits_test.cc */; };
@@ -766,6 +767,7 @@
 		7AD020FC27493FF8E659436C /* existence_filter_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA129D1F315EE100DD57A1 /* existence_filter_spec_test.json */; };
 		7B0EA399F899537ACCC84E53 /* string_format_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */; };
 		7B0F073BDB6D0D6E542E23D4 /* query.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D621C2DDC800EFB9CC /* query.pb.cc */; };
+		7B537CC075119760232EDE0E /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		7B74447D211586D9D1CC82BB /* datastore_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 3167BD972EFF8EC636530E59 /* datastore_test.cc */; };
 		7B8320F12E8092BC86FFCC2C /* fields_array_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA4CBA48204C9E25B56993BC /* fields_array_test.cc */; };
 		7B86B1B21FD0EF2A67547F66 /* byte_string_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5342CDDB137B4E93E2E85CCA /* byte_string_test.cc */; };
@@ -803,11 +805,13 @@
 		81AF02881A8D23D02FC202F6 /* bundle_loader_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = A853C81A6A5A51C9D0389EDA /* bundle_loader_test.cc */; };
 		81B23D2D4E061074958AF12F /* target.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE7D20B89AAC00B5BCE7 /* target.pb.cc */; };
 		81D1B1D2B66BD8310AC5707F /* string_win_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 79507DF8378D3C42F5B36268 /* string_win_test.cc */; };
+		820ED8448BFBD492B1116DC0 /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		82228CD6CE4A7A9254F8E82D /* leveldb_snappy_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = D9D94300B9C02F7069523C00 /* leveldb_snappy_test.cc */; };
 		822E5D5EC4955393DF26BC5C /* string_apple_benchmark.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4C73C0CC6F62A90D8573F383 /* string_apple_benchmark.mm */; };
 		82E3634FCF4A882948B81839 /* FIRQueryUnitTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = FF73B39D04D1760190E6B84A /* FIRQueryUnitTests.mm */; };
 		8342277EB0553492B6668877 /* leveldb_opener_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 75860CD13AF47EB1EA39EC2F /* leveldb_opener_test.cc */; };
 		8388418F43042605FB9BFB92 /* testutil.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352820A3B3BD003E0143 /* testutil.cc */; };
+		839A6D74498D706EBAF7A384 /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		839D8B502026706419FE09D6 /* leveldb_index_manager_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 166CE73C03AB4366AAC5201C /* leveldb_index_manager_test.cc */; };
 		83A9CD3B6E791A860CE81FA1 /* async_queue_std_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4681208EA0BE00554BA2 /* async_queue_std_test.cc */; };
 		8403D519C916C72B9C7F2FA1 /* FIRValidationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E06D202154D600B64F25 /* FIRValidationTests.mm */; };
@@ -935,6 +939,7 @@
 		A27096F764227BC73526FED3 /* leveldb_remote_document_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0840319686A223CC4AD3FAB1 /* leveldb_remote_document_cache_test.cc */; };
 		A27908A198E1D2230C1801AC /* bundle_serializer_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B5C2A94EE24E60543F62CC35 /* bundle_serializer_test.cc */; };
 		A3262936317851958C8EABAF /* byte_stream_cpp_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 01D10113ECC5B446DB35E96D /* byte_stream_cpp_test.cc */; };
+		A42246FDDC5DE8427422B748 /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		A4757C171D2407F61332EA38 /* byte_stream_cpp_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 01D10113ECC5B446DB35E96D /* byte_stream_cpp_test.cc */; };
 		A478FDD7C3F48FBFDDA7D8F5 /* leveldb_mutation_queue_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5C7942B6244F4C416B11B86C /* leveldb_mutation_queue_test.cc */; };
 		A4AD189BDEF7A609953457A6 /* leveldb_key_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54995F6E205B6E12004EFFA0 /* leveldb_key_test.cc */; };
@@ -1292,6 +1297,7 @@
 		EA46611779C3EEF12822508C /* annotations.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9520B89AAC00B5BCE7 /* annotations.pb.cc */; };
 		EAA1962BFBA0EBFBA53B343F /* bundle_builder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B96F3ABCD2CA901DB1CD4 /* bundle_builder.cc */; };
 		EAC0914B6DCC53008483AEE3 /* leveldb_snappy_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = D9D94300B9C02F7069523C00 /* leveldb_snappy_test.cc */; };
+		EAC22DDD9E5E9E532B0CF8D3 /* aggregate_query_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */; };
 		EADD28A7859FBB9BE4D913B0 /* memory_remote_document_cache_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1CA9800A53669EFBFFB824E3 /* memory_remote_document_cache_test.cc */; };
 		EB04FE18E5794FEC187A09E3 /* FSTMemorySpecTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E02F20213FFC00B64F25 /* FSTMemorySpecTests.mm */; };
 		EB2137E6FBB0DDE2DF80E3D0 /* target_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 526D755F65AC676234F57125 /* target_test.cc */; };
@@ -1697,6 +1703,7 @@
 		84434E57CA72951015FC71BC /* Pods-Firestore_FuzzTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_FuzzTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		872C92ABD71B12784A1C5520 /* async_testing.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = async_testing.cc; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = aggregate_query_test.cc; path = api/aggregate_query_test.cc; sourceTree = "<group>"; };
 		87553338E42B8ECA05BA987E /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
 		88CF09277CFA45EE1273E3BA /* leveldb_transaction_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = leveldb_transaction_test.cc; sourceTree = "<group>"; };
 		899FC22684B0F7BEEAE13527 /* task_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = task_test.cc; sourceTree = "<group>"; };
@@ -2492,6 +2499,7 @@
 		8FC5BFAD63BAC5AADAC8A94A /* api */ = {
 			isa = PBXGroup;
 			children = (
+				8745CB808EE94E16A64E5F9B /* aggregate_query_test.cc */,
 				1B342370EAE3AA02393E33EB /* cc_compilation_test.cc */,
 				8F1A7B4158D9DD76EE4836BF /* load_bundle_task_test.cc */,
 				DD12BC1DB2480886D2FB0005 /* settings_test.cc */,
@@ -3656,6 +3664,7 @@
 				072D805A94E767DE4D371881 /* FSTSyncEngineTestDriver.mm in Sources */,
 				5424AB6FF5035495C03344E7 /* FSTUserDataReaderTests.mm in Sources */,
 				6DCA8E54E652B78EFF3EEDAC /* XCTestCase+Await.mm in Sources */,
+				EAC22DDD9E5E9E532B0CF8D3 /* aggregate_query_test.cc in Sources */,
 				C8BA36C8B5E26C173F91E677 /* aggregation_result.pb.cc in Sources */,
 				45939AFF906155EA27D281AB /* annotations.pb.cc in Sources */,
 				FF3405218188DFCE586FB26B /* app_testing.mm in Sources */,
@@ -3864,6 +3873,7 @@
 				D69B97FF4C065EACEDD91886 /* FSTSyncEngineTestDriver.mm in Sources */,
 				A124744C6CBEF3DD415A1A72 /* FSTUserDataReaderTests.mm in Sources */,
 				AAC15E7CCAE79619B2ABB972 /* XCTestCase+Await.mm in Sources */,
+				839A6D74498D706EBAF7A384 /* aggregate_query_test.cc in Sources */,
 				156429A2993B86A905A42D96 /* aggregation_result.pb.cc in Sources */,
 				1C19D796DB6715368407387A /* annotations.pb.cc in Sources */,
 				6EEA00A737690EF82A3C91C6 /* app_testing.mm in Sources */,
@@ -4092,6 +4102,7 @@
 				3B1E27D951407FD237E64D07 /* FirestoreEncoderTests.swift in Sources */,
 				621D620C28F9CE7400D2FA26 /* QueryIntegrationTests.swift in Sources */,
 				4D42E5C756229C08560DD731 /* XCTestCase+Await.mm in Sources */,
+				0D497A561061A0FA4C4844B0 /* aggregate_query_test.cc in Sources */,
 				0EC3921AE220410F7394729B /* aggregation_result.pb.cc in Sources */,
 				276A563D546698B6AAC20164 /* annotations.pb.cc in Sources */,
 				7B8D7BAC1A075DB773230505 /* app_testing.mm in Sources */,
@@ -4320,6 +4331,7 @@
 				5E89B1A5A5430713C79C4854 /* FirestoreEncoderTests.swift in Sources */,
 				621D620B28F9CE7400D2FA26 /* QueryIntegrationTests.swift in Sources */,
 				736C4E82689F1CA1859C4A3F /* XCTestCase+Await.mm in Sources */,
+				820ED8448BFBD492B1116DC0 /* aggregate_query_test.cc in Sources */,
 				DF983A9C1FBF758AF3AF110D /* aggregation_result.pb.cc in Sources */,
 				EA46611779C3EEF12822508C /* annotations.pb.cc in Sources */,
 				8F4F40E9BC7ED588F67734D5 /* app_testing.mm in Sources */,
@@ -4538,6 +4550,7 @@
 				5492E03320213FFC00B64F25 /* FSTSyncEngineTestDriver.mm in Sources */,
 				6FC85C48CF8235BA1845E1C8 /* FSTUserDataReaderTests.mm in Sources */,
 				5492E03C2021401F00B64F25 /* XCTestCase+Await.mm in Sources */,
+				7B537CC075119760232EDE0E /* aggregate_query_test.cc in Sources */,
 				B81B6F327B5E3FE820DC3FB3 /* aggregation_result.pb.cc in Sources */,
 				618BBEAF20B89AAC00B5BCE7 /* annotations.pb.cc in Sources */,
 				5467FB08203E6A44009C9584 /* app_testing.mm in Sources */,
@@ -4785,6 +4798,7 @@
 				6F45846C159D3C063DBD3CBE /* FirestoreEncoderTests.swift in Sources */,
 				621D620A28F9CE7400D2FA26 /* QueryIntegrationTests.swift in Sources */,
 				5492E0442021457E00B64F25 /* XCTestCase+Await.mm in Sources */,
+				A42246FDDC5DE8427422B748 /* aggregate_query_test.cc in Sources */,
 				1A3D8028303B45FCBB21CAD3 /* aggregation_result.pb.cc in Sources */,
 				02EB33CC2590E1484D462912 /* annotations.pb.cc in Sources */,
 				EBFC611B1BF195D0EC710AF4 /* app_testing.mm in Sources */,

--- a/Firestore/Source/API/FIRAggregateQuery.mm
+++ b/Firestore/Source/API/FIRAggregateQuery.mm
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)aggregationWithSource:(FIRAggregateSource)source
                    completion:(void (^)(FIRAggregateQuerySnapshot *_Nullable snapshot,
                                         NSError *_Nullable error))completion {
-  _aggregateQuery->Get([self, completion](const StatusOr<ObjectValue> &result) {
+  _aggregateQuery->GetAggregate([self, completion](const StatusOr<ObjectValue> &result) {
     if (result.ok()) {
       completion([[FIRAggregateQuerySnapshot alloc] initWithObject:result.ValueOrDie() query:self],
                  nil);

--- a/Firestore/core/src/api/aggregate_query.cc
+++ b/Firestore/core/src/api/aggregate_query.cc
@@ -43,13 +43,7 @@ AggregateQuery::AggregateQuery(Query query,
     : query_{std::move(query)}, aggregates_{std::move(aggregates)} {
 }
 
-AggregateQuery::AggregateQuery(Query query) : query_{std::move(query)} {
-  AggregateField countAf(AggregateField::OpKind::Count,
-                         AggregateAlias("count"));
-  aggregates_ = std::vector<AggregateField>{countAf};
-}
-
-void AggregateQuery::Get(AggregateQueryCallback&& callback) {
+void AggregateQuery::GetAggregate(AggregateQueryCallback&& callback) {
   query_.firestore()->client()->RunAggregateQuery(query_.query(), aggregates_,
                                                   std::move(callback));
 }

--- a/Firestore/core/src/api/aggregate_query.h
+++ b/Firestore/core/src/api/aggregate_query.h
@@ -36,10 +36,6 @@ class AggregateQuery {
   explicit AggregateQuery(Query query,
                           std::vector<AggregateField>&& aggregates);
 
-  // Backward-compatible constructor that creates an AggregateQuery
-  // only performing a count aggregation
-  explicit AggregateQuery(Query query);
-
   const Query& query() const {
     return query_;
   }
@@ -47,7 +43,7 @@ class AggregateQuery {
   friend bool operator==(const AggregateQuery& lhs, const AggregateQuery& rhs);
   size_t Hash() const;
 
-  void Get(AggregateQueryCallback&& callback);
+  void GetAggregate(AggregateQueryCallback&& callback);
 
   // Backward-compatible getter for count result
   void Get(CountQueryCallback&& callback);

--- a/Firestore/core/src/api/aggregate_query.h
+++ b/Firestore/core/src/api/aggregate_query.h
@@ -43,7 +43,7 @@ class AggregateQuery {
   friend bool operator==(const AggregateQuery& lhs, const AggregateQuery& rhs);
   size_t Hash() const;
 
-  void GetAggregate(AggregateQueryCallback&& callback);
+  virtual void GetAggregate(AggregateQueryCallback&& callback);
 
   // Backward-compatible getter for count result
   void Get(CountQueryCallback&& callback);

--- a/Firestore/core/src/api/aggregate_query.h
+++ b/Firestore/core/src/api/aggregate_query.h
@@ -36,6 +36,10 @@ class AggregateQuery {
   explicit AggregateQuery(Query query,
                           std::vector<AggregateField>&& aggregates);
 
+  // Backward-compatible constructor that creates an AggregateQuery
+  // only performing a count aggregation
+  explicit AggregateQuery(Query query);
+
   const Query& query() const {
     return query_;
   }
@@ -44,6 +48,9 @@ class AggregateQuery {
   size_t Hash() const;
 
   void Get(AggregateQueryCallback&& callback);
+
+  // Backward-compatible getter for count result
+  void Get(CountQueryCallback&& callback);
 
  private:
   Query query_;

--- a/Firestore/core/src/api/api_fwd.h
+++ b/Firestore/core/src/api/api_fwd.h
@@ -61,6 +61,7 @@ using QuerySnapshotListener =
 using QueryCallback = std::function<void(core::Query, bool)>;
 using AggregateQueryCallback =
     std::function<void(const StatusOr<ObjectValue>&)>;
+using CountQueryCallback = std::function<void(const util::StatusOr<int64_t>&)>;
 
 }  // namespace api
 }  // namespace firestore

--- a/Firestore/core/src/api/query_core.cc
+++ b/Firestore/core/src/api/query_core.cc
@@ -58,6 +58,7 @@ using core::IsDisjunctiveOperator;
 using core::ListenOptions;
 using core::QueryListener;
 using core::ViewSnapshot;
+using model::AggregateAlias;
 using model::AggregateField;
 using model::DocumentKey;
 using model::FieldPath;
@@ -478,6 +479,12 @@ std::string Query::Describe(Operator op) const {
 AggregateQuery Query::Aggregate(
     std::vector<AggregateField>&& aggregations) const {
   return AggregateQuery(*this, std::move(aggregations));
+}
+
+AggregateQuery Query::Count() const {
+  return AggregateQuery(
+      *this, std::vector<AggregateField>{AggregateField(
+                 AggregateField::OpKind::Count, AggregateAlias("count"))});
 }
 
 }  // namespace api

--- a/Firestore/core/src/api/query_core.h
+++ b/Firestore/core/src/api/query_core.h
@@ -200,6 +200,15 @@ class Query {
    */
   AggregateQuery Aggregate(std::vector<AggregateField>&& aggregations) const;
 
+  /**
+   * Creates a new `AggregateQuery` counting the number of documents matching
+   * this query. This API is preserved for backward-compatability with
+   * the c++ SDK.
+   *
+   * @return The created `AggregateQuery`.
+   */
+  AggregateQuery Count() const;
+
  private:
   void ValidateNewFilter(const core::Filter& filter) const;
   void ValidateNewFieldFilter(const core::Query& query,

--- a/Firestore/core/test/unit/api/CMakeLists.txt
+++ b/Firestore/core/test/unit/api/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 firebase_ios_add_test(
   firestore_api_test
+  aggregate_query_test.cc
   cc_compilation_test.cc
   load_bundle_task_test.cc
   settings_test.cc

--- a/Firestore/core/test/unit/api/aggregate_query_test.cc
+++ b/Firestore/core/test/unit/api/aggregate_query_test.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "Firestore/core/src/api/query_core.h"
+#include "Firestore/core/src/util/status.h"
+#include "gtest/gtest.h"
+
+#define private public
+#include "Firestore/core/src/api/aggregate_query.h"
+
+namespace firebase {
+namespace firestore {
+
+using model::AggregateAlias;
+using util::Status;
+
+namespace api {
+
+class MockAggregateQuery : public AggregateQuery {
+ public:
+  StatusOr<ObjectValue> mockResult;
+
+  MockAggregateQuery(Query query,
+                     std::vector<AggregateField>&& aggregates,
+                     StatusOr<ObjectValue>&& mockResult)
+      : AggregateQuery(query, std::move(aggregates)),
+        mockResult(std::move(mockResult)){};
+  void GetAggregate(AggregateQueryCallback&& callback) {
+    callback(mockResult);
+  }
+};
+
+namespace {
+
+// Assert that the Get method calls GetAggregate method
+// and that the result from GetAggregate is processed
+// appropriately
+TEST(AggregateQuery, GetCallsGetAggregateOk) {
+  // Params for Get: Query and AggregateField vector
+  Query query;
+  AggregateField countAggregateField(AggregateField::OpKind::Count,
+                                     AggregateAlias("count"));
+  std::vector<AggregateField> aggregates{countAggregateField};
+
+  // Mock aggregate field result
+  google_firestore_v1_AggregationResult_AggregateFieldsEntry
+      mockAggregatesField[1];
+  mockAggregatesField[0].key =
+      nanopb::ByteString(absl::string_view("count")).release();
+  mockAggregatesField[0].value.which_value_type =
+      google_firestore_v1_Value_integer_value_tag;
+  mockAggregatesField[0].value.integer_value = 10;
+
+  // Mock ObjectValue result
+  ObjectValue mockObjectValue =
+      ObjectValue::FromAggregateFieldsEntry(mockAggregatesField, 1);
+
+  // Set mocked result on our MockAggregateQuery object
+  MockAggregateQuery aggregateQuery(query, std::move(aggregates),
+                                    StatusOr<ObjectValue>(mockObjectValue));
+
+  // Call the Get method
+  size_t callbackCount = 0;
+  aggregateQuery.Get([&callbackCount](const StatusOr<int64_t>& result) mutable {
+    callbackCount++;
+    EXPECT_EQ(result.ok(), true);
+    EXPECT_EQ(result.ValueOrDie(), 10);
+  });
+
+  // Assert
+  EXPECT_EQ(callbackCount, 1);
+}
+
+// Assert that the Get method calls GetAggregate method
+// and that an error result from GetAggregate is processed
+// appropriately
+TEST(AggregateQuery, GetCallsGetAggregateError) {
+  // Params for Get: Query and AggregateField vector
+  Query query;
+  AggregateField countAggregateField(AggregateField::OpKind::Count,
+                                     AggregateAlias("count"));
+  std::vector<AggregateField> aggregates{countAggregateField};
+
+  // Mock error status
+  Status mockError = Status(Error::kErrorInternal, "foo");
+
+  // Set mocked result on our MockAggregateQuery object
+  MockAggregateQuery aggregateQuery(query, std::move(aggregates),
+                                    StatusOr<ObjectValue>(mockError));
+
+  // Call the Get method
+  size_t callbackCount = 0;
+  aggregateQuery.Get([&callbackCount](const StatusOr<int64_t>& result) mutable {
+    callbackCount++;
+    EXPECT_EQ(result.ok(), false);
+    EXPECT_EQ(result.status().code(), Error::kErrorInternal);
+    EXPECT_EQ(result.status().error_message(), "foo");
+  });
+
+  // Assert
+  EXPECT_EQ(callbackCount, 1);
+}
+
+// Assert that the Query.Count method creates an AggregateQuery
+// with the expected query and aggregates
+TEST(Query, Count) {
+  // Baseline Query
+  Query query;
+
+  // Testing the Count() method
+  AggregateQuery aggregateQuery = query.Count();
+
+  // Assert
+  EXPECT_EQ(aggregateQuery.query_, query);
+  EXPECT_EQ(aggregateQuery.aggregates_.size(), 1);
+  EXPECT_EQ(aggregateQuery.aggregates_[0].op, AggregateField::OpKind::Count);
+  EXPECT_EQ(aggregateQuery.aggregates_[0].alias.StringValue(), "count");
+}
+
+}  // namespace
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
Update the C++ API so the c++ SDK will build as-is using the old Count API.