### PR TITLE
[Crashlytics] Fix Xcode 14.3 Analyzer issues

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [changed] Removed references to deprecated CTCarrier API in FirebaseSessions. (#11144)
+- [fixed] Fix Xcode 14.3 Analyzer issue. (#11228)
 
 # 10.9.0
 - [fixed] Updated upload-symbols to 3.15. Disabled dSYM uploads for Flutter

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.c
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.c
@@ -915,7 +915,7 @@ void FIRCLSDwarfPointerEncodingShow(const char* leadString, uint8_t encoding) {
   if (encoding == DW_EH_PE_omit) {
     FIRCLSSDKLog("%s: 0x%02x (omit)\n", leadString, encoding);
   } else {
-    const char* peValue = "";
+    const char* peValue = "unknown";
     const char* peOffset = "";
 
     switch (encoding & DW_EH_PE_VALUE_MASK) {
@@ -950,7 +950,6 @@ void FIRCLSDwarfPointerEncodingShow(const char* leadString, uint8_t encoding) {
         peValue = "DW_EH_PE_sdata8";
         break;
       default:
-        peValue = "unknown";
         break;
     }
 


### PR DESCRIPTION
### Context
- Address Analyzer issue surfaced in Xcode Cloud with 14.3:
   
    > Value stored to 'peValue' during its initialization is never read
    > FIRCLSDwarfUnwind.c:918  

- This was not reproducible when following the repro instructions in the related [google/GoogleDataTransport/#95](https://github.com/google/GoogleDataTransport/pull/95), but this PR's fix should address it.

Fix #11228