### PR TITLE
FirebaseInAppMessaging: Fix crash on message presentation while a CarPlay is running 

### DIFF
--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.m
@@ -19,6 +19,7 @@
 
 #import "FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewUIWindow.h"
 #import "FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMRenderingWindowHelper.h"
+#import "FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h"
 
 @implementation FIRIAMRenderingWindowHelper
 
@@ -63,17 +64,8 @@
 }
 
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-+ (UIWindowScene *)foregroundedScene API_AVAILABLE(ios(13.0)) {
-  for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
-    if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
-      return connectedScene;
-    }
-  }
-  return nil;
-}
-
 + (UIWindow *)iOS13PlusWindow API_AVAILABLE(ios(13.0)) {
-  UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
+  UIWindowScene *foregroundedScene = [[UIApplication sharedApplication] fir_foregroundWindowScene];
   if (foregroundedScene.delegate) {
     return [[UIWindow alloc] initWithWindowScene:foregroundedScene];
   } else {
@@ -82,7 +74,7 @@
 }
 
 + (FIRIAMBannerViewUIWindow *)iOS13PlusBannerWindow API_AVAILABLE(ios(13.0)) {
-  UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
+  UIWindowScene *foregroundedScene = [[UIApplication sharedApplication] fir_foregroundWindowScene];
   if (foregroundedScene.delegate) {
     return [[FIRIAMBannerViewUIWindow alloc] initWithWindowScene:foregroundedScene];
   } else {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -25,6 +25,7 @@
 #import "FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h"
 #import "FirebaseInAppMessaging/Sources/Private/Flows/FIRIAMActivityLogger.h"
 #import "FirebaseInAppMessaging/Sources/Private/Flows/FIRIAMDisplayExecutor.h"
+#import "FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h"
 #import "FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FIRInAppMessaging.h"
 #import "FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h"
 #import "FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKRuntimeErrorCodes.h"
@@ -356,13 +357,8 @@
   dispatch_async(dispatch_get_main_queue(), ^{
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, tvOS 13.0, *)) {
-      UIWindowScene *foregroundedScene = nil;
-      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
-        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
-          foregroundedScene = connectedScene;
-          break;
-        }
-      }
+      UIWindowScene *foregroundedScene =
+          [[UIApplication sharedApplication] fir_foregroundWindowScene];
 
       if (foregroundedScene == nil) {
         return;

--- a/FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h
+++ b/FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Extension on UIApplication to get the first foreground connected scene
+@interface UIApplication (FIRForegroundWindowScene)
+
+- (nullable UIWindowScene *)fir_foregroundWindowScene API_AVAILABLE(ios(13.0));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
+++ b/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <TargetConditionals.h>
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+#import "FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h"
+
+@implementation UIApplication (FIRForegroundWindowScene)
+
+- (nullable UIWindowScene *)fir_foregroundWindowScene {
+  for (UIScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
+    // Direct check for UIWindowScene class is required to avoid return an instance of another
+    // UIScene subclass. It may be an instance of CPTemplateApplicationScene or
+    // CPTemplateApplicationDashboardScene in case of CarPlay. This check fixes the following crash:
+    // https://github.com/firebase/firebase-ios-sdk/issues/9376
+    if ([connectedScene isKindOfClass:[UIWindowScene class]] &&
+        connectedScene.activationState == UISceneActivationStateForegroundActive) {
+      return (UIWindowScene *)connectedScene;
+    }
+  }
+  return nil;
+}
+
+@end
+
+#endif  // TARGET_OS_IOS || TARGET_OS_TV


### PR DESCRIPTION
### Changes:

- This PR fixes a crash which is caused by an attempt to present an In App message on a CarPlay scene. 
The issue was reported here: #9376 
- I didn't add a changelog entry since I couldn't found neither `Unreleased` nor `Upcoming` entry in the  FirebaseInApp's [changelog file](https://github.com/firebase/firebase-ios-sdk/blob/4ef20cb7d30d1fee638217ce95949c718974c8ad/FirebaseInAppMessaging/CHANGELOG.md). Should I add one? If so — which version is planned for the next release?
- I also found similar problem in in FIRAppDistributionUIService.m implementation [here](https://github.com/firebase/firebase-ios-sdk/blob/4ef20cb7d30d1fee638217ce95949c718974c8ad/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m#L205). Do you think that fix for that should be introduced in a separate PR or it is fine to include it to the existing one? 

### API Changes

No public API changes introduced.  