### PR TITLE
Add getLimitedUseToken method in FIRAppCheckInterop

### DIFF
--- a/FirebaseAppCheck/Interop/FIRAppCheckInterop.h
+++ b/FirebaseAppCheck/Interop/FIRAppCheckInterop.h
@@ -31,6 +31,10 @@ NS_SWIFT_NAME(AppCheckInterop) @protocol FIRAppCheckInterop
                     completion:(FIRAppCheckTokenHandlerInterop)handler
     NS_SWIFT_NAME(getToken(forcingRefresh:completion:));
 
+/// Retrieve a new limitedUseToken
+- (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler
+    NS_SWIFT_NAME(getlimitedUseToken(completion:));
+
 /// A notification with the specified name is sent to the default notification center
 /// (`NotificationCenter.default`) each time a Firebase app check token is refreshed.
 /// The user info dictionary contains `-[self notificationTokenKey]` and

--- a/FirebaseAppCheck/Interop/FIRAppCheckInterop.h
+++ b/FirebaseAppCheck/Interop/FIRAppCheckInterop.h
@@ -31,9 +31,9 @@ NS_SWIFT_NAME(AppCheckInterop) @protocol FIRAppCheckInterop
                     completion:(FIRAppCheckTokenHandlerInterop)handler
     NS_SWIFT_NAME(getToken(forcingRefresh:completion:));
 
-/// Retrieve a new limitedUseToken
+/// Retrieve a new limited-use Firebase App Check token
 - (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler
-    NS_SWIFT_NAME(getlimitedUseToken(completion:));
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
 
 /// A notification with the specified name is sent to the default notification center
 /// (`NotificationCenter.default`) each time a Firebase app check token is refreshed.

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -234,6 +234,21 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
       });
 }
 
+- (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler {
+    [self retrieveLimitedUseToken]
+        .then(^id _Nullable(FIRAppCheckToken *token) {
+            FIRAppCheckTokenResult *result = [[FIRAppCheckTokenResult alloc] initWithToken:token.token
+                                                                                     error:nil];
+            handler(result);
+            return result;
+        })
+        .catch(^(NSError *_Nonnull error) {
+            FIRAppCheckTokenResult *result =
+                [[FIRAppCheckTokenResult alloc] initWithToken:kDummyFACTokenValue error:error];
+            handler(result);
+        });
+}
+
 - (nonnull NSString *)tokenDidChangeNotificationName {
   return FIRAppCheckAppCheckTokenDidChangeNotification;
 }

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -235,18 +235,18 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 }
 
 - (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler {
-    [self retrieveLimitedUseToken]
-        .then(^id _Nullable(FIRAppCheckToken *token) {
-            FIRAppCheckTokenResult *result = [[FIRAppCheckTokenResult alloc] initWithToken:token.token
-                                                                                     error:nil];
-            handler(result);
-            return result;
-        })
-        .catch(^(NSError *_Nonnull error) {
-            FIRAppCheckTokenResult *result =
-                [[FIRAppCheckTokenResult alloc] initWithToken:kDummyFACTokenValue error:error];
-            handler(result);
-        });
+  [self retrieveLimitedUseToken]
+      .then(^id _Nullable(FIRAppCheckToken *token) {
+        FIRAppCheckTokenResult *result = [[FIRAppCheckTokenResult alloc] initWithToken:token.token
+                                                                                 error:nil];
+        handler(result);
+        return result;
+      })
+      .catch(^(NSError *_Nonnull error) {
+        FIRAppCheckTokenResult *result =
+            [[FIRAppCheckTokenResult alloc] initWithToken:kDummyFACTokenValue error:error];
+        handler(result);
+      });
 }
 
 - (nonnull NSString *)tokenDidChangeNotificationName {

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
@@ -36,7 +36,7 @@
 }
 
 - (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler {
-    handler(self.tokenResult);
+  handler(self.tokenResult);
 }
 
 - (nonnull NSString *)notificationAppNameKey {

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
@@ -35,6 +35,10 @@
   });
 }
 
+- (void)getLimitedUseTokenWithCompletion:(FIRAppCheckTokenHandlerInterop)handler {
+    handler(self.tokenResult);
+}
+
 - (nonnull NSString *)notificationAppNameKey {
   return @"FakeAppCheckTokenDidChangeNotification";
 }


### PR DESCRIPTION
### Discussion

  * Add getLimitedUseToken in FirebaseAppCheckInterop to implement [Firebase App CheckOne-time Use Tokens for Callable Functions SDK](https://docs.google.com/document/d/1fZ8w6lIj5rODUQYqr4IUUUodCmcb_aWLS9w2LgLKgdU/edit?resourcekey=0-xnc7HhmtcKf8JPNdGKtCIg#heading=h.ptb4ebwum9vl) later

### Testing

  * Passed all Unit Tests

