### PR TITLE
[Performance] Address Xcode 14.3 Analyzer issues

### DIFF
--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -76,7 +76,8 @@ static firebase_perf_v1_NetworkRequestMetric_HttpMethod FPRHTTPMethodForString(
  * format.
  *  @return Current network connection type.
  */
-static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType() {
+static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType(
+    void) {
   firebase_perf_v1_NetworkConnectionInfo_NetworkType networkType =
       firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
@@ -106,7 +107,7 @@ static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionIn
  * firebase_perf_v1_NetworkConnectionInfo_MobileSubtype format.
  *  @return Current cellular network connection type.
  */
-static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkType() {
+static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkType(void) {
   static NSDictionary<NSString *, NSNumber *> *cellularNetworkToMobileSubtype;
   static dispatch_once_t onceToken = 0;
   dispatch_once(&onceToken, ^{
@@ -206,7 +207,7 @@ firebase_perf_v1_PerfMetric FPRGetPerfMetricMessage(NSString *appID) {
   return perfMetricMessage;
 }
 
-firebase_perf_v1_ApplicationInfo FPRGetApplicationInfoMessage() {
+firebase_perf_v1_ApplicationInfo FPRGetApplicationInfoMessage(void) {
   firebase_perf_v1_ApplicationInfo appInfoMessage = firebase_perf_v1_ApplicationInfo_init_default;
   firebase_perf_v1_IosApplicationInfo iosAppInfo = firebase_perf_v1_IosApplicationInfo_init_default;
   NSBundle *mainBundle = [NSBundle mainBundle];
@@ -433,7 +434,7 @@ firebase_perf_v1_ApplicationProcessState FPRApplicationProcessState(FPRTraceStat
 }
 
 #ifdef TARGET_HAS_MOBILE_CONNECTIVITY
-CTTelephonyNetworkInfo *FPRNetworkInfo() {
+CTTelephonyNetworkInfo *FPRNetworkInfo(void) {
   static CTTelephonyNetworkInfo *networkInfo;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeCollector.m
+++ b/FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeCollector.m
@@ -34,7 +34,7 @@
 
 @end
 
-FPRMemoryGaugeData *fprCollectMemoryMetric() {
+FPRMemoryGaugeData *fprCollectMemoryMetric(void) {
   NSDate *collectionTime = [NSDate date];
 
   struct mstats ms = mstats();

--- a/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLConnectionDelegateInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLConnectionDelegateInstrument.m
@@ -24,7 +24,7 @@
 #pragma mark - NSURLConnectionDelegate methods
 
 /** Returns the dispatch queue for all instrumentation to occur on. */
-static dispatch_queue_t GetInstrumentationQueue() {
+static dispatch_queue_t GetInstrumentationQueue(void) {
   static dispatch_queue_t queue;
   static dispatch_once_t token;
   dispatch_once(&token, ^{

--- a/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLSessionDelegateInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLSessionDelegateInstrument.m
@@ -23,7 +23,7 @@
 #import "FirebasePerformance/Sources/Instrumentation/Network/FPRNetworkInstrumentHelpers.h"
 
 /** Returns the dispatch queue for all instrumentation to occur on. */
-static dispatch_queue_t GetInstrumentationQueue() {
+static dispatch_queue_t GetInstrumentationQueue(void) {
   static dispatch_queue_t queue;
   static dispatch_once_t token;
   dispatch_once(&token, ^{

--- a/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
@@ -35,7 +35,7 @@ typedef void (^FPRNSURLConnectionCompletionHandler)(NSURLResponse *_Nullable res
                                                     NSError *_Nullable connectionError);
 
 /** Returns the dispatch queue for all instrumentation to occur on. */
-static dispatch_queue_t GetInstrumentationQueue() {
+static dispatch_queue_t GetInstrumentationQueue(void) {
   static dispatch_queue_t queue = nil;
   static dispatch_once_t token = 0;
   dispatch_once(&token, ^{

--- a/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLSessionInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLSessionInstrument.m
@@ -51,7 +51,7 @@
 @end
 
 /** Returns the dispatch queue for all instrumentation to occur on. */
-static dispatch_queue_t GetInstrumentationQueue() {
+static dispatch_queue_t GetInstrumentationQueue(void) {
   static dispatch_queue_t queue = nil;
   static dispatch_once_t token = 0;
   dispatch_once(&token, ^{

--- a/FirebasePerformance/Sources/Instrumentation/UIKit/FPRUIViewControllerInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/UIKit/FPRUIViewControllerInstrument.m
@@ -27,7 +27,7 @@
 #import <GoogleUtilities/GULOriginalIMPConvenienceMacros.h>
 
 /** Returns the dispatch queue for all instrumentation to occur on. */
-static dispatch_queue_t GetInstrumentationQueue() {
+static dispatch_queue_t GetInstrumentationQueue(void) {
   static dispatch_queue_t queue = nil;
   static dispatch_once_t token = 0;
   dispatch_once(&token, ^{
@@ -40,7 +40,7 @@ static dispatch_queue_t GetInstrumentationQueue() {
 // Returns the singleton UIApplication of the application this is currently running in or nil if
 // it's in an app extension.
 NS_EXTENSION_UNAVAILABLE("Firebase Performance is not supported for extensions.")
-static UIApplication *FPRSharedApplication() {
+static UIApplication *FPRSharedApplication(void) {
   if ([GULAppEnvironmentUtil isAppExtension]) {
     return nil;
   }


### PR DESCRIPTION
### Context
- Address 14.3 Analyzer issues

<details>
<summary>See the before and after results.</summary>
<br>

- Before
```
bundle exec pod lib lint --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ --include-podspecs={FirebaseCore.podspec,FirebaseCoreInternal.podspec,FirebaseInstallations.podspec,FirebaseRemoteConfig.podspec,FirebaseABTesting.podspec,FirebaseSessions.podspec,FirebaseCoreExtension.podspec} --analyze FirebasePerformance.podspec --analyze --platforms=ios --skip-tests

 -> FirebasePerformance (10.10.0)
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'PromisesSwift' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseCoreInternal' from project 'Pods')
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/UIKit/FPRUIViewControllerInstrument.m:30:48: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/UIKit/FPRUIViewControllerInstrument.m:43:43: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/FPRNanoPbUtils.m:79:94: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/FPRNanoPbUtils.m:109:83: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/FPRNanoPbUtils.m:209:62: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/FPRNanoPbUtils.m:436:39: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLSessionInstrument.m:54:48: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLSessionDelegateInstrument.m:26:48: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m:38:48: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLConnectionDelegateInstrument.m:27:48: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeCollector.m:37:43: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeCollector.m:48:37: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseSessions' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'PromisesObjC' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'GoogleUtilities' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'nanopb' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'PromisesSwift' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'GoogleDataTransport' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseInstallations' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCoreInternal' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCoreExtension' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCore' from project 'Pods')

[!] FirebasePerformance did not pass validation, due to 12 warnings (but you can use `--allow-warnings` to ignore them).
You can use the `--no-clean` option to inspect any issue.
```

- After
```
bundle exec pod lib lint --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ --include-podspecs=\{FirebaseCore.podspec,FirebaseCoreInternal.podspec,FirebaseInstallations.podspec,FirebaseRemoteConfig.podspec,FirebaseABTesting.podspec,FirebaseSessions.podspec,FirebaseCoreExtension.podspec\} --analyze FirebasePerformance.podspec --analyze --platforms=ios --skip-tests

 -> FirebasePerformance (10.10.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | [iOS] xcodebuild:  note: Planning
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order

FirebasePerformance passed validation.
```

</details>

#no-changelog