### PR TITLE
[Dynamic Links] Address Xcode 14.3 Analyzer issues

### DIFF
--- a/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m
@@ -156,7 +156,7 @@ NSString *GINFingerprintJSMethodString(void) {
 // From:
 // https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
 #if TARGET_OS_SIMULATOR
-static int processIsTranslated() {
+static int processIsTranslated(void) {
   int ret = 0;
   size_t size = sizeof(ret);
   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -162,7 +162,7 @@ BOOL FIRDLOSVersionSupported(NSString *_Nullable systemVersion, NSString *minSup
   return [systemVersion compare:minSupportedVersion options:NSNumericSearch] != NSOrderedAscending;
 }
 
-NSDate *_Nullable FIRDLAppInstallationDate() {
+NSDate *_Nullable FIRDLAppInstallationDate(void) {
   NSURL *documentsDirectoryURL =
       [[[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory
                                               inDomains:NSUserDomainMask] firstObject];
@@ -178,7 +178,7 @@ NSDate *_Nullable FIRDLAppInstallationDate() {
   return nil;
 }
 
-NSString *FIRDLDeviceModelName() {
+NSString *FIRDLDeviceModelName(void) {
   // this method will return string like iPad3,3
   // for Simulator this will be x86_64
   static NSString *machineString = @"";
@@ -199,17 +199,17 @@ NSString *FIRDLDeviceModelName() {
   return machineString;
 }
 
-NSString *FIRDLDeviceLocale() {
+NSString *FIRDLDeviceLocale(void) {
   // expected return value from this method looks like: @"en-US"
   return [[[NSLocale currentLocale] localeIdentifier] stringByReplacingOccurrencesOfString:@"_"
                                                                                 withString:@"-"];
 }
 
-NSString *FIRDLDeviceLocaleRaw() {
+NSString *FIRDLDeviceLocaleRaw(void) {
   return [[NSLocale currentLocale] localeIdentifier];
 }
 
-NSString *FIRDLDeviceTimezone() {
+NSString *FIRDLDeviceTimezone(void) {
   NSString *timeZoneName = [[NSTimeZone localTimeZone] name];
   return timeZoneName;
 }


### PR DESCRIPTION
### Context
- Address 14.3 Analyzer issues

<details>
<summary>See the before and after results.</summary>
<br>

- Before
```
bundle exec pod lib lint --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ --include-podspecs={FirebaseCore.podspec,FirebaseCoreInternal.podspec} --analyze FirebaseDynamicLinks.podspec --analyze --platforms=ios --skip-tests

 -> FirebaseDynamicLinks (10.10.0)
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseCoreInternal' from project 'Pods')
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/FIRDLJavaScriptExecutor.m:159:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m:165:43: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m:181:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m:202:28: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m:208:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/nickcooke/Developer/firebase-ios-sdk/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m:212:30: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCoreInternal' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'GoogleUtilities' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCore' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'PromisesObjC' from project 'Pods')

[!] FirebaseDynamicLinks did not pass validation, due to 6 warnings (but you can use `--allow-warnings` to ignore them).
You can use the `--no-clean` option to inspect any issue.
```
- After
```
bundle exec pod lib lint --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ --include-podspecs=\{FirebaseCore.podspec,FirebaseCoreInternal.podspec\} --analyze FirebaseDynamicLinks.podspec --analyze --platforms=ios --skip-tests

 -> FirebaseDynamicLinks (10.10.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | [iOS] xcodebuild:  note: Planning
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order

FirebaseDynamicLinks passed validation.
```

</details>



#no-changelog