### PR TITLE
Firestore Spec Tests: Port JS PR 7285 (remove no-android tag from bloom filter tests)

### DIFF
--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -3,8 +3,7 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter can process special characters in document name",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -208,8 +207,7 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter fills in default values for undefined padding and hashCount",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -396,8 +394,7 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter is handled at global snapshot",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -636,8 +633,7 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter limbo resolution is denied",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -897,8 +893,7 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter with large size works as expected",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -6522,8 +6517,7 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is skipped when bloom filter can identify documents deleted",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -6983,8 +6977,7 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter can not identify documents deleted",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7197,8 +7190,7 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter hashCount is invalid",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7387,8 +7379,7 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter is empty",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7577,8 +7568,7 @@
     "describeName": "Existence Filters:",
     "itName": "Same documents can have different bloom filters",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -7956,8 +7956,7 @@
     "describeName": "Limbo Documents:",
     "itName": "Limbo resolution throttling with bloom filter application",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "maxConcurrentLimboResolutions": 2,

--- a/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
@@ -3385,8 +3385,7 @@
     "describeName": "Listens:",
     "itName": "ExpectedCount in listen request should work after coming back online",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -12746,8 +12745,7 @@
     "describeName": "Listens:",
     "itName": "Resuming a query should specify expectedCount that does not include pending mutations",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -12949,8 +12947,7 @@
     "describeName": "Listens:",
     "itName": "Resuming a query should specify expectedCount when adding the target",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,


### PR DESCRIPTION
Sync spec tests with changes from https://github.com/firebase/firebase-js-sdk/pull/7285: "Remove the no-android tag from bloom filter spec tests".

The changes in this PR have no effect on this SDK, but serves to keep the spec tests in sync for easier updating in the future.

#no-changelog