### PR TITLE
[auth-swift] unowned instead of weak for holding app in the component

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -68,7 +68,7 @@ import FirebaseAppCheckInterop
   @objc public class func auth(app: FirebaseApp) -> Auth {
     let provider = ComponentType<AuthProvider>.instance(for: AuthProvider.self,
                                                         in: app.container)
-    return provider.auth(app)
+    return provider.auth()
   }
 
   /** @property app

--- a/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
@@ -20,14 +20,15 @@ import FirebaseCore
 @_implementationOnly import FirebaseCoreExtension
 
 @objc(FIRAuthProvider) public protocol AuthProvider {
-  @objc func auth(_ app: FirebaseApp) -> Auth
+  @objc func auth() -> Auth
 }
 
 @objc(FIRAuthComponent) class AuthComponent: NSObject, Library, AuthProvider {
   // MARK: - Private Variables
 
   /// The app associated with all Auth instances in this container.
-  private weak var app: FirebaseApp?
+  /// This is `unowned` instead of `weak` so it can be used without unwrapping in `auth()`
+  private unowned var app: FirebaseApp
 
   /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are arrays
   /// containing all instances of Auth associated with the given app.
@@ -59,7 +60,7 @@ import FirebaseCore
 
   // MARK: - AuthProvider conformance
 
-  func auth(_ app: FirebaseApp) -> Auth {
+  func auth() -> Auth {
     os_unfair_lock_lock(&instancesLock)
 
     // Unlock before the function returns.

--- a/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
@@ -28,7 +28,7 @@ import FirebaseCore
 
   /// The app associated with all Auth instances in this container.
   /// This is `unowned` instead of `weak` so it can be used without unwrapping in `auth()`
-  private unowned var app: FirebaseApp
+  private unowned let app: FirebaseApp
 
   /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are arrays
   /// containing all instances of Auth associated with the given app.


### PR DESCRIPTION
Using unowned saves passing app as a parameter as well as avoiding an unwrap.

Additional context and discussion in #11248

#no-changelog 