### PR TITLE
[App Check] Rename FIR symbols in unit tests for generic SDK

### DIFF
--- a/AppCheck.podspec
+++ b/AppCheck.podspec
@@ -66,8 +66,6 @@ Pod::Spec.new do |s|
       unit_tests.source_files = [
         base_dir + 'Tests/Unit/**/*.[mh]',
         base_dir + 'Tests/Utils/**/*.[mh]',
-        'SharedTestUtilities/AppCheckFake/*',
-        'SharedTestUtilities/AppCheckBackoffWrapperFake/*',
         'SharedTestUtilities/Date/*',
         'SharedTestUtilities/URLSession/*',
       ]

--- a/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -37,15 +37,15 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
-@interface FIRDeviceCheckAPIServiceE2ETests : XCTestCase
-@property(nonatomic) FIRDeviceCheckAPIService *deviceCheckAPIService;
+@interface GACDeviceCheckAPIServiceE2ETests : XCTestCase
+@property(nonatomic) GACDeviceCheckAPIService *deviceCheckAPIService;
 @property(nonatomic) GACAppCheckAPIService *APIService;
 @property(nonatomic) NSURLSession *URLSession;
 @end
 
 // TODO(ncooke3): Fix these tests up and get them running on CI.
 
-@implementation FIRDeviceCheckAPIServiceE2ETests
+@implementation GACDeviceCheckAPIServiceE2ETests
 
 - (void)setUp {
   self.URLSession = [NSURLSession
@@ -59,7 +59,7 @@
                                                                 appID:options.googleAppID
                                                       heartbeatLogger:heartbeatLogger];
   self.deviceCheckAPIService =
-      [[FIRDeviceCheckAPIService alloc] initWithAPIService:self.APIService
+      [[GACDeviceCheckAPIService alloc] initWithAPIService:self.APIService
                                                  projectID:options.projectID
                                                      appID:options.googleAppID];
 }

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -33,9 +33,9 @@
 #import "SharedTestUtilities/Date/FIRDateTestUtils.h"
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
 
-@interface FIRAppAttestAPIServiceTests : XCTestCase
+@interface GACAppAttestAPIServiceTests : XCTestCase
 
-@property(nonatomic) FIRAppAttestAPIService *appAttestAPIService;
+@property(nonatomic) GACAppAttestAPIService *appAttestAPIService;
 
 @property(nonatomic) id mockAPIService;
 
@@ -44,7 +44,7 @@
 
 @end
 
-@implementation FIRAppAttestAPIServiceTests
+@implementation GACAppAttestAPIServiceTests
 
 - (void)setUp {
   [super setUp];
@@ -55,7 +55,7 @@
   self.mockAPIService = OCMProtocolMock(@protocol(GACAppCheckAPIServiceProtocol));
   OCMStub([self.mockAPIService baseURL]).andReturn(@"https://test.appcheck.url.com/beta");
 
-  self.appAttestAPIService = [[FIRAppAttestAPIService alloc] initWithAPIService:self.mockAPIService
+  self.appAttestAPIService = [[GACAppAttestAPIService alloc] initWithAPIService:self.mockAPIService
                                                                       projectID:self.projectID
                                                                           appID:self.appID];
 }
@@ -72,7 +72,7 @@
 
 - (void)testGetRandomChallengeWhenAPIResponseValid {
   // 1. Prepare API response.
-  NSData *responseBody = [FIRFixtureLoader loadFixtureNamed:@"AppAttestResponseSuccess.json"];
+  NSData *responseBody = [GACFixtureLoader loadFixtureNamed:@"AppAttestResponseSuccess.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
   // 2. Stub API Service Request to return prepared API response.
@@ -178,7 +178,7 @@
 - (void)assertMissingFieldErrorWithFixture:(NSString *)fixtureName
                               missingField:(NSString *)fieldName {
   // 1. Prepare API response.
-  NSData *missingFieldBody = [FIRFixtureLoader loadFixtureNamed:fixtureName];
+  NSData *missingFieldBody = [GACFixtureLoader loadFixtureNamed:fixtureName];
   GULURLSessionDataResponse *incompleteAPIResponse = [self APIResponseWithCode:200
                                                                   responseBody:missingFieldBody];
   // 2. Stub API Service Request to return prepared API response.
@@ -212,7 +212,7 @@
 
   // 1. Prepare response.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
@@ -254,7 +254,7 @@
 
   // 1. Prepare response.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
@@ -288,7 +288,7 @@
 
   // 1. Prepare response.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"DeviceCheckResponseMissingToken.json"];
+      [GACFixtureLoader loadFixtureNamed:@"DeviceCheckResponseMissingToken.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
@@ -325,7 +325,7 @@
 
   // 1. Prepare response.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"AppAttestAttestationResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"AppAttestAttestationResponseSuccess.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 
@@ -396,7 +396,7 @@
 
   // 1. Prepare unexpected response.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   GULURLSessionDataResponse *validAPIResponse = [self APIResponseWithCode:200
                                                              responseBody:responseBody];
 

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -37,26 +37,26 @@
 
 #import "AppCheck/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 
-#if FIR_APP_ATTEST_SUPPORTED_TARGETS
+#if GAC_APP_ATTEST_SUPPORTED_TARGETS
 
-FIR_APP_ATTEST_PROVIDER_AVAILABILITY
-@interface FIRAppAttestProvider (Tests)
-- (instancetype)initWithAppAttestService:(id<FIRAppAttestService>)appAttestService
-                              APIService:(id<FIRAppAttestAPIServiceProtocol>)APIService
-                            keyIDStorage:(id<FIRAppAttestKeyIDStorageProtocol>)keyIDStorage
-                         artifactStorage:(id<FIRAppAttestArtifactStorageProtocol>)artifactStorage
+GAC_APP_ATTEST_PROVIDER_AVAILABILITY
+@interface GACAppAttestProvider (Tests)
+- (instancetype)initWithAppAttestService:(id<GACAppAttestService>)appAttestService
+                              APIService:(id<GACAppAttestAPIServiceProtocol>)APIService
+                            keyIDStorage:(id<GACAppAttestKeyIDStorageProtocol>)keyIDStorage
+                         artifactStorage:(id<GACAppAttestArtifactStorageProtocol>)artifactStorage
                           backoffWrapper:(id<GACAppCheckBackoffWrapperProtocol>)backoffWrapper;
 @end
 
-FIR_APP_ATTEST_PROVIDER_AVAILABILITY
-@interface FIRAppAttestProviderTests : XCTestCase
+GAC_APP_ATTEST_PROVIDER_AVAILABILITY
+@interface GACAppAttestProviderTests : XCTestCase
 
-@property(nonatomic) FIRAppAttestProvider *provider;
+@property(nonatomic) GACAppAttestProvider *provider;
 
-@property(nonatomic) OCMockObject<FIRAppAttestService> *mockAppAttestService;
-@property(nonatomic) OCMockObject<FIRAppAttestAPIServiceProtocol> *mockAPIService;
-@property(nonatomic) OCMockObject<FIRAppAttestKeyIDStorageProtocol> *mockStorage;
-@property(nonatomic) OCMockObject<FIRAppAttestArtifactStorageProtocol> *mockArtifactStorage;
+@property(nonatomic) OCMockObject<GACAppAttestService> *mockAppAttestService;
+@property(nonatomic) OCMockObject<GACAppAttestAPIServiceProtocol> *mockAPIService;
+@property(nonatomic) OCMockObject<GACAppAttestKeyIDStorageProtocol> *mockStorage;
+@property(nonatomic) OCMockObject<GACAppAttestArtifactStorageProtocol> *mockArtifactStorage;
 
 @property(nonatomic) NSData *randomChallenge;
 @property(nonatomic) NSData *randomChallengeHash;
@@ -65,21 +65,21 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 
 @end
 
-@implementation FIRAppAttestProviderTests
+@implementation GACAppAttestProviderTests
 
 - (void)setUp {
   [super setUp];
 
-  self.mockAppAttestService = OCMProtocolMock(@protocol(FIRAppAttestService));
-  self.mockAPIService = OCMProtocolMock(@protocol(FIRAppAttestAPIServiceProtocol));
-  self.mockStorage = OCMProtocolMock(@protocol(FIRAppAttestKeyIDStorageProtocol));
-  self.mockArtifactStorage = OCMProtocolMock(@protocol(FIRAppAttestArtifactStorageProtocol));
+  self.mockAppAttestService = OCMProtocolMock(@protocol(GACAppAttestService));
+  self.mockAPIService = OCMProtocolMock(@protocol(GACAppAttestAPIServiceProtocol));
+  self.mockStorage = OCMProtocolMock(@protocol(GACAppAttestKeyIDStorageProtocol));
+  self.mockArtifactStorage = OCMProtocolMock(@protocol(GACAppAttestArtifactStorageProtocol));
 
   self.fakeBackoffWrapper = [[GACAppCheckBackoffWrapperFake alloc] init];
   // Don't backoff by default.
   self.fakeBackoffWrapper.isNextOperationAllowed = YES;
 
-  self.provider = [[FIRAppAttestProvider alloc] initWithAppAttestService:self.mockAppAttestService
+  self.provider = [[GACAppAttestProvider alloc] initWithAppAttestService:self.mockAppAttestService
                                                               APIService:self.mockAPIService
                                                             keyIDStorage:self.mockStorage
                                                          artifactStorage:self.mockArtifactStorage
@@ -111,7 +111,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   options.projectID = @"project_id";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
-  XCTAssertNotNil([[FIRAppAttestProvider alloc] initWithApp:app]);
+  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithApp:app]);
 }
 #endif  // !TARGET_OS_MACCATALYST
 
@@ -132,7 +132,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
     return GACAppCheckBackoffType1Day;
   };
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(NO)];
 
   // 2. Don't expect other operations.
@@ -173,7 +173,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -209,7 +209,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type attestKeyResponse =
-      [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
+      [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:generatedKeyID
                                                 challenge:self.randomChallenge])
@@ -247,7 +247,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -283,7 +283,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type attestKeyResponse =
-      [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
+      [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:existingKeyID
                                                 challenge:self.randomChallenge])
@@ -321,7 +321,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -373,7 +373,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -431,7 +431,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -518,7 +518,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   NSData *artifactData = [@"attestation artifact" dataUsingEncoding:NSUTF8StringEncoding];
   __auto_type attestKeyResponse =
-      [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
+      [[GACAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
                                                 challenge:self.randomChallenge])
@@ -590,7 +590,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        FIRAppAttestRejectionError *expectedError = [[FIRAppAttestRejectionError alloc] init];
+        GACAppAttestRejectionError *expectedError = [[GACAppAttestRejectionError alloc] init];
         XCTAssertEqualObjects(error, expectedError);
       }];
 
@@ -607,7 +607,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetToken_WhenKeyRegisteredAndChallengeRequestError {
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -651,7 +651,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetToken_WhenKeyRegisteredAndGenerateAssertionError {
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -702,7 +702,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetToken_WhenKeyRegisteredAndTokenExchangeRequestError {
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -760,7 +760,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used only once.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -835,7 +835,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used only once.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -990,7 +990,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 0. Expect backoff wrapper to be used.
   self.fakeBackoffWrapper.backoffExpectation = [self expectationWithDescription:@"Backoff"];
 
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -1047,7 +1047,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 }
 
 - (void)expectAppAttestAvailabilityToBeCheckedAndNotExistingStoredKeyRequested {
-  // 1. Expect FIRAppAttestService.isSupported.
+  // 1. Expect GACAppAttestService.isSupported.
   [OCMExpect([self.mockAppAttestService isSupported]) andReturnValue:@(YES)];
 
   // 2. Expect storage getAppAttestKeyID.
@@ -1090,4 +1090,4 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
 
 @end
 
-#endif  // FIR_APP_ATTEST_SUPPORTED_TARGETS
+#endif  // GAC_APP_ATTEST_SUPPORTED_TARGETS

--- a/AppCheck/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/Storage/GACAppAttestArtifactStorageTests.m
@@ -36,23 +36,23 @@
 #import "AppCheck/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.h"
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 
-@interface FIRAppAttestArtifactStorageTests : XCTestCase
+@interface GACAppAttestArtifactStorageTests : XCTestCase
 
 @property(nonatomic) NSString *appName;
 @property(nonatomic) NSString *appID;
-@property(nonatomic) FIRAppAttestArtifactStorage *storage;
+@property(nonatomic) GACAppAttestArtifactStorage *storage;
 
 @end
 
-@implementation FIRAppAttestArtifactStorageTests
+@implementation GACAppAttestArtifactStorageTests
 
 - (void)setUp {
   [super setUp];
 
-  self.appName = @"FIRAppAttestArtifactStorageTests";
+  self.appName = @"GACAppAttestArtifactStorageTests";
   self.appID = @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa";
 
-  self.storage = [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
+  self.storage = [[GACAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                                 appID:self.appID
                                                           accessGroup:nil];
 }
@@ -133,8 +133,8 @@
 - (void)testGetArtifact_KeychainError {
   // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-  FIRAppAttestArtifactStorage *artifactStorage =
-      [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
+  GACAppAttestArtifactStorage *artifactStorage =
+      [[GACAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
@@ -160,8 +160,8 @@
 - (void)testSetArtifact_KeychainError {
   // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-  FIRAppAttestArtifactStorage *artifactStorage =
-      [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
+  GACAppAttestArtifactStorage *artifactStorage =
+      [[GACAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
@@ -187,8 +187,8 @@
 - (void)testRemoveArtifact_KeychainError {
   // 1. Set up storage mock.
   id mockKeychainStorage = OCMClassMock([GULKeychainStorage class]);
-  FIRAppAttestArtifactStorage *artifactStorage =
-      [[FIRAppAttestArtifactStorage alloc] initWithAppName:self.appName
+  GACAppAttestArtifactStorage *artifactStorage =
+      [[GACAppAttestArtifactStorage alloc] initWithAppName:self.appName
                                                      appID:self.appID
                                            keychainStorage:mockKeychainStorage
                                                accessGroup:nil];
@@ -244,10 +244,10 @@
   NSString *keyID = [NSUUID UUID].UUIDString;
 
   // Create two storages.
-  FIRAppAttestArtifactStorage *storage1 =
-      [[FIRAppAttestArtifactStorage alloc] initWithAppName:appName1 appID:appID1 accessGroup:nil];
-  FIRAppAttestArtifactStorage *storage2 =
-      [[FIRAppAttestArtifactStorage alloc] initWithAppName:appName2 appID:appID2 accessGroup:nil];
+  GACAppAttestArtifactStorage *storage1 =
+      [[GACAppAttestArtifactStorage alloc] initWithAppName:appName1 appID:appID1 accessGroup:nil];
+  GACAppAttestArtifactStorage *storage2 =
+      [[GACAppAttestArtifactStorage alloc] initWithAppName:appName2 appID:appID2 accessGroup:nil];
   // 1. Independently set artifacts for the two storages.
   NSData *artifact1 = [@"app_attest_artifact1" dataUsingEncoding:NSUTF8StringEncoding];
   FBLPromise *setPromise1 = [storage1 setArtifact:artifact1 forKey:keyID];

--- a/AppCheck/Tests/Unit/AppAttestProvider/Storage/GACAppAttestKeyIDStorageTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/Storage/GACAppAttestKeyIDStorageTests.m
@@ -22,20 +22,20 @@
 
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 
-@interface FIRAppAttestKeyIDStorageTests : XCTestCase
+@interface GACAppAttestKeyIDStorageTests : XCTestCase
 @property(nonatomic) NSString *appName;
 @property(nonatomic) NSString *appID;
-@property(nonatomic) FIRAppAttestKeyIDStorage *storage;
+@property(nonatomic) GACAppAttestKeyIDStorage *storage;
 @end
 
-@implementation FIRAppAttestKeyIDStorageTests
+@implementation GACAppAttestKeyIDStorageTests
 
 - (void)setUp {
   [super setUp];
 
-  self.appName = @"FIRAppAttestKeyIDStorageTestsApp";
+  self.appName = @"GACAppAttestKeyIDStorageTestsApp";
   self.appID = @"app_id";
-  self.storage = [[FIRAppAttestKeyIDStorage alloc] initWithAppName:self.appName appID:self.appID];
+  self.storage = [[GACAppAttestKeyIDStorage alloc] initWithAppName:self.appName appID:self.appID];
 }
 
 - (void)tearDown {
@@ -48,7 +48,7 @@
 }
 
 - (void)testInitWithApp {
-  XCTAssertNotNil([[FIRAppAttestKeyIDStorage alloc] initWithAppName:self.appName appID:self.appID]);
+  XCTAssertNotNil([[GACAppAttestKeyIDStorage alloc] initWithAppName:self.appName appID:self.appID]);
 }
 
 - (void)testSetAndGetAppAttestKeyID {
@@ -104,9 +104,9 @@
                                               appName2:(NSString *)appName2
                                                 appID2:(NSString *)appID2 {
   // Create two storages.
-  FIRAppAttestKeyIDStorage *storage1 = [[FIRAppAttestKeyIDStorage alloc] initWithAppName:appName1
+  GACAppAttestKeyIDStorage *storage1 = [[GACAppAttestKeyIDStorage alloc] initWithAppName:appName1
                                                                                    appID:appID1];
-  FIRAppAttestKeyIDStorage *storage2 = [[FIRAppAttestKeyIDStorage alloc] initWithAppName:appName2
+  GACAppAttestKeyIDStorage *storage2 = [[GACAppAttestKeyIDStorage alloc] initWithAppName:appName2
                                                                                    appID:appID2];
   // 1. Independently set app attest key IDs for the two storages.
   NSString *appAttestKeyID1 = @"app_attest_key_ID1";

--- a/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -209,7 +209,7 @@
 - (void)testAppCheckTokenWithAPIResponseValidResponse {
   // 1. Prepare input parameters.
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
   NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
@@ -269,7 +269,7 @@
 - (void)assertMissingFieldErrorWithFixture:(NSString *)fixtureName
                               missingField:(NSString *)fieldName {
   // 1. Parse API response.
-  NSData *missingFiledBody = [FIRFixtureLoader loadFixtureNamed:fixtureName];
+  NSData *missingFiledBody = [GACFixtureLoader loadFixtureNamed:fixtureName];
   XCTAssertNotNil(missingFiledBody);
 
   NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];

--- a/AppCheck/Tests/Unit/Core/GACAppCheckIntegrationTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckIntegrationTests.m
@@ -34,7 +34,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
 
 @interface DummyAppCheckProvider : NSObject <GACAppCheckProvider>
 @end
@@ -66,7 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, nullable) id mockAppCheckProvider;
 @property(nonatomic, nullable) id mockTokenRefresher;
 
-- (void)testDefaultAppCheckProvider FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY;
+// TODO(andrewheard): Remove section from generic App Check SDK.
+#ifdef FIREBASE_APP_CHECK_ONLY
+
+- (void)testDefaultAppCheckProvider GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY;
+
+#endif  // FIREBASE_APP_CHECK_ONLY
 
 @end
 
@@ -87,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   if (@available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, watchOS 9.0, *)) {
     // Recover default provider factory.
-    [GACAppCheck setAppCheckProviderFactory:[[FIRDeviceCheckProviderFactory alloc] init]];
+    [GACAppCheck setAppCheckProviderFactory:[[GACDeviceCheckProviderFactory alloc] init]];
   }
 
   [self.mockTokenRefresher stopMocking];
@@ -100,12 +105,15 @@ NS_ASSUME_NONNULL_BEGIN
   [super tearDown];
 }
 
+// TODO(andrewheard): Remove section from generic App Check SDK.
+#ifdef FIREBASE_APP_CHECK_ONLY
+
 - (void)testDefaultAppCheckProvider {
   NSString *appName = @"testDefaultAppCheckProvider";
 
-  // 1. Expect FIRDeviceCheckProvider to be instantiated.
+  // 1. Expect GACDeviceCheckProvider to be instantiated.
 
-  id deviceCheckProviderMock = OCMClassMock([FIRDeviceCheckProvider class]);
+  id deviceCheckProviderMock = OCMClassMock([GACDeviceCheckProvider class]);
   id appValidationArg = [OCMArg checkWithBlock:^BOOL(FIRApp *app) {
     XCTAssertEqualObjects(app.name, appName);
     return YES;
@@ -126,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // 4. Cleanup
   // Recover default provider factory.
-  [GACAppCheck setAppCheckProviderFactory:[[FIRDeviceCheckProviderFactory alloc] init]];
+  [GACAppCheck setAppCheckProviderFactory:[[GACDeviceCheckProviderFactory alloc] init]];
   [deviceCheckProviderMock stopMocking];
 }
 
@@ -187,6 +195,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #endif  // !SWIFT_PACKAGE
 
+#endif  // FIREBASE_APP_CHECK_ONLY
+
 #pragma mark - Helpers
 
 - (void)configureAppWithName:(NSString *)appName {
@@ -226,6 +236,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS
 
 NS_ASSUME_NONNULL_END

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTests.m
@@ -40,7 +40,7 @@
 
 // Since DeviceCheck is the default attestation provider for AppCheck, disable
 // test cases that may be dependent on DeviceCheck being available.
-#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
 
 // The FAC token value returned when an error occurs.
 static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
@@ -1079,4 +1079,4 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 
 @end
 
-#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTimerTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTimerTests.m
@@ -31,7 +31,7 @@
   NSDate *startTime = [NSDate date];
   NSDate *fireDate = [NSDate dateWithTimeIntervalSinceNow:fireTimerIn];
 
-  FIRTimerProvider timerProvider = [GACAppCheckTimer timerProvider];
+  GACTimerProvider timerProvider = [GACAppCheckTimer timerProvider];
 
   XCTestExpectation *timerExpectation = [self expectationWithDescription:@"timer"];
   GACAppCheckTimer *timer = timerProvider(fireDate, queue, ^{

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
@@ -26,7 +26,7 @@
 
 @interface GACAppCheckTokenRefresherTests : XCTestCase
 
-@property(nonatomic) FIRFakeTimer *fakeTimer;
+@property(nonatomic) GACFakeTimer *fakeTimer;
 
 @property(nonatomic) OCMockObject<GACAppCheckSettingsProtocol> *mockSettings;
 
@@ -38,7 +38,7 @@
 
 - (void)setUp {
   self.mockSettings = OCMProtocolMock(@protocol(GACAppCheckSettingsProtocol));
-  self.fakeTimer = [[FIRFakeTimer alloc] init];
+  self.fakeTimer = [[GACFakeTimer alloc] init];
 
   NSDate *receivedAtDate = [NSDate date];
   self.initialTokenRefreshResult = [[GACAppCheckTokenRefreshResult alloc]

--- a/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -34,8 +34,8 @@
 
 typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
-@interface FIRDeviceCheckAPIServiceTests : XCTestCase
-@property(nonatomic) FIRDeviceCheckAPIService *APIService;
+@interface GACDeviceCheckAPIServiceTests : XCTestCase
+@property(nonatomic) GACDeviceCheckAPIService *APIService;
 
 @property(nonatomic) id mockAPIService;
 
@@ -44,7 +44,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
 @end
 
-@implementation FIRDeviceCheckAPIServiceTests
+@implementation GACDeviceCheckAPIServiceTests
 
 - (void)setUp {
   [super setUp];
@@ -55,7 +55,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   self.mockAPIService = OCMProtocolMock(@protocol(GACAppCheckAPIServiceProtocol));
   OCMStub([self.mockAPIService baseURL]).andReturn(@"https://test.appcheck.url.com/alpha");
 
-  self.APIService = [[FIRDeviceCheckAPIService alloc] initWithAPIService:self.mockAPIService
+  self.APIService = [[GACDeviceCheckAPIService alloc] initWithAPIService:self.mockAPIService
                                                                projectID:self.projectID
                                                                    appID:self.appID];
 }
@@ -86,7 +86,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData];
 
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
 
   NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
@@ -137,7 +137,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
   id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDeviceToken:deviceTokenData];
 
   NSData *responseBody =
-      [FIRFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
+      [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
 
   NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];

--- a/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -28,40 +28,40 @@
 
 #import "AppCheck/Tests/Utils/AppCheckBackoffWrapperFake/GACAppCheckBackoffWrapperFake.h"
 
-#if FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
 
-FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
-@interface FIRDeviceCheckProvider (Tests)
+GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
+@interface GACDeviceCheckProvider (Tests)
 
-- (instancetype)initWithAPIService:(id<FIRDeviceCheckAPIServiceProtocol>)APIService
-              deviceTokenGenerator:(id<FIRDeviceCheckTokenGenerator>)deviceTokenGenerator
+- (instancetype)initWithAPIService:(id<GACDeviceCheckAPIServiceProtocol>)APIService
+              deviceTokenGenerator:(id<GACDeviceCheckTokenGenerator>)deviceTokenGenerator
                     backoffWrapper:(id<GACAppCheckBackoffWrapperProtocol>)backoffWrapper;
 
 @end
 
-FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
-@interface FIRDeviceCheckProviderTests : XCTestCase
+GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
+@interface GACDeviceCheckProviderTests : XCTestCase
 
-@property(nonatomic) FIRDeviceCheckProvider *provider;
+@property(nonatomic) GACDeviceCheckProvider *provider;
 @property(nonatomic) id fakeAPIService;
 @property(nonatomic) id fakeTokenGenerator;
 @property(nonatomic) GACAppCheckBackoffWrapperFake *fakeBackoffWrapper;
 
 @end
 
-@implementation FIRDeviceCheckProviderTests
+@implementation GACDeviceCheckProviderTests
 
 - (void)setUp {
   [super setUp];
 
-  self.fakeAPIService = OCMProtocolMock(@protocol(FIRDeviceCheckAPIServiceProtocol));
-  self.fakeTokenGenerator = OCMProtocolMock(@protocol(FIRDeviceCheckTokenGenerator));
+  self.fakeAPIService = OCMProtocolMock(@protocol(GACDeviceCheckAPIServiceProtocol));
+  self.fakeTokenGenerator = OCMProtocolMock(@protocol(GACDeviceCheckTokenGenerator));
 
   self.fakeBackoffWrapper = [[GACAppCheckBackoffWrapperFake alloc] init];
   // Don't backoff by default.
   self.fakeBackoffWrapper.isNextOperationAllowed = YES;
 
-  self.provider = [[FIRDeviceCheckProvider alloc] initWithAPIService:self.fakeAPIService
+  self.provider = [[GACDeviceCheckProvider alloc] initWithAPIService:self.fakeAPIService
                                                 deviceTokenGenerator:self.fakeTokenGenerator
                                                       backoffWrapper:self.fakeBackoffWrapper];
 }
@@ -79,7 +79,7 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
   options.projectID = @"project_id";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
-  XCTAssertNotNil([[FIRDeviceCheckProvider alloc] initWithApp:app]);
+  XCTAssertNotNil([[GACDeviceCheckProvider alloc] initWithApp:app]);
 }
 
 - (void)testInitWithIncompleteApp {
@@ -88,13 +88,13 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
   options.projectID = @"project_id";
   FIRApp *missingAPIKeyApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
                                                           options:options];
-  XCTAssertNil([[FIRDeviceCheckProvider alloc] initWithApp:missingAPIKeyApp]);
+  XCTAssertNil([[GACDeviceCheckProvider alloc] initWithApp:missingAPIKeyApp]);
 
   options.projectID = nil;
   options.APIKey = @"api_key";
   FIRApp *missingProjectIDApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
                                                              options:options];
-  XCTAssertNil([[FIRDeviceCheckProvider alloc] initWithApp:missingProjectIDApp]);
+  XCTAssertNil([[GACDeviceCheckProvider alloc] initWithApp:missingProjectIDApp]);
 }
 
 - (void)testGetTokenSuccess {
@@ -142,7 +142,7 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetTokenWhenDeviceTokenFails {
-  NSError *deviceTokenError = [NSError errorWithDomain:@"FIRDeviceCheckProviderTests"
+  NSError *deviceTokenError = [NSError errorWithDomain:@"GACDeviceCheckProviderTests"
                                                   code:-1
                                               userInfo:nil];
 
@@ -189,7 +189,7 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 }
 
 - (void)testGetTokenWhenAPIServiceFails {
-  NSError *APIServiceError = [NSError errorWithDomain:@"FIRDeviceCheckProviderTests"
+  NSError *APIServiceError = [NSError errorWithDomain:@"GACDeviceCheckProviderTests"
                                                  code:-1
                                              userInfo:nil];
 
@@ -271,4 +271,4 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
 
 @end
 
-#endif  // FIR_DEVICE_CHECK_SUPPORTED_TARGETS
+#endif  // GAC_DEVICE_CHECK_SUPPORTED_TARGETS

--- a/AppCheck/Tests/Unit/Utils/GACFakeTimer.h
+++ b/AppCheck/Tests/Unit/Utils/GACFakeTimer.h
@@ -20,15 +20,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^FIRFakeTimerCreateHandler)(NSDate *fireDate);
+typedef void (^GACFakeTimerCreateHandler)(NSDate *fireDate);
 
-@interface FIRFakeTimer : NSObject <GACAppCheckTimerProtocol>
+@interface GACFakeTimer : NSObject <GACAppCheckTimerProtocol>
 
-- (FIRTimerProvider)fakeTimerProvider;
+- (GACTimerProvider)fakeTimerProvider;
 
 /// `createHandler` is called each time the timer provider returned by `fakeTimerProvider` is asked
 /// to create a timer.
-@property(nonatomic, copy, nullable) FIRFakeTimerCreateHandler createHandler;
+@property(nonatomic, copy, nullable) GACFakeTimerCreateHandler createHandler;
 
 @property(nonatomic, copy, nullable) dispatch_block_t invalidationHandler;
 

--- a/AppCheck/Tests/Unit/Utils/GACFakeTimer.m
+++ b/AppCheck/Tests/Unit/Utils/GACFakeTimer.m
@@ -16,9 +16,9 @@
 
 #import "AppCheck/Tests/Unit/Utils/GACFakeTimer.h"
 
-@implementation FIRFakeTimer
+@implementation GACFakeTimer
 
-- (FIRTimerProvider)fakeTimerProvider {
+- (GACTimerProvider)fakeTimerProvider {
   return ^id<GACAppCheckTimerProtocol> _Nullable(NSDate *fireDate, dispatch_queue_t queue,
                                                  dispatch_block_t handler) {
     self.handler = handler;

--- a/AppCheck/Tests/Unit/Utils/GACFixtureLoader.h
+++ b/AppCheck/Tests/Unit/Utils/GACFixtureLoader.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FIRFixtureLoader : NSObject
+@interface GACFixtureLoader : NSObject
 
 + (NSData *)loadFixtureNamed:(NSString *)fileName;
 

--- a/AppCheck/Tests/Unit/Utils/GACFixtureLoader.m
+++ b/AppCheck/Tests/Unit/Utils/GACFixtureLoader.m
@@ -14,7 +14,7 @@
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
 
-@implementation FIRFixtureLoader
+@implementation GACFixtureLoader
 
 + (NSData *)loadFixtureNamed:(NSString *)fileName {
   NSURL *fileURL;


### PR DESCRIPTION
- Renamed `FIR`-prefixed symbols to `GAC` in unit tests for the generic (non-Firebase-specific) App Check SDK.
- Removed `SharedTestUtilities/AppCheck*` directories from the `unit_tests` spec sources (imports already changed to `AppCheck/Tests/Utils/AppCheck*`).

#no-changelog