### PR TITLE
Replace GACAppCheckLogger macros with NSLog wrappers

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -221,8 +221,8 @@ NS_ASSUME_NONNULL_BEGIN
   return [self attestationState].thenOn(self.queue, ^id(GACAppAttestProviderState *attestState) {
     switch (attestState.state) {
       case GACAppAttestAttestationStateUnsupported:
-        GACAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeAppAttestNotSupported,
-                            @"App Attest is not supported.");
+        GACLogDebug(kFIRLoggerAppCheckMessageCodeAppAttestNotSupported,
+                    @"App Attest is not supported.");
         return attestState.appAttestUnsupportedError;
         break;
 
@@ -341,9 +341,9 @@ NS_ASSUME_NONNULL_BEGIN
         GACAppCheckHTTPError *HTTPError = (GACAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[GACAppCheckHTTPError class]] &&
             HTTPError.HTTPResponse.statusCode == 403) {
-          GACAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeAttestationRejected,
-                              @"App Attest attestation was rejected by backend. The existing "
-                              @"attestation will be reset.");
+          GACLogDebug(kFIRLoggerAppCheckMessageCodeAttestationRejected,
+                      @"App Attest attestation was rejected by backend. The existing "
+                      @"attestation will be reset.");
           // Reset the attestation.
           return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
             // Throw the rejection error.

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -143,10 +143,9 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
   NSInteger statusCode = response.HTTPResponse.statusCode;
   return [FBLPromise do:^id _Nullable {
     if (statusCode < 200 || statusCode >= 300) {
-      GACAppCheckDebugLog(kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode,
-                          @"Unexpected API response: %@, body: %@.", response.HTTPResponse,
-                          [[NSString alloc] initWithData:response.HTTPBody
-                                                encoding:NSUTF8StringEncoding]);
+      GACLogDebug(kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode,
+                  @"Unexpected API response: %@, body: %@.", response.HTTPResponse,
+                  [[NSString alloc] initWithData:response.HTTPBody encoding:NSUTF8StringEncoding]);
       return [GACAppCheckErrorUtil APIErrorWithHTTPResponse:response.HTTPResponse
                                                        data:response.HTTPBody];
     }

--- a/AppCheck/Sources/Core/GACAppCheck.m
+++ b/AppCheck/Sources/Core/GACAppCheck.m
@@ -39,6 +39,8 @@
 #import "AppCheck/Interop/GACAppCheckInterop.h"
 #import "AppCheck/Interop/GACAppCheckTokenResultInterop.h"
 
+#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// A notification with the specified name is sent to the default notification center
@@ -91,7 +93,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   id<GACAppCheckProviderFactory> providerFactory = [GACAppCheck providerFactory];
 
   if (providerFactory == nil) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeProviderFactoryIsMissing,
+    GACLogError(kFIRLoggerAppCheckMessageCodeProviderFactoryIsMissing,
                 @"Cannot instantiate `GACAppCheck` for app: %@ without a provider factory. "
                 @"Please register a provider factory using "
                 @"`AppCheck.setAppCheckProviderFactory(_ ,forAppName:)` method.",
@@ -101,7 +103,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
   id<GACAppCheckProvider> appCheckProvider = [providerFactory createProviderWithApp:app];
   if (appCheckProvider == nil) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeProviderIsMissing,
+    GACLogError(kFIRLoggerAppCheckMessageCodeProviderIsMissing,
                 @"Cannot instantiate `GACAppCheck` for app: %@ without an app check provider. "
                 @"Please make sure the provider factory returns a valid app check provider.",
                 app.name);

--- a/AppCheck/Sources/Core/GACAppCheckLogger.h
+++ b/AppCheck/Sources/Core/GACAppCheckLogger.h
@@ -16,9 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
-extern FIRLoggerService kFIRLoggerAppCheck;
+NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnknown;
 
@@ -43,4 +41,15 @@ FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIn
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported;
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected;
 
-void GACAppCheckDebugLog(NSString *messageCode, NSString *message, ...);
+#define GAC_LOGGING_FUNCTION(level) \
+  void GACLog##level(NSString *messageCode, NSString *format, ...);
+
+GAC_LOGGING_FUNCTION(Error)
+GAC_LOGGING_FUNCTION(Warning)
+GAC_LOGGING_FUNCTION(Notice)
+GAC_LOGGING_FUNCTION(Info)
+GAC_LOGGING_FUNCTION(Debug)
+
+#undef GAC_LOGGING_FUNCTION
+
+NS_ASSUME_NONNULL_END

--- a/AppCheck/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheck/Sources/Core/GACAppCheckLogger.m
@@ -20,7 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FIRLoggerService kFIRLoggerAppCheck = @"[FirebaseAppCheck]";
+#pragma mark - Log Message Codes
 
 NSString *const kFIRLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
 
@@ -45,12 +45,32 @@ NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions
 NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported = @"I-FAA007001";
 NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected = @"I-FAA007002";
 
-#pragma mark - Log functions
-void GACAppCheckDebugLog(NSString *messageCode, NSString *message, ...) {
-  va_list args_ptr;
-  va_start(args_ptr, message);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, messageCode, message, args_ptr);
-  va_end(args_ptr);
-}
+#pragma mark - Logging Functions
+
+/**
+ * Generates the logging functions using macros.
+ *
+ * Calling GACLogError(@"Firebase", @"I-GAC000001", @"Configure %@ failed.", @"blah") shows:
+ * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Error> [Firebase/AppCheck][I-GAC000001] Configure blah
+ * failed. Calling GACLogDebug(@"GoogleSignIn", @"I-GAC000002", @"Configure succeed.") shows:
+ * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [GoogleSignIn/AppCheck][I-COR000002] Configure
+ * succeed.
+ */
+#define GAC_LOGGING_FUNCTION(level)                                                  \
+  void GACLog##level(NSString *messageCode, NSString *format, ...) {                 \
+    va_list args_ptr;                                                                \
+    va_start(args_ptr, format);                                                      \
+    NSString *message = [[NSString alloc] initWithFormat:format arguments:args_ptr]; \
+    va_end(args_ptr);                                                                \
+    NSLog(@"<" #level "> [AppCheck][%@] %@", messageCode, message);                  \
+  }
+
+GAC_LOGGING_FUNCTION(Error)
+GAC_LOGGING_FUNCTION(Warning)
+GAC_LOGGING_FUNCTION(Notice)
+GAC_LOGGING_FUNCTION(Info)
+GAC_LOGGING_FUNCTION(Debug)
+
+#undef GAC_LOGGING_FUNCTION
 
 NS_ASSUME_NONNULL_END

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -53,7 +53,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   NSArray<NSString *> *missingOptionsFields =
       [GACAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions,
+    FIRLogError(kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions,
                 @"Cannot instantiate `GACAppCheckDebugProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);
@@ -119,8 +119,8 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
         return nil;
       })
       .catch(^void(NSError *error) {
-        GACAppCheckDebugLog(kFIRLoggerAppCheckMessageDebugProviderFailedExchange,
-                            @"Failed to exchange debug token to app check token: %@", error);
+        GACLogDebug(kFIRLoggerAppCheckMessageDebugProviderFailedExchange,
+                    @"Failed to exchange debug token to app check token: %@", error);
         handler(nil, error);
       });
 }

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProviderFactory.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProviderFactory.m
@@ -27,8 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
   GACAppCheckDebugProvider *provider = [[GACAppCheckDebugProvider alloc] initWithApp:app];
 
   // Print only locally generated token to avoid a valid token leak on CI.
-  FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
-                @"Firebase App Check debug token: '%@'.", [provider localDebugToken]);
+  GACLogWarning(kFIRLoggerAppCheckMessageCodeDebugToken, @"Firebase App Check debug token: '%@'.",
+                [provider localDebugToken]);
 
   return provider;
 }

--- a/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -77,8 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<NSString *> *missingOptionsFields =
       [GACAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheck,
-                kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions,
+    GACLogError(kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions,
                 @"Cannot instantiate `GACDeviceCheckProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);


### PR DESCRIPTION
Added logging macros as drop-in replacements for the `GAC`/`FIRAppCheckLogger` macros. These are simple wrappers around `NSLog` and are not compiled out based on the desired logging level.

#no-changelog