### PR TITLE
Remove Firebase-specific implementation in GACAppCheckStorage

### DIFF
--- a/AppCheck/Sources/Core/GACAppCheck.m
+++ b/AppCheck/Sources/Core/GACAppCheck.m
@@ -121,9 +121,13 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   GACAppCheckTokenRefresher *tokenRefresher =
       [[GACAppCheckTokenRefresher alloc] initWithRefreshResult:refreshResult settings:settings];
 
-  GACAppCheckStorage *storage = [[GACAppCheckStorage alloc] initWithAppName:app.name
-                                                                      appID:app.options.googleAppID
-                                                                accessGroup:app.options.appGroupID];
+  // TODO(andrewheard): Remove from generic App Check SDK.
+  // FIREBASE_APP_CHECK_ONLY_BEGIN
+  NSString *tokenKey =
+      [NSString stringWithFormat:@"app_check_token.%@.%@", app.name, app.options.googleAppID];
+  // FIREBASE_APP_CHECK_ONLY_END
+  GACAppCheckStorage *storage =
+      [[GACAppCheckStorage alloc] initWithTokenKey:tokenKey accessGroup:app.options.appGroupID];
 
   return [self initWithAppName:app.name
               appCheckProvider:appCheckProvider

--- a/AppCheck/Sources/Core/Storage/GACAppCheckStorage.h
+++ b/AppCheck/Sources/Core/Storage/GACAppCheckStorage.h
@@ -45,28 +45,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Default convenience initializer.
- *  @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
- * the key to store the token for the storage instance.
- *  @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
- * as a part of the key to store the token for the storage instance.
+ *  @param tokenKey The key to store the token for the storage instance.
  *  @param accessGroup The Keychain Access Group.
  */
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                    accessGroup:(nullable NSString *)accessGroup;
+- (instancetype)initWithTokenKey:(NSString *)tokenKey accessGroup:(nullable NSString *)accessGroup;
 
 /** Designated initializer.
- *  @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
- * the key to store the token for the storage instance.
- *  @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
- * as a part of the key to store the token for the storage instance.
+ *  @param tokenKey The key to store the token for the storage instance.
  *  @param keychainStorage An instance of `GULKeychainStorage` used as an underlying secure storage.
  *  @param accessGroup The Keychain Access Group.
  */
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                keychainStorage:(GULKeychainStorage *)keychainStorage
-                    accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTokenKey:(NSString *)tokenKey
+                 keychainStorage:(GULKeychainStorage *)keychainStorage
+                     accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/AppCheck/Sources/Core/Storage/GACAppCheckStorage.m
+++ b/AppCheck/Sources/Core/Storage/GACAppCheckStorage.m
@@ -33,8 +33,7 @@ static NSString *const kKeychainService = @"com.firebase.app_check.token_storage
 
 @interface GACAppCheckStorage ()
 
-@property(nonatomic, readonly) NSString *appName;
-@property(nonatomic, readonly) NSString *appID;
+@property(nonatomic, readonly) NSString *tokenKey;
 @property(nonatomic, readonly) GULKeychainStorage *keychainStorage;
 @property(nonatomic, readonly, nullable) NSString *accessGroup;
 
@@ -42,29 +41,22 @@ static NSString *const kKeychainService = @"com.firebase.app_check.token_storage
 
 @implementation GACAppCheckStorage
 
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                keychainStorage:(GULKeychainStorage *)keychainStorage
-                    accessGroup:(nullable NSString *)accessGroup {
+- (instancetype)initWithTokenKey:(NSString *)tokenKey
+                 keychainStorage:(GULKeychainStorage *)keychainStorage
+                     accessGroup:(nullable NSString *)accessGroup {
   self = [super init];
   if (self) {
-    _appName = [appName copy];
-    _appID = [appID copy];
+    _tokenKey = [tokenKey copy];
     _keychainStorage = keychainStorage;
     _accessGroup = [accessGroup copy];
   }
   return self;
 }
 
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                    accessGroup:(nullable NSString *)accessGroup {
+- (instancetype)initWithTokenKey:(NSString *)tokenKey accessGroup:(nullable NSString *)accessGroup {
   GULKeychainStorage *keychainStorage =
       [[GULKeychainStorage alloc] initWithService:kKeychainService];
-  return [self initWithAppName:appName
-                         appID:appID
-               keychainStorage:keychainStorage
-                   accessGroup:accessGroup];
+  return [self initWithTokenKey:tokenKey keychainStorage:keychainStorage accessGroup:accessGroup];
 }
 
 - (FBLPromise<GACAppCheckToken *> *)getToken {
@@ -110,14 +102,6 @@ static NSString *const kKeychainService = @"com.firebase.app_check.token_storage
       .then(^id _Nullable(NSNull *_Nullable value) {
         return token;
       });
-}
-
-- (NSString *)tokenKey {
-  return [[self class] tokenKeyForAppName:self.appName appID:self.appID];
-}
-
-+ (NSString *)tokenKeyForAppName:(NSString *)appName appID:(NSString *)appID {
-  return [NSString stringWithFormat:@"app_check_token.%@.%@", appName, appID];
 }
 
 @end

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -53,7 +53,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   NSArray<NSString *> *missingOptionsFields =
       [GACAppCheckValidator tokenExchangeMissingFieldsInOptions:app.options];
   if (missingOptionsFields.count > 0) {
-    FIRLogError(kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions,
+    GACLogError(kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions,
                 @"Cannot instantiate `GACAppCheckDebugProvider` for app: %@. The following "
                 @"`FirebaseOptions` fields are missing: %@",
                 app.name, [missingOptionsFields componentsJoinedByString:@", "]);

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTests.m
@@ -107,6 +107,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
 - (void)testInitWithApp {
   NSString *googleAppID = @"testInitWithApp_googleAppID";
   NSString *appName = @"testInitWithApp_appName";
+  NSString *tokenKey = [NSString stringWithFormat:@"app_check_token.%@.%@", appName, googleAppID];
   NSString *appGroupID = @"testInitWithApp_appGroupID";
 
   // 1. Stub FIRApp and validate usage.
@@ -142,8 +143,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   // 3. Stub GACAppCheckStorage and validate usage.
   id mockStorage = OCMClassMock([GACAppCheckStorage class]);
   OCMExpect([mockStorage alloc]).andReturn(mockStorage);
-  OCMExpect([mockStorage initWithAppName:appName appID:googleAppID accessGroup:appGroupID])
-      .andReturn(mockStorage);
+  OCMExpect([mockStorage initWithTokenKey:tokenKey accessGroup:appGroupID]).andReturn(mockStorage);
 
   // 4. Stub attestation provider.
   OCMockObject<GACAppCheckProviderFactory> *mockProviderFactory =


### PR DESCRIPTION
Removed Firebase-specific implementation details (Google App ID and Firebase App Name) from `GACAppCheckStorage`.

#no-changelog