### PR TITLE
Create API Diff Report only when the first commit in PR has an API change

### DIFF
--- a/scripts/api_diff_report/pr_commenter.py
+++ b/scripts/api_diff_report/pr_commenter.py
@@ -62,7 +62,7 @@ def main():
                                     api_diff_report.API_DIFF_FILE_NAME)
     with open(diff_report_file, 'r') as file:
       report_content = file.read()
-    if report_content: # Diff detected
+    if report_content:  # Diff detected
       report = COMMENT_HIDDEN_IDENTIFIER + generate_markdown_title(
           TITLE_END_DIFF, commit, run_id) + report_content
       if comment_id:
@@ -70,7 +70,7 @@ def main():
       else:
         add_comment(token, pr_number, report)
       add_label(token, pr_number, PR_LABEL)
-    else: # No diff
+    else:  # No diff
       if comment_id:
         report = COMMENT_HIDDEN_IDENTIFIER + generate_markdown_title(
             TITLE_END_NO_DIFF, commit, run_id)

--- a/scripts/api_diff_report/pr_commenter.py
+++ b/scripts/api_diff_report/pr_commenter.py
@@ -50,30 +50,32 @@ def main():
   run_id = args.run_id
 
   report = ""
+  comment_id = get_comment_id(token, pr_number, COMMENT_HIDDEN_IDENTIFIER)
   if stage == STAGES_PROGRESS:
-    report = COMMENT_HIDDEN_IDENTIFIER
-    report += generate_markdown_title(TITLE_PROGESS, commit, run_id)
-    delete_label(token, pr_number, PR_LABEL)
+    if comment_id:
+      report = COMMENT_HIDDEN_IDENTIFIER
+      report += generate_markdown_title(TITLE_PROGESS, commit, run_id)
+      update_comment(token, comment_id, report)
+      delete_label(token, pr_number, PR_LABEL)
   elif stage == STAGES_END:
     diff_report_file = os.path.join(os.path.expanduser(args.report),
                                     api_diff_report.API_DIFF_FILE_NAME)
     with open(diff_report_file, 'r') as file:
       report_content = file.read()
-    if report_content:
+    if report_content: # Diff detected
       report = COMMENT_HIDDEN_IDENTIFIER + generate_markdown_title(
           TITLE_END_DIFF, commit, run_id) + report_content
+      if comment_id:
+        update_comment(token, comment_id, report)
+      else:
+        add_comment(token, pr_number, report)
       add_label(token, pr_number, PR_LABEL)
-    else:
-      report = COMMENT_HIDDEN_IDENTIFIER + generate_markdown_title(
-          TITLE_END_NO_DIFF, commit, run_id)
-      delete_label(token, pr_number, PR_LABEL)
-
-  if report:
-    comment_id = get_comment_id(token, pr_number, COMMENT_HIDDEN_IDENTIFIER)
-    if not comment_id:
-      add_comment(token, pr_number, report)
-    else:
-      update_comment(token, comment_id, report)
+    else: # No diff
+      if comment_id:
+        report = COMMENT_HIDDEN_IDENTIFIER + generate_markdown_title(
+            TITLE_END_NO_DIFF, commit, run_id)
+        update_comment(token, comment_id, report)
+        delete_label(token, pr_number, PR_LABEL)
 
 
 def generate_markdown_title(title, commit, run_id):


### PR DESCRIPTION
Won't create Diff Report until the first commit has an API change.
If the API change got reverted in the following commit, the Diff Report will update with title "No API diff detected".