### PR TITLE
Extract heartbeat logger from GACAppCheckAPIService

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -44,6 +44,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+static NSString *const kHeartbeatKey = @"X-firebase-client";
+// FIREBASE_APP_CHECK_ONLY_END
+
 /// A data object that contains all key attest data required for FAC token exchange.
 @interface GACAppAttestKeyAttestationResult : NSObject
 
@@ -143,11 +148,17 @@ NS_ASSUME_NONNULL_BEGIN
   GACAppAttestKeyIDStorage *keyIDStorage =
       [[GACAppAttestKeyIDStorage alloc] initWithAppName:app.name appID:app.options.googleAppID];
 
+  GACAppCheckAPIRequestHook heartbeatLoggerHook = ^(NSMutableURLRequest *request) {
+    [request setValue:FIRHeaderValueFromHeartbeatsPayload(
+                          [app.heartbeatLogger flushHeartbeatsIntoPayload])
+        forHTTPHeaderField:kHeartbeatKey];
+  };
+
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
                                                   appID:app.options.googleAppID
-                                        heartbeatLogger:app.heartbeatLogger];
+                                           requestHooks:@[ heartbeatLoggerHook ]];
 
   GACAppAttestAPIService *appAttestAPIService =
       [[GACAppAttestAPIService alloc] initWithAPIService:APIService

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
@@ -20,9 +20,9 @@
 @class GULURLSessionDataResponse;
 @class GACAppCheckToken;
 
-@protocol FIRHeartbeatLoggerProtocol;
-
 NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
 
 @protocol GACAppCheckAPIServiceProtocol <NSObject>
 
@@ -46,12 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @param session The URL session used to make network requests.
  * @param APIKey The Firebase project API key (see `FIROptions.APIKey`).
  * @param appID The Firebase app ID (see `FIROptions.googleAppID`).
- * @param heartbeatLogger The heartbeat logger used to populate heartbeat data in request headers.
+ * @param requestHooks Hooks that will be invoked on requests through this service.
  */
 - (instancetype)initWithURLSession:(NSURLSession *)session
                             APIKey:(NSString *)APIKey
                              appID:(NSString *)appID
-                   heartbeatLogger:(id<FIRHeartbeatLoggerProtocol>)heartbeatLogger;
+                      requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -32,6 +32,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+static NSString *const kHeartbeatKey = @"X-firebase-client";
+// FIREBASE_APP_CHECK_ONLY_END
+
 static NSString *const kDebugTokenEnvKey = @"FIRAAppCheckDebugToken";
 static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
@@ -63,11 +68,17 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 
+  GACAppCheckAPIRequestHook heartbeatLoggerHook = ^(NSMutableURLRequest *request) {
+    [request setValue:FIRHeaderValueFromHeartbeatsPayload(
+                          [app.heartbeatLogger flushHeartbeatsIntoPayload])
+        forHTTPHeaderField:kHeartbeatKey];
+  };
+
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
                                                   appID:app.options.googleAppID
-                                        heartbeatLogger:app.heartbeatLogger];
+                                           requestHooks:@[ heartbeatLoggerHook ]];
 
   GACAppCheckDebugProviderAPIService *debugAPIService =
       [[GACAppCheckDebugProviderAPIService alloc] initWithAPIService:APIService

--- a/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -40,6 +40,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+static NSString *const kHeartbeatKey = @"X-firebase-client";
+// FIREBASE_APP_CHECK_ONLY_END
+
 @interface GACDeviceCheckProvider ()
 @property(nonatomic, readonly) id<GACDeviceCheckAPIServiceProtocol> APIService;
 @property(nonatomic, readonly) id<GACDeviceCheckTokenGenerator> deviceTokenGenerator;
@@ -87,11 +92,17 @@ NS_ASSUME_NONNULL_BEGIN
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 
+  GACAppCheckAPIRequestHook heartbeatLoggerHook = ^(NSMutableURLRequest *request) {
+    [request setValue:FIRHeaderValueFromHeartbeatsPayload(
+                          [app.heartbeatLogger flushHeartbeatsIntoPayload])
+        forHTTPHeaderField:kHeartbeatKey];
+  };
+
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
                                                   appID:app.options.googleAppID
-                                        heartbeatLogger:app.heartbeatLogger];
+                                           requestHooks:@[ heartbeatLoggerHook ]];
 
   GACDeviceCheckAPIService *deviceCheckAPIService =
       [[GACDeviceCheckAPIService alloc] initWithAPIService:APIService


### PR DESCRIPTION
Removed the direct dependency on `FIRHeartbeatLoggerProtocol` from `GACAppCheckAPIService`, moving it up into the App Check providers.

Added request hooks (blocks) to allow heartbeat logging headers to be added to requests before they are sent.

#no-changelog