### PR TITLE
[auth-swift] CocoaPods Swift-only sources

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -40,10 +40,8 @@ supports email and password accounts, as well as several 3rd party authenticatio
 
   source = 'FirebaseAuth/Sources/'
   s.source_files = [
-    'FirebaseAuth/Sources/Swift/**/*.swift',
-    source + '**/*.[mh]',
-    'FirebaseAuth/Interop/*.h',
-    'FirebaseAppCheck/Interop/*.h',
+    source + 'Swift/**/*.swift',
+    source + 'Public/FirebaseAuth/*.h'
   ]
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
 
@@ -67,6 +65,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
+  s.dependency 'FirebaseAuthInterop', '~> 10.9'
   s.dependency 'FirebaseAppCheckInterop', '~> 10.0'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -26,10 +26,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
 
   s.swift_version = '5.3'
 
-  s.prepare_command = <<-CMD
-    ruby scripts/build_private_module_map.rb FirebaseAuth.podspec
-  CMD
-
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -45,12 +45,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
   ]
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
 
-  # All headers except the ones in the `Public` should be private.
-  s.private_header_files = Dir['FirebaseAuth/Sources/**/*.h']
-    .reject{ |f| f['FirebaseAuth/Sources/Public/'] } + [
-      'FirebaseAuth/Interop/*.h'
-    ]
-
   s.preserve_paths = [
     'FirebaseAuth/README.md',
     'FirebaseAuth/CHANGELOG.md'
@@ -59,9 +53,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     # The second path is to find FirebaseAuth-Swift.h from a pod gen project
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}" "${OBJECT_FILE_DIR_normal}/${NATIVE_ARCH_ACTUAL}"',
-    # Point to the private module map.
-    'MODULEMAP_PRIVATE_FILE' =>
-        '${PODS_TARGET_SRCROOT}/FirebaseAuth/Sources/FirebaseAuth.private.modulemap'
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -15,12 +15,6 @@
 import Foundation
 import FirebaseCore
 
-// When building for CocoaPods, non-public headers are exposed to Swift via a
-// private module map.
-#if COCOAPODS
-  @_implementationOnly import FirebaseAuth_Private
-#endif // COCOAPODS
-
 /**
  @brief A concrete implementation of `AuthProvider` for phone auth providers.
      This class is available on iOS only.

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -16,10 +16,6 @@ import Foundation
 import XCTest
 
 @testable import FirebaseAuth
-// TODO(ncooke3): Remove below import after `FIRAuth.[hm]` has been ported.
-// Note– This will break building with SPM. There is a way to achieve the same
-// thing with SPM mixed targets–– I'm just going to port `FIRAuth` next.
-import FirebaseAuth_Private
 
 import FirebaseCore
 


### PR DESCRIPTION
- No more Objective C `.m` files. 
- Public headers are kept around for typedef and global constant backwards compatibility
- Depend on Interop pods instead of headers in the repo

#no-changelog