### PR TITLE
Progress closure for async/await APIs

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [added] Add progress tracking capability for `putDataAsync`, `putFileAsync`, and
+  `writeAsync`. (#10574)
+
 # 10.10.0
 - [fixed] Fixed potential memory leak of Storage instances. (#11248)
 

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -44,7 +44,7 @@ import Foundation
     ///   - uploadData: The Data to upload.
     ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
     ///              about the object being uploaded.
-    ///   - onProgress: An optional callback function to return a `Progress` instance while the upload proceeds.
+    ///   - onProgress: An optional closure function to return a `Progress` instance while the upload proceeds.
     /// - Throws:
     ///   - An error if the operation failed, for example if Storage was unreachable.
     /// - Returns: StorageMetadata with additional information about the object being uploaded.
@@ -82,7 +82,7 @@ import Foundation
     ///   - url: A URL representing the system file path of the object to be uploaded.
     ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
     ///              about the object being uploaded.
-    ///   - onProgress: An optional callback function to return a `Progress` instance while the upload proceeds.
+    ///   - onProgress: An optional closure function to return a `Progress` instance while the upload proceeds.
     /// - Throws:
     ///   - An error if the operation failed, for example if no file was present at the specified `url`.
     /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
@@ -117,7 +117,7 @@ import Foundation
     ///
     /// - Parameters:
     ///   - fileUrl: A URL representing the system file path of the object to be uploaded.
-    ///   - onProgress: An optional callback function to return a `Progress` instance while the download proceeds.
+    ///   - onProgress: An optional closure function to return a `Progress` instance while the download proceeds.
     /// - Throws:
     ///   - An error if the operation failed, for example if Storage was unreachable
     ///   or `fileURL` did not reference a valid path on disk.

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -48,7 +48,6 @@ import Foundation
     /// - Throws:
     ///   - An error if the operation failed, for example if Storage was unreachable.
     /// - Returns: StorageMetadata with additional information about the object being uploaded.
-    @discardableResult
     func putDataAsync(_ uploadData: Data,
                       metadata: StorageMetadata? = nil,
                       onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
@@ -86,7 +85,6 @@ import Foundation
     /// - Throws:
     ///   - An error if the operation failed, for example if no file was present at the specified `url`.
     /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
-    @discardableResult
     func putFileAsync(from url: URL,
                       metadata: StorageMetadata? = nil,
                       onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
@@ -122,7 +120,6 @@ import Foundation
     ///   - An error if the operation failed, for example if Storage was unreachable
     ///   or `fileURL` did not reference a valid path on disk.
     /// - Returns: A `URL` pointing to the file path of the downloaded file.
-    @discardableResult
     func writeAsync(toFile fileURL: URL,
                     onProgress: ((Progress?) -> Void)? = nil) async throws -> URL {
       guard let onProgress else {

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -63,14 +63,32 @@ import Foundation
     ///   - url: A URL representing the system file path of the object to be uploaded.
     ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
     ///              about the object being uploaded.
+    ///   - onProgress: An optional callback function to return a `Progress` while the upload proceeds.
     /// - Throws:
     ///   - An error if the operation failed, for example if no file was present at the specified `url`.
     /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
     func putFileAsync(from url: URL,
-                      metadata: StorageMetadata? = nil) async throws -> StorageMetadata {
+                      metadata: StorageMetadata? = nil,
+                      onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
+      guard let onProgress else {
+        return try await withCheckedThrowingContinuation { continuation in
+          self.putFile(from: url, metadata: metadata) { result in
+            continuation.resume(with: result)
+          }
+        }
+      }
+      let downloadTask = putFile(from: url, metadata: metadata)
       return try await withCheckedThrowingContinuation { continuation in
-        _ = self.putFile(from: url, metadata: metadata) { result in
-          continuation.resume(with: result)
+        downloadTask.observe(.progress) {
+          onProgress($0.progress)
+        }
+        downloadTask.observe(.success) { _ in
+          continuation.resume(with: .success(downloadTask.metadata!))
+        }
+        downloadTask.observe(.failure) { snapshot in
+          continuation.resume(with: .failure(
+            snapshot.error ?? StorageError.internalError("Internal Storage Error in putFileAsync")
+          ))
         }
       }
     }
@@ -79,14 +97,33 @@ import Foundation
     ///
     /// - Parameters:
     ///   - fileUrl: A URL representing the system file path of the object to be uploaded.
+    ///   - onProgress: An optional callback function to return a `Progress` while the upload proceeds.
     /// - Throws:
     ///   - An error if the operation failed, for example if Storage was unreachable
     ///   or `fileURL` did not reference a valid path on disk.
     /// - Returns: A `URL` pointing to the file path of the downloaded file.
-    func writeAsync(toFile fileURL: URL) async throws -> URL {
+    @discardableResult
+    func writeAsync(toFile fileURL: URL,
+                    onProgress: ((Progress?) -> Void)? = nil) async throws -> URL {
+      guard let onProgress else {
+        return try await withCheckedThrowingContinuation { continuation in
+          _ = self.write(toFile: fileURL) { result in
+            continuation.resume(with: result)
+          }
+        }
+      }
+      let downloadTask = write(toFile: fileURL)
       return try await withCheckedThrowingContinuation { continuation in
-        _ = self.write(toFile: fileURL) { result in
-          continuation.resume(with: result)
+        downloadTask.observe(.progress) {
+          onProgress($0.progress)
+        }
+        downloadTask.observe(.success) { _ in
+          continuation.resume(with: .success(fileURL))
+        }
+        downloadTask.observe(.failure) { snapshot in
+          continuation.resume(with: .failure(
+            snapshot.error ?? StorageError.internalError("Internal Storage Error in writeAsync")
+          ))
         }
       }
     }

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -48,6 +48,7 @@ import Foundation
     /// - Throws:
     ///   - An error if the operation failed, for example if Storage was unreachable.
     /// - Returns: StorageMetadata with additional information about the object being uploaded.
+    @discardableResult
     func putDataAsync(_ uploadData: Data,
                       metadata: StorageMetadata? = nil,
                       onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
@@ -85,6 +86,7 @@ import Foundation
     /// - Throws:
     ///   - An error if the operation failed, for example if no file was present at the specified `url`.
     /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
+    @discardableResult
     func putFileAsync(from url: URL,
                       metadata: StorageMetadata? = nil,
                       onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -270,7 +270,7 @@ import XCTest
       let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
       Task {
-        try await ref.putDataAsync(data)
+        _ = try await ref.putDataAsync(data)
         let task = ref.write(toFile: fileURL)
 
         task.observe(StorageTaskStatus.success) { snapshot in

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -270,7 +270,7 @@ import XCTest
       let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
       Task {
-        _ = try await ref.putDataAsync(data)
+        try await ref.putDataAsync(data)
         let task = ref.write(toFile: fileURL)
 
         task.observe(StorageTaskStatus.success) { snapshot in
@@ -286,7 +286,7 @@ import XCTest
 
         task.observe(StorageTaskStatus.progress) { snapshot in
           XCTAssertNil(snapshot.error, "Error should be nil")
-          guard let _ = snapshot.progress else {
+          guard snapshot.progress != nil else {
             XCTFail("Missing progress")
             return
           }


### PR DESCRIPTION
Fix #10574 

- Add an optional `onProgress` parameter to `putDataAsync`, `putFileAsync`, and `writeAsync`. 

Googlers, see API review at [go/firebase-storage-async-progress](http://goto.google.com/firebase-storage-async-progress)