### PR TITLE
Extract Firebase-specific identifiers from GACAppAttestAPIService

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
+++ b/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.h
@@ -29,14 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// Request a random challenge from server.
 - (FBLPromise<NSData *> *)getRandomChallenge;
 
-/// Sends attestation data to Firebase backend for validation.
+/// Sends attestation data to the App Check backend for validation.
 /// @param attestation The App Attest key attestation data obtained from the method
 /// `-[DCAppAttestService attestKey:clientDataHash:completionHandler:]` using the random challenge
-/// received from Firebase backend.
+/// received from App Check backend.
 /// @param keyID The key ID used to generate the attestation.
 /// @param challenge The challenge used to generate the attestation.
 /// @return A promise that is fulfilled with a response object with an encrypted attestation
-/// artifact and an Firebase App Check token or rejected with an error.
+/// artifact and an App Check token or rejected with an error.
 - (FBLPromise<GACAppAttestAttestationResponse *> *)attestKeyWithAttestation:(NSData *)attestation
                                                                       keyID:(NSString *)keyID
                                                                   challenge:(NSData *)challenge;
@@ -53,12 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Default initializer.
 /// @param APIService An instance implementing `GACAppCheckAPIServiceProtocol` to be used to send
-/// network requests to Firebase App Check backend.
-/// @param projectID A Firebase project ID for the requests (`FIRApp.options.projectID`).
-/// @param appID A Firebase app ID for the requests (`FIRApp.options.googleAppID`).
+/// network requests to the App Check backend.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}".
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID;
+                      resourceName:(NSString *)resourceName;
 
 @end
 

--- a/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
+++ b/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
@@ -48,21 +48,18 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 @property(nonatomic, readonly) id<GACAppCheckAPIServiceProtocol> APIService;
 
-@property(nonatomic, readonly) NSString *projectID;
-@property(nonatomic, readonly) NSString *appID;
+@property(nonatomic, readonly) NSString *resourceName;
 
 @end
 
 @implementation GACAppAttestAPIService
 
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID {
+                      resourceName:(NSString *)resourceName {
   self = [super init];
   if (self) {
     _APIService = APIService;
-    _projectID = projectID;
-    _appID = appID;
+    _resourceName = [resourceName copy];
   }
   return self;
 }
@@ -241,15 +238,12 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 - (NSURL *)URLForEndpoint:(NSString *)endpoint {
   NSString *URL = [[self class] URLWithBaseURL:self.APIService.baseURL
-                                     projectID:self.projectID
-                                         appID:self.appID];
+                                  resourceName:self.resourceName];
   return [NSURL URLWithString:[NSString stringWithFormat:@"%@:%@", URL, endpoint]];
 }
 
-+ (NSString *)URLWithBaseURL:(NSString *)baseURL
-                   projectID:(NSString *)projectID
-                       appID:(NSString *)appID {
-  return [NSString stringWithFormat:@"%@/projects/%@/apps/%@", baseURL, projectID, appID];
++ (NSString *)URLWithBaseURL:(NSString *)baseURL resourceName:(NSString *)resourceName {
+  return [NSString stringWithFormat:@"%@/%@", baseURL, resourceName];
 }
 
 - (dispatch_queue_t)backgroundQueue {

--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -163,10 +163,9 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
                                                   appID:app.options.googleAppID
                                            requestHooks:@[ heartbeatLoggerHook ]];
 
-  GACAppAttestAPIService *appAttestAPIService =
-      [[GACAppAttestAPIService alloc] initWithAPIService:APIService
-                                               projectID:app.options.projectID
-                                                   appID:app.options.googleAppID];
+  GACAppAttestAPIService *appAttestAPIService = [[GACAppAttestAPIService alloc]
+      initWithAPIService:APIService
+            resourceName:[GACAppAttestProvider resourceNameFromApp:app]];
 
   GACAppAttestArtifactStorage *artifactStorage =
       [[GACAppAttestArtifactStorage alloc] initWithAppName:app.name
@@ -501,6 +500,16 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
         return [self.keyIDStorage setAppAttestKeyID:keyID];
       });
 }
+
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+
++ (NSString *)resourceNameFromApp:(FIRApp *)app {
+  return [NSString
+      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
+}
+
+// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 


### PR DESCRIPTION
Removed the Firebase-specific identifiers `projectID` and `appID` from `GACAppAttestAPIService` in favour of a generic `resourceName`.

#no-changelog