### PR TITLE
Always print out class name as title if there are changes in the class API

### DIFF
--- a/scripts/api_diff_report/api_diff_report.py
+++ b/scripts/api_diff_report/api_diff_report.py
@@ -177,9 +177,9 @@ def generate_markdown_report(diff, level=0):
       else:
         current_status = value.get('status')
         if current_status:
-          # Module level: Always print out module name as title
-          if level == 0:
-            report += f'{header_str} {key} [{current_status}]\n'
+          # Module level: Always print out module name and class name as title
+          if level in [0, 2]:
+            report += f'{header_str} [{current_status}] {key}\n'
           if current_status != STATUS_ERROR:  # ADDED,REMOVED,MODIFIED
             report += '<details>\n<summary>\n'
             report += f'[{current_status}] {key}\n'


### PR DESCRIPTION
A minor bug in the API diff. The report here should be showing `HTTPSCallableOptions` as a new class: https://github.com/firebase/firebase-ios-sdk/pull/11270#issuecomment-1546118031

Fix: Print out the class name as title.
e.g. 

### FirebaseFunctions
#### Classes
##### Functions
<details>
<summary>
[ADDED] httpsCallable(_:options:)
</summary>

```diff
Swift:
+  @objc(HTTPSCallableWithURL:options:) public func httpsCallable ( _ url : URL , options : HTTPSCallableOptions ) -> HTTPSCallable
```

</details>

<details>
<summary>
[ADDED] httpsCallable(_:options:requestAs:responseAs:encoder:decoder:)
</summary>

```diff
Swift:
+  open func httpsCallable < Request : Encodable , Response : Decodable > ( _ url : URL , options : HTTPSCallableOptions , requestAs : Request . Type = Request . self , responseAs : Response . Type = Response . self , encoder : FirebaseDataEncoder = FirebaseDataEncoder ( ), decoder : FirebaseDataDecoder = FirebaseDataDecoder ( )) -> Callable < Request , Response >
```

</details>

##### [ADDED] HTTPSCallableOptions
<details>
<summary>
[ADDED] HTTPSCallableOptions
</summary>

```diff
Swift:
+  @objc(FIRHTTPSCallableOptions) public class HTTPSCallableOptions : NSObject
+    @objc public let requireLimitedUseAppCheckTokens : Bool
+    @objc public init ( requireLimitedUseAppCheckTokens : Bool )
```

</details>