### PR TITLE
API Diff Report CI set env FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1

### DIFF
--- a/.github/workflows/api_diff_report.yml
+++ b/.github/workflows/api_diff_report.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   diff_report:
     runs-on: macos-latest
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
During the release cycle, the new version of googleAppMeasurement (https://github.com/google/GoogleAppMeasurement) haven't been released during the release cycle. As a result, `Jazzy` plus `xcodebuild` failed due to dependency issue:
https://github.com/firebase/firebase-ios-sdk/actions/runs/4996800540/jobs/8950788280#step:10:375

We need to add an ENV and use the latest released dependency (configed in master branch) instead.



Test PR - branch abased from `pb-storage-async-progress` branch: 
https://github.com/firebase/firebase-ios-sdk/pull/11302

Workflow run - API doc generated successfully: 
https://github.com/firebase/firebase-ios-sdk/actions/runs/5006429308/jobs/8971699171?pr=11302#step:10:383