### PR TITLE
Integrate FirebaseAppCheck changes into AppCheck

### DIFF
--- a/AppCheck/Interop/GACAppCheckInterop.h
+++ b/AppCheck/Interop/GACAppCheckInterop.h
@@ -43,6 +43,14 @@ NS_SWIFT_NAME(InternalAppCheckInterop) @protocol GACAppCheckInterop
 /// `tokenDidChangeNotificationName`.
 - (NSString *)notificationAppNameKey;
 
+// MARK: - Optional API
+
+@optional
+
+/// Retrieve a new limited-use App Check token
+- (void)getLimitedUseTokenWithCompletion:(GACAppCheckTokenHandlerInterop)handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
@@ -36,6 +36,7 @@ FOUNDATION_EXPORT NSString *const kGACAppCheckTokenNotificationKey NS_SWIFT_NAME
 /// `userInfo` key for the `AppCheckToken` in `AppCheckTokenDidChangeNotification`.
 FOUNDATION_EXPORT NSString *const kGACAppCheckAppNameNotificationKey NS_SWIFT_NAME(InternalAppCheckAppNameNotificationKey);
 
+/// A class used to manage App Check tokens for a given resource.
 NS_SWIFT_NAME(InternalAppCheck)
 @interface GACAppCheck : NSObject <GACAppCheckInterop>
 

--- a/AppCheck/Tests/Utils/AppCheckFake/GACAppCheckFake.h
+++ b/AppCheck/Tests/Utils/AppCheckFake/GACAppCheckFake.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The tokenResult to be passed to `-[getTokenWithCompletion:]` completion handler. */
 @property(nonatomic, nonnull) id<GACAppCheckTokenResultInterop> tokenResult;
 
+/** The token result to be passed to `-[getLimitedUseTokenWithCompletion:]` completion handler. */
+@property(nonatomic, nonnull) id<GACAppCheckTokenResultInterop> limitedUseTokenResult;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCheck/Tests/Utils/AppCheckFake/GACAppCheckFake.m
+++ b/AppCheck/Tests/Utils/AppCheckFake/GACAppCheckFake.m
@@ -24,6 +24,9 @@
   self = [super init];
   if (self) {
     _tokenResult = [[GACAppCheckTokenResultFake alloc] initWithToken:@"fake_valid_token" error:nil];
+    _limitedUseTokenResult =
+        [[GACAppCheckTokenResultFake alloc] initWithToken:@"fake_limited_use_valid_token"
+                                                    error:nil];
   }
   return self;
 }
@@ -32,6 +35,12 @@
                     completion:(nonnull GACAppCheckTokenHandlerInterop)handler {
   dispatch_async(dispatch_get_main_queue(), ^{
     handler(self.tokenResult);
+  });
+}
+
+- (void)getLimitedUseTokenWithCompletion:(GACAppCheckTokenHandlerInterop)handler {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    handler(self.limitedUseTokenResult);
   });
 }
 


### PR DESCRIPTION
Merged the latest `FirebaseAppCheck` changes (from PR #11307) into the generic `AppCheck` SDK.

#no-changelog