### PR TITLE
Fix error generation when status is .internal

### DIFF
--- a/FirebaseFunctions/Sources/FunctionsError.swift
+++ b/FirebaseFunctions/Sources/FunctionsError.swift
@@ -225,18 +225,18 @@ internal func FunctionsErrorForResponse(status: NSInteger,
     if let status = errorDetails["status"] as? String {
       code = FunctionsErrorCode.errorCode(forName: status)
 
+      if let message = errorDetails["message"] as? String {
+        description = message
+      } else {
+        description = code.descriptionForErrorCode
+      }
+      
       // If the code in the body is invalid, treat the whole response as malformed.
       guard code != .internal else {
-        return code.generatedError(userInfo: nil)
+        return code.generatedError(userInfo: [NSLocalizedDescriptionKey: description])
       }
     }
-
-    if let message = errorDetails["message"] as? String {
-      description = message
-    } else {
-      description = code.descriptionForErrorCode
-    }
-
+    
     details = errorDetails["details"] as AnyObject?
     if let innerDetails = details {
       // Just ignore the details if there an error decoding them.


### PR DESCRIPTION
[REQUIRED] Step 1: Describe your environment
Xcode version: Version 14.3 (14E222b)
Firebase SDK version: 10.9.0
Installation method: Swift Package Manager
Firebase Component: Functions
Target platform(s): iOS
[REQUIRED] Step 2: Describe the problem
When the error received is of type `.internal`, the current code rewrites the message with `descriptionForErrorCode`. This is pretty bad because any contextual information we might have received from Firebase is destroyed. This fix attempts to extract the message from the response payload, preserving the original value. However, if message is not found, the message is set to the value returned by `descriptionForErrorCode`, as was done before.

Steps to reproduce:
Simple. Just throw the following from a Cloud Function:

throw new functions.https.HttpsError('internal', 'Something really bad happened!')

The error generated in `func generatedError(userInfo: [String: Any]? = nil) -> NSError {...}` received a nil `userInfo`. This causes the message to be set to the error's `descriptionForErrorCode` value.

If you have a downloadable sample project that reproduces the bug you're reporting, you will
likely receive a faster response on your issue.

Relevant Code:
https://github.com/firebase/firebase-ios-sdk/commit/2aedc9a8c8321c0a8e2410c8ec610f07800a6b50