### PR TITLE
[Docs] Fix 'intializer' typos in repo

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/Heartbeat.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/Heartbeat.swift
@@ -48,7 +48,7 @@ struct Heartbeat: Codable, Equatable {
   /// a moving average.
   let timePeriods: [TimePeriod]
 
-  /// Designated intializer.
+  /// Designated initializer.
   /// - Parameters:
   ///   - agent: An anonymous string of information to associate the heartbeat with.
   ///   - date: The date when the heartbeat was recorded.

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
@@ -36,7 +36,7 @@ public final class HeartbeatController {
     self.init(id: id, dateProvider: Date.init)
   }
 
-  /// Convenience initializer. Mirrors the semantics of the public intializer with the added benefit of
+  /// Convenience initializer. Mirrors the semantics of the public initializer with the added benefit of
   /// injecting a custom date provider for improved testability.
   /// - Parameters:
   ///   - id: The id to associate this controller's heartbeat storage with.

--- a/FirebaseDatabase/Sources/Api/FIRDatabaseComponent.m
+++ b/FirebaseDatabase/Sources/Api/FIRDatabaseComponent.m
@@ -32,7 +32,7 @@ typedef NSMutableDictionary<NSString *, FIRDatabase *> FIRDatabaseDictionary;
 
 @interface FIRDatabaseComponent () <FIRComponentLifecycleMaintainer, FIRLibrary>
 @property(nonatomic) FIRDatabaseDictionary *instances;
-/// Internal intializer.
+/// Internal initializer.
 - (instancetype)initWithApp:(FIRApp *)app;
 @end
 

--- a/FirebaseFunctions/Sources/HTTPSCallableOptions.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallableOptions.swift
@@ -19,7 +19,7 @@ import Foundation
   /// Whether or not to protect the callable function with a limited-use App Check token.
   @objc public let requireLimitedUseAppCheckTokens: Bool
 
-  /// Designated intializer.
+  /// Designated initializer.
   /// - Parameter requireLimitedUseAppCheckTokens: A boolean used to decide whether or not to
   /// protect the callable function with a limited use App Check token.
   @objc public init(requireLimitedUseAppCheckTokens: Bool) {

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.h
@@ -48,7 +48,7 @@ typedef NS_OPTIONS(NSUInteger, FIRMessagingInvalidTokenReason) {
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- *  Designated intializer.
+ *  Designated initializer.
  *
  *  @param heartbeatLogger The heartbeat logger that is injected into token operations.
  */


### PR DESCRIPTION
### Context
s/intializer/initializer

#no-changelog