### PR TITLE
Remove Firebase-specific implementation from GACAppCheckAPIService

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -160,7 +160,6 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
-                                                  appID:app.options.googleAppID
                                            requestHooks:@[ heartbeatLoggerHook ]];
 
   GACAppAttestAPIService *appAttestAPIService = [[GACAppAttestAPIService alloc]

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
@@ -44,13 +44,11 @@ typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
 /**
  * The default initializer.
  * @param session The URL session used to make network requests.
- * @param APIKey The Firebase project API key (see `FIROptions.APIKey`).
- * @param appID The Firebase app ID (see `FIROptions.googleAppID`).
+ * @param APIKey The Google Cloud Platform API key, if needed, or nil.
  * @param requestHooks Hooks that will be invoked on requests through this service.
  */
 - (instancetype)initWithURLSession:(NSURLSession *)session
-                            APIKey:(NSString *)APIKey
-                             appID:(NSString *)appID
+                            APIKey:(nullable NSString *)APIKey
                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end

--- a/AppCheck/Sources/Core/GACAppCheck.m
+++ b/AppCheck/Sources/Core/GACAppCheck.m
@@ -24,10 +24,10 @@
 
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckErrors.h"
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckProvider.h"
+#import "AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h"
 
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheck/Sources/Core/GACAppCheckLogger.h"
-#import "AppCheck/Sources/Core/GACAppCheckSettings.h"
 #import "AppCheck/Sources/Core/GACAppCheckToken+Internal.h"
 #import "AppCheck/Sources/Core/GACAppCheckTokenResult.h"
 #import "AppCheck/Sources/Core/Storage/GACAppCheckStorage.h"
@@ -111,13 +111,8 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 #pragma mark - Public
 
 - (instancetype)initWithApp:(FIRApp *)app
-           appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider {
-  id<GACAppCheckSettingsProtocol> settings = [[GACAppCheckSettings alloc]
-                       initWithUserDefaults:[NSUserDefaults standardUserDefaults]
-                                 mainBundle:[NSBundle mainBundle]
-      tokenAutoRefreshPolicyUserDefaultsKey:[kGACAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix
-                                                stringByAppendingString:app.name]
-         tokenAutoRefreshPolicyInfoPListKey:kGACAppCheckTokenAutoRefreshEnabledInfoPlistKey];
+           appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                   settings:(id<GACAppCheckSettingsProtocol>)settings {
   GACAppCheckTokenRefreshResult *refreshResult =
       [[GACAppCheckTokenRefreshResult alloc] initWithStatusNever];
   GACAppCheckTokenRefresher *tokenRefresher =

--- a/AppCheck/Sources/Core/GACAppCheckSettings.m
+++ b/AppCheck/Sources/Core/GACAppCheckSettings.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "AppCheck/Sources/Core/GACAppCheckSettings.h"
+#import "AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -44,6 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
     _tokenAutoRefreshPolicyInfoPListKey = [tokenAutoRefreshPolicyInfoPListKey copy];
   }
   return self;
+}
+
+- (instancetype)
+    initWitTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey {
+  return [self initWithUserDefaults:[NSUserDefaults standardUserDefaults]
+                                 mainBundle:[NSBundle mainBundle]
+      tokenAutoRefreshPolicyUserDefaultsKey:tokenAutoRefreshPolicyUserDefaultsKey
+         tokenAutoRefreshPolicyInfoPListKey:tokenAutoRefreshPolicyInfoPListKey];
 }
 
 - (BOOL)isTokenAutoRefreshEnabled {

--- a/AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.m
+++ b/AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.m
@@ -16,7 +16,8 @@
 
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.h"
 
-#import "AppCheck/Sources/Core/GACAppCheckSettings.h"
+#import "AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h"
+
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTimer.h"
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefreshResult.h"
 

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -80,7 +80,6 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
-                                                  appID:app.options.googleAppID
                                            requestHooks:@[ heartbeatLoggerHook ]];
 
   GACAppCheckDebugProviderAPIService *debugAPIService =

--- a/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -104,7 +104,6 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
                                                  APIKey:app.options.APIKey
-                                                  appID:app.options.googleAppID
                                            requestHooks:@[ heartbeatLoggerHook ]];
 
   GACDeviceCheckAPIService *deviceCheckAPIService =

--- a/AppCheck/Sources/Public/AppCheck/AppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/AppCheck.h
@@ -17,6 +17,7 @@
 #import "GACAppCheck.h"
 #import "GACAppCheckErrors.h"
 #import "GACAppCheckProvider.h"
+#import "GACAppCheckSettings.h"
 #import "GACAppCheckToken.h"
 
 // Debug provider

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
@@ -21,6 +21,7 @@
 @class FIRApp;
 @class GACAppCheckToken;
 @protocol GACAppCheckProvider;
+@protocol GACAppCheckSettingsProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -47,7 +48,8 @@ NS_SWIFT_NAME(InternalAppCheck)
 /// @param appCheckProvider  An `InternalAppCheckProvider` instance that provides App Check tokens.
 /// @return An instance of `AppCheck` corresponding to the provided `app`.
 - (instancetype)initWithApp:(FIRApp *)app
-           appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider;
+           appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                   settings:(id<GACAppCheckSettingsProtocol>)settings;
 
 /// Requests Firebase app check token. This method should *only* be used if you need to authorize
 /// requests to a non-Firebase backend. Requests to Firebase backend are authorized automatically if

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
@@ -59,6 +59,16 @@ typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
        tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
     NS_DESIGNATED_INITIALIZER;
 
+/// The designated initializer.
+/// - Parameters:
+///   - tokenAutoRefreshPolicyUserDefaultsKey: The user defaults key for the token auto-refresh
+///   configuration value.
+///   - tokenAutoRefreshPolicyInfoPListKey: The Info.plist key for the token auto-refresh
+///   configuration value.
+- (instancetype)
+    initWitTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -66,7 +66,6 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
 
   self.APIService = [[GACAppCheckAPIService alloc] initWithURLSession:self.URLSession
                                                                APIKey:options.APIKey
-                                                                appID:options.googleAppID
                                                          requestHooks:@[ heartbeatLoggerHook ]];
   self.deviceCheckAPIService =
       [[GACDeviceCheckAPIService alloc] initWithAPIService:self.APIService

--- a/AppCheck/Tests/Unit/Core/GACAppCheckSettingsTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckSettingsTests.m
@@ -18,7 +18,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import "AppCheck/Sources/Core/GACAppCheckSettings.h"
+#import "AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
@@ -18,7 +18,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import "AppCheck/Sources/Core/GACAppCheckSettings.h"
+#import "AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h"
+
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefreshResult.h"
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.h"
 #import "AppCheck/Tests/Unit/Utils/GACFakeTimer.h"


### PR DESCRIPTION
- Removed the unused `appID` property from `GACAppCheckAPIService`.
- Removed heartbeat logging tests from `GACAppCheckAPIServiceTests`.
- Added request hook, additional headers and API key tests to `GACAppCheckAPIServiceTests`.

#no-changelog