### PR TITLE
[Firestore] Add linked frameworks to Firestore wrapper target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -668,7 +668,12 @@ let package = Package(
         "FirebaseCore",
         "leveldb",
       ],
-      path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
+      path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap",
+      linkerSettings: [
+        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
+        .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+        .linkedLibrary("c++"),
+      ]
     ),
 
     .binaryTarget(


### PR DESCRIPTION
### Context
- Adding back the linked frameworks previously part of the _source_ Firestore target before the switch to a _binary_ target.
- This diff matches with pre-10.8.0 linked frameworks: https://github.com/firebase/firebase-ios-sdk/blob/10.7.0/Package.swift#L705-L709

#no-changelog