### PR TITLE
Extract Firebase-specific symbols from GACAppAttestArtifactStorage

### DIFF
--- a/AppCheck.podspec
+++ b/AppCheck.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheck'
-  s.version          = '10.10.0'
+  s.version          = '10.11.0'
   s.summary          = 'App Check SDK.'
 
   s.description      = <<-DESC
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'AppCheckInterop', '~> 10.10'
+  s.dependency 'AppCheckInterop', '~> 10.11'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -166,10 +166,9 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
       initWithAPIService:APIService
             resourceName:[GACAppAttestProvider resourceNameFromApp:app]];
 
-  GACAppAttestArtifactStorage *artifactStorage =
-      [[GACAppAttestArtifactStorage alloc] initWithAppName:app.name
-                                                     appID:app.options.googleAppID
-                                               accessGroup:app.options.appGroupID];
+  GACAppAttestArtifactStorage *artifactStorage = [[GACAppAttestArtifactStorage alloc]
+      initWithKeySuffix:[GACAppAttestProvider storageKeySuffixForApp:app]
+            accessGroup:app.options.appGroupID];
 
   GACAppCheckBackoffWrapper *backoffWrapper = [[GACAppCheckBackoffWrapper alloc] init];
 

--- a/AppCheck/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.h
+++ b/AppCheck/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.h
@@ -48,26 +48,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Default convenience initializer.
-/// @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
-/// the key to store the token for the storage instance.
-/// @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
-/// as a part of the key to store the token for the storage instance.
+/// @param keySuffix A unique suffix that will be used as a part of the key to store the token for
+/// the storage instance.
 /// @param accessGroup The Keychain Access Group.
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                    accessGroup:(nullable NSString *)accessGroup;
+- (instancetype)initWithKeySuffix:(NSString *)keySuffix
+                      accessGroup:(nullable NSString *)accessGroup;
 
 /// Designated initializer.
-/// @param appName A Firebase App name (`FirebaseApp.name`). The app name will be used as a part of
-/// the key to store the token for the storage instance.
-/// @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
-/// as a part of the key to store the token for the storage instance.
+/// @param keySuffix A unique suffix that will be used as a part of the key to store the token for
+/// the storage instance.
 /// @param keychainStorage An instance of `GULKeychainStorage` used as an underlying secure storage.
 /// @param accessGroup The Keychain Access Group.
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                keychainStorage:(GULKeychainStorage *)keychainStorage
-                    accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithKeySuffix:(NSString *)keySuffix
+                  keychainStorage:(GULKeychainStorage *)keychainStorage
+                      accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/AppCheck/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
+++ b/AppCheck/Sources/AppAttestProvider/Storage/GACAppAttestArtifactStorage.m
@@ -33,8 +33,7 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
 
 @interface GACAppAttestArtifactStorage ()
 
-@property(nonatomic, readonly) NSString *appName;
-@property(nonatomic, readonly) NSString *appID;
+@property(nonatomic, readonly) NSString *keySuffix;
 @property(nonatomic, readonly) GULKeychainStorage *keychainStorage;
 @property(nonatomic, readonly, nullable) NSString *accessGroup;
 
@@ -42,29 +41,23 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
 
 @implementation GACAppAttestArtifactStorage
 
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                keychainStorage:(GULKeychainStorage *)keychainStorage
-                    accessGroup:(nullable NSString *)accessGroup {
+- (instancetype)initWithKeySuffix:(NSString *)keySuffix
+                  keychainStorage:(GULKeychainStorage *)keychainStorage
+                      accessGroup:(nullable NSString *)accessGroup {
   self = [super init];
   if (self) {
-    _appName = [appName copy];
-    _appID = [appID copy];
+    _keySuffix = [keySuffix copy];
     _keychainStorage = keychainStorage;
     _accessGroup = [accessGroup copy];
   }
   return self;
 }
 
-- (instancetype)initWithAppName:(NSString *)appName
-                          appID:(NSString *)appID
-                    accessGroup:(nullable NSString *)accessGroup {
+- (instancetype)initWithKeySuffix:(NSString *)keySuffix
+                      accessGroup:(nullable NSString *)accessGroup {
   GULKeychainStorage *keychainStorage =
       [[GULKeychainStorage alloc] initWithService:kKeychainService];
-  return [self initWithAppName:appName
-                         appID:appID
-               keychainStorage:keychainStorage
-                   accessGroup:accessGroup];
+  return [self initWithKeySuffix:keySuffix keychainStorage:keychainStorage accessGroup:accessGroup];
 }
 
 - (FBLPromise<NSData *> *)getArtifactForKey:(NSString *)keyID {
@@ -116,8 +109,7 @@ static NSString *const kKeychainService = @"com.firebase.app_check.app_attest_ar
 }
 
 - (NSString *)artifactKey {
-  return
-      [NSString stringWithFormat:@"app_check_app_attest_artifact.%@.%@", self.appName, self.appID];
+  return [NSString stringWithFormat:@"app_check_app_attest_artifact.%@", self.keySuffix];
 }
 
 @end

--- a/AppCheckInterop.podspec
+++ b/AppCheckInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCheckInterop'
-  s.version          = '10.10.0'
+  s.version          = '10.11.0'
   s.summary          = 'Interfaces that allow other SDKs to use AppCheck functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'AppCheck', '~> 10.0'
+  s.dependency 'AppCheck', '~> 10.11'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'


### PR DESCRIPTION
Removed the Firebase-specific references `appName` and `appId` from `GACAppAttestArtifactStorage`. They have been moved up one layer into `GACAppAttestProvider`.

#no-changelog