### PR TITLE
Remove FIRApp dependencies from GACAppAttestProvider

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
+++ b/AppCheck/Sources/AppAttestProvider/API/GACAppAttestAPIService.m
@@ -24,9 +24,9 @@
 
 #import "AppCheck/Sources/AppAttestProvider/API/GACAppAttestAttestationResponse.h"
 #import "AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h"
+#import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 
 #import <GoogleUtilities/GULURLSessionDataResponse.h>
-#import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
@@ -16,13 +16,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import "AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h"
+
 @class FBLPromise<Result>;
 @class GULURLSessionDataResponse;
 @class GACAppCheckToken;
 
 NS_ASSUME_NONNULL_BEGIN
-
-typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
 
 @protocol GACAppCheckAPIServiceProtocol <NSObject>
 

--- a/AppCheck/Sources/Core/GACAppCheckSettings.m
+++ b/AppCheck/Sources/Core/GACAppCheckSettings.m
@@ -47,8 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)
-    initWitTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
-              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey {
+    initWithTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+               tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey {
   return [self initWithUserDefaults:[NSUserDefaults standardUserDefaults]
                                  mainBundle:[NSBundle mainBundle]
       tokenAutoRefreshPolicyUserDefaultsKey:tokenAutoRefreshPolicyUserDefaultsKey

--- a/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
@@ -20,8 +20,6 @@
 
 #import "GACAppCheckAvailability.h"
 
-@class FIRApp;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /// Firebase App Check provider that verifies app integrity using the
@@ -35,10 +33,20 @@ NS_SWIFT_NAME(InternalAppAttestProvider)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// The default initializer.
-/// @param app A `FirebaseApp` instance.
-/// @return An instance of `AppAttestProvider` if the provided `FirebaseApp` instance contains all
-/// required parameters.
-- (nullable instancetype)initWithApp:(FIRApp *)app;
+/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// `resourceName`; may be a Firebase App Name or an SDK name.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}".
+/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
+/// @param accessGroup The Keychain Access Group.
+/// @param requestHooks Hooks that will be invoked on requests through this service.
+/// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
+- (nullable instancetype)initWithStorageID:(NSString *)storageID
+                              resourceName:(NSString *)resourceName
+                                    APIKey:(nullable NSString *)APIKey
+                       keychainAccessGroup:(nullable NSString *)accessGroup
+                              requestHooks:
+                                  (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckProvider.h
@@ -20,6 +20,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// A block to be called before sending API requests.
+/// @param request The request that is about to be sent.
+typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
+
 /// Defines the methods required to be implemented by a specific Firebase App Check
 /// provider.
 NS_SWIFT_NAME(InternalAppCheckProvider)

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
@@ -67,7 +67,8 @@ typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
 ///   configuration value.
 - (instancetype)
     initWitTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
-              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey;
+              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
+    NS_SWIFT_NAME(init(tokenAutoRefreshPolicyUserDefaultsKey:tokenAutoRefreshPolicyInfoPListKey:));
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
@@ -66,8 +66,8 @@ typedef NS_CLOSED_ENUM(NSInteger, GACAppCheckTokenAutoRefreshPolicy) {
 ///   - tokenAutoRefreshPolicyInfoPListKey: The Info.plist key for the token auto-refresh
 ///   configuration value.
 - (instancetype)
-    initWitTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
-              tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
+    initWithTokenAutoRefreshPolicyUserDefaultsKey:(NSString *)tokenAutoRefreshPolicyUserDefaultsKey
+               tokenAutoRefreshPolicyInfoPListKey:(NSString *)tokenAutoRefreshPolicyInfoPListKey
     NS_SWIFT_NAME(init(tokenAutoRefreshPolicyUserDefaultsKey:tokenAutoRefreshPolicyInfoPListKey:));
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -110,8 +110,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   options.APIKey = @"api_key";
   options.projectID = @"project_id";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
+  NSString *resourceName = [GACAppAttestProviderTests resourceNameFromApp:app];
 
-  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithApp:app]);
+  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithStorageID:app.name
+                                                     resourceName:resourceName
+                                                           APIKey:app.options.APIKey
+                                              keychainAccessGroup:nil
+                                                     requestHooks:nil]);
 }
 #endif  // !TARGET_OS_MACCATALYST
 
@@ -1087,6 +1092,16 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   OCMExpect([self.mockArtifactStorage setArtifact:nil forKey:@""])
       .andReturn([FBLPromise resolvedWith:nil]);
 }
+
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+
++ (NSString *)resourceNameFromApp:(FIRApp *)app {
+  return [NSString
+      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
+}
+
+// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -51,7 +51,14 @@ final class AppCheckAPITests {
     guard let app = FirebaseApp.app() else { return }
 
     // Retrieving an AppCheck instance
-    let appCheck = InternalAppCheck(app: app, appCheckProvider: DummyAppCheckProvider())
+    let appCheck = InternalAppCheck(
+      app: app,
+      appCheckProvider: DummyAppCheckProvider(),
+      settings: GACAppCheckSettings(
+        tokenAutoRefreshPolicyUserDefaultsKey: "token-refresh-key",
+        tokenAutoRefreshPolicyInfoPListKey: "token-refresh-key"
+      )
+    )
 
     // Get token
     appCheck.token(forcingRefresh: false) { token, error in

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -55,8 +55,8 @@ final class AppCheckAPITests {
       app: app,
       appCheckProvider: DummyAppCheckProvider(),
       settings: GACAppCheckSettings(
-        tokenAutoRefreshPolicyUserDefaultsKey: "token-refresh-key",
-        tokenAutoRefreshPolicyInfoPListKey: "token-refresh-key"
+        tokenAutoRefreshPolicyUserDefaultsKey: "token-refresh-user-defaults-key",
+        tokenAutoRefreshPolicyInfoPListKey: "token-refresh-info-plist-key"
       )
     )
 


### PR DESCRIPTION
Removed Firebase-specific dependencies, specifically `FIRApp`, from `GACAppAttestProvider`.

#no-changelog
