### PR TITLE
[App Check] Remove Firebase specifics from Debug Provider

### DIFF
--- a/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
+++ b/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
@@ -32,8 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     : NSObject <GACAppCheckDebugProviderAPIServiceProtocol>
 
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID;
+                      resourceName:(NSString *)resourceName;
 
 @end
 

--- a/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
+++ b/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h
@@ -31,6 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GACAppCheckDebugProviderAPIService
     : NSObject <GACAppCheckDebugProviderAPIServiceProtocol>
 
+/// Default initializer.
+/// @param APIService An instance implementing `GACAppCheckAPIServiceProtocol` to be used to send
+/// network requests to the App Check backend.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}". See https://google.aip.dev/122 for more details about
+/// resource names.
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
                       resourceName:(NSString *)resourceName;
 

--- a/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
+++ b/AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.m
@@ -31,8 +31,6 @@
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheck/Sources/Core/GACAppCheckLogger.h"
 
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kContentTypeKey = @"Content-Type";
@@ -43,21 +41,18 @@ static NSString *const kDebugTokenField = @"debug_token";
 
 @property(nonatomic, readonly) id<GACAppCheckAPIServiceProtocol> APIService;
 
-@property(nonatomic, readonly) NSString *projectID;
-@property(nonatomic, readonly) NSString *appID;
+@property(nonatomic, readonly) NSString *resourceName;
 
 @end
 
 @implementation GACAppCheckDebugProviderAPIService
 
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID {
+                      resourceName:(NSString *)resourceName {
   self = [super init];
   if (self) {
     _APIService = APIService;
-    _projectID = projectID;
-    _appID = appID;
+    _resourceName = resourceName;
   }
   return self;
 }
@@ -65,9 +60,8 @@ static NSString *const kDebugTokenField = @"debug_token";
 #pragma mark - Public API
 
 - (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDebugToken:(NSString *)debugToken {
-  NSString *URLString =
-      [NSString stringWithFormat:@"%@/projects/%@/apps/%@:exchangeDebugToken",
-                                 self.APIService.baseURL, self.projectID, self.appID];
+  NSString *URLString = [NSString
+      stringWithFormat:@"%@/%@:exchangeDebugToken", self.APIService.baseURL, self.resourceName];
   NSURL *URL = [NSURL URLWithString:URLString];
 
   return [self HTTPBodyWithDebugToken:debugToken]

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckDebugProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckDebugProvider.h
@@ -18,7 +18,6 @@
 
 #import "GACAppCheckProvider.h"
 
-@class FIRApp;
 @protocol GACAppCheckDebugProviderAPIServiceProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -66,7 +65,18 @@ NS_SWIFT_NAME(InternalAppCheckDebugProvider)
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (nullable instancetype)initWithApp:(FIRApp *)app;
+/// The default initializer.
+/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// `resourceName`; may be a Firebase App Name or an SDK name.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}".
+/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
+/// @param requestHooks Hooks that will be invoked on requests through this service.
+/// @return An instance of `AppCheckDebugProvider` .
+- (instancetype)initWithStorageID:(NSString *)storageID
+                     resourceName:(NSString *)resourceName
+                           APIKey:(nullable NSString *)APIKey
+                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 /** Return the locally generated token. */
 - (NSString *)localDebugToken;

--- a/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -28,13 +28,15 @@
 
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
 
+static NSString *const kProjectID = @"project_id";
+static NSString *const kAppID = @"app_id";
+
 @interface GACAppCheckDebugProviderAPIServiceTests : XCTestCase
 @property(nonatomic) GACAppCheckDebugProviderAPIService *debugAPIService;
 
 @property(nonatomic) id mockAPIService;
 
-@property(nonatomic) NSString *projectID;
-@property(nonatomic) NSString *appID;
+@property(nonatomic) NSString *resourceName;
 @end
 
 @implementation GACAppCheckDebugProviderAPIServiceTests
@@ -42,16 +44,14 @@
 - (void)setUp {
   [super setUp];
 
-  self.projectID = @"project_id";
-  self.appID = @"app_id";
+  self.resourceName = [NSString stringWithFormat:@"projects/%@/apps/%@", kProjectID, kAppID];
 
   self.mockAPIService = OCMProtocolMock(@protocol(GACAppCheckAPIServiceProtocol));
   OCMStub([self.mockAPIService baseURL]).andReturn(@"https://test.appcheck.url.com/alpha");
 
   self.debugAPIService =
       [[GACAppCheckDebugProviderAPIService alloc] initWithAPIService:self.mockAPIService
-                                                           projectID:self.projectID
-                                                               appID:self.appID];
+                                                        resourceName:self.resourceName];
 }
 
 - (void)tearDown {

--- a/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -69,22 +69,11 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   options.projectID = @"project_id";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
-  XCTAssertNotNil([[GACAppCheckDebugProvider alloc] initWithApp:app]);
-}
-
-- (void)testInitWithIncompleteApp {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-
-  options.projectID = @"project_id";
-  FIRApp *missingAPIKeyApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
-                                                          options:options];
-  XCTAssertNil([[GACAppCheckDebugProvider alloc] initWithApp:missingAPIKeyApp]);
-
-  options.projectID = nil;
-  options.APIKey = @"api_key";
-  FIRApp *missingProjectIDApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
-                                                             options:options];
-  XCTAssertNil([[GACAppCheckDebugProvider alloc] initWithApp:missingProjectIDApp]);
+  XCTAssertNotNil([[GACAppCheckDebugProvider alloc]
+      initWithStorageID:options.googleAppID
+           resourceName:[GACAppCheckDebugProviderTests resourceNameFromApp:app]
+                 APIKey:app.options.APIKey
+           requestHooks:nil]);
 }
 
 #pragma mark - Debug token generating/storing
@@ -178,5 +167,15 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
 
   [self waitForExpectations:@[ expectation ] timeout:0.5];
 }
+
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+
++ (NSString *)resourceNameFromApp:(FIRApp *)app {
+  return [NSString
+      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
+}
+
+// FIREBASE_APP_CHECK_ONLY_END
 
 @end


### PR DESCRIPTION
Removed Firebase-specific symbols and implementation details from the generic App Check Debug Provider (`GACAppCheckDebugProvider`).

#no-changelog