### PR TITLE
[App Check] Remove Firebase specifics from Device Check Provider

### DIFF
--- a/AppCheck/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h
+++ b/AppCheck/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h
@@ -30,9 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GACDeviceCheckAPIService : NSObject <GACDeviceCheckAPIServiceProtocol>
 
+/// Default initializer.
+/// @param APIService An instance implementing `GACAppCheckAPIServiceProtocol` to be used to send
+/// network requests to the App Check backend.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}". See https://google.aip.dev/122 for more details about
+/// resource names.
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID;
+                      resourceName:(NSString *)resourceName;
 
 @end
 

--- a/AppCheck/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
+++ b/AppCheck/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.m
@@ -30,8 +30,6 @@
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheck/Sources/Core/GACAppCheckLogger.h"
 
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kContentTypeKey = @"Content-Type";
@@ -42,21 +40,18 @@ static NSString *const kDeviceTokenField = @"device_token";
 
 @property(nonatomic, readonly) id<GACAppCheckAPIServiceProtocol> APIService;
 
-@property(nonatomic, readonly) NSString *projectID;
-@property(nonatomic, readonly) NSString *appID;
+@property(nonatomic, readonly) NSString *resourceName;
 
 @end
 
 @implementation GACDeviceCheckAPIService
 
 - (instancetype)initWithAPIService:(id<GACAppCheckAPIServiceProtocol>)APIService
-                         projectID:(NSString *)projectID
-                             appID:(NSString *)appID {
+                      resourceName:(NSString *)resourceName {
   self = [super init];
   if (self) {
     _APIService = APIService;
-    _projectID = projectID;
-    _appID = appID;
+    _resourceName = resourceName;
   }
   return self;
 }
@@ -64,9 +59,8 @@ static NSString *const kDeviceTokenField = @"device_token";
 #pragma mark - Public API
 
 - (FBLPromise<GACAppCheckToken *> *)appCheckTokenWithDeviceToken:(NSData *)deviceToken {
-  NSString *URLString =
-      [NSString stringWithFormat:@"%@/projects/%@/apps/%@:exchangeDeviceCheckToken",
-                                 self.APIService.baseURL, self.projectID, self.appID];
+  NSString *URLString = [NSString stringWithFormat:@"%@/%@:exchangeDeviceCheckToken",
+                                                   self.APIService.baseURL, self.resourceName];
   NSURL *URL = [NSURL URLWithString:URLString];
 
   return [self HTTPBodyWithDeviceToken:deviceToken]

--- a/AppCheck/Sources/Public/AppCheck/GACDeviceCheckProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACDeviceCheckProvider.h
@@ -21,7 +21,6 @@
 
 #if GAC_DEVICE_CHECK_SUPPORTED_TARGETS
 
-@class FIRApp;
 @protocol GACDeviceCheckAPIServiceProtocol;
 @protocol GACDeviceCheckTokenGenerator;
 
@@ -38,10 +37,17 @@ NS_SWIFT_NAME(InternalDeviceCheckProvider)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// The default initializer.
-/// @param app A `FirebaseApp` instance.
-/// @return An instance of `DeviceCheckProvider` if the provided `FirebaseApp` instance contains all
-/// required parameters.
-- (nullable instancetype)initWithApp:(FIRApp *)app;
+/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// `resourceName`; may be a Firebase App Name or an SDK name.
+/// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
+/// "projects/{project_id}/apps/{app_id}".
+/// @param APIKey The Google Cloud Platform API key, if needed, or nil.
+/// @param requestHooks Hooks that will be invoked on requests through this service.
+/// @return An instance of `DeviceCheckProvider` .
+- (instancetype)initWithStorageID:(NSString *)storageID
+                     resourceName:(NSString *)resourceName
+                           APIKey:(nullable NSString *)APIKey
+                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -67,10 +67,9 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   self.APIService = [[GACAppCheckAPIService alloc] initWithURLSession:self.URLSession
                                                                APIKey:options.APIKey
                                                          requestHooks:@[ heartbeatLoggerHook ]];
-  self.deviceCheckAPIService =
-      [[GACDeviceCheckAPIService alloc] initWithAPIService:self.APIService
-                                                 projectID:options.projectID
-                                                     appID:options.googleAppID];
+  self.deviceCheckAPIService = [[GACDeviceCheckAPIService alloc]
+      initWithAPIService:self.APIService
+            resourceName:[GACDeviceCheckAPIServiceE2ETests resourceNameFromOptions:options]];
 }
 
 - (void)tearDown {
@@ -102,6 +101,15 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:plistPath];
   return options;
 }
+
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+
++ (NSString *)resourceNameFromOptions:(FIROptions *)options {
+  return [NSString stringWithFormat:@"projects/%@/apps/%@", options.projectID, options.googleAppID];
+}
+
+// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 

--- a/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -32,15 +32,14 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
+static NSString *const kResourceName = @"projects/project_id/apps/app_id";
+
 typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 
 @interface GACDeviceCheckAPIServiceTests : XCTestCase
 @property(nonatomic) GACDeviceCheckAPIService *APIService;
 
 @property(nonatomic) id mockAPIService;
-
-@property(nonatomic) NSString *projectID;
-@property(nonatomic) NSString *appID;
 
 @end
 
@@ -49,15 +48,11 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
 - (void)setUp {
   [super setUp];
 
-  self.projectID = @"project_id";
-  self.appID = @"app_id";
-
   self.mockAPIService = OCMProtocolMock(@protocol(GACAppCheckAPIServiceProtocol));
   OCMStub([self.mockAPIService baseURL]).andReturn(@"https://test.appcheck.url.com/alpha");
 
   self.APIService = [[GACDeviceCheckAPIService alloc] initWithAPIService:self.mockAPIService
-                                                               projectID:self.projectID
-                                                                   appID:self.appID];
+                                                            resourceName:kResourceName];
 }
 
 - (void)tearDown {

--- a/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -79,22 +79,11 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   options.projectID = @"project_id";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
-  XCTAssertNotNil([[GACDeviceCheckProvider alloc] initWithApp:app]);
-}
-
-- (void)testInitWithIncompleteApp {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-
-  options.projectID = @"project_id";
-  FIRApp *missingAPIKeyApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
-                                                          options:options];
-  XCTAssertNil([[GACDeviceCheckProvider alloc] initWithApp:missingAPIKeyApp]);
-
-  options.projectID = nil;
-  options.APIKey = @"api_key";
-  FIRApp *missingProjectIDApp = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp"
-                                                             options:options];
-  XCTAssertNil([[GACDeviceCheckProvider alloc] initWithApp:missingProjectIDApp]);
+  XCTAssertNotNil([[GACDeviceCheckProvider alloc]
+      initWithStorageID:app.name
+           resourceName:[GACDeviceCheckProviderTests resourceNameFromApp:app]
+                 APIKey:app.options.APIKey
+           requestHooks:nil]);
 }
 
 - (void)testGetTokenSuccess {
@@ -268,6 +257,18 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   OCMVerifyAll(self.fakeAPIService);
   OCMVerifyAll(self.fakeTokenGenerator);
 }
+
+#pragma mark - Helpers
+
+// TODO(andrewheard): Remove from generic App Check SDK.
+// FIREBASE_APP_CHECK_ONLY_BEGIN
+
++ (NSString *)resourceNameFromApp:(FIRApp *)app {
+  return [NSString
+      stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
+}
+
+// FIREBASE_APP_CHECK_ONLY_END
 
 @end
 

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -81,18 +81,16 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            try await appCheck.token(forcingRefresh: false)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is only available on iOS 13+
+      Task {
+        do {
+          try await appCheck.token(forcingRefresh: false)
+        } catch {
+          // ...
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
+    }
 
     // Get & Set `isTokenAutoRefreshEnabled`
     _ = appCheck.isTokenAutoRefreshEnabled
@@ -118,18 +116,16 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            _ = try await debugProvider.getToken()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is only available on iOS 13+
+      Task {
+        do {
+          _ = try await debugProvider.getToken()
+        } catch {
+          // ...
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
+    }
 
     _ = debugProvider.localDebugToken()
     _ = debugProvider.currentDebugToken()
@@ -190,20 +186,18 @@ final class AppCheckAPITests {
           }
         }
         // Get token (async/await)
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
-          if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // async/await is a Swift 5.5+ feature available on iOS 15+
-            Task {
-              do {
-                _ = try await deviceCheckProvider.getToken()
-              } catch InternalAppCheckErrorCode.unsupported {
-                // ...
-              } catch {
-                // ...
-              }
+        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+          // async/await is only available on iOS 13+
+          Task {
+            do {
+              _ = try await deviceCheckProvider.getToken()
+            } catch InternalAppCheckErrorCode.unsupported {
+              // ...
+            } catch {
+              // ...
             }
           }
-        #endif // compiler(>=5.5.2) && canImport(_Concurrency)
+        }
       }
     #endif // !os(watchOS)
   }

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -81,7 +81,7 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is only available on iOS 13+
       Task {
         do {
@@ -116,7 +116,7 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is only available on iOS 13+
       Task {
         do {
@@ -186,7 +186,7 @@ final class AppCheckAPITests {
           }
         }
         // Get token (async/await)
-        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+        if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
           // async/await is only available on iOS 13+
           Task {
             do {

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -174,32 +174,36 @@ final class AppCheckAPITests {
     // `DeviceCheckProvider` initializer
     #if !os(watchOS)
       if #available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, *) {
-        if let app = FirebaseApp.app(),
-           let deviceCheckProvider = InternalDeviceCheckProvider(app: app) {
-          // Get token
-          deviceCheckProvider.getToken { token, error in
-            if let _ /* error */ = error {
-              // ...
-            } else if let _ /* token */ = token {
-              // ...
-            }
+        // TODO(andrewheard): Add `requestHooks` in API tests.
+        let deviceCheckProvider = InternalDeviceCheckProvider(
+          storageID: app.name,
+          resourceName: resourceName,
+          apiKey: app.options.apiKey,
+          requestHooks: nil
+        )
+        // Get token
+        deviceCheckProvider.getToken { token, error in
+          if let _ /* error */ = error {
+            // ...
+          } else if let _ /* token */ = token {
+            // ...
           }
-          // Get token (async/await)
-          #if compiler(>=5.5.2) && canImport(_Concurrency)
-            if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-              // async/await is a Swift 5.5+ feature available on iOS 15+
-              Task {
-                do {
-                  _ = try await deviceCheckProvider.getToken()
-                } catch InternalAppCheckErrorCode.unsupported {
-                  // ...
-                } catch {
-                  // ...
-                }
+        }
+        // Get token (async/await)
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+          if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // async/await is a Swift 5.5+ feature available on iOS 15+
+            Task {
+              do {
+                _ = try await deviceCheckProvider.getToken()
+              } catch InternalAppCheckErrorCode.unsupported {
+                // ...
+              } catch {
+                // ...
               }
             }
-          #endif // compiler(>=5.5.2) && canImport(_Concurrency)
-        }
+          }
+        #endif // compiler(>=5.5.2) && canImport(_Concurrency)
       }
     #endif // !os(watchOS)
   }


### PR DESCRIPTION
Removed Firebase-specific symbols and implementation details from the generic Device Check Provider (`GACDeviceCheckProvider`).

#no-changelog