### PR TITLE
[auth-swift] AuthTests.swift - 15 more unit tests

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -55,7 +55,7 @@ import FirebaseAppCheckInterop
    */
   @objc public class func auth() -> Auth {
     guard let defaultApp = FirebaseApp.app() else {
-      fatalError("The default FirebaseApp instance must be configured before the default Auth" +
+      fatalError("The default FirebaseApp instance must be configured before the default Auth " +
         "instance can be initialized. One way to ensure this is to call " +
         "`FirebaseApp.configure()` in the App Delegate's " +
         "`application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's " +

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -95,6 +95,7 @@ import Foundation
     request.requestURI = OAuthResponseURLString
     request.sessionID = sessionID
     request.providerOAuthTokenSecret = secret
+    request.fullName = fullName
     request.pendingToken = pendingToken
   }
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -177,6 +177,13 @@ import CommonCrypto
   }
 
   #if os(iOS)
+    /** @fn getCredentialWithUIDelegate:completion:
+        @brief Used to obtain an auth credential via a mobile web flow.
+            This method is available on iOS only.
+        @param UIDelegate An optional UI delegate used to present the mobile web flow.
+        @param completion Optionally; a block which is invoked asynchronously on the main thread when
+            the mobile web flow is completed.
+     */
     @objc(getCredentialWithUIDelegate:completion:)
     public func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
                                   completion: ((AuthCredential?, Error?) -> Void)? = nil) {
@@ -242,28 +249,12 @@ import CommonCrypto
       }
     }
 
-    /** @fn appleCredentialWithIDToken:rawNonce:fullName:
-     *  @brief Creates an `AuthCredential` for the Sign in with Apple OAuth 2 provider identified by ID
-     * token, raw nonce, and full name. This method is specific to the Sign in with Apple OAuth 2
-     * provider as this provider requires the full name to be passed explicitly.
-     *
-     *  @param idToken The IDToken associated with the Sign in with Apple Auth credential being created.
-     *  @param rawNonce The raw nonce associated with the Sign in with Apple Auth credential being
-     * created.
-     *  @param fullName The full name associated with the Sign in with Apple Auth credential being
-     * created.
-     *  @return An `AuthCredential`.
+    /** @fn getCredentialWithUIDelegate:completion:
+        @brief Used to obtain an auth credential via a mobile web flow.
+            This method is available on iOS only.
+        @param UIDelegate An optional UI delegate used to present the mobile web flow.
+        @return An `AuthCredential`.
      */
-    @objc(appleCredentialWithIDToken:rawNonce:fullName:)
-    public static func appleCredential(withIDToken idToken: String,
-                                       rawNonce: String?,
-                                       fullName: PersonNameComponents?) -> OAuthCredential {
-      return OAuthCredential(withProviderID: AuthProviderString.apple.rawValue,
-                             idToken: idToken,
-                             rawNonce: rawNonce,
-                             fullName: fullName)
-    }
-
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
     public func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
       return try await withCheckedThrowingContinuation { continuation in
@@ -276,163 +267,184 @@ import CommonCrypto
         }
       }
     }
+  #endif
 
-    // MARK: - Private Methods
+  /** @fn appleCredentialWithIDToken:rawNonce:fullName:
+   *  @brief Creates an `AuthCredential` for the Sign in with Apple OAuth 2 provider identified by ID
+   * token, raw nonce, and full name. This method is specific to the Sign in with Apple OAuth 2
+   * provider as this provider requires the full name to be passed explicitly.
+   *
+   *  @param idToken The IDToken associated with the Sign in with Apple Auth credential being created.
+   *  @param rawNonce The raw nonce associated with the Sign in with Apple Auth credential being
+   * created.
+   *  @param fullName The full name associated with the Sign in with Apple Auth credential being
+   * created.
+   *  @return An `AuthCredential`.
+   */
+  @objc(appleCredentialWithIDToken:rawNonce:fullName:)
+  public static func appleCredential(withIDToken idToken: String,
+                                     rawNonce: String?,
+                                     fullName: PersonNameComponents?) -> OAuthCredential {
+    return OAuthCredential(withProviderID: AuthProviderString.apple.rawValue,
+                           idToken: idToken,
+                           rawNonce: rawNonce,
+                           fullName: fullName)
+  }
 
-    /** @fn OAuthResponseForURL:error:
-        @brief Parses the redirected URL and returns a string representation of the OAuth response URL.
-        @param URL The url to be parsed for an OAuth response URL.
-        @param error The error that occurred if any.
-        @return The OAuth response if successful.
-     */
-    private func oAuthResponseForURL(url: URL) -> (String?, Error?) {
-      var urlQueryItems = AuthWebUtils.dictionary(withHttpArgumentsString: url.query)
-      if let item = urlQueryItems["deep_link_id"],
-         let deepLinkURL = URL(string: item) {
-        urlQueryItems = AuthWebUtils.dictionary(withHttpArgumentsString: deepLinkURL.query)
-        if let queryItemLink = urlQueryItems["link"] {
-          return (queryItemLink, nil)
-        }
+  // MARK: - Private Methods
+
+  /** @fn OAuthResponseForURL:error:
+      @brief Parses the redirected URL and returns a string representation of the OAuth response URL.
+      @param URL The url to be parsed for an OAuth response URL.
+      @param error The error that occurred if any.
+      @return The OAuth response if successful.
+   */
+  private func oAuthResponseForURL(url: URL) -> (String?, Error?) {
+    var urlQueryItems = AuthWebUtils.dictionary(withHttpArgumentsString: url.query)
+    if let item = urlQueryItems["deep_link_id"],
+       let deepLinkURL = URL(string: item) {
+      urlQueryItems = AuthWebUtils.dictionary(withHttpArgumentsString: deepLinkURL.query)
+      if let queryItemLink = urlQueryItems["link"] {
+        return (queryItemLink, nil)
       }
-      if let errorData = urlQueryItems["firebaseError"]?.data(using: .utf8) {
-        do {
-          let error = try JSONSerialization.jsonObject(with: errorData) as? [String: Any]
-          let code = (error?["code"] as? String) ?? "missing code"
-          let message = (error?["message"] as? String) ?? "missing message"
-          return (nil, AuthErrorUtils.urlResponseError(code: code, message: message))
-        } catch {
-          return (nil, AuthErrorUtils.JSONSerializationError(underlyingError: error))
-        }
-      }
-      return (nil, AuthErrorUtils.webSignInUserInteractionFailure(
-        reason: "SignIn failed with unparseable firebaseError"
-      ))
     }
+    if let errorData = urlQueryItems["firebaseError"]?.data(using: .utf8) {
+      do {
+        let error = try JSONSerialization.jsonObject(with: errorData) as? [String: Any]
+        let code = (error?["code"] as? String) ?? "missing code"
+        let message = (error?["message"] as? String) ?? "missing message"
+        return (nil, AuthErrorUtils.urlResponseError(code: code, message: message))
+      } catch {
+        return (nil, AuthErrorUtils.JSONSerializationError(underlyingError: error))
+      }
+    }
+    return (nil, AuthErrorUtils.webSignInUserInteractionFailure(
+      reason: "SignIn failed with unparseable firebaseError"
+    ))
+  }
 
-    /** @fn getHeadfulLiteURLWithEventID
-        @brief Constructs a URL used for opening a headful-lite flow using a given event
-            ID and session ID.
-        @param eventID The event ID used for this purpose.
-        @param sessionID The session ID used when completing the headful lite flow.
-        @param completion The callback invoked after the URL has been constructed or an error
-            has been encountered.
-     */
-    private func getHeadfulLiteUrl(eventID: String,
-                                   sessionID: String,
-                                   completion: @escaping ((URL?, Error?) -> Void)) {
-      weak var weakSelf = self
-      AuthWebUtils
-        .fetchAuthDomain(withRequestConfiguration: auth.requestConfiguration) { authDomain, error in
-          if let error = error {
-            completion(nil, error)
-            return
-          }
-          let strongSelf = weakSelf
-          let bundleID = Bundle.main.bundleIdentifier
-          let clientID = strongSelf?.auth.app?.options.clientID
-          let appID = strongSelf?.auth.app?.options.googleAppID
-          let apiKey = strongSelf?.auth.requestConfiguration.apiKey
-          let tenantID = strongSelf?.auth.tenantID
-          let appCheck = strongSelf?.auth.requestConfiguration.appCheck
+  /** @fn getHeadfulLiteURLWithEventID
+      @brief Constructs a URL used for opening a headful-lite flow using a given event
+          ID and session ID.
+      @param eventID The event ID used for this purpose.
+      @param sessionID The session ID used when completing the headful lite flow.
+      @param completion The callback invoked after the URL has been constructed or an error
+          has been encountered.
+   */
+  private func getHeadfulLiteUrl(eventID: String,
+                                 sessionID: String,
+                                 completion: @escaping ((URL?, Error?) -> Void)) {
+    weak var weakSelf = self
+    AuthWebUtils
+      .fetchAuthDomain(withRequestConfiguration: auth.requestConfiguration) { authDomain, error in
+        if let error = error {
+          completion(nil, error)
+          return
+        }
+        let strongSelf = weakSelf
+        let bundleID = Bundle.main.bundleIdentifier
+        let clientID = strongSelf?.auth.app?.options.clientID
+        let appID = strongSelf?.auth.app?.options.googleAppID
+        let apiKey = strongSelf?.auth.requestConfiguration.apiKey
+        let tenantID = strongSelf?.auth.tenantID
+        let appCheck = strongSelf?.auth.requestConfiguration.appCheck
 
-          // TODO: Should we fail if these strings are empty? Only ibi was explicit in ObjC.
-          var urlArguments = ["apiKey": apiKey ?? "",
-                              "authType": "signInWithRedirect",
-                              "ibi": bundleID ?? "",
-                              "sessionId": strongSelf?.hash(forString: sessionID) ?? "",
-                              "v": AuthBackend.authUserAgent(),
-                              "eventId": eventID,
-                              "providerId": strongSelf?.providerID ?? ""]
+        // TODO: Should we fail if these strings are empty? Only ibi was explicit in ObjC.
+        var urlArguments = ["apiKey": apiKey ?? "",
+                            "authType": "signInWithRedirect",
+                            "ibi": bundleID ?? "",
+                            "sessionId": strongSelf?.hash(forString: sessionID) ?? "",
+                            "v": AuthBackend.authUserAgent(),
+                            "eventId": eventID,
+                            "providerId": strongSelf?.providerID ?? ""]
 
-          if let usingClientIDScheme = strongSelf?.usingClientIDScheme, usingClientIDScheme {
-            urlArguments["clientId"] = clientID
-          } else {
-            urlArguments["appId"] = appID
+        if let usingClientIDScheme = strongSelf?.usingClientIDScheme, usingClientIDScheme {
+          urlArguments["clientId"] = clientID
+        } else {
+          urlArguments["appId"] = appID
+        }
+        if let tenantID {
+          urlArguments["tid"] = tenantID
+        }
+        if let scopes = strongSelf?.scopes, scopes.count > 0 {
+          urlArguments["scopes"] = scopes.joined(separator: ",")
+        }
+        if let customParameters = strongSelf?.customParameters, customParameters.count > 0 {
+          do {
+            let customParametersJSONData = try JSONSerialization
+              .data(withJSONObject: customParameters)
+            let rawJson = String(decoding: customParametersJSONData, as: UTF8.self)
+            urlArguments["customParameters"] = rawJson
+          } catch {
+            completion(nil, AuthErrorUtils.JSONSerializationError(underlyingError: error))
           }
-          if let tenantID {
-            urlArguments["tid"] = tenantID
-          }
-          if let scopes = strongSelf?.scopes, scopes.count > 0 {
-            urlArguments["scopes"] = scopes.joined(separator: ",")
-          }
-          if let customParameters = strongSelf?.customParameters, customParameters.count > 0 {
-            do {
-              let customParametersJSONData = try JSONSerialization
-                .data(withJSONObject: customParameters)
-              let rawJson = String(decoding: customParametersJSONData, as: UTF8.self)
-              urlArguments["customParameters"] = rawJson
-            } catch {
-              completion(nil, AuthErrorUtils.JSONSerializationError(underlyingError: error))
+        }
+        if let languageCode = strongSelf?.auth.requestConfiguration.languageCode {
+          urlArguments["hl"] = languageCode
+        }
+        let argumentsString = strongSelf?
+          .httpArgumentsString(forArgsDictionary: urlArguments) ?? ""
+        var urlString: String
+        if (strongSelf?.auth.requestConfiguration.emulatorHostAndPort) != nil {
+          urlString = "http://\(authDomain ?? "")/emulator/auth/handler?\(argumentsString)"
+        } else {
+          urlString = "https://\(authDomain ?? "")/__/auth/handler?\(argumentsString)"
+        }
+        guard let percentEncoded = urlString.addingPercentEncoding(
+          withAllowedCharacters: CharacterSet.urlFragmentAllowed
+        ) else {
+          fatalError("Internal Auth Error: failed to percent encode a string")
+        }
+        var components = URLComponents(string: percentEncoded)
+        if let appCheck {
+          appCheck.getToken(forcingRefresh: false) { tokenResult in
+            if let error = tokenResult.error {
+              AuthLog.logWarning(code: "I-AUT000018",
+                                 message: "Error getting App Check token; using placeholder " +
+                                   "token instead. Error: \(error)")
             }
-          }
-          if let languageCode = strongSelf?.auth.requestConfiguration.languageCode {
-            urlArguments["hl"] = languageCode
-          }
-          let argumentsString = strongSelf?
-            .httpArgumentsString(forArgsDictionary: urlArguments) ?? ""
-          var urlString: String
-          if (strongSelf?.auth.requestConfiguration.emulatorHostAndPort) != nil {
-            urlString = "http://\(authDomain ?? "")/emulator/auth/handler?\(argumentsString)"
-          } else {
-            urlString = "https://\(authDomain ?? "")/__/auth/handler?\(argumentsString)"
-          }
-          guard let percentEncoded = urlString.addingPercentEncoding(
-            withAllowedCharacters: CharacterSet.urlFragmentAllowed
-          ) else {
-            fatalError("Internal Auth Error: failed to percent encode a string")
-          }
-          var components = URLComponents(string: percentEncoded)
-          if let appCheck {
-            appCheck.getToken(forcingRefresh: false) { tokenResult in
-              if let error = tokenResult.error {
-                AuthLog.logWarning(code: "I-AUT000018",
-                                   message: "Error getting App Check token; using placeholder " +
-                                     "token instead. Error: \(error)")
-              }
-              let appCheckTokenFragment = "fac=\(tokenResult.token)"
-              components?.fragment = appCheckTokenFragment
-              completion(components?.url, nil)
-            }
-          } else {
+            let appCheckTokenFragment = "fac=\(tokenResult.token)"
+            components?.fragment = appCheckTokenFragment
             completion(components?.url, nil)
           }
+        } else {
+          completion(components?.url, nil)
         }
-    }
-
-    /** @fn hashforString:
-        @brief Returns the SHA256 hash representation of a given string object.
-        @param string The string for which a SHA256 hash is desired.
-        @return An hexadecimal string representation of the SHA256 hash.
-     */
-    private func hash(forString string: String) -> String {
-      guard let sessionIdData = string.data(using: .utf8) as? NSData else {
-        fatalError("FirebaseAuth Internal error: Failed to create hash for sessionID")
       }
-      let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
-      var hash = [UInt8](repeating: 0, count: digestLength)
-      CC_SHA256(sessionIdData.bytes, UInt32(sessionIdData.length), &hash)
-      let dataHash = NSData(bytes: hash, length: digestLength)
-      var bytes = [UInt8](repeating: 0, count: digestLength)
-      dataHash.getBytes(&bytes, length: digestLength)
+  }
 
-      var hexString = ""
-      for byte in bytes {
-        hexString += String(format: "%02x", UInt8(byte))
-      }
-      return hexString
+  /** @fn hashforString:
+      @brief Returns the SHA256 hash representation of a given string object.
+      @param string The string for which a SHA256 hash is desired.
+      @return An hexadecimal string representation of the SHA256 hash.
+   */
+  private func hash(forString string: String) -> String {
+    guard let sessionIdData = string.data(using: .utf8) as? NSData else {
+      fatalError("FirebaseAuth Internal error: Failed to create hash for sessionID")
     }
+    let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+    var hash = [UInt8](repeating: 0, count: digestLength)
+    CC_SHA256(sessionIdData.bytes, UInt32(sessionIdData.length), &hash)
+    let dataHash = NSData(bytes: hash, length: digestLength)
+    var bytes = [UInt8](repeating: 0, count: digestLength)
+    dataHash.getBytes(&bytes, length: digestLength)
 
-    private func httpArgumentsString(forArgsDictionary argsDictionary: [String: String]) -> String {
-      var argsString: [String] = []
-      for (key, value) in argsDictionary {
-        let keyString = AuthWebUtils.string(byUnescapingFromURLArgument: key)
-        let valueString = AuthWebUtils.string(byUnescapingFromURLArgument: value.description)
-        argsString.append("\(keyString)=\(valueString)")
-      }
-      return argsString.joined(separator: "&")
+    var hexString = ""
+    for byte in bytes {
+      hexString += String(format: "%02x", UInt8(byte))
     }
+    return hexString
+  }
 
-  #endif
+  private func httpArgumentsString(forArgsDictionary argsDictionary: [String: String]) -> String {
+    var argsString: [String] = []
+    for (key, value) in argsDictionary {
+      let keyString = AuthWebUtils.string(byUnescapingFromURLArgument: key)
+      let valueString = AuthWebUtils.string(byUnescapingFromURLArgument: value.description)
+      argsString.append("\(keyString)=\(valueString)")
+    }
+    return argsString.joined(separator: "&")
+  }
 
   private let auth: Auth
   private let callbackScheme: String

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -2026,23 +2026,32 @@ import Foundation
   }
 
   public required init?(coder: NSCoder) {
-    guard let userID = coder.decodeObject(of:NSString.self, forKey: kUserIDCodingKey) as? String,
-          let apiKey = coder.decodeObject(of:NSString.self, forKey: kAPIKeyCodingKey) as? String,
-          let appID = coder.decodeObject(of:NSString.self, forKey: kFirebaseAppIDCodingKey) as? String,
+    guard let userID = coder.decodeObject(of: NSString.self, forKey: kUserIDCodingKey) as? String,
+          let apiKey = coder.decodeObject(of: NSString.self, forKey: kAPIKeyCodingKey) as? String,
+          let appID = coder.decodeObject(
+            of: NSString.self,
+            forKey: kFirebaseAppIDCodingKey
+          ) as? String,
           let tokenService = coder.decodeObject(forKey: kTokenServiceCodingKey)
           as? SecureTokenService else {
       return nil
     }
     let anonymous = coder.decodeBool(forKey: kAnonymousCodingKey)
     let hasEmailPasswordCredential = coder.decodeBool(forKey: kHasEmailPasswordCredentialCodingKey)
-    let displayName = coder.decodeObject(of:NSString.self, forKey: kDisplayNameCodingKey) as? String
+    let displayName = coder.decodeObject(
+      of: NSString.self,
+      forKey: kDisplayNameCodingKey
+    ) as? String
     let photoURL = coder.decodeObject(forKey: kPhotoURLCodingKey) as? URL
-    let email = coder.decodeObject(of:NSString.self, forKey: kEmailCodingKey) as? String
-    let phoneNumber = coder.decodeObject(of:NSString.self, forKey: kPhoneNumberCodingKey) as? String
+    let email = coder.decodeObject(of: NSString.self, forKey: kEmailCodingKey) as? String
+    let phoneNumber = coder.decodeObject(
+      of: NSString.self,
+      forKey: kPhoneNumberCodingKey
+    ) as? String
     let emailVerified = coder.decodeBool(forKey: kEmailVerifiedCodingKey)
     let providerData = coder.decodeObject(forKey: kProviderDataKey) as? [String: UserInfoImpl]
     let metadata = coder.decodeObject(forKey: kMetadataCodingKey) as? UserMetadata
-    let tenantID = coder.decodeObject(of:NSString.self, forKey: kTenantIDCodingKey) as? String
+    let tenantID = coder.decodeObject(of: NSString.self, forKey: kTenantIDCodingKey) as? String
     #if os(iOS)
       let multiFactor = coder.decodeObject(forKey: kMultiFactorCodingKey) as? MultiFactor
     #endif

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -2026,23 +2026,23 @@ import Foundation
   }
 
   public required init?(coder: NSCoder) {
-    guard let userID = coder.decodeObject(forKey: kUserIDCodingKey) as? String,
-          let apiKey = coder.decodeObject(forKey: kAPIKeyCodingKey) as? String,
-          let appID = coder.decodeObject(forKey: kFirebaseAppIDCodingKey) as? String,
+    guard let userID = coder.decodeObject(of:NSString.self, forKey: kUserIDCodingKey) as? String,
+          let apiKey = coder.decodeObject(of:NSString.self, forKey: kAPIKeyCodingKey) as? String,
+          let appID = coder.decodeObject(of:NSString.self, forKey: kFirebaseAppIDCodingKey) as? String,
           let tokenService = coder.decodeObject(forKey: kTokenServiceCodingKey)
           as? SecureTokenService else {
       return nil
     }
     let anonymous = coder.decodeBool(forKey: kAnonymousCodingKey)
     let hasEmailPasswordCredential = coder.decodeBool(forKey: kHasEmailPasswordCredentialCodingKey)
-    let displayName = coder.decodeObject(forKey: kDisplayNameCodingKey) as? String
+    let displayName = coder.decodeObject(of:NSString.self, forKey: kDisplayNameCodingKey) as? String
     let photoURL = coder.decodeObject(forKey: kPhotoURLCodingKey) as? URL
-    let email = coder.decodeObject(forKey: kEmailCodingKey) as? String
-    let phoneNumber = coder.decodeObject(forKey: kPhoneNumberCodingKey) as? String
+    let email = coder.decodeObject(of:NSString.self, forKey: kEmailCodingKey) as? String
+    let phoneNumber = coder.decodeObject(of:NSString.self, forKey: kPhoneNumberCodingKey) as? String
     let emailVerified = coder.decodeBool(forKey: kEmailVerifiedCodingKey)
     let providerData = coder.decodeObject(forKey: kProviderDataKey) as? [String: UserInfoImpl]
     let metadata = coder.decodeObject(forKey: kMetadataCodingKey) as? UserMetadata
-    let tenantID = coder.decodeObject(forKey: kTenantIDCodingKey) as? String
+    let tenantID = coder.decodeObject(of:NSString.self, forKey: kTenantIDCodingKey) as? String
     #if os(iOS)
       let multiFactor = coder.decodeObject(forKey: kMultiFactorCodingKey) as? MultiFactor
     #endif

--- a/FirebaseAuth/Tests/Unit/AdditionalUserInfoTests.swift
+++ b/FirebaseAuth/Tests/Unit/AdditionalUserInfoTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseAuth
 
-class AdditionaUserInfoTests: XCTestCase {
+class AdditionalUserInfoTests: XCTestCase {
   let kFakeProfile = ["email": "user@mail.com", "given_name": "User", "family_name": "Doe"]
   let kUserName = "User Doe"
   let kProviderID = "PROVIDER_ID"

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class RPCBaseTests: XCTestCase {
   let kEmail = "user@company.com"
   let kFakePassword = "!@#$%^"
-  let kDisplayName = "Google Doe"
+  let kDisplayName = "User Doe"
   let kLocalID = "testLocalId"
   let kFakeOobCode = "fakeOobCode"
   let kRefreshToken = "fakeRefreshToken"
@@ -34,13 +34,22 @@ class RPCBaseTests: XCTestCase {
     "https://example.domain.com/?apiKey=testAPIKey&oobCode=testoobcode&mode=signIn"
   let kContinueURL = "continueURL"
   let kIosBundleID = "testBundleID"
-  let kAndroidPackageName = "adroidpackagename"
+  let kAndroidPackageName = "androidpackagename"
   let kAndroidMinimumVersion = "3.0"
   let kDynamicLinkDomain = "test.page.link"
   let kTestPhotoURL = "https://host.domain/image"
   let kCreationDateTimeIntervalInSeconds = 1_505_858_500.0
   let kLastSignInDateTimeIntervalInSeconds = 1_505_858_583.0
   let kTestPhoneNumber = "415-555-1234"
+  static let kOAuthSessionID = "sessionID"
+  static let kOAuthRequestURI = "requestURI"
+  let kGoogleIDToken = "GOOGLE_ID_TOKEN"
+  let kGoogleAccessToken = "GOOGLE_ACCESS_TOKEN"
+  let kGoogleID = "GOOGLE_ID"
+  let kGoogleEmail = "usergmail.com"
+  let kGoogleDisplayName = "Google Doe"
+  let kGoogleProfile = ["email": "usergmail.com", "given_name": "MyFirst", "family_name": "MyLast"]
+  let kUserName = "User Doe"
 
   /** @var kTestAPIKey
       @brief Fake API key used for testing.
@@ -236,7 +245,7 @@ class RPCBaseTests: XCTestCase {
     rpcIssuer?.fakeSecureTokenServiceJSON = ["access_token": fakeAccessToken]
   }
 
-  func setFakeGetAccountProvider(withNewDisplayName displayName: String = "Google Doe",
+  func setFakeGetAccountProvider(withNewDisplayName displayName: String = "User Doe",
                                  withLocalID localID: String = "testLocalId",
                                  withProviderID providerID: String = "testProviderID",
                                  withFederatedID federatedID: String = "testFederatedId",
@@ -271,6 +280,13 @@ class RPCBaseTests: XCTestCase {
     ]]
   }
 
+  func setFakeGoogleGetAccountProvider() {
+    setFakeGetAccountProvider(withNewDisplayName: kGoogleDisplayName,
+                              withProviderID: GoogleAuthProvider.id,
+                              withFederatedID:kGoogleID,
+                              withEmail: kGoogleEmail)
+  }
+
   func setFakeGetAccountProviderAnonymous() {
     let kPasswordHashKey = "passwordHash"
     let kTestPasswordHash = "testPasswordHash"
@@ -299,5 +315,17 @@ class RPCBaseTests: XCTestCase {
     settings.url = URL(string: kContinueURL)
     settings.dynamicLinkDomain = kDynamicLinkDomain
     return settings
+  }
+
+  func assertUserGoogle(_ user: User?) throws {
+    let user = try XCTUnwrap(user)
+    XCTAssertEqual(user.uid, kLocalID)
+    XCTAssertEqual(user.displayName, kGoogleDisplayName)
+    XCTAssertEqual(user.providerData.count, 1)
+    let googleUserInfo = user.providerData[0]
+    XCTAssertEqual(googleUserInfo.providerID, GoogleAuthProvider.id)
+    XCTAssertEqual(googleUserInfo.uid, kGoogleID)
+    XCTAssertEqual(googleUserInfo.displayName, kGoogleDisplayName)
+    XCTAssertEqual(googleUserInfo.email, kGoogleEmail)
   }
 }

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -283,7 +283,7 @@ class RPCBaseTests: XCTestCase {
   func setFakeGoogleGetAccountProvider() {
     setFakeGetAccountProvider(withNewDisplayName: kGoogleDisplayName,
                               withProviderID: GoogleAuthProvider.id,
-                              withFederatedID:kGoogleID,
+                              withFederatedID: kGoogleID,
                               withEmail: kGoogleEmail)
   }
 

--- a/FirebaseAuth/Tests/Unit/UserTests.swift
+++ b/FirebaseAuth/Tests/Unit/UserTests.swift
@@ -20,11 +20,6 @@ import FirebaseCore
 
 class UserTests: RPCBaseTests {
   static let kFakeAPIKey = "FAKE_API_KEY"
-  let kGoogleIDToken = "GOOGLE_ID_TOKEN"
-  let kGoogleAccessToken = "GOOGLE_ACCESS_TOKEN"
-  let kGoogleID = "GOOGLE_ID"
-  let kGoogleEmail = "usergmail.com"
-  let kGoogleDisplayName = "Google Doe"
   let kFacebookAccessToken = "FACEBOOK_ACCESS_TOKEN"
   let kFacebookID = "FACEBOOK_ID"
   let kFacebookEmail = "user@facebook.com"
@@ -33,8 +28,6 @@ class UserTests: RPCBaseTests {
   let kNewEmail = "newuser@company.com"
   let kNewPassword = "newpassword"
   let kNewDisplayName = "New User Doe"
-  let kUserName = "User Doe"
-  let kGoogleProfile = ["email": "usergmail.com", "given_name": "MyFirst", "family_name": "MyLast"]
   let kVerificationCode = "12345678"
   let kVerificationID = "55432"
   let kPhoneNumber = "555-1234"
@@ -869,7 +862,7 @@ class UserTests: RPCBaseTests {
                                                "federatedId": self.kGoogleID,
                                                "providerId": GoogleAuthProvider.id,
                                                "localId": self.kLocalID,
-                                               "displayName": self.kDisplayName,
+                                               "displayName": self.kGoogleDisplayName,
                                                "rawUserInfo": self.kGoogleProfile,
                                                "username": self.kUserName])
       } catch {
@@ -955,9 +948,7 @@ class UserTests: RPCBaseTests {
     signInWithFacebookCredential { user in
       XCTAssertNotNil(user)
       do {
-        self.setFakeGetAccountProvider(withProviderID: GoogleAuthProvider.id,
-                                       withFederatedID: self.kGoogleID,
-                                       withEmail: self.kGoogleEmail)
+        self.setFakeGoogleGetAccountProvider()
         let group = self.createGroup()
         let googleCredential = GoogleAuthProvider.credential(withIDToken: self.kGoogleIDToken,
                                                              accessToken: self.kGoogleAccessToken)
@@ -988,7 +979,7 @@ class UserTests: RPCBaseTests {
                                                "federatedId": self.kGoogleID,
                                                "providerId": GoogleAuthProvider.id,
                                                "localId": self.kLocalID,
-                                               "displayName": self.kDisplayName,
+                                               "displayName": self.kGoogleDisplayName,
                                                "rawUserInfo": self.kGoogleProfile,
                                                "username": self.kUserName])
       } catch {
@@ -1241,15 +1232,13 @@ class UserTests: RPCBaseTests {
 
   #if os(iOS)
     private class FakeOAuthProvider: OAuthProvider {
-      static let kOAuthSessionID = "sessionID"
-      static let kOAuthRequestURI = "requestURI"
       override func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
                                       completion: ((AuthCredential?, Error?) -> Void)? = nil) {
         if let completion {
           let credential = OAuthCredential(
             withProviderID: GoogleAuthProvider.id,
-            sessionID: UserTests.FakeOAuthProvider.kOAuthSessionID,
-            OAuthResponseURLString: UserTests.FakeOAuthProvider.kOAuthRequestURI
+            sessionID: UserTests.kOAuthSessionID,
+            OAuthResponseURLString: UserTests.kOAuthRequestURI
           )
           completion(credential, nil)
         }
@@ -1672,9 +1661,7 @@ class UserTests: RPCBaseTests {
 
   private func signInWithGoogleCredential(completion: @escaping (User) -> Void) {
     setFakeSecureTokenService(fakeAccessToken: RPCBaseTests.kFakeAccessToken)
-    setFakeGetAccountProvider(withProviderID: GoogleAuthProvider.id,
-                              withFederatedID: kGoogleID,
-                              withEmail: kGoogleEmail)
+    setFakeGoogleGetAccountProvider()
 
     // 1. Create a group to synchronize request creation by the fake rpcIssuer.
     let group = createGroup()
@@ -1800,18 +1787,6 @@ class UserTests: RPCBaseTests {
     } catch {
       XCTFail("Throw in \(#function): \(error)")
     }
-  }
-
-  private func assertUserGoogle(_ user: User?) throws {
-    let user = try XCTUnwrap(user)
-    XCTAssertEqual(user.uid, kLocalID)
-    XCTAssertEqual(user.displayName, kGoogleDisplayName)
-    XCTAssertEqual(user.providerData.count, 1)
-    let googleUserInfo = user.providerData[0]
-    XCTAssertEqual(googleUserInfo.providerID, GoogleAuthProvider.id)
-    XCTAssertEqual(googleUserInfo.uid, kGoogleID)
-    XCTAssertEqual(googleUserInfo.displayName, kGoogleDisplayName)
-    XCTAssertEqual(googleUserInfo.email, kGoogleEmail)
   }
 
   // TODO: For testUpdateEmailWithAuthLinkAccountSuccess. Revisit after auth.swift. Should be able to


### PR DESCRIPTION
- 15 more AuthTests.swift (25 to go)
- Refactoring to centralize more common constants in `RPCBaseTests`
- Distinguish between `User Doe` and `Google Doe` constants to clean up test sloppiness.
- Fix bug of not propagating fullName from an OAuthCredential to a VerifyAssertionRequest
- A few additional typo fixes