### PR TITLE
[App Check] Prefix test module names with Firebase

### DIFF
--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -1,10 +1,10 @@
-name: app_check
+name: firebase_app_check
 
 on:
   pull_request:
     paths:
     - 'FirebaseAppCheck**'
-    - '.github/workflows/app_check.yml'
+    - '.github/workflows/firebase_app_check.yml'
     - 'Gemfile*'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
@@ -65,7 +65,7 @@ jobs:
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AppCheckUnit iOS spm ${{ matrix.diagnostic }}
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseAppCheckUnit iOS spm ${{ matrix.diagnostic }}
     - name: Upload raw logs if failed
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
@@ -107,6 +107,6 @@ jobs:
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AppCheckUnit ${{ matrix.target }} spm
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseAppCheckUnit ${{ matrix.target }} spm
     - name: Swift Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AppCheckUnitSwift ${{ matrix.target }} spm
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseAppCheckUnitSwift ${{ matrix.target }} spm

--- a/Package.swift
+++ b/Package.swift
@@ -1277,7 +1277,7 @@ let package = Package(
       ]
     ),
     .testTarget(
-      name: "AppCheckUnit",
+      name: "FirebaseAppCheckUnit",
       dependencies: [
         "FirebaseAppCheck",
         "SharedTestUtilities",
@@ -1286,7 +1286,8 @@ let package = Package(
       ],
       path: "FirebaseAppCheck/Tests",
       exclude: [
-        // Disable Swift tests as mixed targets are not supported (Xcode 12.3).
+        // Swift tests are in the target `FirebaseAppCheckUnitSwift` since mixed language targets
+        // are not supported (as of Xcode 14.3).
         "Unit/Swift",
       ],
       resources: [
@@ -1297,7 +1298,7 @@ let package = Package(
       ]
     ),
     .testTarget(
-      name: "AppCheckUnitSwift",
+      name: "FirebaseAppCheckUnitSwift",
       dependencies: ["FirebaseAppCheck"],
       path: "FirebaseAppCheck/Tests/Unit/Swift",
       cSettings: [

--- a/scripts/spm_test_schemes/FirebaseAppCheckUnit.xcscheme
+++ b/scripts/spm_test_schemes/FirebaseAppCheckUnit.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AppCheckUnit"
-               BuildableName = "AppCheckUnit"
-               BlueprintName = "AppCheckUnit"
+               BlueprintIdentifier = "FirebaseAppCheckUnit"
+               BuildableName = "FirebaseAppCheckUnit"
+               BlueprintName = "FirebaseAppCheckUnit"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AppCheckUnit"
-               BuildableName = "AppCheckUnit"
-               BlueprintName = "AppCheckUnit"
+               BlueprintIdentifier = "FirebaseAppCheckUnit"
+               BuildableName = "FirebaseAppCheckUnit"
+               BlueprintName = "FirebaseAppCheckUnit"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/scripts/spm_test_schemes/FirebaseAppCheckUnitSwift.xcscheme
+++ b/scripts/spm_test_schemes/FirebaseAppCheckUnitSwift.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AppCheckUnitSwift"
-               BuildableName = "AppCheckUnitSwift"
-               BlueprintName = "AppCheckUnitSwift"
+               BlueprintIdentifier = "FirebaseAppCheckUnitSwift"
+               BuildableName = "FirebaseAppCheckUnitSwift"
+               BlueprintName = "FirebaseAppCheckUnitSwift"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AppCheckUnitSwift"
-               BuildableName = "AppCheckUnitSwift"
-               BlueprintName = "AppCheckUnitSwift"
+               BlueprintIdentifier = "FirebaseAppCheckUnitSwift"
+               BuildableName = "FirebaseAppCheckUnitSwift"
+               BlueprintName = "FirebaseAppCheckUnitSwift"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
Renamed `AppCheckUnit` to `FirebaseAppCheckUnit` and `AppCheckUnitSwift` to `FirebaseAppCheckUnitSwift`. This is in preparation for extracting core App Check functionality into a separate SDK.

#no-changelog