### PR TITLE
Trying to reproduce #11199

### DIFF
--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCPUExceptionDiagnostic.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCPUExceptionDiagnostic.h
@@ -23,6 +23,7 @@
 #import "Crashlytics/UnitTests/Mocks/FIRCLSMockMXMetadata.h"
 
 NS_ASSUME_NONNULL_BEGIN
+// Hello
 
 API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXCPUExceptionDiagnostic : MXCPUExceptionDiagnostic


### PR DESCRIPTION
I'm not seeing https://github.com/firebase/firebase-ios-sdk/issues/11199 on my machine, so I'm trying on GitHub Actions

```
./scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=ios --no-clean
bundle exec pod lib lint --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ --include-podspecs={FirebaseCore.podspec,FirebaseCoreInternal.podspec,FirebaseInstallations.podspec,FirebaseSessions.podspec,FirebaseCoreExtension.podspec} --analyze FirebaseCrashlytics.podspec --platforms=ios --no-clean

Still working, running for 1min.
 -> FirebaseCrashlytics (10.11.0)
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Building targets in dependency order
    - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'PromisesSwift' from project 'Pods')
    - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseCoreInternal' from project 'Pods')
    - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseSessions' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'PromisesSwift' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'GoogleUtilities' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'nanopb' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'PromisesObjC' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'GoogleDataTransport' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseInstallations' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCoreInternal' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCoreExtension' from project 'Pods')
    - NOTE  | xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.4.99. (in target 'FirebaseCore' from project 'Pods')
    - ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - NOTE  | [iOS] xcodebuild:  /Users/samedson/Firebase/ios-sdk/Crashlytics/UnitTests/FIRCLSReportManagerTests.m:322: error: -[FIRCLSReportManagerTests testExistingUnimportantReportOnStartWithDataCollectionDisabled] : (([[self contentsOfActivePath] count]) equal to (1)) failed: ("2") is not equal to ("1")
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.910230-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to read JSON from file (/Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Bundle/Application/E44CD2A7-5C4A-456C-BC02-C134A79817D9/AppHost-FirebaseCrashlytics-Unit-Tests.app/PlugIns/FirebaseCrashlytics-Unit-unit.xctest/corrupt_metadata/metadata.clsrecord) line (1) with error: Error Domain=NSCocoaErrorDomain Code=3840 "Badly formed object around line 1, column 102." UserInfo={NSDebugDescription=Badly formed object around line 1, column 102., NSJSONSerializationErrorIndex=102}
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.916571-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from nonExistentPath with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “nonExistentPath” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.946240-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “prepared” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.948988-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “prepared” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.955520-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared/pkg_uuid with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “pkg_uuid” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.957462-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared/pkg_uuid with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “pkg_uuid” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.959551-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared/pkg_uuid with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “pkg_uuid” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.961621-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared/pkg_uuid with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “pkg_uuid” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.963663-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to send crash report due to GoogleDataTransport error: The operation couldn’t be completed. (domain error 1.)
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.965125-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Failed to find .clsrecords from /Users/samedson/Library/Developer/CoreSimulator/Devices/65A2A9B6-5CCE-4711-9188-A411C2646CBF/data/Containers/Data/Application/490D09AF-8FDB-4A71-9688-26E49A370BEA/Library/Caches/com.crashlytics.data/org.cocoapods.AppHost-FirebaseCrashlytics-Unit-Tests/v5/reports/prepared/pkg_uuid with error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “pkg_uuid” doesn’t exist." UserInfo={NSUserStringVariant=(
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.972485-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Could not load settings file data with error: The data couldn’t be read because it isn’t in the correct format.
    - NOTE  | [iOS] xcodebuild:  2023-05-31 11:08:06.973952-0400 AppHost-FirebaseCrashlytics-Unit-Tests[50548:494435] 10.11.0 - [FirebaseCrashlytics][I-CLS000000] Could not load settings file data with error: The data couldn’t be read because it isn’t in the correct format.

Pods workspace available at `/var/folders/6f/bct6r56d1c93215jsg8cxbg000dn17/T/CocoaPods-Lint-20230531-47868-16trvoy-FirebaseCrashlytics/App.xcworkspace` for inspection.

```