### PR TITLE
[Infra] Remove GHA env var that is no longer needed

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -22,9 +22,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
     runs-on: macos-12
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
@@ -45,8 +42,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
@@ -98,9 +93,6 @@ jobs:
   catalyst:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -22,9 +22,6 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos]
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -55,9 +52,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
     runs-on: macos-12
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/.github/workflows/core_extension.yml
+++ b/.github/workflows/core_extension.yml
@@ -21,9 +21,6 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos]
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/core_internal.yml
+++ b/.github/workflows/core_internal.yml
@@ -19,9 +19,6 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos]
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -48,9 +45,6 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-12
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -22,9 +22,6 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos]
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -39,9 +36,6 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-12
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: macos-12
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
         target: [ios, tvos, macos]
@@ -67,9 +65,6 @@ jobs:
   catalyst:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-12
-    env:
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -128,8 +123,6 @@ jobs:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      # This env var is set because the job has a dependency on the unpublished HeatbeatLoggingTestUtils.
-      POD_LIB_LINT_ONLY: 1
     strategy:
       matrix:
         target: [ios, tvos, macos]


### PR DESCRIPTION
### Context
Following #11370, the POD_LIB_LINT_ONLY env var is no longer needed. So, removing it from CI scripts.

No remaining references within the repo.
```
➜  firebase-ios-sdk git:(nc/cleanup-gha) 
‣ git grep POD_LIB_LINT_ONLY
➜  firebase-ios-sdk git:(nc/cleanup-gha) 
```

#no-changelog

