### PR TITLE
Added TOTP MFA Assertion logics

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -74,6 +74,8 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo+Internal.h"
+#import "FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h"
+
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -846,9 +848,17 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 #if TARGET_OS_IOS
                    NSMutableArray<FIRMultiFactorInfo *> *multiFactorInfo = [NSMutableArray array];
                    for (FIRAuthProtoMFAEnrollment *MFAEnrollment in response.MFAInfo) {
-                     FIRPhoneMultiFactorInfo *info =
-                         [[FIRPhoneMultiFactorInfo alloc] initWithProto:MFAEnrollment];
-                     [multiFactorInfo addObject:info];
+                     // check which MFA factors are enabled.
+                     if (MFAEnrollment.phoneInfo != nil) {
+                       FIRPhoneMultiFactorInfo *info =
+                           [[FIRPhoneMultiFactorInfo alloc] initWithProto:MFAEnrollment];
+                       [multiFactorInfo addObject:info];
+                     }
+                     if (MFAEnrollment.TOTPInfo != nil) {
+                       FIRTOTPMultiFactorInfo *info =
+                           [[FIRTOTPMultiFactorInfo alloc] initWithProto:MFAEnrollment];
+                       [multiFactorInfo addObject:info];
+                     }
                    }
                    NSError *multiFactorRequiredError = [FIRAuthErrorUtils
                        secondFactorRequiredErrorWithPendingCredential:response.MFAPendingCredential

--- a/FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h
+++ b/FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRAuthProtoMFAEnrollment : NSObject <FIRAuthProto>
 
 @property(nonatomic, copy, readonly, nullable) NSString *phoneInfo;
+
 @property(nonatomic, copy, readonly, nullable) NSObject *TOTPInfo;
 
 @property(nonatomic, copy, readonly, nullable) NSString *MFAEnrollmentID;

--- a/FirebaseAuth/Sources/Backend/RPC/Proto/TOTP/FIRAuthProtoFinalizeMFATOTPSignInRequestInfo.h
+++ b/FirebaseAuth/Sources/Backend/RPC/Proto/TOTP/FIRAuthProtoFinalizeMFATOTPSignInRequestInfo.h
@@ -18,12 +18,28 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ @brief FIRAuthProtoFinalizeMFATOTPSignInRequestInfo class.  This class is used to compose
+ finalizeMFASignInRequest for TOTP case.
+ */
 @interface FIRAuthProtoFinalizeMFATOTPSignInRequestInfo : NSObject <FIRAuthProto>
 
+/**
+ @brief Multifactor enrollment ID.
+ */
 @property(nonatomic, strong, readonly, nullable) NSString *mfaEnrollmentID;
 
+/**
+ @brief Verification code.
+ */
 @property(nonatomic, strong, readonly, nullable) NSString *verificationCode;
 
+/**
+ @fn initWithMfaEnrollmentID:verificationCode
+ @brief initialize function for FIRAuthProtoFinalizeMFATOTPSignInRequestInfo.
+ @param mfaEnrollmentID Multifactor enrollment ID.
+ @param verificationCode One time verification code.
+ */
 - (instancetype)initWithMfaEnrollmentID:(NSString *)mfaEnrollmentID
                        verificationCode:(NSString *)verificationCode;
 @end

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
@@ -24,14 +24,18 @@
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend+MultiFactor.h"
 #import "FirebaseAuth/Sources/Backend/RPC/MultiFactor/SignIn/FIRFinalizeMFASignInRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/Proto/Phone/FIRAuthProtoFinalizeMFAPhoneRequestInfo.h"
+#import "FirebaseAuth/Sources/Backend/RPC/Proto/TOTP/FIRAuthProtoFinalizeMFATOTPSignInRequestInfo.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
 
 #if TARGET_OS_IOS
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRPhoneMultiFactorAssertion.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRTOTPMultiFactorAssertion.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h"
+#import "FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorAssertion+Internal.h"
+
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -55,14 +59,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resolveSignInWithAssertion:(nonnull FIRMultiFactorAssertion *)assertion
                         completion:(nullable FIRAuthDataResultCallback)completion {
 #if TARGET_OS_IOS
-  FIRPhoneMultiFactorAssertion *phoneAssertion = (FIRPhoneMultiFactorAssertion *)assertion;
-  FIRAuthProtoFinalizeMFAPhoneRequestInfo *finalizeMFAPhoneRequestInfo =
-      [[FIRAuthProtoFinalizeMFAPhoneRequestInfo alloc]
-          initWithSessionInfo:phoneAssertion.authCredential.verificationID
-             verificationCode:phoneAssertion.authCredential.verificationCode];
+  NSObject<FIRAuthProto> *finalizedMFARequestInfo;
+  if ([assertion isKindOfClass:[FIRPhoneMultiFactorAssertion class]]) {
+    FIRPhoneMultiFactorAssertion *phoneAssertion = (FIRPhoneMultiFactorAssertion *)assertion;
+    finalizedMFARequestInfo = [[FIRAuthProtoFinalizeMFAPhoneRequestInfo alloc]
+        initWithSessionInfo:phoneAssertion.authCredential.verificationID
+           verificationCode:phoneAssertion.authCredential.verificationCode];
+  } else {
+    FIRTOTPMultiFactorAssertion *totpAssertion = (FIRTOTPMultiFactorAssertion *)assertion;
+    finalizedMFARequestInfo = [[FIRAuthProtoFinalizeMFATOTPSignInRequestInfo alloc]
+        initWithMfaEnrollmentID:totpAssertion.enrollmentID
+               verificationCode:totpAssertion.oneTimePassword];
+  }
   FIRFinalizeMFASignInRequest *request = [[FIRFinalizeMFASignInRequest alloc]
       initWithMFAPendingCredential:self.MFAPendingCredential
-                  verificationInfo:finalizeMFAPhoneRequestInfo
+                  verificationInfo:finalizedMFARequestInfo
               requestConfiguration:self.auth.requestConfiguration];
   [FIRAuthBackend
       finalizeMultiFactorSignIn:request

--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorAssertion+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorAssertion+Internal.h
@@ -32,10 +32,16 @@ NS_ASSUME_NONNULL_BEGIN
  @brief secret TOTPSecret
  */
 @property(nonatomic, copy, readonly, nonnull) FIRTOTPSecret *secret;
+
 /**
  @brief one time password string
  */
 @property(nonatomic, copy, readonly, nonnull) NSString *oneTimePassword;
+
+/**
+ @brief the enrollment ID
+ */
+@property(nonatomic, copy, readonly, nonnull) NSString *enrollmentID;
 
 /**
  @fn initWithSecret
@@ -44,6 +50,15 @@ NS_ASSUME_NONNULL_BEGIN
  @param oneTimePassword one time password string
  */
 - (instancetype)initWithSecret:(FIRTOTPSecret *)secret oneTimePassword:(NSString *)oneTimePassword;
+
+/**
+ @fn initWithEnrollmentID:oneTimePassword
+ @brief initializing function
+ @param enrollmentID enrollment ID
+ @param oneTimePassword one time password string
+ */
+- (instancetype)initWithEnrollmentID:(NSString *)enrollmentID
+                     oneTimePassword:(NSString *)oneTimePassword;
 
 @end
 

--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorAssertion.m
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorAssertion.m
@@ -45,6 +45,17 @@ extern NSString *const _Nonnull FIRTOTPMultiFactorID;
   return self;
 }
 
+- (instancetype)initWithEnrollmentID:(NSString *)enrollmentID
+                     oneTimePassword:(NSString *)oneTimePassword {
+  self = [super init];
+  if (self) {
+    _factorID = FIRTOTPMultiFactorID;
+    _enrollmentID = enrollmentID;
+    _oneTimePassword = oneTimePassword;
+  }
+  return self;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorGenerator.m
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorGenerator.m
@@ -93,6 +93,12 @@
                                              oneTimePassword:oneTimePassword];
 }
 
++ (FIRTOTPMultiFactorAssertion *)assertionForSignInWithEnrollmentID:(NSString *)enrollmentID
+                                                    oneTimePassword:(NSString *)oneTimePassword {
+  return [[FIRTOTPMultiFactorAssertion alloc] initWithEnrollmentID:enrollmentID
+                                                   oneTimePassword:oneTimePassword];
+}
+
 @end
 
 #endif

--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @class FIRTotpMultiFactorInfo
+ @brief Extends the MultiFactorInfo class for time based one-time password second factors.
+        The identifier of this second factor is "totp".
+        This class is available on iOS only.
+*/
+NS_SWIFT_NAME(TOTPMultiFactorInfo) API_UNAVAILABLE(macos, tvos, watchos)
+    @interface FIRTOTPMultiFactorInfo : FIRMultiFactorInfo
+
+/**
+ @brief This is the totp info for the second factor.
+*/
+@property(nonatomic, readonly, nullable) NSObject *TOTPInfo;
+
+/**
+ @fn initWithProto:
+ @brief Initilize the FIRAuthProtoMFAEnrollment instance with proto.
+ @param proto FIRAuthProtoMFAEnrollment proto object.
+*/
+- (instancetype)initWithProto:(FIRAuthProtoMFAEnrollment *)proto;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.m
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.m
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <TargetConditionals.h>
+#if TARGET_OS_IOS
+
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorInfo.h"
+
+#import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
+#import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo+Internal.h"
+#import "FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h"
+
+extern NSString *const FIRTOTPMultiFactorID;
+
+@implementation FIRTOTPMultiFactorInfo
+
+- (instancetype)initWithProto:(FIRAuthProtoMFAEnrollment *)proto {
+  self = [super initWithProto:proto];
+  if (self) {
+    _factorID = FIRTOTPMultiFactorID;
+    _TOTPInfo = proto.TOTPInfo;
+  }
+  return self;
+}
+
+@end
+
+#endif

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRTOTPMultiFactorGenerator.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRTOTPMultiFactorGenerator.h
@@ -53,11 +53,12 @@ NS_SWIFT_NAME(TOTPMultiFactorGenerator) API_UNAVAILABLE(macos, tvos, watchos)
 + (FIRTOTPMultiFactorAssertion *)assertionForEnrollmentWithSecret:(FIRTOTPSecret *)secret
                                                   oneTimePassword:(NSString *)oneTimePassword;
 
-/** @fn assertionForSignInWithenrollmentID:
-    @brief Initializes the MFA assertion to confirm ownership of the totp second factor. This
-   assertion is used to complete signIn with TOTP as a second factor.
-    @param enrollmentID The id that identifies the enrolled TOTP second factor.
-    @param oneTimePassword one time password string.
+/**
+ @fn assertionForSignInWithenrollmentID:
+ @brief Initializes the MFA assertion to confirm ownership of the totp second factor. This
+ assertion is used to complete signIn with TOTP as a second factor.
+ @param enrollmentID The id that identifies the enrolled TOTP second factor.
+ @param oneTimePassword one time password string.
 */
 + (FIRTOTPMultiFactorAssertion *)assertionForSignInWithEnrollmentID:(NSString *)enrollmentID
                                                     oneTimePassword:(NSString *)oneTimePassword;

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRTOTPMultiFactorGenerator.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRTOTPMultiFactorGenerator.h
@@ -53,6 +53,15 @@ NS_SWIFT_NAME(TOTPMultiFactorGenerator) API_UNAVAILABLE(macos, tvos, watchos)
 + (FIRTOTPMultiFactorAssertion *)assertionForEnrollmentWithSecret:(FIRTOTPSecret *)secret
                                                   oneTimePassword:(NSString *)oneTimePassword;
 
+/** @fn assertionForSignInWithenrollmentID:
+    @brief Initializes the MFA assertion to confirm ownership of the totp second factor. This
+   assertion is used to complete signIn with TOTP as a second factor.
+    @param enrollmentID The id that identifies the enrolled TOTP second factor.
+    @param oneTimePassword one time password string.
+*/
++ (FIRTOTPMultiFactorAssertion *)assertionForSignInWithEnrollmentID:(NSString *)enrollmentID
+                                                    oneTimePassword:(NSString *)oneTimePassword;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Added Assertion, generator and resolver logic for TOTP MFA.
Updated the backend rpc call finalizeMFASignInRequest to take TOTP parameters.

This PR is an updated version of #11217.