### PR TITLE
[App Check] Rename symbols in GACAppCheckLogger

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -228,7 +228,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   return [self attestationState].thenOn(self.queue, ^id(GACAppAttestProviderState *attestState) {
     switch (attestState.state) {
       case GACAppAttestAttestationStateUnsupported:
-        GACLogDebug(kFIRLoggerAppCheckMessageCodeAppAttestNotSupported,
+        GACLogDebug(kGACLoggerAppCheckMessageCodeAppAttestNotSupported,
                     @"App Attest is not supported.");
         return attestState.appAttestUnsupportedError;
         break;
@@ -348,7 +348,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
         GACAppCheckHTTPError *HTTPError = (GACAppCheckHTTPError *)error;
         if ([HTTPError isKindOfClass:[GACAppCheckHTTPError class]] &&
             HTTPError.HTTPResponse.statusCode == 403) {
-          GACLogDebug(kFIRLoggerAppCheckMessageCodeAttestationRejected,
+          GACLogDebug(kGACLoggerAppCheckMessageCodeAttestationRejected,
                       @"App Attest attestation was rejected by backend. The existing "
                       @"attestation will be reset.");
           // Reset the attestation.

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -137,7 +137,7 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
   NSInteger statusCode = response.HTTPResponse.statusCode;
   return [FBLPromise do:^id _Nullable {
     if (statusCode < 200 || statusCode >= 300) {
-      GACLogDebug(kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode,
+      GACLogDebug(kGACLoggerAppCheckMessageCodeUnexpectedHTTPCode,
                   @"Unexpected API response: %@, body: %@.", response.HTTPResponse,
                   [[NSString alloc] initWithData:response.HTTPBody encoding:NSUTF8StringEncoding]);
       return [GACAppCheckErrorUtil APIErrorWithHTTPResponse:response.HTTPResponse

--- a/AppCheck/Sources/Core/GACAppCheckLogger.h
+++ b/AppCheck/Sources/Core/GACAppCheckLogger.h
@@ -18,24 +18,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnknown;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageCodeUnknown;
 
 // GACAppCheck.m
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageCodeProviderIsMissing;
 
 // GACAppCheckAPIService.m
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageCodeUnexpectedHTTPCode;
 
 // GACAppCheckDebugProvider.m
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions;
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDebugProviderFailedExchange;
-
-// GACDeviceCheckProvider.m
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageDebugProviderFailedExchange;
 
 // GACAppAttestProvider.m
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported;
-FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageCodeAppAttestNotSupported;
+FOUNDATION_EXPORT NSString *const kGACLoggerAppCheckMessageCodeAttestationRejected;
 
 #define GAC_LOGGING_FUNCTION(level) \
   void GACLog##level(NSString *messageCode, NSString *format, ...);

--- a/AppCheck/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheck/Sources/Core/GACAppCheckLogger.m
@@ -20,24 +20,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Log Message Codes
 
-NSString *const kFIRLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
+NSString *const kGACLoggerAppCheckMessageCodeUnknown = @"I-FAA001001";
 
 // GACAppCheck.m
-NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing = @"I-FAA002002";
+NSString *const kGACLoggerAppCheckMessageCodeProviderIsMissing = @"I-FAA002002";
 
 // GACAppCheckAPIService.m
-NSString *const kFIRLoggerAppCheckMessageCodeUnexpectedHTTPCode = @"I-FAA003001";
+NSString *const kGACLoggerAppCheckMessageCodeUnexpectedHTTPCode = @"I-FAA003001";
 
 // GACAppCheckDebugProvider.m
-NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions = @"I-FAA004001";
-NSString *const kFIRLoggerAppCheckMessageDebugProviderFailedExchange = @"I-FAA004002";
-
-// GACDeviceCheckProvider.m
-NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions = @"I-FAA006001";
+NSString *const kGACLoggerAppCheckMessageDebugProviderFailedExchange = @"I-FAA004002";
 
 // GACAppAttestProvider.m
-NSString *const kFIRLoggerAppCheckMessageCodeAppAttestNotSupported = @"I-FAA007001";
-NSString *const kFIRLoggerAppCheckMessageCodeAttestationRejected = @"I-FAA007002";
+NSString *const kGACLoggerAppCheckMessageCodeAppAttestNotSupported = @"I-FAA007001";
+NSString *const kGACLoggerAppCheckMessageCodeAttestationRejected = @"I-FAA007002";
 
 #pragma mark - Logging Functions
 

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -110,7 +110,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
         return nil;
       })
       .catch(^void(NSError *error) {
-        GACLogDebug(kFIRLoggerAppCheckMessageDebugProviderFailedExchange,
+        GACLogDebug(kGACLoggerAppCheckMessageDebugProviderFailedExchange,
                     @"Failed to exchange debug token to app check token: %@", error);
         handler(nil, error);
       });


### PR DESCRIPTION
The constants in `GACAppCheckLogger` conflict with those in [`FIRAppCheckLogger`](https://github.com/firebase/firebase-ios-sdk/blob/3abef641cd8bbf0893075f683e7dde802e53df15/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m#L25-L46).

#no-changelog
