### PR TITLE
[auth-swift] Revoke Token unit tests

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1543,7 +1543,9 @@ extension Auth: AuthInterop {
           return
         }
       }
-      // Note: If both idToken and error are nil, we still want to proceed.
+      guard let idToken else {
+        fatalError("Internal Auth Error: Both idToken and error are nil")
+      }
       let request = RevokeTokenRequest(withToken: authorizationCode,
                                        idToken: idToken,
                                        requestConfiguration: self.requestConfiguration)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -63,7 +63,7 @@ private let kIDTokenKey = "idToken"
   /** @property idToken
       @brief The ID Token associated with this credential.
    */
-  @objc public var idToken: String
+  @objc public var idToken: String?
 
   /** @var response
       @brief The corresponding response for this request
@@ -80,7 +80,7 @@ private let kIDTokenKey = "idToken"
   }
 
   @objc public init(withToken token: String,
-                    idToken: String,
+                    idToken: String?,
                     requestConfiguration: AuthRequestConfiguration) {
     // Apple and authorization code are the only provider and token type we support for now.
     // Generalize this initializer to accept other providers and token types once supported.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -63,7 +63,7 @@ private let kIDTokenKey = "idToken"
   /** @property idToken
       @brief The ID Token associated with this credential.
    */
-  @objc public var idToken: String?
+  @objc public var idToken: String
 
   /** @var response
       @brief The corresponding response for this request
@@ -80,7 +80,7 @@ private let kIDTokenKey = "idToken"
   }
 
   @objc public init(withToken token: String,
-                    idToken: String?,
+                    idToken: String,
                     requestConfiguration: AuthRequestConfiguration) {
     // Apple and authorization code are the only provider and token type we support for now.
     // Generalize this initializer to accept other providers and token types once supported.


### PR DESCRIPTION
Add Swift implementations for the two Revoke Token unit tests. This completes the implementation transformation of FIRAuthTests.m to AuthTests.swift

Two Revoke Token implementation questions came up while doing the tests. 
- The old Revoke Token proceeds and the old tests depend on continuing with a nil idToken. I matched this in the Swift implementation
- The Objective C implementation was using the public `getIDToken` instead of `internalGetToken`. This added the requirement to use the main thread internally and made the test implementation difficult. I changed the implementation to use `internalGetToken` and only do the `revokeToken` callback on the main thread.