### PR TITLE
[Xcode 15] Spaces are now valid in URL strings

### DIFF
--- a/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
@@ -241,12 +241,10 @@
 
     /// Test how URL conversion behaves if there are spaces in the path.
     func testURLConversion() {
-      /// Spaces in the string only convert to URL when using URL(fileURLWithPath: ).
       let fakeURLWithSpace = URL(string: "file:///fakeDir1/fake%20Dir2/fakeFile")!
 
       XCTAssertEqual(fakeURLWithSpace, URL(string: fakeURLWithSpace.absoluteString))
       XCTAssertEqual(fakeURLWithSpace, URL(fileURLWithPath: fakeURLWithSpace.path))
-      XCTAssertNil(URL(string: fakeURLWithSpace.path))
 
       /// Strings without spaces should work fine either way.
       let fakeURLWithoutSpace = URL(string: "fakeDir1/fakeDir2/fakeFile")!

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingLinkHandlingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingLinkHandlingTest.m
@@ -82,14 +82,6 @@ NSString *const kFIRMessagingTestsLinkHandlingSuiteName = @"com.messaging.test_l
   XCTAssertNil(url);
 }
 
-- (void)testInvalidURLStringLinkInMessage {
-  NSMutableDictionary *notification =
-      [FIRMessagingTestNotificationUtilities createBasicNotificationWithUniqueMessageID];
-  notification[kFIRMessagingMessageLinkKey] = @"This is not a valid url string";
-  NSURL *url = [_messaging linkURLFromMessage:notification];
-  XCTAssertNil(url);
-}
-
 - (void)testValidURLStringLinkInMessage {
   NSMutableDictionary *notification =
       [FIRMessagingTestNotificationUtilities createBasicNotificationWithUniqueMessageID];


### PR DESCRIPTION
Address URL unit test failures with the Xcode 15 beta. The Apple APIs will automatically percent-encode spaces.

From the Xcode 15 release notes:

**_Fixed: For apps linked on or after iOS 17 and aligned OS versions, URL parsing has updated from the obsolete RFC 1738/1808 parsing to the same RFC 3986 parsing as URLComponents. This unifies the parsing behaviors of the URL and URLComponents APIs. Now, URL automatically percent- or IDNA-encodes invalid characters to help create a valid URL._**
_- To check if a urlString is strictly valid according to the RFC, use the new URL(string: urlString, encodingInvalidCharacters: false) initializer. This init leaves all characters as they are and will return nil if urlString is explicitly invalid. (93368104)_