### PR TITLE
Make Firebase Performance XCode 15 compatible.

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Make Firebase performance compatible with XCode15.
+- [fixed] Make Firebase performance compatible with Xcode15.
 - [changed] Removed the capability to access Carrier information of the device since that API is deprecated by Apple.
 
 # 10.11.0

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Make Firebase performance compatible with XCode15.
+- [changed] Removed the capability to access Carrier information of the device since that API is deprecated by Apple.
+
 # 10.11.0
 - [fixed] Fixed a bug to disable data collection if the data collection was disabled before Firebase application was configured.
 

--- a/FirebasePerformance/Sources/FPRDataUtils.h
+++ b/FirebasePerformance/Sources/FPRDataUtils.h
@@ -46,11 +46,3 @@ FOUNDATION_EXTERN NSString *FPRValidatedAttributeValue(NSString *value);
  *  @return The unchanged url string or a truncated version if the length goes beyond the limit.
  */
 FOUNDATION_EXTERN NSString *FPRTruncatedURLString(NSString *URLString);
-
-/** Ensures proper length and numerals and returns a concatenated version if valid.
- *
- *  @param mcc 3 digit MCC code.
- *  @param mnc 2 or 3 digit MNC code.
- *  @return Concatenated mcc and mnc codes if valid. Otherwise nil.
- */
-FOUNDATION_EXTERN NSString *FPRValidatedMccMnc(NSString *mcc, NSString *mnc);

--- a/FirebasePerformance/Sources/FPRDataUtils.m
+++ b/FirebasePerformance/Sources/FPRDataUtils.m
@@ -124,16 +124,3 @@ NSString *FPRTruncatedURLString(NSString *URLString) {
   }
   return truncatedURLString;
 }
-
-NSString *FPRValidatedMccMnc(NSString *mcc, NSString *mnc) {
-  if ([mcc length] != 3 || [mnc length] < 2 || [mnc length] > 3) return nil;
-
-  static NSCharacterSet *notDigits;
-  static dispatch_once_t token;
-  dispatch_once(&token, ^{
-    notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
-  });
-  NSString *mccMnc = [mcc stringByAppendingString:mnc];
-  if ([mccMnc rangeOfCharacterFromSet:notDigits].location != NSNotFound) return nil;
-  return mccMnc;
-}

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -139,17 +139,17 @@ static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkTy
       return cellularNetworkType.intValue;
     }
   } else {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
     NSString *networkString = FPRNetworkInfo().currentRadioAccessTechnology;
-    
-    #pragma clang diagnostic pop
-    
+
+#pragma clang diagnostic pop
+
     NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
     return cellularNetworkType.intValue;
   }
-  
+
   return firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE;
 }
 #endif

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -129,7 +129,8 @@ static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkTy
     };
   });
 
-  NSDictionary<NSString *, NSString *> *radioAccessors = FPRNetworkInfo().serviceCurrentRadioAccessTechnology;
+  NSDictionary<NSString *, NSString *> *radioAccessors =
+      FPRNetworkInfo().serviceCurrentRadioAccessTechnology;
   if (radioAccessors.count > 0) {
     NSString *networkString = [radioAccessors.allValues objectAtIndex:0];
     NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -129,9 +129,13 @@ static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkTy
     };
   });
 
-  NSString *networkString = FPRNetworkInfo().currentRadioAccessTechnology;
-  NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
-  return cellularNetworkType.intValue;
+  NSDictionary<NSString *, NSString *> *radioAccessors = FPRNetworkInfo().serviceCurrentRadioAccessTechnology;
+  if (radioAccessors.count > 0) {
+    NSString *networkString = [radioAccessors.allValues objectAtIndex:0];
+    NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
+    return cellularNetworkType.intValue;
+  }
+  return firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE;
 }
 #endif
 
@@ -218,12 +222,6 @@ firebase_perf_v1_ApplicationInfo FPRGetApplicationInfoMessage(void) {
   iosAppInfo.has_network_connection_info = true;
   iosAppInfo.network_connection_info.has_network_type = true;
 #ifdef TARGET_HAS_MOBILE_CONNECTIVITY
-  CTTelephonyNetworkInfo *networkInfo = FPRNetworkInfo();
-  CTCarrier *provider = networkInfo.subscriberCellularProvider;
-  NSString *mccMnc = FPRValidatedMccMnc(provider.mobileCountryCode, provider.mobileNetworkCode);
-  if (mccMnc) {
-    iosAppInfo.mcc_mnc = FPREncodeString(mccMnc);
-  }
   if (iosAppInfo.network_connection_info.network_type ==
       firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE) {
     iosAppInfo.network_connection_info.mobile_subtype = FPRCellularNetworkType();

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -129,13 +129,27 @@ static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkTy
     };
   });
 
-  NSDictionary<NSString *, NSString *> *radioAccessors =
-      FPRNetworkInfo().serviceCurrentRadioAccessTechnology;
-  if (radioAccessors.count > 0) {
-    NSString *networkString = [radioAccessors.allValues objectAtIndex:0];
+  // Use recent APIs for iOS 12 and above and older APIs for before.
+  if (@available(iOS 12, *)) {
+    NSDictionary<NSString *, NSString *> *radioAccessors =
+        FPRNetworkInfo().serviceCurrentRadioAccessTechnology;
+    if (radioAccessors.count > 0) {
+      NSString *networkString = [radioAccessors.allValues objectAtIndex:0];
+      NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
+      return cellularNetworkType.intValue;
+    }
+  } else {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    
+    NSString *networkString = FPRNetworkInfo().currentRadioAccessTechnology;
+    
+    #pragma clang diagnostic pop
+    
     NSNumber *cellularNetworkType = cellularNetworkToMobileSubtype[networkString];
     return cellularNetworkType.intValue;
   }
+  
   return firebase_perf_v1_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE;
 }
 #endif

--- a/FirebasePerformance/Tests/Unit/FPRNanoPbUtilsTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRNanoPbUtilsTest.m
@@ -95,30 +95,6 @@
   [performance removeAttribute:@"foo2"];
 }
 
-/** Tests if mccMnc validation is catching non numerals. */
-- (void)testMccMncOnlyHasNumbers {
-  NSString *mccMnc = FPRValidatedMccMnc(@"123", @"MKV");
-  XCTAssertNil(mccMnc);
-  mccMnc = FPRValidatedMccMnc(@"ABC", @"123");
-  XCTAssertNil(mccMnc);
-}
-
-/** Tests if mccMnc validation is working. */
-- (void)testMccMnc {
-  NSString *mccMnc = FPRValidatedMccMnc(@"123", @"22");
-  XCTAssertNotNil(mccMnc);
-  mccMnc = FPRValidatedMccMnc(@"123", @"223");
-  XCTAssertNotNil(mccMnc);
-}
-
-/** Tests if mccMnc validation catches improper lengths. */
-- (void)testMccMncLength {
-  NSString *mccMnc = FPRValidatedMccMnc(@"12", @"22");
-  XCTAssertNil(mccMnc);
-  mccMnc = FPRValidatedMccMnc(@"123", @"2");
-  XCTAssertNil(mccMnc);
-}
-
 /** Validates that a valid FIRTrace object to firebase_perf_v1_TraceMetric conversion is successful.
  */
 - (void)testTraceMetricMessageCreation {

--- a/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
@@ -433,7 +433,7 @@
   NSURLRequest *URLRequest = [NSURLRequest requestWithURL:URL];
   FPRNetworkTrace *networkTrace = [[FPRNetworkTrace alloc] initWithURLRequest:URLRequest];
   XCTAssertNotNil(networkTrace);
-  XCTAssertEqual(networkTrace.URLRequest.URL.absoluteString, urlString);
+  XCTAssertEqualObjects(networkTrace.URLRequest.URL.absoluteString, urlString);
 }
 
 /** Validates that every trace contains a session Id. */


### PR DESCRIPTION
Fixes #11397. Includes 2 changes:

1. Fix the failing unit test for XCode15
2. Remote the CTCarrier dependency since it is deprecated