### PR TITLE
Update the integration test to verify that bloom filter averted full requery

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -1192,7 +1192,7 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
                      matchesResult:@[ @"doc6", @"doc3" ]];
 }
 
-- (void)testResumingAQueryShouldUseExistenceFilterToDetectDeletes {
+- (void)testResumingAQueryShouldUseBloomFilterToAvoidFullRequery {
   // Set this test to stop when the first failure occurs because some test assertion failures make
   // the rest of the test not applicable or will even crash.
   [self setContinueAfterFailure:NO];

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -1193,6 +1193,9 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
 }
 
 - (void)testResumingAQueryShouldUseBloomFilterToAvoidFullRequery {
+  using firebase::firestore::testutil::CaptureExistenceFilterMismatches;
+  using firebase::firestore::util::TestingHooks;
+
   // Set this test to stop when the first failure occurs because some test assertion failures make
   // the rest of the test not applicable or will even crash.
   [self setContinueAfterFailure:NO];
@@ -1204,100 +1207,135 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
     [testDocs setValue:@{@"key" : @42} forKey:[NSString stringWithFormat:@"doc%@", @(1000 + i)]];
   }
 
-  // Create 100 documents in a new collection.
-  FIRCollectionReference *collRef = [self collectionRefWithDocuments:testDocs];
+  // Each iteration of the "while" loop below runs a single iteration of the test. The test will
+  // be run multiple times only if a bloom filter false positive occurs.
+  int attemptNumber = 0;
+  while (true) {
+    attemptNumber++;
 
-  // Run a query to populate the local cache with the 100 documents and a resume token.
-  FIRQuerySnapshot *querySnapshot1 = [self readDocumentSetForRef:collRef
-                                                          source:FIRFirestoreSourceDefault];
-  XCTAssertEqual(querySnapshot1.count, 100, @"querySnapshot1.count has an unexpected value");
-  NSArray<FIRDocumentReference *> *createdDocuments =
-      FIRDocumentReferenceArrayFromQuerySnapshot(querySnapshot1);
+    // Create 100 documents in a new collection.
+    FIRCollectionReference *collRef = [self collectionRefWithDocuments:testDocs];
 
-  // Delete 50 of the 100 documents. Do this in a transaction, rather than
-  // [FIRDocumentReference deleteDocument], to avoid affecting the local cache.
-  NSSet<NSString *> *deletedDocumentIds;
-  {
-    NSMutableArray<NSString *> *deletedDocumentIdsAccumulator = [[NSMutableArray alloc] init];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"DeleteTransaction"];
-    [collRef.firestore
-        runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **) {
-          for (decltype(createdDocuments.count) i = 0; i < createdDocuments.count; i += 2) {
-            FIRDocumentReference *documentToDelete = createdDocuments[i];
-            [transaction deleteDocument:documentToDelete];
-            [deletedDocumentIdsAccumulator addObject:documentToDelete.documentID];
-          }
-          return @"document deletion successful";
-        }
-        completion:^(id, NSError *) {
-          [expectation fulfill];
-        }];
-    [self awaitExpectation:expectation];
-    deletedDocumentIds = [NSSet setWithArray:deletedDocumentIdsAccumulator];
-  }
-  XCTAssertEqual(deletedDocumentIds.count, 50u, @"deletedDocumentIds has the wrong size");
+    // Run a query to populate the local cache with the 100 documents and a resume token.
+    FIRQuerySnapshot *querySnapshot1 = [self readDocumentSetForRef:collRef
+                                                            source:FIRFirestoreSourceDefault];
+    XCTAssertEqual(querySnapshot1.count, 100, @"querySnapshot1.count has an unexpected value");
+    NSArray<FIRDocumentReference *> *createdDocuments =
+        FIRDocumentReferenceArrayFromQuerySnapshot(querySnapshot1);
 
-  // Wait for 10 seconds, during which Watch will stop tracking the query and will send an existence
-  // filter rather than "delete" events when the query is resumed.
-  [NSThread sleepForTimeInterval:10.0f];
-
-  // Resume the query and save the resulting snapshot for verification.
-  // Use some internal testing hooks to "capture" the existence filter mismatches to verify them.
-  FIRQuerySnapshot *querySnapshot2;
-  std::vector<firebase::firestore::util::TestingHooks::ExistenceFilterMismatchInfo>
-      existence_filter_mismatches =
-          firebase::firestore::testutil::CaptureExistenceFilterMismatches([&] {
-            querySnapshot2 = [self readDocumentSetForRef:collRef source:FIRFirestoreSourceDefault];
-          });
-
-  // Verify that the snapshot from the resumed query contains the expected documents; that is,
-  // that it contains the 50 documents that were _not_ deleted.
-  // TODO(b/270731363): Remove the "if" condition below once the Firestore Emulator is fixed to
-  // send an existence filter. At the time of writing, the Firestore emulator fails to send an
-  // existence filter, resulting in the client including the deleted documents in the snapshot
-  // of the resumed query.
-  if (!([FSTIntegrationTestCase isRunningAgainstEmulator] && querySnapshot2.count == 100)) {
-    NSSet<NSString *> *actualDocumentIds =
-        [NSSet setWithArray:FIRQuerySnapshotGetIDs(querySnapshot2)];
-    NSSet<NSString *> *expectedDocumentIds;
+    // Delete 50 of the 100 documents. Do this in a transaction, rather than
+    // [FIRDocumentReference deleteDocument], to avoid affecting the local cache.
+    NSSet<NSString *> *deletedDocumentIds;
     {
-      NSMutableArray<NSString *> *expectedDocumentIdsAccumulator = [[NSMutableArray alloc] init];
-      for (FIRDocumentReference *documentRef in createdDocuments) {
-        if (![deletedDocumentIds containsObject:documentRef.documentID]) {
-          [expectedDocumentIdsAccumulator addObject:documentRef.documentID];
+      NSMutableArray<NSString *> *deletedDocumentIdsAccumulator = [[NSMutableArray alloc] init];
+      XCTestExpectation *expectation = [self expectationWithDescription:@"DeleteTransaction"];
+      [collRef.firestore
+          runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **) {
+            for (decltype(createdDocuments.count) i = 0; i < createdDocuments.count; i += 2) {
+              FIRDocumentReference *documentToDelete = createdDocuments[i];
+              [transaction deleteDocument:documentToDelete];
+              [deletedDocumentIdsAccumulator addObject:documentToDelete.documentID];
+            }
+            return @"document deletion successful";
+          }
+          completion:^(id, NSError *) {
+            [expectation fulfill];
+          }];
+      [self awaitExpectation:expectation];
+      deletedDocumentIds = [NSSet setWithArray:deletedDocumentIdsAccumulator];
+    }
+    XCTAssertEqual(deletedDocumentIds.count, 50u, @"deletedDocumentIds has the wrong size");
+
+    // Wait for 10 seconds, during which Watch will stop tracking the query and will send an
+    // existence filter rather than "delete" events when the query is resumed.
+    [NSThread sleepForTimeInterval:10.0f];
+
+    // Resume the query and save the resulting snapshot for verification.
+    // Use some internal testing hooks to "capture" the existence filter mismatches to verify that
+    // Watch sent a bloom filter, and it was used to avert a full requery.
+    FIRQuerySnapshot *querySnapshot2;
+    std::vector<TestingHooks::ExistenceFilterMismatchInfo> existence_filter_mismatches =
+        CaptureExistenceFilterMismatches([&] {
+          querySnapshot2 = [self readDocumentSetForRef:collRef source:FIRFirestoreSourceDefault];
+        });
+
+    // Verify that the snapshot from the resumed query contains the expected documents; that is,
+    // that it contains the 50 documents that were _not_ deleted.
+    // TODO(b/270731363): Remove the "if" condition below once the Firestore Emulator is fixed to
+    // send an existence filter. At the time of writing, the Firestore emulator fails to send an
+    // existence filter, resulting in the client including the deleted documents in the snapshot
+    // of the resumed query.
+    if (!([FSTIntegrationTestCase isRunningAgainstEmulator] && querySnapshot2.count == 100)) {
+      NSSet<NSString *> *actualDocumentIds =
+          [NSSet setWithArray:FIRQuerySnapshotGetIDs(querySnapshot2)];
+      NSSet<NSString *> *expectedDocumentIds;
+      {
+        NSMutableArray<NSString *> *expectedDocumentIdsAccumulator = [[NSMutableArray alloc] init];
+        for (FIRDocumentReference *documentRef in createdDocuments) {
+          if (![deletedDocumentIds containsObject:documentRef.documentID]) {
+            [expectedDocumentIdsAccumulator addObject:documentRef.documentID];
+          }
         }
+        expectedDocumentIds = [NSSet setWithArray:expectedDocumentIdsAccumulator];
       }
-      expectedDocumentIds = [NSSet setWithArray:expectedDocumentIdsAccumulator];
+      if (![actualDocumentIds isEqualToSet:expectedDocumentIds]) {
+        NSArray<NSString *> *unexpectedDocumentIds =
+            SortedStringsNotIn(actualDocumentIds, expectedDocumentIds);
+        NSArray<NSString *> *missingDocumentIds =
+            SortedStringsNotIn(expectedDocumentIds, actualDocumentIds);
+        XCTFail(@"querySnapshot2 contained %lu documents (expected %lu): "
+                @"%lu unexpected and %lu missing; "
+                @"unexpected documents: %@; missing documents: %@",
+                (unsigned long)actualDocumentIds.count, (unsigned long)expectedDocumentIds.count,
+                (unsigned long)unexpectedDocumentIds.count, (unsigned long)missingDocumentIds.count,
+                [unexpectedDocumentIds componentsJoinedByString:@", "],
+                [missingDocumentIds componentsJoinedByString:@", "]);
+      }
     }
-    if (![actualDocumentIds isEqualToSet:expectedDocumentIds]) {
-      NSArray<NSString *> *unexpectedDocumentIds =
-          SortedStringsNotIn(actualDocumentIds, expectedDocumentIds);
-      NSArray<NSString *> *missingDocumentIds =
-          SortedStringsNotIn(expectedDocumentIds, actualDocumentIds);
-      XCTFail(@"querySnapshot2 contained %lu documents (expected %lu): "
-              @"%lu unexpected and %lu missing; "
-              @"unexpected documents: %@; missing documents: %@",
-              (unsigned long)actualDocumentIds.count, (unsigned long)expectedDocumentIds.count,
-              (unsigned long)unexpectedDocumentIds.count, (unsigned long)missingDocumentIds.count,
-              [unexpectedDocumentIds componentsJoinedByString:@", "],
-              [missingDocumentIds componentsJoinedByString:@", "]);
+
+    // Skip the verification of the existence filter mismatch when testing against the Firestore
+    // emulator because the Firestore emulator fails to to send an existence filter at all.
+    // TODO(b/270731363): Enable the verification of the existence filter mismatch once the
+    // Firestore emulator is fixed to send an existence filter.
+    if ([FSTIntegrationTestCase isRunningAgainstEmulator]) {
+      return;
     }
-  }
 
-  // Skip the verification of the existence filter mismatch when testing against the Firestore
-  // emulator because the Firestore emulator fails to to send an existence filter at all.
-  // TODO(b/270731363): Enable the verification of the existence filter mismatch once the Firestore
-  // emulator is fixed to send an existence filter.
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) {
-    return;
-  }
+    // Verify that Watch sent an existence filter with the correct counts when the query was
+    // resumed.
+    XCTAssertEqual(existence_filter_mismatches.size(), size_t{1},
+                   @"Watch should have sent exactly 1 existence filter");
+    const TestingHooks::ExistenceFilterMismatchInfo &existenceFilterMismatchInfo =
+        existence_filter_mismatches[0];
+    XCTAssertEqual(existenceFilterMismatchInfo.local_cache_count, 100);
+    XCTAssertEqual(existenceFilterMismatchInfo.existence_filter_count, 50);
 
-  // Verify that Watch sent an existence filter with the correct counts when the query was resumed.
-  XCTAssertEqual(existence_filter_mismatches.size(), size_t{1});
-  firebase::firestore::util::TestingHooks::ExistenceFilterMismatchInfo &info =
-      existence_filter_mismatches[0];
-  XCTAssertEqual(info.local_cache_count, 100);
-  XCTAssertEqual(info.existence_filter_count, 50);
+    // Verify that Watch sent a valid bloom filter.
+    const absl::optional<TestingHooks::BloomFilterInfo> &bloom_filter =
+        existence_filter_mismatches[0].bloom_filter;
+    XCTAssertTrue(bloom_filter.has_value(),
+                  "Watch should have included a bloom filter in the existence filter");
+    XCTAssertGreaterThan(bloom_filter->hash_count, 0);
+    XCTAssertGreaterThan(bloom_filter->bitmap_length, 0);
+    XCTAssertGreaterThan(bloom_filter->padding, 0);
+    XCTAssertLessThan(bloom_filter->padding, 8);
+
+    // Verify that the bloom filter was successfully used to avert a full requery. If a false
+    // positive occurred then retry the entire test. Although statistically rare, false positives
+    // are expected to happen occasionally. When a false positive _does_ happen, just retry the test
+    // with a different set of documents. If that retry _also_ experiences a false positive, then
+    // fail the test because that is so improbable that something must have gone wrong.
+    if (attemptNumber == 1 && !bloom_filter->applied) {
+      continue;
+    }
+
+    XCTAssertTrue(bloom_filter->applied,
+                  @"The bloom filter should have been successfully applied with attemptNumber=%@",
+                  @(attemptNumber));
+
+    // Break out of the test loop now that the test passes.
+    break;
+  }
 }
 
 @end

--- a/Firestore/core/src/remote/remote_event.cc
+++ b/Firestore/core/src/remote/remote_event.cc
@@ -212,6 +212,19 @@ std::vector<TargetId> WatchChangeAggregator::GetTargetIds(
   return result;
 }
 
+namespace {
+
+TestingHooks::ExistenceFilterMismatchInfo
+create_existence_filter_mismatch_info_for_testing_hooks(
+    BloomFilterApplicationStatus status,
+    int local_cache_count,
+    const ExistenceFilterWatchChange& existence_filter) {
+  (void)status;
+  return {local_cache_count, existence_filter.filter().count()};
+}
+
+}  // namespace
+
 void WatchChangeAggregator::HandleExistenceFilter(
     const ExistenceFilterWatchChange& existence_filter) {
   TargetId target_id = existence_filter.target_id();
@@ -255,7 +268,8 @@ void WatchChangeAggregator::HandleExistenceFilter(
         }
 
         TestingHooks::GetInstance().NotifyOnExistenceFilterMismatch(
-            {current_size, expected_count});
+            create_existence_filter_mismatch_info_for_testing_hooks(
+                status, current_size, existence_filter));
       }
     }
   }

--- a/Firestore/core/src/remote/remote_event.cc
+++ b/Firestore/core/src/remote/remote_event.cc
@@ -219,8 +219,18 @@ create_existence_filter_mismatch_info_for_testing_hooks(
     BloomFilterApplicationStatus status,
     int local_cache_count,
     const ExistenceFilterWatchChange& existence_filter) {
-  (void)status;
-  return {local_cache_count, existence_filter.filter().count()};
+  absl::optional<TestingHooks::BloomFilterInfo> bloom_filter;
+  if (existence_filter.filter().bloom_filter_parameters().has_value()) {
+    const BloomFilterParameters& bloom_filter_parameters =
+        existence_filter.filter().bloom_filter_parameters().value();
+    bloom_filter = {status == BloomFilterApplicationStatus::kSuccess,
+                    bloom_filter_parameters.hash_count,
+                    static_cast<int>(bloom_filter_parameters.bitmap.size()),
+                    bloom_filter_parameters.padding};
+  }
+
+  return {local_cache_count, existence_filter.filter().count(),
+          std::move(bloom_filter)};
 }
 
 }  // namespace

--- a/Firestore/core/src/util/testing_hooks.h
+++ b/Firestore/core/src/util/testing_hooks.h
@@ -24,6 +24,7 @@
 
 #include "Firestore/core/src/api/listener_registration.h"
 #include "Firestore/core/src/util/no_destructor.h"
+#include "absl/types/optional.h"
 
 namespace firebase {
 namespace firestore {
@@ -40,6 +41,28 @@ class TestingHooks final {
   static TestingHooks& GetInstance();
 
   /**
+   * Information about the bloom filter provided by Watch in the ExistenceFilter
+   * message's `unchangedNames` field.
+   */
+  struct BloomFilterInfo {
+    /**
+     * Whether a full requery was averted by using the bloom filter. If false,
+     * then something happened, such as a false positive, to prevent using the
+     * bloom filter to avoid a full requery.
+     */
+    bool applied = false;
+
+    /** The number of hash functions used in the bloom filter. */
+    int hash_count = -1;
+
+    /** The number of bytes in the bloom filter's bitmask. */
+    int bitmap_length = -1;
+
+    /** The number of bits of padding in the last byte of the bloom filter. */
+    int padding = -1;
+  };
+
+  /**
    * Information about an existence filter mismatch, as specified to callbacks
    * registered with `OnExistenceFilterMismatch()`.
    */
@@ -52,6 +75,13 @@ class TestingHooks final {
      * specified in the `ExistenceFilter` message's `count` field.
      */
     int existence_filter_count = -1;
+
+    /**
+     * Information about the bloom filter provided by Watch in the
+     * ExistenceFilter message's `unchangedNames` field. If empty, then that
+     * means that Watch did _not_ provide a bloom filter.
+     */
+    absl::optional<BloomFilterInfo> bloom_filter;
   };
 
   using ExistenceFilterMismatchCallback =


### PR DESCRIPTION
Update the integration test for the bloom filter to also verify that Watch specified a bloom filter that could be used to avert the full requery.

Googlers see b/274140502 for more details.

This PR is a port of https://github.com/firebase/firebase-js-sdk/pull/7095, and its follow-up improvements in https://github.com/firebase/firebase-js-sdk/pull/7112. The corresponding Android port is https://github.com/firebase/firebase-android-sdk/pull/4768.

#no-changelog