### PR TITLE
Add reCAPTCHA support to email flows of sign up, send email link, reset password

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1883,7 +1883,11 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     [FIRAuthBackend
      signUpNewUser:(FIRSignUpNewUserRequest *)request
               callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
-                if (error) {
+        if (!error) {
+            completion(response, nil);
+          return;
+
+        }
                   NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
                   if (error.code == FIRAuthErrorCodeInternalError &&
                       [[underlyingError.userInfo
@@ -1899,15 +1903,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                    }];
                   } else {
                       completion(nil, error);
-                    return;
                   }
-                } else {
-                  if (error) {
-                      completion(nil, error);
-                    return;
-                  }
-                    completion(nil, error);
-                }
               }];
   }
 #else

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1412,41 +1412,45 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                      }];
     } else {
       [FIRAuthBackend
-          signUpNewUser:(FIRSignUpNewUserRequest *)request
-               callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
-                 if (!error) {
-                   completion(nil);
-                   return;
-                 }
-                 NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
-                 if (error.code == FIRAuthErrorCodeInternalError &&
-                     [[underlyingError.userInfo
-                         objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
-                         hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
-                   [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
-                       injectRecaptchaFields:request
-                                    provider:FIRAuthRecaptchaProviderPassword
-                                      action:FIRAuthRecaptchaActionSignInWithPassword
-                                  completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
-                                                   *requestWithRecaptchaToken) {
-                                    [FIRAuthBackend
-                                        getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
-                                                                   requestWithRecaptchaToken
-                                                      callback:^(FIRGetOOBConfirmationCodeResponse
-                                                                     *_Nullable response,
-                                                                 NSError *_Nullable error) {
-                                                        if (completion) {
-                                                          dispatch_async(dispatch_get_main_queue(),
-                                                                         ^{
-                                                                           completion(error);
-                                                                         });
-                                                        }
-                                                      }];
-                                  }];
-                 } else {
-                   completion(error);
-                 }
-               }];
+          getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)request
+                        callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                   NSError *_Nullable error) {
+                          if (!error) {
+                            completion(nil);
+                            return;
+                          }
+                          NSError *underlyingError =
+                              [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                          if (error.code == FIRAuthErrorCodeInternalError &&
+                              [[underlyingError.userInfo
+                                  objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey]
+                                      [@"message"] hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
+                            [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+                                injectRecaptchaFields:request
+                                             provider:FIRAuthRecaptchaProviderPassword
+                                               action:FIRAuthRecaptchaActionSignInWithPassword
+                                           completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
+                                                            *requestWithRecaptchaToken) {
+                                             [FIRAuthBackend
+                                                 getOOBConfirmationCode:
+                                                     (FIRGetOOBConfirmationCodeRequest *)
+                                                         requestWithRecaptchaToken
+                                                               callback:^(
+                                                                   FIRGetOOBConfirmationCodeResponse
+                                                                       *_Nullable response,
+                                                                   NSError *_Nullable error) {
+                                                                 if (completion) {
+                                                                   dispatch_async(
+                                                                       dispatch_get_main_queue(), ^{
+                                                                         completion(error);
+                                                                       });
+                                                                 }
+                                                               }];
+                                           }];
+                          } else {
+                            completion(error);
+                          }
+                        }];
     }
 #else
     [FIRAuthBackend getOOBConfirmationCode:request
@@ -1503,41 +1507,45 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                      }];
     } else {
       [FIRAuthBackend
-          signUpNewUser:(FIRSignUpNewUserRequest *)request
-               callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
-                 if (!error) {
-                   completion(nil);
-                   return;
-                 }
-                 NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
-                 if (error.code == FIRAuthErrorCodeInternalError &&
-                     [[underlyingError.userInfo
-                         objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
-                         hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
-                   [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
-                       injectRecaptchaFields:request
-                                    provider:FIRAuthRecaptchaProviderPassword
-                                      action:FIRAuthRecaptchaActionSignInWithPassword
-                                  completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
-                                                   *requestWithRecaptchaToken) {
-                                    [FIRAuthBackend
-                                        getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
-                                                                   requestWithRecaptchaToken
-                                                      callback:^(FIRGetOOBConfirmationCodeResponse
-                                                                     *_Nullable response,
-                                                                 NSError *_Nullable error) {
-                                                        if (completion) {
-                                                          dispatch_async(dispatch_get_main_queue(),
-                                                                         ^{
-                                                                           completion(error);
-                                                                         });
-                                                        }
-                                                      }];
-                                  }];
-                 } else {
-                   completion(error);
-                 }
-               }];
+          getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)request
+                        callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                   NSError *_Nullable error) {
+                          if (!error) {
+                            completion(nil);
+                            return;
+                          }
+                          NSError *underlyingError =
+                              [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                          if (error.code == FIRAuthErrorCodeInternalError &&
+                              [[underlyingError.userInfo
+                                  objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey]
+                                      [@"message"] hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
+                            [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+                                injectRecaptchaFields:request
+                                             provider:FIRAuthRecaptchaProviderPassword
+                                               action:FIRAuthRecaptchaActionSignInWithPassword
+                                           completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
+                                                            *requestWithRecaptchaToken) {
+                                             [FIRAuthBackend
+                                                 getOOBConfirmationCode:
+                                                     (FIRGetOOBConfirmationCodeRequest *)
+                                                         requestWithRecaptchaToken
+                                                               callback:^(
+                                                                   FIRGetOOBConfirmationCodeResponse
+                                                                       *_Nullable response,
+                                                                   NSError *_Nullable error) {
+                                                                 if (completion) {
+                                                                   dispatch_async(
+                                                                       dispatch_get_main_queue(), ^{
+                                                                         completion(error);
+                                                                       });
+                                                                 }
+                                                               }];
+                                           }];
+                          } else {
+                            completion(error);
+                          }
+                        }];
     }
 #else
     [FIRAuthBackend getOOBConfirmationCode:request

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1404,9 +1404,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                              FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
                                            if (completion) {
-                                             dispatch_async(dispatch_get_main_queue(), ^{
-                                               completion(error);
-                                             });
+                                             completion(error);
                                            }
                                          }];
                      }];
@@ -1440,10 +1438,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                                        *_Nullable response,
                                                                    NSError *_Nullable error) {
                                                                  if (completion) {
-                                                                   dispatch_async(
-                                                                       dispatch_get_main_queue(), ^{
-                                                                         completion(error);
-                                                                       });
+                                                                   completion(error);
                                                                  }
                                                                }];
                                            }];
@@ -1499,9 +1494,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                              FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
                                            if (completion) {
-                                             dispatch_async(dispatch_get_main_queue(), ^{
-                                               completion(error);
-                                             });
+                                             completion(error);
                                            }
                                          }];
                      }];
@@ -1535,10 +1528,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                                        *_Nullable response,
                                                                    NSError *_Nullable error) {
                                                                  if (completion) {
-                                                                   dispatch_async(
-                                                                       dispatch_get_main_queue(), ^{
-                                                                         completion(error);
-                                                                       });
+                                                                   completion(error);
                                                                  }
                                                                }];
                                            }];

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1404,7 +1404,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                              FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
                                            if (completion) {
-                                             completion(error);
+                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                               completion(error);
+                                             });
                                            }
                                          }];
                      }];
@@ -1414,7 +1416,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                         callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                    NSError *_Nullable error) {
                           if (!error) {
-                            completion(nil);
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                              completion(nil);
+                            });
                             return;
                           }
                           NSError *underlyingError =
@@ -1438,12 +1442,17 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                                        *_Nullable response,
                                                                    NSError *_Nullable error) {
                                                                  if (completion) {
-                                                                   completion(error);
+                                                                   dispatch_async(
+                                                                       dispatch_get_main_queue(), ^{
+                                                                         completion(error);
+                                                                       });
                                                                  }
                                                                }];
                                            }];
                           } else {
-                            completion(error);
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                              completion(error);
+                            });
                           }
                         }];
     }
@@ -1494,7 +1503,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                              FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
                                            if (completion) {
-                                             completion(error);
+                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                               completion(error);
+                                             });
                                            }
                                          }];
                      }];
@@ -1504,7 +1515,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                         callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                    NSError *_Nullable error) {
                           if (!error) {
-                            completion(nil);
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                              completion(nil);
+                            });
                             return;
                           }
                           NSError *underlyingError =
@@ -1528,12 +1541,17 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                                        *_Nullable response,
                                                                    NSError *_Nullable error) {
                                                                  if (completion) {
-                                                                   completion(error);
+                                                                   dispatch_async(
+                                                                       dispatch_get_main_queue(), ^{
+                                                                         completion(error);
+                                                                       });
                                                                  }
                                                                }];
                                            }];
                           } else {
-                            completion(error);
+                            dispatch_async(dispatch_get_main_queue(), ^{
+                              completion(error);
+                            });
                           }
                         }];
     }

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1394,7 +1394,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
           injectRecaptchaFields:request
                        provider:FIRAuthRecaptchaProviderPassword
-                         action:FIRAuthRecaptchaActionSignInWithPassword
+                         action:FIRAuthRecaptchaActionGetOobCode
                      completion:^(
                          FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
                        [FIRAuthBackend
@@ -1430,7 +1430,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                             [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
                                 injectRecaptchaFields:request
                                              provider:FIRAuthRecaptchaProviderPassword
-                                               action:FIRAuthRecaptchaActionSignInWithPassword
+                                               action:FIRAuthRecaptchaActionGetOobCode
                                            completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
                                                             *requestWithRecaptchaToken) {
                                              [FIRAuthBackend
@@ -1493,7 +1493,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
           injectRecaptchaFields:request
                        provider:FIRAuthRecaptchaProviderPassword
-                         action:FIRAuthRecaptchaActionSignInWithPassword
+                         action:FIRAuthRecaptchaActionGetOobCode
                      completion:^(
                          FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
                        [FIRAuthBackend
@@ -1529,7 +1529,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                             [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
                                 injectRecaptchaFields:request
                                              provider:FIRAuthRecaptchaProviderPassword
-                                               action:FIRAuthRecaptchaActionSignInWithPassword
+                                               action:FIRAuthRecaptchaActionGetOobCode
                                            completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
                                                             *requestWithRecaptchaToken) {
                                              [FIRAuthBackend
@@ -2014,7 +2014,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
         injectRecaptchaFields:request
                      provider:FIRAuthRecaptchaProviderPassword
-                       action:FIRAuthRecaptchaActionSignInWithPassword
+                       action:FIRAuthRecaptchaActionSignUpPassword
                    completion:^(
                        FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
                      [FIRAuthBackend
@@ -2037,7 +2037,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                  [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
                      injectRecaptchaFields:request
                                   provider:FIRAuthRecaptchaProviderPassword
-                                    action:FIRAuthRecaptchaActionSignInWithPassword
+                                    action:FIRAuthRecaptchaActionSignUpPassword
                                 completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
                                                  *requestWithRecaptchaToken) {
                                   [FIRAuthBackend signUpNewUser:(FIRSignUpNewUserRequest *)

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1388,6 +1388,67 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         passwordResetRequestWithEmail:email
                    actionCodeSettings:actionCodeSettings
                  requestConfiguration:self->_requestConfiguration];
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    if ([[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+            enablementStatusForProvider:FIRAuthRecaptchaProviderPassword]) {
+      [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+          injectRecaptchaFields:request
+                       provider:FIRAuthRecaptchaProviderPassword
+                         action:FIRAuthRecaptchaActionSignInWithPassword
+                     completion:^(
+                         FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
+                       [FIRAuthBackend
+                           getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
+                                                      requestWithRecaptchaToken
+                                         callback:^(
+                                             FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                             NSError *_Nullable error) {
+                                           if (completion) {
+                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                               completion(error);
+                                             });
+                                           }
+                                         }];
+                     }];
+    } else {
+      [FIRAuthBackend
+          signUpNewUser:(FIRSignUpNewUserRequest *)request
+               callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
+                 if (!error) {
+                   completion(nil);
+                   return;
+                 }
+                 NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                 if (error.code == FIRAuthErrorCodeInternalError &&
+                     [[underlyingError.userInfo
+                         objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
+                         hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
+                   [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+                       injectRecaptchaFields:request
+                                    provider:FIRAuthRecaptchaProviderPassword
+                                      action:FIRAuthRecaptchaActionSignInWithPassword
+                                  completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
+                                                   *requestWithRecaptchaToken) {
+                                    [FIRAuthBackend
+                                        getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
+                                                                   requestWithRecaptchaToken
+                                                      callback:^(FIRGetOOBConfirmationCodeResponse
+                                                                     *_Nullable response,
+                                                                 NSError *_Nullable error) {
+                                                        if (completion) {
+                                                          dispatch_async(dispatch_get_main_queue(),
+                                                                         ^{
+                                                                           completion(error);
+                                                                         });
+                                                        }
+                                                      }];
+                                  }];
+                 } else {
+                   completion(error);
+                 }
+               }];
+    }
+#else
     [FIRAuthBackend getOOBConfirmationCode:request
                                   callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
@@ -1397,6 +1458,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                       });
                                     }
                                   }];
+#endif
   });
 }
 
@@ -1417,6 +1479,67 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         [FIRGetOOBConfirmationCodeRequest signInWithEmailLinkRequest:email
                                                   actionCodeSettings:actionCodeSettings
                                                 requestConfiguration:self->_requestConfiguration];
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    if ([[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+            enablementStatusForProvider:FIRAuthRecaptchaProviderPassword]) {
+      [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+          injectRecaptchaFields:request
+                       provider:FIRAuthRecaptchaProviderPassword
+                         action:FIRAuthRecaptchaActionSignInWithPassword
+                     completion:^(
+                         FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
+                       [FIRAuthBackend
+                           getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
+                                                      requestWithRecaptchaToken
+                                         callback:^(
+                                             FIRGetOOBConfirmationCodeResponse *_Nullable response,
+                                             NSError *_Nullable error) {
+                                           if (completion) {
+                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                               completion(error);
+                                             });
+                                           }
+                                         }];
+                     }];
+    } else {
+      [FIRAuthBackend
+          signUpNewUser:(FIRSignUpNewUserRequest *)request
+               callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
+                 if (!error) {
+                   completion(nil);
+                   return;
+                 }
+                 NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                 if (error.code == FIRAuthErrorCodeInternalError &&
+                     [[underlyingError.userInfo
+                         objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
+                         hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
+                   [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+                       injectRecaptchaFields:request
+                                    provider:FIRAuthRecaptchaProviderPassword
+                                      action:FIRAuthRecaptchaActionSignInWithPassword
+                                  completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
+                                                   *requestWithRecaptchaToken) {
+                                    [FIRAuthBackend
+                                        getOOBConfirmationCode:(FIRGetOOBConfirmationCodeRequest *)
+                                                                   requestWithRecaptchaToken
+                                                      callback:^(FIRGetOOBConfirmationCodeResponse
+                                                                     *_Nullable response,
+                                                                 NSError *_Nullable error) {
+                                                        if (completion) {
+                                                          dispatch_async(dispatch_get_main_queue(),
+                                                                         ^{
+                                                                           completion(error);
+                                                                         });
+                                                        }
+                                                      }];
+                                  }];
+                 } else {
+                   completion(error);
+                 }
+               }];
+    }
+#else
     [FIRAuthBackend getOOBConfirmationCode:request
                                   callback:^(FIRGetOOBConfirmationCodeResponse *_Nullable response,
                                              NSError *_Nullable error) {
@@ -1426,6 +1549,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                       });
                                     }
                                   }];
+#endif
   });
 }
 
@@ -1867,7 +1991,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     completion(nil, [FIRAuthErrorUtils missingEmailErrorWithMessage:nil]);
     return;
   }
-    
+
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   if ([[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
           enablementStatusForProvider:FIRAuthRecaptchaProviderPassword]) {
@@ -1877,34 +2001,37 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                        action:FIRAuthRecaptchaActionSignInWithPassword
                    completion:^(
                        FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
-                           [FIRAuthBackend signUpNewUser:(FIRSignUpNewUserRequest *)requestWithRecaptchaToken callback:completion];
+                     [FIRAuthBackend
+                         signUpNewUser:(FIRSignUpNewUserRequest *)requestWithRecaptchaToken
+                              callback:completion];
                    }];
   } else {
     [FIRAuthBackend
-     signUpNewUser:(FIRSignUpNewUserRequest *)request
-              callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
-        if (!error) {
-            completion(response, nil);
-          return;
-
-        }
-                  NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
-                  if (error.code == FIRAuthErrorCodeInternalError &&
-                      [[underlyingError.userInfo
-                          objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
-                          hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
-                    [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
-                        injectRecaptchaFields:request
-                                     provider:FIRAuthRecaptchaProviderPassword
-                                       action:FIRAuthRecaptchaActionSignInWithPassword
-                                   completion:^(
-                                       FIRIdentityToolkitRequest<FIRAuthRPCRequest> *requestWithRecaptchaToken) {
-                                           [FIRAuthBackend signUpNewUser:(FIRSignUpNewUserRequest *)requestWithRecaptchaToken callback:completion];
-                                   }];
-                  } else {
-                      completion(nil, error);
-                  }
-              }];
+        signUpNewUser:(FIRSignUpNewUserRequest *)request
+             callback:^(FIRSignUpNewUserResponse *_Nullable response, NSError *_Nullable error) {
+               if (!error) {
+                 completion(response, nil);
+                 return;
+               }
+               NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+               if (error.code == FIRAuthErrorCodeInternalError &&
+                   [[underlyingError.userInfo
+                       objectForKey:FIRAuthErrorUserInfoDeserializedResponseKey][@"message"]
+                       hasPrefix:kMissingRecaptchaTokenErrorPrefix]) {
+                 [[FIRAuthRecaptchaVerifier sharedRecaptchaVerifier:self]
+                     injectRecaptchaFields:request
+                                  provider:FIRAuthRecaptchaProviderPassword
+                                    action:FIRAuthRecaptchaActionSignInWithPassword
+                                completion:^(FIRIdentityToolkitRequest<FIRAuthRPCRequest>
+                                                 *requestWithRecaptchaToken) {
+                                  [FIRAuthBackend signUpNewUser:(FIRSignUpNewUserRequest *)
+                                                                    requestWithRecaptchaToken
+                                                       callback:completion];
+                                }];
+               } else {
+                 completion(nil, error);
+               }
+             }];
   }
 #else
   [FIRAuthBackend signUpNewUser:request callback:completion];

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -304,6 +304,12 @@ static NSString *const kRecaptchaVersion = @"recaptchaVersion";
   return body;
 }
 
+- (void)injectRecaptchaFields:(NSString *_Nullable)recaptchaResponse
+             recaptchaVersion:(NSString *)recaptchaVersion {
+  _captchaResponse = recaptchaResponse;
+  _recaptchaVersion = recaptchaVersion;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.m
@@ -117,6 +117,12 @@ static NSString *const kTenantIDKey = @"tenantId";
   return [postBody copy];
 }
 
+- (void)injectRecaptchaFields:(NSString *_Nullable)recaptchaResponse
+             recaptchaVersion:(NSString *)recaptchaVersion {
+  _captchaResponse = recaptchaResponse;
+  _recaptchaVersion = recaptchaVersion;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -63,6 +63,7 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPhoneNumberResponse.h"
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
+#import "FirebaseAuth/Sources/Utilities/FIRAuthRecaptchaVerifier.h"
 #import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"
 #import "FirebaseAuth/Tests/Unit/OCMStubRecorder+FIRAuthUnitTests.h"
 
@@ -266,6 +267,16 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief The time waiting for background tasks to finish before continue when necessary.
  */
 static const NSTimeInterval kWaitInterval = .5;
+
+/** @var kFakeRecaptchaResponse
+    @brief The fake recaptcha response.
+ */
+static NSString *const kFakeRecaptchaResponse = @"RecaptchaResponse";
+
+/** @var kFakeRecaptchaVersion
+    @brief The fake recaptcha version.
+ */
+static NSString *const kFakeRecaptchaVersion = @"RecaptchaVersion";
 
 #if TARGET_OS_IOS
 /** @class FIRAuthAppDelegate
@@ -628,6 +639,120 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   OCMVerifyAll(_mockBackend);
 }
+
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+/** @fn testSignInWithEmailPasswordWithRecaptchaSuccess
+    @brief Tests the flow of a successful @c signInWithEmail:password:completion: call.
+ */
+- (void)testSignInWithEmailPasswordWithRecaptchaSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRVerifyPasswordRequest *constRequestWithRecaptchaToken =
+      [[FIRVerifyPasswordRequest alloc] initWithEmail:kEmail
+                                             password:kFakePassword
+                                 requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionSignInWithPassword
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend verifyPassword:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyPasswordRequest *_Nullable request,
+                       FIRVerifyPasswordResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.password, kFakePassword);
+        XCTAssertTrue(request.returnSecureToken);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockVerifyPasswordResponse = OCMClassMock([FIRVerifyPasswordResponse class]);
+          [self stubTokensWithMockResponse:mockVerifyPasswordResponse];
+          callback(mockVerifyPasswordResponse, nil);
+        });
+      });
+  [self expectGetAccountInfo];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth] signInWithEmail:kEmail
+                         password:kFakePassword
+                       completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                         XCTAssertTrue([NSThread isMainThread]);
+                         [self assertUser:result.user];
+                         XCTAssertNil(error);
+                         [expectation fulfill];
+                       }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  [self assertUser:[FIRAuth auth].currentUser];
+}
+
+/** @fn testSignInWithEmailPasswordWithRecaptchaFallbackSuccess
+    @brief Tests the flow of a successful @c signInWithEmail:password:completion: call.
+ */
+- (void)testSignInWithEmailPasswordWithRecaptchaFallbackSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRVerifyPasswordRequest *constRequestWithRecaptchaToken =
+      [[FIRVerifyPasswordRequest alloc] initWithEmail:kEmail
+                                             password:kFakePassword
+                                 requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionSignInWithPassword
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend verifyPassword:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyPasswordRequest *_Nullable request,
+                       FIRVerifyPasswordResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.password, kFakePassword);
+        XCTAssertTrue(request.returnSecureToken);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockVerifyPasswordResponse = OCMClassMock([FIRVerifyPasswordResponse class]);
+          [self stubTokensWithMockResponse:mockVerifyPasswordResponse];
+          callback(mockVerifyPasswordResponse, nil);
+        });
+      });
+  OCMExpect([_mockBackend verifyPassword:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyPasswordRequest *_Nullable request,
+                       FIRVerifyPasswordResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.password, kFakePassword);
+        XCTAssertTrue(request.returnSecureToken);
+        NSError *underlyingError =
+            [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                       code:FIRAuthErrorCodeInternalError
+                                   userInfo:@{NSUnderlyingErrorKey : @"MISSING_RECAPTCHA_TOKEN"}];
+        NSError *error = [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                                    code:FIRAuthErrorCodeInternalError
+                                                userInfo:@{NSUnderlyingErrorKey : underlyingError}];
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback(nil, error);
+        });
+      });
+  [self expectGetAccountInfo];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth] signInWithEmail:kEmail
+                         password:kFakePassword
+                       completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                         XCTAssertTrue([NSThread isMainThread]);
+                         [self assertUser:result.user];
+                         XCTAssertNil(error);
+                         [expectation fulfill];
+                       }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  [self assertUser:[FIRAuth auth].currentUser];
+}
+#endif
 
 /** @fn testSignInWithEmailPasswordSuccess
     @brief Tests the flow of a successful @c signInWithEmail:password:completion: call.
@@ -1677,6 +1802,129 @@ static const NSTimeInterval kWaitInterval = .5;
   OCMVerifyAll(_mockBackend);
 }
 
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+/** @fn testCreateUserWithEmailPasswordWithRecaptchaVerificationSuccess
+    @brief Tests the flow of a successful @c createUserWithEmail:password:completion: call.
+ */
+- (void)testCreateUserWithEmailPasswordWithRecaptchaVerificationSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRSignUpNewUserRequest *constRequestWithRecaptchaToken =
+      [[FIRSignUpNewUserRequest alloc] initWithEmail:kEmail
+                                            password:kFakePassword
+                                         displayName:kDisplayName
+                                requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionSignUpPassword
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend signUpNewUser:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(
+          ^(FIRSignUpNewUserRequest *_Nullable request, FIRSignupNewUserCallback callback) {
+            XCTAssertEqualObjects(request.APIKey, kAPIKey);
+            XCTAssertEqualObjects(request.email, kEmail);
+            XCTAssertEqualObjects(request.password, kFakePassword);
+            XCTAssertTrue(request.returnSecureToken);
+            dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+              id mockSignUpNewUserResponse = OCMClassMock([FIRSignUpNewUserResponse class]);
+              [self stubTokensWithMockResponse:mockSignUpNewUserResponse];
+              callback(mockSignUpNewUserResponse, nil);
+            });
+          });
+  [self expectGetAccountInfo];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth]
+      createUserWithEmail:kEmail
+                 password:kFakePassword
+               completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                 XCTAssertTrue([NSThread isMainThread]);
+                 [self assertUser:result.user];
+                 XCTAssertNil(error);
+                 [expectation fulfill];
+               }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  [self assertUser:[FIRAuth auth].currentUser];
+}
+
+/** @fn testCreateUserWithEmailPasswordWithRecaptchaVerificationFallbackSuccess
+    @brief Tests the flow of a successful @c createUserWithEmail:password:completion: call.
+ */
+- (void)testCreateUserWithEmailPasswordWithRecaptchaVerificationFallbackSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRSignUpNewUserRequest *constRequest =
+      [[FIRSignUpNewUserRequest alloc] initWithEmail:kEmail
+                                            password:kFakePassword
+                                         displayName:kDisplayName
+                                requestConfiguration:[FIRAuth auth].requestConfiguration];
+  FIRSignUpNewUserRequest *constRequestWithRecaptchaToken =
+      [[FIRSignUpNewUserRequest alloc] initWithEmail:kEmail
+                                            password:kFakePassword
+                                         displayName:kDisplayName
+                                requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionSignUpPassword
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend signUpNewUser:constRequest callback:[OCMArg any]])
+      .andCallBlock2(^(FIRSignUpNewUserRequest *_Nullable request,
+                       FIRSignupNewUserCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.password, kFakePassword);
+        XCTAssertTrue(request.returnSecureToken);
+        NSError *underlyingError =
+            [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                       code:FIRAuthErrorCodeInternalError
+                                   userInfo:@{NSUnderlyingErrorKey : @"MISSING_RECAPTCHA_TOKEN"}];
+        NSError *error = [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                                    code:FIRAuthErrorCodeInternalError
+                                                userInfo:@{NSUnderlyingErrorKey : underlyingError}];
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback(nil, error);
+        });
+      });
+  OCMExpect([_mockBackend signUpNewUser:constRequestWithRecaptchaToken callback:[OCMArg any]])
+      .andCallBlock2(
+          ^(FIRSignUpNewUserRequest *_Nullable request, FIRSignupNewUserCallback callback) {
+            XCTAssertEqualObjects(request.APIKey, kAPIKey);
+            XCTAssertEqualObjects(request.email, kEmail);
+            XCTAssertEqualObjects(request.password, kFakePassword);
+            XCTAssertTrue(request.returnSecureToken);
+            dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+              id mockSignUpNewUserResponse = OCMClassMock([FIRSignUpNewUserResponse class]);
+              [self stubTokensWithMockResponse:mockSignUpNewUserResponse];
+              callback(mockSignUpNewUserResponse, nil);
+            });
+          });
+  [self expectGetAccountInfo];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth]
+      createUserWithEmail:kEmail
+                 password:kFakePassword
+               completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                 XCTAssertTrue([NSThread isMainThread]);
+                 [self assertUser:result.user];
+                 XCTAssertNil(error);
+                 [expectation fulfill];
+               }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  [self assertUser:[FIRAuth auth].currentUser];
+}
+#endif
+
 /** @fn testCreateUserWithEmailPasswordSuccess
     @brief Tests the flow of a successful @c createUserWithEmail:password:completion: call.
  */
@@ -1836,6 +2084,102 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
 }
 
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+/** @fn testSendPasswordResetEmailWithRecaptchaSuccess
+    @brief Tests the flow of a successful @c sendPasswordResetWithEmail:completion: call.
+ */
+- (void)testSendPasswordResetEmailWithRecaptchaSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRGetOOBConfirmationCodeRequest *constRequestWithRecaptchaToken =
+      [FIRGetOOBConfirmationCodeRequest
+          passwordResetRequestWithEmail:kEmail
+                     actionCodeSettings:nil
+                   requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionGetOobCode
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback([[FIRGetOOBConfirmationCodeResponse alloc] init], nil);
+        });
+      });
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] sendPasswordResetWithEmail:kEmail
+                                  completion:^(NSError *_Nullable error) {
+                                    XCTAssertTrue([NSThread isMainThread]);
+                                    XCTAssertNil(error);
+                                    [expectation fulfill];
+                                  }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+
+/** @fn testSendPasswordResetEmailWithRecaptchaFallbackSuccess
+    @brief Tests the flow of a successful @c sendPasswordResetWithEmail:completion: call.
+ */
+- (void)testSendPasswordResetEmailWithRecaptchaFallbackSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRGetOOBConfirmationCodeRequest *constRequestWithRecaptchaToken =
+      [FIRGetOOBConfirmationCodeRequest
+          passwordResetRequestWithEmail:kEmail
+                     actionCodeSettings:nil
+                   requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionGetOobCode
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback([[FIRGetOOBConfirmationCodeResponse alloc] init], nil);
+        });
+      });
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        NSError *underlyingError =
+            [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                       code:FIRAuthErrorCodeInternalError
+                                   userInfo:@{NSUnderlyingErrorKey : @"MISSING_RECAPTCHA_TOKEN"}];
+        NSError *error = [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                                    code:FIRAuthErrorCodeInternalError
+                                                userInfo:@{NSUnderlyingErrorKey : underlyingError}];
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback(nil, error);
+        });
+      });
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] sendPasswordResetWithEmail:kEmail
+                                  completion:^(NSError *_Nullable error) {
+                                    XCTAssertTrue([NSThread isMainThread]);
+                                    XCTAssertNil(error);
+                                    [expectation fulfill];
+                                  }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+#endif
+
 /** @fn testSendPasswordResetEmailSuccess
     @brief Tests the flow of a successful @c sendPasswordResetWithEmail:completion: call.
  */
@@ -1877,6 +2221,112 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   OCMVerifyAll(_mockBackend);
 }
+
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+/** @fn testSendSignInLinkToEmailWithRecaptchaSuccess
+    @brief Tests the flow of a successful @c sendSignInLinkToEmail:actionCodeSettings:completion:
+        call.
+ */
+- (void)testSendSignInLinkToEmailWithRecaptchaSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRGetOOBConfirmationCodeRequest *constRequestWithRecaptchaToken =
+      [FIRGetOOBConfirmationCodeRequest
+          signInWithEmailLinkRequest:kEmail
+                  actionCodeSettings:[self fakeActionCodeSettings]
+                requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionGetOobCode
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.continueURL, kContinueURL);
+        XCTAssertTrue(request.handleCodeInApp);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback([[FIRGetOOBConfirmationCodeResponse alloc] init], nil);
+        });
+      });
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] sendSignInLinkToEmail:kEmail
+                     actionCodeSettings:[self fakeActionCodeSettings]
+                             completion:^(NSError *_Nullable error) {
+                               XCTAssertTrue([NSThread isMainThread]);
+                               XCTAssertNil(error);
+                               [expectation fulfill];
+                             }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+
+/** @fn testSendSignInLinkToEmailWithRecaptchaFallbackSuccess
+    @brief Tests the flow of a successful @c sendSignInLinkToEmail:actionCodeSettings:completion:
+        call.
+ */
+- (void)testSendSignInLinkToEmailWithRecaptchaFallbackSuccess {
+  id mockVerifier = OCMClassMock([FIRAuthRecaptchaVerifier class]);
+  OCMStub([mockVerifier sharedRecaptchaVerifier:[FIRAuth auth]]).andReturn(mockVerifier);
+  OCMExpect([mockVerifier enablementStatusForProvider:FIRAuthRecaptchaProviderPassword])
+      .andReturn(YES);
+  FIRGetOOBConfirmationCodeRequest *constRequestWithRecaptchaToken =
+      [FIRGetOOBConfirmationCodeRequest
+          signInWithEmailLinkRequest:kEmail
+                  actionCodeSettings:[self fakeActionCodeSettings]
+                requestConfiguration:[FIRAuth auth].requestConfiguration];
+  [constRequestWithRecaptchaToken injectRecaptchaFields:kFakeRecaptchaResponse
+                                       recaptchaVersion:kFakeRecaptchaVersion];
+  OCMStub([mockVerifier
+      injectRecaptchaFields:[OCMArg any]
+                   provider:FIRAuthRecaptchaProviderPassword
+                     action:FIRAuthRecaptchaActionGetOobCode
+                 completion:([OCMArg invokeBlockWithArgs:constRequestWithRecaptchaToken, nil])]);
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.continueURL, kContinueURL);
+        XCTAssertTrue(request.handleCodeInApp);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback([[FIRGetOOBConfirmationCodeResponse alloc] init], nil);
+        });
+      });
+  OCMExpect([_mockBackend getOOBConfirmationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetOOBConfirmationCodeRequest *_Nullable request,
+                       FIRGetOOBConfirmationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.email, kEmail);
+        XCTAssertEqualObjects(request.continueURL, kContinueURL);
+        XCTAssertTrue(request.handleCodeInApp);
+        NSError *underlyingError =
+            [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                       code:FIRAuthErrorCodeInternalError
+                                   userInfo:@{NSUnderlyingErrorKey : @"MISSING_RECAPTCHA_TOKEN"}];
+        NSError *error = [[NSError alloc] initWithDomain:FIRAuthErrorDomain
+                                                    code:FIRAuthErrorCodeInternalError
+                                                userInfo:@{NSUnderlyingErrorKey : underlyingError}];
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          callback(nil, error);
+        });
+      });
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] sendSignInLinkToEmail:kEmail
+                     actionCodeSettings:[self fakeActionCodeSettings]
+                             completion:^(NSError *_Nullable error) {
+                               XCTAssertTrue([NSThread isMainThread]);
+                               XCTAssertNil(error);
+                               [expectation fulfill];
+                             }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+#endif
 
 /** @fn testSendSignInLinkToEmailSuccess
     @brief Tests the flow of a successful @c sendSignInLinkToEmail:actionCodeSettings:completion:


### PR DESCRIPTION
Note that most of the code are duplicated from the email password sign in flow. Was trying to create a shared helper method but didn't find a good way due to the callback mechanism. Will try to simplify it with async/await after migrate to swift.