### PR TITLE
fix duplicated period in realtime remote config error

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -488,7 +488,7 @@ static NSInteger const gMaxRetries = 7;
                                            code:FIRRemoteConfigUpdateErrorNotFetched
                                        userInfo:@{
                                          NSLocalizedDescriptionKey :
-                                             @"Unable to fetch the latest version of the template.."
+                                             @"Unable to fetch the latest version of the template."
                                        }];
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000011",
                   @"Ran out of fetch attempts, cannot find target config version.");


### PR DESCRIPTION

Pretty self-explanatory so I won't waste anyone's time with a lot of typing here

All of the other error messages have a single period at the end, I assume this one should as well?