### PR TITLE
Cast listener with __block

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -688,16 +688,17 @@ static NSInteger const gMaxRetries = 7;
   if (listener == nil) {
     return nil;
   }
+  __block id listenerCopy = listener;
 
   __weak RCNConfigRealtime *weakSelf = self;
   dispatch_async(_realtimeLockQueue, ^{
     __strong RCNConfigRealtime *strongSelf = weakSelf;
-    [strongSelf->_listeners addObject:listener];
+    [strongSelf->_listeners addObject:listenerCopy];
     [strongSelf beginRealtimeStream];
   });
 
   return [[FIRConfigUpdateListenerRegistration alloc] initWithClient:self
-                                                   completionHandler:listener];
+                                                   completionHandler:listenerCopy];
 }
 
 - (void)removeConfigUpdateListener:(void (^_Nonnull)(FIRRemoteConfigUpdate *configUpdate,


### PR DESCRIPTION
Cast Listener with __block so changes can be made inside dispatch_async block.
Fixes [bug](https://github.com/firebase/firebase-ios-sdk/issues/11458) reported by user