### PR TITLE
add `setNumberOfStackFramesToSkipForNotFatalErrors` 

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -81,7 +81,9 @@ void FIRCLSUserLoggingRecordUserKeysAndValues(NSDictionary* keysAndValues);
 void FIRCLSUserLoggingRecordInternalKeyValue(NSString* key, id value);
 void FIRCLSUserLoggingWriteInternalKeyValue(NSString* key, NSString* value);
 
-void FIRCLSUserLoggingRecordError(NSError* error, NSDictionary<NSString*, id>* additionalUserInfo);
+void FIRCLSUserLoggingRecordError(NSError* error,
+                                  NSDictionary<NSString*, id>* additionalUserInfo,
+                                  NSUInteger skipStacks);
 
 NSDictionary* FIRCLSUserLoggingGetCompactedKVEntries(FIRCLSUserLoggingKVStorage* storage,
                                                      bool decodeHex);

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -379,7 +379,8 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
 }
 
 void FIRCLSUserLoggingRecordError(NSError *error,
-                                  NSDictionary<NSString *, id> *additionalUserInfo) {
+                                  NSDictionary<NSString *, id> *additionalUserInfo,
+                                  NSUInteger numberOfStacksToSkip) {
   if (!error) {
     return;
   }
@@ -391,6 +392,10 @@ void FIRCLSUserLoggingRecordError(NSError *error,
   // record the stacktrace and timestamp here, so we
   // are as close as possible to the user's log statement
   NSArray *addresses = [NSThread callStackReturnAddresses];
+  if (numberOfStacksToSkip > 0 && [addresses count] >= numberOfStacksToSkip) {
+    NSRange range = NSMakeRange(0, numberOfStacksToSkip);
+    addresses = [addresses subarrayWithRange:range];
+  }
   uint64_t timestamp = time(NULL);
 
   FIRCLSUserLoggingWriteAndCheckABFiles(

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -392,8 +392,8 @@ void FIRCLSUserLoggingRecordError(NSError *error,
   // record the stacktrace and timestamp here, so we
   // are as close as possible to the user's log statement
   NSArray *addresses = [NSThread callStackReturnAddresses];
-  if (numberOfStacksToSkip > 0 && [addresses count] >= numberOfStacksToSkip) {
-    NSRange range = NSMakeRange(0, numberOfStacksToSkip);
+  if (numberOfStacksToSkip > 0 && [addresses count] > numberOfStacksToSkip) {
+    NSRange range = NSMakeRange(numberOfStacksToSkip, [addresses count] - numberOfStacksToSkip);
     addresses = [addresses subarrayWithRange:range];
   }
   uint64_t timestamp = time(NULL);

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -94,6 +94,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 // Dependencies common to each of the Controllers
 @property(nonatomic, strong) FIRCLSManagerData *managerData;
 
+@property(nonatomic) NSUInteger *frameStacksToSkip;
 @end
 
 @implementation FIRCrashlytics
@@ -129,6 +130,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     _fileManager = [[FIRCLSFileManager alloc] init];
     _googleAppID = app.options.googleAppID;
     _dataArbiter = [[FIRCLSDataCollectionArbiter alloc] initWithApp:app withAppInfo:appInfo];
+    _frameStacksToSkip = 0;
 
     FIRCLSApplicationIdentifierModel *appModel = [[FIRCLSApplicationIdentifierModel alloc] init];
     FIRCLSSettings *settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager
@@ -377,7 +379,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
-  FIRCLSUserLoggingRecordError(error, userInfo);
+    FIRCLSUserLoggingRecordError(error, userInfo, self.frameStacksToSkip);
 }
 
 - (void)recordExceptionModel:(FIRExceptionModel *)exceptionModel {
@@ -389,6 +391,10 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       recordOnDemandExceptionIfQuota:exceptionModel
            withDataCollectionEnabled:[self.dataArbiter isCrashlyticsCollectionEnabled]
           usingExistingReportManager:self.existingReportManager];
+}
+
+- (void)setNumberOfStackFramesToSkipForNotFatalErrors:(NSUInteger)frames {
+  self.frameStacksToSkip = frames;
 }
 
 #pragma mark - FIRSessionsSubscriber

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -379,7 +379,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
-    FIRCLSUserLoggingRecordError(error, userInfo, self.frameStacksToSkip);
+  FIRCLSUserLoggingRecordError(error, userInfo, self.frameStacksToSkip);
 }
 
 - (void)recordExceptionModel:(FIRExceptionModel *)exceptionModel {

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -243,6 +243,8 @@ NS_SWIFT_NAME(Crashlytics)
  */
 - (void)deleteUnsentReports;
 
+- (void)setNumberOfStackFramesToSkipForNotFatalErrors:(NSUInteger)frames;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Proposal for https://github.com/firebase/firebase-ios-sdk/issues/11475

### API Changes

  * This is a proposal to add a method to set number of stack trace frames to be skipped for non-fatal errors.

Similar to Bugsnag: https://docs.bugsnag.com/platforms/ios/customizing-error-reports/#modifying-stack-traces