### PR TITLE
[Database] Replace deprecated `NSKeyedUnarchiver` method in `FLevelDBStorageEngine`

### DIFF
--- a/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
+++ b/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
@@ -166,12 +166,18 @@ static NSString *trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
             // it'll go fine :P
             [writes enumerateKeysAndValuesAsData:^(NSString *key, NSData *data,
                                                    BOOL *stop) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-              // Update the deprecated API when minimum iOS version is 11+.
-              id pendingPut = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#pragma clang diagnostic pop
-              if ([pendingPut isKindOfClass:[FPendingPut class]]) {
+              NSError *error;
+              id pendingPut = [NSKeyedUnarchiver
+                  unarchivedObjectOfClasses:
+                      [NSSet setWithObjects:[FPendingPut class],
+                                            [FPendingPutPriority class],
+                                            [FPendingUpdate class], nil]
+                                   fromData:data
+                                      error:&error];
+              if (error) {
+                  FFWarn(@"I-RDB076003", @"Failed to migrate legacy write: %@",
+                         error);
+              } else if ([pendingPut isKindOfClass:[FPendingPut class]]) {
                   FPendingPut *put = pendingPut;
                   id<FNode> newNode =
                       [FSnapshotUtilities nodeFrom:put.data
@@ -205,7 +211,9 @@ static NSString *trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
                   numberOfWritesRestored++;
               } else {
                   FFWarn(@"I-RDB076003",
-                         @"Failed to migrate legacy write, meh!");
+                         @"Failed to migrate legacy write: unrecognized class "
+                         @"\"%@\"",
+                         [pendingPut class]);
               }
             }];
             FFWarn(@"I-RDB076004", @"Migrated %lu writes",


### PR DESCRIPTION
Replaced use of the deprecated `unarchiveObjectWithData:` method with `unarchivedObjectOfClasses:fromData:error:`, available in iOS 11+ (above our minimum deployment target).

#no-changelog