### PR TITLE
[App Check] Fix JSON key ordering in `HeartbeatsPayload`

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -92,6 +92,8 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .formatted(Self.dateFormatter)
     #if DEBUG
+      // TODO: Remove the following #available check when FirebaseCore's minimum deployment target
+      // is iOS 11+; all other supported platforms already meet the minimum for `.sortedKeys`.
       if #available(iOS 11, *) {
         // Sort keys in debug builds to simplify output comparisons in unit tests.
         encoder.outputFormatting = .sortedKeys

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -91,6 +91,10 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
   public func headerValue() -> String {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .formatted(Self.dateFormatter)
+#if DEBUG
+    // Sort keys in debug builds to simplify output comparisons in unit tests.
+    encoder.outputFormatting = .sortedKeys
+#endif
 
     guard let data = try? encoder.encode(self) else {
       // If encoding fails, fall back to encoding with an empty payload.

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -92,9 +92,11 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .formatted(Self.dateFormatter)
     #if DEBUG
-      // Sort keys in debug builds to simplify output comparisons in unit tests.
-      encoder.outputFormatting = .sortedKeys
-    #endif
+      if #available(iOS 11, *) {
+        // Sort keys in debug builds to simplify output comparisons in unit tests.
+        encoder.outputFormatting = .sortedKeys
+      }
+    #endif // DEBUG
 
     guard let data = try? encoder.encode(self) else {
       // If encoding fails, fall back to encoding with an empty payload.

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -91,10 +91,10 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
   public func headerValue() -> String {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .formatted(Self.dateFormatter)
-#if DEBUG
-    // Sort keys in debug builds to simplify output comparisons in unit tests.
-    encoder.outputFormatting = .sortedKeys
-#endif
+    #if DEBUG
+      // Sort keys in debug builds to simplify output comparisons in unit tests.
+      encoder.outputFormatting = .sortedKeys
+    #endif
 
     guard let data = try? encoder.encode(self) else {
       // If encoding fails, fall back to encoding with an empty payload.


### PR DESCRIPTION
Key ordering from `JSONEncoder` is not guaranteed, resulting in test failures when output is compared directly (e.g., [`testDataRequestSuccessWhenHeartbeatsNeedSending`](https://github.com/firebase/firebase-ios-sdk/blob/f0378e9f9ea5d2d131b75d8745c778468b9b2118/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckAPIServiceTests.m#L125-L135) and [`testRequest_IncludesHeartbeatPayload_WhenHeartbeatsNeedSending`](https://github.com/firebase/firebase-ios-sdk/blob/f0378e9f9ea5d2d131b75d8745c778468b9b2118/FirebaseAuth/Tests/Unit/FIRAuthBackendRPCImplementationTests.m#L421-L448)).

Added the `sortedKeys` output formatting option in debug builds to fix non-deterministic test results while avoiding unnecessary sorting costs in release builds. This resolves #11406 in local testing.

#no-changelog
