### PR TITLE
[Messaging] Fix build issues on visionOS

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -420,9 +420,11 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   SEL openURLWithOptionsSelector = @selector(application:openURL:options:);
   SEL openURLWithSourceApplicationSelector = @selector(application:
                                                            openURL:sourceApplication:annotation:);
-#if TARGET_OS_IOS
+// TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
+// check if `TARGET_OS_XR` is defined.
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   // Due to FIRAAppDelegateProxy swizzling, this selector will most likely get chosen, whether or
   // not the actual application has implemented
   // |application:continueUserActivity:restorationHandler:|. A warning will be displayed to the user
@@ -439,14 +441,13 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
           }];
 
   } else if ([appDelegate respondsToSelector:openURLWithOptionsSelector]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
     [appDelegate application:application openURL:url options:@{}];
-#pragma clang diagnostic pop
     // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called,
     // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
-#if TARGET_OS_IOS
+// TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
+// check if `TARGET_OS_XR` is defined.
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application
@@ -459,9 +460,9 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   }
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 }
 
 - (NSURL *)linkURLFromMessage:(NSDictionary *)message {

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -209,57 +209,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 }
 
 + (void)scheduleLocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date {
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     [self scheduleiOS10LocalNotificationForMessage:message atDate:date];
     return;
   }
-#if TARGET_OS_IOS
-  NSDictionary *apsDictionary = message;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  UILocalNotification *notification = [[UILocalNotification alloc] init];
-#pragma clang diagnostic pop
-
-  // A great way to understand timezones and UILocalNotifications
-  // http://stackoverflow.com/questions/18424569/understanding-uilocalnotification-timezone
-  notification.timeZone = [NSTimeZone defaultTimeZone];
-  notification.fireDate = date;
-
-  // In the current solution all of the display stuff goes into a special "aps" dictionary
-  // being sent in the message.
-  if ([apsDictionary[kFIRMessagingContextManagerBodyKey] length]) {
-    notification.alertBody = apsDictionary[kFIRMessagingContextManagerBodyKey];
-  }
-  if (@available(iOS 8.2, *)) {
-    if ([apsDictionary[kFIRMessagingContextManagerTitleKey] length]) {
-      notification.alertTitle = apsDictionary[kFIRMessagingContextManagerTitleKey];
-    }
-  }
-
-  if (apsDictionary[kFIRMessagingContextManagerSoundKey]) {
-    notification.soundName = apsDictionary[kFIRMessagingContextManagerSoundKey];
-  }
-  if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
-    notification.applicationIconBadgeNumber =
-        [apsDictionary[kFIRMessagingContextManagerBadgeKey] integerValue];
-  }
-  if (apsDictionary[kFIRMessagingContextManagerCategoryKey]) {
-    notification.category = apsDictionary[kFIRMessagingContextManagerCategoryKey];
-  }
-
-  NSDictionary *userInfo = [self parseDataFromMessage:message];
-  if (userInfo.count) {
-    notification.userInfo = userInfo;
-  }
-  UIApplication *application = [GULAppDelegateSwizzler sharedApplication];
-  if (!application) {
-    return;
-  }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [application scheduleLocalNotification:notification];
-#pragma clang diagnostic pop
-#endif
 }
 
 + (NSDictionary *)parseDataFromMessage:(NSDictionary *)message {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -36,7 +36,8 @@ static NSString *const kMessageIdentifierValue = @"1584748495200141";
 
 @interface FIRMessagingContextManagerService (ExposedForTest)
 + (void)scheduleiOS10LocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date;
-+ (UNMutableNotificationContent *)contentFromContextualMessage:(NSDictionary *)message;
++ (UNMutableNotificationContent *)contentFromContextualMessage:(NSDictionary *)message
+    API_AVAILABLE(macos(10.14));
 @end
 
 API_AVAILABLE(macos(10.14))
@@ -44,8 +45,7 @@ API_AVAILABLE(macos(10.14))
 
 @property(nonatomic, readwrite, strong) NSDateFormatter *dateFormatter;
 @property(nonatomic, readwrite, strong) NSMutableArray *scheduledLocalNotifications;
-@property(nonatomic, readwrite, strong)
-    NSMutableArray<UNNotificationRequest *> *requests API_AVAILABLE(ios(10.0), macos(10.4));
+@property(nonatomic, readwrite, strong) NSMutableArray<UNNotificationRequest *> *requests;
 
 @end
 
@@ -57,7 +57,7 @@ API_AVAILABLE(macos(10.14))
   self.dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
   [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
   self.scheduledLocalNotifications = [[NSMutableArray alloc] init];
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     self.requests = [[NSMutableArray alloc] init];
   }
 
@@ -104,7 +104,7 @@ API_AVAILABLE(macos(10.14))
   };
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     XCTAssertEqual(self.requests.count, 1);
     UNNotificationRequest *request = self.requests.firstObject;
     XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
@@ -146,7 +146,7 @@ API_AVAILABLE(macos(10.14))
   };
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     XCTAssertEqual(self.requests.count, 0);
     return;
   }
@@ -176,7 +176,7 @@ API_AVAILABLE(macos(10.14))
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     XCTAssertEqual(self.requests.count, 1);
     UNNotificationRequest *request = self.requests.firstObject;
     XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
@@ -216,7 +216,7 @@ API_AVAILABLE(macos(10.14))
   };
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     XCTAssertEqual(self.requests.count, 1);
     UNNotificationRequest *request = self.requests.firstObject;
     XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
@@ -278,7 +278,7 @@ API_AVAILABLE(macos(10.14))
 }
 
 - (void)testScheduleiOS10LocalNotification {
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     id mockContextManagerService = OCMClassMock([FIRMessagingContextManagerService class]);
     NSDictionary *message = @{};
 
@@ -290,7 +290,7 @@ API_AVAILABLE(macos(10.14))
 }
 
 - (void)testContentFromConetxtualMessage {
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+  if (@available(macOS 10.14, *)) {
     NSDictionary *message = @{
       @"aps" : @{@"content-available" : @1},
       @"gcm.message_id" : @1623702615599207,


### PR DESCRIPTION
Fixed Firebase Messaging build issues in `FIRMessaging.m` and `FIRMessagingContextManagerService.m` when targeting visionOS. Also cleaned up extraneous `@availability` checks for platforms below the current minimum deployment target in these files.

#no-changelog