### PR TITLE
[Firestore] Make Swift code compatible with Xcode 13.3.1

### DIFF
--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# 10.12.0
 - [added] Added support animations on the `@FirestoreQuery` property wrapper.
 
 # 10.9.0

--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQueryObservable.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQueryObservable.swift
@@ -41,7 +41,7 @@ internal class FirestoreQueryObservable<T>: ObservableObject {
     items = []
     self.configuration = configuration
     setupListener = createListener { [weak self] querySnapshot, error in
-      guard let self else { return }
+      guard let self = self else { return }
       if let error = error {
         self.animated {
           self.items = []
@@ -98,7 +98,7 @@ internal class FirestoreQueryObservable<T>: ObservableObject {
     items = .success([])
     self.configuration = configuration
     setupListener = createListener { [weak self] querySnapshot, error in
-      guard let self else { return }
+      guard let self = self else { return }
       if let error = error {
         self.animated {
           self.items = .failure(error)


### PR DESCRIPTION
This should fix the RC build on Xcode 13.3.1. The concise optional unwrapping syntax (`if let foo {}`) was shipped with Swift 5.7, but Xcode 13.3.1 shipped with Swift 5.6.

#no-changelog