### PR TITLE
[Crashlytics] Fix build issues on visionOS

### DIFF
--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -33,7 +33,9 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseSessions.podspec --platforms=${{ matrix.target }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseSessions.podspec \
+            --platforms=${{ matrix.target }} \
+            --allow-warnings
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
@@ -38,6 +38,7 @@
                                            selector:@selector(didBecomeInactive:)
                                                name:UIApplicationDidEnterBackgroundNotification
                                              object:nil];
+#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didChangeOrientation:)
                                                name:UIDeviceOrientationDidChangeNotification
@@ -51,6 +52,7 @@
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
 #pragma clang diagnostic pop
+#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
 
 #elif CLS_TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -65,22 +67,22 @@
 }
 
 - (void)captureInitialNotificationStates {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   UIInterfaceOrientation statusBarOrientation =
       [FIRCLSApplicationSharedInstance() statusBarOrientation];
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 
   // It's nice to do this async, so we don't hold up the main thread while doing three
   // consecutive IOs here.
   dispatch_async(FIRCLSGetLoggingQueue(), ^{
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSInBackgroundKey, @"0");
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSDeviceOrientationKey,
                                            [@(orientation) description]);
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSUIOrientationKey,
                                            [@(statusBarOrientation) description]);
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   });
 }
 
@@ -92,7 +94,7 @@
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSInBackgroundKey, @YES);
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 - (void)didChangeOrientation:(NSNotification *)notification {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
 
@@ -105,6 +107,6 @@
 
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSUIOrientationKey, @(statusBarOrientation));
 }
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 
 @end

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -256,7 +256,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     -> firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
-    #if os(iOS) && !targetEnvironment(macCatalyst)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       switch mobileSubtype {
       case CTRadioAccessTechnologyGPRS:
         subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
@@ -291,10 +291,10 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
           subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
         }
       }
-    #else
+    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       subtype =
         firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-    #endif
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 
     return subtype
   }

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -222,11 +222,11 @@ class SessionStartEventTests: XCTestCase {
     mockNetworkInfo.networkType = .mobile
     // Mobile Subtypes are always empty on non-iOS platforms, and
     // Performance doesn't support those platforms anyways
-    #if os(iOS) && !targetEnvironment(macCatalyst)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-    #else
+    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       mockNetworkInfo.mobileSubtype = ""
-    #endif
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     appInfo.networkInfo = mockNetworkInfo
 
     let event = SessionStartEvent(sessionInfo: defaultSessionInfo, appInfo: appInfo, time: time)
@@ -265,17 +265,17 @@ class SessionStartEventTests: XCTestCase {
       )
       // Mobile Subtypes are always empty on non-iOS platforms, and
       // Performance doesn't support those platforms anyways
-      #if os(iOS) && !targetEnvironment(macCatalyst)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
         XCTAssertEqual(
           event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
         )
-      #else
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
         XCTAssertEqual(
           event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
         )
-      #endif
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       assertEqualProtoString(
         proto.application_info.apple_app_info.mcc_mnc,
         expected: "",
@@ -330,7 +330,7 @@ class SessionStartEventTests: XCTestCase {
   }
 
   /// Following tests can be run only in iOS environment
-  #if os(iOS) && !targetEnvironment(macCatalyst)
+  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
       let expectations: [(
         given: String,
@@ -412,9 +412,9 @@ class SessionStartEventTests: XCTestCase {
           }
         }
     }
-  #endif
+  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 
-  #if os(iOS) && !targetEnvironment(macCatalyst)
+  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     @available(iOS 14.1, *)
     func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
       let expectations: [(
@@ -505,5 +505,5 @@ class SessionStartEventTests: XCTestCase {
           }
         }
     }
-  #endif
+  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 }


### PR DESCRIPTION
Fixed Firebase Crashlytics SDK build issues for visionOS, along with corresponding unit test changes. This also resolves build issues with the underlying Firebase Sessions SDK.

#no-changelog