### PR TITLE
[Auth] Forward declare type in header

### DIFF
--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPMultiFactorInfo.h
@@ -20,6 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class FIRAuthProtoMFAEnrollment;
+
 /**
  @class FIRTotpMultiFactorInfo
  @brief Extends the MultiFactorInfo class for time based one-time password second factors.


### PR DESCRIPTION
Oddly, the type being forward declared in this header is not otherwise defined in either the header or in one of the header's imported headers. Yet, this somehow does not cause a build error locally or in CI. This instead surfaced when copybara'ing FirebaseAuth. 

#no-changelog