### PR TITLE
[Docs] Add a release note w.r.t. Xcode 15 Beta 1 support

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -3,6 +3,8 @@
   (e.g. FirebaseAuth) may fail to access the keychain on the visionOS
   simulator. To workaround this, add the Keychain Sharing capability to the
   visionOS target and explicitly add a keychain group (e.g. the bundle ID).
+- Firebase's Swift Package Manager distribution does not support
+  Xcode 15 Beta 1. Please use Xcode 15 Beta 2 or later.
 
 # Firebase 10.11.0
 - [changed] Improved error reporting for misnamed configuration plist files (#11317).


### PR DESCRIPTION
### Context

For upcoming 10.12.0 release, this `Package.swift` code was added in order to support visionOS where possible: https://github.com/firebase/firebase-ios-sdk/blob/CocoaPods-10.12.0/Package.swift#L1460-L1474

The new `Platform.visionOS` API is only available on Xcode 15 Beta 2 and later. The only way to gate the APIs use without breaking Xcode 14 SPM users is to wrap it with `#if swift(>=5.9)`. While this protect Xcode 14 use, it breaks Xcode 15 Beta **1** use as the visionOS API was not added there. 