### PR TITLE
[Crashlytics] update deprecated kernel api for visionPro

### DIFF
--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -33,7 +33,9 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseSessions.podspec --platforms=${{ matrix.target }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseSessions.podspec \
+            --platforms=${{ matrix.target }} \
+            --allow-warnings
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -35,7 +35,6 @@ jobs:
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseSessions.podspec \
             --platforms=${{ matrix.target }} \
-            --allow-warnings
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
@@ -23,6 +23,7 @@
 
 #include "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
 #include "Crashlytics/Crashlytics/Components/FIRCLSHost.h"
+#include "Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFeatures.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFile.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h"
@@ -241,7 +242,7 @@ static FIRCLSMachOSegmentCommand FIRCLSBinaryImageMachOGetSegmentCommand(
 
   return segmentCommand;
 }
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
 static bool FIRCLSBinaryImageMachOSliceInitSectionByName(FIRCLSMachOSliceRef slice,
                                                          const char* segName,
                                                          const char* sectionName,
@@ -344,7 +345,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
   FIRCLSMachOSection section;
 
 #if CLS_COMPACT_UNWINDING_SUPPORTED
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_TEXT, "__unwind_info",
                                                    &section)) {
     details->node.unwindInfo = (void*)(section.addr + details->vmaddr_slide);
@@ -357,7 +358,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
 #endif
 
 #if CLS_DWARF_UNWINDING_SUPPORTED
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_TEXT, "__eh_frame",
                                                    &section)) {
     details->node.ehFrame = (void*)(section.addr + details->vmaddr_slide);
@@ -369,7 +370,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
 #endif
 #endif
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_DATA, "__crash_info",
                                                    &section)) {
     details->node.crashInfo = (void*)(section.addr + details->vmaddr_slide);

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
@@ -38,6 +38,7 @@
                                            selector:@selector(didBecomeInactive:)
                                                name:UIApplicationDidEnterBackgroundNotification
                                              object:nil];
+#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didChangeOrientation:)
                                                name:UIDeviceOrientationDidChangeNotification
@@ -51,6 +52,7 @@
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
 #pragma clang diagnostic pop
+#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
 
 #elif CLS_TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -65,22 +67,22 @@
 }
 
 - (void)captureInitialNotificationStates {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   UIInterfaceOrientation statusBarOrientation =
       [FIRCLSApplicationSharedInstance() statusBarOrientation];
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 
   // It's nice to do this async, so we don't hold up the main thread while doing three
   // consecutive IOs here.
   dispatch_async(FIRCLSGetLoggingQueue(), ^{
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSInBackgroundKey, @"0");
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSDeviceOrientationKey,
                                            [@(orientation) description]);
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSUIOrientationKey,
                                            [@(statusBarOrientation) description]);
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
   });
 }
 
@@ -92,7 +94,7 @@
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSInBackgroundKey, @YES);
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 - (void)didChangeOrientation:(NSNotification *)notification {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
 
@@ -105,6 +107,6 @@
 
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSUIOrientationKey, @(statusBarOrientation));
 }
-#endif
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
 
 @end

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
@@ -17,6 +17,7 @@
 #import "Crashlytics/Crashlytics/Components/FIRCLSApplication.h"
 #import "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
 #import "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
+#include "Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -38,7 +39,7 @@
                                            selector:@selector(didBecomeInactive:)
                                                name:UIApplicationDidEnterBackgroundNotification
                                              object:nil];
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didChangeOrientation:)
                                                name:UIDeviceOrientationDidChangeNotification
@@ -52,7 +53,7 @@
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
 #pragma clang diagnostic pop
-#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#endif  // !CLS_TARGET_OS_XR
 
 #elif CLS_TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -67,22 +68,22 @@
 }
 
 - (void)captureInitialNotificationStates {
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   UIInterfaceOrientation statusBarOrientation =
       [FIRCLSApplicationSharedInstance() statusBarOrientation];
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
 
   // It's nice to do this async, so we don't hold up the main thread while doing three
   // consecutive IOs here.
   dispatch_async(FIRCLSGetLoggingQueue(), ^{
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSInBackgroundKey, @"0");
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSDeviceOrientationKey,
                                            [@(orientation) description]);
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSUIOrientationKey,
                                            [@(statusBarOrientation) description]);
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
   });
 }
 
@@ -94,7 +95,7 @@
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSInBackgroundKey, @YES);
 }
 
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
 - (void)didChangeOrientation:(NSNotification *)notification {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
 
@@ -107,6 +108,6 @@
 
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSUIOrientationKey, @(statusBarOrientation));
 }
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
 
 @end

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
@@ -57,6 +57,13 @@
 #include <arm/arch.h>
 #endif
 
+// VisionOS support
+#if defined(TARGET_OS_XR) && TARGET_OS_XR
+#define CLS_TARGET_OS_XR 1
+#else
+#define CLS_TARGET_OS_XR 0
+#endif
+
 #if defined(__arm__)
 #define CLS_CPU_ARM 1
 #endif

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h"
+#include "Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h"
 
 #include <Foundation/Foundation.h>
 
@@ -266,7 +267,7 @@ struct FIRCLSMachOSlice FIRCLSMachOSliceGetCurrent(void) {
   void* executableSymbol;
   Dl_info dlinfo;
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   const NXArchInfo* archInfo;
   archInfo = NXGetLocalArchInfo();
 
@@ -341,7 +342,7 @@ const char* FIRCLSMachOSliceGetArchitectureName(FIRCLSMachOSliceRef slice) {
     return "armv7k";
   }
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
   const NXArchInfo* archInfo;
 
   archInfo = NXGetArchInfoFromCpuType(slice->cputype, slice->cpusubtype);

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
@@ -17,8 +17,9 @@
 #include <mach-o/getsect.h>
 #include <mach-o/utils.h>
 
-#import "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h"
+#include "Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h"
 
+#import "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h"
 #import "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachOBinary.h"
 #import "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachOSlice.h"
 #import "Crashlytics/Shared/FIRCLSMachO/FIRCLSdSYM.h"
@@ -316,7 +317,7 @@
   XCTAssert(ptr != NULL);
 }
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !CLS_TARGET_OS_XR
 - (void)testReadArm64Section {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"armv7-armv7s-arm64.dylib"];
   struct FIRCLSMachOFile file;
@@ -339,7 +340,7 @@
 }
 #endif
 
-#if defined(TARGET_OS_XR) && TARGET_OS_XR
+#if CLS_TARGET_OS_XR
 
 - (void)testVisionProGetSlice {
   struct FIRCLSMachOSlice slice = FIRCLSMachOSliceGetCurrent();

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #import "Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.h"
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#include <mach-o/utils.h>
 
 #import "Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.h"
 
@@ -313,6 +316,7 @@
   XCTAssert(ptr != NULL);
 }
 
+#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
 - (void)testReadArm64Section {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"armv7-armv7s-arm64.dylib"];
   struct FIRCLSMachOFile file;
@@ -333,5 +337,17 @@
   XCTAssert(FIRCLSMachOSliceGetSectionByName(&slice, SEG_TEXT, "__unwind_info", &ptr));
   XCTAssert(ptr != NULL);
 }
+#endif
+
+#if defined(TARGET_OS_XR) && TARGET_OS_XR
+
+- (void)testVisionProGetSlice {
+  struct FIRCLSMachOSlice slice = FIRCLSMachOSliceGetCurrent();
+  XCTAssertEqual(slice.cputype, CPU_TYPE_ARM64);
+
+  const char* archname = macho_arch_name_for_mach_header(NULL);
+  XCTAssertEqualObjects(@(archname), @"arm64");
+}
+#endif
 
 @end

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -256,7 +256,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     -> firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
-    #if os(iOS) && !targetEnvironment(macCatalyst)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       switch mobileSubtype {
       case CTRadioAccessTechnologyGPRS:
         subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
@@ -291,10 +291,10 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
           subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
         }
       }
-    #else
+    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       subtype =
         firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-    #endif
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 
     return subtype
   }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -256,45 +256,88 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     -> firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
-    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-      switch mobileSubtype {
-      case CTRadioAccessTechnologyGPRS:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-      case CTRadioAccessTechnologyEdge:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-      case CTRadioAccessTechnologyWCDMA:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-      case CTRadioAccessTechnologyCDMA1x:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-      case CTRadioAccessTechnologyHSDPA:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-      case CTRadioAccessTechnologyHSUPA:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-      case CTRadioAccessTechnologyCDMAEVDORev0:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-      case CTRadioAccessTechnologyCDMAEVDORevA:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-      case CTRadioAccessTechnologyCDMAEVDORevB:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-      case CTRadioAccessTechnologyeHRPD:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-      case CTRadioAccessTechnologyLTE:
-        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-      default:
+    // swift(>=5.9) implies Xcode 15+
+    #if swift(>=5.9)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        switch mobileSubtype {
+        case CTRadioAccessTechnologyGPRS:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+        case CTRadioAccessTechnologyEdge:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+        case CTRadioAccessTechnologyWCDMA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        case CTRadioAccessTechnologyCDMA1x:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        case CTRadioAccessTechnologyHSDPA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+        case CTRadioAccessTechnologyHSUPA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+        case CTRadioAccessTechnologyCDMAEVDORev0:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+        case CTRadioAccessTechnologyCDMAEVDORevA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+        case CTRadioAccessTechnologyCDMAEVDORevB:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+        case CTRadioAccessTechnologyeHRPD:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+        case CTRadioAccessTechnologyLTE:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+        default:
+          subtype =
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+        }
+
+        if #available(iOS 14.1, *) {
+          if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
+            CTRadioAccessTechnologyNR {
+            subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          }
+        }
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
         subtype =
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-      }
-
-      if #available(iOS 14.1, *) {
-        if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
-          CTRadioAccessTechnologyNR {
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #else // swift(>=5.9)
+      #if os(iOS) && !targetEnvironment(macCatalyst)
+        switch mobileSubtype {
+        case CTRadioAccessTechnologyGPRS:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+        case CTRadioAccessTechnologyEdge:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+        case CTRadioAccessTechnologyWCDMA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        case CTRadioAccessTechnologyCDMA1x:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        case CTRadioAccessTechnologyHSDPA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+        case CTRadioAccessTechnologyHSUPA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+        case CTRadioAccessTechnologyCDMAEVDORev0:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+        case CTRadioAccessTechnologyCDMAEVDORevA:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+        case CTRadioAccessTechnologyCDMAEVDORevB:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+        case CTRadioAccessTechnologyeHRPD:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+        case CTRadioAccessTechnologyLTE:
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+        default:
+          subtype =
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
         }
-      }
-    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-      subtype =
-        firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
+
+        if #available(iOS 14.1, *) {
+          if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
+            CTRadioAccessTechnologyNR {
+            subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          }
+        }
+      #else // os(iOS) && !targetEnvironment(macCatalyst)
+        subtype =
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+      #endif // os(iOS) && !targetEnvironment(macCatalyst)
+    #endif
 
     return subtype
   }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -257,6 +257,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
     // swift(>=5.9) implies Xcode 15+
+    // Need to have this swift version check to use os(xrOS) macro, VisionOS support.
     #if swift(>=5.9)
       #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
         switch mobileSubtype {

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -222,11 +222,19 @@ class SessionStartEventTests: XCTestCase {
     mockNetworkInfo.networkType = .mobile
     // Mobile Subtypes are always empty on non-iOS platforms, and
     // Performance doesn't support those platforms anyways
-    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-      mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-      mockNetworkInfo.mobileSubtype = ""
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
+    #if swift(>=5.9)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        mockNetworkInfo.mobileSubtype = ""
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #else // swift(>=5.9)
+      #if os(iOS) && !targetEnvironment(macCatalyst)
+        mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
+      #else // os(iOS) && !targetEnvironment(macCatalyst)
+        mockNetworkInfo.mobileSubtype = ""
+      #endif // os(iOS) && !targetEnvironment(macCatalyst)
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
     appInfo.networkInfo = mockNetworkInfo
 
     let event = SessionStartEvent(sessionInfo: defaultSessionInfo, appInfo: appInfo, time: time)
@@ -265,17 +273,31 @@ class SessionStartEventTests: XCTestCase {
       )
       // Mobile Subtypes are always empty on non-iOS platforms, and
       // Performance doesn't support those platforms anyways
-      #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-        XCTAssertEqual(
-          event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-        )
-      #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-        XCTAssertEqual(
-          event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-        )
-      #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
+      #if swift(>=5.9)
+        #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+          XCTAssertEqual(
+            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          )
+        #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+          XCTAssertEqual(
+            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          )
+        #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #else // swift(>=5.9)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+          XCTAssertEqual(
+            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          )
+        #else // os(iOS) && !targetEnvironment(macCatalyst)
+          XCTAssertEqual(
+            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          )
+        #endif // os(iOS) && !targetEnvironment(macCatalyst)
+      #endif // swift(>=5.9)
       assertEqualProtoString(
         proto.application_info.apple_app_info.mcc_mnc,
         expected: "",
@@ -330,180 +352,361 @@ class SessionStartEventTests: XCTestCase {
   }
 
   /// Following tests can be run only in iOS environment
-  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-    func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
-      let expectations: [(
-        given: String,
-        expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-      )] = [
-        (
-          CTRadioAccessTechnologyGPRS,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-        ),
-        (
-          CTRadioAccessTechnologyEdge,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-        ),
-        (
-          CTRadioAccessTechnologyWCDMA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        ),
-        (
-          CTRadioAccessTechnologyCDMA1x,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        ),
-        (
-          CTRadioAccessTechnologyHSDPA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-        ),
-        (
-          CTRadioAccessTechnologyHSUPA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORev0,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORevA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORevB,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-        ),
-        (
-          CTRadioAccessTechnologyeHRPD,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-        ),
-        (
-          CTRadioAccessTechnologyLTE,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-        ),
-        (
-          "random",
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-        ),
-      ]
-
-      expectations
-        .forEach { (
+  #if swift(>=5.9)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
+        let expectations: [(
           given: String,
           expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        ) in
-          let mockNetworkInfo = MockNetworkInfo()
-          mockNetworkInfo.mobileSubtype = given
-          appInfo.networkInfo = mockNetworkInfo
+        )] = [
+          (
+            CTRadioAccessTechnologyGPRS,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+          ),
+          (
+            CTRadioAccessTechnologyEdge,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+          ),
+          (
+            CTRadioAccessTechnologyWCDMA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyCDMA1x,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyHSDPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+          ),
+          (
+            CTRadioAccessTechnologyHSUPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORev0,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevB,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+          ),
+          (
+            CTRadioAccessTechnologyeHRPD,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+          ),
+          (
+            CTRadioAccessTechnologyLTE,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+          ),
+          (
+            "random",
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          ),
+        ]
 
-          let event = SessionStartEvent(
-            sessionInfo: self.defaultSessionInfo,
-            appInfo: appInfo,
-            time: time
-          )
+        expectations
+          .forEach { (
+            given: String,
+            expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+          ) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
 
-          // These fields will only be filled in when the Perf SDK is installed
-          event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
-
-          testProtoAndDecodedProto(sessionEvent: event) { proto in
-            XCTAssertEqual(
-              event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-              expected
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
             )
+
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+                expected
+              )
+            }
           }
-        }
-    }
-  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-
-  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
-    @available(iOS 14.1, *)
-    func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
-      let expectations: [(
-        given: String,
-        expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-      )] = [
-        (
-          CTRadioAccessTechnologyGPRS,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-        ),
-        (
-          CTRadioAccessTechnologyEdge,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-        ),
-        (
-          CTRadioAccessTechnologyWCDMA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        ),
-        (
-          CTRadioAccessTechnologyCDMA1x,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        ),
-        (
-          CTRadioAccessTechnologyHSDPA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-        ),
-        (
-          CTRadioAccessTechnologyHSUPA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORev0,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORevA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-        ),
-        (
-          CTRadioAccessTechnologyCDMAEVDORevB,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-        ),
-        (
-          CTRadioAccessTechnologyeHRPD,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-        ),
-        (
-          CTRadioAccessTechnologyLTE,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-        ),
-        (
-          CTRadioAccessTechnologyNRNSA,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-        ),
-        (
-          CTRadioAccessTechnologyNR,
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-        ),
-        (
-          "random",
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-        ),
-      ]
-
-      expectations
-        .forEach { (
+      }
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+  #else // swift(>=5.9)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
+        let expectations: [(
           given: String,
           expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        ) in
-          let mockNetworkInfo = MockNetworkInfo()
-          mockNetworkInfo.mobileSubtype = given
-          appInfo.networkInfo = mockNetworkInfo
+        )] = [
+          (
+            CTRadioAccessTechnologyGPRS,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+          ),
+          (
+            CTRadioAccessTechnologyEdge,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+          ),
+          (
+            CTRadioAccessTechnologyWCDMA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyCDMA1x,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyHSDPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+          ),
+          (
+            CTRadioAccessTechnologyHSUPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORev0,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevB,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+          ),
+          (
+            CTRadioAccessTechnologyeHRPD,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+          ),
+          (
+            CTRadioAccessTechnologyLTE,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+          ),
+          (
+            "random",
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          ),
+        ]
 
-          let event = SessionStartEvent(
-            sessionInfo: self.defaultSessionInfo,
-            appInfo: appInfo,
-            time: time
-          )
+        expectations
+          .forEach { (
+            given: String,
+            expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+          ) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
 
-          // These fields will only be filled in when the Perf SDK is installed
-          event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
-
-          testProtoAndDecodedProto(sessionEvent: event) { proto in
-            XCTAssertEqual(
-              event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-              expected
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
             )
+
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+                expected
+              )
+            }
           }
-        }
-    }
-  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
+      }
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
+  #endif // swift(>=5.9)
+
+  #if swift(>=5.9)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      @available(iOS 14.1, *)
+      func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
+        let expectations: [(
+          given: String,
+          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+        )] = [
+          (
+            CTRadioAccessTechnologyGPRS,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+          ),
+          (
+            CTRadioAccessTechnologyEdge,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+          ),
+          (
+            CTRadioAccessTechnologyWCDMA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyCDMA1x,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyHSDPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+          ),
+          (
+            CTRadioAccessTechnologyHSUPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORev0,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevB,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+          ),
+          (
+            CTRadioAccessTechnologyeHRPD,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+          ),
+          (
+            CTRadioAccessTechnologyLTE,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+          ),
+          (
+            CTRadioAccessTechnologyNRNSA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          ),
+          (
+            CTRadioAccessTechnologyNR,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          ),
+          (
+            "random",
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          ),
+        ]
+
+        expectations
+          .forEach { (
+            given: String,
+            expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+          ) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
+
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
+            )
+
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+                expected
+              )
+            }
+          }
+      }
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+  #else // swift(>=5.9)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      @available(iOS 14.1, *)
+      func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
+        let expectations: [(
+          given: String,
+          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+        )] = [
+          (
+            CTRadioAccessTechnologyGPRS,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+          ),
+          (
+            CTRadioAccessTechnologyEdge,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+          ),
+          (
+            CTRadioAccessTechnologyWCDMA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyCDMA1x,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+          ),
+          (
+            CTRadioAccessTechnologyHSDPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+          ),
+          (
+            CTRadioAccessTechnologyHSUPA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORev0,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+          ),
+          (
+            CTRadioAccessTechnologyCDMAEVDORevB,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+          ),
+          (
+            CTRadioAccessTechnologyeHRPD,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+          ),
+          (
+            CTRadioAccessTechnologyLTE,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+          ),
+          (
+            CTRadioAccessTechnologyNRNSA,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          ),
+          (
+            CTRadioAccessTechnologyNR,
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+          ),
+          (
+            "random",
+            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+          ),
+        ]
+
+        expectations
+          .forEach { (
+            given: String,
+            expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+          ) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
+
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
+            )
+
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+                expected
+              )
+            }
+          }
+      }
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
+  #endif // swift(>=5.9)
 }

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -222,11 +222,11 @@ class SessionStartEventTests: XCTestCase {
     mockNetworkInfo.networkType = .mobile
     // Mobile Subtypes are always empty on non-iOS platforms, and
     // Performance doesn't support those platforms anyways
-    #if os(iOS) && !targetEnvironment(macCatalyst)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-    #else
+    #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       mockNetworkInfo.mobileSubtype = ""
-    #endif
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     appInfo.networkInfo = mockNetworkInfo
 
     let event = SessionStartEvent(sessionInfo: defaultSessionInfo, appInfo: appInfo, time: time)
@@ -265,17 +265,17 @@ class SessionStartEventTests: XCTestCase {
       )
       // Mobile Subtypes are always empty on non-iOS platforms, and
       // Performance doesn't support those platforms anyways
-      #if os(iOS) && !targetEnvironment(macCatalyst)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
         XCTAssertEqual(
           event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
         )
-      #else
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
         XCTAssertEqual(
           event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
         )
-      #endif
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
       assertEqualProtoString(
         proto.application_info.apple_app_info.mcc_mnc,
         expected: "",
@@ -330,7 +330,7 @@ class SessionStartEventTests: XCTestCase {
   }
 
   /// Following tests can be run only in iOS environment
-  #if os(iOS) && !targetEnvironment(macCatalyst)
+  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
       let expectations: [(
         given: String,
@@ -412,9 +412,9 @@ class SessionStartEventTests: XCTestCase {
           }
         }
     }
-  #endif
+  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 
-  #if os(iOS) && !targetEnvironment(macCatalyst)
+  #if os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
     @available(iOS 14.1, *)
     func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
       let expectations: [(
@@ -505,5 +505,5 @@ class SessionStartEventTests: XCTestCase {
           }
         }
     }
-  #endif
+  #endif // os(iOS) && !targetEnvironment(macCatalyst) && (swift(<5.9) || !os(xrOS))
 }


### PR DESCRIPTION
Build on top of https://github.com/firebase/firebase-ios-sdk/pull/11498, 
Fixed Firebase Crashlytics SDK build issues for visionOS, along with corresponding unit test changes. This also resolves build issues with the underlying Firebase Sessions SDK.

Get rid of deprecated api warning for visionPro, there are two sets of functions getting deprecated:
- `NXGetLocalArchInfo()` -> `macho_arch_name_for_mach_header()` // for cpu type, subtype and archname
- `getsectbynamefromheader(mach_header, segementName, sectionName)` -> `getsectiondata(mach_header, segementName, sectionName)` // finding the runtime section ref for DWARF or other strategy of unwinding

#no-changelog