### PR TITLE
[auth-swift] Fix runtime warnings detected by Xcode 15 b3

### DIFF
--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -78,13 +78,13 @@ class EmailAuthCredential: AuthCredential, NSSecureCoding {
   }
 
   public required init?(coder: NSCoder) {
-    guard let email = coder.decodeObject(forKey: "email") as? String else {
+    guard let email = coder.decodeObject(of: NSString.self, forKey: "email") as? String else {
       return nil
     }
     self.email = email
-    if let password = coder.decodeObject(forKey: "password") as? String {
+    if let password = coder.decodeObject(of: NSString.self, forKey: "password") as? String {
       emailType = .password(password)
-    } else if let link = coder.decodeObject(forKey: "link") as? String {
+    } else if let link = coder.decodeObject(of: NSString.self, forKey: "link") as? String {
       emailType = .link(link)
     } else {
       return nil

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -57,7 +57,8 @@ import Foundation
   }
 
   required init?(coder: NSCoder) {
-    guard let accessToken = coder.decodeObject(forKey: "accessToken") as? String else {
+    guard let accessToken = coder.decodeObject(of: NSString.self, forKey: "accessToken") as? String
+    else {
       return nil
     }
     self.accessToken = accessToken

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -160,11 +160,20 @@
     }
 
     public required init?(coder: NSCoder) {
-      guard let playerID = coder.decodeObject(forKey: "playerID") as? String,
-            let teamPlayerID = coder.decodeObject(forKey: "teamPlayerID") as? String,
-            let gamePlayerID = coder.decodeObject(forKey: "gamePlayerID") as? String,
+      guard let playerID = coder.decodeObject(of: NSString.self, forKey: "playerID") as? String,
+            let teamPlayerID = coder.decodeObject(
+              of: NSString.self,
+              forKey: "teamPlayerID"
+            ) as? String,
+            let gamePlayerID = coder.decodeObject(
+              of: NSString.self,
+              forKey: "gamePlayerID"
+            ) as? String,
             let timestamp = coder.decodeObject(forKey: "timestamp") as? UInt64,
-            let displayName = coder.decodeObject(forKey: "displayName") as? String else {
+            let displayName = coder.decodeObject(
+              of: NSString.self,
+              forKey: "displayName"
+            ) as? String else {
         return nil
       }
       self.playerID = playerID
@@ -173,8 +182,8 @@
       self.timestamp = timestamp
       self.displayName = displayName
       publicKeyURL = coder.decodeObject(forKey: "publicKeyURL") as? URL
-      signature = coder.decodeObject(forKey: "signature") as? Data
-      salt = coder.decodeObject(forKey: "salt") as? Data
+      signature = coder.decodeObject(of: NSData.self, forKey: "signature") as? Data
+      salt = coder.decodeObject(of: NSData.self, forKey: "salt") as? Data
       super.init(provider: GameCenterAuthProvider.id)
     }
   }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
@@ -57,7 +57,7 @@ class GitHubAuthCredential: AuthCredential, NSSecureCoding {
   }
 
   required init?(coder: NSCoder) {
-    guard let token = coder.decodeObject(forKey: "token") as? String else {
+    guard let token = coder.decodeObject(of: NSString.self, forKey: "token") as? String else {
       return nil
     }
     self.token = token

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -63,8 +63,9 @@ import Foundation
   }
 
   required init?(coder: NSCoder) {
-    guard let idToken = coder.decodeObject(forKey: "idToken") as? String,
-          let accessToken = coder.decodeObject(forKey: "accessToken") as? String else {
+    guard let idToken = coder.decodeObject(of: NSString.self, forKey: "idToken") as? String,
+          let accessToken = coder.decodeObject(of: NSString.self, forKey: "accessToken") as? String
+    else {
       return nil
     }
     self.idToken = idToken

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -113,11 +113,11 @@ import Foundation
   }
 
   public required init?(coder: NSCoder) {
-    idToken = coder.decodeObject(forKey: "IDToken") as? String
-    rawNonce = coder.decodeObject(forKey: "rawNonce") as? String
-    accessToken = coder.decodeObject(forKey: "accessToken") as? String
-    pendingToken = coder.decodeObject(forKey: "pendingToken") as? String
-    secret = coder.decodeObject(forKey: "secret") as? String
+    idToken = coder.decodeObject(of: NSString.self, forKey: "IDToken") as? String
+    rawNonce = coder.decodeObject(of: NSString.self, forKey: "rawNonce") as? String
+    accessToken = coder.decodeObject(of: NSString.self, forKey: "accessToken") as? String
+    pendingToken = coder.decodeObject(of: NSString.self, forKey: "pendingToken") as? String
+    secret = coder.decodeObject(of: NSString.self, forKey: "secret") as? String
     fullName = coder.decodeObject(forKey: "fullName") as? PersonNameComponents
     OAuthResponseURLString = nil
     sessionID = nil

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
@@ -52,8 +52,12 @@ import Foundation
   }
 
   public required init?(coder: NSCoder) {
-    if let verificationID = coder.decodeObject(forKey: "verificationID") as? String,
-       let verificationCode = coder.decodeObject(forKey: "verificationCode") as? String {
+    if let verificationID = coder.decodeObject(
+      of: NSString.self,
+      forKey: "verificationID"
+    ) as? String,
+      let verificationCode = coder.decodeObject(of: NSString.self, forKey: "verificationCode")
+      as? String {
       credentialKind = .verification(verificationID, verificationCode)
       super.init(provider: PhoneAuthProvider.id)
     } else if let temporaryProof = coder.decodeObject(forKey: "temporaryProof") as? String,

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -62,8 +62,8 @@ class TwitterAuthCredential: AuthCredential, NSSecureCoding {
   }
 
   required init?(coder: NSCoder) {
-    guard let token = coder.decodeObject(forKey: "token") as? String,
-          let secret = coder.decodeObject(forKey: "secret") as? String else {
+    guard let token = coder.decodeObject(of: NSString.self, forKey: "token") as? String,
+          let secret = coder.decodeObject(of: NSString.self, forKey: "secret") as? String else {
       return nil
     }
     self.token = token

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebView.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebView.swift
@@ -20,6 +20,7 @@
   /** @class AuthWebView
       @brief A class responsible for creating a WKWebView for use within Firebase Auth.
    */
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc(FIRAuthWebView) public class AuthWebView: UIView {
     public lazy var webView: WKWebView = createWebView()
     public lazy var spinner: UIActivityIndicatorView = createSpinner()
@@ -73,11 +74,7 @@
     }
 
     private func createSpinner() -> UIActivityIndicatorView {
-      if #available(iOS 13.0, macCatalyst 13.0, *) {
-        return UIActivityIndicatorView(style: .medium)
-      } else {
-        return UIActivityIndicatorView(style: .gray)
-      }
+      return UIActivityIndicatorView(style: .medium)
     }
   }
 #endif

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
@@ -21,6 +21,7 @@
   /** @protocol AuthWebViewControllerDelegate
       @brief Defines a delegate for AuthWebViewController
    */
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   protocol AuthWebViewControllerDelegate: AnyObject {
     /** @fn webViewControllerDidCancel:
         @brief Notifies the delegate that the web view controller is being cancelled by the user.
@@ -55,6 +56,7 @@
                  completion: @escaping (URL?, Error?) -> Void)
   }
 
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class AuthWebViewController: UIViewController,
     WKNavigationDelegate {
     // MARK: - Properties


### PR DESCRIPTION
Fix warnings like _Attempted to decode a collection type 'NSString' (subclass of 'NSObject') for key 'NS.keys'. 'NSString' requires its subclasses to be explicitly added to the allowed classes list but it is not present. Allowing this has been a source of security issues_ that are shown in Xcode 15 beta 3

Also, added a few missing iOS 13 availability checks.

#no-changelog