### PR TITLE
[App Check] Replace token refresh `NSNotification`s with delegate

### DIFF
--- a/AppCheck/Interop/Public/AppCheckInterop/GACAppCheckInterop.h
+++ b/AppCheck/Interop/Public/AppCheckInterop/GACAppCheckInterop.h
@@ -46,18 +46,6 @@ NS_SWIFT_NAME(InternalAppCheckInterop) @protocol GACAppCheckInterop
 - (void)getLimitedUseTokenWithCompletion:(void (^)(id<GACAppCheckTokenInterop> _Nullable token,
                                                    NSError *_Nullable error))handler;
 
-/// A notification with the specified name is sent to the default notification center
-/// (`NotificationCenter.default`) each time a Firebase app check token is refreshed.
-/// The user info dictionary contains `-[self notificationTokenKey]` and
-/// `-[self notificationAppNameKey]` keys.
-- (NSString *)tokenDidChangeNotificationName;
-
-/// `userInfo` key for the FAC token in a notification for `tokenDidChangeNotificationName`.
-- (NSString *)notificationTokenKey;
-/// `userInfo` key for the `FirebaseApp.name` in a notification for
-/// `tokenDidChangeNotificationName`.
-- (NSString *)notificationInstanceNameKey;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCheck/Sources/Public/AppCheck/AppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/AppCheck.h
@@ -19,6 +19,7 @@
 #import "GACAppCheckProvider.h"
 #import "GACAppCheckSettings.h"
 #import "GACAppCheckToken.h"
+#import "GACAppCheckTokenDelegate.h"
 
 // Debug provider
 #import "GACAppCheckDebugProvider.h"

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
@@ -21,20 +21,9 @@
 @class GACAppCheckToken;
 @protocol GACAppCheckProvider;
 @protocol GACAppCheckSettingsProtocol;
+@protocol GACAppCheckTokenDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
-
-/// A notification with the specified name is sent to the default notification center
-/// (`NotificationCenter.default`) each time a Firebase app check token is refreshed.
-/// The user info dictionary contains `kGACAppCheckTokenNotificationKey` and
-/// `kGACAppCheckAppNameNotificationKey` keys.
-FOUNDATION_EXPORT const NSNotificationName
-    GACAppCheckAppCheckTokenDidChangeNotification NS_SWIFT_NAME(InternalAppCheckTokenDidChange);
-
-/// `userInfo` key for the `FirebaseApp.name` in `AppCheckTokenDidChangeNotification`.
-FOUNDATION_EXPORT NSString *const kGACAppCheckTokenNotificationKey NS_SWIFT_NAME(InternalAppCheckTokenNotificationKey);
-/// `userInfo` key for the `AppCheckToken` in `AppCheckTokenDidChangeNotification`.
-FOUNDATION_EXPORT NSString *const kGACAppCheckInstanceNameNotificationKey NS_SWIFT_NAME(InternalAppCheckInstanceNameNotificationKey);
 
 /// A class used to manage App Check tokens for a given resource.
 NS_SWIFT_NAME(InternalAppCheck)
@@ -48,6 +37,7 @@ NS_SWIFT_NAME(InternalAppCheck)
 - (instancetype)initWithInstanceName:(NSString *)instanceName
                     appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
                             settings:(id<GACAppCheckSettingsProtocol>)settings
+                       tokenDelegate:(id<GACAppCheckTokenDelegate>)tokenDelegate
                         resourceName:(NSString *)resourceName
                  keychainAccessGroup:(nullable NSString *)accessGroup;
 

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol GACAppCheckTokenDelegate <NSObject>
+
+- (void)tokenDidUpdate:(GACAppCheckToken *)token instanceName:(NSString *)instanceName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
@@ -20,6 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol GACAppCheckTokenDelegate <NSObject>
 
+/// Called each time an App Check token is refreshed.
+///
+/// @param token The updated App Check token.
+/// @param instanceName A unique identifier for the App Check instance, may be a Firebase App Name
+/// or an SDK name.
 - (void)tokenDidUpdate:(GACAppCheckToken *)token instanceName:(NSString *)instanceName;
 
 @end

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -48,17 +48,6 @@ final class AppCheckAPITests {
 
     // MARK: - AppCheck
 
-    // `AppCheckTokenDidChange` & associated notification keys
-    _ = NotificationCenter.default
-      .addObserver(
-        forName: .InternalAppCheckTokenDidChange,
-        object: nil,
-        queue: .main
-      ) { notification in
-        _ = notification.userInfo?[InternalAppCheckTokenNotificationKey]
-        _ = notification.userInfo?[InternalAppCheckInstanceNameNotificationKey]
-      }
-
     guard let app = FirebaseApp.app() else { return }
 
     // Retrieving an AppCheck instance
@@ -66,6 +55,7 @@ final class AppCheckAPITests {
       instanceName: app.name,
       appCheckProvider: DummyAppCheckProvider(),
       settings: DummyAppCheckSettings(),
+      tokenDelegate: DummyAppCheckTokenDelegate(),
       resourceName: resourceName,
       keychainAccessGroup: app.options.appGroupID
     )
@@ -206,4 +196,8 @@ class DummyAppCheckProvider: NSObject, InternalAppCheckProvider {
 
 class DummyAppCheckSettings: NSObject, GACAppCheckSettingsProtocol {
   var isTokenAutoRefreshEnabled: Bool = true
+}
+
+class DummyAppCheckTokenDelegate: NSObject, GACAppCheckTokenDelegate {
+  func tokenDidUpdate(_ token: InternalAppCheckToken, instanceName: String) {}
 }


### PR DESCRIPTION
Replaced token refresh notifications via `NSNotificationCenter` with `GACAppCheckTokenDelegate` in the internal App Check SDK.

Firebase App Check (shim SDK) can continue to support the existing `NSNotification`s by providing a `GACAppCheckTokenDelegate` that posts notifications in its `tokenDidUpdate:instanceName:` method.

#no-changelog