### PR TITLE
[App Check] Copy SharedTestUtilities for Lite SDK

### DIFF
--- a/AppCheck.podspec
+++ b/AppCheck.podspec
@@ -61,8 +61,6 @@ Pod::Spec.new do |s|
     unit_tests.source_files = [
       base_dir + 'Tests/Unit/**/*.[mh]',
       base_dir + 'Tests/Utils/**/*.[mh]',
-      'SharedTestUtilities/Date/*',
-      'SharedTestUtilities/URLSession/*',
     ]
 
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -30,7 +30,7 @@
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h"
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
-#import "SharedTestUtilities/Date/FIRDateTestUtils.h"
+#import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
 
 static NSString *const kBaseURL = @"https://test.appcheck.url.com/beta";
@@ -349,7 +349,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 
   XCTAssertEqualObjects(promise.value.artifact, expectedArtifact);
   XCTAssertEqualObjects(promise.value.token.token, @"valid_app_check_token");
-  XCTAssertTrue([FIRDateTestUtils isDate:promise.value.token.expirationDate
+  XCTAssertTrue([GACDateTestUtils isDate:promise.value.token.expirationDate
       approximatelyEqualCurrentPlusTimeInterval:1800
                                       precision:10]);
 

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestAPIServiceTests.m
@@ -31,7 +31,7 @@
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
 #import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
-#import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
+#import "AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
 
 static NSString *const kBaseURL = @"https://test.appcheck.url.com/beta";
 static NSString *const kResourceName = @"projects/project_id/apps/app_id";
@@ -424,7 +424,7 @@ static NSString *const kResourceName = @"projects/project_id/apps/app_id";
 - (GULURLSessionDataResponse *)APIResponseWithCode:(NSInteger)code
                                       responseBody:(NSData *)responseBody {
   XCTAssertNotNil(responseBody);
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:code];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:code];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
   return APIResponse;

--- a/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -28,7 +28,7 @@
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h"
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
-#import "SharedTestUtilities/Date/FIRDateTestUtils.h"
+#import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
@@ -320,7 +320,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   XCTAssertNil(tokenPromise.error);
 
   XCTAssertEqualObjects(tokenPromise.value.token, expectedFACToken);
-  XCTAssertTrue([FIRDateTestUtils isDate:tokenPromise.value.expirationDate
+  XCTAssertTrue([GACDateTestUtils isDate:tokenPromise.value.expirationDate
       approximatelyEqualCurrentPlusTimeInterval:1800
                                       precision:10]);
 }

--- a/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -29,7 +29,7 @@
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
 #import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
-#import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
+#import "AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -112,7 +112,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSString *responseBodyString = @"Token verification failed.";
 
   NSData *HTTPResponseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:300];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:300];
   [self stubURLSessionDataTaskPromiseWithResponse:HTTPResponse
                                              body:HTTPResponseBody
                                             error:nil
@@ -180,7 +180,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   };
 
   NSData *HTTPResponseBody = [@"A response" dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   [self stubURLSessionDataTaskPromiseWithResponse:HTTPResponse
                                              body:HTTPResponseBody
                                             error:nil
@@ -224,7 +224,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   };
 
   NSData *HTTPResponseBody = [@"A response" dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   [self stubURLSessionDataTaskPromiseWithResponse:HTTPResponse
                                              body:HTTPResponseBody
                                             error:nil
@@ -271,7 +271,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   };
 
   NSData *HTTPResponseBody = [@"A response" dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   [self stubURLSessionDataTaskPromiseWithResponse:HTTPResponse
                                              body:HTTPResponseBody
                                             error:nil
@@ -303,7 +303,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSData *responseBody =
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
@@ -329,7 +329,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   // 1. Prepare input parameters.
   NSString *responseBodyString = @"Token verification failed.";
   NSData *responseBody = [responseBodyString dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
@@ -364,7 +364,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   NSData *missingFiledBody = [GACFixtureLoader loadFixtureNamed:fixtureName];
   XCTAssertNotNil(missingFiledBody);
 
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:missingFiledBody];
 

--- a/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckTokenRefresherTests.m
@@ -23,7 +23,7 @@
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefreshResult.h"
 #import "AppCheck/Sources/Core/TokenRefresh/GACAppCheckTokenRefresher.h"
 #import "AppCheck/Tests/Unit/Utils/GACFakeTimer.h"
-#import "SharedTestUtilities/Date/FIRDateTestUtils.h"
+#import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
 
 @interface GACAppCheckTokenRefresherTests : XCTestCase
 
@@ -452,7 +452,7 @@
     weakSelf.fakeTimer.createHandler = nil;
 
     // 1 minute is the minimal interval between successful refreshes.
-    XCTAssert([FIRDateTestUtils isDate:fireDate
+    XCTAssert([GACDateTestUtils isDate:fireDate
         approximatelyEqualCurrentPlusTimeInterval:60
                                         precision:1]);
     [timerCreateExpectation fulfill];

--- a/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/DebugProvider/GACAppCheckDebugProviderAPIServiceTests.m
@@ -28,7 +28,7 @@
 #import "AppCheck/Sources/Core/Errors/GACAppCheckErrorUtil.h"
 #import "AppCheck/Sources/DebugProvider/API/GACAppCheckDebugProviderAPIService.h"
 
-#import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
+#import "AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
 
 static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_id";
 
@@ -75,7 +75,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
 
   id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
 
@@ -122,7 +122,7 @@ static NSString *const kResourceName = @"projects/test_project_id/apps/test_app_
 
   id HTTPBodyValidationArg = [self HTTPBodyValidationArgWithDebugToken:debugToken];
   NSData *fakeResponseData = [@"fake response" dataUsingEncoding:NSUTF8StringEncoding];
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:fakeResponseData];
 

--- a/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/DeviceCheckProvider/GACDeviceCheckAPIServiceTests.m
@@ -28,7 +28,7 @@
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h"
 
 #import "AppCheck/Tests/Unit/Utils/GACFixtureLoader.h"
-#import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
+#import "AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -84,7 +84,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
 
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 
@@ -135,7 +135,7 @@ typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
       [GACFixtureLoader loadFixtureNamed:@"FACTokenExchangeResponseSuccess.json"];
   XCTAssertNotNil(responseBody);
 
-  NSHTTPURLResponse *HTTPResponse = [FIRURLSessionOCMockStub HTTPResponseWithCode:200];
+  NSHTTPURLResponse *HTTPResponse = [GACURLSessionOCMockStub HTTPResponseWithCode:200];
   GULURLSessionDataResponse *APIResponse =
       [[GULURLSessionDataResponse alloc] initWithResponse:HTTPResponse HTTPBody:responseBody];
 

--- a/AppCheck/Tests/Utils/Date/GACDateTestUtils.h
+++ b/AppCheck/Tests/Utils/Date/GACDateTestUtils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GACDateTestUtils : NSObject
+
++ (BOOL)isDate:(NSDate *)date
+    approximatelyEqualCurrentPlusTimeInterval:(NSTimeInterval)timeInterval
+                                    precision:(NSTimeInterval)precision;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCheck/Tests/Utils/Date/GACDateTestUtils.m
+++ b/AppCheck/Tests/Utils/Date/GACDateTestUtils.m
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppCheck/Tests/Utils/Date/GACDateTestUtils.h"
+
+#import <XCTest/XCTest.h>
+
+@implementation GACDateTestUtils
+
++ (BOOL)isDate:(NSDate *)date
+    approximatelyEqualCurrentPlusTimeInterval:(NSTimeInterval)timeInterval
+                                    precision:(NSTimeInterval)precision {
+  NSDate *expectedDate = [NSDate dateWithTimeIntervalSinceNow:timeInterval];
+  return ABS([date timeIntervalSinceDate:expectedDate]) <= precision;
+}
+
+@end

--- a/AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h
+++ b/AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef BOOL (^FIRRequestValidationBlock)(NSURLRequest *request);
+
+@interface GACURLSessionOCMockStub : NSObject
+
++ (id)stubURLSessionDataTaskWithResponse:(nullable NSHTTPURLResponse *)response
+                                    body:(nullable NSData *)body
+                                   error:(nullable NSError *)error
+                          URLSessionMock:(id)URLSessionMock
+                  requestValidationBlock:(nullable FIRRequestValidationBlock)requestValidationBlock;
+
++ (NSHTTPURLResponse *)HTTPResponseWithCode:(NSInteger)statusCode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.m
+++ b/AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.m
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppCheck/Tests/Utils/URLSession/GACURLSessionOCMockStub.h"
+
+#import <OCMock/OCMock.h>
+
+@implementation GACURLSessionOCMockStub
+
++ (id)stubURLSessionDataTaskWithResponse:(NSHTTPURLResponse *)response
+                                    body:(NSData *)body
+                                   error:(NSError *)error
+                          URLSessionMock:(id)URLSessionMock
+                  requestValidationBlock:(FIRRequestValidationBlock)requestValidationBlock {
+  id mockDataTask = OCMStrictClassMock([NSURLSessionDataTask class]);
+
+  // Validate request content.
+  FIRRequestValidationBlock nonOptionalRequestValidationBlock =
+      requestValidationBlock ?: ^BOOL(id request) {
+        return YES;
+      };
+
+  id URLRequestValidationArg = [OCMArg checkWithBlock:nonOptionalRequestValidationBlock];
+
+  // Save task completion to be called on the `[NSURLSessionDataTask resume]`
+  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
+  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
+    taskCompletion = obj;
+    return YES;
+  }];
+
+  // Expect `dataTaskWithRequest` to be called.
+  OCMExpect([URLSessionMock dataTaskWithRequest:URLRequestValidationArg
+                              completionHandler:completionArg])
+      .andReturn(mockDataTask);
+
+  // Expect the task to be resumed and call the task completion.
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask resume]).andDo(^(NSInvocation *invocation) {
+    taskCompletion(body, response, error);
+  });
+
+  return mockDataTask;
+}
+
++ (NSHTTPURLResponse *)HTTPResponseWithCode:(NSInteger)statusCode {
+  return [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://localhost"]
+                                     statusCode:statusCode
+                                    HTTPVersion:@"HTTP/1.1"
+                                   headerFields:nil];
+}
+
+@end


### PR DESCRIPTION
Copied `FIRDateTestUtils` (as `GACDateTestUtils`) and `FIRURLSessionOCMockStub` (as `GACURLSessionOCMockStub`) from the `SharedTestUtilities` directory in the root of the repo into `AppCheck/Tests/Utils/...`. The `SharedTestUtilities` directory won't be available when `AppCheck` is moved into a separate repo.

#no-changelog