### PR TITLE
Fixed installation with CocoaPods to include CrashlyticsInputFiles.xcfilelist

### DIFF
--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-PREPARE_COMMAND_END
     cp -f ./Crashlytics/run ./run
     cp -f ./Crashlytics/upload-symbols ./upload-symbols
+    cp -f ./Crashlytics/CrashlyticsInputFiles.xcfilelist ./CrashlyticsInputFiles.xcfilelist
   PREPARE_COMMAND_END
 
   s.dependency 'FirebaseCore', '~> 10.5'


### PR DESCRIPTION
`CrashlyticsInputFiles.xcfilelist` was not included correctly when installing FirebaseCrashlytics v10.12.0 with CocoaPods.

Fixed to copy `CrashlyticsInputFiles.xcfilelist` to folder during installation as well as `run` and `upload-symbols`