### PR TITLE
[App Check] Depend on FirebaseCoreExtension via podspec

### DIFF
--- a/AppCheck.podspec
+++ b/AppCheck.podspec
@@ -78,10 +78,10 @@ Pod::Spec.new do |s|
     integration_tests.source_files = [
       base_dir + 'Tests/Integration/**/*.[mh]',
       base_dir + 'Tests/Integration/**/*.[mh]',
-      'FirebaseCore/Extension/*.h',
     ]
     integration_tests.resources = base_dir + 'Tests/Fixture/**/*'
     integration_tests.dependency 'FirebaseCore', '~> 10.0'
+    integration_tests.dependency 'FirebaseCoreExtension', '~> 10.0'
     integration_tests.requires_app_host = true
   end
 

--- a/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -30,12 +30,11 @@
 #import "FBLPromise+Testing.h"
 
 #import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseCoreExtension/FirebaseCoreInternal.h>
 
 #import "AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h"
 #import "AppCheck/Sources/DeviceCheckProvider/API/GACDeviceCheckAPIService.h"
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h"
-
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 // TODO(andrewheard): Remove from generic App Check SDK.
 // FIREBASE_APP_CHECK_ONLY_BEGIN


### PR DESCRIPTION
Added a dependency on the `FirebaseCoreExtension` pod in `AppCheck` since the local paths to `FirebaseCore/Extension/...` will not be accessible when App Check Lite is moved into a separate repo.

#no-changelog