### PR TITLE
[Crashlytics][CocoaPods] Fix preserve_paths of `CrashlyticsInputFiles.xcfilelist`

### DIFF
--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
     'Crashlytics/README.md',
     'run',
     'upload-symbols',
-    'CrashlyticsInputFiles.xcfilelist',
+    'Crashlytics/CrashlyticsInputFiles.xcfilelist',
   ]
 
   # Ensure the run script and upload-symbols are callable via


### PR DESCRIPTION
In 10.12.0, `CrashlyticsInputFiles.xcfilelist` is not correctly included in CocoaPods installation due to specifying wrong path.

<img width="231" alt="image" src="https://github.com/firebase/firebase-ios-sdk/assets/909674/def099ab-a990-4374-9551-d2e3ed774f57">

ref:
- #11428