### PR TITLE
[App Check] Support custom base URL

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -141,6 +141,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
 
 - (nullable instancetype)initWithStorageID:(NSString *)storageID
                               resourceName:(NSString *)resourceName
+                                   baseURL:(nullable NSString *)baseURL
                                     APIKey:(nullable NSString *)APIKey
                        keychainAccessGroup:(nullable NSString *)accessGroup
                               requestHooks:
@@ -157,6 +158,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
 
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
+                                                baseURL:baseURL
                                                  APIKey:APIKey
                                            requestHooks:requestHooks];
 

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.h
@@ -44,12 +44,18 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The default initializer.
  * @param session The URL session used to make network requests.
+ * @param baseURL The base URL for the App Check service, e.g.,
+ * `https://firebaseappcheck.googleapis.com/v1`.
  * @param APIKey The Google Cloud Platform API key, if needed, or nil.
  * @param requestHooks Hooks that will be invoked on requests through this service.
  */
 - (instancetype)initWithURLSession:(NSURLSession *)session
+                           baseURL:(nullable NSString *)baseURL
                             APIKey:(nullable NSString *)APIKey
-                      requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+                      requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks
+    NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
+++ b/AppCheck/Sources/Core/APIService/GACAppCheckAPIService.m
@@ -50,24 +50,15 @@ static NSString *const kDefaultBaseURL = @"https://firebaseappcheck.googleapis.c
 @synthesize baseURL = _baseURL;
 
 - (instancetype)initWithURLSession:(NSURLSession *)session
+                           baseURL:(nullable NSString *)baseURL
                             APIKey:(nullable NSString *)APIKey
                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
-  return [self initWithURLSession:session
-                           APIKey:APIKey
-                     requestHooks:requestHooks
-                          baseURL:kDefaultBaseURL];
-}
-
-- (instancetype)initWithURLSession:(NSURLSession *)session
-                            APIKey:(nullable NSString *)APIKey
-                      requestHooks:(NSArray<GACAppCheckAPIRequestHook> *)requestHooks
-                           baseURL:(NSString *)baseURL {
   self = [super init];
   if (self) {
     _URLSession = session;
     _APIKey = APIKey;
     _requestHooks = requestHooks ? [requestHooks copy] : @[];
-    _baseURL = baseURL;
+    _baseURL = baseURL ?: kDefaultBaseURL;
   }
   return self;
 }

--- a/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheck/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -59,6 +59,7 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
 
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
+                                                baseURL:nil
                                                  APIKey:APIKey
                                            requestHooks:requestHooks];
 

--- a/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheck/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -79,6 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   GACAppCheckAPIService *APIService =
       [[GACAppCheckAPIService alloc] initWithURLSession:URLSession
+                                                baseURL:nil
                                                  APIKey:APIKey
                                            requestHooks:requestHooks];
 

--- a/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
@@ -37,12 +37,15 @@ NS_SWIFT_NAME(InternalAppAttestProvider)
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
+/// @param baseURL The base URL for the App Check service; defaults to
+/// `https://firebaseappcheck.googleapis.com/v1` if nil.
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param accessGroup The Keychain Access Group.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
 - (nullable instancetype)initWithStorageID:(NSString *)storageID
                               resourceName:(NSString *)resourceName
+                                   baseURL:(nullable NSString *)baseURL
                                     APIKey:(nullable NSString *)APIKey
                        keychainAccessGroup:(nullable NSString *)accessGroup
                               requestHooks:

--- a/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
+++ b/AppCheck/Tests/Integration/GACDeviceCheckAPIServiceE2ETests.m
@@ -65,6 +65,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
   };
 
   self.APIService = [[GACAppCheckAPIService alloc] initWithURLSession:self.URLSession
+                                                              baseURL:nil
                                                                APIKey:options.APIKey
                                                          requestHooks:@[ heartbeatLoggerHook ]];
   self.deviceCheckAPIService = [[GACDeviceCheckAPIService alloc]

--- a/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheck/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -114,6 +114,7 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
 
   XCTAssertNotNil([[GACAppAttestProvider alloc] initWithStorageID:app.name
                                                      resourceName:resourceName
+                                                          baseURL:nil
                                                            APIKey:app.options.APIKey
                                               keychainAccessGroup:nil
                                                      requestHooks:nil]);

--- a/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
+++ b/AppCheck/Tests/Unit/Core/GACAppCheckAPIServiceTests.m
@@ -62,6 +62,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
       dictionaryWithDictionary:@{kBundleIDHeaderKey : [[NSBundle mainBundle] bundleIdentifier]}];
 
   self.APIService = [[GACAppCheckAPIService alloc] initWithURLSession:self.mockURLSession
+                                                              baseURL:nil
                                                                APIKey:nil
                                                          requestHooks:nil];
 }
@@ -73,6 +74,34 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   [self.mockURLSession stopMocking];
   self.mockURLSession = nil;
 }
+
+#pragma mark - Init
+
+- (void)testInitDefaultBaseURL {
+  GACAppCheckAPIService *APIService =
+      [[GACAppCheckAPIService alloc] initWithURLSession:self.mockURLSession
+                                                baseURL:nil
+                                                 APIKey:nil
+                                           requestHooks:nil];
+
+  XCTAssertNotNil(APIService);
+  XCTAssertEqualObjects(APIService.baseURL, @"https://firebaseappcheck.googleapis.com/v1");
+}
+
+- (void)testInitCustomBaseURL {
+  NSString *customBaseURL = @"https://custom.example.com/v1beta";
+
+  GACAppCheckAPIService *APIService =
+      [[GACAppCheckAPIService alloc] initWithURLSession:self.mockURLSession
+                                                baseURL:customBaseURL
+                                                 APIKey:nil
+                                           requestHooks:nil];
+
+  XCTAssertNotNil(APIService);
+  XCTAssertEqualObjects(APIService.baseURL, customBaseURL);
+}
+
+#pragma mark - Send Requests
 
 - (void)testDataRequestNetworkError {
   NSURL *URL = [NSURL URLWithString:@"https://some.url.com"];
@@ -163,6 +192,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
 
   self.APIService = [[GACAppCheckAPIService alloc]
       initWithURLSession:self.mockURLSession
+                 baseURL:nil
                   APIKey:nil
             requestHooks:@[ headerRequestHook, timeoutRequestHook, cellularAccessRequestHook ]];
 
@@ -256,6 +286,7 @@ static NSString *const kTestHeaderValue = @"TEST_HEADER_VALUE";
   [self.expectedHTTPHeaderFields setObject:kAPIKeyHeaderValue forKey:kAPIKeyHeaderKey];
 
   self.APIService = [[GACAppCheckAPIService alloc] initWithURLSession:self.mockURLSession
+                                                              baseURL:nil
                                                                APIKey:kAPIKeyHeaderValue
                                                          requestHooks:nil];
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
   GACAppAttestProvider *appAttestProvider =
       [[GACAppAttestProvider alloc] initWithStorageID:app.name
                                          resourceName:app.resourceName
+                                              baseURL:nil
                                                APIKey:app.options.APIKey
                                   keychainAccessGroup:app.options.appGroupID
                                          requestHooks:@[ [app.heartbeatLogger requestHook] ]];

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -74,6 +74,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   OCMExpect([self.appAttestProviderMock alloc]).andReturn(self.appAttestProviderMock);
   OCMExpect([self.appAttestProviderMock initWithStorageID:kAppName
                                              resourceName:self.resourceName
+                                                  baseURL:nil
                                                    APIKey:kAPIKey
                                       keychainAccessGroup:OCMOCK_ANY
                                              requestHooks:OCMOCK_ANY])


### PR DESCRIPTION
Allows clients to override the default base URL for the App Check service (`https://firebaseappcheck.googleapis.com/v1`) with a custom URL (e.g., `https://staging-firebaseappcheck.sandbox.googleapis.com/v1beta`).

#no-changelog