### PR TITLE
[auth-swift] First internal async-await transtion

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -2457,30 +2457,28 @@ extension Auth: AuthInterop {
           Auth's backend.
    */
   // TODO: internal
-  @objc public var requestConfiguration: AuthRequestConfiguration
+  var requestConfiguration: AuthRequestConfiguration
 
   #if os(iOS)
-
-    // TODO: the next three should be internal after Sample is ported.
     /** @property tokenManager
         @brief The manager for APNs tokens used by phone number auth.
      */
-    @objc public var tokenManager: AuthAPNSTokenManager!
+    var tokenManager: AuthAPNSTokenManager!
 
     /** @property appCredentailManager
         @brief The manager for app credentials used by phone number auth.
      */
-    @objc public var appCredentialManager: AuthAppCredentialManager!
+    var appCredentialManager: AuthAppCredentialManager!
 
     /** @property notificationManager
         @brief The manager for remote notifications used by phone number auth.
      */
-    @objc public var notificationManager: AuthNotificationManager!
+    var notificationManager: AuthNotificationManager!
 
     /** @property authURLPresenter
         @brief An object that takes care of presenting URLs via the auth instance.
      */
-    internal var authURLPresenter: AuthWebViewControllerDelegate
+    var authURLPresenter: AuthWebViewControllerDelegate
 
   #endif // TARGET_OS_IOS
 

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -25,18 +25,18 @@
     @_implementationOnly import GoogleUtilities
   #endif // SWIFT_PACKAGE
 
-  @objc public protocol AuthAPNSTokenApplication {
+  // Protocol to help with unit tests.
+  public protocol AuthAPNSTokenApplication {
     func registerForRemoteNotifications()
   }
 
   extension UIApplication: AuthAPNSTokenApplication {}
 
-  // TODO: remove objc public here and below after Sample ported.
   /** @class AuthAPNSToken
       @brief A data structure for an APNs token.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRAuthAPNSTokenManager) public class AuthAPNSTokenManager: NSObject {
+  class AuthAPNSTokenManager: NSObject {
     /** @property timeout
         @brief The timeout for registering for remote notification.
         @remarks Only tests should access this property.
@@ -57,7 +57,7 @@
         @param callback The block to be called either immediately or in future, either when a token
             becomes available, or when timeout occurs, whichever happens earlier.
      */
-    @objc public func getToken(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
+    func getToken(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
       if failFastForTesting {
         let error = NSError(domain: "dummy domain", code: AuthErrorCode.missingAppToken.rawValue)
         callback(nil, error)
@@ -91,7 +91,7 @@
         @remarks Setting a token with AuthAPNSTokenTypeUnknown will automatically converts it to
             a token with the automatically detected type.
      */
-    @objc public var token: AuthAPNSToken? {
+    var token: AuthAPNSToken? {
       get {
         return tokenStore
       }

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
@@ -25,7 +25,7 @@
       @brief A Class responsible for presenting URL via SFSafariViewController or WKWebView.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRAuthURLPresenter) public class AuthURLPresenter: NSObject,
+  class AuthURLPresenter: NSObject,
     SFSafariViewControllerDelegate, AuthWebViewControllerDelegate {
     /** @fn
         @brief Presents an URL to interact with user.
@@ -34,7 +34,6 @@
         @param completion A block to be called either synchronously if the presentation fails to start,
             or asynchronously in future on an unspecified thread once the presentation finishes.
      */
-    @objc(presentURL:UIDelegate:callbackMatcher:completion:) public
     func present(_ url: URL,
                  uiDelegate: AuthUIDelegate?,
                  callbackMatcher: @escaping (URL?) -> Bool,
@@ -82,7 +81,7 @@
         @param url The URL to handle.
         @return Whether the URL could be handled or not.
      */
-    @objc(canHandleURL:) public func canHandle(url: URL) -> Bool {
+    func canHandle(url: URL) -> Bool {
       if isPresenting,
          let callbackMatcher = callbackMatcher,
          callbackMatcher(url) {


### PR DESCRIPTION
- Start transition of RPC post to async/await calls
- Use `postAA` as an interim function name to do an incremental transition
- Start with the `GetProjectConfigRequest` in `fetchAuthDomain` from this (internal) [link](https://paste.googleplex.com/5238823498809344) from @ryanwilson 
- Also update part of the call tree above `fetchAuthDomain`