### PR TITLE
[App Check] Replace `gGACAppCheckLogLevel` with class property

### DIFF
--- a/AppCheck/Sources/Core/GACAppCheckLogger.m
+++ b/AppCheck/Sources/Core/GACAppCheckLogger.m
@@ -22,7 +22,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Public
 
-volatile NSInteger gGACAppCheckLogLevel = GACAppCheckLogLevelError;
+@implementation GACAppCheckLogger
+
+// Note: Declared as volatile to make getting and setting atomic.
+static volatile GACAppCheckLogLevel _logLevel;
+
++ (GACAppCheckLogLevel)logLevel {
+  return _logLevel;
+}
+
++ (void)setLogLevel:(GACAppCheckLogLevel)logLevel {
+  _logLevel = logLevel;
+}
+
+@end
 
 #pragma mark - Helpers
 
@@ -59,7 +72,7 @@ NSString *GACAppCheckLoggerLevelEnumToString(GACAppCheckLogLevel logLevel) {
 void GACAppCheckLog(GACAppCheckMessageCode code, GACAppCheckLogLevel logLevel, NSString *message) {
   // Don't log anything in not debug builds.
 #if !NDEBUG
-  if (logLevel >= gGACAppCheckLogLevel) {
+  if (logLevel >= GACAppCheckLogger.logLevel) {
     NSLog(@"<%@> [AppCheckCore][%@] %@", GACAppCheckLoggerLevelEnumToString(logLevel),
           GACAppCheckMessageCodeEnumToString(code), message);
   }

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckLogger.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckLogger.h
@@ -16,14 +16,6 @@
 
 #import "GACAppCheckErrors.h"
 
-/// The current logging level.
-///
-/// Messages with levels equal to or higher priority than `GACAppCheckLogLevel` will be printed,
-/// where Fault > Error > Warning > Info > Debug.
-///
-/// Note: Declared as volatile to make getting and setting atomic.
-FOUNDATION_EXPORT volatile NSInteger gGACAppCheckLogLevel;
-
 /// Constants that specify the level of logging to perform in App Check Core.
 typedef NS_ENUM(NSInteger, GACAppCheckLogLevel) {
   /// The debug log level; equivalent to `OS_LOG_TYPE_DEBUG`.
@@ -37,3 +29,16 @@ typedef NS_ENUM(NSInteger, GACAppCheckLogLevel) {
   /// The fault log level; equivalent to `OS_LOG_TYPE_FAULT`.
   GACAppCheckLogLevelFault = 5
 } NS_SWIFT_NAME(AppCheckCoreLogLevel);
+
+NS_SWIFT_NAME(AppCheckCoreLogger)
+@interface GACAppCheckLogger : NSObject
+
+/// The current logging level.
+///
+/// Messages with levels equal to or higher priority than `logLevel` will be printed, where
+/// Fault > Error > Warning > Info > Debug.
+@property(class, atomic, assign) GACAppCheckLogLevel logLevel;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -185,6 +185,11 @@ final class AppCheckAPITests {
         }
       }
     #endif // !os(watchOS)
+
+    // MARK: - AppCheckCoreLogger
+
+    // Set the log level for App Check Core
+    AppCheckCoreLogger.logLevel = .debug
   }
 }
 


### PR DESCRIPTION
Replaced the global variable `gGACAppCheckLogLevel` with a class property on a new `GACAppCheckLogger` class.

#no-changelog