### PR TITLE
Rename Swift symbols to AppCheckCore*

### DIFF
--- a/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppAttestProvider.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// This class is available on all platforms for select OS versions. See
 /// https://firebase.google.com/docs/ios/learn-more for more details.
 GAC_APP_ATTEST_PROVIDER_AVAILABILITY
-NS_SWIFT_NAME(InternalAppAttestProvider)
+NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 @interface GACAppAttestProvider : NSObject <GACAppCheckProvider>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheck.h
@@ -26,14 +26,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A class used to manage App Check tokens for a given resource.
-NS_SWIFT_NAME(InternalAppCheck)
+NS_SWIFT_NAME(AppCheckCore)
 @interface GACAppCheck : NSObject <GACAppCheckInterop>
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Returns an instance of `AppCheck` for an application.
-/// @param appCheckProvider  An `InternalAppCheckProvider` instance that provides App Check tokens.
-/// @return An instance of `AppCheck` corresponding to the provided `app`.
+/// @param appCheckProvider  An `AppCheckCoreProvider` instance that provides App Check tokens.
+/// @return An instance of `AppCheckCore` corresponding to the provided `app`.
 - (instancetype)initWithInstanceName:(NSString *)instanceName
                     appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
                             settings:(id<GACAppCheckSettingsProtocol>)settings

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckDebugProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckDebugProvider.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// `xcodebuild test -scheme InstallationsExample -workspace InstallationsExample.xcworkspace \
 /// MY_APP_CHECK_DEBUG_TOKEN=$(MY_SECRET_ON_CI)`
 ///
-NS_SWIFT_NAME(InternalAppCheckDebugProvider)
+NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 @interface GACAppCheckDebugProvider : NSObject <GACAppCheckProvider>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckErrors.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckErrors.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 /// Firebase app check error domain.
-FOUNDATION_EXTERN NSErrorDomain const GACAppCheckErrorDomain NS_SWIFT_NAME(InternalAppCheckErrorDomain);
+FOUNDATION_EXTERN NSErrorDomain const GACAppCheckErrorDomain NS_SWIFT_NAME(AppCheckCoreErrorDomain);
 
 typedef NS_ERROR_ENUM(GACAppCheckErrorDomain, GACAppCheckErrorCode){
     /// An unknown or non-actionable error.
@@ -36,7 +36,7 @@ typedef NS_ERROR_ENUM(GACAppCheckErrorDomain, GACAppCheckErrorCode){
     /// Selected app attestation provider is not supported on the current platform or OS version.
     GACAppCheckErrorCodeUnsupported = 4
 
-} NS_SWIFT_NAME(InternalAppCheckErrorCode);
+} NS_SWIFT_NAME(AppCheckCoreErrorCode);
 
 #pragma mark - Error Message Codes
 
@@ -53,4 +53,4 @@ typedef NS_ENUM(NSInteger, GACAppCheckMessageCode) {
   // App Attest Provider
   GACLoggerAppCheckMessageCodeAppAttestNotSupported = 7001,
   GACLoggerAppCheckMessageCodeAttestationRejected = 7002
-};
+} NS_SWIFT_NAME(AppCheckCoreMessageCode);

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckProvider.h
@@ -26,7 +26,7 @@ typedef void (^GACAppCheckAPIRequestHook)(NSMutableURLRequest *request);
 
 /// Defines the methods required to be implemented by a specific Firebase App Check
 /// provider.
-NS_SWIFT_NAME(InternalAppCheckProvider)
+NS_SWIFT_NAME(AppCheckCoreProvider)
 @protocol GACAppCheckProvider <NSObject>
 
 /// Returns a new Firebase App Check token.

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckSettings.h
@@ -19,6 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A collection of App Check-wide settings and parameters.
+NS_SWIFT_NAME(AppCheckCoreSettingsProtocol)
 @protocol GACAppCheckSettingsProtocol <NSObject>
 
 /// If App Check token auto-refresh is enabled.

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckToken.h
@@ -21,7 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// An object representing a Firebase App Check token.
-NS_SWIFT_NAME(InternalAppCheckToken)
+NS_SWIFT_NAME(AppCheckCoreToken)
 @interface GACAppCheckToken : NSObject <GACAppCheckTokenInterop>
 
 /// A Firebase App Check token.

--- a/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
+++ b/AppCheck/Sources/Public/AppCheck/GACAppCheckTokenDelegate.h
@@ -18,6 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(AppCheckCoreTokenDelegate)
 @protocol GACAppCheckTokenDelegate <NSObject>
 
 /// Called each time an App Check token is refreshed.

--- a/AppCheck/Sources/Public/AppCheck/GACDeviceCheckProvider.h
+++ b/AppCheck/Sources/Public/AppCheck/GACDeviceCheckProvider.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// This class is available on all platforms for select OS versions. See
 /// https://firebase.google.com/docs/ios/learn-more for more details.
 GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
-NS_SWIFT_NAME(InternalDeviceCheckProvider)
+NS_SWIFT_NAME(AppCheckCoreDeviceCheckProvider)
 @interface GACDeviceCheckProvider : NSObject <GACAppCheckProvider>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -32,7 +32,7 @@ final class AppCheckAPITests {
     #if TARGET_OS_IOS
       if #available(iOS 14.0, *) {
         // TODO(andrewheard): Add `requestHooks` in API tests.
-        if let provider = InternalAppAttestProvider(
+        if let provider = AppCheckCoreAppAttestProvider(
           storageID: app.name,
           resourceName: resourceName,
           apiKey: app.options.apiKey,
@@ -51,7 +51,7 @@ final class AppCheckAPITests {
     guard let app = FirebaseApp.app() else { return }
 
     // Retrieving an AppCheck instance
-    let appCheck = InternalAppCheck(
+    let appCheck = AppCheckCore(
       instanceName: app.name,
       appCheckProvider: DummyAppCheckProvider(),
       settings: DummyAppCheckSettings(),
@@ -85,7 +85,7 @@ final class AppCheckAPITests {
 
     // `AppCheckDebugProvider` initializer
     // TODO(andrewheard): Add `requestHooks` in API tests.
-    let debugProvider = InternalAppCheckDebugProvider(
+    let debugProvider = AppCheckCoreDebugProvider(
       storageID: app.name,
       resourceName: resourceName,
       apiKey: app.options.apiKey,
@@ -117,7 +117,7 @@ final class AppCheckAPITests {
 
     // MARK: - AppCheckToken
 
-    let token = InternalAppCheckToken(token: "token", expirationDate: Date.distantFuture)
+    let token = AppCheckCoreToken(token: "token", expirationDate: Date.distantFuture)
     _ = token.token
     _ = token.expirationDate
 
@@ -126,15 +126,15 @@ final class AppCheckAPITests {
     appCheck.token(forcingRefresh: false) { _, error in
       if let error = error {
         switch error {
-        case InternalAppCheckErrorCode.unknown:
+        case AppCheckCoreErrorCode.unknown:
           break
-        case InternalAppCheckErrorCode.serverUnreachable:
+        case AppCheckCoreErrorCode.serverUnreachable:
           break
-        case InternalAppCheckErrorCode.invalidConfiguration:
+        case AppCheckCoreErrorCode.invalidConfiguration:
           break
-        case InternalAppCheckErrorCode.keychain:
+        case AppCheckCoreErrorCode.keychain:
           break
-        case InternalAppCheckErrorCode.unsupported:
+        case AppCheckCoreErrorCode.unsupported:
           break
         default:
           break
@@ -156,7 +156,7 @@ final class AppCheckAPITests {
     #if !os(watchOS)
       if #available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, *) {
         // TODO(andrewheard): Add `requestHooks` in API tests.
-        let deviceCheckProvider = InternalDeviceCheckProvider(
+        let deviceCheckProvider = AppCheckCoreDeviceCheckProvider(
           storageID: app.name,
           resourceName: resourceName,
           apiKey: app.options.apiKey,
@@ -176,7 +176,7 @@ final class AppCheckAPITests {
           Task {
             do {
               _ = try await deviceCheckProvider.getToken()
-            } catch InternalAppCheckErrorCode.unsupported {
+            } catch AppCheckCoreErrorCode.unsupported {
               // ...
             } catch {
               // ...
@@ -193,16 +193,16 @@ final class AppCheckAPITests {
   }
 }
 
-class DummyAppCheckProvider: NSObject, InternalAppCheckProvider {
-  func getToken(completion handler: @escaping (InternalAppCheckToken?, Error?) -> Void) {
-    handler(InternalAppCheckToken(token: "token", expirationDate: .distantFuture), nil)
+class DummyAppCheckProvider: NSObject, AppCheckCoreProvider {
+  func getToken(completion handler: @escaping (AppCheckCoreToken?, Error?) -> Void) {
+    handler(AppCheckCoreToken(token: "token", expirationDate: .distantFuture), nil)
   }
 }
 
-class DummyAppCheckSettings: NSObject, GACAppCheckSettingsProtocol {
+class DummyAppCheckSettings: NSObject, AppCheckCoreSettingsProtocol {
   var isTokenAutoRefreshEnabled: Bool = true
 }
 
-class DummyAppCheckTokenDelegate: NSObject, GACAppCheckTokenDelegate {
-  func tokenDidUpdate(_ token: InternalAppCheckToken, instanceName: String) {}
+class DummyAppCheckTokenDelegate: NSObject, AppCheckCoreTokenDelegate {
+  func tokenDidUpdate(_ token: AppCheckCoreToken, instanceName: String) {}
 }


### PR DESCRIPTION
Renamed App Check Lite Swift symbols from `InternalAppCheck*` to `AppCheckCore*`.

#no-changelog