### PR TITLE
Cleanup some Firebase references in App Check Core

### DIFF
--- a/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheck/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -43,11 +43,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// TODO(andrewheard): Remove from generic App Check SDK.
-// FIREBASE_APP_CHECK_ONLY_BEGIN
-static NSString *const kHeartbeatKey = @"X-firebase-client";
-// FIREBASE_APP_CHECK_ONLY_END
-
 /// A data object that contains all key attest data required for FAC token exchange.
 @interface GACAppAttestKeyAttestationResult : NSObject
 
@@ -134,7 +129,7 @@ static NSString *const kHeartbeatKey = @"X-firebase-client";
     _keyIDStorage = keyIDStorage;
     _artifactStorage = artifactStorage;
     _backoffWrapper = backoffWrapper;
-    _queue = dispatch_queue_create("com.firebase.GACAppAttestProvider", DISPATCH_QUEUE_SERIAL);
+    _queue = dispatch_queue_create("com.google.GACAppAttestProvider", DISPATCH_QUEUE_SERIAL);
   }
   return self;
 }

--- a/AppCheck/Sources/Core/Errors/GACAppCheckErrors.m
+++ b/AppCheck/Sources/Core/Errors/GACAppCheckErrors.m
@@ -18,4 +18,4 @@
 
 #import "AppCheck/Sources/Public/AppCheck/GACAppCheckErrors.h"
 
-NSErrorDomain const GACAppCheckErrorDomain = @"com.firebase.appCheck";
+NSErrorDomain const GACAppCheckErrorDomain = @"com.google.app_check_core";

--- a/AppCheck/Sources/Core/GACAppCheck.m
+++ b/AppCheck/Sources/Core/GACAppCheck.m
@@ -38,14 +38,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// TODO(andrewheard): Remove from generic App Check SDK.
-// FIREBASE_APP_CHECK_ONLY_BEGIN
-static NSString *const kGACAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix =
-    @"GACAppCheckTokenAutoRefreshEnabled_";
-static NSString *const kGACAppCheckTokenAutoRefreshEnabledInfoPlistKey =
-    @"FirebaseAppCheckTokenAutoRefreshEnabled";
-// FIREBASE_APP_CHECK_ONLY_END
-
 static const NSTimeInterval kTokenExpirationThreshold = 5 * 60;  // 5 min.
 
 static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";

--- a/AppCheck/Sources/Core/Storage/GACAppCheckStorage.m
+++ b/AppCheck/Sources/Core/Storage/GACAppCheckStorage.m
@@ -29,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString *const kKeychainService = @"com.firebase.app_check.token_storage";
+static NSString *const kKeychainService = @"com.google.app_check_core.token_storage";
 
 @interface GACAppCheckStorage ()
 


### PR DESCRIPTION
Cleaned up or renamed some of the Firebase references in App Check Core (Lite).

#no-changelog