### PR TITLE
[Docs] Xcode 15 and User Script Sandboxing

### DIFF
--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -61,6 +61,8 @@ eg. `scripts/upload-symbols`, and make sure that the file is executable:
 This script can be used to manually upload dSYM files (for usage notes and
 additional instructions, run with the `--help` parameter).
 
+If you're getting `error: Could not get GOOGLE_APP_ID in Google Services file from build environment` on the Crashlytics run script step and you're using Xcode 15 and specifically `User Script Sandboxing = YES`, make sure to include all input files referenced [here](https://github.com/firebase/firebase-ios-sdk/pull/11463) in the Crashlytics run script.
+
 ---
 
 ### Alternatively, add Firebase to a `Package.swift` manifest


### PR DESCRIPTION
Apps created with Xcode 15 have `User Script Sandboxing = YES` set by default which requires all referenced files to be specified in the run script inputs. The official docs don't state this yet: https://firebase.google.com/docs/crashlytics/get-started?platform=ios#set-up-dsym-uploading
Fix from @samedson is here: https://github.com/firebase/firebase-ios-sdk/pull/11463#issue-1767693978
I think if would make sense to add this to the in-repo docs to save people some time searching.