### PR TITLE
Implement `FIRAppCheckSettings` as subclass

### DIFF
--- a/AppCheckCore/Sources/Core/GACAppCheckSettings.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckSettings.m
@@ -22,14 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @synthesize isTokenAutoRefreshEnabled = _isTokenAutoRefreshEnabled;
 
-- (instancetype)initWithTokenAutoRefreshEnabled:(BOOL)tokenAutoRefreshEnabled {
-  if (self = [super init]) {
-    _isTokenAutoRefreshEnabled = tokenAutoRefreshEnabled;
-  }
-
-  return self;
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCheckCore/Sources/Core/GACAppCheckSettings.m
+++ b/AppCheckCore/Sources/Core/GACAppCheckSettings.m
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import "AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// A collection of App Check-wide settings and parameters.
-NS_SWIFT_NAME(AppCheckCoreSettingsProtocol)
-@protocol GACAppCheckSettingsProtocol <NSObject>
+@implementation GACAppCheckSettings
 
-/// If App Check token auto-refresh is enabled.
-@property(nonatomic, readonly) BOOL isTokenAutoRefreshEnabled;
+@synthesize isTokenAutoRefreshEnabled = _isTokenAutoRefreshEnabled;
 
-@end
+- (instancetype)initWithTokenAutoRefreshEnabled:(BOOL)tokenAutoRefreshEnabled {
+  if (self = [super init]) {
+    _isTokenAutoRefreshEnabled = tokenAutoRefreshEnabled;
+  }
 
-@interface GACAppCheckSettings : NSObject <GACAppCheckSettingsProtocol>
-
-- (instancetype)initWithTokenAutoRefreshEnabled:(BOOL)tokenAutoRefreshEnabled;
-
-- (instancetype)init NS_UNAVAILABLE;
+  return self;
+}
 
 @end
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckSettings.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckSettings.h
@@ -23,16 +23,11 @@ NS_SWIFT_NAME(AppCheckCoreSettingsProtocol)
 @protocol GACAppCheckSettingsProtocol <NSObject>
 
 /// If App Check token auto-refresh is enabled.
-@property(nonatomic, readonly) BOOL isTokenAutoRefreshEnabled;
+@property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;
 
 @end
 
 @interface GACAppCheckSettings : NSObject <GACAppCheckSettingsProtocol>
-
-- (instancetype)initWithTokenAutoRefreshEnabled:(BOOL)tokenAutoRefreshEnabled;
-
-- (instancetype)init NS_UNAVAILABLE;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h
@@ -26,7 +26,7 @@ FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledUserDefault
 FOUNDATION_EXPORT NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey;
 
 /// Handles storing and updating the Firebase app check wide settings and parameters.
-@interface FIRAppCheckSettings : NSObject <GACAppCheckSettingsProtocol>
+@interface FIRAppCheckSettings : GACAppCheckSettings
 
 /// If Firebase app check token auto-refresh is allowed.
 @property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.m
@@ -40,13 +40,14 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 - (instancetype)initWithApp:(FIRApp *)firebaseApp
                 userDefault:(NSUserDefaults *)userDefaults
                  mainBundle:(NSBundle *)mainBundle {
-  self = [super initWithTokenAutoRefreshEnabled:NO];
+  self = [super init];
   if (self) {
     _firebaseApp = firebaseApp;
     _userDefaults = userDefaults;
     _mainBundle = mainBundle;
     _userDefaultKey = [kFIRAppCheckTokenAutoRefreshEnabledUserDefaultsPrefix
         stringByAppendingString:firebaseApp.name];
+    [super setIsTokenAutoRefreshEnabled:NO];
     _isTokenAutoRefreshConfigured = NO;
   }
   return self;
@@ -57,7 +58,7 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
     if (self.isTokenAutoRefreshConfigured) {
       // Return value form the in-memory cache to avoid accessing the user default or bundle when
       // not required.
-      return self.isTokenAutoRefreshEnabled;
+      return [super isTokenAutoRefreshEnabled];
     }
 
     // Check user defaults for a value set during the previous launch.
@@ -75,7 +76,7 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
       self.isTokenAutoRefreshConfigured = YES;
       self.isTokenAutoRefreshEnabled = isTokenAutoRefreshEnabledNumber.boolValue;
       // Return the value.
-      return self.isTokenAutoRefreshEnabled;
+      return [super isTokenAutoRefreshEnabled];
     }
 
     // Fallback to the global data collection flag.
@@ -92,8 +93,8 @@ NSString *const kFIRAppCheckTokenAutoRefreshEnabledInfoPlistKey =
 - (void)setIsTokenAutoRefreshEnabled:(BOOL)isTokenAutoRefreshEnabled {
   @synchronized(self) {
     self.isTokenAutoRefreshConfigured = YES;
-    self.isTokenAutoRefreshEnabled = isTokenAutoRefreshEnabled;
-    [self.userDefaults setBool:self.isTokenAutoRefreshEnabled forKey:self.userDefaultKey];
+    [super setIsTokenAutoRefreshEnabled:isTokenAutoRefreshEnabled];
+    [self.userDefaults setBool:isTokenAutoRefreshEnabled forKey:self.userDefaultKey];
   }
 }
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckSettingsTests.m
@@ -104,7 +104,7 @@
   OCMReject([self.mockApp isDataCollectionDefaultEnabled]);
 
   // 1.4. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(newFlagValue) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:newFlagValue forKey:self.userDefaultKey]);
 
   // 2. Set flag value.
   self.settings.isTokenAutoRefreshEnabled = newFlagValue;
@@ -206,7 +206,7 @@
 - (void)testSetIsTokenAutoRefreshEnabled {
   // 1. Set first time.
   // 1.1. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(YES) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:YES forKey:self.userDefaultKey]);
 
   // 1.2 Set.
   self.settings.isTokenAutoRefreshEnabled = YES;
@@ -217,7 +217,7 @@
 
   // 2. Set second time.
   // 2.1. Expect the new value to be saved to the user defaults.
-  OCMExpect([self.mockUserDefaults setObject:@(NO) forKey:self.userDefaultKey]);
+  OCMExpect([self.mockUserDefaults setBool:NO forKey:self.userDefaultKey]);
 
   // 2.2 Set.
   self.settings.isTokenAutoRefreshEnabled = NO;


### PR DESCRIPTION
Added a class `GACAppCheckSettings` that conforms to `GACAppCheckSettingsProtocol` and implemented `FIRAppCheckSettings` as a subclass of it.

#no-changelog