### PR TITLE
[App Check] Rename `instanceName` and `storageID` to `serviceName`

### DIFF
--- a/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
+++ b/AppCheckCore/Sources/AppAttestProvider/GACAppAttestProvider.m
@@ -134,36 +134,36 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (nullable instancetype)initWithStorageID:(NSString *)storageID
-                              resourceName:(NSString *)resourceName
-                                   baseURL:(nullable NSString *)baseURL
-                                    APIKey:(nullable NSString *)APIKey
-                       keychainAccessGroup:(nullable NSString *)accessGroup
-                              requestHooks:
-                                  (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
-  return [self initWithStorageID:storageID
-                    resourceName:resourceName
-                         baseURL:baseURL
-                          APIKey:APIKey
-             keychainAccessGroup:accessGroup
-                      limitedUse:NO
-                    requestHooks:requestHooks];
+- (nullable instancetype)initWithServiceName:(NSString *)serviceName
+                                resourceName:(NSString *)resourceName
+                                     baseURL:(nullable NSString *)baseURL
+                                      APIKey:(nullable NSString *)APIKey
+                         keychainAccessGroup:(nullable NSString *)accessGroup
+                                requestHooks:
+                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+  return [self initWithServiceName:serviceName
+                      resourceName:resourceName
+                           baseURL:baseURL
+                            APIKey:APIKey
+               keychainAccessGroup:accessGroup
+                        limitedUse:NO
+                      requestHooks:requestHooks];
 }
 
-- (nullable instancetype)initWithStorageID:(NSString *)storageID
-                              resourceName:(NSString *)resourceName
-                                   baseURL:(nullable NSString *)baseURL
-                                    APIKey:(nullable NSString *)APIKey
-                       keychainAccessGroup:(nullable NSString *)accessGroup
-                                limitedUse:(BOOL)limitedUse
-                              requestHooks:
-                                  (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+- (nullable instancetype)initWithServiceName:(NSString *)serviceName
+                                resourceName:(NSString *)resourceName
+                                     baseURL:(nullable NSString *)baseURL
+                                      APIKey:(nullable NSString *)APIKey
+                         keychainAccessGroup:(nullable NSString *)accessGroup
+                                  limitedUse:(BOOL)limitedUse
+                                requestHooks:
+                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
 #if GAC_APP_ATTEST_SUPPORTED_TARGETS
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 
-  NSString *storageKeySuffix = [GACAppAttestProvider storageKeySuffixWithID:storageID
-                                                               resourceName:resourceName];
+  NSString *storageKeySuffix = [GACAppAttestProvider storageKeySuffixWithServiceName:serviceName
+                                                                        resourceName:resourceName];
 
   GACAppAttestKeyIDStorage *keyIDStorage =
       [[GACAppAttestKeyIDStorage alloc] initWithKeySuffix:storageKeySuffix];
@@ -512,8 +512,9 @@ NS_ASSUME_NONNULL_BEGIN
       });
 }
 
-+ (NSString *)storageKeySuffixWithID:(NSString *)storageID resourceName:(NSString *)resourceName {
-  return [NSString stringWithFormat:@"%@.%@", storageID, resourceName];
++ (NSString *)storageKeySuffixWithServiceName:(NSString *)serviceName
+                                 resourceName:(NSString *)resourceName {
+  return [NSString stringWithFormat:@"%@.%@", serviceName, resourceName];
 }
 
 @end

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -87,9 +87,9 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 #pragma mark - Public
 
 - (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                       resourceName:(NSString *)resourceName
                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
                 keychainAccessGroup:(nullable NSString *)accessGroup {
   GACAppCheckTokenRefreshResult *refreshResult =

--- a/AppCheckCore/Sources/Core/GACAppCheck.m
+++ b/AppCheckCore/Sources/Core/GACAppCheck.m
@@ -44,7 +44,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 @interface GACAppCheck ()
 
-@property(nonatomic, readonly) NSString *instanceName;
+@property(nonatomic, readonly) NSString *serviceName;
 @property(nonatomic, readonly) id<GACAppCheckProvider> appCheckProvider;
 @property(nonatomic, readonly) id<GACAppCheckStorageProtocol> storage;
 @property(nonatomic, readonly) id<GACAppCheckSettingsProtocol> settings;
@@ -60,15 +60,15 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 #pragma mark - Internal
 
-- (instancetype)initWithInstanceName:(NSString *)instanceName
-                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
-                             storage:(id<GACAppCheckStorageProtocol>)storage
-                      tokenRefresher:(id<GACAppCheckTokenRefresherProtocol>)tokenRefresher
-                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                   appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                            storage:(id<GACAppCheckStorageProtocol>)storage
+                     tokenRefresher:(id<GACAppCheckTokenRefresherProtocol>)tokenRefresher
+                           settings:(id<GACAppCheckSettingsProtocol>)settings
+                      tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate {
   self = [super init];
   if (self) {
-    _instanceName = instanceName;
+    _serviceName = serviceName;
     _appCheckProvider = appCheckProvider;
     _storage = storage;
     _tokenRefresher = tokenRefresher;
@@ -86,28 +86,28 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 
 #pragma mark - Public
 
-- (instancetype)initWithInstanceName:(NSString *)instanceName
-                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
-                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                        resourceName:(NSString *)resourceName
-                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
-                 keychainAccessGroup:(nullable NSString *)accessGroup {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                   appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                           settings:(id<GACAppCheckSettingsProtocol>)settings
+                       resourceName:(NSString *)resourceName
+                      tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
+                keychainAccessGroup:(nullable NSString *)accessGroup {
   GACAppCheckTokenRefreshResult *refreshResult =
       [[GACAppCheckTokenRefreshResult alloc] initWithStatusNever];
   GACAppCheckTokenRefresher *tokenRefresher =
       [[GACAppCheckTokenRefresher alloc] initWithRefreshResult:refreshResult settings:settings];
 
   NSString *tokenKey =
-      [NSString stringWithFormat:@"app_check_token.%@.%@", instanceName, resourceName];
+      [NSString stringWithFormat:@"app_check_token.%@.%@", serviceName, resourceName];
   GACAppCheckStorage *storage = [[GACAppCheckStorage alloc] initWithTokenKey:tokenKey
                                                                  accessGroup:accessGroup];
 
-  return [self initWithInstanceName:instanceName
-                   appCheckProvider:appCheckProvider
-                            storage:storage
-                     tokenRefresher:tokenRefresher
-                           settings:settings
-                      tokenDelegate:tokenDelegate];
+  return [self initWithServiceName:serviceName
+                  appCheckProvider:appCheckProvider
+                           storage:storage
+                    tokenRefresher:tokenRefresher
+                          settings:settings
+                     tokenDelegate:tokenDelegate];
 }
 
 #pragma mark - GACAppCheckInterop
@@ -205,7 +205,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
                                     receivedAtDate:token.receivedAtDate];
         [self.tokenRefresher updateWithRefreshResult:refreshResult];
         if (self.tokenDelegate) {
-          [self.tokenDelegate tokenDidUpdate:token instanceName:self.instanceName];
+          [self.tokenDelegate tokenDidUpdate:token serviceName:self.serviceName];
         }
         return token;
       });

--- a/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
+++ b/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m
@@ -50,10 +50,10 @@ static NSString *const kDebugTokenUserDefaultsKey = @"FIRAAppCheckDebugToken";
   return self;
 }
 
-- (instancetype)initWithStorageID:(NSString *)storageID
-                     resourceName:(NSString *)resourceName
-                           APIKey:(nullable NSString *)APIKey
-                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                             APIKey:(nullable NSString *)APIKey
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
+++ b/AppCheckCore/Sources/DeviceCheckProvider/GACDeviceCheckProvider.m
@@ -70,10 +70,10 @@ NS_ASSUME_NONNULL_BEGIN
                    backoffWrapper:backoffWrapper];
 }
 
-- (instancetype)initWithStorageID:(NSString *)storageID
-                     resourceName:(NSString *)resourceName
-                           APIKey:(nullable NSString *)APIKey
-                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                             APIKey:(nullable NSString *)APIKey
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks {
   NSURLSession *URLSession = [NSURLSession
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppAttestProvider.h
@@ -33,7 +33,7 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// The default initializer.
-/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// @param serviceName A unique identifier to differentiate storage keys corresponding to the same
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
@@ -43,20 +43,20 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 /// @param accessGroup The Keychain Access Group.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
-- (nullable instancetype)initWithStorageID:(NSString *)storageID
-                              resourceName:(NSString *)resourceName
-                                   baseURL:(nullable NSString *)baseURL
-                                    APIKey:(nullable NSString *)APIKey
-                       keychainAccessGroup:(nullable NSString *)accessGroup
-                              requestHooks:
-                                  (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+- (nullable instancetype)initWithServiceName:(NSString *)serviceName
+                                resourceName:(NSString *)resourceName
+                                     baseURL:(nullable NSString *)baseURL
+                                      APIKey:(nullable NSString *)APIKey
+                         keychainAccessGroup:(nullable NSString *)accessGroup
+                                requestHooks:
+                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 /// Initializer with support for short-lived tokens.
 ///
 /// TODO(andrewheard): Remove or refactor this constructor when the short-lived (limited-use) token
 /// feature is fully implemented.
 ///
-/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// @param serviceName A unique identifier to differentiate storage keys corresponding to the same
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
@@ -67,14 +67,14 @@ NS_SWIFT_NAME(AppCheckCoreAppAttestProvider)
 /// @param limitedUse If YES, forces a short-lived token with a 5 minute TTL.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `AppAttestProvider` if App Attest is supported or `nil`.
-- (nullable instancetype)initWithStorageID:(NSString *)storageID
-                              resourceName:(NSString *)resourceName
-                                   baseURL:(nullable NSString *)baseURL
-                                    APIKey:(nullable NSString *)APIKey
-                       keychainAccessGroup:(nullable NSString *)accessGroup
-                                limitedUse:(BOOL)limitedUse
-                              requestHooks:
-                                  (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+- (nullable instancetype)initWithServiceName:(NSString *)serviceName
+                                resourceName:(NSString *)resourceName
+                                     baseURL:(nullable NSString *)baseURL
+                                      APIKey:(nullable NSString *)APIKey
+                         keychainAccessGroup:(nullable NSString *)accessGroup
+                                  limitedUse:(BOOL)limitedUse
+                                requestHooks:
+                                    (nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -32,18 +32,20 @@ NS_SWIFT_NAME(AppCheckCore)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Returns an instance of `AppCheck` for an application.
-/// @param appCheckProvider  An object that provides App Check tokens.
-/// @param settings An object that provides App Check settings.
+/// @param serviceName A unique identifier for the App Check instance, may be a Firebase App Name
+/// or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
+/// @param appCheckProvider  An object that provides App Check tokens.
+/// @param settings An object that provides App Check settings.
 /// @param tokenDelegate A delegate that receives token update notifications.
 /// @param accessGroup The identifier for a keychain group that the app shares items with; if
 /// provided, requires the Keychain Access Groups Entitlement.
 /// @return An instance of `AppCheckCore` with the specified token provider.
 - (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                       resourceName:(NSString *)resourceName
                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
                 keychainAccessGroup:(nullable NSString *)accessGroup;
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheck.h
@@ -40,12 +40,12 @@ NS_SWIFT_NAME(AppCheckCore)
 /// @param accessGroup The identifier for a keychain group that the app shares items with; if
 /// provided, requires the Keychain Access Groups Entitlement.
 /// @return An instance of `AppCheckCore` with the specified token provider.
-- (instancetype)initWithInstanceName:(NSString *)instanceName
-                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
-                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                        resourceName:(NSString *)resourceName
-                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
-                 keychainAccessGroup:(nullable NSString *)accessGroup;
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                   appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                           settings:(id<GACAppCheckSettingsProtocol>)settings
+                       resourceName:(NSString *)resourceName
+                      tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate
+                keychainAccessGroup:(nullable NSString *)accessGroup;
 
 @end
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckDebugProvider.h
@@ -64,17 +64,17 @@ NS_SWIFT_NAME(AppCheckCoreDebugProvider)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// The default initializer.
-/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// @param serviceName A unique identifier to differentiate storage keys corresponding to the same
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `AppCheckDebugProvider` .
-- (instancetype)initWithStorageID:(NSString *)storageID
-                     resourceName:(NSString *)resourceName
-                           APIKey:(nullable NSString *)APIKey
-                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                             APIKey:(nullable NSString *)APIKey
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 /** Return the locally generated token. */
 - (NSString *)localDebugToken;

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACAppCheckTokenDelegate.h
@@ -24,9 +24,9 @@ NS_SWIFT_NAME(AppCheckCoreTokenDelegate)
 /// Called each time an App Check token is refreshed.
 ///
 /// @param token The updated App Check token.
-/// @param instanceName A unique identifier for the App Check instance, may be a Firebase App Name
+/// @param serviceName A unique identifier for the App Check instance, may be a Firebase App Name
 /// or an SDK name.
-- (void)tokenDidUpdate:(GACAppCheckToken *)token instanceName:(NSString *)instanceName;
+- (void)tokenDidUpdate:(GACAppCheckToken *)token serviceName:(NSString *)serviceName;
 
 @end
 

--- a/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
+++ b/AppCheckCore/Sources/Public/AppCheckCore/GACDeviceCheckProvider.h
@@ -37,17 +37,17 @@ NS_SWIFT_NAME(AppCheckCoreDeviceCheckProvider)
 - (instancetype)init NS_UNAVAILABLE;
 
 /// The default initializer.
-/// @param storageID A unique identifier to differentiate storage keys corresponding to the same
+/// @param serviceName A unique identifier to differentiate storage keys corresponding to the same
 /// `resourceName`; may be a Firebase App Name or an SDK name.
 /// @param resourceName The name of the resource protected by App Check; for a Firebase App this is
 /// "projects/{project_id}/apps/{app_id}".
 /// @param APIKey The Google Cloud Platform API key, if needed, or nil.
 /// @param requestHooks Hooks that will be invoked on requests through this service.
 /// @return An instance of `DeviceCheckProvider` .
-- (instancetype)initWithStorageID:(NSString *)storageID
-                     resourceName:(NSString *)resourceName
-                           APIKey:(nullable NSString *)APIKey
-                     requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
+- (instancetype)initWithServiceName:(NSString *)serviceName
+                       resourceName:(NSString *)resourceName
+                             APIKey:(nullable NSString *)APIKey
+                       requestHooks:(nullable NSArray<GACAppCheckAPIRequestHook> *)requestHooks;
 
 @end
 

--- a/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
+++ b/AppCheckCore/Tests/Unit/AppAttestProvider/GACAppAttestProviderTests.m
@@ -112,13 +112,13 @@ GAC_APP_ATTEST_PROVIDER_AVAILABILITY
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
   NSString *resourceName = [GACAppAttestProviderTests resourceNameFromApp:app];
 
-  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithStorageID:app.name
-                                                     resourceName:resourceName
-                                                          baseURL:nil
-                                                           APIKey:app.options.APIKey
-                                              keychainAccessGroup:nil
-                                                       limitedUse:NO
-                                                     requestHooks:nil]);
+  XCTAssertNotNil([[GACAppAttestProvider alloc] initWithServiceName:app.name
+                                                       resourceName:resourceName
+                                                            baseURL:nil
+                                                             APIKey:app.options.APIKey
+                                                keychainAccessGroup:nil
+                                                         limitedUse:NO
+                                                       requestHooks:nil]);
 }
 #endif  // !TARGET_OS_MACCATALYST
 

--- a/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
+++ b/AppCheckCore/Tests/Unit/Core/GACAppCheckTests.m
@@ -43,12 +43,12 @@ static NSString *const kAppGroupID = @"app_group_id";
 
 @interface GACAppCheck (Tests) <GACAppCheckInterop>
 
-- (instancetype)initWithInstanceName:(NSString *)instanceName
-                    appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
-                             storage:(id<GACAppCheckStorageProtocol>)storage
-                      tokenRefresher:(id<GACAppCheckTokenRefresherProtocol>)tokenRefresher
-                            settings:(id<GACAppCheckSettingsProtocol>)settings
-                       tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate;
+- (instancetype)initWithServiceName:(NSString *)instanceName
+                   appCheckProvider:(id<GACAppCheckProvider>)appCheckProvider
+                            storage:(id<GACAppCheckStorageProtocol>)storage
+                     tokenRefresher:(id<GACAppCheckTokenRefresherProtocol>)tokenRefresher
+                           settings:(id<GACAppCheckSettingsProtocol>)settings
+                      tokenDelegate:(nullable id<GACAppCheckTokenDelegate>)tokenDelegate;
 
 @end
 
@@ -78,12 +78,12 @@ static NSString *const kAppGroupID = @"app_group_id";
 
   [self stubSetTokenRefreshHandler];
 
-  self.appCheck = [[GACAppCheck alloc] initWithInstanceName:kAppName
-                                           appCheckProvider:self.mockAppCheckProvider
-                                                    storage:self.mockStorage
-                                             tokenRefresher:self.mockTokenRefresher
-                                                   settings:self.mockSettings
-                                              tokenDelegate:self.mockTokenDelegate];
+  self.appCheck = [[GACAppCheck alloc] initWithServiceName:kAppName
+                                          appCheckProvider:self.mockAppCheckProvider
+                                                   storage:self.mockStorage
+                                            tokenRefresher:self.mockTokenRefresher
+                                                  settings:self.mockSettings
+                                             tokenDelegate:self.mockTokenDelegate];
 }
 
 - (void)tearDown {
@@ -144,12 +144,12 @@ static NSString *const kAppGroupID = @"app_group_id";
       OCMStrictProtocolMock(@protocol(GACAppCheckTokenDelegate));
 
   // 6. Call init.
-  GACAppCheck *appCheck = [[GACAppCheck alloc] initWithInstanceName:kAppName
-                                                   appCheckProvider:mockProvider
-                                                           settings:mockSettings
-                                                       resourceName:kResourceName
-                                                      tokenDelegate:mockTokenDelegate
-                                                keychainAccessGroup:kAppGroupID];
+  GACAppCheck *appCheck = [[GACAppCheck alloc] initWithServiceName:kAppName
+                                                      resourceName:kResourceName
+                                                  appCheckProvider:mockProvider
+                                                          settings:mockSettings
+                                                     tokenDelegate:mockTokenDelegate
+                                               keychainAccessGroup:kAppGroupID];
   XCTAssert([appCheck isKindOfClass:[GACAppCheck class]]);
 
   // 7. Verify mocks.
@@ -287,7 +287,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMExpect([self.mockTokenRefresher updateWithRefreshResult:[OCMArg any]]);
 
   // 4. Expect token update notification to be sent.
-  OCMExpect([self.mockTokenDelegate tokenDidUpdate:tokenToReturn instanceName:kAppName]);
+  OCMExpect([self.mockTokenDelegate tokenDidUpdate:tokenToReturn serviceName:kAppName]);
 
   // 5. Trigger refresh and expect the result.
   if (self.tokenRefreshHandler == nil) {
@@ -319,7 +319,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
   // 4. Don't expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 5. Trigger refresh and expect the result.
   if (self.tokenRefreshHandler == nil) {
@@ -352,7 +352,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMReject([self.mockStorage setToken:expectedToken]);
 
   // 4. Don't expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
@@ -381,7 +381,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
   // 4. Don't expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
@@ -410,7 +410,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMExpect([self.mockTokenRefresher updateWithRefreshResult:[OCMArg any]]);
 
   // 2. Expect token update notification to be sent.
-  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken instanceName:kAppName]);
+  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken serviceName:kAppName]);
 
   // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
@@ -455,7 +455,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   NSError *storageError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
 
   // 2. Don't expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 3. Request token several times.
   NSInteger getTokenCallsCount = 10;
@@ -572,7 +572,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMExpect([self.mockTokenRefresher updateWithRefreshResult:[OCMArg any]]);
 
   // 4. Expect token update notification to be sent.
-  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken instanceName:kAppName]);
+  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken serviceName:kAppName]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
@@ -589,7 +589,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
   // 3. Don't expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 4. Expect token request to be completed.
   return [self expectationWithDescription:@"getToken"];
@@ -611,7 +611,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMExpect([self.mockTokenRefresher updateWithRefreshResult:[OCMArg any]]);
 
   // 4. Expect token update notification to be sent.
-  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken instanceName:kAppName]);
+  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken serviceName:kAppName]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
@@ -636,7 +636,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMExpect([self.mockTokenRefresher updateWithRefreshResult:[OCMArg any]]);
 
   // 4. Expect token update notification to be sent.
-  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken instanceName:kAppName]);
+  OCMExpect([self.mockTokenDelegate tokenDidUpdate:expectedToken serviceName:kAppName]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];
@@ -658,7 +658,7 @@ static NSString *const kAppGroupID = @"app_group_id";
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);
 
   // 4. Expect token update notification to be sent.
-  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY instanceName:OCMOCK_ANY]);
+  OCMReject([self.mockTokenDelegate tokenDidUpdate:OCMOCK_ANY serviceName:OCMOCK_ANY]);
 
   // 5. Expect token request to be completed.
   XCTestExpectation *getTokenExpectation = [self expectationWithDescription:@"getToken"];

--- a/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DebugProvider/GACAppCheckDebugProviderTests.m
@@ -70,10 +70,10 @@ typedef void (^GACAppCheckTokenValidationBlock)(GACAppCheckToken *_Nullable toke
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
   XCTAssertNotNil([[GACAppCheckDebugProvider alloc]
-      initWithStorageID:options.googleAppID
-           resourceName:[GACAppCheckDebugProviderTests resourceNameFromApp:app]
-                 APIKey:app.options.APIKey
-           requestHooks:nil]);
+      initWithServiceName:options.googleAppID
+             resourceName:[GACAppCheckDebugProviderTests resourceNameFromApp:app]
+                   APIKey:app.options.APIKey
+             requestHooks:nil]);
 }
 
 #pragma mark - Debug token generating/storing

--- a/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
+++ b/AppCheckCore/Tests/Unit/DeviceCheckProvider/GACDeviceCheckProviderTests.m
@@ -80,10 +80,10 @@ GAC_DEVICE_CHECK_PROVIDER_AVAILABILITY
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testInitWithValidApp" options:options];
 
   XCTAssertNotNil([[GACDeviceCheckProvider alloc]
-      initWithStorageID:app.name
-           resourceName:[GACDeviceCheckProviderTests resourceNameFromApp:app]
-                 APIKey:app.options.APIKey
-           requestHooks:nil]);
+      initWithServiceName:app.name
+             resourceName:[GACDeviceCheckProviderTests resourceNameFromApp:app]
+                   APIKey:app.options.APIKey
+             requestHooks:nil]);
 }
 
 - (void)testGetTokenSuccess {

--- a/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/AppCheckCore/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -52,10 +52,10 @@ final class AppCheckAPITests {
 
     // Retrieving an AppCheck instance
     let appCheck = AppCheckCore(
-      instanceName: app.name,
+      serviceName: app.name,
+      resourceName: resourceName,
       appCheckProvider: DummyAppCheckProvider(),
       settings: DummyAppCheckSettings(),
-      resourceName: resourceName,
       tokenDelegate: DummyAppCheckTokenDelegate(),
       keychainAccessGroup: app.options.appGroupID
     )
@@ -86,7 +86,7 @@ final class AppCheckAPITests {
     // `AppCheckDebugProvider` initializer
     // TODO(andrewheard): Add `requestHooks` in API tests.
     let debugProvider = AppCheckCoreDebugProvider(
-      storageID: app.name,
+      serviceName: app.name,
       resourceName: resourceName,
       apiKey: app.options.apiKey,
       requestHooks: nil
@@ -157,7 +157,7 @@ final class AppCheckAPITests {
       if #available(iOS 11.0, macOS 10.15, macCatalyst 13.0, tvOS 11.0, *) {
         // TODO(andrewheard): Add `requestHooks` in API tests.
         let deviceCheckProvider = AppCheckCoreDeviceCheckProvider(
-          storageID: app.name,
+          serviceName: app.name,
           resourceName: resourceName,
           apiKey: app.options.apiKey,
           requestHooks: nil
@@ -204,5 +204,5 @@ class DummyAppCheckSettings: NSObject, AppCheckCoreSettingsProtocol {
 }
 
 class DummyAppCheckTokenDelegate: NSObject, AppCheckCoreTokenDelegate {
-  func tokenDidUpdate(_ token: AppCheckCoreToken, instanceName: String) {}
+  func tokenDidUpdate(_ token: AppCheckCoreToken, serviceName: String) {}
 }

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -46,12 +46,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithApp:(FIRApp *)app {
 #if FIR_APP_ATTEST_SUPPORTED_TARGETS
   GACAppAttestProvider *appAttestProvider =
-      [[GACAppAttestProvider alloc] initWithStorageID:app.name
-                                         resourceName:app.resourceName
-                                              baseURL:nil
-                                               APIKey:app.options.APIKey
-                                  keychainAccessGroup:app.options.appGroupID
-                                         requestHooks:@[ [app.heartbeatLogger requestHook] ]];
+      [[GACAppAttestProvider alloc] initWithServiceName:app.name
+                                           resourceName:app.resourceName
+                                                baseURL:nil
+                                                 APIKey:app.options.APIKey
+                                    keychainAccessGroup:app.options.appGroupID
+                                           requestHooks:@[ [app.heartbeatLogger requestHook] ]];
 
   return [self initWithAppAttestProvider:appAttestProvider];
 #else   // FIR_APP_ATTEST_SUPPORTED_TARGETS

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
@@ -62,10 +62,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   GACAppCheckDebugProvider *debugProvider =
-      [[GACAppCheckDebugProvider alloc] initWithStorageID:app.name
-                                             resourceName:app.resourceName
-                                                   APIKey:app.options.APIKey
-                                             requestHooks:@[ [app.heartbeatLogger requestHook] ]];
+      [[GACAppCheckDebugProvider alloc] initWithServiceName:app.name
+                                               resourceName:app.resourceName
+                                                     APIKey:app.options.APIKey
+                                               requestHooks:@[ [app.heartbeatLogger requestHook] ]];
 
   return [self initWithDebugProvider:debugProvider];
 }

--- a/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
+++ b/FirebaseAppCheck/Sources/DeviceCheckProvider/FIRDeviceCheckProvider.m
@@ -61,10 +61,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   GACDeviceCheckProvider *deviceCheckProvider =
-      [[GACDeviceCheckProvider alloc] initWithStorageID:app.name
-                                           resourceName:app.resourceName
-                                                 APIKey:app.options.APIKey
-                                           requestHooks:@[ [app.heartbeatLogger requestHook] ]];
+      [[GACDeviceCheckProvider alloc] initWithServiceName:app.name
+                                             resourceName:app.resourceName
+                                                   APIKey:app.options.APIKey
+                                             requestHooks:@[ [app.heartbeatLogger requestHook] ]];
 
   return [self initWithDeviceCheckProvider:deviceCheckProvider];
 }

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -73,12 +73,12 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:kAppName options:options];
 
   OCMExpect([self.appAttestProviderMock alloc]).andReturn(self.appAttestProviderMock);
-  OCMExpect([self.appAttestProviderMock initWithStorageID:kAppName
-                                             resourceName:self.resourceName
-                                                  baseURL:nil
-                                                   APIKey:kAPIKey
-                                      keychainAccessGroup:OCMOCK_ANY
-                                             requestHooks:OCMOCK_ANY])
+  OCMExpect([self.appAttestProviderMock initWithServiceName:kAppName
+                                               resourceName:self.resourceName
+                                                    baseURL:nil
+                                                     APIKey:kAPIKey
+                                        keychainAccessGroup:OCMOCK_ANY
+                                               requestHooks:OCMOCK_ANY])
       .andReturn(self.appAttestProviderMock);
 
   XCTAssertNotNil([[FIRAppAttestProvider alloc] initWithApp:app]);

--- a/FirebaseAppCheck/Tests/Unit/DebugProvider/FIRAppCheckDebugProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DebugProvider/FIRAppCheckDebugProviderTests.m
@@ -68,10 +68,10 @@ static NSString *const kProjectNumber = @"123456789";
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:kAppName options:options];
 
   OCMExpect([self.debugProviderMock alloc]).andReturn(self.debugProviderMock);
-  OCMExpect([self.debugProviderMock initWithStorageID:kAppName
-                                         resourceName:self.resourceName
-                                               APIKey:kAPIKey
-                                         requestHooks:OCMOCK_ANY])
+  OCMExpect([self.debugProviderMock initWithServiceName:kAppName
+                                           resourceName:self.resourceName
+                                                 APIKey:kAPIKey
+                                           requestHooks:OCMOCK_ANY])
       .andReturn(self.debugProviderMock);
 
   XCTAssertNotNil([[FIRAppCheckDebugProvider alloc] initWithApp:app]);

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -72,10 +72,10 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
   FIRApp *app = [[FIRApp alloc] initInstanceWithName:kAppName options:options];
 
   OCMExpect([self.deviceCheckProviderMock alloc]).andReturn(self.deviceCheckProviderMock);
-  OCMExpect([self.deviceCheckProviderMock initWithStorageID:kAppName
-                                               resourceName:self.resourceName
-                                                     APIKey:kAPIKey
-                                               requestHooks:OCMOCK_ANY])
+  OCMExpect([self.deviceCheckProviderMock initWithServiceName:kAppName
+                                                 resourceName:self.resourceName
+                                                       APIKey:kAPIKey
+                                                 requestHooks:OCMOCK_ANY])
       .andReturn(self.deviceCheckProviderMock);
 
   XCTAssertNotNil([[FIRDeviceCheckProvider alloc] initWithApp:app]);


### PR DESCRIPTION
For consistency, renamed both `instanceName` and `storageID` to `serviceName` for consistency. Please feel free to suggest different names. 

In all cases, the `serviceName` is an identifier that differentiates multiple `GACAppCheck` instances such as when there are multiple `FIRApp`s in use, or multiple dependent SDKs (e.g., Firebase and Google Sign-In). This unique identifier ensures their state is not shared in the Keychain or in User Defaults.

#no-changelog