### PR TITLE
[visionOS] Replace `TARGET_OS_XR` with `TARGET_OS_VISION`

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
@@ -242,7 +242,7 @@ static FIRCLSMachOSegmentCommand FIRCLSBinaryImageMachOGetSegmentCommand(
 
   return segmentCommand;
 }
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
 static bool FIRCLSBinaryImageMachOSliceInitSectionByName(FIRCLSMachOSliceRef slice,
                                                          const char* segName,
                                                          const char* sectionName,
@@ -345,7 +345,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
   FIRCLSMachOSection section;
 
 #if CLS_COMPACT_UNWINDING_SUPPORTED
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_TEXT, "__unwind_info",
                                                    &section)) {
     details->node.unwindInfo = (void*)(section.addr + details->vmaddr_slide);
@@ -358,7 +358,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
 #endif
 
 #if CLS_DWARF_UNWINDING_SUPPORTED
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_TEXT, "__eh_frame",
                                                    &section)) {
     details->node.ehFrame = (void*)(section.addr + details->vmaddr_slide);
@@ -370,7 +370,7 @@ static bool FIRCLSBinaryImageFillInImageDetails(FIRCLSBinaryImageDetails* detail
 #endif
 #endif
 
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   if (FIRCLSBinaryImageMachOSliceInitSectionByName(&details->slice, SEG_DATA, "__crash_info",
                                                    &section)) {
     details->node.crashInfo = (void*)(section.addr + details->vmaddr_slide);

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSNotificationManager.m
@@ -39,7 +39,7 @@
                                            selector:@selector(didBecomeInactive:)
                                                name:UIApplicationDidEnterBackgroundNotification
                                              object:nil];
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didChangeOrientation:)
                                                name:UIDeviceOrientationDidChangeNotification
@@ -53,7 +53,7 @@
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
 #pragma clang diagnostic pop
-#endif  // !CLS_TARGET_OS_XR
+#endif  // !CLS_TARGET_OS_VISION
 
 #elif CLS_TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -68,22 +68,22 @@
 }
 
 - (void)captureInitialNotificationStates {
-#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   UIInterfaceOrientation statusBarOrientation =
       [FIRCLSApplicationSharedInstance() statusBarOrientation];
-#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
 
   // It's nice to do this async, so we don't hold up the main thread while doing three
   // consecutive IOs here.
   dispatch_async(FIRCLSGetLoggingQueue(), ^{
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSInBackgroundKey, @"0");
-#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSDeviceOrientationKey,
                                            [@(orientation) description]);
     FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSUIOrientationKey,
                                            [@(statusBarOrientation) description]);
-#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
   });
 }
 
@@ -95,7 +95,7 @@
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSInBackgroundKey, @YES);
 }
 
-#if TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#if TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
 - (void)didChangeOrientation:(NSNotification *)notification {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
 
@@ -108,6 +108,6 @@
 
   FIRCLSUserLoggingRecordInternalKeyValue(FIRCLSUIOrientationKey, @(statusBarOrientation));
 }
-#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!CLS_TARGET_OS_VISION)
 
 @end

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
@@ -58,10 +58,10 @@
 #endif
 
 // VisionOS support
-#if defined(TARGET_OS_XR) && TARGET_OS_XR
-#define CLS_TARGET_OS_XR 1
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#define CLS_TARGET_OS_VISION 1
 #else
-#define CLS_TARGET_OS_XR 0
+#define CLS_TARGET_OS_VISION 0
 #endif
 
 #if defined(__arm__)

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -267,7 +267,7 @@ struct FIRCLSMachOSlice FIRCLSMachOSliceGetCurrent(void) {
   void* executableSymbol;
   Dl_info dlinfo;
 
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   const NXArchInfo* archInfo;
   archInfo = NXGetLocalArchInfo();
 
@@ -342,7 +342,7 @@ const char* FIRCLSMachOSliceGetArchitectureName(FIRCLSMachOSliceRef slice) {
     return "armv7k";
   }
 
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
   const NXArchInfo* archInfo;
 
   archInfo = NXGetArchInfoFromCpuType(slice->cputype, slice->cpusubtype);

--- a/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMachO/FIRCLSMachOTests.m
@@ -317,7 +317,7 @@
   XCTAssert(ptr != NULL);
 }
 
-#if !CLS_TARGET_OS_XR
+#if !CLS_TARGET_OS_VISION
 - (void)testReadArm64Section {
   NSString* path = [[self resourcePath] stringByAppendingPathComponent:@"armv7-armv7s-arm64.dylib"];
   struct FIRCLSMachOFile file;
@@ -340,7 +340,7 @@
 }
 #endif
 
-#if CLS_TARGET_OS_XR
+#if CLS_TARGET_OS_VISION
 
 - (void)testVisionProGetSlice {
   struct FIRCLSMachOSlice slice = FIRCLSMachOSliceGetCurrent();

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -469,9 +469,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                      appCheck:FIR_COMPONENT(FIRAppCheckInterop, app.container)];
   if (self) {
     _app = app;
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
     _authURLPresenter = [[FIRAuthURLPresenter alloc] init];
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   }
   return self;
 }
@@ -648,7 +648,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 - (void)signInWithProvider:(id<FIRFederatedAuthProvider>)provider
                 UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                 completion:(nullable FIRAuthDataResultCallback)completion {
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     FIRAuthDataResultCallback decoratedCallback =
         [self signInFlowAuthDataResultCallbackByDecoratingCallback:completion];
@@ -665,7 +665,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                                         callback:decoratedCallback];
                                }];
   });
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 }
 
 - (void)fetchSignInMethodsForEmail:(nonnull NSString *)email
@@ -1638,11 +1638,11 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 - (BOOL)canHandleURL:(NSURL *)URL {
   __block BOOL result = NO;
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   dispatch_sync(FIRAuthGlobalWorkQueue(), ^{
     result = [self->_authURLPresenter canHandleURL:URL];
   });
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   return result;
 }
 

--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
@@ -149,7 +149,7 @@ static NSString *const kCustomUrlSchemePrefix = @"app-";
   return [[self alloc] initWithProviderID:providerID auth:auth];
 }
 
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 - (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                          completion:(nullable FIRAuthCredentialCallback)completion {
   if (![FIRAuthWebUtils isCallbackSchemeRegisteredForCustomURLScheme:self->_callbackScheme]) {
@@ -216,7 +216,7 @@ static NSString *const kCustomUrlSchemePrefix = @"app-";
                           }];
   });
 }
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #pragma mark - Internal Methods
 

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthSettings.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactorResolver.h"
@@ -789,4 +789,4 @@ extern NSString *const FIRPhoneMultiFactorID;
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
@@ -52,7 +52,7 @@ typedef void (^FIRAuthCredentialCallback)(FIRAuthCredential *_Nullable credentia
                     watchos
 #if defined(TARGET_OS_VISION)
                     ,
-                    xros
+                    visionos
 #endif  // defined(TARGET_OS_VISION)
     );
 

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
@@ -50,10 +50,10 @@ typedef void (^FIRAuthCredentialCallback)(FIRAuthCredential *_Nullable credentia
     API_UNAVAILABLE(macos,
                     tvos,
                     watchos
-#if defined(TARGET_OS_XR)
+#if defined(TARGET_OS_VISION)
                     ,
                     xros
-#endif  // defined(TARGET_OS_XR)
+#endif  // defined(TARGET_OS_VISION)
     );
 
 @end

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.m
@@ -79,9 +79,9 @@ static const NSTimeInterval kLegacyRegistrationTimeout = 30;
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
       [self->_application registerForRemoteNotificationTypes:UIRemoteNotificationTypeAlert];
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 #pragma clang diagnostic pop
     }
   });

--- a/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
@@ -115,7 +115,7 @@ static const NSTimeInterval kProbingTimeout = 1;
                   didReceiveRemoteNotification:proberNotification
                         fetchCompletionHandler:^(UIBackgroundFetchResult result){
                         }];
-#if !TARGET_OS_TV && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if !TARGET_OS_TV && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
     } else if ([self->_application.delegate
                    respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
 // iOS 10 deprecation
@@ -124,7 +124,7 @@ static const NSTimeInterval kProbingTimeout = 1;
       [self->_application.delegate application:self->_application
                   didReceiveRemoteNotification:proberNotification];
 #pragma clang diagnostic pop
-#endif  // !TARGET_OS_TV && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // !TARGET_OS_TV && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
     } else {
       FIRLogWarning(kFIRLoggerAuth, @"I-AUT000015",
                     @"The UIApplicationDelegate must handle remote notification for phone number "

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -850,7 +850,7 @@ static void callInMainThreadWithAuthDataResultAndError(
 - (void)reauthenticateWithProvider:(id<FIRFederatedAuthProvider>)provider
                         UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                         completion:(nullable FIRAuthDataResultCallback)completion {
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     [provider getCredentialWithUIDelegate:UIDelegate
                                completion:^(FIRAuthCredential *_Nullable credential,
@@ -863,7 +863,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                                          completion:completion];
                                }];
   });
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 }
 
 - (nullable NSString *)refreshToken {
@@ -1339,7 +1339,7 @@ static void callInMainThreadWithAuthDataResultAndError(
 - (void)linkWithProvider:(id<FIRFederatedAuthProvider>)provider
               UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
               completion:(nullable FIRAuthDataResultCallback)completion {
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     [provider getCredentialWithUIDelegate:UIDelegate
                                completion:^(FIRAuthCredential *_Nullable credential,
@@ -1351,7 +1351,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                  [self linkWithCredential:credential completion:completion];
                                }];
   });
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 }
 
 - (void)unlinkFromProvider:(NSString *)provider

--- a/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.m
@@ -91,14 +91,14 @@ NS_ASSUME_NONNULL_BEGIN
       }
     }
   } else {
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
     UIApplication *application = [applicationClass sharedApplication];
 // iOS 13 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     topViewController = application.keyWindow.rootViewController;
 #pragma clang diagnostic pop
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   }
 #else
   UIApplication *application = [applicationClass sharedApplication];

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.h
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import <Foundation/Foundation.h>
 
@@ -66,4 +66,4 @@ typedef BOOL (^FIRAuthURLCallbackMatcher)(NSURL *_Nullable callbackURL);
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import <SafariServices/SafariServices.h>
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthUIDelegate.h"
@@ -205,4 +205,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Sources/Utilities/FIRAuthWebView.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthWebView.h
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
@@ -41,4 +41,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Sources/Utilities/FIRAuthWebView.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthWebView.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebView.h"
 
@@ -101,4 +101,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Sources/Utilities/FIRAuthWebViewController.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthWebViewController.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebView.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebViewController.h"
@@ -115,4 +115,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m
@@ -36,7 +36,7 @@ static const NSTimeInterval kRegistrationTimeout = .5;
  */
 static const NSTimeInterval kExpectationTimeout = 2;
 
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 /** @class FIRAuthLegacyUIApplication
     @brief A fake legacy (< iOS 7) UIApplication class.
@@ -60,7 +60,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
 @end
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 /** @class FIRAuthAPNSTokenManagerTests
     @brief Unit tests for @c FIRAuthAPNSTokenManager .
@@ -241,7 +241,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
   OCMVerifyAll(_mockApplication);
 }
 
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 /** @fn testLegacyRegistration
     @brief Tests remote notification registration on legacy systems.
@@ -278,7 +278,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
 }
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 @end
 

--- a/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
@@ -146,4 +146,4 @@ static NSTimeInterval kExpectationTimeout = 2;
 
 @end
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -198,12 +198,12 @@ static NSString *const kUnknownErrorString =
    */
   id _mockAuth;
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
   /** @var _mockURLPresenter
       @brief The mock @c FIRAuthURLPresenter instance associated with @c _mockAuth.
    */
   id _mockURLPresenter;
-#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#endif  // !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
 
   /** @var _mockApp
       @brief The mock @c FIRApp instance associated with @c _mockAuth.
@@ -231,10 +231,10 @@ static NSString *const kUnknownErrorString =
   _mockOptions = OCMClassMock([FIROptions class]);
   OCMStub([(FIRApp *)_mockApp options]).andReturn(_mockOptions);
   OCMStub([_mockOptions googleAppID]).andReturn(kFakeFirebaseAppID);
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
   _mockURLPresenter = OCMClassMock([FIRAuthURLPresenter class]);
   OCMStub([_mockAuth authURLPresenter]).andReturn(_mockURLPresenter);
-#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#endif  // !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
   _mockRequestConfiguration = OCMClassMock([FIRAuthRequestConfiguration class]);
   OCMStub([_mockAuth requestConfiguration]).andReturn(_mockRequestConfiguration);
   OCMStub([_mockRequestConfiguration APIKey]).andReturn(kFakeAPIKey);
@@ -303,7 +303,7 @@ static NSString *const kUnknownErrorString =
   XCTAssertEqualObjects(OAuthProvider.providerID, kFakeProviderID);
 }
 
-#if !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#if !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
 
 /** @fn testGetCredentialWithUIDelegateWithClientID
     @brief Tests a successful invocation of @c getCredentialWithUIDelegte:completion:
@@ -1445,7 +1445,7 @@ static NSString *const kUnknownErrorString =
   OCMVerifyAll(_mockBackend);
 }
 
-#endif  // !defined(TARGET_OS_XR) || !TARGET_OS_XR
+#endif  // !defined(TARGET_OS_VISION) || !TARGET_OS_VISION
 
 @end
 

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 
 #import <OCMock/OCMock.h>
 #import <SafariServices/SafariServices.h>
@@ -1659,4 +1659,4 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
 NS_ASSUME_NONNULL_END
 
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 10.13.0
+- For developers building for visionOS, Xcode beta 5 or later is required.
+ 
 # Firebase 10.12.0
 - For developers building for visionOS, using products that use the Keychain
   (e.g. FirebaseAuth) may fail to access the keychain on the visionOS

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Firebase 10.13.0
-- For developers building for visionOS, Xcode beta 5 or later is required.
+- For developers building for visionOS, Xcode 15 beta 5 or later is required.
 
 # Firebase 10.12.0
 - For developers building for visionOS, using products that use the Keychain

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 10.13.0
 - For developers building for visionOS, Xcode beta 5 or later is required.
- 
+
 # Firebase 10.12.0
 - For developers building for visionOS, using products that use the Keychain
   (e.g. FirebaseAuth) may fail to access the keychain on the visionOS

--- a/FirebaseCore/Tests/Unit/FIRFirebaseUserAgentTests.m
+++ b/FirebaseCore/Tests/Unit/FIRFirebaseUserAgentTests.m
@@ -35,12 +35,21 @@
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
   XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
+#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/ios"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/tvos"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
 #elif TARGET_OS_IOS
   XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"apple-platform/ios"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/tvos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
 #endif  // TARGET_OS_MACCATALYST
 
 #if TARGET_OS_TV
@@ -49,6 +58,7 @@
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
 #endif  // TARGET_OS_TV
 
 #if TARGET_OS_OSX
@@ -57,6 +67,7 @@
   XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
 #endif  // TARGET_OS_OSX
 
 #if TARGET_OS_WATCH
@@ -65,6 +76,7 @@
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/macos"]);
   XCTAssertTrue([[FIRApp firebaseUserAgent] containsString:@"apple-platform/watchos"]);
   XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/maccatalyst"]);
+  XCTAssertFalse([[FIRApp firebaseUserAgent] containsString:@"apple-platform/visionos"]);
 #endif  // TARGET_OS_WATCH
 }
 

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -421,10 +421,10 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   SEL openURLWithSourceApplicationSelector = @selector(application:
                                                            openURL:sourceApplication:annotation:);
 // TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
-// check if `TARGET_OS_XR` is defined.
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+// check if `TARGET_OS_VISION` is defined.
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   // Due to FIRAAppDelegateProxy swizzling, this selector will most likely get chosen, whether or
   // not the actual application has implemented
   // |application:continueUserActivity:restorationHandler:|. A warning will be displayed to the user
@@ -446,8 +446,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
 // TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
-// check if `TARGET_OS_XR` is defined.
-#if TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+// check if `TARGET_OS_VISION` is defined.
+#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application
@@ -460,7 +460,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_XR) || !TARGET_OS_XR)
+#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
   }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -257,9 +257,9 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
     // swift(>=5.9) implies Xcode 15+
-    // Need to have this swift version check to use os(xrOS) macro, VisionOS support.
+    // Need to have this swift version check to use os(visionOS) macro, VisionOS support.
     #if swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
         switch mobileSubtype {
         case CTRadioAccessTechnologyGPRS:
           subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
@@ -294,10 +294,10 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
             subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
           }
         }
-      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
         subtype =
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
     #else // swift(>=5.9)
       #if os(iOS) && !targetEnvironment(macCatalyst)
         switch mobileSubtype {

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -223,11 +223,11 @@ class SessionStartEventTests: XCTestCase {
     // Mobile Subtypes are always empty on non-iOS platforms, and
     // Performance doesn't support those platforms anyways
     #if swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
         mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
         mockNetworkInfo.mobileSubtype = ""
-      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
     #else // swift(>=5.9)
       #if os(iOS) && !targetEnvironment(macCatalyst)
         mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
@@ -274,17 +274,17 @@ class SessionStartEventTests: XCTestCase {
       // Mobile Subtypes are always empty on non-iOS platforms, and
       // Performance doesn't support those platforms anyways
       #if swift(>=5.9)
-        #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
           XCTAssertEqual(
             event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
             firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
           )
-        #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
           XCTAssertEqual(
             event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
             firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
           )
-        #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+        #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
       #else // swift(>=5.9)
         #if os(iOS) && !targetEnvironment(macCatalyst)
           XCTAssertEqual(
@@ -351,7 +351,7 @@ class SessionStartEventTests: XCTestCase {
 
   /// Following tests can be run only in iOS environment
   #if swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
       func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
         let expectations: [(
           given: String,
@@ -432,7 +432,7 @@ class SessionStartEventTests: XCTestCase {
               }
           }
       }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
   #else // swift(>=5.9)
     #if os(iOS) && !targetEnvironment(macCatalyst)
       func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
@@ -519,7 +519,7 @@ class SessionStartEventTests: XCTestCase {
   #endif // swift(>=5.9)
 
   #if swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
       @available(iOS 14.1, *)
       func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
         let expectations: [(
@@ -609,7 +609,7 @@ class SessionStartEventTests: XCTestCase {
               }
           }
       }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(xrOS)
+    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
   #else // swift(>=5.9)
     #if os(iOS) && !targetEnvironment(macCatalyst)
       @available(iOS 14.1, *)


### PR DESCRIPTION
In Xcode 15 beta 5, `TARGET_OS_XR` was replaced with `TARGET_OS_VISION` in ObjC and `os(xrOS)` was replaced with `os(visionOS)` in Swift.
