### PR TITLE
Firestore: FIRQueryTests.mm: Use a different Firestore instance to delete documents instead of a transaction

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -639,13 +639,7 @@
     NSString* path = [NSString stringWithFormat:format, collectionGroup];
     [batch setData:@{@"x" : @2} forDocument:[self.db documentWithPath:path]];
   }
-
-  XCTestExpectation* expectation = [self expectationWithDescription:@"commit"];
-  [batch commitWithCompletion:^(NSError* error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
-  [self awaitExpectation:expectation];
+  [self commitWriteBatch:batch];
 
   FIRAggregateQuerySnapshot* snapshot =
       [self readSnapshotForAggregate:[[self.db collectionGroupWithID:collectionGroup] aggregate:@[

--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -163,12 +163,7 @@
     [batch setData:@{@"x" : @"a"} forDocument:[self.db documentWithPath:path]];
   }
 
-  XCTestExpectation* expectation = [self expectationWithDescription:@"commit"];
-  [batch commitWithCompletion:^(NSError* error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
-  [self awaitExpectation:expectation];
+  [self commitWriteBatch:batch];
 
   FIRAggregateQuerySnapshot* snapshot =
       [self readSnapshotForAggregate:[[self.db collectionGroupWithID:collectionGroup] count]];

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -790,12 +790,7 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
                                                         withString:collectionGroup];
     [batch setData:@{@"x" : @1} forDocument:[self.db documentWithPath:path]];
   }
-  XCTestExpectation *expectation = [self expectationWithDescription:@"batch written"];
-  [batch commitWithCompletion:^(NSError *error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
-  [self awaitExpectations];
+  [self commitWriteBatch:batch];
 
   FIRQuerySnapshot *querySnapshot =
       [self readDocumentSetForRef:[self.db collectionGroupWithID:collectionGroup]];
@@ -821,12 +816,7 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
                                                         withString:collectionGroup];
     [batch setData:@{@"x" : @1} forDocument:[self.db documentWithPath:path]];
   }
-  XCTestExpectation *expectation = [self expectationWithDescription:@"batch written"];
-  [batch commitWithCompletion:^(NSError *error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
-  [self awaitExpectations];
+  [self commitWriteBatch:batch];
 
   FIRQuerySnapshot *querySnapshot = [self
       readDocumentSetForRef:[[[[self.db collectionGroupWithID:collectionGroup]
@@ -858,12 +848,7 @@ NSArray<NSString *> *SortedStringsNotIn(NSSet<NSString *> *set, NSSet<NSString *
                                                         withString:collectionGroup];
     [batch setData:@{@"x" : @1} forDocument:[self.db documentWithPath:path]];
   }
-  XCTestExpectation *expectation = [self expectationWithDescription:@"batch written"];
-  [batch commitWithCompletion:^(NSError *error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
-  [self awaitExpectations];
+  [self commitWriteBatch:batch];
 
   FIRQuerySnapshot *querySnapshot = [self
       readDocumentSetForRef:[[[self.db collectionGroupWithID:collectionGroup]

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
@@ -33,6 +33,7 @@
 @class FIRFirestore;
 @class FIRFirestoreSettings;
 @class FIRQuery;
+@class FIRWriteBatch;
 @class FSTEventAccumulator;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
@@ -115,6 +115,8 @@ extern "C" {
                     data:(NSDictionary<NSString *, id> *)data
                   fields:(NSArray<id> *)fields;
 
+- (void)commitWriteBatch:(FIRWriteBatch *)batch;
+
 - (void)disableNetwork;
 
 - (void)enableNetwork;

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -412,9 +412,7 @@ class FakeAuthCredentialsProvider : public EmptyAuthCredentialsProvider {
       XCTestExpectation *commitExpectation = [self expectationWithDescription:@"WriteBatch commit"];
       [writeBatch commitWithCompletion:^(NSError *_Nullable error) {
         [commitExpectation fulfill];
-        if (error != nil) {
-          XCTFail(@"WriteBatch commit failed: %@", error);
-        }
+        XCTAssertNil(error, @"WriteBatch commit failed: %@", error);
       }];
       [commits addObject:commitExpectation];
       writeBatch = nil;
@@ -426,9 +424,7 @@ class FakeAuthCredentialsProvider : public EmptyAuthCredentialsProvider {
     XCTestExpectation *commitExpectation = [self expectationWithDescription:@"WriteBatch commit"];
     [writeBatch commitWithCompletion:^(NSError *_Nullable error) {
       [commitExpectation fulfill];
-      if (error != nil) {
-        XCTFail(@"WriteBatch commit failed: %@", error);
-      }
+      XCTAssertNil(error, @"WriteBatch commit failed: %@", error);
     }];
     [commits addObject:commitExpectation];
   }
@@ -567,6 +563,15 @@ class FakeAuthCredentialsProvider : public EmptyAuthCredentialsProvider {
                   fields:(NSArray<id> *)fields {
   XCTestExpectation *expectation = [self expectationWithDescription:@"setDataWithMerge"];
   [ref setData:data mergeFields:fields completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
+}
+
+- (void)commitWriteBatch:(FIRWriteBatch *)batch {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"WriteBatch commit"];
+  [batch commitWithCompletion:^(NSError *_Nullable error) {
+    [expectation fulfill];
+    XCTAssertNil(error, @"WriteBatch commit should have succeeded, but it failed: %@", error);
+  }];
   [self awaitExpectation:expectation];
 }
 


### PR DESCRIPTION
Use a different Firestore instance to delete documents in `testResumingAQueryShouldUseBloomFilterToAvoidFullRequery` instead of a transaction. A transaction is more complicated and subject to re-runs, whereas using a separate Firestore instance is simple.

Also, modify tests to use the new method `[FSTIntegrationTestCase commitWriteBatch]` that previously manually implemented the "expectation" logic to wait for the commit result.

This is a port of https://github.com/firebase/firebase-js-sdk/pull/7415 and https://github.com/firebase/firebase-js-sdk/pull/7486

#no-changelog