### PR TITLE
Fix crash building a module map for a product with an iOS-only Interop dependency

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -132,7 +132,8 @@ struct ModuleMapBuilder {
       // Don't include Interop pods in the module map calculation since they shouldn't add anything
       // and it uses the platform-independent version of the dependency list, which causes a crash
       // for the iOS-only RecaptchaInterop pod when the subsequent code tries to `pod install` it
-      // for macOS. All this module code should go away when we switch to building dynamic frameworks.
+      // for macOS. All this module code should go away when we switch to building dynamic
+      // frameworks.
       !$0.name.hasSuffix("Interop")
     }
 

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -129,6 +129,10 @@ struct ModuleMapBuilder {
   private func generate(framework: FrameworkInfo) {
     let podName = framework.versionedPod.name
     let deps = CocoaPodUtils.transitiveVersionedPodDependencies(for: podName, in: allPods).filter {
+      // Don't include Interop pods in the module map calculation since they shouldn't add anything
+      // and it uses the platform-independent version of the dependency list, which causes a crash
+      // for the iOS-only RecaptchaInterop pod when the subsequent code tries to `pod install` it
+      // for macOS. All this module code should go away when we switch to building dynamic frameworks.
       !$0.name.hasSuffix("Interop")
     }
 

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -128,7 +128,9 @@ struct ModuleMapBuilder {
   /// to make sure we install the right version and from the right location.
   private func generate(framework: FrameworkInfo) {
     let podName = framework.versionedPod.name
-    let deps = CocoaPodUtils.transitiveVersionedPodDependencies(for: podName, in: allPods)
+    let deps = CocoaPodUtils.transitiveVersionedPodDependencies(for: podName, in: allPods).filter {
+      !$0.name.hasSuffix("Interop")
+    }
 
     CocoaPodUtils.installPods(allSubspecList(framework: framework) + deps,
                               inDir: projectDir,

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -211,10 +211,7 @@ struct ZipBuilder {
       // build order bugs.
       // Also AppCheck must be built after other pods so that its restricted architecture
       // selection does not restrict any of its dependencies.
-      var sortedPods = podsToBuild.keys.sorted().filter {
-        // Don't build header-only Interop pods for binary distributions.
-        !$0.hasSuffix("Interop")
-      }
+      var sortedPods = podsToBuild.keys.sorted()
 
       sortedPods.removeAll(where: { value in
         value == "FirebaseAppCheck"
@@ -588,9 +585,7 @@ struct ZipBuilder {
     // it to the destination directory.
     for podName in installedPods {
       // Skip the Firebase pod and specifically ignored frameworks.
-      guard podName != "Firebase",
-            // Interop pods weren't built, so don't try to copy.
-            !podName.hasSuffix("Interop") else {
+      guard podName != "Firebase" else {
         continue
       }
 

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -211,7 +211,10 @@ struct ZipBuilder {
       // build order bugs.
       // Also AppCheck must be built after other pods so that its restricted architecture
       // selection does not restrict any of its dependencies.
-      var sortedPods = podsToBuild.keys.sorted()
+      var sortedPods = podsToBuild.keys.sorted().filter {
+        // Don't build header-only Interop pods for binary distributions.
+        !$0.hasSuffix("Interop")
+      }
 
       sortedPods.removeAll(where: { value in
         value == "FirebaseAppCheck"
@@ -585,7 +588,9 @@ struct ZipBuilder {
     // it to the destination directory.
     for podName in installedPods {
       // Skip the Firebase pod and specifically ignored frameworks.
-      guard podName != "Firebase" else {
+      guard podName != "Firebase",
+            // Interop pods weren't built, so don't try to copy.
+            !podName.hasSuffix("Interop") else {
         continue
       }
 


### PR DESCRIPTION
While header-only internal Interop pods for binary distributions don't need to be built for Objective-C internal dependencies, the included module dependencies are needed for internal Swift implementations like FirebaseStorage and FirebaseFunctions.

However, the module map calculation uses platform-agnostic dependencies for setting up a `Podfile` for its `pod install` . This has the side effect of causing a crash when building the iOS-only ReCaptchaInterop.

That issue should become moot if we address #8945 and switch to dynamic libraries along with `xcodebuild` generated modulemaps for Firebase 11.