### PR TITLE
[App Check] Return error if refreshed token is nil

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.13.0
+- [fixed] Fixed a crash when an `AppCheckProvider` returns a nil-token without an accompanying
+  error. (#11625)
+
 # 10.9.0
 - [feature] Added `limitedUseToken(completion:)` for obtaining limited-use tokens for
   protecting non-Firebase backends. (#11086)

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -325,12 +325,19 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
         // TODO: Make sure the self.tokenRefresher is updated only once. Currently the timer will be
         // updated twice in the case when the refresh triggered by self.tokenRefresher, but it
         // should be fine for now as it is a relatively cheap operation.
-        __auto_type refreshResult = [[FIRAppCheckTokenRefreshResult alloc]
-            initWithStatusSuccessAndExpirationDate:token.expirationDate
-                                    receivedAtDate:token.receivedAtDate];
-        [self.tokenRefresher updateWithRefreshResult:refreshResult];
-        [self postTokenUpdateNotificationWithToken:token];
-        return token;
+        if (token) {
+          __auto_type refreshResult = [[FIRAppCheckTokenRefreshResult alloc]
+              initWithStatusSuccessAndExpirationDate:token.expirationDate
+                                      receivedAtDate:token.receivedAtDate];
+          [self.tokenRefresher updateWithRefreshResult:refreshResult];
+          [self postTokenUpdateNotificationWithToken:token];
+          return token;
+        } else {
+          __auto_type refreshResult = [[FIRAppCheckTokenRefreshResult alloc] initWithStatusFailure];
+          [self.tokenRefresher updateWithRefreshResult:refreshResult];
+          return
+              [FIRAppCheckErrorUtil errorWithFailureReason:@"Token refresh error: token is nil"];
+        }
       });
 }
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -335,8 +335,7 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
         } else {
           __auto_type refreshResult = [[FIRAppCheckTokenRefreshResult alloc] initWithStatusFailure];
           [self.tokenRefresher updateWithRefreshResult:refreshResult];
-          return
-              [FIRAppCheckErrorUtil errorWithFailureReason:@"Token refresh error: token is nil"];
+          return [FIRAppCheckErrorUtil errorWithFailureReason:@"Token refresh error: token is nil"];
         }
       });
 }

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -246,7 +246,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], [NSNull null], nil];
   OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
 
-  // 1.33. Expect stored token to be cleared.
+  // 1.3. Expect stored token to be cleared.
   OCMExpect([self.mockStorage setToken:nil]).andReturn([FBLPromise resolvedWith:nil]);
 
   // 1.4. Don't expect token update notification to be sent.


### PR DESCRIPTION
Added a `nil` check in `FIRAppCheck`'s `refreshToken` method.

This handles an edge-case (still under investigation) where `FIRAppCheckProvider` `getTokenWithCompletion:`'s handler is called with `nil` for both the `token` and `error`, which results in a crash in `postTokenUpdateNotificationWithToken:` (attempting to populate an `NSDictionary` value with `nil`).