### PR TITLE
[auth-swift] Fix Extensions build, AuthNotificationManager fixes

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1685,6 +1685,7 @@ extension Auth: AuthInterop {
           return
         }
 
+        // Using reflection here to avoid build errors in extensions.
         let sel = NSSelectorFromString("sharedApplication")
         guard UIApplication.responds(to: sel),
               let application = UIApplication.perform(sel).takeUnretainedValue() as? UIApplication

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1684,7 +1684,14 @@ extension Auth: AuthInterop {
           // UIApplication responds to it.
           return
         }
-        let application = UIApplication.shared
+
+        let sel = NSSelectorFromString("sharedApplication")
+        guard UIApplication.responds(to: sel),
+              let application = UIApplication.perform(sel).takeUnretainedValue() as? UIApplication
+        else {
+          return
+        }
+
         // Initialize for phone number auth.
         self.tokenManager = AuthAPNSTokenManager(withApplication: application)
         self.appCredentialManager = AuthAppCredentialManager(withKeychain: self.keychainServices)

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1688,8 +1688,8 @@ extension Auth: AuthInterop {
         // Using reflection here to avoid build errors in extensions.
         let sel = NSSelectorFromString("sharedApplication")
         guard UIApplication.responds(to: sel),
-              let application = UIApplication.perform(sel).takeUnretainedValue() as? UIApplication
-        else {
+              let rawApplication = UIApplication.perform(sel),
+              let application = rawApplication.takeUnretainedValue() as? UIApplication else {
           return
         }
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -186,7 +186,10 @@ import FirebaseCore
       guard phoneNumber.count > 0 else {
         throw AuthErrorUtils.missingPhoneNumberError(message: nil)
       }
-      guard await auth.notificationManager.checkNotificationForwarding() else {
+      guard let manager = auth.notificationManager else {
+        throw AuthErrorUtils.notificationNotForwardedError()
+      }
+      guard await manager.checkNotificationForwarding() else {
         throw AuthErrorUtils.notificationNotForwardedError()
       }
       return try await verifyClAndSendVerificationCode(toPhoneNumber: phoneNumber,

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -49,7 +49,7 @@
     /** @var _application
         @brief The application.
      */
-    private let application: Application
+    private let application: UIApplication
 
     /** @var _appCredentialManager
         @brief The object to handle app credentials delivered via notification.
@@ -89,7 +89,7 @@
         @param appCredentialManager The object to handle app credentials delivered via notification.
         @return The initialized instance.
      */
-    init(withApplication application: Application,
+    init(withApplication application: UIApplication,
          appCredentialManager: AuthAppCredentialManager) {
       self.application = application
       self.appCredentialManager = appCredentialManager
@@ -121,10 +121,8 @@
         let proberNotification = [self.kNotificationDataKey: [self.kNotificationProberKey:
             "This fake notification should be forwarded to Firebase Auth."]]
         if let delegate = self.application.delegate {
-          delegate.application!(
-            UIApplication.shared,
-            didReceiveRemoteNotification: proberNotification
-          ) { _ in
+          delegate.application?(self.application,
+                                didReceiveRemoteNotification: proberNotification) { _ in
           }
         } else {
           AuthLog.logWarning(
@@ -195,18 +193,4 @@
       }
     }
   }
-
-  // Protocol for UIApplication to enable unit testing
-  @objc public protocol ApplicationDelegate {
-    @objc optional func application(_ application: Application,
-                                    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
-                                    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult)
-                                      -> Void)
-  }
-
-  @objc public protocol Application {
-    var delegate: UIApplicationDelegate? { get set }
-  }
-
-  extension UIApplication: Application {}
 #endif

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthDefaultUIDelegate.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthDefaultUIDelegate.swift
@@ -42,8 +42,8 @@
       // Using reflection here to avoid build errors in extensions.
       let sel = NSSelectorFromString("sharedApplication")
       guard UIApplication.responds(to: sel),
-            let application = UIApplication.perform(sel).takeUnretainedValue() as? UIApplication
-      else {
+            let rawApplication = UIApplication.perform(sel),
+            let application = rawApplication.takeUnretainedValue() as? UIApplication else {
         return nil
       }
       var topViewController: UIViewController?

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
@@ -19,8 +19,6 @@
   import WebKit
   import SafariServices
 
-  // TODO: Remove objc's and publics
-
   /** @class AuthURLPresenter
       @brief A Class responsible for presenting URL via SFSafariViewController or WKWebView.
    */

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -51,7 +51,7 @@
         storage: FakeAuthKeychainStorage()
       )
       appCredentialManager = AuthAppCredentialManager(withKeychain: fakeKeychain)
-      let application = FakeApplication()
+      let application = UIApplication.shared
       notificationManager = AuthNotificationManager(withApplication: application,
                                                     appCredentialManager: appCredentialManager!)
       modernDelegate = FakeForwardingDelegate(notificationManager!)
@@ -139,9 +139,7 @@
         .canHandle(notification: ["com.google.firebase.auth": ["warning": "asdf"]]))
     }
 
-    private class FakeApplication: Application {
-      var delegate: UIApplicationDelegate?
-    }
+    private class FakeApplication: UIApplication {}
 
     private class FakeForwardingDelegate: NSObject, UIApplicationDelegate {
       let notificationManager: AuthNotificationManager

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -1858,50 +1858,45 @@ class AuthTests: RPCBaseTests {
     XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
   }
 
-  #if COCOAPODS // This test depends on a non-nil UIApplication.shared
-    #if os(iOS)
-      /** @fn testAutoRefreshAppForegroundedNotification
-          @brief Tests that app foreground notification triggers the scheduling of an automatic token
-              refresh task.
-       */
-      func testAutoRefreshAppForegroundedNotification() throws {
-        try auth.signOut()
-        // Enable auto refresh
-        enableAutoTokenRefresh()
+  #if os(iOS)
+    /** @fn testAutoRefreshAppForegroundedNotification
+        @brief Tests that app foreground notification triggers the scheduling of an automatic token
+            refresh task.
+     */
+    func testAutoRefreshAppForegroundedNotification() throws {
+      try auth.signOut()
+      // Enable auto refresh
+      enableAutoTokenRefresh()
 
-        // Sign in a user.
-        try waitForSignInWithAccessToken()
+      // Sign in a user.
+      try waitForSignInWithAccessToken()
 
-        // Post "UIApplicationDidBecomeActiveNotification" to trigger scheduling token refresh task.
-        NotificationCenter.default.post(
-          name: UIApplication.didBecomeActiveNotification,
-          object: nil
-        )
+      // Post "UIApplicationDidBecomeActiveNotification" to trigger scheduling token refresh task.
+      NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
-        setFakeSecureTokenService(fakeAccessToken: AuthTests.kNewAccessToken)
+      setFakeSecureTokenService(fakeAccessToken: AuthTests.kNewAccessToken)
 
-        // Verify that the current user's access token is the "old" access token before automatic
-        // token refresh.
-        XCTAssertEqual(AuthTests.kAccessToken, auth.currentUser?.rawAccessToken())
+      // Verify that the current user's access token is the "old" access token before automatic
+      // token refresh.
+      XCTAssertEqual(AuthTests.kAccessToken, auth.currentUser?.rawAccessToken())
 
-        // Execute saved token refresh task.
-        let expectation = self.expectation(description: #function)
-        kAuthGlobalWorkQueue.async {
-          XCTAssertNotNil(self.authDispatcherCallback)
-          self.authDispatcherCallback?()
-          expectation.fulfill()
-        }
-        waitForExpectations(timeout: 5)
-        waitForAuthGlobalWorkQueueDrain()
-
-        // Time for callback to run.
-        RPCBaseTests.waitSleep()
-
-        // Verify that current user's access token is the "new" access token provided in the mock
-        // secure token response during automatic token refresh.
-        XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
+      // Execute saved token refresh task.
+      let expectation = self.expectation(description: #function)
+      kAuthGlobalWorkQueue.async {
+        XCTAssertNotNil(self.authDispatcherCallback)
+        self.authDispatcherCallback?()
+        expectation.fulfill()
       }
-    #endif
+      waitForExpectations(timeout: 5)
+      waitForAuthGlobalWorkQueueDrain()
+
+      // Time for callback to run.
+      RPCBaseTests.waitSleep()
+
+      // Verify that current user's access token is the "new" access token provided in the mock
+      // secure token response during automatic token refresh.
+      XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
+    }
   #endif
 
   // MARK: Application Delegate tests.

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -1890,6 +1890,9 @@ class AuthTests: RPCBaseTests {
       waitForExpectations(timeout: 5)
       waitForAuthGlobalWorkQueueDrain()
 
+      // Time for callback to run.
+      RPCBaseTests.waitSleep()
+
       // Verify that current user's access token is the "new" access token provided in the mock
       // secure token response during automatic token refresh.
       XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -1858,45 +1858,50 @@ class AuthTests: RPCBaseTests {
     XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
   }
 
-  #if os(iOS)
-    /** @fn testAutoRefreshAppForegroundedNotification
-        @brief Tests that app foreground notification triggers the scheduling of an automatic token
-            refresh task.
-     */
-    func testAutoRefreshAppForegroundedNotification() throws {
-      try auth.signOut()
-      // Enable auto refresh
-      enableAutoTokenRefresh()
+  #if COCOAPODS // This test depends on a non-nil UIApplication.shared
+    #if os(iOS)
+      /** @fn testAutoRefreshAppForegroundedNotification
+          @brief Tests that app foreground notification triggers the scheduling of an automatic token
+              refresh task.
+       */
+      func testAutoRefreshAppForegroundedNotification() throws {
+        try auth.signOut()
+        // Enable auto refresh
+        enableAutoTokenRefresh()
 
-      // Sign in a user.
-      try waitForSignInWithAccessToken()
+        // Sign in a user.
+        try waitForSignInWithAccessToken()
 
-      // Post "UIApplicationDidBecomeActiveNotification" to trigger scheduling token refresh task.
-      NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        // Post "UIApplicationDidBecomeActiveNotification" to trigger scheduling token refresh task.
+        NotificationCenter.default.post(
+          name: UIApplication.didBecomeActiveNotification,
+          object: nil
+        )
 
-      setFakeSecureTokenService(fakeAccessToken: AuthTests.kNewAccessToken)
+        setFakeSecureTokenService(fakeAccessToken: AuthTests.kNewAccessToken)
 
-      // Verify that the current user's access token is the "old" access token before automatic
-      // token refresh.
-      XCTAssertEqual(AuthTests.kAccessToken, auth.currentUser?.rawAccessToken())
+        // Verify that the current user's access token is the "old" access token before automatic
+        // token refresh.
+        XCTAssertEqual(AuthTests.kAccessToken, auth.currentUser?.rawAccessToken())
 
-      // Execute saved token refresh task.
-      let expectation = self.expectation(description: #function)
-      kAuthGlobalWorkQueue.async {
-        XCTAssertNotNil(self.authDispatcherCallback)
-        self.authDispatcherCallback?()
-        expectation.fulfill()
+        // Execute saved token refresh task.
+        let expectation = self.expectation(description: #function)
+        kAuthGlobalWorkQueue.async {
+          XCTAssertNotNil(self.authDispatcherCallback)
+          self.authDispatcherCallback?()
+          expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+        waitForAuthGlobalWorkQueueDrain()
+
+        // Time for callback to run.
+        RPCBaseTests.waitSleep()
+
+        // Verify that current user's access token is the "new" access token provided in the mock
+        // secure token response during automatic token refresh.
+        XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
       }
-      waitForExpectations(timeout: 5)
-      waitForAuthGlobalWorkQueueDrain()
-
-      // Time for callback to run.
-      RPCBaseTests.waitSleep()
-
-      // Verify that current user's access token is the "new" access token provided in the mock
-      // secure token response during automatic token refresh.
-      XCTAssertEqual(AuthTests.kNewAccessToken, auth.currentUser?.rawAccessToken())
-    }
+    #endif
   #endif
 
   // MARK: Application Delegate tests.

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -298,7 +298,7 @@ import FirebaseCore
         let projectConfigExpectation = self.expectation(description: "projectConfiguration")
         rpcIssuer?.projectConfigRequester = { request in
           // 3. Validate the created Request instance.
-          XCTAssertEqual(request.apiKey, PhoneAuthProviderTests.kFakeAPIKey)
+          XCTAssertEqual(request.apiKey, OAuthProviderTests.kFakeAPIKey)
           XCTAssertEqual(request.endpoint, "getProjectConfig")
           // 4. Fulfill the expectation.
           projectConfigExpectation.fulfill()

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -348,7 +348,7 @@
       let expectation = self.expectation(description: function)
 
       // Fake push notification.
-      auth.appCredentialManager.fakeCredential = AuthAppCredential(
+      auth.appCredentialManager?.fakeCredential = AuthAppCredential(
         receipt: kTestReceipt,
         secret: kTestSecret
       )
@@ -438,7 +438,7 @@
       let expectation = self.expectation(description: function)
 
       // Fake push notification.
-      auth.appCredentialManager.fakeCredential = AuthAppCredential(
+      auth.appCredentialManager?.fakeCredential = AuthAppCredential(
         receipt: kTestReceipt,
         secret: reCAPTCHAfallback ? nil : kTestSecret
       )
@@ -556,8 +556,8 @@
 
       if !reCAPTCHAfallback {
         // Fake out appCredentialManager flow.
-        auth.appCredentialManager.credential = AuthAppCredential(receipt: kTestReceipt,
-                                                                 secret: kTestSecret)
+        auth.appCredentialManager?.credential = AuthAppCredential(receipt: kTestReceipt,
+                                                                  secret: kTestSecret)
       } else {
         // 1. Intercept, handle, and test the projectConfiguration RPC calls.
         let projectConfigExpectation = self.expectation(description: "projectConfiguration")
@@ -673,7 +673,7 @@
           settings.appVerificationDisabledForTesting = true
           auth.settings = settings
         }
-        auth.notificationManager.immediateCallbackForTestFaking = { forwardingNotification }
+        auth.notificationManager?.immediateCallbackForTestFaking = { forwardingNotification }
         auth.mainBundleUrlTypes = [["CFBundleURLSchemes": [scheme]]]
 
         if fakeToken {
@@ -681,7 +681,7 @@
             XCTFail("Failed to encode data for fake token")
             return
           }
-          auth.tokenManager.tokenStore = AuthAPNSToken(withData: data, type: .prod)
+          auth.tokenManager?.tokenStore = AuthAPNSToken(withData: data, type: .prod)
         } else {
           // Skip APNS token fetching.
           auth.tokenManager = FakeTokenManager(withApplication: UIApplication.shared)

--- a/Package.swift
+++ b/Package.swift
@@ -447,7 +447,11 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
       ],
-      path: "FirebaseAuth/Tests/Unit"
+      path: "FirebaseAuth/Tests/Unit",
+      exclude: [
+        "PhoneAuthProviderTests.swift", // TODO: these tests rely on a non-zero UIApplication.shared
+        "AuthNotificationManagerTests.swift",
+      ]
     ),
     .target(
       name: "FirebaseAuthCombineSwift",

--- a/Package.swift
+++ b/Package.swift
@@ -449,7 +449,8 @@ let package = Package(
       ],
       path: "FirebaseAuth/Tests/Unit",
       exclude: [
-        "PhoneAuthProviderTests.swift", // TODO: these tests rely on a non-zero UIApplication.shared
+        // TODO: these tests rely on a non-zero UIApplication.shared. They run from CocoaPods.
+        "PhoneAuthProviderTests.swift",
         "AuthNotificationManagerTests.swift",
       ]
     ),


### PR DESCRIPTION
- Address compile time failures for app extensions in Auth.swift (thanks to @ryanwilson for the incantation)
- Similar extension build fix for AuthDefaultUIDelegate.swift
- Fix and simplify implementation and unit tests for AuthNotificationManager
- Fix a unit test flake 
- Disable unit tests for SPM that rely on `UIApplication.shared` being non-zero