### PR TITLE
[auth-swift] Implement fake with subclass instead of a library bool

### DIFF
--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -59,11 +59,6 @@
             becomes available, or when timeout occurs, whichever happens earlier.
      */
     func getTokenInternal(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
-      if failFastForTesting {
-        let error = NSError(domain: "dummy domain", code: AuthErrorCode.missingAppToken.rawValue)
-        callback(nil, error)
-        return
-      }
       if let token = tokenStore {
         callback(token, nil)
         return
@@ -134,8 +129,6 @@
     func cancel(withError error: Error) {
       callback(withToken: nil, error: error)
     }
-
-    var failFastForTesting: Bool = false
 
     // `application` is a var to enable unit test faking.
     var application: AuthAPNSTokenApplication

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -684,13 +684,16 @@
           auth.tokenManager.tokenStore = AuthAPNSToken(withData: data, type: .prod)
         } else {
           // Skip APNS token fetching.
-          auth.tokenManager.failFastForTesting = true
+          auth.tokenManager = FakeTokenManager(withApplication: UIApplication.shared)
         }
       }
     }
 
-    private class FakeApplication: Application {
-      var delegate: UIApplicationDelegate?
+    class FakeTokenManager: AuthAPNSTokenManager {
+      override func getTokenInternal(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
+        let error = NSError(domain: "dummy domain", code: AuthErrorCode.missingAppToken.rawValue)
+        callback(nil, error)
+      }
     }
 
     class FakePresenter: NSObject, AuthWebViewControllerDelegate {


### PR DESCRIPTION
#no-changelog