### PR TITLE
[App Check] Add strict nil token / error handling in App Attest service

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAttestationResponse.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAttestationResponse.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Init with the server response.
 - (nullable instancetype)initWithResponseData:(NSData *)response
                                   requestDate:(NSDate *)requestDate
-                                        error:(NSError **)outError;
+                                        error:(NSError **_Nonnull)outError;
 
 @end
 


### PR DESCRIPTION
Added checks / handling to ensure that callbacks in App Check's App Attest service are always called with a token or an error (they must not both be `nil`).

#no-changelog