### PR TITLE
[CI] Handle empty list in `check_copyright.sh`

### DIFF
--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -27,10 +27,12 @@ list=$(git grep "${options[@]}" -- \
     ':(exclude)**/third_party/**')
 
 # Allow copyrights before 2020 without LLC.
-result=$(grep -L 'Copyright 20[0-1][0-9].*Google' $list)
+if [[ $list ]]; then
+  result=$(grep -L 'Copyright 20[0-1][0-9].*Google' "$list")
+fi
 
 if [[ $result ]]; then
-    echo "$result"
-    echo "ERROR: Missing copyright notices in the files above. Please fix."
-    exit 1
+  echo "$result"
+  echo "ERROR: Missing copyright notices in the files above. Please fix."
+  exit 1
 fi


### PR DESCRIPTION
- Added handling for an empty list of files with invalid copyright declarations.
  - This should resolve the CI failure in https://github.com/google/app-check/pull/6.
- Fixed indentation to 2 spaces.

#no-changelog