### PR TITLE
[Core] Fix API misnomer within FIRApp.m

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -711,9 +711,9 @@ static FIRApp *sDefaultApp;
 
   // Validate version part (see part between '*' symbols below)
   // '<version #>:<project number>:ios:*<hashed bundle id>*'.
-  unsigned long long fingerprint = NSNotFound;
-  if (![stringScanner scanHexLongLong:&fingerprint]) {
-    // Fingerprint part is missing
+  unsigned long long bundleIDHash = NSNotFound;
+  if (![stringScanner scanHexLongLong:&bundleIDHash]) {
+    // Hashed bundleID part is missing
     return NO;
   }
 

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -573,8 +573,8 @@ static FIRApp *sDefaultApp;
 #pragma mark - private - App ID Validation
 
 /**
- * Validates the format of app ID and its included bundle ID contained in GOOGLE_APP_ID in the plist
- * file. This is the main method for validating app ID.
+ * Validates the format of app ID and its included bundle ID hash contained in GOOGLE_APP_ID in the
+ * plist file. This is the main method for validating app ID.
  *
  * @return YES if the app ID fulfills the expected format and contains a hashed bundle ID, NO
  * otherwise.

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -627,7 +627,7 @@ static FIRApp *sDefaultApp;
     return NO;
   }
 
-  if (![self validateAppIDFingerprint:appID withVersion:appIDVersion]) {
+  if (![self validateBundleIDHashWithinAppID:appID forVersion:appIDVersion]) {
     return NO;
   }
 
@@ -735,7 +735,7 @@ static FIRApp *sDefaultApp;
  * @return YES if provided string fufills the expected fingerprint and the version is known, NO
  *         otherwise.
  */
-+ (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version {
++ (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {
   // Extract the supplied fingerprint from the supplied app ID.
   // This assumes the app ID format is the same for all known versions below. If the app ID format
   // changes in future versions, the tokenizing of the app ID format will need to take into account

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -573,7 +573,7 @@ static FIRApp *sDefaultApp;
 #pragma mark - private - App ID Validation
 
 /**
- * Validates the format and hashed bundle ID of the app ID contained in GOOGLE_APP_ID in the plist
+ * Validates the format of app ID and its included bundle ID contained in GOOGLE_APP_ID in the plist
  * file. This is the main method for validating app ID.
  *
  * @return YES if the app ID fulfills the expected format and contains a hashed bundle ID, NO

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -576,7 +576,8 @@ static FIRApp *sDefaultApp;
  * Validates the format and fingerprint of the app ID contained in GOOGLE_APP_ID in the plist file.
  * This is the main method for validating app ID.
  *
- * @return YES if the app ID fulfills the expected format and fingerprint, NO otherwise.
+ * @return YES if the app ID fulfills the expected format and contains a hashed bundle ID, NO
+ * otherwise.
  */
 - (BOOL)isAppIDValid {
   NSString *appID = _options.googleAppID;

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -573,8 +573,8 @@ static FIRApp *sDefaultApp;
 #pragma mark - private - App ID Validation
 
 /**
- * Validates the format and fingerprint of the app ID contained in GOOGLE_APP_ID in the plist file.
- * This is the main method for validating app ID.
+ * Validates the format and hashed bundle ID of the app ID contained in GOOGLE_APP_ID in the plist
+ * file. This is the main method for validating app ID.
  *
  * @return YES if the app ID fulfills the expected format and contains a hashed bundle ID, NO
  * otherwise.
@@ -598,7 +598,7 @@ static FIRApp *sDefaultApp;
 
 + (BOOL)validateAppID:(NSString *)appID {
   // Failing validation only occurs when we are sure we are looking at a V2 app ID and it does not
-  // have a valid fingerprint, otherwise we just warn about the potential issue.
+  // have a valid hashed bundle ID, otherwise we just warn about the potential issue.
   if (!appID.length) {
     return NO;
   }
@@ -718,7 +718,7 @@ static FIRApp *sDefaultApp;
   }
 
   if (!stringScanner.isAtEnd) {
-    // There are not allowed characters in the fingerprint part
+    // There are not allowed characters in the hashed bundle ID part
     return NO;
   }
 
@@ -733,7 +733,7 @@ static FIRApp *sDefaultApp;
  *
  * @param appID Contents of GOOGLE_APP_ID from the plist file.
  * @param version Indicates what version of the app id format this string should be.
- * @return YES if provided string fufills the expected fingerprint and the version is known, NO
+ * @return YES if provided string fufills the expected hashed bundle ID and the version is known, NO
  *         otherwise.
  */
 + (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -725,8 +725,8 @@ static FIRApp *sDefaultApp;
 }
 
 /**
- * Validates that the fingerprint of the app ID string is what is expected based on the supplied
- * version.
+ * Validates that the hashed bundle ID included in the app ID string is what is expected based on
+ * the supplied version.
  *
  * Note that the v1 hash algorithm is not permitted on the client and cannot be fully validated.
  *
@@ -736,23 +736,23 @@ static FIRApp *sDefaultApp;
  *         otherwise.
  */
 + (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {
-  // Extract the supplied fingerprint from the supplied app ID.
-  // This assumes the app ID format is the same for all known versions below. If the app ID format
-  // changes in future versions, the tokenizing of the app ID format will need to take into account
-  // the version of the app ID.
+  // Extract the hashed bundle ID from the given app ID.
+  // This assumes the app ID format is the same for all known versions below.
+  // If the app ID format changes in future versions, the tokenizing of the app
+  // ID format will need to take into account the version of the app ID.
   NSArray *components = [appID componentsSeparatedByString:@":"];
   if (components.count != 4) {
     return NO;
   }
 
-  NSString *suppliedFingerprintString = components[3];
-  if (!suppliedFingerprintString.length) {
+  NSString *suppliedBundleIDHashString = components[3];
+  if (!suppliedBundleIDHashString.length) {
     return NO;
   }
 
-  uint64_t suppliedFingerprint;
-  NSScanner *scanner = [NSScanner scannerWithString:suppliedFingerprintString];
-  if (![scanner scanHexLongLong:&suppliedFingerprint]) {
+  uint64_t suppliedBundleIDHash;
+  NSScanner *scanner = [NSScanner scannerWithString:suppliedBundleIDHashString];
+  if (![scanner scanHexLongLong:&suppliedBundleIDHash]) {
     return NO;
   }
 

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -644,7 +644,7 @@ static FIRApp *sDefaultApp;
  * The version must end in ":".
  *
  * For v1 app ids the format is expected to be
- * '<version #>:<project number>:ios:<fingerprint of bundle id>'.
+ * '<version #>:<project number>:ios:<hashed bundle id>'.
  *
  * This method does not verify that the contents of the app id are correct, just that they fulfill
  * the expected format.
@@ -662,21 +662,21 @@ static FIRApp *sDefaultApp;
   stringScanner.charactersToBeSkipped = nil;
 
   // Skip version part
-  // '*<version #>*:<project number>:ios:<fingerprint of bundle id>'
+  // '*<version #>*:<project number>:ios:<hashed bundle id>'
   if (![stringScanner scanString:version intoString:NULL]) {
     // The version part is missing or mismatched
     return NO;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>*:*<project number>:ios:<fingerprint of bundle id>'
+  // '<version #>*:*<project number>:ios:<hashed bundle id>'
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // appIDVersion must be separated by ":"
     return NO;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>:*<project number>*:ios:<fingerprint of bundle id>'.
+  // '<version #>:*<project number>*:ios:<hashed bundle id>'.
   NSInteger projectNumber = NSNotFound;
   if (![stringScanner scanInteger:&projectNumber]) {
     // NO project number found.
@@ -684,14 +684,14 @@ static FIRApp *sDefaultApp;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>:<project number>*:*ios:<fingerprint of bundle id>'.
+  // '<version #>:<project number>*:*ios:<hashed bundle id>'.
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // The project number must be separated by ":"
     return NO;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>:<project number>:*ios*:<fingerprint of bundle id>'.
+  // '<version #>:<project number>:*ios*:<hashed bundle id>'.
   NSString *platform;
   if (![stringScanner scanUpToString:@":" intoString:&platform]) {
     return NO;
@@ -703,14 +703,14 @@ static FIRApp *sDefaultApp;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>:<project number>:ios*:*<fingerprint of bundle id>'.
+  // '<version #>:<project number>:ios*:*<hashed bundle id>'.
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // The platform must be separated by ":"
     return NO;
   }
 
   // Validate version part (see part between '*' symbols below)
-  // '<version #>:<project number>:ios:*<fingerprint of bundle id>*'.
+  // '<version #>:<project number>:ios:*<hashed bundle id>*'.
   unsigned long long fingerprint = NSNotFound;
   if (![stringScanner scanHexLongLong:&fingerprint]) {
     // Fingerprint part is missing

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -423,33 +423,34 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 #pragma mark - App ID v1
 
 - (void)testAppIDV1 {
-  // Missing separator between platform:fingerprint.
+  // Missing separator between platform:hashed bundle ID.
   XCTAssertFalse([FIRApp validateAppID:@"1:1337:iosdeadbeef"]);
 
   // Wrong platform "android".
   XCTAssertFalse([FIRApp validateAppID:@"1:1337:android:deadbeef"]);
 
-  // The fingerprint, aka 4th field, should only contain hex characters.
+  // The hashed bundle ID, aka 4th field, should only contain hex characters.
   XCTAssertFalse([FIRApp validateAppID:@"1:1337:ios:123abcxyz"]);
 
-  // The fingerprint, aka 4th field, is not tested in V1, so a bad value shouldn't cause a failure.
+  // The hashed bundle ID, aka 4th field, is not tested in V1, so a bad value shouldn't cause a
+  // failure.
   XCTAssertTrue([FIRApp validateAppID:@"1:1337:ios:deadbeef"]);
 }
 
 #pragma mark - App ID v2
 
 - (void)testAppIDV2 {
-  // Missing separator between platform:fingerprint.
+  // Missing separator between platform:hashed bundle ID.
   XCTAssertTrue([FIRApp validateAppID:@"2:1337:ios5e18052ab54fbfec"]);
 
   // Unknown versions may contain anything.
   XCTAssertTrue([FIRApp validateAppID:@"2:1337:ios:123abcxyz"]);
   XCTAssertTrue([FIRApp validateAppID:@"2:thisdoesn'teven_m:a:t:t:e:r_"]);
 
-  // Known good fingerprint.
+  // Known good hashed bundle ID.
   XCTAssertTrue([FIRApp validateAppID:@"2:1337:ios:5e18052ab54fbfec"]);
 
-  // Unknown fingerprint, not tested so shouldn't cause a failure.
+  // Unknown hashed bundle ID, not tested so shouldn't cause a failure.
   XCTAssertTrue([FIRApp validateAppID:@"2:1337:ios:deadbeef"]);
 }
 

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -573,7 +573,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)testAppIDContainsInvalidBundleIDHash {
   OCMStub([self.appClassMock actualBundleID]).andReturn(@"com.google.bundleID");
-  // Some direct tests of the validateAppIDFingerprint:withVersion: method.
+  // Some direct tests of the validateBundleIDHashWithinAppID:forVersion: method.
   // Sanity checks first.
   NSString *const kGoodAppIDV1 = @"1:1337:ios:deadbeef";
   NSString *const kGoodVersionV1 = @"1";

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -571,7 +571,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([FIRApp validateAppIDFormat:@"1:1337:ios:deadbeef:ab" withVersion:kGoodVersionV1]);
 }
 
-- (void)testAppIDFingerprintInvalid {
+- (void)testAppIDContainsInvalidBundleIDHash {
   OCMStub([self.appClassMock actualBundleID]).andReturn(@"com.google.bundleID");
   // Some direct tests of the validateAppIDFingerprint:withVersion: method.
   // Sanity checks first.

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -55,7 +55,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 + (void)logAppInfo:(NSNotification *)notification;
 + (BOOL)validateAppID:(NSString *)appID;
 + (BOOL)validateAppIDFormat:(NSString *)appID withVersion:(NSString *)version;
-+ (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version;
++ (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version;
 
 + (nullable NSNumber *)readDataCollectionSwitchFromPlist;
 + (nullable NSNumber *)readDataCollectionSwitchFromUserDefaultsForApp:(FIRApp *)app;
@@ -577,24 +577,24 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   // Sanity checks first.
   NSString *const kGoodAppIDV1 = @"1:1337:ios:deadbeef";
   NSString *const kGoodVersionV1 = @"1";
-  XCTAssertTrue([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodVersionV1]);
+  XCTAssertTrue([FIRApp validateBundleIDHashWithinAppID:kGoodAppIDV1 forVersion:kGoodVersionV1]);
 
   NSString *const kGoodAppIDV2 = @"2:1337:ios:5e18052ab54fbfec";
   NSString *const kGoodVersionV2 = @"2";
   XCTAssertTrue([FIRApp validateAppIDFormat:kGoodAppIDV2 withVersion:kGoodVersionV2]);
 
   // Nil or empty strings.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:nil]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:@""]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:nil withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"" withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:nil withVersion:nil]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"" withVersion:@""]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:kGoodAppIDV1 forVersion:nil]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:kGoodAppIDV1 forVersion:@""]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:nil forVersion:kGoodVersionV1]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:@"" forVersion:kGoodVersionV1]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:nil forVersion:nil]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:@"" forVersion:@""]);
 
   // App ID contains only the version prefix.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodVersionV1 withVersion:kGoodVersionV1]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:kGoodVersionV1 forVersion:kGoodVersionV1]);
   // The version is the entire app ID.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodAppIDV1]);
+  XCTAssertFalse([FIRApp validateBundleIDHashWithinAppID:kGoodAppIDV1 forVersion:kGoodAppIDV1]);
 }
 
 // Uncomment if you need to measure performance of [FIRApp validateAppID:].

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -600,7 +600,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 // Uncomment if you need to measure performance of [FIRApp validateAppID:].
 // It is commented because measures are heavily dependent on a build agent configuration,
 // so it cannot produce reliable resault on CI
-//- (void)testAppIDFingerprintPerfomance {
+//- (void)testAppIDValidationPerfomance {
 //  [self measureBlock:^{
 //    for (NSInteger i = 0; i < 100; ++i) {
 //      [self testAppIDPrefix];


### PR DESCRIPTION
### Context
Within FirebaseCore's implementation, there was a misnomer where the string "fingerprinting"  was incorrectly used to describe parts of the implementation that validates that the Firebase app ID contains a valid bundle ID hash. This validation serves to catch issues with a developer's Firebase options (which are either custom provided or set by the `GoogleService-Info.plist`). The implementation does **not** actually do any _fingerprinting_.  

#no-changelog