### PR TITLE
Add `FIRAppCheckProtocol` to `FirebaseAppCheckInterop` SDK

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -36,7 +36,6 @@ Pod::Spec.new do |s|
 
   s.source_files = [
     base_dir + 'Sources/**/*.[mh]',
-    base_dir + 'Interop/*.h',
     'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseAppCheck/*.h'

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
-  s.dependency 'FirebaseAppCheckInterop', '~> 10.14'
+  s.dependency 'FirebaseAppCheckInterop', '~> 10.16'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   s.osx.weak_framework = 'DeviceCheck'
   s.tvos.weak_framework = 'DeviceCheck'
 
+  s.dependency 'FirebaseAppCheckInterop', '~> 10.14'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/FirebaseAppCheck/Interop/FIRAppCheckProtocol.h
+++ b/FirebaseAppCheck/Interop/FIRAppCheckProtocol.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import Foundation;
+
+@class FIRAppCheckToken;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(AppCheckProtocol)
+@protocol FIRAppCheckProtocol <NSObject>
+
+/// Requests Firebase app check token. This method should *only* be used if you need to authorize
+/// requests to a non-Firebase backend. Requests to Firebase backend are authorized automatically if
+/// configured.
+///
+/// If your non-Firebase backend exposes sensitive or expensive endpoints that have low traffic
+/// volume, consider protecting it with [Replay
+/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
+/// In this case, use the ``limitedUseToken(completion:)`` instead to obtain a limited-use token.
+/// @param forcingRefresh If `YES`,  a new Firebase app check token is requested and the token
+/// cache is ignored. If `NO`, the cached token is used if it exists and has not expired yet. In
+/// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
+/// error, indicating a revoked token.
+/// @param handler The completion handler. Includes the app check token if the request succeeds,
+/// or an error if the request fails.
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:
+                     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(token(forcingRefresh:completion:));
+
+/// Requests a limited-use Firebase App Check token. This method should be used only if you need to
+/// authorize requests to a non-Firebase backend.
+///
+/// Returns limited-use tokens that are intended for use with your non-Firebase backend endpoints
+/// that are protected with [Replay
+/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
+/// This method does not affect the token generation behavior of the
+/// ``tokenForcingRefresh()`` method.
+- (void)limitedUseTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                                NSError *_Nullable error))handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -16,6 +16,8 @@
 
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
 
+@import FirebaseAppCheckInterop;
+
 #if __has_include(<FBLPromises/FBLPromises.h>)
 #import <FBLPromises/FBLPromises.h>
 #else
@@ -35,9 +37,6 @@
 #import "FirebaseAppCheck/Sources/Core/Storage/FIRAppCheckStorage.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefreshResult.h"
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
-
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckComponent.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckComponent.m
@@ -16,10 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
+@import FirebaseAppCheckInterop;
+
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheck+Internal.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
-
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckTokenResult.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckTokenResult.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
+@import FirebaseAppCheckInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+@import FirebaseAppCheckInterop;
+
 @class FIRApp;
 @class FIRAppCheckToken;
 @protocol FIRAppCheckProviderFactory;
@@ -36,7 +38,7 @@ FOUNDATION_EXPORT NSString *const kFIRAppCheckAppNameNotificationKey NS_SWIFT_NA
 
 /// A class used to manage app check tokens for a given Firebase app.
 NS_SWIFT_NAME(AppCheck)
-@interface FIRAppCheck : NSObject
+@interface FIRAppCheck : NSObject <FIRAppCheckProtocol>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -54,36 +54,6 @@ NS_SWIFT_NAME(AppCheck)
 /// @throw Throws an exception if required `FirebaseApp` options are missing.
 + (nullable instancetype)appCheckWithApp:(FIRApp *)firebaseApp NS_SWIFT_NAME(appCheck(app:));
 
-/// Requests Firebase app check token. This method should *only* be used if you need to authorize
-/// requests to a non-Firebase backend. Requests to Firebase backend are authorized automatically if
-/// configured.
-///
-/// If your non-Firebase backend exposes sensitive or expensive endpoints that have low traffic
-/// volume, consider protecting it with [Replay
-/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
-/// In this case, use the ``limitedUseToken(completion:)`` instead to obtain a limited-use token.
-/// @param forcingRefresh If `YES`,  a new Firebase app check token is requested and the token
-/// cache is ignored. If `NO`, the cached token is used if it exists and has not expired yet. In
-/// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
-/// error, indicating a revoked token.
-/// @param handler The completion handler. Includes the app check token if the request succeeds,
-/// or an error if the request fails.
-- (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:
-                     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
-    NS_SWIFT_NAME(token(forcingRefresh:completion:));
-
-/// Requests a limited-use Firebase App Check token. This method should be used only if you need to
-/// authorize requests to a non-Firebase backend.
-///
-/// Returns limited-use tokens that are intended for use with your non-Firebase backend endpoints
-/// that are protected with [Replay
-/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
-/// This method does not affect the token generation behavior of the
-/// ``tokenForcingRefresh()`` method.
-- (void)limitedUseTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
-                                                NSError *_Nullable error))handler;
-
 /// Sets the `AppCheckProviderFactory` to use to generate
 /// `AppCheckDebugProvider` objects.
 ///

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckIntegrationTests.m
@@ -20,13 +20,13 @@
 
 #import <TargetConditionals.h>
 
+@import FirebaseAppCheckInterop;
+
 #import "FirebaseAppCheck/Sources/Core/TokenRefresh/FIRAppCheckTokenRefresher.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProviderFactory.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckToken.h"
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProviderFactory.h"
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -20,14 +20,11 @@
 
 #import "FBLPromise+Testing.h"
 
-#import <FirebaseAppCheck/FirebaseAppCheck.h>
+@import FirebaseAppCheckInterop;
 
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h"
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h"
-
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
 
 #import "FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h"
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckSettings.h"

--- a/Package.swift
+++ b/Package.swift
@@ -1217,6 +1217,7 @@ let package = Package(
 
     .target(name: "FirebaseAppCheck",
             dependencies: [
+              "FirebaseAppCheckInterop",
               "FirebaseCore",
               .product(name: "FBLPromises", package: "Promises"),
               .product(name: "GULEnvironment", package: "GoogleUtilities"),

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.h
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
+@import FirebaseAppCheckInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckTokenResultFake.h
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckTokenResultFake.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
+@import FirebaseAppCheckInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Added a protocol named `FIRAppCheckProtocol` to the `FirebaseAppCheckInterop` SDK that duplicates the token fetching public APIs of `FIRAppCheck`. Updated `FIRAppCheck` to publicly conform to `FIRAppCheckProtocol`.

This will allow other SDKs to accept an instance of App Check through a parameter of type `id<FIRAppCheckProtocol>`, while not requiring a hard dependency on `FirebaseAppCheck`.

#no-changelog