### PR TITLE
update thread-safety docs on Storage

### DIFF
--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -29,7 +29,7 @@ import FirebaseAuthInterop
 /**
  * Firebase Storage is a service that supports uploading and downloading binary objects,
  * such as images, videos, and other files to Google Cloud Storage. Instances of `Storage`
- * are not thread-safe.
+ * are not thread-safe, but can be accessed from any thread.
  *
  * If you call `Storage.storage()`, the instance will initialize with the default `FirebaseApp`,
  * `FirebaseApp.app()`, and the storage location will come from the provided

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -28,7 +28,6 @@ import Foundation
  * Downloads can currently be returned as `Data` in memory, or as a `URL` to a file on disk.
  * Downloads are performed on a background queue, and callbacks are raised on the developer
  * specified `callbackQueue` in Storage, or the main queue if left unspecified.
- * Currently all downloads must be initiated and managed on the main queue.
  */
 @objc(FIRStorageDownloadTask)
 open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -25,7 +25,6 @@ import Foundation
  * in task state.
  * Observers produce a `StorageHandle`, which is used to keep track of and remove specific
  * observers at a later date.
- * This class is not thread safe and can only be called on the main thread.
  */
 @objc(FIRStorageObservableTask) open class StorageObservableTask: StorageTask {
   /**

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -26,7 +26,7 @@ import Foundation
  * for metadata and errors.
  * Callbacks are always fired on the developer-specified callback queue.
  * If no queue is specified, it defaults to the main queue.
- * This class is not thread safe, so only call methods on the main thread.
+ * This class is thread-safe.
  */
 @objc(FIRStorageTask) open class StorageTask: NSObject {
   /**

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -28,7 +28,6 @@ import Foundation
  * Uploads can be initialized from `Data` in memory, or a URL to a file on disk.
  * Uploads are performed on a background queue, and callbacks are raised on the developer
  * specified `callbackQueue` in Storage, or the main queue if unspecified.
- * Currently all uploads must be initiated and managed on the main queue.
  */
 @objc(FIRStorageUploadTask) open class StorageUploadTask: StorageObservableTask,
   StorageTaskManagement {


### PR DESCRIPTION
Fixes #11653. I did not document Storage as thread-safe because its properties and `ensureInitialized()` have no thread-safety protections.