### PR TITLE
[App Check] Fix App Attest and DeviceCheck API availability

### DIFF
--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckAvailability.h
@@ -21,32 +21,15 @@
 
 #pragma mark - DeviceCheck
 
-// DeviceCheck availability was extended to watchOS in Xcode 14.
-#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
 // Targets where DeviceCheck framework is available to be used in preprocessor conditions.
 #define FIR_DEVICE_CHECK_SUPPORTED_TARGETS \
   TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV || TARGET_OS_WATCH
 
 // `DeviceCheckProvider` availability.
 #define FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0), watchos(9.0))
-
-// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
-#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
-// Targets where DeviceCheck framework is available to be used in preprocessor conditions.
-#define FIR_DEVICE_CHECK_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
-
-// `DeviceCheckProvider` availability.
-#define FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(ios(11.0), macos(10.15), tvos(11.0)) API_UNAVAILABLE(watchos)
-
-#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+  API_AVAILABLE(ios(11.0), macos(10.15), macCatalyst(13.0), tvos(11.0), watchos(9.0))
 
 #pragma mark - App Attest
-
-#if defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
 
 // Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
 #define FIR_APP_ATTEST_SUPPORTED_TARGETS \
@@ -54,16 +37,4 @@
 
 // `AppAttestProvider` availability annotations
 #define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0), watchos(9.0))
-
-// TODO(ncooke3): Remove `#else` clause when Xcode 14 is the minimum supported Xcode.
-#else  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
-
-// Targets where `DCAppAttestService` is available to be used in preprocessor conditions.
-#define FIR_APP_ATTEST_SUPPORTED_TARGETS TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_TV
-
-// `AppAttestProvider` availability annotations
-#define FIR_APP_ATTEST_PROVIDER_AVAILABILITY \
-  API_AVAILABLE(macos(11.0), ios(14.0), tvos(15.0)) API_UNAVAILABLE(watchos)
-
-#endif  // defined(__WATCHOS_9_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_9_0
+  API_AVAILABLE(ios(14.0), macos(11.3), macCatalyst(14.5), tvos(15.0), watchos(9.0))

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -25,15 +25,13 @@ final class AppCheckAPITests {
   func usage() {
     // MARK: - AppAttestProvider
 
-    #if TARGET_OS_IOS
-      if #available(iOS 14.0, *) {
-        if let app = FirebaseApp.app(), let provider = AppAttestProvider(app: app) {
-          provider.getToken { token, error in
-            // ...
-          }
+    if #available(iOS 14.0, macOS 11.3, macCatalyst 14.5, tvOS 15.0, watchOS 9.0, *) {
+      if let app = FirebaseApp.app(), let provider = AppAttestProvider(app: app) {
+        provider.getToken { token, error in
+          // ...
         }
       }
-    #endif // TARGET_OS_IOS
+    }
 
     // MARK: - AppCheck
 


### PR DESCRIPTION
- Updated the `FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY` and `FIR_APP_ATTEST_PROVIDER_AVAILABILITY` API availability macros to reflect the set of supported platforms for [DeviceCheck](https://developer.apple.com/documentation/devicecheck/dcdevice/2891519-supported) (iOS 11+, macOS 10.15+, macCatalyst 13+, tvOS 11+, watchOS 9+) and [App Attest](https://developer.apple.com/documentation/devicecheck/dcappattestservice/3573915-supported) (iOS 14+, macOS 11.3+, macCatalyst 14.5+, tvOS 15+, watchOS 9+).
  - Removed the extraneous check for the watchOS 9 SDK now that Xcode 14 is the minimum supported by Firebase.
- Removed the `#if TARGET_OS_IOS` compiler directive in `AppCheckAPITests.swift` since `TARGET_OS_IOS` is only available in Objective-C and was always false.

#no-changelog