### PR TITLE
[visionOS] Fix Sessions SDK build on Xcode 15 beta 6

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 10.14.0
+- For developers building for visionOS, Xcode 15 beta 6 or later is required.
+
 # Firebase 10.13.0
 - For developers building for visionOS, Xcode 15 beta 5 or later is required.
 

--- a/FirebaseSessions/Sources/SessionInitiator.swift
+++ b/FirebaseSessions/Sources/SessionInitiator.swift
@@ -20,7 +20,15 @@ import Foundation
   import AppKit
 #elseif os(watchOS)
   import WatchKit
-#endif
+// swift(>=5.9) implies Xcode 15+
+// Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+// TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+// when Xcode 15 is the minimum supported by Firebase.
+#elseif swift(>=5.9)
+  #if os(visionOS)
+    import UIKit
+  #endif // os(visionOS)
+#endif // os(iOS) || os(tvOS)
 
 ///
 /// The SessionInitiator is responsible for:
@@ -87,7 +95,26 @@ class SessionInitiator {
           object: nil
         )
       }
-    #endif
+    // swift(>=5.9) implies Xcode 15+
+    // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+    // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+    // when Xcode 15 is the minimum supported by Firebase.
+    #elseif swift(>=5.9)
+      #if os(visionOS)
+        notificationCenter.addObserver(
+          self,
+          selector: #selector(appBackgrounded),
+          name: UIApplication.didEnterBackgroundNotification,
+          object: nil
+        )
+        notificationCenter.addObserver(
+          self,
+          selector: #selector(appForegrounded),
+          name: UIApplication.didBecomeActiveNotification,
+          object: nil
+        )
+      #endif // os(visionOS)
+    #endif // os(iOS) || os(tvOS)
   }
 
   @objc private func appBackgrounded() {

--- a/FirebaseSessions/Sources/SessionInitiator.swift
+++ b/FirebaseSessions/Sources/SessionInitiator.swift
@@ -20,15 +20,17 @@ import Foundation
   import AppKit
 #elseif os(watchOS)
   import WatchKit
+#endif // os(iOS) || os(tvOS)
+
 // swift(>=5.9) implies Xcode 15+
 // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
 // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
 // when Xcode 15 is the minimum supported by Firebase.
-#elseif swift(>=5.9)
+#if swift(>=5.9)
   #if os(visionOS)
     import UIKit
   #endif // os(visionOS)
-#endif // os(iOS) || os(tvOS)
+#endif // swift(>=5.9)
 
 ///
 /// The SessionInitiator is responsible for:
@@ -95,11 +97,13 @@ class SessionInitiator {
           object: nil
         )
       }
+    #endif // os(iOS) || os(tvOS)
+
     // swift(>=5.9) implies Xcode 15+
     // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
     // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
     // when Xcode 15 is the minimum supported by Firebase.
-    #elseif swift(>=5.9)
+    #if swift(>=5.9)
       #if os(visionOS)
         notificationCenter.addObserver(
           self,
@@ -114,7 +118,7 @@ class SessionInitiator {
           object: nil
         )
       #endif // os(visionOS)
-    #endif // os(iOS) || os(tvOS)
+    #endif // swift(>=5.9)
   }
 
   @objc private func appBackgrounded() {

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -256,89 +256,45 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
     -> firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype {
     var subtype: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
 
-    // swift(>=5.9) implies Xcode 15+
-    // Need to have this swift version check to use os(visionOS) macro, VisionOS support.
-    #if swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-        switch mobileSubtype {
-        case CTRadioAccessTechnologyGPRS:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-        case CTRadioAccessTechnologyEdge:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-        case CTRadioAccessTechnologyWCDMA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        case CTRadioAccessTechnologyCDMA1x:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        case CTRadioAccessTechnologyHSDPA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-        case CTRadioAccessTechnologyHSUPA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-        case CTRadioAccessTechnologyCDMAEVDORev0:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-        case CTRadioAccessTechnologyCDMAEVDORevA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-        case CTRadioAccessTechnologyCDMAEVDORevB:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-        case CTRadioAccessTechnologyeHRPD:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-        case CTRadioAccessTechnologyLTE:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-        default:
-          subtype =
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-        }
-
-        if #available(iOS 14.1, *) {
-          if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
-            CTRadioAccessTechnologyNR {
-            subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          }
-        }
-      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      switch mobileSubtype {
+      case CTRadioAccessTechnologyGPRS:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+      case CTRadioAccessTechnologyEdge:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+      case CTRadioAccessTechnologyWCDMA:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+      case CTRadioAccessTechnologyCDMA1x:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+      case CTRadioAccessTechnologyHSDPA:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+      case CTRadioAccessTechnologyHSUPA:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+      case CTRadioAccessTechnologyCDMAEVDORev0:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+      case CTRadioAccessTechnologyCDMAEVDORevA:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+      case CTRadioAccessTechnologyCDMAEVDORevB:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+      case CTRadioAccessTechnologyeHRPD:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+      case CTRadioAccessTechnologyLTE:
+        subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+      default:
         subtype =
           firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-    #else // swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst)
-        switch mobileSubtype {
-        case CTRadioAccessTechnologyGPRS:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-        case CTRadioAccessTechnologyEdge:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-        case CTRadioAccessTechnologyWCDMA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        case CTRadioAccessTechnologyCDMA1x:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-        case CTRadioAccessTechnologyHSDPA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-        case CTRadioAccessTechnologyHSUPA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-        case CTRadioAccessTechnologyCDMAEVDORev0:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-        case CTRadioAccessTechnologyCDMAEVDORevA:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-        case CTRadioAccessTechnologyCDMAEVDORevB:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-        case CTRadioAccessTechnologyeHRPD:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-        case CTRadioAccessTechnologyLTE:
-          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-        default:
-          subtype =
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-        }
+      }
 
-        if #available(iOS 14.1, *) {
-          if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
-            CTRadioAccessTechnologyNR {
-            subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          }
+      if #available(iOS 14.1, *) {
+        if mobileSubtype == CTRadioAccessTechnologyNRNSA || mobileSubtype ==
+          CTRadioAccessTechnologyNR {
+          subtype = firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
         }
-      #else // os(iOS) && !targetEnvironment(macCatalyst)
-        subtype =
-          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-      #endif // os(iOS) && !targetEnvironment(macCatalyst)
-    #endif
+      }
+    #else // os(iOS) && !targetEnvironment(macCatalyst)
+      subtype =
+        firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
 
     return subtype
   }

--- a/FirebaseSessions/Tests/Unit/Library/LifecycleNotifications.swift
+++ b/FirebaseSessions/Tests/Unit/Library/LifecycleNotifications.swift
@@ -24,15 +24,17 @@ import Dispatch
   import AppKit
 #elseif os(watchOS)
   import WatchKit
+#endif // os(iOS) || os(tvOS)
+
 // swift(>=5.9) implies Xcode 15+
 // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
 // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
 // when Xcode 15 is the minimum supported by Firebase.
-#elseif swift(>=5.9)
+#if swift(>=5.9)
   #if os(visionOS)
     import UIKit
   #endif // os(visionOS)
-#endif // os(iOS) || os(tvOS)
+#endif // swift(>=5.9)
 
 extension XCTestCase {
   func postBackgroundedNotification() {
@@ -59,15 +61,17 @@ extension XCTestCase {
           object: nil
         )
       }
+    #endif // os(iOS) || os(tvOS)
+
     // swift(>=5.9) implies Xcode 15+
     // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
     // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
     // when Xcode 15 is the minimum supported by Firebase.
-    #elseif swift(>=5.9)
+    #if swift(>=5.9)
       #if os(visionOS)
         notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
       #endif // os(visionOS)
-    #endif // os(iOS) || os(tvOS)
+    #endif // swift(>=5.9)
   }
 
   func postForegroundedNotification() {
@@ -94,14 +98,16 @@ extension XCTestCase {
           object: nil
         )
       }
+    #endif // os(iOS) || os(tvOS)
+
     // swift(>=5.9) implies Xcode 15+
     // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
     // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
     // when Xcode 15 is the minimum supported by Firebase.
-    #elseif swift(>=5.9)
+    #if swift(>=5.9)
       #if os(visionOS)
         notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
       #endif // os(visionOS)
-    #endif // os(iOS) || os(tvOS)
+    #endif // swift(>=5.9)
   }
 }

--- a/FirebaseSessions/Tests/Unit/Library/LifecycleNotifications.swift
+++ b/FirebaseSessions/Tests/Unit/Library/LifecycleNotifications.swift
@@ -24,7 +24,15 @@ import Dispatch
   import AppKit
 #elseif os(watchOS)
   import WatchKit
-#endif
+// swift(>=5.9) implies Xcode 15+
+// Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+// TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+// when Xcode 15 is the minimum supported by Firebase.
+#elseif swift(>=5.9)
+  #if os(visionOS)
+    import UIKit
+  #endif // os(visionOS)
+#endif // os(iOS) || os(tvOS)
 
 extension XCTestCase {
   func postBackgroundedNotification() {
@@ -51,7 +59,15 @@ extension XCTestCase {
           object: nil
         )
       }
-    #endif
+    // swift(>=5.9) implies Xcode 15+
+    // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+    // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+    // when Xcode 15 is the minimum supported by Firebase.
+    #elseif swift(>=5.9)
+      #if os(visionOS)
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+      #endif // os(visionOS)
+    #endif // os(iOS) || os(tvOS)
   }
 
   func postForegroundedNotification() {
@@ -78,6 +94,14 @@ extension XCTestCase {
           object: nil
         )
       }
-    #endif
+    // swift(>=5.9) implies Xcode 15+
+    // Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+    // TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+    // when Xcode 15 is the minimum supported by Firebase.
+    #elseif swift(>=5.9)
+      #if os(visionOS)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+      #endif // os(visionOS)
+    #endif // os(iOS) || os(tvOS)
   }
 }

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -222,18 +222,10 @@ class SessionStartEventTests: XCTestCase {
     mockNetworkInfo.networkType = .mobile
     // Mobile Subtypes are always empty on non-iOS platforms, and
     // Performance doesn't support those platforms anyways
-    #if swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-        mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-      #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-        mockNetworkInfo.mobileSubtype = ""
-      #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-    #else // swift(>=5.9)
-      #if os(iOS) && !targetEnvironment(macCatalyst)
-        mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
-      #else // os(iOS) && !targetEnvironment(macCatalyst)
-        mockNetworkInfo.mobileSubtype = ""
-      #endif // os(iOS) && !targetEnvironment(macCatalyst)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      mockNetworkInfo.mobileSubtype = CTRadioAccessTechnologyHSUPA
+    #else // os(iOS) && !targetEnvironment(macCatalyst)
+      mockNetworkInfo.mobileSubtype = ""
     #endif // os(iOS) && !targetEnvironment(macCatalyst)
     appInfo.networkInfo = mockNetworkInfo
 
@@ -273,31 +265,18 @@ class SessionStartEventTests: XCTestCase {
       )
       // Mobile Subtypes are always empty on non-iOS platforms, and
       // Performance doesn't support those platforms anyways
-      #if swift(>=5.9)
-        #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-          XCTAssertEqual(
-            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          )
-        #else // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-          XCTAssertEqual(
-            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          )
-        #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-      #else // swift(>=5.9)
-        #if os(iOS) && !targetEnvironment(macCatalyst)
-          XCTAssertEqual(
-            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          )
-        #else // os(iOS) && !targetEnvironment(macCatalyst)
-          XCTAssertEqual(
-            event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          )
-        #endif // os(iOS) && !targetEnvironment(macCatalyst)
-      #endif // swift(>=5.9)
+      #if os(iOS) && !targetEnvironment(macCatalyst)
+        XCTAssertEqual(
+          event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+        )
+      #else // os(iOS) && !targetEnvironment(macCatalyst)
+        XCTAssertEqual(
+          event.proto.application_info.apple_app_info.network_connection_info.mobile_subtype,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+        )
+      #endif // os(iOS) && !targetEnvironment(macCatalyst)
+
       assertEqualProtoString(
         proto.application_info.apple_app_info.mcc_mnc,
         expected: "",
@@ -350,357 +329,178 @@ class SessionStartEventTests: XCTestCase {
   }
 
   /// Following tests can be run only in iOS environment
-  #if swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-      func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
-        let expectations: [(
-          given: String,
-          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        )] = [
-          (
-            CTRadioAccessTechnologyGPRS,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-          ),
-          (
-            CTRadioAccessTechnologyEdge,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-          ),
-          (
-            CTRadioAccessTechnologyWCDMA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyCDMA1x,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyHSDPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-          ),
-          (
-            CTRadioAccessTechnologyHSUPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORev0,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevB,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-          ),
-          (
-            CTRadioAccessTechnologyeHRPD,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-          ),
-          (
-            CTRadioAccessTechnologyLTE,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-          ),
-          (
-            "random",
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          ),
-        ]
+  #if os(iOS) && !targetEnvironment(macCatalyst)
+    func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
+      let expectations: [(
+        given: String,
+        expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+      )] = [
+        (
+          CTRadioAccessTechnologyGPRS,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+        ),
+        (
+          CTRadioAccessTechnologyEdge,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+        ),
+        (
+          CTRadioAccessTechnologyWCDMA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        ),
+        (
+          CTRadioAccessTechnologyCDMA1x,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        ),
+        (
+          CTRadioAccessTechnologyHSDPA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+        ),
+        (
+          CTRadioAccessTechnologyHSUPA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORev0,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORevA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORevB,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+        ),
+        (
+          CTRadioAccessTechnologyeHRPD,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+        ),
+        (
+          CTRadioAccessTechnologyLTE,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+        ),
+        (
+          "random",
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+        ),
+      ]
 
-        expectations
-          .forEach { (given: String,
-                      expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
-              let mockNetworkInfo = MockNetworkInfo()
-              mockNetworkInfo.mobileSubtype = given
-              appInfo.networkInfo = mockNetworkInfo
+      expectations
+        .forEach { (given: String,
+                    expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
 
-              let event = SessionStartEvent(
-                sessionInfo: self.defaultSessionInfo,
-                appInfo: appInfo,
-                time: time
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
+            )
+
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info
+                  .mobile_subtype,
+                expected
               )
+            }
+        }
+    }
+  #endif // os(iOS) && !targetEnvironment(macCatalyst)
 
-              // These fields will only be filled in when the Perf SDK is installed
-              event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+  #if os(iOS) && !targetEnvironment(macCatalyst)
+    @available(iOS 14.1, *)
+    func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
+      let expectations: [(
+        given: String,
+        expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
+      )] = [
+        (
+          CTRadioAccessTechnologyGPRS,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
+        ),
+        (
+          CTRadioAccessTechnologyEdge,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
+        ),
+        (
+          CTRadioAccessTechnologyWCDMA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        ),
+        (
+          CTRadioAccessTechnologyCDMA1x,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
+        ),
+        (
+          CTRadioAccessTechnologyHSDPA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
+        ),
+        (
+          CTRadioAccessTechnologyHSUPA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORev0,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORevA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
+        ),
+        (
+          CTRadioAccessTechnologyCDMAEVDORevB,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
+        ),
+        (
+          CTRadioAccessTechnologyeHRPD,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
+        ),
+        (
+          CTRadioAccessTechnologyLTE,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
+        ),
+        (
+          CTRadioAccessTechnologyNRNSA,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+        ),
+        (
+          CTRadioAccessTechnologyNR,
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
+        ),
+        (
+          "random",
+          firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
+        ),
+      ]
 
-              testProtoAndDecodedProto(sessionEvent: event) { proto in
-                XCTAssertEqual(
-                  event.proto.application_info.apple_app_info.network_connection_info
-                    .mobile_subtype,
-                  expected
-                )
-              }
-          }
-      }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-  #else // swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst)
-      func test_convertMobileSubtype_convertsCorrectlyPreOS14() {
-        let expectations: [(
-          given: String,
-          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        )] = [
-          (
-            CTRadioAccessTechnologyGPRS,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-          ),
-          (
-            CTRadioAccessTechnologyEdge,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-          ),
-          (
-            CTRadioAccessTechnologyWCDMA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyCDMA1x,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyHSDPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-          ),
-          (
-            CTRadioAccessTechnologyHSUPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORev0,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevB,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-          ),
-          (
-            CTRadioAccessTechnologyeHRPD,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-          ),
-          (
-            CTRadioAccessTechnologyLTE,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-          ),
-          (
-            "random",
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          ),
-        ]
+      expectations
+        .forEach { (given: String,
+                    expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
+            let mockNetworkInfo = MockNetworkInfo()
+            mockNetworkInfo.mobileSubtype = given
+            appInfo.networkInfo = mockNetworkInfo
 
-        expectations
-          .forEach { (given: String,
-                      expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
-              let mockNetworkInfo = MockNetworkInfo()
-              mockNetworkInfo.mobileSubtype = given
-              appInfo.networkInfo = mockNetworkInfo
+            let event = SessionStartEvent(
+              sessionInfo: self.defaultSessionInfo,
+              appInfo: appInfo,
+              time: time
+            )
 
-              let event = SessionStartEvent(
-                sessionInfo: self.defaultSessionInfo,
-                appInfo: appInfo,
-                time: time
+            // These fields will only be filled in when the Perf SDK is installed
+            event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
+
+            testProtoAndDecodedProto(sessionEvent: event) { proto in
+              XCTAssertEqual(
+                event.proto.application_info.apple_app_info.network_connection_info
+                  .mobile_subtype,
+                expected
               )
-
-              // These fields will only be filled in when the Perf SDK is installed
-              event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
-
-              testProtoAndDecodedProto(sessionEvent: event) { proto in
-                XCTAssertEqual(
-                  event.proto.application_info.apple_app_info.network_connection_info
-                    .mobile_subtype,
-                  expected
-                )
-              }
-          }
-      }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst)
-  #endif // swift(>=5.9)
-
-  #if swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-      @available(iOS 14.1, *)
-      func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
-        let expectations: [(
-          given: String,
-          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        )] = [
-          (
-            CTRadioAccessTechnologyGPRS,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-          ),
-          (
-            CTRadioAccessTechnologyEdge,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-          ),
-          (
-            CTRadioAccessTechnologyWCDMA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyCDMA1x,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyHSDPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-          ),
-          (
-            CTRadioAccessTechnologyHSUPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORev0,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevB,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-          ),
-          (
-            CTRadioAccessTechnologyeHRPD,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-          ),
-          (
-            CTRadioAccessTechnologyLTE,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-          ),
-          (
-            CTRadioAccessTechnologyNRNSA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          ),
-          (
-            CTRadioAccessTechnologyNR,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          ),
-          (
-            "random",
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          ),
-        ]
-
-        expectations
-          .forEach { (given: String,
-                      expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
-              let mockNetworkInfo = MockNetworkInfo()
-              mockNetworkInfo.mobileSubtype = given
-              appInfo.networkInfo = mockNetworkInfo
-
-              let event = SessionStartEvent(
-                sessionInfo: self.defaultSessionInfo,
-                appInfo: appInfo,
-                time: time
-              )
-
-              // These fields will only be filled in when the Perf SDK is installed
-              event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
-
-              testProtoAndDecodedProto(sessionEvent: event) { proto in
-                XCTAssertEqual(
-                  event.proto.application_info.apple_app_info.network_connection_info
-                    .mobile_subtype,
-                  expected
-                )
-              }
-          }
-      }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst) && !os(visionOS)
-  #else // swift(>=5.9)
-    #if os(iOS) && !targetEnvironment(macCatalyst)
-      @available(iOS 14.1, *)
-      func test_convertMobileSubtype_convertsCorrectlyPostOS14() {
-        let expectations: [(
-          given: String,
-          expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype
-        )] = [
-          (
-            CTRadioAccessTechnologyGPRS,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_GPRS
-          ),
-          (
-            CTRadioAccessTechnologyEdge,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EDGE
-          ),
-          (
-            CTRadioAccessTechnologyWCDMA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyCDMA1x,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_CDMA
-          ),
-          (
-            CTRadioAccessTechnologyHSDPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSDPA
-          ),
-          (
-            CTRadioAccessTechnologyHSUPA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_HSUPA
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORev0,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_0
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_A
-          ),
-          (
-            CTRadioAccessTechnologyCDMAEVDORevB,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EVDO_B
-          ),
-          (
-            CTRadioAccessTechnologyeHRPD,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_EHRPD
-          ),
-          (
-            CTRadioAccessTechnologyLTE,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_LTE
-          ),
-          (
-            CTRadioAccessTechnologyNRNSA,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          ),
-          (
-            CTRadioAccessTechnologyNR,
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_NR
-          ),
-          (
-            "random",
-            firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE
-          ),
-        ]
-
-        expectations
-          .forEach { (given: String,
-                      expected: firebase_appquality_sessions_NetworkConnectionInfo_MobileSubtype) in
-              let mockNetworkInfo = MockNetworkInfo()
-              mockNetworkInfo.mobileSubtype = given
-              appInfo.networkInfo = mockNetworkInfo
-
-              let event = SessionStartEvent(
-                sessionInfo: self.defaultSessionInfo,
-                appInfo: appInfo,
-                time: time
-              )
-
-              // These fields will only be filled in when the Perf SDK is installed
-              event.set(subscriber: .Performance, isDataCollectionEnabled: true, appInfo: appInfo)
-
-              testProtoAndDecodedProto(sessionEvent: event) { proto in
-                XCTAssertEqual(
-                  event.proto.application_info.apple_app_info.network_connection_info
-                    .mobile_subtype,
-                  expected
-                )
-              }
-          }
-      }
-    #endif // os(iOS) && !targetEnvironment(macCatalyst)
-  #endif // swift(>=5.9)
+            }
+        }
+    }
+  #endif // os(iOS) && !targetEnvironment(macCatalyst)
 }


### PR DESCRIPTION
In Xcode 15 beta 6, `#if os(iOS)` no longer evaluates to true when building for visionOS.

Note: `TARGET_OS_IOS` continues to be defined so Objective-C code is unchanged.