### PR TITLE
[visionOS] Fix Storage SDK build on Xcode 15 beta 6

### DIFF
--- a/FirebaseStorage/Sources/Internal/StorageUtils.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUtils.swift
@@ -17,7 +17,17 @@ import Foundation
   import MobileCoreServices
 #elseif os(macOS) || os(watchOS)
   import CoreServices
-#endif
+#endif // os(iOS) || os(tvOS)
+
+// swift(>=5.9) implies Xcode 15+
+// Need to have this Swift version check to use os(visionOS) macro, VisionOS support.
+// TODO: Remove this check and add `os(visionOS)` to the `os(iOS) || os(tvOS)` conditional above
+// when Xcode 15 is the minimum supported by Firebase.
+#if swift(>=5.9)
+  #if os(visionOS)
+    import MobileCoreServices
+  #endif // os(visionOS)
+#endif // swift(>=5.9)
 
 class StorageUtils {
   internal class func defaultRequestForReference(reference: StorageReference,


### PR DESCRIPTION
In Xcode 15 beta 6, `#if os(iOS)` no longer evaluates to true when building for visionOS.

Note: `TARGET_OS_IOS` continues to be defined so Objective-C code is unchanged.

#no-changelog -- Updated in #11666