### PR TITLE
Fix mutating array during iteration crash

### DIFF
--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -92,7 +92,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
   // Check if the experiment is in experiments but not payloads.
   for (id experiment in [experiments copy]) {
     BOOL doesExperimentNoLongerExist = YES;
-    for (NSData *payload in payloads) {
+    for (NSData *payload in [payloads copy]) {
       ABTExperimentPayload *experimentPayload = ABTDeserializeExperimentPayload(payload);
       if (!experimentPayload) {
         FIRLogInfo(kFIRLoggerABTesting, @"I-ABT000002",


### PR DESCRIPTION
@paulb777 @morganchen12 @karenyz Please take a look! This PR is a follow-up to https://github.com/firebase/firebase-ios-sdk/pull/11379

The above linked PR fixes iterating over an array that can be mutated simultaneously elsewhere, but it only fixes it for the `experiments` array. I have been seeing crashes in my app using FirebaseABTesting on 10.12.0, but for the `payloads` array. 

This file has three locations that iterate over `payloads`, and the two other locations do `[payloads copy]` to avoid this problem, and this is the last callsite of `payloads` in this file without a matching `copy` to avoid this crash.

Fixes:
<img width="1197" alt="Screenshot 2023-08-10 at 12 23 45 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/647626/738c87be-f8e6-41f0-bcdc-ed35b4077080">

Text:
```
Fatal Exception: NSGenericException
0  CoreFoundation                 0x9cb4 __exceptionPreprocess
1  libobjc.A.dylib                0x183d0 objc_exception_throw
2  CoreFoundation                 0x176920 -[__NSSingleObjectEnumerator init]
3  <redacted>                     0x436a0 ABTExperimentsToClearFromPayloads + 95 (FIRExperimentController.m:95)
4  <redacted>                     0x43db8 -[FIRExperimentController updateExperimentConditionalUserPropertiesWithServiceOrigin:events:policy:lastStartTime:payloads:completionHandler:] + 216 (FIRExperimentController.m:216)
5  <redacted>                     0x43c30 __117-[FIRExperimentController updateExperimentsWithServiceOrigin:events:policy:lastStartTime:payloads:completionHandler:]_block_invoke + 180 (FIRExperimentController.m:180)
6  libdispatch.dylib              0x2320 _dispatch_call_block_and_release
7  libdispatch.dylib              0x3eac _dispatch_client_callout
8  libdispatch.dylib              0x15a64 _dispatch_root_queue_drain
9  libdispatch.dylib              0x16158 _dispatch_worker_thread2
10 libsystem_pthread.dylib        0xda0 _pthread_wqthread
11 libsystem_pthread.dylib        0xb7c start_wqthread
```
