### PR TITLE
[App Check] Add generation of limited-use tokens with a TTL of 5 mins

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.h
@@ -39,12 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// artifact and an Firebase App Check token or rejected with an error.
 - (FBLPromise<FIRAppAttestAttestationResponse *> *)attestKeyWithAttestation:(NSData *)attestation
                                                                       keyID:(NSString *)keyID
-                                                                  challenge:(NSData *)challenge;
+                                                                  challenge:(NSData *)challenge
+                                                                 limitedUse:(BOOL)limitedUse;
 
 /// Exchanges attestation data (artifact & assertion) and a challenge for a FAC token.
 - (FBLPromise<FIRAppCheckToken *> *)getAppCheckTokenWithArtifact:(NSData *)artifact
                                                        challenge:(NSData *)challenge
-                                                       assertion:(NSData *)assertion;
+                                                       assertion:(NSData *)assertion
+                                                      limitedUse:(BOOL)limitedUse;
 
 @end
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/API/FIRAppAttestAPIService.m
@@ -35,6 +35,7 @@ static NSString *const kRequestFieldAssertion = @"assertion";
 static NSString *const kRequestFieldAttestation = @"attestation_statement";
 static NSString *const kRequestFieldChallenge = @"challenge";
 static NSString *const kRequestFieldKeyID = @"key_id";
+static NSString *const kRequestFieldLimitedUse = @"limited_use";
 
 static NSString *const kExchangeAppAttestAssertionEndpoint = @"exchangeAppAttestAssertion";
 static NSString *const kExchangeAppAttestAttestationEndpoint = @"exchangeAppAttestAttestation";
@@ -71,10 +72,14 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 - (FBLPromise<FIRAppCheckToken *> *)getAppCheckTokenWithArtifact:(NSData *)artifact
                                                        challenge:(NSData *)challenge
-                                                       assertion:(NSData *)assertion {
+                                                       assertion:(NSData *)assertion
+                                                      limitedUse:(BOOL)limitedUse {
   NSURL *URL = [self URLForEndpoint:kExchangeAppAttestAssertionEndpoint];
 
-  return [self HTTPBodyWithArtifact:artifact challenge:challenge assertion:assertion]
+  return [self HTTPBodyWithArtifact:artifact
+                          challenge:challenge
+                          assertion:assertion
+                         limitedUse:limitedUse]
       .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:kHTTPMethodPost
@@ -150,10 +155,14 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 - (FBLPromise<FIRAppAttestAttestationResponse *> *)attestKeyWithAttestation:(NSData *)attestation
                                                                       keyID:(NSString *)keyID
-                                                                  challenge:(NSData *)challenge {
+                                                                  challenge:(NSData *)challenge
+                                                                 limitedUse:(BOOL)limitedUse {
   NSURL *URL = [self URLForEndpoint:kExchangeAppAttestAttestationEndpoint];
 
-  return [self HTTPBodyWithAttestation:attestation keyID:keyID challenge:challenge]
+  return [self HTTPBodyWithAttestation:attestation
+                                 keyID:keyID
+                             challenge:challenge
+                            limitedUse:limitedUse]
       .then(^FBLPromise<GULURLSessionDataResponse *> *(NSData *HTTPBody) {
         return [self.APIService sendRequestWithURL:URL
                                         HTTPMethod:kHTTPMethodPost
@@ -177,7 +186,8 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 - (FBLPromise<NSData *> *)HTTPBodyWithArtifact:(NSData *)artifact
                                      challenge:(NSData *)challenge
-                                     assertion:(NSData *)assertion {
+                                     assertion:(NSData *)assertion
+                                    limitedUse:(BOOL)limitedUse {
   if (artifact.length <= 0 || challenge.length <= 0 || assertion.length <= 0) {
     FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
     [rejectedPromise reject:[FIRAppCheckErrorUtil
@@ -190,7 +200,8 @@ static NSString *const kHTTPMethodPost = @"POST";
                             id JSONObject = @{
                               kRequestFieldArtifact : [self base64StringWithData:artifact],
                               kRequestFieldChallenge : [self base64StringWithData:challenge],
-                              kRequestFieldAssertion : [self base64StringWithData:assertion]
+                              kRequestFieldAssertion : [self base64StringWithData:assertion],
+                              kRequestFieldLimitedUse : @(limitedUse)
                             };
 
                             return [self HTTPBodyWithJSONObject:JSONObject];
@@ -199,7 +210,8 @@ static NSString *const kHTTPMethodPost = @"POST";
 
 - (FBLPromise<NSData *> *)HTTPBodyWithAttestation:(NSData *)attestation
                                             keyID:(NSString *)keyID
-                                        challenge:(NSData *)challenge {
+                                        challenge:(NSData *)challenge
+                                       limitedUse:(BOOL)limitedUse {
   if (attestation.length <= 0 || keyID.length <= 0 || challenge.length <= 0) {
     FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
     [rejectedPromise reject:[FIRAppCheckErrorUtil
@@ -212,7 +224,8 @@ static NSString *const kHTTPMethodPost = @"POST";
                             id JSONObject = @{
                               kRequestFieldKeyID : keyID,
                               kRequestFieldAttestation : [self base64StringWithData:attestation],
-                              kRequestFieldChallenge : [self base64StringWithData:challenge]
+                              kRequestFieldChallenge : [self base64StringWithData:challenge],
+                              kRequestFieldLimitedUse : @(limitedUse)
                             };
 
                             return [self HTTPBodyWithJSONObject:JSONObject];

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -338,7 +338,12 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
   return
       [FBLPromise wrapObjectOrErrorCompletion:^(
                       FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
-        [self.appCheckProvider getTokenWithCompletion:handler];
+        if ([self.appCheckProvider
+                respondsToSelector:@selector(getLimitedUseTokenWithCompletion:)]) {
+          [self.appCheckProvider getLimitedUseTokenWithCompletion:handler];
+        } else {
+          [self.appCheckProvider getTokenWithCompletion:handler];
+        }
       }].then(^id _Nullable(FIRAppCheckToken *_Nullable token) {
         return token;
       });

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h
@@ -25,12 +25,26 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(AppCheckProvider)
 @protocol FIRAppCheckProvider <NSObject>
 
+@required
+
 /// Returns a new Firebase App Check token.
 /// @param handler The completion handler. Make sure to call the handler with either a token
 /// or an error.
 - (void)getTokenWithCompletion:
     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(getToken(completion:));
+
+@optional
+
+/// Returns a new Firebase App Check token.
+/// When implementing this method for your custom provider, the token returned should be suitable
+/// for consumption in a limited-use scenario. If you do not implement this method, then
+/// `getTokenWithCompletion:` will be invoked instead whenever a limited-use token is requested.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getLimitedUseTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
 
 @end
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestAPIServiceTests.m
@@ -232,7 +232,8 @@
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -270,7 +271,8 @@
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -305,7 +307,8 @@
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService getAppCheckTokenWithArtifact:artifact
                                                                      challenge:challenge
-                                                                     assertion:assertion];
+                                                                     assertion:assertion
+                                                                    limitedUse:NO];
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
 
@@ -340,7 +343,8 @@
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -377,7 +381,8 @@
   // 2. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 3. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));
@@ -411,7 +416,8 @@
   // 3. Send request.
   __auto_type promise = [self.appAttestAPIService attestKeyWithAttestation:attestation
                                                                      keyID:keyID
-                                                                 challenge:challenge];
+                                                                 challenge:challenge
+                                                                limitedUse:NO];
 
   // 4. Verify.
   XCTAssert(FBLWaitForPromisesWithTimeout(1));

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -146,7 +146,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 3. Call get token.
   XCTestExpectation *completionExpectation =
@@ -212,8 +214,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
       [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:generatedKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 8. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:generatedKeyID])
@@ -286,8 +293,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
       [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:existingKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 9. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:existingKeyID])
@@ -345,7 +357,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 6. Call get token.
   XCTestExpectation *completionExpectation =
@@ -403,7 +417,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't exchange API request.
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -462,8 +478,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                            userInfo:nil];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData
                                                     keyID:existingKeyID
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:exchangeError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -502,8 +523,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   FIRAppCheckHTTPError *APIError = [self attestationRejectionHTTPError];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData1
                                                     keyID:keyID1
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -521,8 +547,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
       [[FIRAppAttestAttestationResponse alloc] initWithArtifact:artifactData token:FACToken];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:attestKeyResponse]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Expect the artifact received from Firebase backend to be saved.
   OCMExpect([self.mockArtifactStorage setArtifact:artifactData forKey:keyID2])
@@ -559,8 +590,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   FIRAppCheckHTTPError *APIError = [self attestationRejectionHTTPError];
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData1
                                                     keyID:keyID1
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 4. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -573,8 +609,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Expect exchange request to be sent.
   OCMExpect([self.mockAPIService attestKeyWithAttestation:attestationData2
                                                     keyID:keyID2
-                                                challenge:self.randomChallenge])
+                                                challenge:self.randomChallenge
+                                               limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:APIError]);
+  OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
+                                                    keyID:OCMOCK_ANY
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:YES]);
 
   // 7. Stored attestation to be reset.
   [self expectAttestationReset];
@@ -631,7 +672,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't expect assertion request to be sent.
   OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
                                                     challenge:OCMOCK_ANY
-                                                    assertion:OCMOCK_ANY]);
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -682,7 +725,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6. Don't expect assertion request to be sent.
   OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
                                                     challenge:OCMOCK_ANY
-                                                    assertion:OCMOCK_ANY]);
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -734,8 +779,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                       userInfo:nil];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([self rejectedPromiseWithError:tokenExchangeError]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =
@@ -792,8 +842,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:FACToken]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token several times.
   NSInteger callsCount = 10;
@@ -866,8 +921,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   // 6.2. Stub assertion request.
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn(assertionRequestPromise);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
   // 6.3. Create an expected error to be rejected with later.
   NSError *assertionRequestError = [NSError errorWithDomain:self.name code:0 userInfo:nil];
 
@@ -925,7 +985,9 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                completionHandler:OCMOCK_ANY]);
   OCMReject([self.mockAPIService attestKeyWithAttestation:OCMOCK_ANY
                                                     keyID:OCMOCK_ANY
-                                                challenge:OCMOCK_ANY]);
+                                                challenge:OCMOCK_ANY
+                                               limitedUse:NO])
+      .ignoringNonObjectArgs();
 
   // 3. Call get token.
   XCTestExpectation *completionExpectation =
@@ -1020,8 +1082,13 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
                                                         expirationDate:[NSDate date]];
   OCMExpect([self.mockAPIService getAppCheckTokenWithArtifact:storedArtifact
                                                     challenge:self.randomChallenge
-                                                    assertion:assertion])
+                                                    assertion:assertion
+                                                   limitedUse:NO])
       .andReturn([FBLPromise resolvedWith:FACToken]);
+  OCMReject([self.mockAPIService getAppCheckTokenWithArtifact:OCMOCK_ANY
+                                                    challenge:OCMOCK_ANY
+                                                    assertion:OCMOCK_ANY
+                                                   limitedUse:YES]);
 
   // 7. Call get token.
   XCTestExpectation *completionExpectation =

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -563,7 +563,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   // 2. Expect token requested from app check provider.
   FIRAppCheckToken *expectedToken = [self validToken];
   id completionArg = [OCMArg invokeBlockWithArgs:expectedToken, [NSNull null], nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
+  OCMExpect([self.mockAppCheckProvider getLimitedUseTokenWithCompletion:completionArg]);
 
   // 3. Don't expect token requested from storage.
   OCMReject([self.mockStorage setToken:expectedToken]);
@@ -592,7 +592,7 @@ static NSString *const kDummyToken = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
   // 2. Expect error when requesting token from app check provider.
   NSError *providerError = [FIRAppCheckErrorUtil keychainErrorWithError:[self internalError]];
   id completionArg = [OCMArg invokeBlockWithArgs:[NSNull null], providerError, nil];
-  OCMExpect([self.mockAppCheckProvider getTokenWithCompletion:completionArg]);
+  OCMExpect([self.mockAppCheckProvider getLimitedUseTokenWithCompletion:completionArg]);
 
   // 3. Don't expect token requested from app check provider.
   OCMReject([self.mockAppCheckProvider getTokenWithCompletion:[OCMArg any]]);


### PR DESCRIPTION
Added support for generating App Check tokens with a TTL of 5 minutes when requesting limited-use tokens. This extends upon #11086, which added the ability to request limited-use tokens that aren't cached.

This is implemented by adding an optional `getLimitedUseTokenWithCompletion:` method to the `FIRAppCheckProvider` protocol. When requesting a limited-use token through the public API [`limitedUseTokenWithCompletion:`](https://github.com/firebase/firebase-ios-sdk/blob/8101179fc9ceb31e4e86e32dbeca653dc26bbe08/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h#L74-L83) or through the interop API [`getLimitedUseTokenWithCompletion:`](https://github.com/firebase/firebase-ios-sdk/blob/8101179fc9ceb31e4e86e32dbeca653dc26bbe08/FirebaseAppCheck/Interop/FIRAppCheckInterop.h#L50-L52), the new `FIRAppCheckProvider` method `getLimitedUseTokenWithCompletion:` will be called instead of the existing `getTokenWithCompletion:` method, if implemented by the provider (e.g., `FIRAppAttestProvider`).

TODOs:
- [x] Add `getLimitedUseTokenWithCompletion:` to `FIRAppCheckProvider`
- [ ] Call `getLimitedUseTokenWithCompletion:` from `FIRAppCheck` in:
  - [x] Public API `limitedUseTokenWithCompletion:`
  - [ ] Interop API `getLimitedUseTokenWithCompletion:`
- [ ] Implement `getLimitedUseTokenWithCompletion:` in providers:
  - [x] `FIRAppAttestProvider`
  - [ ] `FIRAppCheckDebugProvider`
  - [ ] `FIRDeviceCheckProvider`
- [ ] Update existing tests to ensure existing behaviour is unchanged
- [ ] Add new tests to check limited-use methods set `limitedUse` as `YES`
- [ ] Add CHANGELOG entry

#no-changelog