### PR TITLE
Fix FIRCLSContextInitData crash

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -38,6 +38,7 @@ __BEGIN_DECLS
 @class FIRCLSSettings;
 @class FIRCLSInstallIdentifierModel;
 @class FIRCLSFileManager;
+@class FIRCLSContextInitData;
 #endif
 
 typedef struct {
@@ -80,29 +81,13 @@ typedef struct {
   FIRCLSReadWriteContext* writable;
   FIRCLSAllocatorRef allocator;
 } FIRCLSContext;
-
-typedef struct {
-  const char* customBundleId;
-  const char* rootPath;
-  const char* previouslyCrashedFileRootPath;
-  const char* sessionId;
-  const char* appQualitySessionId;
-  const char* betaToken;
-  bool errorsEnabled;
-  bool customExceptionsEnabled;
-  uint32_t maxCustomExceptions;
-  uint32_t maxErrorLogSize;
-  uint32_t maxLogSize;
-  uint32_t maxKeyValues;
-} FIRCLSContextInitData;
-
 #ifdef __OBJC__
 bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager* fileManager);
-FIRCLSContextInitData FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
-                                                 FIRCLSSettings* settings,
-                                                 FIRCLSFileManager* fileManager,
-                                                 NSString* appQualitySessionId);
-bool FIRCLSContextRecordMetadata(NSString* rootPath, const FIRCLSContextInitData* initData);
+FIRCLSContextInitData* FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
+                                                  FIRCLSSettings* settings,
+                                                  FIRCLSFileManager* fileManager,
+                                                  NSString* appQualitySessionId);
+bool FIRCLSContextRecordMetadata(NSString* rootPath, FIRCLSContextInitData* initData);
 #endif
 
 void FIRCLSContextBaseInit(void);

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
@@ -49,8 +49,8 @@
 
   _hasInitializedContext = true;
 
-  FIRCLSContextInitData initDataObj = self.buildInitData;
-  return FIRCLSContextInitialize(&initDataObj, self.fileManager);
+  FIRCLSContextInitData *initDataObj = self.buildInitData;
+  return FIRCLSContextInitialize(initDataObj, self.fileManager);
 }
 
 - (void)setAppQualitySessionId:(NSString *)appQualitySessionId {
@@ -64,13 +64,13 @@
     return;
   }
 
-  FIRCLSContextInitData initDataObj = self.buildInitData;
-  if (!FIRCLSContextRecordMetadata(self.report.path, &initDataObj)) {
+  FIRCLSContextInitData *initDataObj = self.buildInitData;
+  if (!FIRCLSContextRecordMetadata(self.report.path, initDataObj)) {
     FIRCLSErrorLog(@"Failed to write context file while updating App Quality Session ID");
   }
 }
 
-- (FIRCLSContextInitData)buildInitData {
+- (FIRCLSContextInitData *)buildInitData {
   return FIRCLSContextBuildInitData(self.report, self.settings, self.fileManager,
                                     self.appQualitySessionId);
 }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
@@ -1,0 +1,38 @@
+// Copyright 2023 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRCLSContextInitData : NSObject
+
+@property(nonatomic, copy, nullable) NSString* customBundleId;
+@property(nonatomic, copy) NSString* rootPath;
+@property(nonatomic, copy) NSString* previouslyCrashedFileRootPath;
+@property(nonatomic, copy) NSString* sessionId;
+@property(nonatomic, copy) NSString* appQualitySessionId;
+@property(nonatomic, copy) NSString* betaToken;
+@property(nonatomic) BOOL errorsEnabled;
+@property(nonatomic) BOOL customExceptionsEnabled;
+@property(nonatomic) uint32_t maxCustomExceptions;
+@property(nonatomic) uint32_t maxErrorLogSize;
+@property(nonatomic) uint32_t maxLogSize;
+@property(nonatomic) uint32_t maxKeyValues;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
@@ -1,0 +1,18 @@
+// Copyright 2023 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FIRCLSContextInitData.h"
+
+@implementation FIRCLSContextInitData
+@end

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FIRCLSContextInitData.h"
+#import "Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h"
 
 @implementation FIRCLSContextInitData
 @end


### PR DESCRIPTION
I'm getting a crash during startup using 10.13.0, 10.12.0, 10.3.0 and master.
This happens on an iPad (6th generation) running 16.6.

<img width="1191" alt="Screenshot 2023-08-18 at 11 52 31 AM" src="https://github.com/firebase/firebase-ios-sdk/assets/1197020/590fc6f0-eb2c-490f-9031-906d8fd7476f">



It happens all the time with our app when the Address Sanitizer is on and Detect use of stack after return is on.

<img width="440" alt="Screenshot 2023-08-18 at 3 03 36 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/1197020/c1a6c918-d21e-4f66-adba-a3e6088312ff">

### The Problem

In [FIRCLSContextManager setupContextWithReport:settings:fileManager],

1. A instance of the FIRCLSContextInitData struct is assigned to initDataObj but it's still a struct.
2. The pointer of it is assigned to initData.
3. The initData pointer is passed to asynchronous functions. The pointer is captured by not what it points at.
4. FIRCLSContextInitData returns
5. When the async functions run they try to access the stack and crash.

### The Fix

In this PR I've made FIRCLSContextInitData a class and copy the strings into it instead of storing a pointer to the private buffer inside NSString that UTF8String returns. Being a class it will get captured in the async blocks and dealloc'ed after the last use.

### Related tickets.

[#8883](https://github.com/firebase/firebase-ios-sdk/issues/8883)
[#10104](https://github.com/firebase/firebase-ios-sdk/issues/10104)
[#9254](https://github.com/firebase/firebase-ios-sdk/issues/9254)
[PR #10750](https://github.com/firebase/firebase-ios-sdk/pull/10750)

