### PR TITLE
Run xcodebuild in parallel for firestore

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -338,10 +338,10 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     name: Check all required Firestore tests results
-    needs: [cmake, cmake-prod-db, xcodebuild]
+    needs: [cmake, cmake-prod-db, xcodebuild, spm]
     steps:
       - name: Check test matrix
-        if: needs.cmake.result == 'failure' || needs.cmake-prod-db.result == 'failure' || needs.xcodebuild.result == 'failure'
+        if: needs.cmake.result == 'failure' || needs.cmake-prod-db.result == 'failure' || needs.xcodebuild.result == 'failure' || needs.spm.result == 'failure'
         run: exit 1
 
 

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -57,7 +57,7 @@ jobs:
               # Note that this doesn't include check scripts because changing those will
               # already trigger the check workflow.
               - 'scripts/binary_to_array.py'
-              # - 'scripts/build.sh'
+              - 'scripts/build.sh'
               - 'scripts/install_prereqs.sh'
               - 'scripts/localize_podfile.swift'
               - 'scripts/pod_lib_lint.rb'
@@ -68,7 +68,7 @@ jobs:
               - 'scripts/xcresult_logs.py'
 
               # This workflow
-              # - '.github/workflows/firestore.yml'
+              - '.github/workflows/firestore.yml'
 
               # Rebuild on Ruby infrastructure changes.
               - 'Gemfile*'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -16,45 +16,6 @@ name: firestore
 
 on:
   pull_request:
-    paths:
-    # Firestore sources
-    - 'Firestore/**'
-
-    # Interop headers
-    - 'FirebaseAuth/Interop/*.h'
-
-    # FirebaseCore header change
-    - 'FirebaseCore/Internal'
-    - 'FirebaseCore/Sources/Public'
-
-    # Podspec
-    - 'FirebaseFirestore.podspec'
-
-    # CMake
-    - '**CMakeLists.txt'
-    - 'cmake/**'
-
-    # Build scripts to which Firestore is sensitive
-    #
-    # Note that this doesn't include check scripts because changing those will
-    # already trigger the check workflow.
-    - 'scripts/binary_to_array.py'
-    # - 'scripts/build.sh'
-    - 'scripts/install_prereqs.sh'
-    - 'scripts/localize_podfile.swift'
-    - 'scripts/pod_lib_lint.rb'
-    - 'scripts/run_firestore_emulator.sh'
-    - 'scripts/setup_*'
-    - 'scripts/sync_project.rb'
-    - 'scripts/test_quickstart.sh'
-    - 'scripts/xcresult_logs.py'
-
-    # This workflow
-    # - '.github/workflows/firestore.yml'
-
-    # Rebuild on Ruby infrastructure changes.
-    - 'Gemfile*'
-
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
     - cron:  '0 8 * * *'
@@ -64,9 +25,60 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: macos-12
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            changed:
+              # Firestore sources
+              - 'Firestore/**'
+
+              # Interop headers
+              - 'FirebaseAuth/Interop/*.h'
+
+              # FirebaseCore header change
+              - 'FirebaseCore/Internal'
+              - 'FirebaseCore/Sources/Public'
+
+              # Podspec
+              - 'FirebaseFirestore.podspec'
+
+              # CMake
+              - '**CMakeLists.txt'
+              - 'cmake/**'
+
+              # Build scripts to which Firestore is sensitive
+              #
+              # Note that this doesn't include check scripts because changing those will
+              # already trigger the check workflow.
+              - 'scripts/binary_to_array.py'
+              # - 'scripts/build.sh'
+              - 'scripts/install_prereqs.sh'
+              - 'scripts/localize_podfile.swift'
+              - 'scripts/pod_lib_lint.rb'
+              - 'scripts/run_firestore_emulator.sh'
+              - 'scripts/setup_*'
+              - 'scripts/sync_project.rb'
+              - 'scripts/test_quickstart.sh'
+              - 'scripts/xcresult_logs.py'
+
+              # This workflow
+              # - '.github/workflows/firestore.yml'
+
+              # Rebuild on Ruby infrastructure changes.
+              - 'Gemfile*'
+
   check:
+    needs: changes
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
@@ -83,10 +95,11 @@ jobs:
 
 
   cmake:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     needs: check
-
+    # Don't run on private repo unless it is a PR.
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     strategy:
       matrix:
         os: [macos-12, ubuntu-latest]
@@ -125,7 +138,9 @@ jobs:
 
   cmake-prod-db:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     needs: check
 
     strategy:
@@ -173,7 +188,9 @@ jobs:
 
   sanitizers:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     needs: check
 
     strategy:
@@ -210,7 +227,9 @@ jobs:
 
   xcodebuild:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
 
@@ -235,7 +254,9 @@ jobs:
 
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
     strategy:
@@ -298,7 +319,9 @@ jobs:
 
   spm:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
+      (needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
     steps:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -57,7 +57,7 @@ jobs:
               # Note that this doesn't include check scripts because changing those will
               # already trigger the check workflow.
               - 'scripts/binary_to_array.py'
-              # - 'scripts/build.sh'
+              - 'scripts/build.sh'
               - 'scripts/install_prereqs.sh'
               - 'scripts/localize_podfile.swift'
               - 'scripts/pod_lib_lint.rb'
@@ -68,17 +68,17 @@ jobs:
               - 'scripts/xcresult_logs.py'
 
               # This workflow
-              # - '.github/workflows/firestore.yml'
+              - '.github/workflows/firestore.yml'
 
               # Rebuild on Ruby infrastructure changes.
               - 'Gemfile*'
 
   check:
     needs: changes
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
@@ -96,10 +96,10 @@ jobs:
 
   cmake:
     needs: check
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     strategy:
       matrix:
         os: [macos-12, ubuntu-latest]
@@ -137,10 +137,10 @@ jobs:
 
 
   cmake-prod-db:
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     needs: check
 
     strategy:
@@ -187,10 +187,10 @@ jobs:
 
 
   sanitizers:
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     needs: check
 
     strategy:
@@ -226,10 +226,10 @@ jobs:
 
 
   xcodebuild:
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
 
@@ -253,10 +253,10 @@ jobs:
 
 
   pod-lib-lint:
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
     strategy:
@@ -318,10 +318,10 @@ jobs:
             --no-analyze
 
   spm:
-    # Don't run on private repo unless it is a PR.
+    # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
-      ((github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request') &&
-      (needs.changes.outputs.changed == 'true')
+      (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
+      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-12
     needs: check
     steps:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -39,7 +39,7 @@ on:
     # Note that this doesn't include check scripts because changing those will
     # already trigger the check workflow.
     - 'scripts/binary_to_array.py'
-    - 'scripts/build.sh'
+    # - 'scripts/build.sh'
     - 'scripts/install_prereqs.sh'
     - 'scripts/localize_podfile.swift'
     - 'scripts/pod_lib_lint.rb'
@@ -50,7 +50,7 @@ on:
     - 'scripts/xcresult_logs.py'
 
     # This workflow
-    - '.github/workflows/firestore.yml'
+    # - '.github/workflows/firestore.yml'
 
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile*'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -57,7 +57,7 @@ jobs:
               # Note that this doesn't include check scripts because changing those will
               # already trigger the check workflow.
               - 'scripts/binary_to_array.py'
-              - 'scripts/build.sh'
+              # - 'scripts/build.sh'
               - 'scripts/install_prereqs.sh'
               - 'scripts/localize_podfile.swift'
               - 'scripts/pod_lib_lint.rb'
@@ -68,7 +68,7 @@ jobs:
               - 'scripts/xcresult_logs.py'
 
               # This workflow
-              - '.github/workflows/firestore.yml'
+              # - '.github/workflows/firestore.yml'
 
               # Rebuild on Ruby infrastructure changes.
               - 'Gemfile*'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -332,6 +332,19 @@ jobs:
     - name: Swift Build
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift ${{ matrix.target }} spmbuildonly
 
+  # A job that fails if any required job in the test matrix fails,
+  # to be used as a required check for merging.
+  check-required-tests:
+    runs-on: ubuntu-latest
+    if: always()
+    name: Check all required Firestore tests results
+    needs: [cmake, cmake-prod-db, xcodebuild]
+    steps:
+      - name: Check test matrix
+        if: needs.cmake.result == 'failure' || needs.cmake-prod-db.result == 'failure' || needs.xcodebuild.result == 'failure'
+        run: exit 1
+
+
   # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept
   # Firebase UI 12
   # quickstart:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -330,10 +330,13 @@ case "$product-$platform-$method" in
     "${firestore_emulator}" start
     trap '"${firestore_emulator}" stop' ERR EXIT
 
+    nproc=$(sysctl -n hw.ncpu)
     RunXcodebuild \
         -workspace 'Firestore/Example/Firestore.xcworkspace' \
         -scheme "Firestore_IntegrationTests_$platform" \
         -enableCodeCoverage YES \
+        -parallelizeTargets \
+        -jobs ${nproc} \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -330,13 +330,10 @@ case "$product-$platform-$method" in
     "${firestore_emulator}" start
     trap '"${firestore_emulator}" stop' ERR EXIT
 
-    nproc=$(sysctl -n hw.ncpu)
     RunXcodebuild \
         -workspace 'Firestore/Example/Firestore.xcworkspace' \
         -scheme "Firestore_IntegrationTests_$platform" \
         -enableCodeCoverage YES \
-        -parallelizeTargets \
-        -jobs ${nproc} \
         "${xcb_flags[@]}" \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -338,7 +338,6 @@ case "$product-$platform-$method" in
         -parallelizeTargets \
         -jobs ${nproc} \
         "${xcb_flags[@]}" \
-        build \
         test
     ;;
 


### PR DESCRIPTION
This PR includes a few improvements to Firestore's CI jobs:

* Always trigger Firestore workflow, but change the workflow to skip its jobs if no firestore changes are detected.
* Introduce a new job `check-required-tests` to the workflow to check if all required jobs are successful or skipped. This should be the required check.
* Add parallelization parameters to xcodebuild
* Skip a `build` step with xcodebuild, and only do `test` which triggers `build` anyways. This removes a redundant `build` run. This should be applied to other components as well.

Workflow with firestore change: https://github.com/firebase/firebase-ios-sdk/actions/runs/5932626191/job/16086899587?pr=11708

Workflow without firestore change: https://github.com/firebase/firebase-ios-sdk/actions/runs/5939661290/job/16106528971?pr=11708