### PR TITLE
[auth-swift] Use headers instead of footers in Sample

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthProvider.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthProvider.swift
@@ -111,7 +111,7 @@ extension AuthProvider: DataSourceProvidable {
 
   static var emailPasswordSection: Section {
     let image = UIImage(named: "firebaseIcon")
-    let header = "Email & Password Login"
+    let header = "Email and Password Login"
     let item = Item(title: emailPassword.name, hasNestedContent: true, image: image)
     return Section(headerDescription: header, items: [item])
   }

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthProvider.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthProvider.swift
@@ -111,9 +111,9 @@ extension AuthProvider: DataSourceProvidable {
 
   static var emailPasswordSection: Section {
     let image = UIImage(named: "firebaseIcon")
+    let header = "Email & Password Login"
     let item = Item(title: emailPassword.name, hasNestedContent: true, image: image)
-    let footer = "A example login flow with password authentication."
-    return Section(footerDescription: footer, items: [item])
+    return Section(headerDescription: header, items: [item])
   }
 
   static var otherSection: Section {
@@ -128,7 +128,8 @@ extension AuthProvider: DataSourceProvidable {
       Item(title: anonymous.name, image: anonSymbol),
       Item(title: custom.name, image: shieldSymbol),
     ]
-    return Section(footerDescription: "Other authentication methods.", items: otherOptions)
+    let header = "Other Authentication Methods"
+    return Section(headerDescription: header, items: otherOptions)
   }
 
   static var sections: [Section] {

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
@@ -66,14 +66,9 @@ class UserViewController: UIViewController, DataSourceProviderDelegate {
 
   func didSelectRowAt(_ indexPath: IndexPath, on tableView: UITableView) {
     let item = dataSourceProvider.item(at: indexPath)
-    guard let title = item.detailTitle else {
-      return
-    }
+    let actionName = item.isEditable ? item.detailTitle! : item.title!
 
-    let actionName = item.isEditable ? title : item.title!
-
-    guard let action = UserAction(rawValue: actionName),
-          let title = item.detailTitle else {
+    guard let action = UserAction(rawValue: actionName) else {
       // The row tapped has no affiliated action.
       return
     }
@@ -95,17 +90,17 @@ class UserViewController: UIViewController, DataSourceProviderDelegate {
       deleteCurrentUser()
 
     case .updateEmail:
-      presentEditUserInfoController(for: title, to: updateUserEmail)
+      presentEditUserInfoController(for: actionName, to: updateUserEmail)
 
     case .updateDisplayName:
-      presentEditUserInfoController(for: title, to: updateUserDisplayName)
+      presentEditUserInfoController(for: actionName, to: updateUserDisplayName)
 
     case .updatePhotoURL:
-      presentEditUserInfoController(for: title, to: updatePhotoURL)
+      presentEditUserInfoController(for: actionName, to: updatePhotoURL)
 
     case .updatePhoneNumber:
       presentEditUserInfoController(
-        for: title + " formatted like +16509871234",
+        for: actionName + " formatted like +16509871234",
         to: updatePhoneNumber
       )
 


### PR DESCRIPTION
Go from first screen shot to second screenshot. The second and third sections are now labeled with headers instead of footers. (Also fix a logic bug introduced in UserViewController.swift in the previous PR)

![Screenshot 2023-08-21 at 1 57 35 PM](https://github.com/firebase/firebase-ios-sdk/assets/73870/632a8b31-5da8-47b4-bf12-64728f38d9b0)

![Screenshot 2023-08-21 at 1 57 53 PM](https://github.com/firebase/firebase-ios-sdk/assets/73870/9cd16f08-e95c-429e-987f-33dc3506d44d)
