### PR TITLE
Fix buildcache/ccache for Firestore workflow

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -105,14 +105,29 @@ jobs:
         os: [macos-12, ubuntu-latest]
 
     env:
-      CACHE_LAUNCHER: buildcache
+      MINT_PATH: ${{ github.workspace }}/mint
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: cmake-${{ matrix.os }}
+        cache_key: ${{ matrix.os }}
+
+    - name: Prepare ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          firestore-ccache-${{ runner.os }}-
+
+    - name: Cache Mint packages
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.MINT_PATH }}
+        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
@@ -143,7 +158,22 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: cmake-${{ matrix.os }}
+        cache_key: ${{ matrix.os }}
+
+    - name: Prepare ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          firestore-ccache-${{ runner.os }}-
+
+    - name: Cache Mint packages
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.MINT_PATH }}
+        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
 
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firestore.plist.gpg \
@@ -178,7 +208,15 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: cmake-${{ matrix.os }}-${{ matrix.sanitizer }}
+        cache_key: ${{ matrix.os }}
+
+    - name: Prepare ccache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
+        restore-keys: |
+          firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ${{ runner.temp }}
+        path: ${{ runner.temp }}/ccache
         key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-
@@ -132,7 +132,9 @@ jobs:
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
 
     - name: Build and test
-      run:  scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
+      run: |
+        export CCACHE_DIR=${{ runner.temp }}/ccache
+        scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
 
 
   cmake-prod-db:
@@ -159,7 +161,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ${{ runner.temp }}
+        path: ${{ runner.temp }}/ccache
         key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-
@@ -179,7 +181,9 @@ jobs:
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
 
     - name: Build and test
-      run:  scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
+      run: |
+        export CCACHE_DIR=${{ runner.temp }}/ccache
+        scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
 
 
   sanitizers:
@@ -206,7 +210,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ${{ runner.temp }}
+        path: ${{ runner.temp }}/ccache
         key: firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-
@@ -215,7 +219,9 @@ jobs:
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
 
     - name: Build and test
-      run:  scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
+      run: |
+        export CCACHE_DIR=${{ runner.temp }}/ccache
+        scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ runner.os }} cmake
 
 
   xcodebuild:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -162,9 +162,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ runner.temp }}/ccache
-        key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
+        key: firestore-ccache-${{ matrix.databaseId }}-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
-          firestore-ccache-${{ runner.os }}-
+          firestore-ccache-${{ matrix.databaseId }}-${{ runner.os }}-
 
     - name: Cache Mint packages
       uses: actions/cache@v3

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -110,9 +110,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
 
     - name: Prepare ccache
       uses: actions/cache@v3
@@ -156,9 +153,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
 
     - name: Prepare ccache
       uses: actions/cache@v3
@@ -206,9 +200,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
 
     - name: Prepare ccache
       uses: actions/cache@v3

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   changes:
     runs-on: macos-12
+    # Only when this is not a scheduled run
+    if: github.event_name != 'schedule'
     outputs:
       changed: ${{ steps.changes.outputs.changed }}
     steps:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ~/.ccache
+        path: ${{ runner.temp }}
         key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-
@@ -157,7 +157,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ~/.ccache
+        path: ${{ runner.temp }}
         key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-
@@ -204,7 +204,7 @@ jobs:
     - name: Prepare ccache
       uses: actions/cache@v3
       with:
-        path: ~/.ccache
+        path: ${{ runner.temp }}
         key: firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
         restore-keys: |
           firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -211,9 +211,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ runner.temp }}/ccache
-        key: firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
+        key: ${{ matrix.sanitizer }}-firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
-          firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-
+          ${{ matrix.sanitizer }}-firestore-ccache-${{ runner.os }}-
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -105,29 +105,14 @@ jobs:
         os: [macos-12, ubuntu-latest]
 
     env:
-      MINT_PATH: ${{ github.workspace }}/mint
+      CACHE_LAUNCHER: buildcache
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: ${{ matrix.os }}
-
-    - name: Prepare ccache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
-        restore-keys: |
-          firestore-ccache-${{ runner.os }}-
-
-    - name: Cache Mint packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.MINT_PATH }}
-        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
+        cache_key: cmake-${{ matrix.os }}
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
@@ -158,22 +143,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: ${{ matrix.os }}
-
-    - name: Prepare ccache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: firestore-ccache-${{ runner.os }}-${{ github.sha }}
-        restore-keys: |
-          firestore-ccache-${{ runner.os }}-
-
-    - name: Cache Mint packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.MINT_PATH }}
-        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-        restore-keys: ${{ runner.os }}-mint-
+        cache_key: cmake-${{ matrix.os }}
 
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firestore.plist.gpg \
@@ -208,15 +178,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: ${{ matrix.os }}
-
-    - name: Prepare ccache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
-        restore-keys: |
-          firestore-ccache-${{ runner.os }}-${{ matrix.sanitizer }}-
+        cache_key: cmake-${{ matrix.os }}-${{ matrix.sanitizer }}
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -241,7 +241,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
-        cache_key: ${{ matrix.os }}
+        cache_key: ${{ matrix.target }}
 
     - uses: ruby/setup-ruby@v1
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -279,6 +279,12 @@ if [[ -n "${SANITIZERS:-}" ]]; then
   done
 fi
 
+if [[ -n "${CACHE_LAUNCHER:-}" ]]; then
+  cmake_options+=(
+    -DCMAKE_C_COMPILER_LAUNCHER=${CACHE_LAUNCHER}
+    -DCMAKE_CXX_COMPILER_LAUNCHER=${CACHE_LAUNCHER}
+  )
+fi
 
 case "$product-$platform-$method" in
   FirebasePod-iOS-*)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -279,12 +279,6 @@ if [[ -n "${SANITIZERS:-}" ]]; then
   done
 fi
 
-if [[ -n "${CACHE_LAUNCHER:-}" ]]; then
-  cmake_options+=(
-    -DCMAKE_C_COMPILER_LAUNCHER=${CACHE_LAUNCHER}
-    -DCMAKE_CXX_COMPILER_LAUNCHER=${CACHE_LAUNCHER}
-  )
-fi
 
 case "$product-$platform-$method" in
   FirebasePod-iOS-*)


### PR DESCRIPTION
* Fix scheduled firestore workflow
* Fix buildcache/ccache for firestore workflow, this should help reduce the workflow runtime to around 30 minutes.