### PR TITLE
[Config] Merge RemoteConfig and its Swift extension in a non-breaking way

### DIFF
--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -40,6 +40,7 @@ app update.
     'FirebaseABTesting/Sources/Private/*.h',
     'FirebaseCore/Extension/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
+    'FirebaseRemoteConfigSwift/Sources/**/*.swift',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseRemoteConfig/*.h'
   s.pod_target_xcconfig = {
@@ -47,6 +48,7 @@ app update.
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
   s.dependency 'FirebaseABTesting', '~> 10.0'
+  s.dependency 'FirebaseSharedSwift', '~> 10.0'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -35,11 +35,10 @@ app update.
   s.prefix_header_file      = false
 
   s.source_files = [
-    'FirebaseRemoteConfigSwift/Sources/**/*.swift',
+    'FirebaseRemoteConfigSwift/Exporter/**/*.swift',
   ]
 
   s.dependency 'FirebaseRemoteConfig', '~> 10.0'
-  s.dependency 'FirebaseSharedSwift', '~> 10.0'
 
   # Run Swift API tests on a real backend.
   s.test_spec 'swift-api-tests' do |swift_api|

--- a/FirebaseRemoteConfigSwift/Exporter/Exporter.swift
+++ b/FirebaseRemoteConfigSwift/Exporter/Exporter.swift
@@ -1,0 +1,20 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(ncooke3): Add warning that importing this extension is deprecated.
+
+// The `@_exported` is needed to prevent breaking clients that are using
+// types prefixed with the `FirebaseRemoteConfigSwift` module name (e.g.
+// `FirebaseRemoteConfigSwift.RemoteConfigValueCodableError`).
+@_exported import FirebaseRemoteConfig

--- a/FirebaseRemoteConfigSwift/Sources/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/Codable.swift
@@ -15,8 +15,25 @@
  */
 
 import Foundation
-import FirebaseRemoteConfig
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+#endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
+
+#if SWIFT_PACKAGE
+  // This is a trick to force generate a `FirebaseRemoteConfig-Swift.h` header
+  // that re-exports `FirebaseRemoteConfigInternal` for Objective-C clients. It
+  // is important for the below code to reference a Remote Config symbol defined
+  // in Objective-C as that will import the symbol's module
+  // (`FirebaseRemoteConfigInternal`) in the generated header. This allows
+  // Objective-C clients to import Remote Config's Objective-C API using
+  // `@import FirebaseRemoteConfig;`. This API is not needed for Swift clients
+  // and is therefore hidden for them for the foreseeable future.
+  @available(iOS 100, *)
+  @objc public extension RemoteConfig {
+    var __do_not_call: String { "" }
+  }
+#endif // SWIFT_PACKAGE
 
 public enum RemoteConfigValueCodableError: Error {
   case unsupportedType(String)

--- a/FirebaseRemoteConfigSwift/Sources/FirebaseRemoteConfigValueDecoderHelper.swift
+++ b/FirebaseRemoteConfigSwift/Sources/FirebaseRemoteConfigValueDecoderHelper.swift
@@ -15,7 +15,9 @@
  */
 
 import Foundation
-import FirebaseRemoteConfig
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+#endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
 
 /// Implement the FirebaseRemoteConfigValueDecoding protocol for the shared Firebase decoder to

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigProperty.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigProperty.swift
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import FirebaseRemoteConfig
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+#endif // SWIFT_PACKAGE
+
 import SwiftUI
 
 /// A property wrapper that listens to a Remote Config value.

--- a/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
+++ b/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import FirebaseRemoteConfig
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+#endif // SWIFT_PACKAGE
 import FirebaseCore
 import SwiftUI
 

--- a/FirebaseRemoteConfigSwift/Sources/Value.swift
+++ b/FirebaseRemoteConfigSwift/Sources/Value.swift
@@ -15,7 +15,9 @@
  */
 
 import Foundation
-import FirebaseRemoteConfig
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+#endif // SWIFT_PACKAGE
 
 /// Implements subscript overloads to enable Remote Config values to be accessed
 /// in a type-safe way directly from the current config.

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import FirebaseRemoteConfig
-import FirebaseRemoteConfigSwift
 
 import XCTest
 

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
@@ -16,7 +16,7 @@
 
 import FirebaseCore
 import FirebaseRemoteConfig
-import FirebaseRemoteConfigSwift
+
 import XCTest
 
 let ConfigKeyForThisTestOnly = "PropertyWrapperDefaultConfigsTestsKey"

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
@@ -15,7 +15,7 @@
  */
 
 import FirebaseRemoteConfig
-import FirebaseRemoteConfigSwift
+
 import XCTest
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import FirebaseRemoteConfig
-import FirebaseRemoteConfigSwift
 
 import XCTest
 

--- a/Package.swift
+++ b/Package.swift
@@ -892,7 +892,9 @@ let package = Package(
       dependencies: [
         "FirebaseCore",
         "FirebaseInstallations",
-        "FirebaseRemoteConfig",
+        // TODO(ncooke3): Consider if this should import the merged module
+        // (`FirebaseRemoteConfig`).
+        "FirebaseRemoteConfigInternal",
         "FirebaseSessions",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
@@ -956,7 +958,7 @@ let package = Package(
     // MARK: - Firebase Remote Config
 
     .target(
-      name: "FirebaseRemoteConfig",
+      name: "FirebaseRemoteConfigInternal",
       dependencies: [
         "FirebaseCore",
         "FirebaseABTesting",
@@ -971,7 +973,7 @@ let package = Package(
     ),
     .testTarget(
       name: "RemoteConfigUnit",
-      dependencies: ["FirebaseRemoteConfig", .product(name: "OCMock", package: "ocmock")],
+      dependencies: ["FirebaseRemoteConfigInternal", .product(name: "OCMock", package: "ocmock")],
       path: "FirebaseRemoteConfig/Tests/Unit",
       exclude: [
         // Need to be evaluated/ported to RC V2.
@@ -991,16 +993,23 @@ let package = Package(
       ]
     ),
     .target(
-      name: "FirebaseRemoteConfigSwift",
+      name: "FirebaseRemoteConfig",
       dependencies: [
-        "FirebaseRemoteConfig",
+        "FirebaseRemoteConfigInternal",
         "FirebaseSharedSwift",
       ],
       path: "FirebaseRemoteConfigSwift/Sources"
     ),
+    .target(
+      name: "FirebaseRemoteConfigSwift",
+      dependencies: [
+        "FirebaseRemoteConfig",
+      ],
+      path: "FirebaseRemoteConfigSwift/Exporter"
+    ),
     .testTarget(
       name: "RemoteConfigFakeConsole",
-      dependencies: ["FirebaseRemoteConfigSwift",
+      dependencies: ["FirebaseRemoteConfig",
                      "RemoteConfigFakeConsoleObjC"],
       path: "FirebaseRemoteConfigSwift/Tests",
       exclude: [


### PR DESCRIPTION
The test specs to test the Swift library code are still part of the `RemoteConfigSwift.podspec`.  I'm leaving them there temporarily to reduce the amount of changes to get this tested across CI. 

I have also left the Swift library sources in the `RemoteConfigSwift` directory. These and the tests mentioned earlier should likely be moved into a reorganized `RemoteConfig` directory.

Different to #11386 in that this PR is aimed to merge the two libraries in a non-breaking way.

---

### CocoaPods approach

- The `FirebaseRemoteConfigSwift` pod now exports the `FirebaseRemoteConfig` module and has no APIs.
- The Swift extension sources are added to the `FirebaseRemoteConfig` pod, making it a mixed lang. pod.

### SPM approach

- The `FirebaseRemoteConfigSwift` target now exports the `FirebaseRemoteConfig` module and has no APIs.
- `FirebaseRemoteConfigSwift`'s previous Swift contents are moved into `FirebaseRemoteConfig`, and the ObjC sources that were in `FirebaseRemoteConfig` are moved into an internal target named `FirebaseRemoteConfigInternal`. See the SPM-specific workaround for re-exporting the ObjC API from the `FirebaseRemoteConfig` target that now contains only Swift extension APIs.

---

Test cases for ensuring this is non-breaking
- [x] Test ObjC app importing  `FirebaseRemoteConfig` via headers still builds/runs
  - [x] CocoaPods tested via `config / sample-build-test`
  - [x] SPM via `spm / client-app` (see `SwiftPMTests/ClientApp/ClientApp/objc-header-import-test.m`)
  - [x] Zip via Legacy RC quickstart [Manual]
- [x] Test ObjC app importing  `FirebaseRemoteConfig` via module import still builds/runs
  - [x] CocoaPods via CocoaPods via Legacy RC quickstart **[Manual]**
  - [x] SPM via `spm / client-app` (see `SwiftPMTests/ClientApp/ClientApp/objc-module-import-test.m`)
  - [x] Zip via Legacy RC quickstart [Manual]
- [x] See if an ObjC app can currently import `FirebaseRemoteConfigSwift` and/or `FirebaseRemoteConfigSwift-Swift.h`
  - I'd be surprised if there are ObjC apps importing `FirebaseRemoteConfigSwift`, but I'd like to understand the implications if one does.
    - I diff'd the `FirebaseRemoteConfigSwift-Swift.h` and there was no functional difference. Should be good here.
- [x] Test Swift app importing  `FirebaseRemoteConfigSwift` via module import still builds/runs
  - [x] CocoaPods via `remoteconfig / quickstart`
  - [x] SPM via `spm / client-app` AND SwiftUI RC app **[Manual]**
  - [x] Zip via zip workflow (see comment below)
- [x] Test Swift app importing  `FirebaseRemoteConfig` via module import still builds/runs
  - [x] CocoaPods via _Legacy_ RC quickstart **[Manual]**
  - [x] SPM via _Legacy_ RC quickstart **[Manual]**
  - [x] Zip via _Legacy_ RC quickstart **[Manual]**
---

Follow-up work:
- [ ] CHANGELOG.md
- [ ] Move Swift sources into `FirebaseRemoteConfig/`
- [ ] Figure out a solution for the tests specs in `FirebaseRemoteConfigSwift.podspec`