### PR TITLE
[#11736] Tests Housekeeping

### DIFF
--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -559,7 +559,7 @@ class IntegrationTests: XCTestCase {
           XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
           XCTAssertEqual("explicit nope", error.localizedDescription)
           XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
-                         error.userInfo["details"] as! [String: Int32])
+                         error.userInfo["details"] as? [String: Int32])
           expectation.fulfill()
           return
         }
@@ -591,7 +591,7 @@ class IntegrationTests: XCTestCase {
           XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
           XCTAssertEqual("explicit nope", error.localizedDescription)
           XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
-                         error.userInfo["details"] as! [String: Int32])
+                         error.userInfo["details"] as? [String: Int32])
         }
       }
     }

--- a/FirebaseSessions/Tests/Unit/RemoteSettingsTests.swift
+++ b/FirebaseSessions/Tests/Unit/RemoteSettingsTests.swift
@@ -25,7 +25,7 @@ class RemoteSettingsTests: XCTestCase {
       "sessions_enabled": false,
       "sampling_rate": 0.5,
       "session_timeout_seconds": 10,
-    ],
+    ] as [String: Any],
   ]
   let validSettings2: [String: Any] = [
     "cache_duration": 20,
@@ -33,7 +33,7 @@ class RemoteSettingsTests: XCTestCase {
       "sessions_enabled": true,
       "sampling_rate": 0.2,
       "session_timeout_seconds": 20,
-    ],
+    ] as [String: Any],
   ]
   let corruptedJSONString: String = "{{{{ non_key: non\"value {}"
   var cache: SettingsCacheClient!

--- a/FirebaseSessions/Tests/Unit/SessionsSettingsTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionsSettingsTests.swift
@@ -24,7 +24,7 @@ class SessionsSettingsTests: XCTestCase {
       "sessions_enabled": false,
       "sampling_rate": 0.5,
       "session_timeout_seconds": 10,
-    ],
+    ] as [String: Any],
   ]
 
   var cache: SettingsCacheClient!
@@ -65,8 +65,7 @@ class SessionsSettingsTests: XCTestCase {
   func test_NoRemoteAndDefaultsPresent_DefaultConfigsApply() {
     let emptySettings: [String: Any] = [
       "cache_duration": 10,
-      "app_quality": [
-      ],
+      "app_quality": [:] as [String: Any],
     ]
 
     cache.removeCache()

--- a/FirebaseSharedSwift/Tests/Codable/FirebaseDataEncoderTests.swift
+++ b/FirebaseSharedSwift/Tests/Codable/FirebaseDataEncoderTests.swift
@@ -268,7 +268,7 @@ class FirebaseFirebaseDataEncoderTests: XCTestCase {
             "weight": 79.2,
           ],
         ],
-      ],
+      ] as [String: Any],
       "id": 123,
     ] as [String: Any]
 
@@ -383,7 +383,7 @@ class FirebaseFirebaseDataEncoderTests: XCTestCase {
   func testClassHierarchy() {
     assertThat(SubModel(power: 100, name: "name", seconds: 123_456_789.123))
       .roundTrips(to: [
-        "super": ["superPower": 100, "superName": "name"],
+        "super": ["superPower": 100, "superName": "name"] as [String: Any],
         "timestamp": 123_456_789.123,
       ])
   }


### PR DESCRIPTION
[Closes #11736]

* Updated Firebase Functions’s `IntegrationTests` to prevent the testing process from crashing in case of test failure
* Updated `RemoteSettingsTests`, `SessionsSettingsTests`, and `FirebaseFirebaseDataEncoderTests` to generate fewer compiler warnings