### PR TITLE
[Infra] Speed up xcodebuilds by only testing

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -296,14 +296,12 @@ case "$product-$platform-$method" in
         -workspace 'FirebaseAuth/Tests/Sample/AuthSample.xcworkspace' \
         -scheme "Auth_ApiTests" \
         "${xcb_flags[@]}" \
-        build \
         test
 
       RunXcodebuild \
         -workspace 'FirebaseAuth/Tests/Sample/AuthSample.xcworkspace' \
         -scheme "SwiftApiTests" \
         "${xcb_flags[@]}" \
-        build \
         test
     fi
     ;;
@@ -323,7 +321,6 @@ case "$product-$platform-$method" in
         -workspace 'FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/InAppMessagingDisplay-Sample.xcworkspace' \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-        build \
         test
     ;;
 
@@ -387,7 +384,6 @@ case "$product-$platform-$method" in
         -scheme "FirebaseMessaging-Unit-integration" \
         "${ios_flags[@]}" \
         "${xcb_flags[@]}" \
-        build \
         test
     fi
 
@@ -572,7 +568,6 @@ case "$product-$platform-$method" in
         -scheme "FirebaseStorage-Unit-integration" \
         "${ios_flags[@]}" \
         "${xcb_flags[@]}" \
-        build \
         test
     fi
 
@@ -583,7 +578,6 @@ case "$product-$platform-$method" in
         -scheme "FirebaseStorage-Unit-ObjCIntegration" \
         "${ios_flags[@]}" \
         "${xcb_flags[@]}" \
-        build \
         test
       fi
     ;;
@@ -603,7 +597,6 @@ case "$product-$platform-$method" in
         -scheme "FirebaseCombineSwift-Unit-integration" \
         "${ios_flags[@]}" \
         "${xcb_flags[@]}" \
-        build \
         test
       fi
     ;;


### PR DESCRIPTION
See description in #11708. `xcodebuild test` will do a build so running `xcodebuild build test` is doing an extra build.

Outstanding follow-up work
- [ ] Some of the xcodebuild invocations don't look to ever be called on CI
- [ ] The script should trigger all CI workflows that depend on it

#no-changelog