### PR TITLE
[Passkey #1] startPasskeyEnrollment RPC call implementation

### DIFF
--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -243,6 +243,13 @@ typedef void (^FIRRevokeTokenResponseCallback)(FIRRevokeTokenResponse *_Nullable
 typedef void (^FIRSignInWithGameCenterResponseCallback)(
     FIRSignInWithGameCenterResponse *_Nullable response, NSError *_Nullable error);
 
+/** @typedef FIRStartPasskeyEnrollmentResponseCallback
+    @brief The type of block used to return the result of a call to the StartPasskeyEnrollment
+   endpoint.
+    @param response The received response, if any.
+    @param error The error which occurred, if any.
+    @remarks One of response or error will be non-nil.
+ */
 typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
     FIRStartPasskeyEnrollmentResponse *_Nullable response, NSError *_Nullable error);
 
@@ -431,6 +438,12 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
 + (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
 
+/** @fn startPasskeyEnrollment:callback:
+    @brief Calls the startPasskeyEnrollment endpoint, which is responsible for receving the
+   challenge that will later be consumed for platform key creation.
+    @param request The request parameters.
+    @param callback The callback.
+ */
 + (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
 
@@ -608,6 +621,12 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
 - (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
 
+/** @fn startPasskeyEnrollment:callback:
+    @brief Calls the startPasskeyEnrollment endpoint, which is responsible for receving the
+   challenge that will later be consumed for platform key creation.
+    @param request The request parameters.
+    @param callback The callback.
+ */
 - (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -56,6 +56,8 @@
 @class FIRSignUpNewUserResponse;
 @class FIRRevokeTokenRequest;
 @class FIRRevokeTokenResponse;
+@class FIRStartPasskeyEnrollmentRequest;
+@class FIRStartPasskeyEnrollmentResponse;
 
 @protocol FIRAuthBackendImplementation;
 @protocol FIRAuthBackendRPCIssuer;
@@ -240,6 +242,9 @@ typedef void (^FIRRevokeTokenResponseCallback)(FIRRevokeTokenResponse *_Nullable
  */
 typedef void (^FIRSignInWithGameCenterResponseCallback)(
     FIRSignInWithGameCenterResponse *_Nullable response, NSError *_Nullable error);
+
+typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
+    FIRStartPasskeyEnrollmentResponse *_Nullable response, NSError *_Nullable error);
 
 /** @class FIRAuthBackend
     @brief Simple static class with methods representing the backend RPCs.
@@ -426,6 +431,9 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
 + (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
 
++ (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
+                      callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
+
 #endif
 
 /** @fn revokeToken:callback:
@@ -599,6 +607,9 @@ typedef void (^FIRSignInWithGameCenterResponseCallback)(
  */
 - (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
+
+- (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
+                      callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
 
 #endif
 

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.h
@@ -438,6 +438,9 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
 + (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
 
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 /** @fn startPasskeyEnrollment:callback:
     @brief Calls the startPasskeyEnrollment endpoint, which is responsible for receving the
    challenge that will later be consumed for platform key creation.
@@ -446,7 +449,6 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
  */
 + (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
-
 #endif
 
 /** @fn revokeToken:callback:
@@ -621,6 +623,9 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
 - (void)verifyClient:(FIRVerifyClientRequest *)request
             callback:(FIRVerifyClientResponseCallback)callback;
 
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 /** @fn startPasskeyEnrollment:callback:
     @brief Calls the startPasskeyEnrollment endpoint, which is responsible for receving the
    challenge that will later be consumed for platform key creation.
@@ -629,7 +634,6 @@ typedef void (^FIRStartPasskeyEnrollmentResponseCallback)(
  */
 - (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback;
-
 #endif
 
 /** @fn revokeToken:callback:

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -56,6 +56,8 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSignInWithGameCenterResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserResponse.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyClientRequest.h"
@@ -611,6 +613,11 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [[self implementation] verifyClient:request callback:callback];
 }
 
++ (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
+                      callback:(FIRStartPasskeyEnrollmentResponseCallback)callback {
+  [[self implementation] startPasskeyEnrollment:request callback:callback];
+}
+
 #endif
 
 + (void)revokeToken:(FIRRevokeTokenRequest *)request
@@ -1019,6 +1026,20 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
 - (void)verifyClient:(id)request callback:(FIRVerifyClientResponseCallback)callback {
   FIRVerifyClientResponse *response = [[FIRVerifyClientResponse alloc] init];
+  [self postWithRequest:request
+               response:response
+               callback:^(NSError *error) {
+                 if (error) {
+                   callback(nil, error);
+                   return;
+                 }
+                 callback(response, nil);
+               }];
+}
+
+- (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
+                      callback:(FIRStartPasskeyEnrollmentResponseCallback)callback {
+  FIRStartPasskeyEnrollmentResponse *response = [[FIRStartPasskeyEnrollmentResponse alloc] init];
   [self postWithRequest:request
                response:response
                callback:^(NSError *error) {

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -613,11 +613,13 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   [[self implementation] verifyClient:request callback:callback];
 }
 
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 + (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback {
   [[self implementation] startPasskeyEnrollment:request callback:callback];
 }
-
 #endif
 
 + (void)revokeToken:(FIRRevokeTokenRequest *)request
@@ -1037,6 +1039,9 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                }];
 }
 
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 - (void)startPasskeyEnrollment:(FIRStartPasskeyEnrollmentRequest *)request
                       callback:(FIRStartPasskeyEnrollmentResponseCallback)callback {
   FIRStartPasskeyEnrollmentResponse *response = [[FIRStartPasskeyEnrollmentResponse alloc] init];
@@ -1050,7 +1055,6 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                  callback(response, nil);
                }];
 }
-
 #endif
 
 - (void)revokeToken:(FIRRevokeTokenRequest *)request

--- a/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthRPCRequest.h"
+#import "FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @class FIRStartPasskeyEnrollmentRequest
+    @brief Represents the parameters for the startPasskeyEnrollment endpoint.
+ */
+@interface FIRStartPasskeyEnrollmentRequest : FIRIdentityToolkitRequest <FIRAuthRPCRequest>
+
+/**
+ @property IDToken
+ @brief The raw user access token
+ */
+@property(nonatomic, copy, readonly) NSString *IDToken;
+
+- (nullable instancetype)initWithIDToken:(NSString *)IDToken
+                    requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.m
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @var kStartPasskeyEnrollmentEndPoint
+ @brief GCIP endpoint for startPasskeyEnrollment rpc
+ */
+static NSString *const kStartPasskeyEnrollmentEndPoint = @"accounts/passkeyEnrollment:start";
+
+/**
+ @var kTenantIDKey
+ @brief The key for the tenant id value in the request.
+ */
+static NSString *const kTenantIDKey = @"tenantId";
+
+/**
+ @var kIDToken
+ @brief The key for idToken value in the request.
+ */
+static NSString *const kIDToken = @"idToken";
+
+@implementation FIRStartPasskeyEnrollmentRequest
+
+- (nullable instancetype)initWithIDToken:(NSString *)IDToken
+                    requestConfiguration:(FIRAuthRequestConfiguration *)requestConfiguration {
+  self = [super initWithEndpoint:kStartPasskeyEnrollmentEndPoint
+            requestConfiguration:requestConfiguration
+             useIdentityPlatform:YES
+                      useStaging:NO];
+  if (self) {
+    _IDToken = IDToken;
+  }
+  return self;
+}
+
+- (nullable id)unencodedHTTPRequestBodyWithError:(NSError *__autoreleasing _Nullable *)error {
+  NSMutableDictionary *postBody = [NSMutableDictionary dictionary];
+  if (_IDToken) {
+    postBody[kIDToken] = _IDToken;
+  }
+  if (self.tenantID) {
+    postBody[kTenantIDKey] = self.tenantID;
+  }
+  return [postBody copy];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthRPCResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @class FIRStartPasskeyEnrollmentResponse
+ @brief Represents the response from the startPasskeyEnrollment endpoint.
+ */
+@interface FIRStartPasskeyEnrollmentResponse : NSObject <FIRAuthRPCResponse>
+
+/**
+ @property rpID
+ @brief The RP ID of the FIDO Relying Party.
+ */
+@property(nonatomic, readonly, copy) NSString *rpID;
+
+/**
+ @property userID
+ @brief The user ID.
+ */
+@property(nonatomic, readonly, copy) NSData *userID;
+
+/**
+ @property challenge
+ @brief The FIDO challenge.
+ */
+@property(nonatomic, readonly, copy) NSData *challenge;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.m
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h"
+
+/**
+ @var kOptionsKey
+ @brief The name of the field in the response JSON for CredentialCreationOptions.
+ */
+static const NSString *kOptionsKey = @"credentialCreationOptions";
+
+/**
+ @var kRpKey
+ @brief The name of the field in the response JSON for Relying Party.
+ */
+static const NSString *kRpKey = @"rp";
+
+/**
+ @var kUserKey
+ @brief The name of the field in the response JSON for User.
+ */
+static const NSString *kUserKey = @"user";
+
+/**
+ @var kIDKey
+ @brief The name of the field in the response JSON for ids.
+ */
+static const NSString *kIDKey = @"id";
+
+/**
+ @var kChallengeKey
+ @brief The name of the field in the response JSON for challenge.
+ */
+static const NSString *kChallengeKey = @"challenge";
+
+@implementation FIRStartPasskeyEnrollmentResponse
+
+- (BOOL)setWithDictionary:(nonnull NSDictionary *)dictionary
+                    error:(NSError *__autoreleasing _Nullable *_Nullable)error {
+  if (dictionary[kOptionsKey] == nil) {
+    return NO;
+  }
+  if (dictionary[kOptionsKey][kRpKey] == nil || dictionary[kOptionsKey][kRpKey][kIDKey] == nil) {
+    return NO;
+  }
+
+  if (dictionary[kOptionsKey][kUserKey] == nil ||
+      dictionary[kOptionsKey][kUserKey][kIDKey] == nil) {
+    return NO;
+  }
+
+  if (dictionary[kOptionsKey][kChallengeKey] == nil) {
+    return NO;
+  }
+
+  _rpID = dictionary[kOptionsKey][kRpKey][kIDKey];
+  _userID = dictionary[kOptionsKey][kUserKey][kIDKey];
+  _challenge = dictionary[kOptionsKey][kChallengeKey];
+  return YES;
+}
+
+@end

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 
 #import <XCTest/XCTest.h>
 

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <TargetConditionals.h>
+#if TARGET_OS_IOS
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthBackend+MultiFactor.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h"
+#import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+
+/**
+ @var kTestAPIKey
+ @brief Fake API key used for testing.
+ */
+static NSString *const kTestAPIKey = @"APIKey";
+
+/**
+ @var kTestFirebaseAppID
+ @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
+/**
+ @var kExpectedAPIURL
+ @brief The expected URL for the test calls.
+ */
+static NSString *const kExpectedAPIURL =
+    @"https://identitytoolkit.googleapis.com/v2/accounts/passkeyEnrollment:start?key=APIKey";
+
+/**
+ @var kIDToken
+ @brief Token representing the user's identity.
+ */
+static NSString *const kIDToken = @"idToken";
+
+/**
+ @class FIRStartPasskeyEnrollmentRequestTests
+ @brief Tests for @c FIRStartPasskeyEnrollmentRequest.
+ */
+@interface FIRStartPasskeyEnrollmentRequestTests : XCTestCase
+@end
+
+@implementation FIRStartPasskeyEnrollmentRequestTests {
+  /**
+   @brief This backend RPC issuer is used to fake network responses for each test in the suite.
+   In the @c setUp method we initialize this and set @c FIRAuthBackend's RPC issuer to it.
+   */
+  FIRFakeBackendRPCIssuer *_RPCIssuer;
+
+  /**
+   @brief This is the request configuration used for testing.
+   */
+  FIRAuthRequestConfiguration *_requestConfiguration;
+}
+
+- (void)setUp {
+  [super setUp];
+  FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
+  _RPCIssuer = RPCIssuer;
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
+}
+
+- (void)tearDown {
+  _RPCIssuer = nil;
+  _requestConfiguration = nil;
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [super tearDown];
+}
+
+- (void)testStartPasskeyEnrollmentRequest {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error){
+                                }];
+
+  XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
+  XCTAssertNotNil(_RPCIssuer.decodedRequest);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kIDToken], kIDToken);
+}
+
+@end
+#endif

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentRequestTests.m
@@ -19,7 +19,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseAuth/Sources/Backend/FIRAuthBackend+MultiFactor.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h"
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h"

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
@@ -24,13 +24,15 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
 #import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
 
-/** @var kTestAPIKey
-    @brief Fake API key used for testing.
+/**
+ @var kTestAPIKey
+ @brief Fake API key used for testing.
  */
 static NSString *const kTestAPIKey = @"APIKey";
 
-/** @var kTestFirebaseAppID
-    @brief Fake Firebase app ID used for testing.
+/**
+ @var kTestFirebaseAppID
+ @brief Fake Firebase app ID used for testing.
  */
 static NSString *const kTestFirebaseAppID = @"appID";
 
@@ -40,20 +42,58 @@ static NSString *const kTestFirebaseAppID = @"appID";
  */
 static NSString *const kIDToken = @"idToken";
 
-/** @var kUsersKey
-    @brief the name of the "users" property in the response.
+/**
+ @var kTestRpID
+ @brief Fake Relying Party ID used for testing.
+ */
+static NSString *const kTestRpID = @"1234567890";
+
+/**
+ @var kTestChallenge
+ @brief Fake challenge used for testing.
+ */
+static NSString *const kTestChallenge = @"challengebytes";
+
+/**
+ @var kTestUserID
+ @brief Fake user id used for testing.
+ */
+static NSString *const kTestUserID = @"user-id";
+
+/**
+ @var kUsersKey
+ @brief the name of the "users" property in the response.
  */
 static NSString *const kUsersKey = @"users";
 
+/**
+ @var kTestRpKey
+ @brief the name of the "rp" property in the response.
+ */
 static NSString *const kTestRpKey = @"rp";
+
+/**
+ @var kTestChallengeKey
+ @brief the name of the "challenge" property in the response.
+ */
 static NSString *const kTestChallengeKey = @"challenge";
+
+/**
+ @var kTestUserKey
+ @brief the name of the "user" property in the response.
+ */
 static NSString *const kTestUserKey = @"user";
+
+/**
+ @var kTestIDKey
+ @brief the name of the "id" property in the response.
+ */
 static NSString *const kTestIDKey = @"id";
 
-static NSString *const kTestRpID = @"1234567890";
-static NSString *const kTestChallenge = @"challengebytes";
-static NSString *const kTestUserID = @"user-id";
-
+/**
+ @class FIRStartPasskeyEnrollmentResponseTests
+ @brief Tests for @c FIRStartPasskeyEnrollmentResponse.
+ */
 @interface FIRStartPasskeyEnrollmentResponseTests : XCTestCase
 @end
 @implementation FIRStartPasskeyEnrollmentResponseTests {
@@ -85,8 +125,8 @@ static NSString *const kTestUserID = @"user-id";
   [super tearDown];
 }
 
-/** @fn testSuccessfulGetAccountInfoResponse
-    @brief This test simulates a successful @c GetAccountInfo flow.
+/** @fn testSuccessfulStartPasskeyEnrollmentResponse
+    @brief This test simulates a successful @c StartPasskeyEnrollment flow.
  */
 - (void)testSuccessfulStartPasskeyEnrollmentResponse {
   FIRStartPasskeyEnrollmentRequest *request =
@@ -121,9 +161,9 @@ static NSString *const kTestUserID = @"user-id";
   XCTAssertEqualObjects(RPCResponse.userID, kTestUserID);
 }
 
-/** @fn testGetAccountInfoUnexpectedResponseError
-    @brief This test simulates an unexpected response returned from server in @c GetAccountInfo
-        flow.
+/** @fn testStartPasskeyEnrollmentResponseMissingCreationOptionsError
+    @brief This test simulates an unexpected response returned from server in @c
+   StartPasskeyEnrollment flow.
  */
 - (void)testStartPasskeyEnrollmentResponseMissingCreationOptionsError {
   FIRStartPasskeyEnrollmentRequest *request =
@@ -150,6 +190,10 @@ static NSString *const kTestUserID = @"user-id";
                                      rpcResponse:RPCResponse];
 }
 
+/** @fn testStartPasskeyEnrollmentResponseMissingRpIdError
+    @brief This test simulates an unexpected response returned from server in @c
+   StartPasskeyEnrollment flow.
+ */
 - (void)testStartPasskeyEnrollmentResponseMissingRpIdError {
   FIRStartPasskeyEnrollmentRequest *request =
       [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
@@ -179,6 +223,10 @@ static NSString *const kTestUserID = @"user-id";
                                      rpcResponse:RPCResponse];
 }
 
+/** @fn testStartPasskeyEnrollmentResponseMissingUserIdError
+    @brief This test simulates an unexpected response returned from server in @c
+   StartPasskeyEnrollment flow.
+ */
 - (void)testStartPasskeyEnrollmentResponseMissingUserIdError {
   FIRStartPasskeyEnrollmentRequest *request =
       [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
@@ -208,6 +256,10 @@ static NSString *const kTestUserID = @"user-id";
                                      rpcResponse:RPCResponse];
 }
 
+/** @fn testStartPasskeyEnrollmentResponseMissingChallengeError
+    @brief This test simulates an unexpected response returned from server in @c
+   StartPasskeyEnrollment flow.
+ */
 - (void)testStartPasskeyEnrollmentResponseMissingChallengeError {
   FIRStartPasskeyEnrollmentRequest *request =
       [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
@@ -236,6 +288,10 @@ static NSString *const kTestUserID = @"user-id";
                                      rpcResponse:RPCResponse];
 }
 
+/** @fn errorValidationHelperWithCallbackInvoked
+    @brief Helper function to validate the unexpected response returned from server in @c
+   StartPasskeyEnrollment flow.
+ */
 - (void)errorValidationHelperWithCallbackInvoked:(BOOL)callbackInvoked
                                         rpcError:(NSError *)RPCError
                                      rpcResponse:(FIRStartPasskeyEnrollmentResponse *)RPCResponse {

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 #import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
@@ -307,3 +308,4 @@ static NSString *const kTestIDKey = @"id";
 }
 
 @end
+#endif

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
@@ -288,7 +288,7 @@ static NSString *const kTestIDKey = @"id";
                                      rpcResponse:RPCResponse];
 }
 
-/** @fn errorValidationHelperWithCallbackInvoked
+/** @fn errorValidationHelperWithCallbackInvoked:rpcError:rpcResponse:
     @brief Helper function to validate the unexpected response returned from server in @c
    StartPasskeyEnrollment flow.
  */

--- a/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRStartPasskeyEnrollmentResponseTests.m
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h"
+
+#import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentRequest.h"
+#import "FirebaseAuth/Sources/Backend/RPC/FIRStartPasskeyEnrollmentResponse.h"
+#import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
+#import "FirebaseAuth/Tests/Unit/FIRFakeBackendRPCIssuer.h"
+
+/** @var kTestAPIKey
+    @brief Fake API key used for testing.
+ */
+static NSString *const kTestAPIKey = @"APIKey";
+
+/** @var kTestFirebaseAppID
+    @brief Fake Firebase app ID used for testing.
+ */
+static NSString *const kTestFirebaseAppID = @"appID";
+
+/**
+ @var kIDToken
+ @brief Token representing the user's identity.
+ */
+static NSString *const kIDToken = @"idToken";
+
+/** @var kUsersKey
+    @brief the name of the "users" property in the response.
+ */
+static NSString *const kUsersKey = @"users";
+
+static NSString *const kTestRpKey = @"rp";
+static NSString *const kTestChallengeKey = @"challenge";
+static NSString *const kTestUserKey = @"user";
+static NSString *const kTestIDKey = @"id";
+
+static NSString *const kTestRpID = @"1234567890";
+static NSString *const kTestChallenge = @"challengebytes";
+static NSString *const kTestUserID = @"user-id";
+
+@interface FIRStartPasskeyEnrollmentResponseTests : XCTestCase
+@end
+@implementation FIRStartPasskeyEnrollmentResponseTests {
+  /**
+   @brief This backend RPC issuer is used to fake network responses for each test in the suite.
+   In the @c setUp method we initialize this and set @c FIRAuthBackend's RPC issuer to it.
+   */
+  FIRFakeBackendRPCIssuer *_RPCIssuer;
+
+  /**
+   @brief This is the request configuration used for testing.
+   */
+  FIRAuthRequestConfiguration *_requestConfiguration;
+}
+
+- (void)setUp {
+  [super setUp];
+  FIRFakeBackendRPCIssuer *RPCIssuer = [[FIRFakeBackendRPCIssuer alloc] init];
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:RPCIssuer];
+  _RPCIssuer = RPCIssuer;
+  _requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:kTestAPIKey
+                                                                        appID:kTestFirebaseAppID];
+}
+
+- (void)tearDown {
+  _RPCIssuer = nil;
+  _requestConfiguration = nil;
+  [FIRAuthBackend setDefaultBackendImplementationWithRPCIssuer:nil];
+  [super tearDown];
+}
+
+/** @fn testSuccessfulGetAccountInfoResponse
+    @brief This test simulates a successful @c GetAccountInfo flow.
+ */
+- (void)testSuccessfulStartPasskeyEnrollmentResponse {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRStartPasskeyEnrollmentResponse *RPCResponse;
+  __block NSError *RPCError;
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"credentialCreationOptions" : @{
+      kTestChallengeKey : kTestChallenge,
+      kTestRpKey : @{kTestIDKey : kTestRpID},
+      kTestUserKey : @{kTestIDKey : kTestUserID},
+    },
+  }];
+
+  XCTAssert(callbackInvoked);
+  XCTAssertNil(RPCError);
+  XCTAssertNotNil(RPCResponse);
+  XCTAssertEqualObjects(RPCResponse.rpID, kTestRpID);
+  XCTAssertEqualObjects(RPCResponse.challenge, kTestChallenge);
+  XCTAssertEqualObjects(RPCResponse.userID, kTestUserID);
+}
+
+/** @fn testGetAccountInfoUnexpectedResponseError
+    @brief This test simulates an unexpected response returned from server in @c GetAccountInfo
+        flow.
+ */
+- (void)testStartPasskeyEnrollmentResponseMissingCreationOptionsError {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRStartPasskeyEnrollmentResponse *RPCResponse;
+  __block NSError *RPCError;
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"wrongkey" : @{},
+  }];
+  [self errorValidationHelperWithCallbackInvoked:callbackInvoked
+                                        rpcError:RPCError
+                                     rpcResponse:RPCResponse];
+}
+
+- (void)testStartPasskeyEnrollmentResponseMissingRpIdError {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRStartPasskeyEnrollmentResponse *RPCResponse;
+  __block NSError *RPCError;
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"credentialCreationOptions" : @{
+      kTestChallengeKey : kTestChallenge,
+      kTestRpKey : @{},
+      kTestUserKey : @{kTestIDKey : kTestUserID},
+    },
+  }];
+  [self errorValidationHelperWithCallbackInvoked:callbackInvoked
+                                        rpcError:RPCError
+                                     rpcResponse:RPCResponse];
+}
+
+- (void)testStartPasskeyEnrollmentResponseMissingUserIdError {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRStartPasskeyEnrollmentResponse *RPCResponse;
+  __block NSError *RPCError;
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"credentialCreationOptions" : @{
+      kTestChallengeKey : kTestChallenge,
+      kTestRpKey : @{kTestIDKey : kTestRpID},
+      kTestUserKey : @{},
+    },
+  }];
+  [self errorValidationHelperWithCallbackInvoked:callbackInvoked
+                                        rpcError:RPCError
+                                     rpcResponse:RPCResponse];
+}
+
+- (void)testStartPasskeyEnrollmentResponseMissingChallengeError {
+  FIRStartPasskeyEnrollmentRequest *request =
+      [[FIRStartPasskeyEnrollmentRequest alloc] initWithIDToken:kIDToken
+                                           requestConfiguration:_requestConfiguration];
+
+  __block BOOL callbackInvoked;
+  __block FIRStartPasskeyEnrollmentResponse *RPCResponse;
+  __block NSError *RPCError;
+
+  [FIRAuthBackend startPasskeyEnrollment:request
+                                callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
+                                           NSError *_Nullable error) {
+                                  callbackInvoked = YES;
+                                  RPCResponse = response;
+                                  RPCError = error;
+                                }];
+
+  [_RPCIssuer respondWithJSON:@{
+    @"credentialCreationOptions" : @{
+      kTestRpKey : @{kTestIDKey : kTestRpID},
+      kTestUserKey : @{kTestIDKey : kTestUserID},
+    },
+  }];
+  [self errorValidationHelperWithCallbackInvoked:callbackInvoked
+                                        rpcError:RPCError
+                                     rpcResponse:RPCResponse];
+}
+
+- (void)errorValidationHelperWithCallbackInvoked:(BOOL)callbackInvoked
+                                        rpcError:(NSError *)RPCError
+                                     rpcResponse:(FIRStartPasskeyEnrollmentResponse *)RPCResponse {
+  XCTAssert(callbackInvoked);
+  XCTAssertNotNil(RPCError);
+  XCTAssertEqualObjects(RPCError.domain, FIRAuthErrorDomain);
+  XCTAssertEqual(RPCError.code, FIRAuthErrorCodeInternalError);
+  XCTAssertNotNil(RPCError.userInfo[NSUnderlyingErrorKey]);
+  NSError *underlyingError = RPCError.userInfo[NSUnderlyingErrorKey];
+  XCTAssertNotNil(underlyingError);
+  XCTAssertNotNil(underlyingError.userInfo[FIRAuthErrorUserInfoDeserializedResponseKey]);
+  XCTAssertNil(RPCResponse);
+}
+
+@end


### PR DESCRIPTION
Added startPasskeyEnrollmentRequest header and implementation
Added startPasskeyEnrollmentResponse header and implementation
Implemented the FIRAuthBackend startPasskeyEnrollment method
Added unit tests.