### PR TITLE
[Config] Lock down no-op API's availability for Swift clients

### DIFF
--- a/FirebaseRemoteConfig/Swift/Codable.swift
+++ b/FirebaseRemoteConfig/Swift/Codable.swift
@@ -20,21 +20,6 @@ import Foundation
 #endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
 
-#if SWIFT_PACKAGE
-  // This is a trick to force generate a `FirebaseRemoteConfig-Swift.h` header
-  // that re-exports `FirebaseRemoteConfigInternal` for Objective-C clients. It
-  // is important for the below code to reference a Remote Config symbol defined
-  // in Objective-C as that will import the symbol's module
-  // (`FirebaseRemoteConfigInternal`) in the generated header. This allows
-  // Objective-C clients to import Remote Config's Objective-C API using
-  // `@import FirebaseRemoteConfig;`. This API is not needed for Swift clients
-  // and is therefore hidden for them for the foreseeable future.
-  @available(iOS 100, *)
-  @objc public extension RemoteConfig {
-    var __do_not_call: String { "" }
-  }
-#endif // SWIFT_PACKAGE
-
 public enum RemoteConfigValueCodableError: Error {
   case unsupportedType(String)
 }

--- a/FirebaseRemoteConfig/Swift/SPMSwiftHeaderWorkaround.swift
+++ b/FirebaseRemoteConfig/Swift/SPMSwiftHeaderWorkaround.swift
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if SWIFT_PACKAGE
+  @_exported import FirebaseRemoteConfigInternal
+
+  // This is a trick to force generate a `FirebaseRemoteConfig-Swift.h` header
+  // that re-exports `FirebaseRemoteConfigInternal` for Objective-C clients. It
+  // is important for the below code to reference a Remote Config symbol defined
+  // in Objective-C as that will import the symbol's module
+  // (`FirebaseRemoteConfigInternal`) in the generated header. This allows
+  // Objective-C clients to import Remote Config's Objective-C API using
+  // `@import FirebaseRemoteConfig;`. This API is not needed for Swift clients
+  // and is therefore unavailable in a Swift context.
+  @available(*, unavailable)
+  @objc public extension RemoteConfig {
+    static var __no_op: () -> Void { {} }
+  }
+#endif // SWIFT_PACKAGE


### PR DESCRIPTION
This is an improvement over the old diff for a few reasons:
- Swift clients will now get a build error if they try to use the property (major improvement)
- Moved it to it's own file as it had nothing to do with the file it was previously in (minor improvement)
- IMO, naming it `__no_op` with a useless function seems a better name than `__do_not_call` that returns an empty string (minor improvement)
- I made the property static to reduce where it's scope of use. (minor improvement)
- The API no longer depends on any types from Foundation (minor improvement)

#no-changelog