### PR TITLE
[ConfigSwift] Fix `client_app / cocoapods` CI from #11769

### DIFF
--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -3,6 +3,7 @@ name: client_app
 on:
   pull_request:
     paths:
+      - "Firebase*"
       - ".github/workflows/client_app.yml"
       - "Package.swift"
       - ".swiftpm/*"

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -39,6 +39,7 @@ app update.
   ]
 
   s.dependency 'FirebaseRemoteConfig', '~> 10.0'
+  s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseSharedSwift', '~> 10.0'
 
   # Run Swift API tests on a real backend.


### PR DESCRIPTION
In #11769, the recent changes to merge the ConfigSwift SDK into the Config SDK were reverted while the API proposal awaits approval. One pair of PRs I didn't revert were #11734 & #11741, which set up a CocoaPods version of the previously existing `spm / client_app` workflow. In the revert PR (#11769), the `client_app / cocoapods` failed. I merged the PR thinking it could have been a tagging issue, but the workflow is still failing on `master`. I was able to reproduce the [error](https://github.com/firebase/firebase-ios-sdk/actions/runs/6053700887/job/16429712771) locally but am unsure what's going on. So, I checked out last release's tag, and cherry-picked in the changes to add the CocoaPods test app. I was able to get the same failure. So despite the failure involving RCSwift, it doesn't seem to be related to all the changes/reverts I've made with regard to RCSwift. Adding `FirebaseCore` in the RCSwift podspec fixes this. Like I said, I was only able to reproduce in the app used by the workflow, and since RCSwift will be changed in a way where this error won't happen in M138, I'm proposing this change to fix CI ahead of M137. 

Seems to be related to this file importing FirebaseCore but the podspec not depending on FirebaseCore: https://github.com/firebase/firebase-ios-sdk/blob/10.14.0/FirebaseRemoteConfigSwift/Sources/PropertyWrapper/RemoteConfigValueObservable.swift#L18


#no-changelog