### PR TITLE
[Release] Update Package.swift with 10.15.0 RC0 Firestore binary artifact URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1459,8 +1459,8 @@ func firestoreTarget() -> Target {
 
   return .binaryTarget(
     name: "FirebaseFirestore",
-    url: "https://dl.google.com/firebase/ios/bin/firestore/10.14.0/FirebaseFirestore.zip",
-    checksum: "c35d3c6dbb4cd16ea8bcb49b980578ccdd56ecb2e4835356d8cd1f52cb4cbd4d"
+    url: "https://dl.google.com/firebase/ios/bin/firestore/10.15.0/FirebaseFirestore.zip",
+    checksum: "67cffbd90c1c2a4bba40e1b8ded5f0d8cf530aebc4c0321406d616d3ac6d9865"
   )
 }
 


### PR DESCRIPTION
- update URL to point to 10.15.0 resource
- update checksum

#no-changelog