### PR TITLE
fix vision pro unit tests

### DIFF
--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -352,7 +352,7 @@ const char* FIRCLSMachOSliceGetArchitectureName(FIRCLSMachOSliceRef slice) {
 
   return archInfo->name;
 #else
-  const char* archname = macho_arch_name_for_mach_header(NULL);
+  const char* archname = macho_arch_name_for_mach_header(slice->startAddress);
 
   if (!archname) {
     return "unknown";


### PR DESCRIPTION
Relate to this change https://github.com/firebase/firebase-ios-sdk/pull/11515/files
Instead of passing NULL to macho_cpu_type_for_arch_name, we want to pass the slice header address to find correct arch for the dSYM.
<img width="805" alt="Screenshot 2023-09-12 at 3 07 11 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/16548721/d210695e-dff0-47c5-8c39-c0b9d16cf5eb">

#no-changelog
