### PR TITLE
[Database] Consolidate Database and DatabaseSwift

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -121,6 +121,9 @@ jobs:
       matrix:
         podspec: [FirebaseDatabase.podspec, FirebaseDatabaseSwift.podspec --allow-warnings]
         target: [ios, tvos, macos, watchos]
+        exclude:
+          - podspec: FirebaseDatabaseSwift.podspec --allow-warnings
+            target: watchos
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -119,6 +119,7 @@ jobs:
 
     strategy:
       matrix:
+        podspec: [FirebaseDatabase.podspec, FirebaseDatabaseSwift.podspec --allow-warnings]
         target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
@@ -126,7 +127,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Build and test
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDatabase.podspec --skip-tests --platforms=${{ matrix.target }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --skip-tests --platforms=${{ matrix.target }}
 
   database-cron-only:
     # Don't run on private repo.
@@ -134,6 +135,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
+        podspec: [FirebaseDatabase.podspec, FirebaseDatabaseSwift.podspec --allow-warnings]
         target: [ios, tvos, macos]
         flags: [
           '--skip-tests --use-static-frameworks'
@@ -145,4 +147,4 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: PodLibLint database Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDatabase.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -37,6 +37,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     base_dir + '**/*.[mh]',
     base_dir + 'third_party/Wrap-leveldb/APLevelDB.mm',
     base_dir + 'third_party/SocketRocket/fbase64.c',
+    'FirebaseDatabase/Swift/Sources/**/*.swift',
     'FirebaseAuth/Interop/*.h',
     'FirebaseCore/Extension/*.h',
   ]
@@ -49,6 +50,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseAppCheckInterop', '~> 10.17'
+  s.dependency 'FirebaseSharedSwift', '~> 10.0'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [feature] The `FirebaseDatabase` module now contains Firebase Database's
+  Swift-only APIs that were previously only available via the
+  `FirebaseDatabaseSwift` extension SDK. See the
+  `FirebaseDatabaseSwift` release note from this release for more details.
+
 # 10.0.0
 - [deprecated] Deprecated `FirebaseDatabase` on watchOS 9 and above.
   watchOS users should instead use the Database REST API directly (#19272).

--- a/FirebaseDatabase/Swift/Sources/Codable/DataSnapshot+ReadDecodable.swift
+++ b/FirebaseDatabase/Swift/Sources/Codable/DataSnapshot+ReadDecodable.swift
@@ -15,7 +15,9 @@
  */
 
 import Foundation
-import FirebaseDatabase
+#if SWIFT_PACKAGE
+  @_exported import FirebaseDatabaseInternal
+#endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
 
 public extension DataSnapshot {

--- a/FirebaseDatabase/Swift/Sources/Codable/DatabaseReference+WriteEncodable.swift
+++ b/FirebaseDatabase/Swift/Sources/Codable/DatabaseReference+WriteEncodable.swift
@@ -15,7 +15,9 @@
  */
 
 import Foundation
-import FirebaseDatabase
+#if SWIFT_PACKAGE
+  @_exported import FirebaseDatabaseInternal
+#endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
 
 public extension DatabaseReference {

--- a/FirebaseDatabase/Swift/Sources/Codable/EncoderDecoder.swift
+++ b/FirebaseDatabase/Swift/Sources/Codable/EncoderDecoder.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import FirebaseDatabase
+#if SWIFT_PACKAGE
+  @_exported import FirebaseDatabaseInternal
+#endif // SWIFT_PACKAGE
 import FirebaseSharedSwift
 
 public extension Database {

--- a/FirebaseDatabase/Swift/Sources/Codable/ServerTimestamp.swift
+++ b/FirebaseDatabase/Swift/Sources/Codable/ServerTimestamp.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import FirebaseDatabase
+#if SWIFT_PACKAGE
+  @_exported import FirebaseDatabaseInternal
+#endif // SWIFT_PACKAGE
 
 /// A property wrapper that marks an `Optional<Date>` field to be
 /// populated with a server timestamp. If a `Codable` object being written

--- a/FirebaseDatabase/Swift/Sources/SPMSwiftHeaderWorkaround.swift
+++ b/FirebaseDatabase/Swift/Sources/SPMSwiftHeaderWorkaround.swift
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if SWIFT_PACKAGE
+  @_exported import FirebaseDatabaseInternal
+
+  // This is a trick to force generate a `FirebaseDatabase-Swift.h`
+  // header that re-exports `FirebaseDatabaseInternal` for Objective-C
+  // clients. It is important for the below code to reference a Remote
+  // Config symbol defined in Objective-C as that will import the symbol's
+  // module (`FirebaseDatabaseInternal`) in the generated header. This
+  // allows Objective-C clients to import Remote Config's Objective-C API
+  // using `@import FirebaseDatabase;`. This API is not needed for Swift
+  // clients and is therefore unavailable in a Swift context.
+  @available(*, unavailable)
+  @objc public extension Database {
+    static var __no_op: () -> Void { {} }
+  }
+#endif // SWIFT_PACKAGE

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -28,5 +28,5 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     'FirebaseDatabaseSwift/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseDatabase', '~> 10.16'
+  s.dependency 'FirebaseDatabase', '~> 10.17'
 end

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -28,6 +28,5 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     'FirebaseDatabaseSwift/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseDatabase', '~> 10.0'
-  s.dependency 'FirebaseSharedSwift', '~> 10.0'
+  s.dependency 'FirebaseDatabase', '~> 10.16'
 end

--- a/FirebaseDatabaseSwift/CHANGELOG.md
+++ b/FirebaseDatabaseSwift/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+- [deprecated] `FirebaseDatabaseSwift` has been deprecated, and will be
+  removed in a future release. All of the public API from
+  `FirebaseDatabaseSwift` can now be accessed through the
+  `FirebaseDatabase` module. To migrate, delete imports of
+  `FirebaseDatabaseSwift` and remove the module as a dependency to your
+  project. If applicable, any APIs namespaced with
+  `FirebaseDatabaseSwift` can now be namespaced with
+  `FirebaseDatabase`. Additionally, if applicable,
+  `@testable import FirebaseDatabaseSwift` should be replaced with
+  `@testable import FirebaseDatabase`.
 # 9.0.0
 - [added] **Breaking change:** `FirebaseDatabaseSwift` has exited beta and is
   now generally available for use.

--- a/FirebaseDatabaseSwift/CHANGELOG.md
+++ b/FirebaseDatabaseSwift/CHANGELOG.md
@@ -9,6 +9,7 @@
   `FirebaseDatabase`. Additionally, if applicable,
   `@testable import FirebaseDatabaseSwift` should be replaced with
   `@testable import FirebaseDatabase`.
+
 # 9.0.0
 - [added] **Breaking change:** `FirebaseDatabaseSwift` has exited beta and is
   now generally available for use.

--- a/FirebaseDatabaseSwift/CHANGELOG.md
+++ b/FirebaseDatabaseSwift/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Unreleased
-- [deprecated] `FirebaseDatabaseSwift` has been deprecated, and will be
-  removed in a future release. All of the public API from
-  `FirebaseDatabaseSwift` can now be accessed through the
-  `FirebaseDatabase` module. To migrate, delete imports of
-  `FirebaseDatabaseSwift` and remove the module as a dependency to your
-  project. If applicable, any APIs namespaced with
-  `FirebaseDatabaseSwift` can now be namespaced with
-  `FirebaseDatabase`. Additionally, if applicable,
-  `@testable import FirebaseDatabaseSwift` should be replaced with
-  `@testable import FirebaseDatabase`.
+- [deprecated] All of the public API from `FirebaseDatabaseSwift` can now
+  be accessed through the `FirebaseDatabase` module. Therefore,
+  `FirebaseDatabaseSwift` has been deprecated, and will be removed in a
+  future release. See https://firebase.google.com/docs/ios/swift-migration for
+  migration instructions.
 
 # 9.0.0
 - [added] **Breaking change:** `FirebaseDatabaseSwift` has exited beta and is

--- a/FirebaseDatabaseSwift/Sources/FirebaseDatabaseSwift.swift
+++ b/FirebaseDatabaseSwift/Sources/FirebaseDatabaseSwift.swift
@@ -12,16 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#warning("""
-The FirebaseDatabaseSwift module is deprecated and will be removed in
-the future. All of the public API from FirebaseDatabaseSwift can now be
-accessed through the FirebaseDatabase module. To migrate, delete imports
-of FirebaseDatabaseSwift and remove the module as a dependency to your
-project. If applicable, any APIs namespaced with `FirebaseDatabaseSwift`
-can now be namespaced with `FirebaseDatabase`. Additionally, if
-applicable, `@testable import FirebaseDatabaseSwift` should be replaced
-with `@testable import FirebaseDatabase`.
-""")
+#warning(
+  "All of the public API from `FirebaseDatabaseSwift` can now be accessed through the `FirebaseDatabase` module. Therefore, the `FirebaseDatabaseSwift` module is deprecated and will be removed in the future. See https://firebase.google.com/docs/ios/swift-migration for migration instructions."
+)
 
 // The `@_exported` is needed to prevent breaking clients that are using
 // types prefixed with the `FirebaseDatabase` namespace.

--- a/FirebaseDatabaseSwift/Sources/FirebaseDatabaseSwift.swift
+++ b/FirebaseDatabaseSwift/Sources/FirebaseDatabaseSwift.swift
@@ -1,0 +1,28 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#warning("""
+The FirebaseDatabaseSwift module is deprecated and will be removed in
+the future. All of the public API from FirebaseDatabaseSwift can now be
+accessed through the FirebaseDatabase module. To migrate, delete imports
+of FirebaseDatabaseSwift and remove the module as a dependency to your
+project. If applicable, any APIs namespaced with `FirebaseDatabaseSwift`
+can now be namespaced with `FirebaseDatabase`. Additionally, if
+applicable, `@testable import FirebaseDatabaseSwift` should be replaced
+with `@testable import FirebaseDatabase`.
+""")
+
+// The `@_exported` is needed to prevent breaking clients that are using
+// types prefixed with the `FirebaseDatabase` namespace.
+@_exported import struct FirebaseDatabase.ServerTimestamp

--- a/Package.swift
+++ b/Package.swift
@@ -556,7 +556,7 @@ let package = Package(
       ]
     ),
     .target(
-      name: "FirebaseDatabase",
+      name: "FirebaseDatabaseInternal",
       dependencies: [
         "FirebaseAppCheckInterop",
         "FirebaseCore",
@@ -607,8 +607,13 @@ let package = Package(
       ]
     ),
     .target(
+      name: "FirebaseDatabase",
+      dependencies: ["FirebaseDatabaseInternal", "FirebaseSharedSwift"],
+      path: "FirebaseDatabase/Swift/Sources"
+    ),
+    .target(
       name: "FirebaseDatabaseSwift",
-      dependencies: ["FirebaseDatabase", "FirebaseSharedSwift"],
+      dependencies: ["FirebaseDatabase"],
       path: "FirebaseDatabaseSwift/Sources"
     ),
     .testTarget(

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -45,7 +45,7 @@ public let shared = Manifest(
     Pod("FirebaseAuth", zip: true),
     Pod("FirebaseCrashlytics", zip: true),
     Pod("FirebaseDatabase"),
-    Pod("FirebaseDatabaseSwift", zip: true),
+    Pod("FirebaseDatabaseSwift", allowWarnings: true, zip: true),
     Pod("FirebaseDynamicLinks", platforms: ["ios"], zip: true),
     Pod("FirebaseFirestore", allowWarnings: true),
     Pod("FirebaseFirestoreSwift", zip: true),


### PR DESCRIPTION
**Context**
- The contents of RTDB's Swift extension SDK has been moved into the main RTDB module, and the RTDB Swift extension SDK now re-exports the API that used to live in it.
- This change should be non-breaking.


---

**Tasks**
- [x] The affected extension podspecs should be versioned to pin to the releasing version.
- [ ] When this PR is merged, stage the affected podspecs and notify the Games team.

---

**Important**
- This PR contains an assumption in the source code that docs will be at hosted at https://firebase.google.com/docs/ios/swift-migration cc: @morganchen12 
