### PR TITLE
Fix Database unit test build regression

### DIFF
--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -38,7 +38,6 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     base_dir + 'third_party/Wrap-leveldb/APLevelDB.mm',
     base_dir + 'third_party/SocketRocket/fbase64.c',
     'FirebaseAuth/Interop/*.h',
-    'FirebaseAppCheck/Interop/*.h',
     'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseDatabase/*.h'
@@ -49,6 +48,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.watchos.frameworks = 'CFNetwork', 'Security', 'WatchKit'
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'FirebaseCore', '~> 10.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 10.16'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
@@ -70,6 +70,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
       'SharedTestUtilities/FIRComponentTestUtilities.[mh]',
       'SharedTestUtilities/FIROptionsMock.[mh]',
     ]
+    unit_tests.dependency 'FirebaseAppCheckInterop', '~> 10.16'
     unit_tests.dependency 'OCMock'
     unit_tests.resources = 'FirebaseDatabase/Tests/Resources/syncPointSpec.json',
                            'FirebaseDatabase/Tests/Resources/GoogleService-Info.plist'


### PR DESCRIPTION
Fix #11811 

After #11660 SharedTestUtilities imports FirebaseAppCheck as a module instead of includes. As a result the unit test build failed because it didn't know where to find the import.

I also updated the library source reference to be consistent with the tests and other Firebase products.