### PR TITLE
More fixes for AppCheckInterop

### DIFF
--- a/FirebaseDatabase/Sources/Api/FIRDatabaseComponent.m
+++ b/FirebaseDatabase/Sources/Api/FIRDatabaseComponent.m
@@ -20,9 +20,10 @@
 #import "FirebaseDatabase/Sources/Core/FRepoManager.h"
 #import "FirebaseDatabase/Sources/FIRDatabaseConfig_Private.h"
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
 #import "FirebaseAuth/Interop/FIRAuthInterop.h"
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+
+@import FirebaseAppCheckInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseDatabase/Sources/Login/FIRDatabaseConnectionContextProvider.m
+++ b/FirebaseDatabase/Sources/Login/FIRDatabaseConnectionContextProvider.m
@@ -18,12 +18,12 @@
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
-#import "FirebaseAppCheck/Interop/FIRAppCheckInterop.h"
-#import "FirebaseAppCheck/Interop/FIRAppCheckTokenResultInterop.h"
 #import "FirebaseAuth/Interop/FIRAuthInterop.h"
 
 #import "FirebaseDatabase/Sources/Api/Private/FIRDatabaseQuery_Private.h"
 #import "FirebaseDatabase/Sources/Utilities/FUtilities.h"
+
+@import FirebaseAppCheckInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Package.swift
+++ b/Package.swift
@@ -557,6 +557,7 @@ let package = Package(
     .target(
       name: "FirebaseDatabase",
       dependencies: [
+        "FirebaseAppCheckInterop",
         "FirebaseCore",
         "leveldb",
       ],


### PR DESCRIPTION
Follow up to #11812 

Changing the podspec to get FirebaseAppCheckInterop via the module means that the module should be imported instead of the headers.