### PR TITLE
[Release Tooling] Explicitly FST link direct/transitive deps. in module.modulemap

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -46,6 +46,13 @@ struct ModuleMapBuilder {
       module * { export * }
 
       """
+
+      if module == "FirebaseFirestore" {
+        content += "  link framework " + "BoringSSL-GRPC" + "\n"
+        content += "  link framework " + "gRPC-Core" + "\n"
+        content += "  link framework " + "gRPC-C++" + "\n"
+      }
+
       for framework in frameworks.sorted() {
         content += "  link framework " + framework + "\n"
       }

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -48,9 +48,11 @@ struct ModuleMapBuilder {
       """
 
       if module == "FirebaseFirestore" {
-        content += "  link framework " + "BoringSSL-GRPC" + "\n"
-        content += "  link framework " + "gRPC-Core" + "\n"
-        content += "  link framework " + "gRPC-C++" + "\n"
+        content += """
+          link framework "BoringSSL-GRPC"
+          link framework "gRPC-Core"
+          link framework "gRPC-C++"
+        """
       }
 
       for framework in frameworks.sorted() {


### PR DESCRIPTION
This resolves undefined symbol errors when using Firestore via SPM and building a target _for testing_. See issue 11656.

All three are needed. Interestingly, abseil is not. Likewise, there were missing leveldb and nanonpb symbols. I'd like to understand why.

I can't pin the behavior difference to an Xcode 15 release note, but it may be related to [this](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#:~:text=Xcode%20now%20automatically,incremental%20builds.%E2%80%A8%20(99972271)) one.

Some other approaches that may work here (though I think generalizing the current approach may be best):
1.  Add modular imports of these frameworks into Firestore's source. I was not successful at it so far, but I suspect another way to link the missing symbols in is to modularly import each of these frameworks into Firestore's source code. The headers should be removed from the gRPC++, Boring-SSL, and gRPC-Core xcframeworks, and the generated module maps for each of those would need to be reworked to support being modularly imported by clients.
2. Check in a custom module map for Firestore that the zip-builder can reference.

Fix #11656
#no-changelog