### PR TITLE
Upgrade to `clang-format` v17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@16
+    brew install clang-format@17
     brew install mint
     ```
 

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -2373,7 +2373,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 #else
       // Encode the user object.
       NSMutableData *archiveData = [NSMutableData data];
-// iOS 12 deprecation
+      // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       NSKeyedArchiver *archiver =
@@ -2439,7 +2439,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       return NO;
     }
 #else
-// iOS 12 deprecation
+    // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSKeyedUnarchiver *unarchiver =
@@ -2621,7 +2621,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       return nil;
     }
 #else
-// iOS 12 deprecation
+    // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSKeyedUnarchiver *unarchiver =

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
@@ -73,7 +73,7 @@ static const NSUInteger kMaximumNumberOfPendingReceipts = 32;
       NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:encodedData
                                                                                   error:&error];
 #else
-// iOS 12 deprecation
+      // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       NSKeyedUnarchiver *unarchiver =

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -89,7 +89,7 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
     return nil;
   }
 #else
-// iOS 12 deprecation
+  // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
@@ -118,7 +118,7 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:false];
 #else
   NSMutableData *data = [NSMutableData data];
-// iOS 12 deprecation
+  // iOS 12 deprecation
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GitHub Actions will verify that any code changes are done in a style-compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@16
+brew install clang-format@17
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@16
+brew install clang-format@17
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -56,7 +56,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  16)
+  17)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -65,7 +65,7 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 16."
+    echo "Please upgrade to clang-format version 17."
     echo "If it's installed via homebrew you can run:"
     echo "brew upgrade clang-format"
     exit 1


### PR DESCRIPTION
Switched to the Homebrew `clang-format@17` formula since `clang-format@16` is no longer available and ran `scripts/style.sh`.

#no-changelog