### PR TITLE
[ML Model Downloader] Migrate from FLL to CCT logging endpoint

### DIFF
--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Unreleased
+- [changed] Migrated from the Firelog to Clearcut telemetry logging endpoint.

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,2 +1,0 @@
-# Unreleased
-- [changed] Migrated from the Firelog to Clearcut telemetry logging endpoint. (#11837)

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,2 +1,2 @@
 # Unreleased
-- [changed] Migrated from the Firelog to Clearcut telemetry logging endpoint.
+- [changed] Migrated from the Firelog to Clearcut telemetry logging endpoint. (#11837)

--- a/FirebaseMLModelDownloader/Sources/TelemetryLogger.swift
+++ b/FirebaseMLModelDownloader/Sources/TelemetryLogger.swift
@@ -124,12 +124,12 @@ class TelemetryLogger {
   private let app: FirebaseApp
 
   /// Transport for Firelog events.
-  private let clearcutTransport: GDTCORTransport
+  private let cctTransport: GDTCORTransport
 
   /// Init logger, could be nil if unable to get event transport.
   init?(app: FirebaseApp) {
     self.app = app
-    guard let clearcutTransport = GDTCORTransport(
+    guard let cctTransport = GDTCORTransport(
       mappingID: mappingID,
       transformers: nil,
       target: GDTCORTarget.CCT
@@ -139,14 +139,14 @@ class TelemetryLogger {
                             messageCode: .telemetryInitError)
       return nil
     }
-    self.clearcutTransport = clearcutTransport
+    self.cctTransport = cctTransport
   }
 
   /// Log events to Firelog.
   private func logModelEvent(event: FirebaseMlLogEvent) {
-    let eventForTransport: GDTCOREvent = clearcutTransport.eventForTransport()
+    let eventForTransport: GDTCOREvent = cctTransport.eventForTransport()
     eventForTransport.dataObject = FBMLDataObject(event: event)
-    clearcutTransport.sendTelemetryEvent(eventForTransport)
+    cctTransport.sendTelemetryEvent(eventForTransport)
   }
 
   /// Log model deleted event to Firelog.

--- a/FirebaseMLModelDownloader/Sources/TelemetryLogger.swift
+++ b/FirebaseMLModelDownloader/Sources/TelemetryLogger.swift
@@ -124,29 +124,29 @@ class TelemetryLogger {
   private let app: FirebaseApp
 
   /// Transport for Firelog events.
-  private let fllTransport: GDTCORTransport
+  private let clearcutTransport: GDTCORTransport
 
   /// Init logger, could be nil if unable to get event transport.
   init?(app: FirebaseApp) {
     self.app = app
-    guard let fllTransport = GDTCORTransport(
+    guard let clearcutTransport = GDTCORTransport(
       mappingID: mappingID,
       transformers: nil,
-      target: GDTCORTarget.FLL
+      target: GDTCORTarget.CCT
     ) else {
       DeviceLogger.logEvent(level: .debug,
                             message: TelemetryLogger.ErrorDescription.initTelemetryLogger,
                             messageCode: .telemetryInitError)
       return nil
     }
-    self.fllTransport = fllTransport
+    self.clearcutTransport = clearcutTransport
   }
 
   /// Log events to Firelog.
   private func logModelEvent(event: FirebaseMlLogEvent) {
-    let eventForTransport: GDTCOREvent = fllTransport.eventForTransport()
+    let eventForTransport: GDTCOREvent = clearcutTransport.eventForTransport()
     eventForTransport.dataObject = FBMLDataObject(event: event)
-    fllTransport.sendTelemetryEvent(eventForTransport)
+    clearcutTransport.sendTelemetryEvent(eventForTransport)
   }
 
   /// Log model deleted event to Firelog.


### PR DESCRIPTION
Migrated from the telemetry logging target `GDTCORTarget.FLL` to `GDTCORTarget.CCT` in the Firebase ML Model Downloader SDK.

#no-changelog