### PR TITLE
Firestore: Downgrade grpc CocoaPods dependency to 1.44.0 (was 1.50.1)

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -90,7 +90,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseCore', '~> 10.0'
 
-  abseil_version = '~> 1.20220623.0'
+  abseil_version = '~> 1.20211102.0'
   s.dependency 'abseil/algorithm', abseil_version
   s.dependency 'abseil/base', abseil_version
   s.dependency 'abseil/container/flat_hash_map', abseil_version
@@ -100,7 +100,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'abseil/time', abseil_version
   s.dependency 'abseil/types', abseil_version
 
-  s.dependency 'gRPC-C++', '~> 1.50.1'
+  s.dependency 'gRPC-C++', '~> 1.44.0'
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
 

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [fixed] Fixed an issue where Firestore's binary SwiftPM distribution would
   not link properly when building a target for testing. This issue affected
   Xcode 15 Beta 5 and later (#11656).
+- [fixed] Downgrade the CocoaPods grpc dependency back to 1.44.0 (from 1.50.1)
+  to fix a crash on iOS 12 devices that was introduced in the Firebase Apple SDK
+  10.10.0 when the grpc dependency was upgraded (#11509).
 
 # 10.15.0
 - [feature] Add the option to allow the SDK to create cache indexes automatically to


### PR DESCRIPTION
Downgrade grpc CocoaPods dependency to 1.44.0 (was 1.50.1) as a workaround for a Firestore crash on iOS 12 that happens with with grpc 1.50.0 and newer: https://github.com/firebase/firebase-ios-sdk/issues/11509. Leave the cmake and swift package manager dependencies at 1.50 since they do not experience this crash.

A workaround for this crash is planned to be merged into grpc upstream (https://github.com/grpc/grpc/pull/34416). Once released (and a few other unrelated grpc build issues with Firestore are fixed) the grpc dependency will be re-upgraded to a version that includes the workaround.

Note: This PR effectively reverts #10650.

Fixes #11509