### PR TITLE
Allow override support for auth endpoints for proxy abilities

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 10.16.0
 - [added] Added custom auth domain support in recaptcha v2 authentication flows. (#7553)
+- [added] Added host override support for IdentityToolKit and SecureToken api endpoints. (#11858)
 
 # 10.14.0
 - [added] Added reCAPTCHA verification support in email authentication flows. (#11231)

--- a/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
+++ b/FirebaseAuth/Sources/Backend/FIRIdentityToolkitRequest.m
@@ -79,6 +79,7 @@ static NSString *const kClientType = @"CLIENT_TYPE_IOS";
   NSString *apiHostAndPathPrefix;
 
   NSString *emulatorHostAndPort = _requestConfiguration.emulatorHostAndPort;
+  NSString *overrideIdentityToolKitHost = _requestConfiguration.auth.overrideIdentityToolKitHost;
 
   if (_useIdentityPlatform) {
     apiURLFormat = kIdentityPlatformAPIURLFormat;
@@ -90,6 +91,8 @@ static NSString *const kClientType = @"CLIENT_TYPE_IOS";
                                      kIdentityPlatformAPIHost];
     } else if (_useStaging) {
       apiHostAndPathPrefix = kIdentityPlatformStagingAPIHost;
+    } else if (overrideIdentityToolKitHost) {
+      apiHostAndPathPrefix = overrideIdentityToolKitHost;
     } else {
       apiHostAndPathPrefix = kIdentityPlatformAPIHost;
     }
@@ -102,6 +105,8 @@ static NSString *const kClientType = @"CLIENT_TYPE_IOS";
           stringWithFormat:kEmulatorHostAndPrefixFormat, emulatorHostAndPort, kFirebaseAuthAPIHost];
     } else if (_useStaging) {
       apiHostAndPathPrefix = kFirebaseAuthStagingAPIHost;
+    } else if (overrideIdentityToolKitHost) {
+      apiHostAndPathPrefix = overrideIdentityToolKitHost;
     } else {
       apiHostAndPathPrefix = kFirebaseAuthAPIHost;
     }

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSecureTokenRequest.m
@@ -84,9 +84,13 @@ static NSString *gAPIHost = @"securetoken.googleapis.com";
   NSString *URLString;
 
   NSString *emulatorHostAndPort = _requestConfiguration.emulatorHostAndPort;
+  NSString *overrideSecureTokenHost = _requestConfiguration.auth.overrideSecureTokenHost;
   if (emulatorHostAndPort) {
     URLString =
         [NSString stringWithFormat:kFIREmulatorURLFormat, emulatorHostAndPort, gAPIHost, _APIKey];
+  } else if (overrideSecureTokenHost) {
+    URLString =
+        [NSString stringWithFormat:kFIRSecureTokenServiceGetTokenURLFormat, overrideSecureTokenHost, _APIKey];
   } else {
     URLString =
         [NSString stringWithFormat:kFIRSecureTokenServiceGetTokenURLFormat, gAPIHost, _APIKey];

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -362,6 +362,20 @@ NS_SWIFT_NAME(Auth)
  */
 @property(nonatomic, copy, nullable) NSString *customAuthDomain;
 
+/**
+ * @property overrideIdentityToolKitHost
+ * @brief A custom host used to handle proxying identityToolKit signins. This gives organizations the ability to create a proxy that
+ * is behind a firewall to prevent brute force attacks using the public key against the identitytoolkit api directly.
+ */
+@property(nonatomic, copy, nullable) NSString *overrideIdentityToolKitHost;
+
+/**
+ * @property overrideSecureTokenHost
+ * @brief A custom host used to handle proxying securetoken signins. This gives organizations the ability to create a proxy that
+ * is behind a firewall to prevent brute force attacks using the public key against the secure token api directly.
+ */
+@property(nonatomic, copy, nullable) NSString *overrideSecureTokenHost;
+
 /** @fn init
     @brief Please access auth instances using `Auth.auth()` and `Auth.auth(app:)`.
  */


### PR DESCRIPTION
This PR adds the ability to override the identitytoolkit auth api and securetoken auth api so that organizations can place a proxy behind a firewall for control against attackers. #11858 
