### PR TITLE
Switch to `#import <Foundation/Foundation.h>` in `FIRAppCheckProtocol.h`

### DIFF
--- a/FirebaseAppCheck/Interop/FIRAppCheckProtocol.h
+++ b/FirebaseAppCheck/Interop/FIRAppCheckProtocol.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class FIRAppCheckToken;
 


### PR DESCRIPTION
This is a no-op change externally but requires one less transformation for use internally (where modules aren't supported).

#no-changelog