### PR TITLE
Update grpc to 1.49.1

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -90,7 +90,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseCore', '~> 10.0'
 
-  abseil_version = '~> 1.20211102.0'
+  abseil_version = '~> 1.20220623.0'
   s.dependency 'abseil/algorithm', abseil_version
   s.dependency 'abseil/base', abseil_version
   s.dependency 'abseil/container/flat_hash_map', abseil_version
@@ -100,7 +100,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'abseil/time', abseil_version
   s.dependency 'abseil/types', abseil_version
 
-  s.dependency 'gRPC-C++', '~> 1.44.0'
+  s.dependency 'gRPC-C++', '~> 1.49.1'
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -1322,13 +1322,13 @@ func abseilDependency() -> Package.Dependency {
   // as the headers in the binary version of abseil are unusable.
   if ProcessInfo.processInfo.environment["FIREBASE_SOURCE_FIRESTORE"] != nil {
     packageInfo = (
-      "https://github.com/abseil/abseil-cpp.git",
-      "20211102.0" ..< "20211103.0"
+      "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "0.20220623.0" ..< "0.20220624.0"
     )
   } else {
     packageInfo = (
       "https://github.com/google/abseil-cpp-binary.git",
-      "1.2021110200.0" ..< "1.2021110300.0"
+      "1.20220623.0" ..< "1.20220624.0"
     )
   }
 
@@ -1341,9 +1341,9 @@ func grpcDependency() -> Package.Dependency {
   // If building Firestore from source, abseil will need to be built as source
   // as the headers in the binary version of abseil are unusable.
   if ProcessInfo.processInfo.environment["FIREBASE_SOURCE_FIRESTORE"] != nil {
-    packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.44.0" ..< "1.45.0")
+    packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
   } else {
-    packageInfo = ("https://github.com/google/grpc-binary.git", "1.44.0" ..< "1.45.0")
+    packageInfo = ("https://github.com/google/grpc-binary.git", "1.49.1" ..< "1.50.0")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)

--- a/Package.swift
+++ b/Package.swift
@@ -1343,9 +1343,8 @@ func grpcDependency() -> Package.Dependency {
   if ProcessInfo.processInfo.environment["FIREBASE_SOURCE_FIRESTORE"] != nil {
     packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
   } else {
-    // TODO(andrewheard): Change back to binary distribution before merging (after the binary repo
-    // is tagged): ("https://github.com/google/grpc-binary.git", "1.50.1" ..< "1.50.2")
-    packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
+    // TODO(andrewheard): Change back to "1.49.1" ..< "1.50.0" before merging.
+    packageInfo = ("https://github.com/google/grpc-binary.git", "1.50.1" ..< "1.50.2")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)

--- a/Package.swift
+++ b/Package.swift
@@ -1328,7 +1328,7 @@ func abseilDependency() -> Package.Dependency {
   } else {
     packageInfo = (
       "https://github.com/google/abseil-cpp-binary.git",
-      "1.20220623.0" ..< "1.20220624.0"
+      "1.2022062300.0" ..< "1.2022062400.0"
     )
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1462,7 +1462,7 @@ func firestoreTarget() -> Target {
   return .binaryTarget(
     name: "FirebaseFirestore",
     url: "https://dl.google.com/firebase/ios/bin/firestore/10.16.0/FirebaseFirestore.zip",
-    checksum: "58c2cee5e004240a21b174358dbf371bfebc3ce24c2d71d7518d0e6a0487dcd6"
+    checksum: "69d2083cc782b7100802035f0209910763a3ca7f338ed3898d73ac669c2e15f7"
   )
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1343,7 +1343,9 @@ func grpcDependency() -> Package.Dependency {
   if ProcessInfo.processInfo.environment["FIREBASE_SOURCE_FIRESTORE"] != nil {
     packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
   } else {
-    packageInfo = ("https://github.com/google/grpc-binary.git", "1.49.1" ..< "1.50.0")
+    // TODO(andrewheard): Change back to binary distribution before merging (after the binary repo
+    // is tagged): ("https://github.com/google/grpc-binary.git", "1.50.1" ..< "1.50.2")
+    packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)

--- a/Package.swift
+++ b/Package.swift
@@ -1343,8 +1343,7 @@ func grpcDependency() -> Package.Dependency {
   if ProcessInfo.processInfo.environment["FIREBASE_SOURCE_FIRESTORE"] != nil {
     packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.49.1" ..< "1.50.0")
   } else {
-    // TODO(andrewheard): Change back to "1.49.1" ..< "1.50.0" before merging.
-    packageInfo = ("https://github.com/google/grpc-binary.git", "1.50.1" ..< "1.50.2")
+    packageInfo = ("https://github.com/google/grpc-binary.git", "1.49.1" ..< "1.50.0")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)


### PR DESCRIPTION
Update grpc to 1.49.1 so that we don't have to change the abseil version from 10.15.0 since we don't have the abseil version associated with grpc 1.44.0 available for SPM