### PR TITLE
crash fix

### DIFF
--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix crash caused by empty experiment payload.
+
 # 10.14.0
 - [fixed] Fix crash caused by mutating array during iteration. (#11669)
 

--- a/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
+++ b/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
@@ -86,13 +86,13 @@
                @"Failed to get conditional user properties from Firebase Analytics.");
     return;
   }
-    
-    if(payload.experimentId==nil){
-            // When doing experiment test on devices, the payload could be empty. Returning here to prevent app crash.
-            FIRLogInfo(kFIRLoggerABTesting, @"I-ABT000020",
-                       @"Experiment Id in payload is empty.");
-            return;
-        }
+
+  if (payload.experimentId == nil) {
+    // When doing experiment test on devices, the payload could be empty. Returning here to prevent
+    // app crash.
+    FIRLogInfo(kFIRLoggerABTesting, @"I-ABT000020", @"Experiment Id in payload is empty.");
+    return;
+  }
 
   if (maxNumOfExperiments <= experiments.count) {
     ABTExperimentPayloadExperimentOverflowPolicy overflowPolicy =

--- a/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
+++ b/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
@@ -86,6 +86,13 @@
                @"Failed to get conditional user properties from Firebase Analytics.");
     return;
   }
+    
+    if(payload.experimentId==nil){
+            // When doing experiment test on devices, the payload could be empty. Returning here to prevent app crash.
+            FIRLogInfo(kFIRLoggerABTesting, @"I-ABT000020",
+                       @"Experiment Id in payload is empty.");
+            return;
+        }
 
   if (maxNumOfExperiments <= experiments.count) {
     ABTExperimentPayloadExperimentOverflowPolicy overflowPolicy =


### PR DESCRIPTION
Fix ABTesting crash when experiment payload is empty.

This happens when testing experiment on devices. Internal Bug : b/300084397