### PR TITLE
Revert "Temporarily disable failing test (#11850)"

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -435,40 +435,37 @@ jobs:
         name: quickstart_artifacts_firestore
         path: quickstart-ios/
 
-  # TODO(#11849) Restore this test when SPM updates its gRPC dependency version and CocoaPods is
-  # realigned.
-
-  # check_framework_firestore_symbols:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     FRAMEWORK_DIR: "Firebase-actions-dir"
-  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-  #   runs-on: macos-12
-  #   steps:
-  #     - name: Xcode 14.1
-  #       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-  #     - uses: actions/checkout@v3
-  #     - name: Get framework dir
-  #       uses: actions/download-artifact@v1
-  #       with:
-  #         name: Firebase-actions-dir
-  #     - uses: ruby/setup-ruby@v1
-  #     - name: Setup Bundler
-  #       run: ./scripts/setup_bundler.sh
-  #     - name: Install xcpretty
-  #       run: gem install xcpretty
-  #     - name: Move frameworks
-  #       run: |
-  #         mkdir -p "${HOME}"/ios_frameworks/
-  #         find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #     - uses: actions/checkout@v3
-  #     - name: Check linked Firestore.xcframework for unlinked symbols.
-  #       run: |
-  #         scripts/check_firestore_symbols.sh \
-  #           $(pwd) \
-  #           "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestore.xcframework
+  check_framework_firestore_symbols:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      FRAMEWORK_DIR: "Firebase-actions-dir"
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    runs-on: macos-12
+    steps:
+      - name: Xcode 14.1
+        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+      - uses: actions/checkout@v3
+      - name: Get framework dir
+        uses: actions/download-artifact@v1
+        with:
+          name: Firebase-actions-dir
+      - uses: ruby/setup-ruby@v1
+      - name: Setup Bundler
+        run: ./scripts/setup_bundler.sh
+      - name: Install xcpretty
+        run: gem install xcpretty
+      - name: Move frameworks
+        run: |
+          mkdir -p "${HOME}"/ios_frameworks/
+          find "${GITHUB_WORKSPACE}/${FRAMEWORK_DIR}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      - uses: actions/checkout@v3
+      - name: Check linked Firestore.xcframework for unlinked symbols.
+        run: |
+          scripts/check_firestore_symbols.sh \
+            $(pwd) \
+            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestore.xcframework
 
   quickstart_framework_inappmessaging:
     # Don't run on private repo.


### PR DESCRIPTION
This reverts commit 02f21660b2c3fa1453a975f3443a753540b2d348.

Fix #11849

I forgot to restore this earlier when we realized that we needed to keep the gRPC versions the same for both CocoaPods and SPM to release.