### PR TITLE
Fix notice generation

### DIFF
--- a/.github/actions/notices_generation/Gemfile
+++ b/.github/actions/notices_generation/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+# cocoapods isn't needed for generating the Gemfile.lock, but is needed for the CI job
+gem "cocoapods"
 gem "octokit", "~> 4.19"
 gem "xcodeproj", "~> 1.21"
 gem "plist"

--- a/.github/workflows/notice_generation.yml
+++ b/.github/workflows/notice_generation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   generate_a_notice:
     # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+    if: github.repository == 'Firebase/firebase-ios-sdk'
     runs-on: macos-12
     name: Generate NOTICES
     env:


### PR DESCRIPTION
I erroneously removed cocoapods from the Gemfile in #11899 because it wasn't used for the Gemfile.lock. It is needed for the CI job. I also enabled the CI job to run immediately when it gets changed.

Fix #11901 