### PR TITLE
[Release Tooling] Create module maps for mixed language targets

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -547,11 +547,15 @@ struct FrameworkBuilder {
           }
         }
         do {
-          // Frameworks built from only Swift sources will contain only two
-          // headers: the CocoaPods-generated umbrella header and the
-          // Swift-generated Swift header. If the framework's `Headers`
+          // If this point is reached, the framework contains a Swift module,
+          // so it's built from either Swift sources or Swift & C Family
+          // Language sources. Frameworks built from only Swift sources will
+          // contain only two headers: the CocoaPods-generated umbrella header
+          // and the Swift-generated Swift header. If the framework's `Headers`
           // directory contains more than two resources, then it is assumed
-          // that the framework was built from mixed language sources.
+          // that the framework was built from mixed language sources because
+          // those additional headers are public headers for the C Family
+          // Language sources.
           let headersDir = destination.appendingPathComponent("Headers")
           let headers = try fileManager.contentsOfDirectory(
             at: headersDir,

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -429,6 +429,7 @@ struct FrameworkBuilder {
   /// Returns true to fail if building for Carthage and there are Swift modules.
   @discardableResult
   private func packageModuleMaps(inFrameworks frameworks: [URL],
+                                 frameworkName: String,
                                  moduleMapContents: String,
                                  destination: URL,
                                  buildingCarthage: Bool = false) -> Bool {
@@ -436,14 +437,14 @@ struct FrameworkBuilder {
     // Instead it use build options to specify them. For the zip build, we need the module maps to
     // include the dependent frameworks and libraries. Therefore we reconstruct them by parsing
     // the CocoaPods config files and add them here.
-    // Currently we only do the construction for Objective-C since Swift Module directories require
-    // several other files. See https://github.com/firebase/firebase-ios-sdk/pull/5040.
-    // Therefore, for Swift we do a simple copy of the Modules files from an Xcode build.
-    // This is sufficient for the testing done so far, but more testing is required to determine
-    // if dependent libraries and frameworks also may need to be added to the Swift module maps in
-    // some cases.
+    // In the case of a mixed language framework, not only are the Swift module
+    // files copied, but a `module.modulemap` is created by combining the given
+    // module map contents and a synthesized submodule that modularizes the
+    // generated Swift header.
     if makeSwiftModuleMap(thinFrameworks: frameworks,
+                          frameworkName: frameworkName,
                           destination: destination,
+                          moduleMapContents: moduleMapContents,
                           buildingCarthage: buildingCarthage) {
       return buildingCarthage
     }
@@ -468,7 +469,9 @@ struct FrameworkBuilder {
   /// URLs pointing to the frameworks containing architecture specific code.
   /// Returns true if there are Swift modules.
   private func makeSwiftModuleMap(thinFrameworks: [URL],
+                                  frameworkName: String,
                                   destination: URL,
+                                  moduleMapContents: String,
                                   buildingCarthage: Bool = false) -> Bool {
     let fileManager = FileManager.default
 
@@ -542,6 +545,40 @@ struct FrameworkBuilder {
             fatalError("Failed to get Modules directory contents - \(moduleDir):" +
               "\(error.localizedDescription)")
           }
+        }
+        do {
+          // Frameworks built from only Swift sources will contain only two
+          // headers: the CocoaPods-generated umbrella header and the
+          // Swift-generated Swift header. If the framework's `Headers`
+          // directory contains more than two resources, then it is assumed
+          // that the framework was built from mixed language sources.
+          let headersDir = destination.appendingPathComponent("Headers")
+          let headers = try fileManager.contentsOfDirectory(
+            at: headersDir,
+            includingPropertiesForKeys: nil
+          )
+          if headers.count > 2 {
+            // It is assumed that the framework will always contain a
+            // `module.modulemap` (either CocoaPods generates it or a custom
+            // one was set in the podspec corresponding to the framework being
+            // processed) within the framework's `Modules` directory. The main
+            // module declaration within this `module.modulemap` should be
+            // replaced with the given module map contents that was computed to
+            // include frameworks and libraries that the framework slice
+            // depends on.
+            let newModuleMapContents = moduleMapContents + """
+            module \(frameworkName).Swift {
+              header "\(frameworkName)-Swift.h"
+              requires objc
+            }
+            """
+            let modulemapURL = destination.appendingPathComponents(["Modules", "module.modulemap"])
+            try newModuleMapContents.write(to: modulemapURL, atomically: true, encoding: .utf8)
+          }
+        } catch {
+          fatalError(
+            "Error while synthesizing a mixed language framework's module map: \(error.localizedDescription)"
+          )
         }
       } catch {
         fatalError("Error while enumerating files \(moduleDir): \(error.localizedDescription)")
@@ -641,6 +678,7 @@ struct FrameworkBuilder {
 
       // Use the appropriate moduleMaps
       packageModuleMaps(inFrameworks: [frameworkPath],
+                        frameworkName: framework,
                         moduleMapContents: moduleMapContents,
                         destination: platformFrameworkDir)
 


### PR DESCRIPTION
These changes are needed to build correct xcframeworks for mixed language CocoaPods. They were informed by work in #11806.

### Problem
The release tooling [creates custom module maps](https://github.com/firebase/firebase-ios-sdk/pull/4895) for some SDKs (e.g. Firestore). The contents of the custom module map is stored in memory until it is written to disk when the slices of the xcframework are assembled. During this assembly, the release tooling currently makes the assumption that if a Swift module is present, the SDK is a pure Swift SDK and it uses the module map contents generated by CocoaPods (which modularizes the Swift header with a submodule). This is problematic since the custom module map contents in memory are ignored.

### Solution
For mixed language SDKs, the custom module map contents should be concatenated with the part that CocoaPods generates (the modularization of the Swift header in a submodule).

### Open Questions
- Does Carthage work?
  - This seems to have no effect on the Carthage build. I diff'd the Firestore and Storage.

#no-changelog
