### PR TITLE
[AppCheck] Fix 'public_headers_dir' in 'FirebaseAppCheckInterop.podspec'

### DIFF
--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '6.0'
 
   s.source_files = 'FirebaseAppCheck/Interop/**/*.[hm]'
-  s.public_header_files = 'FirebaseAppCheck/Interop/Public/FirebaseAppCheck/*.h'
+  s.public_header_files = 'FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/*.h'
 end


### PR DESCRIPTION
I'm not sure why the CI in #11860 didn't surface this. 

I locally tried to stage the FirebaseAppCheckInterop.podspec after merging #11860 and saw:
```
Validating spec
 -> FirebaseAppCheckInterop (10.17.0)
    - NOTE  | url: The URL (https://twitter.com/Firebase) is not reachable.
🔥    - WARN  | file patterns: The `public_header_files` pattern did not match any file.
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Building targets in dependency order
    - NOTE  | [iOS] xcodebuild:  /var/folders/hz/7v68p4h95sb2ypb614xp20jc00r7sc/T/CocoaPods-Lint-20231011-82337-1s67496-FirebaseAppCheckInterop/App.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'FirebaseAppCheckInterop' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'Pods-App' from project 'Pods')
    - NOTE  | xcodebuild:  note: Using codesigning identity override: 

[!] The `FirebaseAppCheckInterop.podspec` specification does not validate.
```

#no-changelog