### PR TITLE
[visionOS] Fix FirebaseMessaging build on Xcode 15.1 beta 1

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -334,7 +334,8 @@ BOOL FIRMessagingIsProductionApp(void) {
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
   NSString *path = [[[[NSBundle mainBundle] resourcePath] stringByDeletingLastPathComponent]
       stringByAppendingPathComponent:@"embedded.provisionprofile"];
-#elif TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
+#elif TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH || \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
   NSString *path = [[[NSBundle mainBundle] bundlePath]
       stringByAppendingPathComponent:@"embedded.mobileprovision"];
 #endif

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
@@ -92,7 +92,7 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
   NSMutableDictionary *keychainQuery = [self keychainQueryForService:service account:account];
   NSMutableArray<NSData *> *results;
   keychainQuery[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
   keychainQuery[(__bridge id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
   keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitAll;
   // FIRMessagingKeychain should only take a query and return a result, will handle the query here.


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1` on visionOS. This PR fixes the build of Firebase Messaging on Xcode 15.1 beta 1 (and `MessagingUnit` passes).

Note: https://github.com/google/GoogleUtilities/pull/132 is also needed to fix the build (not yet tagged / released).

#no-changelog