### PR TITLE
[visionOS] Fix FirebaseInAppMessaging build on Xcode 15.1 beta 1

### DIFF
--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.h"
 
@@ -174,4 +174,4 @@ static NSString *const kFIAMUserDefaualtsKeyForRemoveUserPropertyTimeInSeconds =
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutHttpRequestSender.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutHttpRequestSender.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -204,4 +204,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 
@@ -209,4 +209,4 @@ static NSString *const kEventExtensionJson = @"extension_js";
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogger.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogger.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -214,4 +214,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
@@ -245,4 +245,4 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -399,4 +399,4 @@
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageContentDataWithImageURL.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageContentDataWithImageURL.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -206,4 +206,4 @@ static NSInteger const SuccessHTTPStatusCode = 200;
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h"
 
@@ -109,4 +109,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMRenderingEffectSetting.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMRenderingEffectSetting.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Data/FIRIAMRenderingEffectSetting.h"
 
@@ -34,4 +34,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/DisplayTrigger/FIRIAMDisplayTriggerDefinition.m
+++ b/FirebaseInAppMessaging/Sources/DisplayTrigger/FIRIAMDisplayTriggerDefinition.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/DisplayTrigger/FIRIAMDisplayTriggerDefinition.h"
 
@@ -43,4 +43,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/FIRCore+InAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRCore+InAppMessaging.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <Foundation/Foundation.h>
 #import "FirebaseInAppMessaging/Sources/FIRCore+InAppMessaging.h"
@@ -23,4 +23,4 @@
 NSString *const kFirebaseInAppMessagingErrorDomain = @"com.firebase.inappmessaging";
 FIRLoggerService kFIRLoggerInAppMessaging = @"[FirebaseInAppMessaging]";
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FIRInAppMessaging.h"
 
@@ -145,4 +145,4 @@ static BOOL _autoBootstrapOnFIRAppInit = YES;
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 
@@ -245,4 +245,4 @@ static NSString *const kDetailArchiveKey = @"detail";
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMBookKeeper.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMBookKeeper.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -262,4 +262,4 @@ static NSTimeInterval kMaxFetchWaitTimeInSeconds = 3 * 24 * 60 * 60;
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 #import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
@@ -133,4 +133,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnAnalyticEventsFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnAnalyticEventsFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
@@ -68,4 +68,4 @@
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -67,4 +67,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnFetchDoneNotificationFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckOnFetchDoneNotificationFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -64,4 +64,4 @@ extern NSString *const kFIRIAMFetchIsDoneNotification;
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckTriggerFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayCheckTriggerFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Flows/FIRIAMDisplayCheckTriggerFlow.h"
 
@@ -34,4 +34,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <UIKit/UIKit.h>
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
@@ -778,4 +778,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMFetchFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMFetchFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -267,4 +267,4 @@ NSString *const kFIRIAMFetchIsDoneNotification = @"FIRIAMFetchIsDoneNotification
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -61,4 +61,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -236,4 +236,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -277,4 +277,4 @@ static NSInteger const SuccessHTTPStatusCode = 200;
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMServerMsgFetchStorage.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMServerMsgFetchStorage.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -66,4 +66,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <Foundation/Foundation.h>
 
@@ -371,4 +371,4 @@ NSString *const FIRIAMTestMessageID = @"test_message_id";
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
@@ -227,4 +227,4 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -444,4 +444,4 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKModeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKModeManager.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
@@ -115,4 +115,4 @@ NSInteger const kFIRIAMMaxFetchInNewlyInstalledMode = 5;
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKSettings.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKSettings.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Runtime/FIRIAMSDKSettings.h"
 
@@ -37,4 +37,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRInAppMessaging+Bootstrap.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRInAppMessaging+Bootstrap.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Runtime/FIRInAppMessaging+Bootstrap.h"
 
@@ -136,4 +136,4 @@ static NSString *_fiamServerHostName = @"firebaseinappmessaging.googleapis.com";
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Util/FIRIAMElapsedTimeTracker.m
+++ b/FirebaseInAppMessaging/Sources/Util/FIRIAMElapsedTimeTracker.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Util/FIRIAMElapsedTimeTracker.h"
 @interface FIRIAMElapsedTimeTracker ()
@@ -58,4 +58,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Util/FIRIAMTimeFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Util/FIRIAMTimeFetcher.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Util/FIRIAMTimeFetcher.h"
 
@@ -25,4 +25,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Util/NSString+FIRInterlaceStrings.m
+++ b/FirebaseInAppMessaging/Sources/Util/NSString+FIRInterlaceStrings.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Util/NSString+FIRInterlaceStrings.h"
 
@@ -44,4 +44,4 @@
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
+++ b/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h"
 
@@ -37,4 +37,4 @@
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/FirebaseInAppMessaging/Sources/Util/UIColor+FIRIAMHexString.m
+++ b/FirebaseInAppMessaging/Sources/Util/UIColor+FIRIAMHexString.m
@@ -15,7 +15,7 @@
  */
 
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #import "FirebaseInAppMessaging/Sources/Util/UIColor+FIRIAMHexString.h"
 
@@ -41,4 +41,4 @@
 }
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)

--- a/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 #import <TargetConditionals.h>
-#if !(TARGET_OS_IOS || TARGET_OS_TV)
-#warning "Firebase In App Messaging only supports the iOS and tvOS platforms."
+#if !(TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION))
+#warning "Firebase In App Messaging only supports the iOS, tvOS and visionOS platforms."
 #endif


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1` on visionOS. This PR fixes the build of Firebase In-App Messaging on Xcode 15.1 beta 1 for visionOS.

Note: https://github.com/google/GoogleUtilities/pull/132 is also needed to fix the build (not yet tagged / released).

#no-changelog