### PR TITLE
[Config] Update FirebaseRemoteConfigSwift.podspec

### DIFF
--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -38,7 +38,6 @@ app update.
     'FirebaseRemoteConfigSwift/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseRemoteConfig', '~> 10.17'
 
   # Run Swift API tests on a real backend.


### PR DESCRIPTION
Remove unneeded FirebaseCore import (see convo [here](https://github.com/firebase/firebase-ios-sdk/pull/11914#discussion_r1353054971))