### PR TITLE
[visionOS] Fix FirebaseDatabase build on Xcode 15.1 beta 1

### DIFF
--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -1256,7 +1256,7 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
 - (void)sendConnectStats {
     NSMutableDictionary *stats = [NSMutableDictionary dictionary];
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     if (self.config.persistenceEnabled) {
         stats[@"persistence.ios.enabled"] = @1;
     }

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -1256,7 +1256,8 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
 - (void)sendConnectStats {
     NSMutableDictionary *stats = [NSMutableDictionary dictionary];
 
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     if (self.config.persistenceEnabled) {
         stats[@"persistence.ios.enabled"] = @1;
     }

--- a/FirebaseDatabase/Sources/Core/FRepo.m
+++ b/FirebaseDatabase/Sources/Core/FRepo.m
@@ -52,7 +52,7 @@
 #import "FirebaseDatabase/Sources/Utilities/Tuples/FTupleTransaction.h"
 #import <dlfcn.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
 #endif
 
@@ -815,7 +815,7 @@
 
 // Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     // The idea is to wait until any outstanding sets get written to disk. Since
     // the sets might still be in our dispatch queue, we wait for the dispatch
     // queue to catch up and for persistence to catch up. This may be

--- a/FirebaseDatabase/Sources/Core/FRepo.m
+++ b/FirebaseDatabase/Sources/Core/FRepo.m
@@ -52,7 +52,8 @@
 #import "FirebaseDatabase/Sources/Utilities/Tuples/FTupleTransaction.h"
 #import <dlfcn.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
 #endif
 
@@ -815,7 +816,8 @@
 
 // Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     // The idea is to wait until any outstanding sets get written to disk. Since
     // the sets might still be in our dispatch queue, we wait for the dispatch
     // queue to catch up and for persistence to catch up. This may be

--- a/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
+++ b/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
@@ -275,7 +275,7 @@ static NSString *trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
 }
 
 + (NSString *)firebaseDir {
-#if TARGET_OS_IOS || TARGET_OS_WATCH
+#if TARGET_OS_IOS || TARGET_OS_WATCH || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     NSArray *dirPaths = NSSearchPathForDirectoriesInDomains(
         NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDir = [dirPaths objectAtIndex:0];

--- a/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
+++ b/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
@@ -275,7 +275,8 @@ static NSString *trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
 }
 
 + (NSString *)firebaseDir {
-#if TARGET_OS_IOS || TARGET_OS_WATCH || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_WATCH ||                                        \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     NSArray *dirPaths = NSSearchPathForDirectoriesInDomains(
         NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDir = [dirPaths objectAtIndex:0];

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -26,9 +26,11 @@
 #import "FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h"
 #import "FirebaseDatabase/Sources/Utilities/FStringUtilities.h"
 
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
-#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) &&
+       // TARGET_OS_VISION)
 
 #if TARGET_OS_WATCH
 #import <Network/Network.h>
@@ -144,14 +146,16 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 
 // Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
-#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     Class uiDeviceClass = NSClassFromString(@"UIDevice");
     if (uiDeviceClass) {
         systemVersion = [uiDeviceClass currentDevice].systemVersion;
         deviceName = [uiDeviceClass currentDevice].model;
         hasUiDeviceClass = YES;
     }
-#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) &&
+       // TARGET_OS_VISION)
 
     if (!hasUiDeviceClass) {
         NSDictionary *systemVersionDictionary = [NSDictionary

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -26,9 +26,9 @@
 #import "FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h"
 #import "FirebaseDatabase/Sources/Utilities/FStringUtilities.h"
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
-#endif // TARGET_OS_IOS || TARGET_OS_TV
+#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
 #if TARGET_OS_WATCH
 #import <Network/Network.h>
@@ -144,14 +144,14 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 
 // Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
     Class uiDeviceClass = NSClassFromString(@"UIDevice");
     if (uiDeviceClass) {
         systemVersion = [uiDeviceClass currentDevice].systemVersion;
         deviceName = [uiDeviceClass currentDevice].model;
         hasUiDeviceClass = YES;
     }
-#endif // TARGET_OS_IOS || TARGET_OS_TV
+#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 
     if (!hasUiDeviceClass) {
         NSDictionary *systemVersionDictionary = [NSDictionary


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1` on visionOS. This PR fixes the build and unit tests for RTDB on Xcode 15.1 beta 1 / visionOS.

Note: https://github.com/google/GoogleUtilities/pull/132 is also needed to fix the build (not yet tagged / released).

#no-changelog