### PR TITLE
[visionOS] Fix Crashlytics build on Xcode 15.1 beta 1

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.m
@@ -48,6 +48,8 @@ NSString* FIRCLSApplicationGetPlatform(void) {
   return @"tvos";
 #elif TARGET_OS_WATCH
   return @"ios";  // TODO: temporarily use iOS until Firebase can add watchos to the backend
+#elif defined(TARGET_OS_VISION) && TARGET_OS_VISION
+  return @"ios";  // TODO: temporarily use iOS until Firebase can add visionos to the backend
 #endif
 }
 


### PR DESCRIPTION
In Xcode 15.1 `TARGET_OS_IOS` is now `0` instead of `1` on visionOS. This PR fixes the build and for Crashlytics on Xcode 15.1 beta 1 / visionOS.

Note: https://github.com/google/GoogleUtilities/pull/132 is also needed to fix the build (not yet tagged / released).

#no-changelog