### PR TITLE
[Infra] Add job that builds ClientApp with source Firestore via SPM

### DIFF
--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -38,6 +38,24 @@ jobs:
       - name: Build Client App –– ${{ matrix.platform }}
         run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild
 
+  client-app-spm-source-firestore:
+      if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+      env:
+        FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+        FIREBASE_SOURCE_FIRESTORE: 1
+      runs-on: macos-12
+      strategy:
+        matrix:
+          #TODO(ncooke3): Add multi-platform support: tvOS, macOS, catalyst
+          platform: [iOS]
+      steps:
+        - uses: actions/checkout@v3
+        - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+          with:
+            cache_key: ${{ matrix.os }}
+        - name: Build Client App –– ${{ matrix.platform }}
+          run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild
+
   client-app-cocoapods:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'


### PR DESCRIPTION
In addition to the source FST builds in `firestore.yml`, this should add some additional test coverage.

#no-changelog