### PR TITLE
[App Check] Add failure reasons for App Attest error cases

### DIFF
--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -290,6 +290,10 @@ NS_ASSUME_NONNULL_BEGIN
                                  completionHandler:handler];
                 }];
           })
+      .recoverOn(self.queue,
+                 ^id(NSError *error) {
+                   return [FIRAppCheckErrorUtil appAttestAttestKeyFailedWithError:error];
+                 })
       .thenOn(self.queue, ^FBLPromise<FIRAppAttestKeyAttestationResult *> *(NSData *attestation) {
         FIRAppAttestKeyAttestationResult *result =
             [[FIRAppAttestKeyAttestationResult alloc] initWithKeyID:keyID
@@ -402,6 +406,10 @@ NS_ASSUME_NONNULL_BEGIN
                                          completionHandler:handler];
                 }];
           })
+      .recoverOn(self.queue,
+                 ^id(NSError *error) {
+                   return [FIRAppCheckErrorUtil appAttestGenerateAssertionFailedWithError:error];
+                 })
       // 3. Compose the result object.
       .thenOn(self.queue, ^FIRAppAttestAssertionData *(NSData *assertion) {
         return [[FIRAppAttestAssertionData alloc] initWithChallenge:challenge
@@ -479,6 +487,10 @@ NS_ASSUME_NONNULL_BEGIN
              wrapObjectOrErrorCompletion:^(FBLPromiseObjectOrErrorCompletion _Nonnull handler) {
                [self.appAttestService generateKeyWithCompletionHandler:handler];
              }]
+      .recoverOn(self.queue,
+                 ^id(NSError *error) {
+                   return [FIRAppCheckErrorUtil appAttestGenerateKeyFailedWithError:error];
+                 })
       .thenOn(self.queue, ^FBLPromise<NSString *> *(NSString *keyID) {
         return [self.keyIDStorage setAppAttestKeyID:keyID];
       });

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
@@ -55,9 +55,13 @@ void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error;
 
-+ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error;
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error
+                                         keyId:(NSString *)keyId
+                                clientDataHash:(NSData *)clientDataHash;
 
-+ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error;
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error
+                                                 keyId:(NSString *)keyId
+                                        clientDataHash:(NSData *)clientDataHash;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.h
@@ -51,6 +51,14 @@ void FIRAppCheckSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (NSError *)appAttestKeyIDNotFound;
 
+// MARK: - App Attest Errors
+
++ (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error;
+
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error;
+
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -121,24 +121,36 @@
 #pragma mark - App Attest
 
 + (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error {
-  return [self
-      appCheckErrorWithCode:FIRAppCheckAppAttestGenerateKeyFailed
-              failureReason:
-                  @"Failed to generate a new cryptographic key for use with the App Attest service."
-            underlyingError:error];
+  NSString *failureReason = @"Failed to generate a new cryptographic key for use with the App "
+                            @"Attest service (`generateKeyWithCompletionHandler:`).";
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:error];
 }
 
-+ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error {
-  return [self
-      appCheckErrorWithCode:FIRAppCheckAppAttestAttestKeyFailed
-              failureReason:@"Failed to attest the validity of the generated cryptographic key."
-            underlyingError:error];
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error
+                                         keyId:(NSString *)keyId
+                                clientDataHash:(NSData *)clientDataHash {
+  NSString *failureReason =
+      [NSString stringWithFormat:@"Failed to attest the validity of the generated cryptographic "
+                                 @"key (`attestKey:clientDataHash:completionHandler:`); "
+                                 @"keyId.length = %lu, clientDataHash.length = %lu",
+                                 keyId.length, clientDataHash.length];
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
+                       failureReason:failureReason
+                     underlyingError:error];
 }
 
-+ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error {
-  return [self appCheckErrorWithCode:FIRAppCheckAppAttestGenerateAssertionFailed
-                       failureReason:@"Failed to create a block of data that demonstrates the "
-                                     @"legitimacy of the app instance."
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error
+                                                 keyId:(NSString *)keyId
+                                        clientDataHash:(NSData *)clientDataHash {
+  NSString *failureReason = [NSString
+      stringWithFormat:@"Failed to create a block of data that demonstrates the legitimacy of the "
+                       @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
+                       @"keyId.length = %lu, clientDataHash.length = %lu.",
+                       keyId.length, clientDataHash.length];
+  return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
+                       failureReason:failureReason
                      underlyingError:error];
 }
 

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -123,6 +123,7 @@
 + (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error {
   NSString *failureReason = @"Failed to generate a new cryptographic key for use with the App "
                             @"Attest service (`generateKeyWithCompletionHandler:`).";
+  // TODO(#11967): Add a new error code for this case (e.g., FIRAppCheckAppAttestGenerateKeyFailed).
   return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
                        failureReason:failureReason
                      underlyingError:error];
@@ -136,6 +137,7 @@
                                  @"key (`attestKey:clientDataHash:completionHandler:`); "
                                  @"keyId.length = %lu, clientDataHash.length = %lu",
                                  keyId.length, clientDataHash.length];
+  // TODO(#11967): Add a new error code for this case (e.g., FIRAppCheckAppAttestAttestKeyFailed).
   return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
                        failureReason:failureReason
                      underlyingError:error];
@@ -149,6 +151,7 @@
                        @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
                        @"keyId.length = %lu, clientDataHash.length = %lu.",
                        keyId.length, clientDataHash.length];
+  // TODO(#11967): Add error code for this case (e.g., FIRAppCheckAppAttestGenerateAssertionFailed).
   return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
                        failureReason:failureReason
                      underlyingError:error];

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -118,6 +118,30 @@
                      underlyingError:nil];
 }
 
+#pragma mark - App Attest
+
++ (NSError *)appAttestGenerateKeyFailedWithError:(NSError *)error {
+  return [self
+      appCheckErrorWithCode:FIRAppCheckAppAttestGenerateKeyFailed
+              failureReason:
+                  @"Failed to generate a new cryptographic key for use with the App Attest service."
+            underlyingError:error];
+}
+
++ (NSError *)appAttestAttestKeyFailedWithError:(NSError *)error {
+  return [self
+      appCheckErrorWithCode:FIRAppCheckAppAttestAttestKeyFailed
+              failureReason:@"Failed to attest the validity of the generated cryptographic key."
+            underlyingError:error];
+}
+
++ (NSError *)appAttestGenerateAssertionFailedWithError:(NSError *)error {
+  return [self appCheckErrorWithCode:FIRAppCheckAppAttestGenerateAssertionFailed
+                       failureReason:@"Failed to create a block of data that demonstrates the "
+                                     @"legitimacy of the app instance."
+                     underlyingError:error];
+}
+
 #pragma mark - Helpers
 
 + (NSError *)unknownErrorWithError:(NSError *)error {

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
@@ -34,12 +34,6 @@ typedef NS_ERROR_ENUM(FIRAppCheckErrorDomain, FIRAppCheckErrorCode){
     FIRAppCheckErrorCodeKeychain = 3,
 
     /// Selected app attestation provider is not supported on the current platform or OS version.
-    FIRAppCheckErrorCodeUnsupported = 4,
-
-    FIRAppCheckAppAttestGenerateKeyFailed = 5,
-
-    FIRAppCheckAppAttestAttestKeyFailed = 6,
-
-    FIRAppCheckAppAttestGenerateAssertionFailed = 7
+    FIRAppCheckErrorCodeUnsupported = 4
 
 } NS_SWIFT_NAME(AppCheckErrorCode);

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckErrors.h
@@ -34,6 +34,12 @@ typedef NS_ERROR_ENUM(FIRAppCheckErrorDomain, FIRAppCheckErrorCode){
     FIRAppCheckErrorCodeKeychain = 3,
 
     /// Selected app attestation provider is not supported on the current platform or OS version.
-    FIRAppCheckErrorCodeUnsupported = 4
+    FIRAppCheckErrorCodeUnsupported = 4,
+
+    FIRAppCheckAppAttestGenerateKeyFailed = 5,
+
+    FIRAppCheckAppAttestAttestKeyFailed = 6,
+
+    FIRAppCheckAppAttestGenerateAssertionFailed = 7
 
 } NS_SWIFT_NAME(AppCheckErrorCode);

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -393,6 +393,10 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   NSError *attestationError = [NSError errorWithDomain:@"testGetTokenWhenKeyAttestationError"
                                                   code:0
                                               userInfo:nil];
+  NSError *expectedError =
+      [FIRAppCheckErrorUtil appAttestAttestKeyFailedWithError:attestationError
+                                                        keyId:existingKeyID
+                                               clientDataHash:self.randomChallengeHash];
   id attestCompletionArg = [OCMArg invokeBlockWithArgs:[NSNull null], attestationError, nil];
   OCMExpect([self.mockAppAttestService attestKey:existingKeyID
                                   clientDataHash:self.randomChallengeHash
@@ -411,7 +415,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        XCTAssertEqualObjects(error, attestationError);
+        XCTAssertEqualObjects(error, expectedError);
       }];
 
   [self waitForExpectations:@[ self.fakeBackoffWrapper.backoffExpectation, completionExpectation ]
@@ -422,7 +426,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   [self verifyAllMocks];
 
   // 9. Verify backoff error.
-  XCTAssertEqualObjects(self.fakeBackoffWrapper.operationError, attestationError);
+  XCTAssertEqualObjects(self.fakeBackoffWrapper.operationError, expectedError);
 }
 
 - (void)testGetToken_WhenUnregisteredKeyAndKeyAttestationExchangeError {
@@ -671,6 +675,10 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
       [NSError errorWithDomain:@"testGetToken_WhenKeyRegisteredAndGenerateAssertionError"
                           code:0
                       userInfo:nil];
+  NSError *expectedError =
+      [FIRAppCheckErrorUtil appAttestGenerateAssertionFailedWithError:generateAssertionError
+                                                                keyId:existingKeyID
+                                                       clientDataHash:self.randomChallengeHash];
   id completionBlockArg = [OCMArg invokeBlockWithArgs:[NSNull null], generateAssertionError, nil];
   OCMExpect([self.mockAppAttestService
       generateAssertion:existingKeyID
@@ -690,7 +698,7 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
         [completionExpectation fulfill];
 
         XCTAssertNil(token);
-        XCTAssertEqualObjects(error, generateAssertionError);
+        XCTAssertEqualObjects(error, expectedError);
       }];
 
   [self waitForExpectations:@[ completionExpectation ] timeout:0.5];


### PR DESCRIPTION
This will allow developers to more granularly determine when errors occur in `FIRAppAttestProvider` (when performing `generateKeyWithCompletionHandler:`, `attestKey:clientDataHash:completionHandler:` or `generateAssertion:clientDataHash:completionHandler:`), along with additional debugging information (`keyId` and `clientDataHash` lengths).

#no-changelog