### PR TITLE
[App Check] Migrate AppAttestKeyIDStorage from UserDefaults to Keychain

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 10.17.0
 - [fixed] Replaced semantic imports (`@import FirebaseAppCheckInterop`) with umbrella header imports
-  (`#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>`) for ObjC++ compatibility (#11916).
+  (`#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>`) for ObjC++ compatibility. (#11916)
+- [fixed] Prevented App Attest key migration during setup or restoration of a device from a backup. (#11962)
 
 # 10.9.0
 - [feature] Added `limitedUseToken(completion:)` for obtaining limited-use tokens for

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -140,7 +140,9 @@ NS_ASSUME_NONNULL_BEGIN
       sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
 
   FIRAppAttestKeyIDStorage *keyIDStorage =
-      [[FIRAppAttestKeyIDStorage alloc] initWithAppName:app.name appID:app.options.googleAppID];
+      [[FIRAppAttestKeyIDStorage alloc] initWithAppName:app.name
+                                                  appID:app.options.googleAppID
+                                            accessGroup:app.options.appGroupID];
 
   FIRAppCheckAPIService *APIService =
       [[FIRAppCheckAPIService alloc] initWithURLSession:URLSession

--- a/FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestKeyIDStorage.h
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/Storage/FIRAppAttestKeyIDStorage.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBLPromise<ValueType>;
+@class GULKeychainStorage;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -53,7 +54,14 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param appID A Firebase App identifier (`FirebaseOptions.googleAppID`). The app ID will be used
  * as a part of the key to store the token for the storage instance.
  */
-- (instancetype)initWithAppName:(NSString *)appName appID:(NSString *)appID;
+- (instancetype)initWithAppName:(NSString *)appName
+                          appID:(NSString *)appID
+                    accessGroup:(nullable NSString *)accessGroup;
+
+- (instancetype)initWithAppName:(NSString *)appName
+                          appID:(NSString *)appID
+                keychainStorage:(GULKeychainStorage *)keychainStorage
+                    accessGroup:(nullable NSString *)accessGroup NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestKeyIDStorageTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/Storage/FIRAppAttestKeyIDStorageTests.m
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
+
+// Tests that use the Keychain require a host app and Swift Package Manager
+// does not support adding a host app to test targets.
+#if !SWIFT_PACKAGE
+
+// Skip keychain tests on Catalyst and macOS. Tests are skipped because they
+// involve interactions with the keychain that require a provisioning profile.
+// See go/firebase-macos-keychain-popups for more details.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
@@ -172,3 +183,7 @@
 }
 
 @end
+
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif  // !SWIFT_PACKAGE


### PR DESCRIPTION
Updated `FIRAppAttestKeyIDStorage` to use the Keychain as its underlying storage instead of `NSUserDefaults`. Since we use [`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly) in [`GULKeychainUtils`](https://github.com/google/GoogleUtilities/blob/e5715eba0e1f9f99176ee636d583576611630ba3/GoogleUtilities/Environment/SecureStorage/GULKeychainUtils.m#L69), this means that the key IDs will not be migrated to new devices when restoring from backup.

Context: "The keys that you generate remain valid through regular app updates, but don’t survive app reinstallation, device migration, or restoration of a device from a backup." -- [Start over on reinstallation](https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity#3579384)

#no-changelog