### PR TITLE
[App Check] Fix warning due to NSUInteger length on watchOS

### DIFF
--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         podspec: [FirebaseAppCheckInterop.podspec, FirebaseAppCheck.podspec]
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
+++ b/FirebaseAppCheck/Sources/Core/Errors/FIRAppCheckErrorUtil.m
@@ -136,7 +136,7 @@
       [NSString stringWithFormat:@"Failed to attest the validity of the generated cryptographic "
                                  @"key (`attestKey:clientDataHash:completionHandler:`); "
                                  @"keyId.length = %lu, clientDataHash.length = %lu",
-                                 keyId.length, clientDataHash.length];
+                                 (unsigned long)keyId.length, (unsigned long)clientDataHash.length];
   // TODO(#11967): Add a new error code for this case (e.g., FIRAppCheckAppAttestAttestKeyFailed).
   return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
                        failureReason:failureReason
@@ -150,7 +150,7 @@
       stringWithFormat:@"Failed to create a block of data that demonstrates the legitimacy of the "
                        @"app instance (`generateAssertion:clientDataHash:completionHandler:`); "
                        @"keyId.length = %lu, clientDataHash.length = %lu.",
-                       keyId.length, clientDataHash.length];
+                       (unsigned long)keyId.length, (unsigned long)clientDataHash.length];
   // TODO(#11967): Add error code for this case (e.g., FIRAppCheckAppAttestGenerateAssertionFailed).
   return [self appCheckErrorWithCode:FIRAppCheckErrorCodeUnknown
                        failureReason:failureReason


### PR DESCRIPTION
- Fixed `warning: values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead` on watchOS (introduced in #11956).
- Added `watchos` to `pod lib lint` testing matrix.

#no-changelog