### PR TITLE
[App Check] Reset App Attest key state if `attestKey` fails

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Added invalid key error handling in App Attest key attestation. (#11986)
+
 # 10.17.0
 - [fixed] Replaced semantic imports (`@import FirebaseAppCheckInterop`) with umbrella header imports
   (`#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>`) for ObjC++ compatibility (#11916).

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProvider.m
@@ -322,6 +322,25 @@ NS_ASSUME_NONNULL_BEGIN
 
                 return [self attestKey:keyID challenge:challenge];
               })
+      .recoverOn(
+          self.queue,
+          ^id(NSError *error) {
+            // If Apple rejected the key then reset the attestation and throw a specific error.
+            if ([error.domain isEqualToString:DCErrorDomain] && error.code == DCErrorInvalidKey) {
+              FIRAppCheckDebugLog(
+                  kFIRLoggerAppCheckMessageCodeAttestationRejected,
+                  @"App Attest invalid key; the existing attestation will be reset.");
+
+              // Reset the attestation.
+              return [self resetAttestation].thenOn(self.queue, ^NSError *(id result) {
+                // Throw the rejection error.
+                return [[FIRAppAttestRejectionError alloc] init];
+              });
+            }
+
+            // Otherwise just re-throw the error.
+            return error;
+          })
       .thenOn(self.queue,
               ^FBLPromise<NSArray *> *(FIRAppAttestKeyAttestationResult *result) {
                 // 3. Exchange the attestation to FAC token and pass the results to the next step.


### PR DESCRIPTION
Resets the stored key ID if [`attestKey:clientDataHash:completionHandler:`](https://developer.apple.com/documentation/devicecheck/dcappattestservice/3573911-attestkey?language=objc) fails due to [`DCErrorInvalidKey`](https://developer.apple.com/documentation/devicecheck/dcerror/dcerrorinvalidkey?language=objc). This should resolve App Check / App Attest failures after app reinstallation, device migration, or restoration of a device from a backup (see [docs](https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity?language=objc)).