### PR TITLE
[Infra] Enable testing for iOS 13+ client app scheme

### DIFF
--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -42,6 +42,9 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-12
+    strategy:
+      matrix:
+        scheme: [ClientApp-CocoaPods, ClientApp-CocoaPods-iOS13]
     steps:
       - uses: actions/checkout@v3
       - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -53,4 +56,4 @@ jobs:
       - name: Prereqs
         run: scripts/install_prereqs.sh ClientApp iOS xcodebuild
       - name: Build
-        run: scripts/build.sh ClientApp-CocoaPods iOS xcodebuild
+        run: scripts/build.sh ${{ scheme }} iOS xcodebuild

--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -30,13 +30,14 @@ jobs:
       matrix:
         #TODO(ncooke3): Add multi-platform support: tvOS, macOS, catalyst
         platform: [iOS]
+        scheme: [ClientApp, ClientApp-iOS13]
     steps:
       - uses: actions/checkout@v3
       - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
         with:
           cache_key: ${{ matrix.os }}
       - name: Build Client App –– ${{ matrix.platform }}
-        run: scripts/third_party/travis/retry.sh ./scripts/build.sh SwiftPMClientApp ${{ matrix.platform }} xcodebuild
+        run: scripts/third_party/travis/retry.sh ./scripts/build.sh ${{ matrix.scheme }} ${{ matrix.platform }} xcodebuild
 
   client-app-cocoapods:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Prereqs
         run: scripts/install_prereqs.sh ClientApp iOS xcodebuild
       - name: Build
-        run: scripts/build.sh ${{ scheme }} iOS xcodebuild
+        run: scripts/build.sh ${{ matrix.scheme }} iOS xcodebuild

--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Prereqs
         run: scripts/install_prereqs.sh ClientApp iOS xcodebuild
       - name: Build
-        run: scripts/build.sh CocoaPodsClientApp iOS xcodebuild
+        run: scripts/build.sh ClientApp-CocoaPods iOS xcodebuild

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -698,10 +698,10 @@ case "$product-$platform-$method" in
       build
     ;;
 
-  SwiftPMClientApp-*-xcodebuild)
+  ClientApp-iOS-xcodebuild | ClientApp-iOS13-iOS-xcodebuild)
     RunXcodebuild \
       -project 'ClientApp/ClientApp.xcodeproj' \
-      -scheme "ClientApp" \
+      -scheme $product \
       "${xcb_flags[@]}" \
       build
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -706,7 +706,7 @@ case "$product-$platform-$method" in
       build
     ;;
 
-  CocoaPodsClientApp-iOS-xcodebuild)
+  ClientApp-CocoaPods-iOS-xcodebuild)
     RunXcodebuild \
       -workspace 'ClientApp/ClientApp.xcworkspace' \
       -scheme "ClientApp-CocoaPods" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -706,10 +706,10 @@ case "$product-$platform-$method" in
       build
     ;;
 
-  ClientApp-CocoaPods-iOS-xcodebuild)
+  ClientApp-CocoaPods*-iOS-xcodebuild)
     RunXcodebuild \
       -workspace 'ClientApp/ClientApp.xcworkspace' \
-      -scheme "ClientApp-CocoaPods" \
+      -scheme $product \
       "${xcb_flags[@]}" \
       build
     ;;


### PR DESCRIPTION
This ensures we are testing both iOS11+ and iOS13+ schemes in the client app. There exists two OS specific schemes for each package manager so SDKs that require iOS 13+ can be separately tested (e.g. FirebaseAnalyticsSwift, FIAMSwift).


#no-changelog