### PR TITLE
[SwiftPM] Conditionally link libraries based on Xcode version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -301,9 +301,9 @@ let package = Package(
       ],
       path: "FirebaseAnalyticsWrapper",
       linkerSettings: [
-        .linkedLibrary("sqlite3"),
-        .linkedLibrary("c++"),
-        .linkedLibrary("z"),
+        .xcode14LinkedLibrary("sqlite3"),
+        .xcode14LinkedLibrary("c++"),
+        .xcode14LinkedLibrary("z"),
         .linkedFramework("StoreKit"),
       ]
     ),
@@ -360,9 +360,9 @@ let package = Package(
       ],
       path: "FirebaseAnalyticsWithoutAdIdSupportWrapper",
       linkerSettings: [
-        .linkedLibrary("sqlite3"),
-        .linkedLibrary("c++"),
-        .linkedLibrary("z"),
+        .xcode14LinkedLibrary("sqlite3"),
+        .xcode14LinkedLibrary("c++"),
+        .xcode14LinkedLibrary("z"),
         .linkedFramework("StoreKit"),
       ]
     ),
@@ -376,7 +376,7 @@ let package = Package(
       ],
       path: "FirebaseAnalyticsOnDeviceConversionWrapper",
       linkerSettings: [
-        .linkedLibrary("c++"),
+        .xcode14LinkedLibrary("c++"),
       ]
     ),
 
@@ -1437,7 +1437,7 @@ func firestoreTargets() -> [Target] {
             .when(platforms: [.iOS, .macOS, .tvOS, .firebaseVisionOS])
           ),
           .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS, .firebaseVisionOS])),
-          .linkedLibrary("c++"),
+          .xcode14LinkedLibrary("c++"),
         ]
       ),
       .target(
@@ -1509,7 +1509,7 @@ func firestoreTargets() -> [Target] {
       linkerSettings: [
         .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
         .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
-        .linkedLibrary("c++"),
+        .xcode14LinkedLibrary("c++"),
       ]
     ),
     .target(
@@ -1536,4 +1536,18 @@ extension Platform {
       return .iOS
     #endif // swift(>=5.9)
   }
+}
+
+extension LinkerSetting {
+    static func xcode14LinkedLibrary(_ library: String) -> PackageDescription.LinkerSetting {
+      #if swift(>=5.9)
+        // For Xcode 15, don't link the library or else there will be a
+        // duplicate libraries warning (see #11818).
+        return .linkedLibrary("")
+      #else
+        // TODO(Firebase 11): Remove when Xcode 14 support is dropped.
+        // Link the library for Xcode 14.
+        return .linkedLibrary(library)
+      #endif // swift(>=5.9)
+    }
 }


### PR DESCRIPTION
This looks promising in a manual test I did with Firestore. A similar change will need to happen in our repos like GoogleAppMeasurement.

A couple other approaches I tried that cause an error  for taking too long to resolve:
1. Extension on `LinkerSetting` that provides a counterpart to `.linkedLibrary` that returns `nil` for Xcode 15. Then, each array of `LinkerSetting`s used throughout the manifest needs to add `compactMap { $0 }` to filter out `nil` libraries. This took too long to resolve.
2. Anything to do with concatenating arrays within each target's `linkerSettings` took too long to resolve. There were a few variations of this.