### PR TITLE
Fix Xcode 15.1 build warning

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.18.0
+- [fixed] Fix a Xcode 15.1 build warning (#12027).
+
 # 10.17.0
 - [fixed] Fix a second Xcode 15 runtime warning (#11821).
 

--- a/FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeCollector.m
+++ b/FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeCollector.m
@@ -45,7 +45,7 @@
  *
  * @return Instance of FPRCPUGaugeData.
  */
-FPRCPUGaugeData *fprCollectCPUMetric() {
+FPRCPUGaugeData *fprCollectCPUMetric(void) {
   kern_return_t kernelReturnValue;
   mach_msg_type_number_t task_info_count;
   task_info_data_t taskInfo;


### PR DESCRIPTION
Fix the following:

```
    - WARN  | xcodebuild:  /Users/p/gh6/firebase-ios-sdk/FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeCollector.m:48:37: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```