### PR TITLE
Fix zip quickstart regression

### DIFF
--- a/scripts/zip_quickstart_test.sh
+++ b/scripts/zip_quickstart_test.sh
@@ -34,7 +34,7 @@ fi
 xcodebuild \
 -project ${SAMPLE}Example.xcodeproj \
 -scheme  ${SAMPLE}Example${SWIFT_SUFFIX} \
--destination 'platform=iOS Simulator,name=iPhone 15' "SWIFT_VERSION=5.3" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
+-destination 'platform=iOS Simulator,name=iPhone 14' "SWIFT_VERSION=5.3" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
 build \
 test \
 ) || EXIT_STATUS=$?


### PR DESCRIPTION
This should fix recent failures in the zip tests trying to run quickstarts on the unavailable iPhone 15 with Xcode 14.2. iPhone 14 shows available in https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md and https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md