### PR TITLE
[Core] Add `FIRGetLoggerLevel` function

### DIFF
--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -53,6 +53,11 @@ extern "C" {
 void FIRSetAnalyticsDebugMode(BOOL analyticsDebugMode);
 
 /**
+ * Gets the current FIRLoggerLevel.
+ */
+FIRLoggerLevel FIRGetLoggerLevel(void);
+
+/**
  * Changes the default logging level of FirebaseLoggerLevelNotice to a user-specified level.
  * The default level cannot be set above FirebaseLoggerLevelNotice if the app is running from App
  * Store. (required) log level (one of the FirebaseLoggerLevel enum values).

--- a/FirebaseCore/Sources/FIRLogger.m
+++ b/FirebaseCore/Sources/FIRLogger.m
@@ -90,6 +90,10 @@ __attribute__((no_sanitize("thread"))) void FIRSetAnalyticsDebugMode(BOOL analyt
   sFIRAnalyticsDebugMode = analyticsDebugMode;
 }
 
+FIRLoggerLevel FIRGetLoggerLevel(void) {
+  return (FIRLoggerLevel)GULGetLoggerLevel();
+}
+
 void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel) {
   FIRLoggerInitializeASL();
   GULSetLoggerLevel((GULLoggerLevel)loggerLevel);

--- a/FirebaseCore/Tests/Unit/FIRLoggerTest.m
+++ b/FirebaseCore/Tests/Unit/FIRLoggerTest.m
@@ -185,5 +185,31 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(FIRLoggerLevelDebug, ASL_LEVEL_DEBUG);
 }
 
+- (void)testFIRGetLoggerLevel {
+  FIRLoggerLevel loggerLevel = FIRGetLoggerLevel();
+
+  // The default logger level is FIRLoggerLevelNotice.
+  XCTAssertEqual(loggerLevel, FIRLoggerLevelNotice);
+}
+
+- (void)testFIRSetLoggerLevel {
+  FIRSetLoggerLevel(FIRLoggerLevelDebug);
+
+  FIRLoggerLevel loggerLevel = FIRGetLoggerLevel();
+
+  // The default logger level is FIRLoggerLevelNotice.
+  XCTAssertEqual(loggerLevel, FIRLoggerLevelDebug);
+}
+
+- (void)testFIRResetLogger_ResetsLoggerLevel {
+  FIRSetLoggerLevel(FIRLoggerLevelDebug);
+
+  FIRResetLogger();
+  FIRLoggerLevel loggerLevel = FIRGetLoggerLevel();
+
+  // The default logger level is FIRLoggerLevelNotice.
+  XCTAssertEqual(loggerLevel, FIRLoggerLevelNotice);
+}
+
 @end
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -154,7 +154,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.11.0" ..< "8.0.0"
+      "7.12.0" ..< "8.0.0"
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",


### PR DESCRIPTION
Added a getter for the current logger level. This wraps `GULGetLoggerLevel` added in https://github.com/google/GoogleUtilities/pull/138.

#no-changelog