### PR TITLE
Set `GACAppCheckLogger.logLevel` in Firebase App Check

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -65,6 +65,9 @@ static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1Iif
 #pragma mark - Internal
 
 - (nullable instancetype)initWithApp:(FIRApp *)app {
+  // Set the App Check Core logging level to the current equivalent Firebase logging level.
+  GACAppCheckLogger.logLevel = FIRGetGACAppCheckLogLevel();
+
   id<FIRAppCheckProviderFactory> providerFactory = [FIRAppCheck providerFactory];
 
   if (providerFactory == nil) {

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <AppCheckCore/AppCheckCore.h>
+
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 extern FIRLoggerService kFIRLoggerAppCheck;
@@ -34,3 +36,5 @@ FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeDebugToken;
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions;
 
 void FIRAppCheckDebugLog(NSString *messageCode, NSString *message, ...);
+
+GACAppCheckLogLevel FIRGetGACAppCheckLogLevel(void);

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -16,8 +16,6 @@
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
 
-#import <AppCheckCore/AppCheckCore.h>
-
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -38,11 +36,29 @@ NSString *const kFIRLoggerAppCheckMessageCodeDebugToken = @"I-FAA005001";
 NSString *const kFIRLoggerAppCheckMessageDeviceCheckProviderIncompleteFIROptions = @"I-FAA006001";
 
 #pragma mark - Log functions
+
 void FIRAppCheckDebugLog(NSString *messageCode, NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
   FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppCheck, messageCode, message, args_ptr);
   va_end(args_ptr);
+}
+
+#pragma mark - Helper functions
+
+GACAppCheckLogLevel FIRGetGACAppCheckLogLevel(void) {
+  FIRLoggerLevel loggerLevel = FIRGetLoggerLevel();
+  switch (loggerLevel) {
+    case FIRLoggerLevelError:
+      return GACAppCheckLogLevelError;
+    case FIRLoggerLevelWarning:
+    case FIRLoggerLevelNotice:
+      return GACAppCheckLogLevelWarning;
+    case FIRLoggerLevelInfo:
+      return GACAppCheckLogLevelInfo;
+    case FIRLoggerLevelDebug:
+      return GACAppCheckLogLevelDebug;
+  }
 }
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckLoggerTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckLoggerTests.m
@@ -20,6 +20,9 @@
 
 #import <AppCheckCore/AppCheckCore.h>
 
+@interface FIRAppCheckLoggerTests : XCTestCase
+@end
+
 @implementation FIRAppCheckLoggerTests
 
 - (void)testGetGACAppCheckLogLevel_Error {

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckLoggerTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckLoggerTests.m
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h"
+
+#import <AppCheckCore/AppCheckCore.h>
+
+@implementation FIRAppCheckLoggerTests
+
+- (void)testGetGACAppCheckLogLevel_Error {
+  FIRSetLoggerLevel(FIRLoggerLevelError);
+
+  GACAppCheckLogLevel logLevel = FIRGetGACAppCheckLogLevel();
+
+  XCTAssertEqual(logLevel, GACAppCheckLogLevelError);
+}
+
+- (void)testGetGACAppCheckLogLevel_Warning {
+  FIRSetLoggerLevel(FIRLoggerLevelWarning);
+
+  GACAppCheckLogLevel logLevel = FIRGetGACAppCheckLogLevel();
+
+  XCTAssertEqual(logLevel, GACAppCheckLogLevelWarning);
+}
+
+- (void)testGetGACAppCheckLogLevel_Notice {
+  FIRSetLoggerLevel(FIRLoggerLevelNotice);
+
+  GACAppCheckLogLevel logLevel = FIRGetGACAppCheckLogLevel();
+
+  XCTAssertEqual(logLevel, GACAppCheckLogLevelWarning);
+}
+
+- (void)testGetGACAppCheckLogLevel_Info {
+  FIRSetLoggerLevel(FIRLoggerLevelInfo);
+
+  GACAppCheckLogLevel logLevel = FIRGetGACAppCheckLogLevel();
+
+  XCTAssertEqual(logLevel, GACAppCheckLogLevelInfo);
+}
+
+- (void)testGetGACAppCheckLogLevel_Debug {
+  FIRSetLoggerLevel(FIRLoggerLevelDebug);
+
+  GACAppCheckLogLevel logLevel = FIRGetGACAppCheckLogLevel();
+
+  XCTAssertEqual(logLevel, GACAppCheckLogLevelDebug);
+}
+
+@end

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckTests.m
@@ -115,7 +115,7 @@ extern void FIRResetLogger(void);
   OCMExpect([mockProviderFactory createProviderWithApp:app]).andReturn(mockProvider);
 
   [FIRAppCheck setAppCheckProviderFactory:mockProviderFactory];
-  
+
   // 3. Set the Firebase logging level to Debug.
   FIRSetLoggerLevel(FIRLoggerLevelDebug);
 
@@ -126,7 +126,7 @@ extern void FIRResetLogger(void);
   // 5. Verify mocks.
   OCMVerifyAll(mockProviderFactory);
   OCMVerifyAll(mockProvider);
-  
+
   // 6. Verify that the App Check Core logging level is also Debug.
   XCTAssertEqual(GACAppCheckLogger.logLevel, GACAppCheckLogLevelDebug);
 }
@@ -144,7 +144,7 @@ extern void FIRResetLogger(void);
   XCTAssertNotNil(app);
 
   XCTAssertNotNil([FIRAppCheck appCheckWithApp:app]);
-  
+
   // Verify that the App Check Core logging level is the default (Warning).
   XCTAssertEqual(GACAppCheckLogger.logLevel, GACAppCheckLogLevelWarning);
 }


### PR DESCRIPTION
Sets the App Check Core logging level (`GACAppCheckLogger.logLevel`) to the equivalent Firebase logging level when instantiating `FIRAppCheck`.

#no-changelog
