### PR TITLE
Fix cmake ci

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -130,6 +130,10 @@ jobs:
         key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
         restore-keys: ${{ runner.os }}-mint-
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'
+
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
 
@@ -175,6 +179,10 @@ jobs:
         path: ${{ env.MINT_PATH }}
         key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
         restore-keys: ${{ runner.os }}-mint-
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'
 
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firestore.plist.gpg \
@@ -251,6 +259,10 @@ jobs:
         key: ${{ matrix.sanitizer }}-firestore-ccache-${{ runner.os }}-${{ github.sha }}
         restore-keys: |
           ${{ matrix.sanitizer }}-firestore-ccache-${{ runner.os }}-
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake

--- a/cmake/GoogleUtilities.cmake
+++ b/cmake/GoogleUtilities.cmake
@@ -20,13 +20,14 @@ endif()
 file(
   GLOB sources
   ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/GoogleUtilities/Environment/*.m
-  ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/GoogleUtilities/Environment/third_party/*.m
+  ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/third_party/IsAppEncrypted/*.m
   ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/GoogleUtilities/Logger/*.m
 )
 file(
   GLOB headers
   ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/GoogleUtilities/Environment/Public/GoogleUtilities/*.h
   ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/GoogleUtilities/Logger/Public/GoogleUtilities/*.h
+  ${FIREBASE_EXTERNAL_SOURCE_DIR}/GoogleUtilities/third_party/IsAppEncrypted/Public/*.h
 )
 
 firebase_ios_add_framework(


### PR DESCRIPTION
The default Python in CI changed recently. Fix inspired by #12055

Also update the source and header paths for GoogleUtilities

For some reason, most Firestore jobs are not running in nightlies, but not clear to me why.