### PR TITLE
[auth-swift] Add six missing recaptcha unit tests

### DIFF
--- a/FirebaseAuth/Sources/Swift/Utilities/AuthRecaptchaVerifier.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthRecaptchaVerifier.swift
@@ -151,8 +151,7 @@
       // Response's site key is of the format projects/<project-id>/keys/<site-key>'
       guard let keys = response.recaptchaKey?.components(separatedBy: "/"),
             keys.count == 4 else {
-        throw AuthErrorUtils.error(code: .recaptchaNotEnabled,
-                                   message: "Invalid siteKey")
+        throw AuthErrorUtils.error(code: .recaptchaNotEnabled, message: "Invalid siteKey")
       }
       let siteKey = keys[3]
       var enablementStatus: [String: Bool] = [:]


### PR DESCRIPTION
This is a follow on to #11942 that missed six recaptcha unit tests when adapting #11681 to Swift.

#no-changelog