### PR TITLE
[SwiftPM] Bump GULs dependency's range minimum to 7.12.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -154,7 +154,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.12.0" ..< "8.0.0"
+      "7.12.1" ..< "8.0.0"
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",


### PR DESCRIPTION
See https://github.com/google/GoogleUtilities/blob/7.12.1/CHANGELOG.md#7121-swiftpm-only

cc: @paulb777 

#no-changelog