### PR TITLE
[auth-swift] Remove extra publics

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
@@ -18,7 +18,7 @@ import FirebaseCore
 import FirebaseCoreExtension
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthProvider) public protocol AuthProvider {
+@objc(FIRAuthProvider) protocol AuthProvider {
   @objc func auth() -> Auth
 }
 

--- a/FirebaseAuth/Sources/Swift/Auth/AuthOperationType.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthOperationType.swift
@@ -17,7 +17,7 @@ import Foundation
     @brief Indicates the type of operation performed for RPCs that support the operation
         parameter.
  */
-@objc(FIRAuthOperationType) public enum AuthOperationType: Int {
+enum AuthOperationType: Int {
   /** Indicates that the operation type is uspecified.
    */
   case unspecified = 0

--- a/FirebaseAuth/Sources/Swift/Auth/AuthSerialTaskQueue.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthSerialTaskQueue.swift
@@ -14,14 +14,12 @@
 
 import Foundation
 
-typealias FIRAuthSerialTaskCompletionBlock = () -> Void
-typealias FIRAuthSerialTask = (_ complete: @escaping FIRAuthSerialTaskCompletionBlock)
-  -> Void
+typealias AuthSerialTaskCompletionBlock = () -> Void
 
 class AuthSerialTaskQueue: NSObject {
   private let dispatchQueue: DispatchQueue
 
-  @objc override public init() {
+  override init() {
     dispatchQueue = DispatchQueue(
       label: "com.google.firebase.auth.serialTaskQueue",
       target: kAuthGlobalWorkQueue
@@ -29,7 +27,8 @@ class AuthSerialTaskQueue: NSObject {
     super.init()
   }
 
-  func enqueueTask(_ task: @escaping FIRAuthSerialTask) {
+  func enqueueTask(_ task: @escaping ((_ complete: @escaping AuthSerialTaskCompletionBlock)
+      -> Void)) {
     dispatchQueue.async {
       self.dispatchQueue.suspend()
       task {

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRPCResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRPCResponse.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public protocol AuthRPCResponse {
+protocol AuthRPCResponse {
   /// Bare initializer for a response.
   init()
 
@@ -36,7 +36,7 @@ public protocol AuthRPCResponse {
   func clientError(shortErrorMessage: String, detailedErrorMessage: String?) -> Error?
 }
 
-public extension AuthRPCResponse {
+extension AuthRPCResponse {
   // Default implementation.
   func clientError(shortErrorMessage: String, detailedErrorMessage: String? = nil) -> Error? {
     return nil

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
@@ -19,41 +19,41 @@ import Foundation
     @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/createAuthUri
  */
 
-public class CreateAuthURIResponse: AuthRPCResponse {
+class CreateAuthURIResponse: AuthRPCResponse {
   /** @property authUri
       @brief The URI used by the IDP to authenticate the user.
    */
-  public var authURI: String?
+  var authURI: String?
 
   /** @property registered
       @brief Whether the user is registered if the identifier is an email.
    */
-  public var registered: Bool = false
+  var registered: Bool = false
 
   /** @property providerId
       @brief The provider ID of the auth URI.
    */
-  public var providerID: String?
+  var providerID: String?
 
   /** @property forExistingProvider
       @brief True if the authUri is for user's existing provider.
    */
-  public var forExistingProvider: Bool = false
+  var forExistingProvider: Bool = false
 
   /** @property allProviders
       @brief A list of provider IDs the passed @c identifier could use to sign in with.
    */
-  public var allProviders: [String]?
+  var allProviders: [String]?
 
   /** @property signinMethods
       @brief A list of sign-in methods available for the passed @c identifier.
    */
-  public var signinMethods: [String]?
+  var signinMethods: [String]?
 
   /// Bare initializer.
-  public required init() {}
+  required init() {}
 
-  public func setFields(dictionary: [String: AnyHashable]) throws {
+  func setFields(dictionary: [String: AnyHashable]) throws {
     providerID = dictionary["providerId"] as? String
     authURI = dictionary["authUri"] as? String
     registered = dictionary["registered"] as? Bool ?? false

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
@@ -18,8 +18,8 @@ import Foundation
     @brief Represents the response from the deleteAccount endpoint.
     @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/deleteAccount
  */
-public class DeleteAccountResponse: NSObject, AuthRPCResponse {
-  override public required init() {}
+class DeleteAccountResponse: NSObject, AuthRPCResponse {
+  override required init() {}
 
-  public func setFields(dictionary: [String: AnyHashable]) throws {}
+  func setFields(dictionary: [String: AnyHashable]) throws {}
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -18,7 +18,7 @@ import Foundation
     @brief Represents the response from the emailLinkSignin endpoint.
  */
 class EmailLinkSignInResponse: NSObject, AuthRPCResponse {
-  override public required init() {}
+  override required init() {}
 
   /** @property IDToken
    @brief The ID token in the email link sign-in response.
@@ -56,7 +56,7 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse {
    */
   var mfaInfo: [AuthProtoMFAEnrollment]?
 
-  public func setFields(dictionary: [String: AnyHashable]) throws {
+  func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
     idToken = dictionary["idToken"] as? String
     isNewUser = dictionary["isNewUser"] as? Bool ?? false

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
@@ -185,7 +185,7 @@ class GetAccountInfoResponseUser: NSObject {
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class GetAccountInfoResponse: AuthRPCResponse {
-  public required init() {}
+  required init() {}
 
   /** @property providerUserInfo
    @brief The requested users' profiles.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
@@ -59,7 +59,7 @@ class FinalizeMFAEnrollmentRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     var body: [String: AnyHashable] = [:]
     if let idToken = idToken {
       body["idToken"] = idToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentResponse.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class FinalizeMFAEnrollmentResponse: AuthRPCResponse {
-  public required init() {}
+  required init() {}
 
   private(set) var idToken: String?
   private(set) var refreshToken: String?

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFAResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFAResponse.swift
@@ -20,7 +20,7 @@ class WithdrawMFAResponse: AuthRPCResponse {
   var idToken: String?
   var refreshToken: String?
 
-  public func setFields(dictionary: [String: AnyHashable]) throws {
+  func setFields(dictionary: [String: AnyHashable]) throws {
     idToken = dictionary["idToken"] as? String
     refreshToken = dictionary["refreshToken"] as? String
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProto.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProto.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@objc(FIRAuthProto) public protocol AuthProto: NSObjectProtocol {
-  @objc init(dictionary: [String: AnyHashable])
+@objc protocol AuthProto: NSObjectProtocol {
+  init(dictionary: [String: AnyHashable])
   @objc optional var dictionary: [String: AnyHashable] { get }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
@@ -21,7 +21,7 @@ class AuthProtoMFAEnrollment: NSObject, AuthProto {
   let displayName: String?
   let enrolledAt: Date?
 
-  public required init(dictionary: [String: AnyHashable]) {
+  required init(dictionary: [String: AnyHashable]) {
     phoneInfo = dictionary["phoneInfo"] as? String
     totpInfo = dictionary["totpInfo"] as? NSObject
     mfaEnrollmentID = dictionary["mfaEnrollmentId"] as? String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneRequestInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/Phone/AuthProtoFinalizeMFAPhoneRequestInfo.swift
@@ -21,7 +21,7 @@ class AuthProtoFinalizeMFAPhoneRequestInfo: NSObject, AuthProto {
 
   var sessionInfo: String?
   var code: String?
-  @objc public init(sessionInfo: String?, verificationCode: String?) {
+  init(sessionInfo: String?, verificationCode: String?) {
     self.sessionInfo = sessionInfo
     code = verificationCode
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/TOTP/AuthProtoFinalizeMFATOTPEnrollmentRequestInfo.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/TOTP/AuthProtoFinalizeMFATOTPEnrollmentRequestInfo.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 class AuthProtoStartMFATOTPEnrollmentRequestInfo: NSObject, AuthProto {
-  public required init(dictionary: [String: AnyHashable]) {
+  required init(dictionary: [String: AnyHashable]) {
     fatalError()
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@objc(FIRSecureTokenRequestGrantType) enum SecureTokenRequestGrantType: Int {
+enum SecureTokenRequestGrantType: Int {
   case authorizationCode
   case refreshToken
 
@@ -96,7 +96,7 @@ class SecureTokenRequest: AuthRPCRequest {
   /** @property refreshToken
       @brief The client's refresh token.
    */
-  public var refreshToken: String?
+  var refreshToken: String?
 
   /** @property code
       @brief The client's authorization code (legacy Gitkit "ID Token").
@@ -106,15 +106,15 @@ class SecureTokenRequest: AuthRPCRequest {
   /** @property APIKey
       @brief The client's API Key.
    */
-  public let apiKey: String
+  let apiKey: String
 
   let _requestConfiguration: AuthRequestConfiguration
-  public func requestConfiguration() -> AuthRequestConfiguration {
+  func requestConfiguration() -> AuthRequestConfiguration {
     _requestConfiguration
   }
 
-  public static func authCodeRequest(code: String,
-                                     requestConfiguration: AuthRequestConfiguration)
+  static func authCodeRequest(code: String,
+                              requestConfiguration: AuthRequestConfiguration)
     -> SecureTokenRequest {
     SecureTokenRequest(
       grantType: .authorizationCode,
@@ -125,8 +125,8 @@ class SecureTokenRequest: AuthRPCRequest {
     )
   }
 
-  public static func refreshRequest(refreshToken: String,
-                                    requestConfiguration: AuthRequestConfiguration)
+  static func refreshRequest(refreshToken: String,
+                             requestConfiguration: AuthRequestConfiguration)
     -> SecureTokenRequest {
     SecureTokenRequest(
       grantType: .refreshToken,
@@ -147,7 +147,7 @@ class SecureTokenRequest: AuthRPCRequest {
     _requestConfiguration = requestConfiguration
   }
 
-  public func requestURL() -> URL {
+  func requestURL() -> URL {
     let urlString: String
     if let emulatorHostAndPort = _requestConfiguration.emulatorHostAndPort {
       urlString = "http://\(emulatorHostAndPort)/\(gAPIHost)/v1/token?key=\(apiKey)"
@@ -157,9 +157,9 @@ class SecureTokenRequest: AuthRPCRequest {
     return URL(string: urlString)!
   }
 
-  public func containsPostBody() -> Bool { true }
+  func containsPostBody() -> Bool { true }
 
-  public func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     var postBody: [String: AnyHashable] = [
       kGrantTypeKey: grantType.value,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
@@ -18,28 +18,27 @@ import Foundation
     @brief Represents the provider user info part of the response from the setAccountInfo endpoint.
     @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/setAccountInfo
  */
-@objc(FIRSetAccountInfoResponseProviderUserInfo)
-public class SetAccountInfoResponseProviderUserInfo: NSObject {
+class SetAccountInfoResponseProviderUserInfo: NSObject {
   /** @property providerID
       @brief The ID of the identity provider.
    */
-  @objc public var providerID: String?
+  var providerID: String?
 
   /** @property displayName
       @brief The user's display name at the identity provider.
    */
-  @objc public var displayName: String?
+  var displayName: String?
 
   /** @property photoURL
       @brief The user's photo URL at the identity provider.
    */
-  @objc public var photoURL: URL?
+  var photoURL: URL?
 
   /** @fn initWithAPIKey:
       @brief Designated initializer.
       @param dictionary The provider user info data from endpoint.
    */
-  @objc public init(dictionary: [String: Any]) {
+  init(dictionary: [String: Any]) {
     providerID = dictionary["providerId"] as? String
     displayName = dictionary["displayName"] as? String
     if let photoURL = dictionary["photoUrl"] as? String {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -97,7 +97,7 @@ class VerifyAssertionResponse: AuthRPCResponse {
    access token from Secure Token Service, depending on whether @c returnSecureToken is set
    on the request.
    */
-  @objc(IDToken) var idToken: String?
+  var idToken: String?
 
   /** @property approximateExpirationDate
    @brief The approximate expiration date of the access token.

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
@@ -39,7 +39,7 @@ import Foundation
     }
 
     @available(*, unavailable)
-    public required init?(coder: NSCoder) {
+    required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
   }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSToken.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSToken.swift
@@ -15,14 +15,12 @@
 #if !os(macOS)
   import Foundation
 
-  // TODO: Eliminate objc public after Sample app port.
-
   /** @class AuthAPNSToken
       @brief A data structure for an APNs token.
    */
-  @objc(FIRAuthAPNSToken) public class AuthAPNSToken: NSObject {
-    @objc public let data: Data
-    @objc public let type: AuthAPNSTokenType
+  class AuthAPNSToken: NSObject {
+    let data: Data
+    let type: AuthAPNSTokenType
 
     /** @fn initWithData:type:
         @brief Initializes the instance.
@@ -38,7 +36,7 @@
     /** @property string
         @brief The uppercase hexadecimal string form of the APNs token data.
      */
-    @objc public lazy var string: String = {
+    lazy var string: String = {
       let byteArray = [UInt8](data)
       var s = ""
       for byte in byteArray {

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -26,7 +26,7 @@
   #endif // SWIFT_PACKAGE
 
   // Protocol to help with unit tests.
-  public protocol AuthAPNSTokenApplication {
+  protocol AuthAPNSTokenApplication {
     func registerForRemoteNotifications()
   }
 

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -159,7 +159,7 @@
         @param notification The notification in question.
         @return Whether or the notification has been handled.
      */
-    @objc(canHandleNotification:) public func canHandle(notification: [AnyHashable: Any]) -> Bool {
+    func canHandle(notification: [AnyHashable: Any]) -> Bool {
       var stringDictionary: [String: Any]?
       let data = notification[kNotificationDataKey]
       if let jsonString = data as? String {

--- a/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
@@ -112,11 +112,11 @@ class SecureTokenService: NSObject, NSSecureCoding {
   private static let kAccessTokenKey = "accessToken"
   private static let kAccessTokenExpirationDateKey = "accessTokenExpirationDate"
 
-  public static var supportsSecureCoding: Bool {
+  static var supportsSecureCoding: Bool {
     true
   }
 
-  public required convenience init?(coder: NSCoder) {
+  required convenience init?(coder: NSCoder) {
     guard let refreshToken = coder.decodeObject(of: [NSString.self],
                                                 forKey: Self.kRefreshTokenKey) as? String,
       let accessToken = coder.decodeObject(of: [NSString.self],
@@ -133,7 +133,7 @@ class SecureTokenService: NSObject, NSSecureCoding {
               refreshToken: refreshToken)
   }
 
-  public func encode(with coder: NSCoder) {
+  func encode(with coder: NSCoder) {
     // The API key is encoded even it is not used in decoding to be compatible with previous
     // versions of the library.
     coder.encode(requestConfiguration?.apiKey, forKey: kAPIKeyCodingKey)

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1894,7 +1894,7 @@ extension User: NSSecureCoding {}
                                          result: AuthDataResult,
                                          requestConfiguration: AuthRequestConfiguration,
                                          completion: ((AuthDataResult?, Error?) -> Void)?,
-                                         withTaskComplete complete: FIRAuthSerialTaskCompletionBlock? =
+                                         withTaskComplete complete: AuthSerialTaskCompletionBlock? =
                                            nil) {
     tokenService = SecureTokenService(
       withRequestConfiguration: requestConfiguration,
@@ -2035,7 +2035,7 @@ extension User: NSSecureCoding {}
   private class func callInMainThreadWithAuthDataResultAndError(callback: (
     (AuthDataResult?, Error?) -> Void
   )?,
-  complete: FIRAuthSerialTaskCompletionBlock? = nil,
+  complete: AuthSerialTaskCompletionBlock? = nil,
   result: AuthDataResult? = nil,
   error: Error? = nil) {
     if let callback {

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -76,11 +76,11 @@ class UserInfoImpl: NSObject, UserInfo, NSSecureCoding {
   private static let kEmailCodingKey = "email"
   private static let kPhoneNumberCodingKey = "phoneNumber"
 
-  public static var supportsSecureCoding: Bool {
+  static var supportsSecureCoding: Bool {
     return true
   }
 
-  public func encode(with coder: NSCoder) {
+  func encode(with coder: NSCoder) {
     coder.encode(providerID, forKey: UserInfoImpl.kProviderIDCodingKey)
     coder.encode(uid, forKey: UserInfoImpl.kUserIDCodingKey)
     coder.encode(displayName, forKey: UserInfoImpl.kDisplayNameCodingKey)
@@ -89,7 +89,7 @@ class UserInfoImpl: NSObject, UserInfo, NSSecureCoding {
     coder.encode(phoneNumber, forKey: UserInfoImpl.kPhoneNumberCodingKey)
   }
 
-  public required convenience init?(coder: NSCoder) {
+  required convenience init?(coder: NSCoder) {
     guard let providerID = coder.decodeObject(of: [NSString.self],
                                               forKey: UserInfoImpl.kProviderIDCodingKey) as? String,
       let uid = coder.decodeObject(

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthInternalErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthInternalErrors.swift
@@ -33,7 +33,7 @@ enum SharedErrorCode {
   case `internal`(AuthInternalErrorCode)
 }
 
-@objc(FIRAuthInternalErrorCode) public enum AuthInternalErrorCode: Int {
+enum AuthInternalErrorCode: Int {
   case networkError = 17020
 
   /** @var FIRAuthInternalErrorCodeRPCRequestEncodingError

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthWebUtils) public class AuthWebUtils: NSObject {
+class AuthWebUtils: NSObject {
   static func randomString(withLength length: Int) -> String {
     var randomString = ""
     for _ in 0 ..< length {
@@ -26,8 +26,8 @@ import Foundation
     return randomString
   }
 
-  @objc public static func isCallbackSchemeRegistered(forCustomURLScheme scheme: String,
-                                                      urlTypes: [[String: Any]]) -> Bool {
+  static func isCallbackSchemeRegistered(forCustomURLScheme scheme: String,
+                                         urlTypes: [[String: Any]]) -> Bool {
     let expectedCustomScheme = scheme.lowercased()
     for urlType in urlTypes {
       guard let urlTypeSchemes = urlType["CFBundleURLSchemes"] else {
@@ -155,8 +155,7 @@ import Foundation
     return nil
   }
 
-  @objc public static func dictionary(withHttpArgumentsString argString: String?)
-    -> [String: String] {
+  static func dictionary(withHttpArgumentsString argString: String?) -> [String: String] {
     guard let argString else {
       return [:]
     }
@@ -190,7 +189,7 @@ import Foundation
       .removingPercentEncoding ?? ""
   }
 
-  @objc public static func parseURL(_ urlString: String) -> [String: String] {
+  static func parseURL(_ urlString: String) -> [String: String] {
     let urlComponents = URLComponents(string: urlString)
     guard let linkURL = urlComponents?.query else {
       return [:]

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebView.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebView.swift
@@ -21,9 +21,9 @@
       @brief A class responsible for creating a WKWebView for use within Firebase Auth.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRAuthWebView) public class AuthWebView: UIView {
-    public lazy var webView: WKWebView = createWebView()
-    public lazy var spinner: UIActivityIndicatorView = createSpinner()
+  class AuthWebView: UIView {
+    lazy var webView: WKWebView = createWebView()
+    lazy var spinner: UIActivityIndicatorView = createSpinner()
 
     override init(frame: CGRect) {
       super.init(frame: frame)
@@ -49,9 +49,7 @@
       self.spinner = spinner
     }
 
-    // TODO: Should not be public
-
-    override public func layoutSubviews() {
+    override func layoutSubviews() {
       super.layoutSubviews()
       let height = bounds.size.height
       let width = bounds.size.width

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
@@ -80,7 +80,7 @@
 
     // MARK: - View Lifecycle
 
-    override public func loadView() {
+    override func loadView() {
       let webView = AuthWebView(frame: UIScreen.main.bounds)
       webView.webView.navigationDelegate = self
       view = webView
@@ -92,7 +92,7 @@
       )
     }
 
-    override public func viewDidAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
       super.viewDidAppear(animated)
       webView?.webView.load(URLRequest(url: url))
     }
@@ -105,8 +105,8 @@
 
     // MARK: - WKNavigationDelegate
 
-    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
       let canHandleURL = delegate?.webViewController(
         self,
         canHandle: navigationAction.request.url ?? url
@@ -118,19 +118,19 @@
       }
     }
 
-    public func webView(_ webView: WKWebView,
-                        didStartProvisionalNavigation navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView,
+                 didStartProvisionalNavigation navigation: WKNavigation!) {
       self.webView?.spinner.isHidden = false
       self.webView?.spinner.startAnimating()
     }
 
-    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
       self.webView?.spinner.isHidden = true
       self.webView?.spinner.stopAnimating()
     }
 
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!,
-                        withError error: Error) {
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!,
+                 withError error: Error) {
       if (error as NSError).domain == NSURLErrorDomain,
          (error as NSError).code == NSURLErrorCancelled {
         // It's okay for the page to be redirected before it is completely loaded.  See b/32028062 .


### PR DESCRIPTION
Remove extra `public` specifiers that were used while the source was a mix of languages.

In this PR, I reviewed all files that should not have any `public`s and `@objc` specifications.  There may still be extra specifiers in public classes.