### PR TITLE
Revert "[Release Tooling] Stage and publish with `--skip-import-valid…

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
@@ -54,4 +54,14 @@ public struct Pod {
   public func podspecName() -> String {
     return "\(name).podspec"
   }
+
+  /// The Firebase pod does not support import validation with Xcode 12 because of the deprecated
+  /// ML pods not supporting the ARM Mac slice.
+  public func skipImportValidation() -> String {
+    if name == "Firebase" {
+      return "--skip-import-validation"
+    } else {
+      return ""
+    }
+  }
 }

--- a/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
@@ -48,11 +48,12 @@ enum Push {
         switch destination {
         case .staging:
           return "pod repo push --skip-tests --use-json \(warningsOK) \(stagingLocation) " +
-            "--skip-import-validation" + " \(pod.podspecName()) " +
+            pod.skipImportValidation() + " \(pod.podspecName()) " +
             "--sources=\(stagingRepo).git,https://cdn.cocoapods.org"
         case .trunk:
           return "pod trunk push --skip-tests --synchronous \(warningsOK) " +
-            "--skip-import-validation" + " ~/.cocoapods/repos/\(stagingLocation)/\(pod.name)/" +
+            pod
+            .skipImportValidation() + " ~/.cocoapods/repos/\(stagingLocation)/\(pod.name)/" +
             "\(manifest.versionString(pod))/\(pod.name).podspec.json"
         }
       }()


### PR DESCRIPTION
Restore import validation when publishing pods.

Disabling did not noticeably speed up the release.

Faster Macs is a better option 😄 