### PR TITLE
Reenable macos tests in ci

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -22,8 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -24,8 +24,7 @@ jobs:
     strategy:
       matrix:
         podspec: [FirebaseAuthInterop.podspec, FirebaseAuth.podspec]
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -20,8 +20,7 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -25,8 +25,7 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12

--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       matrix:
         podspec: [FirebaseAppCheckInterop.podspec, FirebaseAppCheck.podspec]
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -23,8 +23,7 @@ jobs:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         os: [macos-12, macos-13]
         include:
           - os: macos-12
@@ -63,7 +62,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
         target: [iOS, tvOS, macOS, watchOS, catalyst]
         os: [macos-12, macos-13]
         include:

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -58,8 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
+        target: [ios, tvos, macos, watchos]
         podspec: [FirebaseRemoteConfig.podspec, FirebaseRemoteConfigSwift.podspec --allow-warnings --skip-tests]
         os: [macos-12, macos-13]
         include:


### PR DESCRIPTION
OCMock published its 3.9.3 release that updated the macOS minimum version to 10.11. macOS tests should now work with Xcode 15.

#no-changelog