### PR TITLE
Messaging: Adopt NSSecureCoding for internal classes

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.19.0
+- [changed] Adopt NSSecureCoding for internal classes. (#12075)
+
 # 10.12.0
 - [changed] Removing fiam scoped tokens set by old FIAM SDK(s) from keychain if exists (b/284207019).
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Represents an APNS device token and whether its environment is for sandbox.
  *  It can read from and write to an NSDictionary for simple serialization.
  */
-@interface FIRMessagingAPNSInfo : NSObject <NSCoding, NSCopying>
+@interface FIRMessagingAPNSInfo : NSObject <NSSecureCoding, NSCopying>
 
 /// The APNs device token, provided by the OS to the application delegate
 @property(nonatomic, readonly, copy) NSData *deviceToken;

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.m
@@ -70,6 +70,10 @@ static NSString *const kFIRInstanceIDAPNSInfoSandboxKey = @"sandbox";
 
 #pragma mark - NSCoding
 
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   id deviceToken = [aDecoder decodeObjectForKey:kFIRInstanceIDAPNSInfoTokenKey];
   if (![deviceToken isKindOfClass:[NSData class]]) {

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  associated with it. It can read from and write to an NSDictionary object, for
  *  simple serialization.
  */
-@interface FIRMessagingTokenInfo : NSObject <NSCoding>
+@interface FIRMessagingTokenInfo : NSObject <NSSecureCoding>
 
 /// The authorized entity (also known as Sender ID), associated with the token.
 @property(nonatomic, readonly, copy) NSString *authorizedEntity;

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -133,7 +133,11 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   return [self.scope isEqualToString:kFIRMessagingDefaultTokenScope];
 }
 
-#pragma mark - NSCoding
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   // These value cannot be nil
@@ -164,28 +168,11 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   if (firebaseAppID && ![firebaseAppID isKindOfClass:[NSString class]]) {
     return nil;
   }
-
-  id rawAPNSInfo = [aDecoder decodeObjectForKey:kFIRInstanceIDAPNSInfoKey];
-  if (rawAPNSInfo && ![rawAPNSInfo isKindOfClass:[NSData class]]) {
+  NSSet *classes = [[NSSet alloc] initWithArray:@[ FIRMessagingAPNSInfo.class ]];
+  FIRMessagingAPNSInfo *rawAPNSInfo = [aDecoder decodeObjectOfClasses:classes
+                                                               forKey:kFIRInstanceIDAPNSInfoKey];
+  if (rawAPNSInfo && ![rawAPNSInfo isKindOfClass:[FIRMessagingAPNSInfo class]]) {
     return nil;
-  }
-
-  FIRMessagingAPNSInfo *APNSInfo = nil;
-  if (rawAPNSInfo) {
-    // TODO(chliangGoogle: Use the new API and secureCoding protocol.
-    @try {
-      [NSKeyedUnarchiver setClass:[FIRMessagingAPNSInfo class]
-                     forClassName:@"FIRInstanceIDAPNSInfo"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      APNSInfo = [NSKeyedUnarchiver unarchiveObjectWithData:rawAPNSInfo];
-#pragma clang diagnostic pop
-    } @catch (NSException *exception) {
-      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
-                             @"Could not parse raw APNS Info while parsing archived token info.");
-      APNSInfo = nil;
-    } @finally {
-    }
   }
 
   id cacheTime = [aDecoder decodeObjectForKey:kFIRInstanceIDCacheTimeKey];
@@ -200,7 +187,7 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
     _token = [token copy];
     _appVersion = [appVersion copy];
     _firebaseAppID = [firebaseAppID copy];
-    _APNSInfo = [APNSInfo copy];
+    _APNSInfo = [rawAPNSInfo copy];
     _cacheTime = cacheTime;
   }
   return self;
@@ -212,16 +199,8 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   [aCoder encodeObject:self.token forKey:kFIRInstanceIDTokenKey];
   [aCoder encodeObject:self.appVersion forKey:kFIRInstanceIDAppVersionKey];
   [aCoder encodeObject:self.firebaseAppID forKey:kFIRInstanceIDFirebaseAppIDKey];
-  NSData *rawAPNSInfo;
   if (self.APNSInfo) {
-    // TODO(chliangGoogle: Use the new API and secureCoding protocol.
-    [NSKeyedArchiver setClassName:@"FIRInstanceIDAPNSInfo" forClass:[FIRMessagingAPNSInfo class]];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    rawAPNSInfo = [NSKeyedArchiver archivedDataWithRootObject:self.APNSInfo];
-#pragma clang diagnostic pop
-
-    [aCoder encodeObject:rawAPNSInfo forKey:kFIRInstanceIDAPNSInfoKey];
+    [aCoder encodeObject:self.APNSInfo forKey:kFIRInstanceIDAPNSInfoKey];
   }
   [aCoder encodeObject:self.cacheTime forKey:kFIRInstanceIDCacheTimeKey];
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
@@ -72,12 +72,20 @@
 - (void)testAPNSInfoEncodingAndDecoding {
   NSDictionary *validDictionary = @{
     kFIRMessagingTokenOptionsAPNSKey : [@"tokenData" dataUsingEncoding:NSUTF8StringEncoding],
-    kFIRMessagingTokenOptionsAPNSIsSandboxKey : @"sandboxValueAsString"
+    kFIRMessagingTokenOptionsAPNSIsSandboxKey : @1234
   };
+  NSError *error;
   FIRMessagingAPNSInfo *info =
       [[FIRMessagingAPNSInfo alloc] initWithTokenOptionsDictionary:validDictionary];
-  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info];
-  FIRMessagingAPNSInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info
+                                          requiringSecureCoding:YES
+                                                          error:&error];
+  XCTAssertNil(error);
+  NSSet *classes = [[NSSet alloc] initWithArray:@[ FIRMessagingAPNSInfo.class, NSData.class ]];
+  FIRMessagingAPNSInfo *restoredInfo = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
+                                                                           fromData:archive
+                                                                              error:&error];
+  XCTAssertNil(error);
   XCTAssertEqualObjects(info.deviceToken, restoredInfo.deviceToken);
   XCTAssertEqual(info.sandbox, restoredInfo.sandbox);
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAPNSInfoTest.m
@@ -76,11 +76,8 @@
   };
   FIRMessagingAPNSInfo *info =
       [[FIRMessagingAPNSInfo alloc] initWithTokenOptionsDictionary:validDictionary];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info];
   FIRMessagingAPNSInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
-#pragma clang diagnostic pop
   XCTAssertEqualObjects(info.deviceToken, restoredInfo.deviceToken);
   XCTAssertEqual(info.sandbox, restoredInfo.sandbox);
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -101,8 +101,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                        // Now query the token and compare, they should not corrupt
                        // each other.
                        NSData *data1 = [weakKeychain dataForService:service account:account1];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                        FIRMessagingTokenInfo *tokenInfo1 =
                            [NSKeyedUnarchiver unarchiveObjectWithData:data1];
                        XCTAssertEqualObjects(kToken1, tokenInfo1.token);
@@ -110,7 +108,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                        NSData *data2 = [weakKeychain dataForService:service account:account2];
                        FIRMessagingTokenInfo *tokenInfo2 =
                            [NSKeyedUnarchiver unarchiveObjectWithData:data2];
-#pragma clang diagnostic pop
                        XCTAssertEqualObjects(kToken2, tokenInfo2.token);
                        // Also check the cache data.
                        XCTAssertEqual(weakKeychain.cachedKeychainData.count, 1);
@@ -175,11 +172,8 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                     // Now query the token and compare, they should not corrupt
                     // each other.
                     NSData *data1 = [weakKeychain dataForService:service1 account:account];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                     FIRMessagingTokenInfo *tokenInfo1 =
                         [NSKeyedUnarchiver unarchiveObjectWithData:data1];
-#pragma clang diagnostic pop
                     XCTAssertEqualObjects(kToken1, tokenInfo1.token);
 
                     NSData *data2 = [weakKeychain dataForService:service2 account:account];
@@ -413,10 +407,7 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                         token:token
                                                    appVersion:@"1.0"
                                                 firebaseAppID:kFirebaseAppID];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   return [NSKeyedArchiver archivedDataWithRootObject:tokenInfo];
-#pragma clang diagnostic pop
 }
 @end
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -102,12 +102,18 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                        // each other.
                        NSData *data1 = [weakKeychain dataForService:service account:account1];
                        FIRMessagingTokenInfo *tokenInfo1 =
-                           [NSKeyedUnarchiver unarchiveObjectWithData:data1];
+                           [NSKeyedUnarchiver unarchivedObjectOfClass:FIRMessagingTokenInfo.class
+                                                             fromData:data1
+                                                                error:&error];
+                       XCTAssertNil(error);
                        XCTAssertEqualObjects(kToken1, tokenInfo1.token);
 
                        NSData *data2 = [weakKeychain dataForService:service account:account2];
                        FIRMessagingTokenInfo *tokenInfo2 =
-                           [NSKeyedUnarchiver unarchiveObjectWithData:data2];
+                           [NSKeyedUnarchiver unarchivedObjectOfClass:FIRMessagingTokenInfo.class
+                                                             fromData:data2
+                                                                error:&error];
+                       XCTAssertNil(error);
                        XCTAssertEqualObjects(kToken2, tokenInfo2.token);
                        // Also check the cache data.
                        XCTAssertEqual(weakKeychain.cachedKeychainData.count, 1);
@@ -173,7 +179,10 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                     // each other.
                     NSData *data1 = [weakKeychain dataForService:service1 account:account];
                     FIRMessagingTokenInfo *tokenInfo1 =
-                        [NSKeyedUnarchiver unarchiveObjectWithData:data1];
+                        [NSKeyedUnarchiver unarchivedObjectOfClass:FIRMessagingTokenInfo.class
+                                                          fromData:data1
+                                                             error:&error];
+                    XCTAssertNil(error);
                     XCTAssertEqualObjects(kToken1, tokenInfo1.token);
 
                     NSData *data2 = [weakKeychain dataForService:service2 account:account];
@@ -407,7 +416,12 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                         token:token
                                                    appVersion:@"1.0"
                                                 firebaseAppID:kFirebaseAppID];
-  return [NSKeyedArchiver archivedDataWithRootObject:tokenInfo];
+  NSError *error;
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:tokenInfo
+                                          requiringSecureCoding:YES
+                                                          error:&error];
+  XCTAssertNil(error);
+  return archive;
 }
 @end
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
@@ -76,11 +76,16 @@ static BOOL const kAPNSSandbox = NO;
 // yields the same values for all the fields.
 - (void)testTokenInfoEncodingAndDecoding {
   FIRMessagingTokenInfo *info = self.validTokenInfo;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info];
-  FIRMessagingTokenInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
-#pragma clang diagnostic pop
+  NSError *error;
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:info
+                                          requiringSecureCoding:YES
+                                                          error:&error];
+  XCTAssertNil(error);
+  NSSet *classes = [[NSSet alloc] initWithArray:@[ FIRMessagingTokenInfo.class, NSDate.class ]];
+  FIRMessagingTokenInfo *restoredInfo = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
+                                                                            fromData:archive
+                                                                               error:&error];
+  XCTAssertNil(error);
   XCTAssertEqualObjects(restoredInfo.authorizedEntity, info.authorizedEntity);
   XCTAssertEqualObjects(restoredInfo.scope, info.scope);
   XCTAssertEqualObjects(restoredInfo.token, info.token);
@@ -101,11 +106,16 @@ static BOOL const kAPNSSandbox = NO;
                                                         token:kToken
                                                    appVersion:nil
                                                 firebaseAppID:nil];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:sparseInfo];
-  FIRMessagingTokenInfo *restoredInfo = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
-#pragma clang diagnostic pop
+  NSError *error;
+  NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:sparseInfo
+                                          requiringSecureCoding:YES
+                                                          error:&error];
+  XCTAssertNil(error);
+  NSSet *classes = [[NSSet alloc] initWithArray:@[ FIRMessagingTokenInfo.class, NSDate.class ]];
+  FIRMessagingTokenInfo *restoredInfo = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
+                                                                            fromData:archive
+                                                                               error:&error];
+  XCTAssertNil(error);
   XCTAssertEqualObjects(restoredInfo.authorizedEntity, sparseInfo.authorizedEntity);
   XCTAssertEqualObjects(restoredInfo.scope, sparseInfo.scope);
   XCTAssertEqualObjects(restoredInfo.token, sparseInfo.token);


### PR DESCRIPTION
Fix #12075 for Messaging.

Passed unit tests before and after updating them. Fixed one of the unit tests that has always been broken.