### PR TITLE
Reduce nightly flakes

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -30,8 +30,11 @@ jobs:
         include:
           - os: macos-12
             xcode: Xcode_14.2
+            tests:
+          # Flaky tests on CI
           - os: macos-13
             xcode: Xcode_15.0.1
+            tests: --skip-tests
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -44,7 +47,8 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Build and test
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} \
+         ${{ matrix.tests }}
 
   integration-tests:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -29,8 +29,11 @@ jobs:
         include:
           - os: macos-12
             xcode: Xcode_14.2
+            tests:
+          # Flaky tests on CI
           - os: macos-13
             xcode: Xcode_15.0.1
+            tests: --skip-tests
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -41,7 +44,8 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Build and test
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} \
+         ${{ matrix.tests }}
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -176,8 +176,10 @@ jobs:
         include:
           - os: macos-12
             xcode: Xcode_14.2
+            tests: --test-specs=unit
           - os: macos-13
             xcode: Xcode_15.0.1
+            tests: --skip-tests
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -190,7 +192,8 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Build and test
       run: |
-       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --test-specs=unit --platforms=${{ matrix.target }}
+       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec ${{ matrix.tests }} \
+         --platforms=${{ matrix.target }}
 
   storage-cron-only:
     # Don't run on private repo.


### PR DESCRIPTION
Disable more macos-13 tests flaking on the iOS simulator. Still running build tests on macos-13 and testing them on macos-12.

#no-changelog