### PR TITLE
Auth: Add Objective C API build tests

### DIFF
--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -115,17 +115,16 @@
   [auth updateCurrentUser:[auth currentUser]
                completion:^(NSError *_Nullable error){
                }];
-  [auth fetchSignInMethodsForEmail:@"a@abc.com"
-                        completion:^(NSArray<NSString *> *_Nullable c, NSError *_Nullable e){
-                        }];
   [auth signInWithEmail:@"a@abc.com"
                password:@"pw"
              completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
              }];
+#if !TARGET_OS_WATCH
   [auth signInWithEmail:@"a@abc.com"
                    link:@"link"
              completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
              }];
+#endif
 #if TARGET_OS_IOS
   [auth signInWithProvider:provider
                 UIDelegate:nil
@@ -166,13 +165,18 @@
                 actionCodeSettings:settings
                         completion:^(NSError *_Nullable error){
                         }];
+#if TARGET_OS_WATCH
   [auth sendSignInLinkToEmail:@"email"
            actionCodeSettings:settings
                    completion:^(NSError *_Nullable error){
                    }];
+#endif
   NSError *error;
   [auth signOut:&error];
-  BOOL b = [auth isSignInWithEmailLink:@"email"];
+  BOOL b;
+#if TARGET_OS_WATCH
+  b = [auth isSignInWithEmailLink:@"email"];
+#endif
   FIRAuthStateDidChangeListenerHandle handle =
       [auth addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user){
       }];

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -46,7 +46,6 @@
                          completion:(nullable void (^)(FIRAuthCredential *_Nullable,
                                                        NSError *_Nullable))completion {
 }
-
 @end
 #endif
 
@@ -165,7 +164,7 @@
                 actionCodeSettings:settings
                         completion:^(NSError *_Nullable error){
                         }];
-#if TARGET_OS_WATCH
+#if !TARGET_OS_WATCH
   [auth sendSignInLinkToEmail:@"email"
            actionCodeSettings:settings
                    completion:^(NSError *_Nullable error){
@@ -174,7 +173,7 @@
   NSError *error;
   [auth signOut:&error];
   __unused BOOL b;
-#if TARGET_OS_WATCH
+#if !TARGET_OS_WATCH
   b = [auth isSignInWithEmailLink:@"email"];
 #endif
   FIRAuthStateDidChangeListenerHandle handle =
@@ -458,7 +457,8 @@
 }
 
 - (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthCredential *)credential {
-  FIRPhoneMultiFactorAssertion *a = [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+  __unused FIRPhoneMultiFactorAssertion *a =
+      [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
 }
 
 - (void)phoneMultiFactorInfo:(FIRPhoneMultiFactorInfo *)info {
@@ -479,7 +479,7 @@
                                              NSError *_Nullable error){
                                 }];
   FIRTOTPMultiFactorAssertion *a =
-  [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:secret oneTimePassword:@"pw"];
+      [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:secret oneTimePassword:@"pw"];
   a = [FIRTOTPMultiFactorGenerator assertionForSignInWithEnrollmentID:@"id" oneTimePassword:@"pw"];
 }
 #endif

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -1,0 +1,596 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+@import FirebaseCore;
+@import FirebaseAuth;
+
+#if !TARGET_OS_MACOS && !TARGET_OS_WATCHOS
+@interface AuthUIImpl : NSObject <FIRAuthUIDelegate>
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^_Nullable)(void))completion;
+- (void)presentViewController:(nonnull UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^_Nullable)(void))completion;
+@end
+@implementation AuthUIImpl
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^_Nullable)(void))completion {
+}
+
+- (void)presentViewController:(nonnull UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^_Nullable)(void))completion {
+}
+@end
+#endif
+
+#if TARGET_OS_IOS
+@interface FederatedAuthImplementation : NSObject <FIRFederatedAuthProvider>
+- (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+                         completion:(nullable void (^)(FIRAuthCredential *_Nullable,
+                                                       NSError *_Nullable))completion;
+@end
+@implementation FederatedAuthImplementation
+- (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+                         completion:(nullable void (^)(FIRAuthCredential *_Nullable,
+                                                       NSError *_Nullable))completion {
+}
+
+@end
+#endif
+
+@interface ObjCAPICoverage : XCTestCase
+@end
+
+@implementation ObjCAPICoverage
+
+- (void)FIRActionCodeSettings_h {
+  FIRActionCodeSettings *codeSettings = [[FIRActionCodeSettings alloc] init];
+  [codeSettings setIOSBundleID:@"abc"];
+  [codeSettings setAndroidPackageName:@"name" installIfNotAvailable:NO minimumVersion:@"1.1"];
+  BOOL b = [codeSettings handleCodeInApp];
+  b = [codeSettings androidInstallIfNotAvailable];
+  NSURL *u = [codeSettings URL];
+  NSString *s = [codeSettings iOSBundleID];
+  s = [codeSettings androidPackageName];
+  s = [codeSettings androidMinimumVersion];
+  s = [codeSettings dynamicLinkDomain];
+}
+
+- (void)FIRAuthAdditionalUserInfo_h:(FIRAdditionalUserInfo *)additionalUserInfo {
+  NSString *s = [additionalUserInfo providerID];
+  BOOL b = [additionalUserInfo isNewUser];
+  NSDictionary<NSString *, NSObject *> *dict = [additionalUserInfo profile];
+  s = [additionalUserInfo username];
+}
+
+- (void)ActionCodeOperationTests:(FIRActionCodeInfo *)info {
+  FIRActionCodeOperation op = [info operation];
+  NSString *s = [info email];
+  s = [info previousEmail];
+}
+
+- (void)ActionCodeURL:(FIRActionCodeURL *)url {
+  FIRActionCodeOperation op = [url operation];
+  NSString *s = [url APIKey];
+  s = [url code];
+  NSURL *u = [url continueURL];
+  s = [url languageCode];
+}
+
+- (void)authProperties:(FIRAuth *)auth {
+  BOOL b = [auth shareAuthStateAcrossDevices];
+  [auth setShareAuthStateAcrossDevices:YES];
+  FIRUser *u = [auth currentUser];
+  NSString *s = [auth languageCode];
+  [auth setLanguageCode:s];
+  FIRAuthSettings *settings = [auth settings];
+  [auth setSettings:settings];
+  s = [auth userAccessGroup];
+  s = [auth tenantID];
+  [auth setTenantID:s];
+  s = [auth customAuthDomain];
+  [auth setCustomAuthDomain:s];
+#if TARGET_OS_IOS
+  NSData *d = [auth APNSToken];
+  auth.APNSToken = [[NSData alloc] init];
+#endif
+}
+
+- (void)FIRAuth_h:(FIRAuth *)auth
+             with:(FIRAuthCredential *)credential
+         provider:(FIROAuthProvider *)provider
+              url:(NSURL *)url {
+  [auth updateCurrentUser:[auth currentUser]
+               completion:^(NSError *_Nullable error){
+               }];
+  [auth fetchSignInMethodsForEmail:@"a@abc.com"
+                        completion:^(NSArray<NSString *> *_Nullable c, NSError *_Nullable e){
+                        }];
+  [auth signInWithEmail:@"a@abc.com"
+               password:@"pw"
+             completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+             }];
+  [auth signInWithEmail:@"a@abc.com"
+                   link:@"link"
+             completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+             }];
+#if TARGET_OS_IOS
+  [auth signInWithProvider:provider
+                UIDelegate:nil
+                completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                }];
+  [auth signInWithCredential:credential
+                  completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                  }];
+#endif
+  [auth signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable authResult,
+                                          NSError *_Nullable error){
+  }];
+  [auth signInWithCustomToken:@"token"
+                   completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                   }];
+  [auth createUserWithEmail:@"a@abc.com"
+                   password:@"pw"
+                 completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                 }];
+  [auth confirmPasswordResetWithCode:@"code"
+                         newPassword:@"pw"
+                          completion:^(NSError *_Nullable error){
+                          }];
+  [auth checkActionCode:@"code"
+             completion:^(FIRActionCodeInfo *_Nullable info, NSError *_Nullable error){
+             }];
+  [auth verifyPasswordResetCode:@"code"
+                     completion:^(NSString *_Nullable email, NSError *_Nullable error){
+                     }];
+  [auth applyActionCode:@"code"
+             completion:^(NSError *_Nullable error){
+             }];
+  [auth sendPasswordResetWithEmail:@"email"
+                        completion:^(NSError *_Nullable error){
+                        }];
+  FIRActionCodeSettings *settings = [[FIRActionCodeSettings alloc] init];
+  [auth sendPasswordResetWithEmail:@"email"
+                actionCodeSettings:settings
+                        completion:^(NSError *_Nullable error){
+                        }];
+  [auth sendSignInLinkToEmail:@"email"
+           actionCodeSettings:settings
+                   completion:^(NSError *_Nullable error){
+                   }];
+  NSError *error;
+  [auth signOut:&error];
+  BOOL b = [auth isSignInWithEmailLink:@"email"];
+  FIRAuthStateDidChangeListenerHandle handle =
+      [auth addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user){
+      }];
+  [auth removeAuthStateDidChangeListener:handle];
+  [auth removeIDTokenDidChangeListener:handle];
+  [auth useAppLanguage];
+  [auth useEmulatorWithHost:@"host" port:123];
+#if TARGET_OS_IOS
+  [auth canHandleURL:url];
+  [auth setAPNSToken:[[NSData alloc] init]];
+  [auth setAPNSToken:[[NSData alloc] init] type:FIRAuthAPNSTokenTypeProd];
+  b = [auth canHandleNotification:@{}];
+#if !TARGET_OS_MACCATALYST && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+  [auth initializeRecaptchaConfigWithCompletion:^(NSError *_Nullable error){
+  }];
+#endif
+#endif
+  [auth revokeTokenWithAuthorizationCode:@"a"
+                              completion:^(NSError *_Nullable error){
+                              }];
+  [auth useUserAccessGroup:@"abc" error:&error];
+  [auth getStoredUserForAccessGroup:@"user" error:&error];
+}
+
+#if !TARGET_OS_MACOS
+- (void)FIRAuthAPNSTokenType_h {
+  FIRAuthAPNSTokenType t = FIRAuthAPNSTokenTypeProd;
+  t = FIRAuthAPNSTokenTypeSandbox;
+  t = FIRAuthAPNSTokenTypeUnknown;
+}
+#endif
+
+- (NSString *)authCredential:(FIRAuthCredential *)credential {
+  return [credential provider];
+}
+
+- (void)authDataResult:(FIRAuthDataResult *)result {
+  FIRUser *u = [result user];
+  FIRAdditionalUserInfo *info = [result additionalUserInfo];
+  FIRAuthCredential *c = [result credential];
+}
+
+- (void)FIRAuthErrors_h {
+  FIRAuthErrorCode c = FIRAuthErrorCodeInvalidCustomToken;
+  c = FIRAuthErrorCodeCustomTokenMismatch;
+  c = FIRAuthErrorCodeInvalidCredential;
+  c = FIRAuthErrorCodeUserDisabled;
+  c = FIRAuthErrorCodeOperationNotAllowed;
+  c = FIRAuthErrorCodeEmailAlreadyInUse;
+  c = FIRAuthErrorCodeInvalidEmail;
+  c = FIRAuthErrorCodeWrongPassword;
+  c = FIRAuthErrorCodeTooManyRequests;
+  c = FIRAuthErrorCodeUserNotFound;
+  c = FIRAuthErrorCodeAccountExistsWithDifferentCredential;
+  c = FIRAuthErrorCodeRequiresRecentLogin;
+  c = FIRAuthErrorCodeProviderAlreadyLinked;
+  c = FIRAuthErrorCodeNoSuchProvider;
+  c = FIRAuthErrorCodeInvalidUserToken;
+  c = FIRAuthErrorCodeNetworkError;
+  c = FIRAuthErrorCodeUserTokenExpired;
+  c = FIRAuthErrorCodeInvalidAPIKey;
+  c = FIRAuthErrorCodeUserMismatch;
+  c = FIRAuthErrorCodeCredentialAlreadyInUse;
+  c = FIRAuthErrorCodeWeakPassword;
+  c = FIRAuthErrorCodeAppNotAuthorized;
+  c = FIRAuthErrorCodeExpiredActionCode;
+  c = FIRAuthErrorCodeInvalidActionCode;
+  c = FIRAuthErrorCodeInvalidMessagePayload;
+  c = FIRAuthErrorCodeInvalidSender;
+  c = FIRAuthErrorCodeInvalidRecipientEmail;
+  c = FIRAuthErrorCodeMissingEmail;
+  c = FIRAuthErrorCodeMissingIosBundleID;
+  c = FIRAuthErrorCodeMissingAndroidPackageName;
+  c = FIRAuthErrorCodeUnauthorizedDomain;
+  c = FIRAuthErrorCodeInvalidContinueURI;
+  c = FIRAuthErrorCodeMissingContinueURI;
+  c = FIRAuthErrorCodeMissingPhoneNumber;
+  c = FIRAuthErrorCodeInvalidPhoneNumber;
+  c = FIRAuthErrorCodeMissingVerificationCode;
+  c = FIRAuthErrorCodeInvalidVerificationCode;
+  c = FIRAuthErrorCodeMissingVerificationID;
+  c = FIRAuthErrorCodeInvalidVerificationID;
+  c = FIRAuthErrorCodeMissingAppCredential;
+  c = FIRAuthErrorCodeInvalidAppCredential;
+  c = FIRAuthErrorCodeSessionExpired;
+  c = FIRAuthErrorCodeQuotaExceeded;
+  c = FIRAuthErrorCodeMissingAppToken;
+  c = FIRAuthErrorCodeNotificationNotForwarded;
+  c = FIRAuthErrorCodeAppNotVerified;
+  c = FIRAuthErrorCodeCaptchaCheckFailed;
+  c = FIRAuthErrorCodeWebContextAlreadyPresented;
+  c = FIRAuthErrorCodeWebContextCancelled;
+  c = FIRAuthErrorCodeAppVerificationUserInteractionFailure;
+  c = FIRAuthErrorCodeInvalidClientID;
+  c = FIRAuthErrorCodeWebNetworkRequestFailed;
+  c = FIRAuthErrorCodeWebInternalError;
+  c = FIRAuthErrorCodeWebSignInUserInteractionFailure;
+  c = FIRAuthErrorCodeLocalPlayerNotAuthenticated;
+  c = FIRAuthErrorCodeNullUser;
+  c = FIRAuthErrorCodeDynamicLinkNotActivated;
+  c = FIRAuthErrorCodeInvalidProviderID;
+  c = FIRAuthErrorCodeTenantIDMismatch;
+  c = FIRAuthErrorCodeUnsupportedTenantOperation;
+  c = FIRAuthErrorCodeInvalidDynamicLinkDomain;
+  c = FIRAuthErrorCodeRejectedCredential;
+  c = FIRAuthErrorCodeGameKitNotLinked;
+  c = FIRAuthErrorCodeSecondFactorRequired;
+  c = FIRAuthErrorCodeMissingMultiFactorSession;
+  c = FIRAuthErrorCodeMissingMultiFactorInfo;
+  c = FIRAuthErrorCodeInvalidMultiFactorSession;
+  c = FIRAuthErrorCodeMultiFactorInfoNotFound;
+  c = FIRAuthErrorCodeAdminRestrictedOperation;
+  c = FIRAuthErrorCodeUnverifiedEmail;
+  c = FIRAuthErrorCodeSecondFactorAlreadyEnrolled;
+  c = FIRAuthErrorCodeMaximumSecondFactorCountExceeded;
+  c = FIRAuthErrorCodeUnsupportedFirstFactor;
+  c = FIRAuthErrorCodeEmailChangeNeedsVerification;
+  c = FIRAuthErrorCodeMissingClientIdentifier;
+  c = FIRAuthErrorCodeMissingOrInvalidNonce;
+  c = FIRAuthErrorCodeBlockingCloudFunctionError;
+  c = FIRAuthErrorCodeRecaptchaNotEnabled;
+  c = FIRAuthErrorCodeMissingRecaptchaToken;
+  c = FIRAuthErrorCodeInvalidRecaptchaToken;
+  c = FIRAuthErrorCodeInvalidRecaptchaAction;
+  c = FIRAuthErrorCodeMissingClientType;
+  c = FIRAuthErrorCodeMissingRecaptchaVersion;
+  c = FIRAuthErrorCodeInvalidRecaptchaVersion;
+  c = FIRAuthErrorCodeInvalidReqType;
+  c = FIRAuthErrorCodeRecaptchaSDKNotLinked;
+  c = FIRAuthErrorCodeKeychainError;
+  c = FIRAuthErrorCodeInternalError;
+  c = FIRAuthErrorCodeMalformedJWT;
+}
+
+- (void)authSettings:(FIRAuthSettings *)settings {
+  BOOL b = [settings isAppVerificationDisabledForTesting];
+  [settings setAppVerificationDisabledForTesting:b];
+}
+
+- (void)authTokenResult:(FIRAuthTokenResult *)result {
+  NSString *s = [result token];
+  NSDate *d = [result expirationDate];
+  d = [result authDate];
+  d = [result issuedAtDate];
+  s = [result signInProvider];
+  s = [result signInSecondFactor];
+  NSDictionary<NSString *, NSObject *> *dict = [result claims];
+}
+
+#if !TARGET_OS_MACOS && !TARGET_OS_WATCHOS
+- (void)authTokenResult {
+  AuthUIImpl *impl = [[AuthUIImpl alloc] init];
+  [impl presentViewController:[[UIViewController alloc] init]
+                     animated:NO
+                   completion:^{
+                   }];
+  [impl dismissViewControllerAnimated:YES
+                           completion:^{
+                           }];
+}
+#endif
+
+- (void)FIREmailAuthProvider_h {
+  FIRAuthCredential *c = [FIREmailAuthProvider credentialWithEmail:@"e" password:@"pw"];
+  c = [FIREmailAuthProvider credentialWithEmail:@"e" link:@"l"];
+}
+
+- (void)FIRFacebookAuthProvider_h {
+  FIRAuthCredential *c = [FIRFacebookAuthProvider credentialWithAccessToken:@"token"];
+}
+
+#if TARGET_OS_IOS
+- (void)FIRFederatedAuthProvider_h {
+  FederatedAuthImplementation *impl = [[FederatedAuthImplementation alloc] init];
+  [impl getCredentialWithUIDelegate:nil
+                         completion:^(FIRAuthCredential *_Nullable c, NSError *_Nullable e){
+                         }];
+}
+#endif
+
+#if !TARGET_OS_WATCHOS
+- (void)FIRGameCenterAuthProvider_h {
+  [FIRGameCenterAuthProvider getCredentialWithCompletion:^(FIRAuthCredential *_Nullable credential,
+                                                           NSError *_Nullable error){
+  }];
+}
+#endif
+
+- (void)FIRGitHubAuthProvider_h {
+  FIRAuthCredential *c = [FIRGitHubAuthProvider credentialWithToken:@"token"];
+}
+
+- (void)FIRGoogleAuthProvider_h {
+  FIRAuthCredential *c = [FIRGoogleAuthProvider credentialWithIDToken:@"token"
+                                                          accessToken:@"token"];
+}
+
+#if TARGET_OS_IOS
+- (void)FIRMultiFactor_h:(FIRMultiFactor *)mf mfa:(FIRMultiFactorAssertion *)mfa {
+  [mf getSessionWithCompletion:^(FIRMultiFactorSession *_Nullable credential,
+                                 NSError *_Nullable error){
+  }];
+  [mf enrollWithAssertion:mfa
+              displayName:@"name"
+               completion:^(NSError *_Nullable error){
+               }];
+  FIRMultiFactorInfo *mfi = [mf enrolledFactors][0];
+  [mf unenrollWithInfo:mfi
+            completion:^(NSError *_Nullable error){
+            }];
+  [mf unenrollWithFactorUID:@"uid"
+                 completion:^(NSError *_Nullable error){
+                 }];
+}
+
+- (void)multiFactorAssertion:(FIRMultiFactorAssertion *)mfa {
+  NSString *s = [mfa factorID];
+}
+
+- (void)multiFactorInfo:(FIRMultiFactorInfo *)mfi {
+  NSString *s = [mfi UID];
+  s = [mfi factorID];
+  s = [mfi displayName];
+  NSDate *d = [mfi enrollmentDate];
+}
+
+- (void)multiFactorResolver:(FIRMultiFactorResolver *)mfr {
+  FIRMultiFactorSession *s = [mfr session];
+  NSArray<FIRMultiFactorInfo *> *hints = [mfr hints];
+  FIRAuth *auth = [mfr auth];
+}
+#endif
+
+- (void)oauthCredential:(FIROAuthCredential *)credential {
+  NSString *s = [credential IDToken];
+  s = [credential accessToken];
+  s = [credential secret];
+}
+
+#if TARGET_OS_IOS
+- (void)FIROAuthProvider_h:(FIROAuthProvider *)provider {
+  FIROAuthCredential *c = [FIROAuthProvider credentialWithProviderID:@"id" accessToken:@"token"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id"
+                                         IDToken:@"idToken"
+                                     accessToken:@"accessToken"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id" IDToken:@"idtoken" rawNonce:@"nonce"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id"
+                                         IDToken:@"token"
+                                        rawNonce:@"nonce"
+                                     accessToken:@"accessToken"];
+  c = [FIROAuthProvider appleCredentialWithIDToken:@"idToken" rawNonce:@"nonce" fullName:nil];
+  [provider getCredentialWithUIDelegate:nil
+                             completion:^(FIRAuthCredential *_Nullable credential,
+                                          NSError *_Nullable error){
+                             }];
+  NSString *s = [provider providerID];
+  NSArray<NSString *> *scopes = [provider scopes];
+  NSDictionary<NSString *, NSString *> *params = [provider customParameters];
+}
+
+- (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthProvider *)provider mfi:(FIRPhoneMultiFactorInfo *)mfi {
+  [provider verifyPhoneNumber:@"123"
+                   UIDelegate:nil
+                   completion:^(NSString *_Nullable verificationID, NSError *_Nullable error){
+                   }];
+  [provider verifyPhoneNumber:@"123"
+                   UIDelegate:nil
+           multiFactorSession:nil
+                   completion:^(NSString *_Nullable verificationID, NSError *_Nullable error){
+                   }];
+  [provider verifyPhoneNumberWithMultiFactorInfo:mfi
+                                      UIDelegate:nil
+                              multiFactorSession:nil
+                                      completion:^(NSString *_Nullable verificationID,
+                                                   NSError *_Nullable error){
+                                      }];
+  FIRPhoneAuthCredential *c = [provider credentialWithVerificationID:@"id"
+                                                    verificationCode:@"code"];
+}
+
+- (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthCredential *)credential {
+  [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+}
+
+- (void)phoneMultiFactorInfo:(FIRPhoneMultiFactorInfo *)info {
+  NSString *s = [info phoneNumber];
+}
+
+- (void)FIRTOTPSecret_h:(FIRTOTPSecret *)secret {
+  NSString *s = [secret sharedSecretKey];
+  s = [secret generateQRCodeURLWithAccountName:@"name" issuer:@"issuer"];
+  [secret openInOTPAppWithQRCodeURL:@"qr"];
+}
+
+- (void)FIRTOTPMultiFactorGenerator_h:(FIRMultiFactorSession *)session
+                               secret:(FIRTOTPSecret *)secret {
+  [FIRTOTPMultiFactorGenerator
+      generateSecretWithMultiFactorSession:session
+                                completion:^(FIRTOTPSecret *_Nullable secret,
+                                             NSError *_Nullable error){
+                                }];
+  [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:secret oneTimePassword:@"pw"];
+  [FIRTOTPMultiFactorGenerator assertionForSignInWithEnrollmentID:@"id" oneTimePassword:@"pw"];
+}
+#endif
+
+- (void)FIRTwitterAuthProvider_h {
+  FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token" secret:@"secret"];
+}
+
+- (void)FIRUser_h:(FIRUser *)user credential:(FIRAuthCredential *)credential {
+  [user updateEmail:@"email"
+         completion:^(NSError *_Nullable error){
+         }];
+  [user updatePassword:@"pw"
+            completion:^(NSError *_Nullable error){
+            }];
+  [user reloadWithCompletion:^(NSError *_Nullable error){
+  }];
+  [user reauthenticateWithCredential:credential
+                          completion:^(FIRAuthDataResult *_Nullable authResult,
+                                       NSError *_Nullable error){
+                          }];
+#if TARGET_OS_IOS
+  FIRPhoneAuthProvider *provider = [FIRPhoneAuthProvider provider];
+  FIRPhoneAuthCredential *phoneCredential = [provider credentialWithVerificationID:@"id"
+                                                                  verificationCode:@"code"];
+  [user updatePhoneNumberCredential:phoneCredential
+                         completion:^(NSError *_Nullable error){
+                         }];
+  [user reauthenticateWithProvider:(NSObject<FIRFederatedAuthProvider> *)provider
+                        UIDelegate:nil
+                        completion:^(FIRAuthDataResult *_Nullable authResult,
+                                     NSError *_Nullable error){
+                        }];
+  [user linkWithProvider:(NSObject<FIRFederatedAuthProvider> *)provider
+              UIDelegate:nil
+              completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+              }];
+#endif
+  [user getIDTokenResultWithCompletion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                         NSError *_Nullable error){
+  }];
+  [user getIDTokenResultForcingRefresh:YES
+                            completion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                         NSError *_Nullable error){
+                            }];
+  [user getIDTokenWithCompletion:^(NSString *_Nullable token, NSError *_Nullable error){
+  }];
+  [user getIDTokenForcingRefresh:NO
+                      completion:^(NSString *_Nullable token, NSError *_Nullable error){
+                      }];
+  [user linkWithCredential:credential
+                completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                }];
+  [user unlinkFromProvider:@"provider"
+                completion:^(FIRUser *_Nullable user, NSError *_Nullable error){
+                }];
+  [user sendEmailVerificationWithCompletion:^(NSError *_Nullable error){
+  }];
+  [user sendEmailVerificationBeforeUpdatingEmail:@"email"
+                                      completion:^(NSError *_Nullable error){
+                                      }];
+  FIRActionCodeSettings *settings = [[FIRActionCodeSettings alloc] init];
+  [user sendEmailVerificationWithActionCodeSettings:settings
+                                         completion:^(NSError *_Nullable error){
+                                         }];
+  [user sendEmailVerificationBeforeUpdatingEmail:@"email"
+                              actionCodeSettings:settings
+                                      completion:^(NSError *_Nullable error){
+                                      }];
+  [user deleteWithCompletion:^(NSError *_Nullable error){
+  }];
+  FIRUserProfileChangeRequest *changeRequest = [user profileChangeRequest];
+  [changeRequest commitChangesWithCompletion:^(NSError *_Nullable error){
+  }];
+  NSString *s = [user providerID];
+  s = [user uid];
+  s = [user displayName];
+  s = [user email];
+  s = [user phoneNumber];
+  s = [changeRequest displayName];
+  NSURL *u = [changeRequest photoURL];
+  u = [user photoURL];
+  [changeRequest setDisplayName:s];
+  [changeRequest setPhotoURL:u];
+}
+
+- (void)userProperties:(FIRUser *)user {
+  BOOL b = [user isAnonymous];
+  b = [user isEmailVerified];
+  NSArray<NSObject<FIRUserInfo> *> *userInfo = [user providerData];
+  FIRUserMetadata *meta = [user metadata];
+#if TARGET_OS_IOS
+  FIRMultiFactor *mf = [user multiFactor];
+#endif
+  NSString *s = [user refreshToken];
+  s = [user tenantID];
+
+  FIRUserProfileChangeRequest *changeRequest = [user profileChangeRequest];
+  s = [changeRequest displayName];
+  NSURL *u = [changeRequest photoURL];
+  [changeRequest setDisplayName:s];
+  [changeRequest setPhotoURL:u];
+}
+
+- (void)userInfoProperties:(NSObject<FIRUserInfo> *)userInfo {
+  NSString *s = [userInfo providerID];
+  s = [userInfo uid];
+  s = [userInfo displayName];
+  s = [userInfo email];
+  s = [userInfo phoneNumber];
+  NSURL *u = [userInfo photoURL];
+}
+
+- (void)userMetadataProperties:(FIRUserMetadata *)metadata {
+  NSDate *d = [metadata lastSignInDate];
+  d = [metadata creationDate];
+}
+
+@end

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -184,8 +184,7 @@
   [auth useAppLanguage];
   [auth useEmulatorWithHost:@"host" port:123];
 #if TARGET_OS_IOS
-  [auth canHandleURL:url];
-  [auth setAPNSToken:[[NSData alloc] init]];
+  b = [auth canHandleURL:url];
   [auth setAPNSToken:[[NSData alloc] init] type:FIRAuthAPNSTokenTypeProd];
   b = [auth canHandleNotification:@{}];
 #if !TARGET_OS_MACCATALYST && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
@@ -197,7 +196,7 @@
                               completion:^(NSError *_Nullable error){
                               }];
   [auth useUserAccessGroup:@"abc" error:&error];
-  [auth getStoredUserForAccessGroup:@"user" error:&error];
+  __unused FIRUser *u = [auth getStoredUserForAccessGroup:@"user" error:&error];
 }
 
 #if !TARGET_OS_OSX

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -367,7 +367,7 @@
 
 - (void)FIRGoogleAuthProvider_h {
   __unused FIRAuthCredential *c = [FIRGoogleAuthProvider credentialWithIDToken:@"token"
-                                                          accessToken:@"token"];
+                                                                   accessToken:@"token"];
 }
 
 #if TARGET_OS_IOS
@@ -450,7 +450,7 @@
                                                    NSError *_Nullable error){
                                       }];
   __unused FIRPhoneAuthCredential *c = [provider credentialWithVerificationID:@"id"
-                                                    verificationCode:@"code"];
+                                                             verificationCode:@"code"];
 }
 
 - (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthCredential *)credential {
@@ -480,7 +480,8 @@
 #endif
 
 - (void)FIRTwitterAuthProvider_h {
-  __unused FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token" secret:@"secret"];
+  __unused FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token"
+                                                                       secret:@"secret"];
 }
 
 - (void)FIRUser_h:(FIRUser *)user credential:(FIRAuthCredential *)credential {

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -17,7 +17,7 @@
 @import FirebaseCore;
 @import FirebaseAuth;
 
-#if !TARGET_OS_MACOS && !TARGET_OS_WATCHOS
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
 @interface AuthUIImpl : NSObject <FIRAuthUIDelegate>
 - (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^_Nullable)(void))completion;
 - (void)presentViewController:(nonnull UIViewController *)viewControllerToPresent
@@ -61,7 +61,7 @@
   [codeSettings setAndroidPackageName:@"name" installIfNotAvailable:NO minimumVersion:@"1.1"];
   BOOL b = [codeSettings handleCodeInApp];
   b = [codeSettings androidInstallIfNotAvailable];
-  NSURL *u = [codeSettings URL];
+  __unused NSURL *u = [codeSettings URL];
   NSString *s = [codeSettings iOSBundleID];
   s = [codeSettings androidPackageName];
   s = [codeSettings androidMinimumVersion];
@@ -70,29 +70,29 @@
 
 - (void)FIRAuthAdditionalUserInfo_h:(FIRAdditionalUserInfo *)additionalUserInfo {
   NSString *s = [additionalUserInfo providerID];
-  BOOL b = [additionalUserInfo isNewUser];
-  NSDictionary<NSString *, NSObject *> *dict = [additionalUserInfo profile];
+  __unused BOOL b = [additionalUserInfo isNewUser];
+  __unused NSDictionary<NSString *, NSObject *> *dict = [additionalUserInfo profile];
   s = [additionalUserInfo username];
 }
 
 - (void)ActionCodeOperationTests:(FIRActionCodeInfo *)info {
-  FIRActionCodeOperation op = [info operation];
+  __unused FIRActionCodeOperation op = [info operation];
   NSString *s = [info email];
   s = [info previousEmail];
 }
 
 - (void)ActionCodeURL:(FIRActionCodeURL *)url {
-  FIRActionCodeOperation op = [url operation];
+  __unused FIRActionCodeOperation op = [url operation];
   NSString *s = [url APIKey];
   s = [url code];
-  NSURL *u = [url continueURL];
+  __unused NSURL *u = [url continueURL];
   s = [url languageCode];
 }
 
 - (void)authProperties:(FIRAuth *)auth {
-  BOOL b = [auth shareAuthStateAcrossDevices];
+  __unused BOOL b = [auth shareAuthStateAcrossDevices];
   [auth setShareAuthStateAcrossDevices:YES];
-  FIRUser *u = [auth currentUser];
+  __unused FIRUser *u = [auth currentUser];
   NSString *s = [auth languageCode];
   [auth setLanguageCode:s];
   FIRAuthSettings *settings = [auth settings];
@@ -103,7 +103,7 @@
   s = [auth customAuthDomain];
   [auth setCustomAuthDomain:s];
 #if TARGET_OS_IOS
-  NSData *d = [auth APNSToken];
+  __unused NSData *d = [auth APNSToken];
   auth.APNSToken = [[NSData alloc] init];
 #endif
 }
@@ -197,7 +197,7 @@
   [auth getStoredUserForAccessGroup:@"user" error:&error];
 }
 
-#if !TARGET_OS_MACOS
+#if !TARGET_OS_OSX
 - (void)FIRAuthAPNSTokenType_h {
   FIRAuthAPNSTokenType t = FIRAuthAPNSTokenTypeProd;
   t = FIRAuthAPNSTokenTypeSandbox;
@@ -210,9 +210,9 @@
 }
 
 - (void)authDataResult:(FIRAuthDataResult *)result {
-  FIRUser *u = [result user];
-  FIRAdditionalUserInfo *info = [result additionalUserInfo];
-  FIRAuthCredential *c = [result credential];
+  __unused FIRUser *u = [result user];
+  __unused FIRAdditionalUserInfo *info = [result additionalUserInfo];
+  __unused FIRAuthCredential *c = [result credential];
 }
 
 - (void)FIRAuthErrors_h {
@@ -319,10 +319,10 @@
   d = [result issuedAtDate];
   s = [result signInProvider];
   s = [result signInSecondFactor];
-  NSDictionary<NSString *, NSObject *> *dict = [result claims];
+  __unused NSDictionary<NSString *, NSObject *> *dict = [result claims];
 }
 
-#if !TARGET_OS_MACOS && !TARGET_OS_WATCHOS
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
 - (void)authTokenResult {
   AuthUIImpl *impl = [[AuthUIImpl alloc] init];
   [impl presentViewController:[[UIViewController alloc] init]
@@ -341,7 +341,7 @@
 }
 
 - (void)FIRFacebookAuthProvider_h {
-  FIRAuthCredential *c = [FIRFacebookAuthProvider credentialWithAccessToken:@"token"];
+  __unused FIRAuthCredential *c = [FIRFacebookAuthProvider credentialWithAccessToken:@"token"];
 }
 
 #if TARGET_OS_IOS
@@ -353,7 +353,7 @@
 }
 #endif
 
-#if !TARGET_OS_WATCHOS
+#if !TARGET_OS_WATCH
 - (void)FIRGameCenterAuthProvider_h {
   [FIRGameCenterAuthProvider getCredentialWithCompletion:^(FIRAuthCredential *_Nullable credential,
                                                            NSError *_Nullable error){
@@ -362,11 +362,11 @@
 #endif
 
 - (void)FIRGitHubAuthProvider_h {
-  FIRAuthCredential *c = [FIRGitHubAuthProvider credentialWithToken:@"token"];
+  __unused FIRAuthCredential *c = [FIRGitHubAuthProvider credentialWithToken:@"token"];
 }
 
 - (void)FIRGoogleAuthProvider_h {
-  FIRAuthCredential *c = [FIRGoogleAuthProvider credentialWithIDToken:@"token"
+  __unused FIRAuthCredential *c = [FIRGoogleAuthProvider credentialWithIDToken:@"token"
                                                           accessToken:@"token"];
 }
 
@@ -389,20 +389,20 @@
 }
 
 - (void)multiFactorAssertion:(FIRMultiFactorAssertion *)mfa {
-  NSString *s = [mfa factorID];
+  __unused NSString *s = [mfa factorID];
 }
 
 - (void)multiFactorInfo:(FIRMultiFactorInfo *)mfi {
   NSString *s = [mfi UID];
   s = [mfi factorID];
   s = [mfi displayName];
-  NSDate *d = [mfi enrollmentDate];
+  __unused NSDate *d = [mfi enrollmentDate];
 }
 
 - (void)multiFactorResolver:(FIRMultiFactorResolver *)mfr {
-  FIRMultiFactorSession *s = [mfr session];
-  NSArray<FIRMultiFactorInfo *> *hints = [mfr hints];
-  FIRAuth *auth = [mfr auth];
+  __unused FIRMultiFactorSession *s = [mfr session];
+  __unused NSArray<FIRMultiFactorInfo *> *hints = [mfr hints];
+  __unused FIRAuth *auth = [mfr auth];
 }
 #endif
 
@@ -428,9 +428,9 @@
                              completion:^(FIRAuthCredential *_Nullable credential,
                                           NSError *_Nullable error){
                              }];
-  NSString *s = [provider providerID];
-  NSArray<NSString *> *scopes = [provider scopes];
-  NSDictionary<NSString *, NSString *> *params = [provider customParameters];
+  __unused NSString *s = [provider providerID];
+  __unused NSArray<NSString *> *scopes = [provider scopes];
+  __unused NSDictionary<NSString *, NSString *> *params = [provider customParameters];
 }
 
 - (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthProvider *)provider mfi:(FIRPhoneMultiFactorInfo *)mfi {
@@ -449,7 +449,7 @@
                                       completion:^(NSString *_Nullable verificationID,
                                                    NSError *_Nullable error){
                                       }];
-  FIRPhoneAuthCredential *c = [provider credentialWithVerificationID:@"id"
+  __unused FIRPhoneAuthCredential *c = [provider credentialWithVerificationID:@"id"
                                                     verificationCode:@"code"];
 }
 
@@ -458,7 +458,7 @@
 }
 
 - (void)phoneMultiFactorInfo:(FIRPhoneMultiFactorInfo *)info {
-  NSString *s = [info phoneNumber];
+  __unused NSString *s = [info phoneNumber];
 }
 
 - (void)FIRTOTPSecret_h:(FIRTOTPSecret *)secret {
@@ -480,7 +480,7 @@
 #endif
 
 - (void)FIRTwitterAuthProvider_h {
-  FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token" secret:@"secret"];
+  __unused FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token" secret:@"secret"];
 }
 
 - (void)FIRUser_h:(FIRUser *)user credential:(FIRAuthCredential *)credential {
@@ -564,10 +564,10 @@
 - (void)userProperties:(FIRUser *)user {
   BOOL b = [user isAnonymous];
   b = [user isEmailVerified];
-  NSArray<NSObject<FIRUserInfo> *> *userInfo = [user providerData];
-  FIRUserMetadata *meta = [user metadata];
+  __unused NSArray<NSObject<FIRUserInfo> *> *userInfo = [user providerData];
+  __unused FIRUserMetadata *meta = [user metadata];
 #if TARGET_OS_IOS
-  FIRMultiFactor *mf = [user multiFactor];
+  __unused FIRMultiFactor *mf = [user multiFactor];
 #endif
   NSString *s = [user refreshToken];
   s = [user tenantID];
@@ -585,7 +585,7 @@
   s = [userInfo displayName];
   s = [userInfo email];
   s = [userInfo phoneNumber];
-  NSURL *u = [userInfo photoURL];
+  __unused NSURL *u = [userInfo photoURL];
 }
 
 - (void)userMetadataProperties:(FIRUserMetadata *)metadata {

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -173,7 +173,7 @@
 #endif
   NSError *error;
   [auth signOut:&error];
-  BOOL b;
+  __unused BOOL b;
 #if TARGET_OS_WATCH
   b = [auth isSignInWithEmailLink:@"email"];
 #endif
@@ -458,7 +458,7 @@
 }
 
 - (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthCredential *)credential {
-  [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+  FIRPhoneMultiFactorAssertion *a = [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
 }
 
 - (void)phoneMultiFactorInfo:(FIRPhoneMultiFactorInfo *)info {
@@ -478,8 +478,9 @@
                                 completion:^(FIRTOTPSecret *_Nullable secret,
                                              NSError *_Nullable error){
                                 }];
+  FIRTOTPMultiFactorAssertion *a =
   [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:secret oneTimePassword:@"pw"];
-  [FIRTOTPMultiFactorGenerator assertionForSignInWithEnrollmentID:@"id" oneTimePassword:@"pw"];
+  a = [FIRTOTPMultiFactorGenerator assertionForSignInWithEnrollmentID:@"id" oneTimePassword:@"pw"];
 }
 #endif
 
@@ -489,9 +490,6 @@
 }
 
 - (void)FIRUser_h:(FIRUser *)user credential:(FIRAuthCredential *)credential {
-  [user updateEmail:@"email"
-         completion:^(NSError *_Nullable error){
-         }];
   [user updatePassword:@"pw"
             completion:^(NSError *_Nullable error){
             }];

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -24,8 +24,7 @@ import FirebaseCore
   import UIKit
 #endif
 
-/// This file tests public methods and enums. Properties are not included.
-/// Each function maps to a public header file.
+/// This file tests public methods and enums. Each function maps to a public header file.
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class AuthAPI_hOnlyTests: XCTestCase {
@@ -88,9 +87,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
 
     #if os(iOS)
       if let _: Data = auth.apnsToken {}
-      // TODO: Should this be supported or should we always use
-      // setAPNSToken(_ token: Data, type: AuthAPNSTokenType)
-      // auth.apnsToken = Data()
+      auth.apnsToken = Data()
     #endif
   }
 
@@ -105,8 +102,6 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
     #if os(iOS)
       let provider = OAuthProvider(providerID: "abc")
-      auth.signIn(with: provider, uiDelegate: nil) { result, error in
-      }
       provider.getCredentialWith(nil) { credential, error in
         auth.signIn(with: credential!) { result, error in
         }
@@ -147,7 +142,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
     auth.useEmulator(withHost: "myHost", port: 123)
     #if os(iOS)
       _ = auth.canHandle(URL(fileURLWithPath: "/my/path"))
-      auth.setAPNSToken(Data(), type: AuthAPNSTokenType(rawValue: 2)!)
+      auth.setAPNSToken(Data(), type: AuthAPNSTokenType.prod)
       _ = auth.canHandleNotification([:])
       #if !targetEnvironment(macCatalyst)
         auth.initializeRecaptchaConfig { _ in
@@ -481,6 +476,9 @@ class AuthAPI_hOnlyTests: XCTestCase {
       _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce",
                                    accessToken: "token")
       _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce")
+      _ = OAuthProvider.appleCredential(withIDToken: "idToken",
+                                        rawNonce: "nonce",
+                                        fullName: nil)
       provider.getCredentialWith(provider as? AuthUIDelegate) { credential, error in
       }
     #endif
@@ -512,8 +510,6 @@ class AuthAPI_hOnlyTests: XCTestCase {
         uiDelegate: nil,
         multiFactorSession: nil
       ) { _, _ in
-      }
-      provider.verifyPhoneNumber("123", uiDelegate: nil, multiFactorSession: nil) { _, _ in
       }
       _ = provider.credential(withVerificationID: "id", verificationCode: "code")
     }


### PR DESCRIPTION
- Add Objective C API build tests
- Few cleanups for Swift API tests of duplicate removal and missing tests
- auth-swift branch version of the PR in #12121 

TODO: enum and typedef testing