### PR TITLE
[auth-swift] Add Objective C API build tests

### DIFF
--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
@@ -35,7 +35,7 @@ import Foundation
   /** @property iOSBundleID
       @brief The iOS bundle ID, if available. The default value is the current app's bundle ID.
    */
-  public var iOSBundleID: String?
+  @objc public var iOSBundleID: String?
 
   /** @property androidPackageName
       @brief The Android package name, if available.
@@ -84,7 +84,7 @@ import Foundation
     androidMinimumVersion = minimumVersion
   }
 
-  @objc public func setIOSBundleID(_ bundleID: String) {
+  public func setIOSBundleID(_ bundleID: String) {
     iOSBundleID = bundleID
   }
 }

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1659,6 +1659,7 @@ extension Auth: AuthInterop {
    This case will return `nil`.
    Please refer to https://github.com/firebase/firebase-ios-sdk/issues/8878 for details.
    */
+  @available(*, unavailable)
   @objc(getStoredUserForAccessGroup:error:)
   public func __getStoredUser(forAccessGroup accessGroup: String?,
                               error outError: NSErrorPointer) -> User? {

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1659,7 +1659,7 @@ extension Auth: AuthInterop {
    This case will return `nil`.
    Please refer to https://github.com/firebase/firebase-ios-sdk/issues/8878 for details.
    */
-  @available(*, unavailable)
+  @available(swift 1000.0) // Objective-C only API
   @objc(getStoredUserForAccessGroup:error:)
   public func __getStoredUser(forAccessGroup accessGroup: String?,
                               error outError: NSErrorPointer) -> User? {

--- a/FirebaseAuth/Sources/Swift/Auth/AuthSettings.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthSettings.swift
@@ -21,17 +21,25 @@ import Foundation
   /** @property appVerificationDisabledForTesting
       @brief Flag to determine whether app verification should be disabled for testing or not.
    */
-  @objc public var isAppVerificationDisabledForTesting: Bool
+  @objc public var appVerificationDisabledForTesting: Bool
+  @objc public var isAppVerificationDisabledForTesting: Bool {
+    get {
+      return appVerificationDisabledForTesting
+    }
+    set {
+      appVerificationDisabledForTesting = newValue
+    }
+  }
 
   override init() {
-    isAppVerificationDisabledForTesting = false
+    appVerificationDisabledForTesting = false
   }
 
   // MARK: NSCopying
 
   public func copy(with zone: NSZone? = nil) -> Any {
     let settings = AuthSettings()
-    settings.isAppVerificationDisabledForTesting = isAppVerificationDisabledForTesting
+    settings.appVerificationDisabledForTesting = appVerificationDisabledForTesting
     return settings
   }
 }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FederatedAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FederatedAuthProvider.swift
@@ -27,7 +27,7 @@ import Foundation
         @param completion Optionally; a block which is invoked asynchronously on the main thread when
             the mobile web flow is completed.
      */
-    @objc(getCredentialWithUIDelegate:completion:)
+    @objc optional
     func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
                            completion: ((AuthCredential?, Error?) -> Void)?)
 
@@ -37,6 +37,7 @@ import Foundation
         @param UIDelegate An optional UI delegate used to present the mobile web flow.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+    @objc(getCredentialWithUIDelegate:completion:)
     func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential
   #endif
 }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FederatedAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FederatedAuthProvider.swift
@@ -24,17 +24,6 @@ import Foundation
         @brief Used to obtain an auth credential via a mobile web flow.
             This method is available on iOS only.
         @param UIDelegate An optional UI delegate used to present the mobile web flow.
-        @param completion Optionally; a block which is invoked asynchronously on the main thread when
-            the mobile web flow is completed.
-     */
-    @objc optional
-    func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
-                           completion: ((AuthCredential?, Error?) -> Void)?)
-
-    /** @fn getCredentialWithUIDelegate:completion:
-        @brief Used to obtain an auth credential via a mobile web flow.
-            This method is available on iOS only.
-        @param UIDelegate An optional UI delegate used to present the mobile web flow.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
     @objc(getCredentialWithUIDelegate:completion:)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -181,11 +181,10 @@ import CommonCrypto
     /** @fn getCredentialWithUIDelegate:completion:
         @brief Used to obtain an auth credential via a mobile web flow.
             This method is available on iOS only.
-        @param UIDelegate An optional UI delegate used to present the mobile web flow.
+        @param uiDelegate An optional UI delegate used to present the mobile web flow.
         @param completion Optionally; a block which is invoked asynchronously on the main thread when
             the mobile web flow is completed.
      */
-    @objc(getCredentialWithUIDelegate:completion:)
     public func getCredentialWith(_ uiDelegate: AuthUIDelegate?,
                                   completion: ((AuthCredential?, Error?) -> Void)? = nil) {
       guard let urlTypes = auth.mainBundleUrlTypes,
@@ -256,10 +255,10 @@ import CommonCrypto
     /** @fn getCredentialWithUIDelegate:completion:
         @brief Used to obtain an auth credential via a mobile web flow.
             This method is available on iOS only.
-        @param UIDelegate An optional UI delegate used to present the mobile web flow.
-        @return An `AuthCredential`.
+        @param uiDelegate An optional UI delegate used to present the mobile web flow.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+    @objc(getCredentialWithUIDelegate:completion:)
     public func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
       return try await withCheckedThrowingContinuation { continuation in
         getCredentialWith(uiDelegate) { credential, error in

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -78,11 +78,10 @@ import FirebaseCore
      factor challenge.
      @param completion The callback to be invoked when the verification flow is finished.
      */
-
     @objc(verifyPhoneNumber:UIDelegate:multiFactorSession:completion:)
     public func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
-                                  multiFactorSession session: MultiFactorSession? = nil,
+                                  multiFactorSession: MultiFactorSession? = nil,
                                   completion: ((_: String?, _: Error?) -> Void)?) {
       guard AuthWebUtils.isCallbackSchemeRegistered(forCustomURLScheme: callbackScheme,
                                                     urlTypes: auth.mainBundleUrlTypes) else {
@@ -93,9 +92,11 @@ import FirebaseCore
       kAuthGlobalWorkQueue.async {
         Task {
           do {
-            let verificationID = try await self.internalVerify(phoneNumber: phoneNumber,
-                                                               uiDelegate: uiDelegate,
-                                                               multiFactorSession: session)
+            let verificationID = try await self.internalVerify(
+              phoneNumber: phoneNumber,
+              uiDelegate: uiDelegate,
+              multiFactorSession: multiFactorSession
+            )
             Auth.wrapMainAsync(callback: completion, withParam: verificationID, error: nil)
           } catch {
             Auth.wrapMainAsync(callback: completion, withParam: nil, error: error)
@@ -104,6 +105,16 @@ import FirebaseCore
       }
     }
 
+    /**
+     @brief Verify ownership of the second factor phone number by the current user.
+     @param phoneNumber The phone number to be verified.
+     @param uiDelegate An object used to present the SFSafariViewController. The object is retained
+     by this method until the completion block is executed.
+     @param multiFactorSession A session to identify the MFA flow. For enrollment, this identifies the user
+     trying to enroll. For sign-in, this identifies that the user already passed the first
+     factor challenge.
+     @returns The verification ID
+     */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
     public func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
@@ -135,12 +146,12 @@ import FirebaseCore
     @objc(verifyPhoneNumberWithMultiFactorInfo:UIDelegate:multiFactorSession:completion:)
     public func verifyPhoneNumber(with multiFactorInfo: PhoneMultiFactorInfo,
                                   uiDelegate: AuthUIDelegate? = nil,
-                                  multiFactorSession session: MultiFactorSession?,
+                                  multiFactorSession: MultiFactorSession?,
                                   completion: ((_: String?, _: Error?) -> Void)?) {
-      session?.multiFactorInfo = multiFactorInfo
+      multiFactorSession?.multiFactorInfo = multiFactorInfo
       verifyPhoneNumber(multiFactorInfo.phoneNumber,
                         uiDelegate: uiDelegate,
-                        multiFactorSession: session,
+                        multiFactorSession: multiFactorSession,
                         completion: completion)
     }
 
@@ -181,7 +192,7 @@ import FirebaseCore
 
     private func internalVerify(phoneNumber: String,
                                 uiDelegate: AuthUIDelegate?,
-                                multiFactorSession session: MultiFactorSession? = nil) async throws
+                                multiFactorSession: MultiFactorSession? = nil) async throws
       -> String? {
       guard phoneNumber.count > 0 else {
         throw AuthErrorUtils.missingPhoneNumberError(message: nil)
@@ -194,7 +205,7 @@ import FirebaseCore
       }
       return try await verifyClAndSendVerificationCode(toPhoneNumber: phoneNumber,
                                                        retryOnInvalidAppCredential: true,
-                                                       multiFactorSession: session,
+                                                       multiFactorSession: multiFactorSession,
                                                        uiDelegate: uiDelegate)
     }
 

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorAssertion.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorAssertion.swift
@@ -22,7 +22,7 @@ import Foundation
        This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class PhoneMultiFactorAssertion: MultiFactorAssertion {
+  @objc(FIRPhoneMultiFactorAssertion) public class PhoneMultiFactorAssertion: MultiFactorAssertion {
     var authCredential: PhoneAuthCredential?
 
     init() {

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorGenerator.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorGenerator.swift
@@ -32,7 +32,7 @@ import Foundation
      */
     @objc(assertionWithCredential:)
     public class func assertion(with phoneAuthCredential: PhoneAuthCredential)
-      -> MultiFactorAssertion {
+      -> PhoneMultiFactorAssertion {
       let assertion = PhoneMultiFactorAssertion()
       assertion.authCredential = phoneAuthCredential
       return assertion

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -496,15 +496,14 @@ extension User: NSSecureCoding {}
                                uiDelegate: AuthUIDelegate?,
                                completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
       kAuthGlobalWorkQueue.async {
-        provider.getCredentialWith(uiDelegate) { credential, error in
-          if let error {
+        Task {
+          do {
+            let credential = try await provider.credential(with: uiDelegate)
+            self.reauthenticate(with: credential, completion: completion)
+          } catch {
             if let completion {
               completion(nil, error)
             }
-            return
-          }
-          if let credential {
-            self.reauthenticate(with: credential, completion: completion)
           }
         }
       }
@@ -837,16 +836,14 @@ extension User: NSSecureCoding {}
                      uiDelegate: AuthUIDelegate?,
                      completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
       kAuthGlobalWorkQueue.async {
-        provider.getCredentialWith(uiDelegate) { credential, error in
-          if let error {
+        Task {
+          do {
+            let credential = try await provider.credential(with: uiDelegate)
+            self.link(with: credential, completion: completion)
+          } catch {
             if let completion {
               completion(nil, error)
             }
-          } else {
-            guard let credential else {
-              fatalError("Failed to get credential for link withProvider")
-            }
-            self.link(with: credential, completion: completion)
           }
         }
       }

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -846,7 +846,8 @@ class AuthTests: RPCBaseTests {
   #if os(iOS)
     class FakeProvider: NSObject, FederatedAuthProvider {
       @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-      func credential(with UIDelegate: FirebaseAuth.AuthUIDelegate?) async throws -> AuthCredential {
+      func credential(with UIDelegate: FirebaseAuth.AuthUIDelegate?) async throws ->
+        FirebaseAuth.AuthCredential {
         let credential = OAuthCredential(withProviderID: GoogleAuthProvider.id,
                                          sessionID: kOAuthSessionID,
                                          OAuthResponseURLString: kOAuthRequestURI)

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -846,19 +846,13 @@ class AuthTests: RPCBaseTests {
   #if os(iOS)
     class FakeProvider: NSObject, FederatedAuthProvider {
       @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-      func credential(with UIDelegate: FirebaseAuth.AuthUIDelegate?) async throws ->
-        FirebaseAuth.AuthCredential {
-        fatalError("Should not use this async method yet")
-      }
-
-      func getCredentialWith(_ UIDelegate: FirebaseAuth.AuthUIDelegate?,
-                             completion: ((FirebaseAuth.AuthCredential?, Error?) -> Void)?) {
+      func credential(with UIDelegate: FirebaseAuth.AuthUIDelegate?) async throws -> AuthCredential {
         let credential = OAuthCredential(withProviderID: GoogleAuthProvider.id,
                                          sessionID: kOAuthSessionID,
                                          OAuthResponseURLString: kOAuthRequestURI)
         XCTAssertEqual(credential.OAuthResponseURLString, kOAuthRequestURI)
         XCTAssertEqual(credential.sessionID, kOAuthSessionID)
-        completion?(credential, nil)
+        return credential
       }
     }
 

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -1,0 +1,599 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+@import FirebaseCore;
+@import FirebaseAuth;
+
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+@interface AuthUIImpl : NSObject <FIRAuthUIDelegate>
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^_Nullable)(void))completion;
+- (void)presentViewController:(nonnull UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^_Nullable)(void))completion;
+@end
+@implementation AuthUIImpl
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^_Nullable)(void))completion {
+}
+
+- (void)presentViewController:(nonnull UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^_Nullable)(void))completion {
+}
+@end
+#endif
+
+#if TARGET_OS_IOS
+@interface FederatedAuthImplementation : NSObject <FIRFederatedAuthProvider>
+- (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+                         completion:(nullable void (^)(FIRAuthCredential *_Nullable,
+                                                       NSError *_Nullable))completion;
+@end
+@implementation FederatedAuthImplementation
+- (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+                         completion:(nullable void (^)(FIRAuthCredential *_Nullable,
+                                                       NSError *_Nullable))completion {
+}
+@end
+#endif
+
+@interface ObjCAPICoverage : XCTestCase
+@end
+
+@implementation ObjCAPICoverage
+
+- (void)FIRActionCodeSettings_h {
+  FIRActionCodeSettings *codeSettings = [[FIRActionCodeSettings alloc] init];
+  [codeSettings setIOSBundleID:@"abc"];
+  [codeSettings setAndroidPackageName:@"name" installIfNotAvailable:NO minimumVersion:@"1.1"];
+  BOOL b = [codeSettings handleCodeInApp];
+  b = [codeSettings androidInstallIfNotAvailable];
+  __unused NSURL *u = [codeSettings URL];
+  NSString *s = [codeSettings iOSBundleID];
+  s = [codeSettings androidPackageName];
+  s = [codeSettings androidMinimumVersion];
+  s = [codeSettings dynamicLinkDomain];
+}
+
+- (void)FIRAuthAdditionalUserInfo_h:(FIRAdditionalUserInfo *)additionalUserInfo {
+  NSString *s = [additionalUserInfo providerID];
+  __unused BOOL b = [additionalUserInfo isNewUser];
+  __unused NSDictionary<NSString *, NSObject *> *dict = [additionalUserInfo profile];
+  s = [additionalUserInfo username];
+}
+
+- (void)ActionCodeOperationTests:(FIRActionCodeInfo *)info {
+  __unused FIRActionCodeOperation op = [info operation];
+  NSString *s = [info email];
+  s = [info previousEmail];
+}
+
+- (void)ActionCodeURL:(FIRActionCodeURL *)url {
+  __unused FIRActionCodeOperation op = [url operation];
+  NSString *s = [url APIKey];
+  s = [url code];
+  __unused NSURL *u = [url continueURL];
+  s = [url languageCode];
+}
+
+- (void)authProperties:(FIRAuth *)auth {
+  __unused BOOL b = [auth shareAuthStateAcrossDevices];
+  [auth setShareAuthStateAcrossDevices:YES];
+  __unused FIRUser *u = [auth currentUser];
+  NSString *s = [auth languageCode];
+  [auth setLanguageCode:s];
+  FIRAuthSettings *settings = [auth settings];
+  [auth setSettings:settings];
+  s = [auth userAccessGroup];
+  s = [auth tenantID];
+  [auth setTenantID:s];
+  s = [auth customAuthDomain];
+  [auth setCustomAuthDomain:s];
+#if TARGET_OS_IOS
+  __unused NSData *d = [auth APNSToken];
+  // TODO: It seems like a no-op and a bug to have this API in Objective C
+  // auth.APNSToken = [[NSData alloc] init];
+#endif
+}
+
+- (void)FIRAuth_h:(FIRAuth *)auth
+             with:(FIRAuthCredential *)credential
+         provider:(FIROAuthProvider *)provider
+              url:(NSURL *)url {
+  [auth updateCurrentUser:[auth currentUser]
+               completion:^(NSError *_Nullable error){
+               }];
+  [auth signInWithEmail:@"a@abc.com"
+               password:@"pw"
+             completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+             }];
+#if !TARGET_OS_WATCH
+  [auth signInWithEmail:@"a@abc.com"
+                   link:@"link"
+             completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+             }];
+#endif
+#if TARGET_OS_IOS
+  [auth signInWithProvider:provider
+                UIDelegate:nil
+                completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                }];
+  [auth signInWithCredential:credential
+                  completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                  }];
+#endif
+  [auth signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable authResult,
+                                          NSError *_Nullable error){
+  }];
+  [auth signInWithCustomToken:@"token"
+                   completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                   }];
+  [auth createUserWithEmail:@"a@abc.com"
+                   password:@"pw"
+                 completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                 }];
+  [auth confirmPasswordResetWithCode:@"code"
+                         newPassword:@"pw"
+                          completion:^(NSError *_Nullable error){
+                          }];
+  [auth checkActionCode:@"code"
+             completion:^(FIRActionCodeInfo *_Nullable info, NSError *_Nullable error){
+             }];
+  [auth verifyPasswordResetCode:@"code"
+                     completion:^(NSString *_Nullable email, NSError *_Nullable error){
+                     }];
+  [auth applyActionCode:@"code"
+             completion:^(NSError *_Nullable error){
+             }];
+  [auth sendPasswordResetWithEmail:@"email"
+                        completion:^(NSError *_Nullable error){
+                        }];
+  FIRActionCodeSettings *settings = [[FIRActionCodeSettings alloc] init];
+  [auth sendPasswordResetWithEmail:@"email"
+                actionCodeSettings:settings
+                        completion:^(NSError *_Nullable error){
+                        }];
+#if !TARGET_OS_WATCH
+  [auth sendSignInLinkToEmail:@"email"
+           actionCodeSettings:settings
+                   completion:^(NSError *_Nullable error){
+                   }];
+#endif
+  NSError *error;
+  [auth signOut:&error];
+  __unused BOOL b;
+#if !TARGET_OS_WATCH
+  b = [auth isSignInWithEmailLink:@"email"];
+#endif
+  FIRAuthStateDidChangeListenerHandle handle =
+      [auth addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user){
+      }];
+  [auth removeAuthStateDidChangeListener:handle];
+  [auth removeIDTokenDidChangeListener:handle];
+  [auth useAppLanguage];
+  [auth useEmulatorWithHost:@"host" port:123];
+#if TARGET_OS_IOS
+  b = [auth canHandleURL:url];
+  [auth setAPNSToken:[[NSData alloc] init] type:FIRAuthAPNSTokenTypeProd];
+  b = [auth canHandleNotification:@{}];
+#if !TARGET_OS_MACCATALYST && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+  [auth initializeRecaptchaConfigWithCompletion:^(NSError *_Nullable error){
+  }];
+#endif
+#endif
+  [auth revokeTokenWithAuthorizationCode:@"a"
+                              completion:^(NSError *_Nullable error){
+                              }];
+  [auth useUserAccessGroup:@"abc" error:&error];
+  __unused FIRUser *u = [auth getStoredUserForAccessGroup:@"user" error:&error];
+}
+
+#if !TARGET_OS_OSX
+- (void)FIRAuthAPNSTokenType_h {
+  FIRAuthAPNSTokenType t = FIRAuthAPNSTokenTypeProd;
+  t = FIRAuthAPNSTokenTypeSandbox;
+  t = FIRAuthAPNSTokenTypeUnknown;
+}
+#endif
+
+- (NSString *)authCredential:(FIRAuthCredential *)credential {
+  return [credential provider];
+}
+
+- (void)authDataResult:(FIRAuthDataResult *)result {
+  __unused FIRUser *u = [result user];
+  __unused FIRAdditionalUserInfo *info = [result additionalUserInfo];
+  __unused FIRAuthCredential *c = [result credential];
+}
+
+- (void)FIRAuthErrors_h {
+  FIRAuthErrorCode c = FIRAuthErrorCodeInvalidCustomToken;
+  c = FIRAuthErrorCodeCustomTokenMismatch;
+  c = FIRAuthErrorCodeInvalidCredential;
+  c = FIRAuthErrorCodeUserDisabled;
+  c = FIRAuthErrorCodeOperationNotAllowed;
+  c = FIRAuthErrorCodeEmailAlreadyInUse;
+  c = FIRAuthErrorCodeInvalidEmail;
+  c = FIRAuthErrorCodeWrongPassword;
+  c = FIRAuthErrorCodeTooManyRequests;
+  c = FIRAuthErrorCodeUserNotFound;
+  c = FIRAuthErrorCodeAccountExistsWithDifferentCredential;
+  c = FIRAuthErrorCodeRequiresRecentLogin;
+  c = FIRAuthErrorCodeProviderAlreadyLinked;
+  c = FIRAuthErrorCodeNoSuchProvider;
+  c = FIRAuthErrorCodeInvalidUserToken;
+  c = FIRAuthErrorCodeNetworkError;
+  c = FIRAuthErrorCodeUserTokenExpired;
+  c = FIRAuthErrorCodeInvalidAPIKey;
+  c = FIRAuthErrorCodeUserMismatch;
+  c = FIRAuthErrorCodeCredentialAlreadyInUse;
+  c = FIRAuthErrorCodeWeakPassword;
+  c = FIRAuthErrorCodeAppNotAuthorized;
+  c = FIRAuthErrorCodeExpiredActionCode;
+  c = FIRAuthErrorCodeInvalidActionCode;
+  c = FIRAuthErrorCodeInvalidMessagePayload;
+  c = FIRAuthErrorCodeInvalidSender;
+  c = FIRAuthErrorCodeInvalidRecipientEmail;
+  c = FIRAuthErrorCodeMissingEmail;
+  c = FIRAuthErrorCodeMissingIosBundleID;
+  c = FIRAuthErrorCodeMissingAndroidPackageName;
+  c = FIRAuthErrorCodeUnauthorizedDomain;
+  c = FIRAuthErrorCodeInvalidContinueURI;
+  c = FIRAuthErrorCodeMissingContinueURI;
+  c = FIRAuthErrorCodeMissingPhoneNumber;
+  c = FIRAuthErrorCodeInvalidPhoneNumber;
+  c = FIRAuthErrorCodeMissingVerificationCode;
+  c = FIRAuthErrorCodeInvalidVerificationCode;
+  c = FIRAuthErrorCodeMissingVerificationID;
+  c = FIRAuthErrorCodeInvalidVerificationID;
+  c = FIRAuthErrorCodeMissingAppCredential;
+  c = FIRAuthErrorCodeInvalidAppCredential;
+  c = FIRAuthErrorCodeSessionExpired;
+  c = FIRAuthErrorCodeQuotaExceeded;
+  c = FIRAuthErrorCodeMissingAppToken;
+  c = FIRAuthErrorCodeNotificationNotForwarded;
+  c = FIRAuthErrorCodeAppNotVerified;
+  c = FIRAuthErrorCodeCaptchaCheckFailed;
+  c = FIRAuthErrorCodeWebContextAlreadyPresented;
+  c = FIRAuthErrorCodeWebContextCancelled;
+  c = FIRAuthErrorCodeAppVerificationUserInteractionFailure;
+  c = FIRAuthErrorCodeInvalidClientID;
+  c = FIRAuthErrorCodeWebNetworkRequestFailed;
+  c = FIRAuthErrorCodeWebInternalError;
+  c = FIRAuthErrorCodeWebSignInUserInteractionFailure;
+  c = FIRAuthErrorCodeLocalPlayerNotAuthenticated;
+  c = FIRAuthErrorCodeNullUser;
+  c = FIRAuthErrorCodeDynamicLinkNotActivated;
+  c = FIRAuthErrorCodeInvalidProviderID;
+  c = FIRAuthErrorCodeTenantIDMismatch;
+  c = FIRAuthErrorCodeUnsupportedTenantOperation;
+  c = FIRAuthErrorCodeInvalidDynamicLinkDomain;
+  c = FIRAuthErrorCodeRejectedCredential;
+  c = FIRAuthErrorCodeGameKitNotLinked;
+  c = FIRAuthErrorCodeSecondFactorRequired;
+  c = FIRAuthErrorCodeMissingMultiFactorSession;
+  c = FIRAuthErrorCodeMissingMultiFactorInfo;
+  c = FIRAuthErrorCodeInvalidMultiFactorSession;
+  c = FIRAuthErrorCodeMultiFactorInfoNotFound;
+  c = FIRAuthErrorCodeAdminRestrictedOperation;
+  c = FIRAuthErrorCodeUnverifiedEmail;
+  c = FIRAuthErrorCodeSecondFactorAlreadyEnrolled;
+  c = FIRAuthErrorCodeMaximumSecondFactorCountExceeded;
+  c = FIRAuthErrorCodeUnsupportedFirstFactor;
+  c = FIRAuthErrorCodeEmailChangeNeedsVerification;
+  c = FIRAuthErrorCodeMissingClientIdentifier;
+  c = FIRAuthErrorCodeMissingOrInvalidNonce;
+  c = FIRAuthErrorCodeBlockingCloudFunctionError;
+  c = FIRAuthErrorCodeRecaptchaNotEnabled;
+  c = FIRAuthErrorCodeMissingRecaptchaToken;
+  c = FIRAuthErrorCodeInvalidRecaptchaToken;
+  c = FIRAuthErrorCodeInvalidRecaptchaAction;
+  c = FIRAuthErrorCodeMissingClientType;
+  c = FIRAuthErrorCodeMissingRecaptchaVersion;
+  c = FIRAuthErrorCodeInvalidRecaptchaVersion;
+  c = FIRAuthErrorCodeInvalidReqType;
+  c = FIRAuthErrorCodeRecaptchaSDKNotLinked;
+  c = FIRAuthErrorCodeKeychainError;
+  c = FIRAuthErrorCodeInternalError;
+  c = FIRAuthErrorCodeMalformedJWT;
+}
+
+- (void)authSettings:(FIRAuthSettings *)settings {
+  BOOL b = [settings isAppVerificationDisabledForTesting];
+  [settings setAppVerificationDisabledForTesting:b];
+}
+
+- (void)authTokenResult:(FIRAuthTokenResult *)result {
+  NSString *s = [result token];
+  NSDate *d = [result expirationDate];
+  d = [result authDate];
+  d = [result issuedAtDate];
+  s = [result signInProvider];
+  s = [result signInSecondFactor];
+  __unused NSDictionary<NSString *, NSObject *> *dict = [result claims];
+}
+
+#if !TARGET_OS_OSX && !TARGET_OS_WATCH
+- (void)authTokenResult {
+  AuthUIImpl *impl = [[AuthUIImpl alloc] init];
+  [impl presentViewController:[[UIViewController alloc] init]
+                     animated:NO
+                   completion:^{
+                   }];
+  [impl dismissViewControllerAnimated:YES
+                           completion:^{
+                           }];
+}
+#endif
+
+- (void)FIREmailAuthProvider_h {
+  FIRAuthCredential *c = [FIREmailAuthProvider credentialWithEmail:@"e" password:@"pw"];
+  c = [FIREmailAuthProvider credentialWithEmail:@"e" link:@"l"];
+}
+
+- (void)FIRFacebookAuthProvider_h {
+  __unused FIRAuthCredential *c = [FIRFacebookAuthProvider credentialWithAccessToken:@"token"];
+}
+
+#if TARGET_OS_IOS
+- (void)FIRFederatedAuthProvider_h {
+  FederatedAuthImplementation *impl = [[FederatedAuthImplementation alloc] init];
+  [impl getCredentialWithUIDelegate:nil
+                         completion:^(FIRAuthCredential *_Nullable c, NSError *_Nullable e){
+                         }];
+}
+#endif
+
+#if !TARGET_OS_WATCH
+- (void)FIRGameCenterAuthProvider_h {
+  [FIRGameCenterAuthProvider getCredentialWithCompletion:^(FIRAuthCredential *_Nullable credential,
+                                                           NSError *_Nullable error){
+  }];
+}
+#endif
+
+- (void)FIRGitHubAuthProvider_h {
+  __unused FIRAuthCredential *c = [FIRGitHubAuthProvider credentialWithToken:@"token"];
+}
+
+- (void)FIRGoogleAuthProvider_h {
+  __unused FIRAuthCredential *c = [FIRGoogleAuthProvider credentialWithIDToken:@"token"
+                                                                   accessToken:@"token"];
+}
+
+#if TARGET_OS_IOS
+- (void)FIRMultiFactor_h:(FIRMultiFactor *)mf mfa:(FIRMultiFactorAssertion *)mfa {
+  [mf getSessionWithCompletion:^(FIRMultiFactorSession *_Nullable credential,
+                                 NSError *_Nullable error){
+  }];
+  [mf enrollWithAssertion:mfa
+              displayName:@"name"
+               completion:^(NSError *_Nullable error){
+               }];
+  FIRMultiFactorInfo *mfi = [mf enrolledFactors][0];
+  [mf unenrollWithInfo:mfi
+            completion:^(NSError *_Nullable error){
+            }];
+  [mf unenrollWithFactorUID:@"uid"
+                 completion:^(NSError *_Nullable error){
+                 }];
+}
+
+- (void)multiFactorAssertion:(FIRMultiFactorAssertion *)mfa {
+  __unused NSString *s = [mfa factorID];
+}
+
+- (void)multiFactorInfo:(FIRMultiFactorInfo *)mfi {
+  NSString *s = [mfi UID];
+  s = [mfi factorID];
+  s = [mfi displayName];
+  __unused NSDate *d = [mfi enrollmentDate];
+}
+
+- (void)multiFactorResolver:(FIRMultiFactorResolver *)mfr {
+  __unused FIRMultiFactorSession *s = [mfr session];
+  __unused NSArray<FIRMultiFactorInfo *> *hints = [mfr hints];
+  __unused FIRAuth *auth = [mfr auth];
+}
+#endif
+
+- (void)oauthCredential:(FIROAuthCredential *)credential {
+  NSString *s = [credential IDToken];
+  s = [credential accessToken];
+  s = [credential secret];
+}
+
+#if TARGET_OS_IOS
+- (void)FIROAuthProvider_h:(FIROAuthProvider *)provider {
+  FIROAuthCredential *c = [FIROAuthProvider credentialWithProviderID:@"id" accessToken:@"token"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id"
+                                         IDToken:@"idToken"
+                                     accessToken:@"accessToken"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id" IDToken:@"idtoken" rawNonce:@"nonce"];
+  c = [FIROAuthProvider credentialWithProviderID:@"id"
+                                         IDToken:@"token"
+                                        rawNonce:@"nonce"
+                                     accessToken:@"accessToken"];
+  c = [FIROAuthProvider appleCredentialWithIDToken:@"idToken" rawNonce:@"nonce" fullName:nil];
+  [provider getCredentialWithUIDelegate:nil
+                             completion:^(FIRAuthCredential *_Nullable credential,
+                                          NSError *_Nullable error){
+                             }];
+  __unused NSString *s = [provider providerID];
+  __unused NSArray<NSString *> *scopes = [provider scopes];
+  __unused NSDictionary<NSString *, NSString *> *params = [provider customParameters];
+}
+
+- (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthProvider *)provider mfi:(FIRPhoneMultiFactorInfo *)mfi {
+  [provider verifyPhoneNumber:@"123"
+                   UIDelegate:nil
+                   completion:^(NSString *_Nullable verificationID, NSError *_Nullable error){
+                   }];
+  [provider verifyPhoneNumber:@"123"
+                   UIDelegate:nil
+           multiFactorSession:nil
+                   completion:^(NSString *_Nullable verificationID, NSError *_Nullable error){
+                   }];
+  [provider verifyPhoneNumberWithMultiFactorInfo:mfi
+                                      UIDelegate:nil
+                              multiFactorSession:nil
+                                      completion:^(NSString *_Nullable verificationID,
+                                                   NSError *_Nullable error){
+                                      }];
+  __unused FIRPhoneAuthCredential *c = [provider credentialWithVerificationID:@"id"
+                                                             verificationCode:@"code"];
+}
+
+- (void)FIRPhoneAuthProvider_h:(FIRPhoneAuthCredential *)credential {
+  __unused FIRPhoneMultiFactorAssertion *a =
+      [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+}
+
+- (void)phoneMultiFactorInfo:(FIRPhoneMultiFactorInfo *)info {
+  __unused NSString *s = [info phoneNumber];
+}
+
+- (void)FIRTOTPSecret_h:(FIRTOTPSecret *)secret {
+  NSString *s = [secret sharedSecretKey];
+  s = [secret generateQRCodeURLWithAccountName:@"name" issuer:@"issuer"];
+  [secret openInOTPAppWithQRCodeURL:@"qr"];
+}
+
+- (void)FIRTOTPMultiFactorGenerator_h:(FIRMultiFactorSession *)session
+                               secret:(FIRTOTPSecret *)secret {
+  [FIRTOTPMultiFactorGenerator
+      generateSecretWithMultiFactorSession:session
+                                completion:^(FIRTOTPSecret *_Nullable secret,
+                                             NSError *_Nullable error){
+                                }];
+  FIRTOTPMultiFactorAssertion *a =
+      [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:secret oneTimePassword:@"pw"];
+  a = [FIRTOTPMultiFactorGenerator assertionForSignInWithEnrollmentID:@"id" oneTimePassword:@"pw"];
+}
+#endif
+
+- (void)FIRTwitterAuthProvider_h {
+  __unused FIRAuthCredential *c = [FIRTwitterAuthProvider credentialWithToken:@"token"
+                                                                       secret:@"secret"];
+}
+
+- (void)FIRUser_h:(FIRUser *)user credential:(FIRAuthCredential *)credential {
+  [user updatePassword:@"pw"
+            completion:^(NSError *_Nullable error){
+            }];
+  [user reloadWithCompletion:^(NSError *_Nullable error){
+  }];
+  [user reauthenticateWithCredential:credential
+                          completion:^(FIRAuthDataResult *_Nullable authResult,
+                                       NSError *_Nullable error){
+                          }];
+#if TARGET_OS_IOS
+  FIRPhoneAuthProvider *provider = [FIRPhoneAuthProvider provider];
+  FIRPhoneAuthCredential *phoneCredential = [provider credentialWithVerificationID:@"id"
+                                                                  verificationCode:@"code"];
+  [user updatePhoneNumberCredential:phoneCredential
+                         completion:^(NSError *_Nullable error){
+                         }];
+  [user reauthenticateWithProvider:(NSObject<FIRFederatedAuthProvider> *)provider
+                        UIDelegate:nil
+                        completion:^(FIRAuthDataResult *_Nullable authResult,
+                                     NSError *_Nullable error){
+                        }];
+  [user linkWithProvider:(NSObject<FIRFederatedAuthProvider> *)provider
+              UIDelegate:nil
+              completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+              }];
+#endif
+  [user getIDTokenResultWithCompletion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                         NSError *_Nullable error){
+  }];
+  [user getIDTokenResultForcingRefresh:YES
+                            completion:^(FIRAuthTokenResult *_Nullable tokenResult,
+                                         NSError *_Nullable error){
+                            }];
+  [user getIDTokenWithCompletion:^(NSString *_Nullable token, NSError *_Nullable error){
+  }];
+  [user getIDTokenForcingRefresh:NO
+                      completion:^(NSString *_Nullable token, NSError *_Nullable error){
+                      }];
+  [user linkWithCredential:credential
+                completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error){
+                }];
+  [user unlinkFromProvider:@"provider"
+                completion:^(FIRUser *_Nullable user, NSError *_Nullable error){
+                }];
+  [user sendEmailVerificationWithCompletion:^(NSError *_Nullable error){
+  }];
+  [user sendEmailVerificationBeforeUpdatingEmail:@"email"
+                                      completion:^(NSError *_Nullable error){
+                                      }];
+  FIRActionCodeSettings *settings = [[FIRActionCodeSettings alloc] init];
+  [user sendEmailVerificationWithActionCodeSettings:settings
+                                         completion:^(NSError *_Nullable error){
+                                         }];
+  [user sendEmailVerificationBeforeUpdatingEmail:@"email"
+                              actionCodeSettings:settings
+                                      completion:^(NSError *_Nullable error){
+                                      }];
+  [user deleteWithCompletion:^(NSError *_Nullable error){
+  }];
+  FIRUserProfileChangeRequest *changeRequest = [user profileChangeRequest];
+  [changeRequest commitChangesWithCompletion:^(NSError *_Nullable error){
+  }];
+  NSString *s = [user providerID];
+  s = [user uid];
+  s = [user displayName];
+  s = [user email];
+  s = [user phoneNumber];
+  s = [changeRequest displayName];
+  NSURL *u = [changeRequest photoURL];
+  u = [user photoURL];
+  [changeRequest setDisplayName:s];
+  [changeRequest setPhotoURL:u];
+}
+
+- (void)userProperties:(FIRUser *)user {
+  BOOL b = [user isAnonymous];
+  b = [user isEmailVerified];
+  __unused NSArray<NSObject<FIRUserInfo> *> *userInfo = [user providerData];
+  __unused FIRUserMetadata *meta = [user metadata];
+#if TARGET_OS_IOS
+  __unused FIRMultiFactor *mf = [user multiFactor];
+#endif
+  NSString *s = [user refreshToken];
+  s = [user tenantID];
+
+  FIRUserProfileChangeRequest *changeRequest = [user profileChangeRequest];
+  s = [changeRequest displayName];
+  NSURL *u = [changeRequest photoURL];
+  [changeRequest setDisplayName:s];
+  [changeRequest setPhotoURL:u];
+}
+
+- (void)userInfoProperties:(NSObject<FIRUserInfo> *)userInfo {
+  NSString *s = [userInfo providerID];
+  s = [userInfo uid];
+  s = [userInfo displayName];
+  s = [userInfo email];
+  s = [userInfo phoneNumber];
+  __unused NSURL *u = [userInfo photoURL];
+}
+
+- (void)userMetadataProperties:(FIRUserMetadata *)metadata {
+  NSDate *d = [metadata lastSignInDate];
+  d = [metadata creationDate];
+}
+
+@end

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -670,7 +670,7 @@
         if testMode {
           // Disable app verification.
           let settings = AuthSettings()
-          settings.isAppVerificationDisabledForTesting = true
+          settings.appVerificationDisabledForTesting = true
           auth.settings = settings
         }
         auth.notificationManager?.immediateCallbackForTestFaking = { forwardingNotification }

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -349,25 +349,11 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if os(iOS)
-    func FIRFederatedAuthProvider_hO() {
-      class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
-        // TODO: Document this API breakage - needing to add this functon for classes implementing
-        // FederatedAuthProvider.
-        func credential(with UIDelegate: FirebaseAuth
-          .AuthUIDelegate?) async throws -> AuthCredential {
-          return FacebookAuthProvider.credential(withAccessToken: "token")
-        }
-        func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
-                               completion: ((AuthCredential?, Error?) -> Void)? = nil) {}
-      }
-      let obj = FederatedAuthImplementation()
-      obj.getCredentialWith(nil) { _, _ in
-      }
-    }
-
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRFedederatedAuthProvider_hAsync() async throws {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
+        // TODO: Document this API breakage - needing to add this functon for classes implementing
+        // FederatedAuthProvider.
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
           return FacebookAuthProvider.credential(withAccessToken: "token")
         }
@@ -381,13 +367,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
           return FacebookAuthProvider.credential(withAccessToken: "token")
         }
-
-        func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
-                               completion: ((AuthCredential?, Error?) -> Void)? = nil) {}
       }
       let obj = FederatedAuthImplementation()
-      obj.getCredentialWith(nil) { _, _ in
-      }
       @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
       func FIRFedederatedAuthProvider_hAsync() async throws {
         let obj = FederatedAuthImplementation()

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -24,8 +24,7 @@ import FirebaseCore
   import UIKit
 #endif
 
-/// This file tests public methods and enums. Properties are not included.
-/// Each function maps to a public header file.
+/// This file tests public methods and enums.  Each function maps to a public header file.
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class AuthAPI_hOnlyTests: XCTestCase {
@@ -90,8 +89,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
 
     #if os(iOS)
       if let _: Data = auth.apnsToken {}
-      // TODO: Should this be supported or should we always use
-      // setAPNSToken(_ token: Data, type: AuthAPNSTokenType)
+      // TODO: This API was defined in the ObjC SDK, but seems to be a no-op.
       // auth.apnsToken = Data()
     #endif
   }
@@ -152,7 +150,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
     auth.useEmulator(withHost: "myHost", port: 123)
     #if os(iOS)
       _ = auth.canHandle(URL(fileURLWithPath: "/my/path"))
-      auth.setAPNSToken(Data(), type: AuthAPNSTokenType(rawValue: 2)!)
+      auth.setAPNSToken(Data(), type: AuthAPNSTokenType.prod)
       _ = auth.canHandleNotification([:])
       #if !targetEnvironment(macCatalyst)
         auth.initializeRecaptchaConfig { _ in
@@ -351,11 +349,36 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   #if os(iOS)
+    func FIRFederatedAuthProvider_hO() {
+      class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
+        // TODO: Document this API breakage - needing to add this functon for classes implementing
+        // FederatedAuthProvider.
+        func credential(with UIDelegate: FirebaseAuth
+          .AuthUIDelegate?) async throws -> AuthCredential {
+          return FacebookAuthProvider.credential(withAccessToken: "token")
+        }
+        func getCredentialWith(_ UIDelegate: AuthUIDelegate?,
+                               completion: ((AuthCredential?, Error?) -> Void)? = nil) {}
+      }
+      let obj = FederatedAuthImplementation()
+      obj.getCredentialWith(nil) { _, _ in
+      }
+    }
+
+    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+    func FIRFedederatedAuthProvider_hAsync() async throws {
+      class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
+        func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
+          return FacebookAuthProvider.credential(withAccessToken: "token")
+        }
+      }
+      let obj = FederatedAuthImplementation()
+      try await _ = obj.credential(with: nil)
+    }
+
     func FIRFederatedAuthProvider_h() {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
-        @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-        func credential(with UIDelegate: AuthUIDelegate?) async throws -> FirebaseAuth
-          .AuthCredential {
+        func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
           return FacebookAuthProvider.credential(withAccessToken: "token")
         }
 
@@ -480,6 +503,9 @@ class AuthAPI_hOnlyTests: XCTestCase {
       _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce",
                                    accessToken: "token")
       _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce")
+      _ = OAuthProvider.appleCredential(withIDToken: "idToken",
+                                        rawNonce: "nonce",
+                                        fullName: nil)
       provider.getCredentialWith(provider as? AuthUIDelegate) { credential, error in
       }
     #endif

--- a/Package.swift
+++ b/Package.swift
@@ -459,6 +459,7 @@ let package = Package(
         // TODO: these tests rely on a non-zero UIApplication.shared. They run from CocoaPods.
         "PhoneAuthProviderTests.swift",
         "AuthNotificationManagerTests.swift",
+        "ObjCAPITests.m", // Only builds via CocoaPods until mixed language or its own target.
       ]
     ),
     .target(


### PR DESCRIPTION
- auth-swift branch version of #12117 
- Add Objective C API build tests and make discovered fixes

I didn't port the setAPNSToken API since it seems to be a mistake and no-op in the Objective C implementation