### PR TITLE
[Passkey #9] Passkey withdraw

### DIFF
--- a/FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.h
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.h
@@ -126,6 +126,11 @@ extern NSString *const FIRSetAccountInfoUserAttributePassword;
  */
 @property(nonatomic, copy, nullable) NSArray<NSString *> *deleteProviders;
 
+/** @property deletePasskeys
+    @brief The list of credential IDs of the passkeys to delete.
+ */
+@property(nonatomic, copy, nullable) NSArray<NSString *> *deletePasskeys;
+
 /** @property returnSecureToken
     @brief Whether the response should return access token and refresh token directly.
     @remarks The default value is @c YES .

--- a/FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.m
@@ -108,6 +108,11 @@ static NSString *const kDeleteAttributesKey = @"deleteAttribute";
  */
 static NSString *const kDeleteProvidersKey = @"deleteProvider";
 
+/** @var kDeletePasskeysKey
+    @brief The key for the "deletePasskey" value in the request.
+ */
+static NSString *const kDeletePasskeysKey = @"deletePasskey";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -169,6 +174,9 @@ static NSString *const kTenantIDKey = @"tenantId";
   }
   if (_deleteAttributes) {
     postBody[kDeleteAttributesKey] = _deleteAttributes;
+  }
+  if (_deletePasskeys) {
+    postBody[kDeletePasskeysKey] = _deletePasskeys;
   }
   if (_deleteProviders) {
     postBody[kDeleteProvidersKey] = _deleteProviders;

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
@@ -212,6 +212,15 @@ NS_SWIFT_NAME(User)
         API_AVAILABLE(macos(12.0), ios(15.0), tvos(16.0));
 #endif
 
+/**
+ @fn unenrollPasskeyWithCredentialID:completion
+ @brief To unenroll a passkey with platform credential.
+ @param credentialID the passkey credential ID to unenroll.
+ */
+- (void)unenrollPasskeyWithCredentialID:(NSString *)credentialID
+                             completion:(nullable void (^)(NSError *_Nullable error))completion
+    NS_SWIFT_NAME(unenrollPasskey(with:completion:));
+
 /** @fn updatePassword:completion:
     @brief Updates the password for the user. On success, the cached user profile data is updated.
 

--- a/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
@@ -174,6 +174,16 @@ static NSString *const kDeleteProvidersKey = @"deleteProvider";
  */
 static NSString *const kTestDeleteProviders = @"TestDeleteProviders";
 
+/** @var kDeleteProvidersKey
+    @brief The key for the "deleteProvider" value in the request.
+ */
+static NSString *const kDeletePasskeysKey = @"deletePasskey";
+
+/** @var kTestDeleteProviders
+    @brief The fake @c deleteProviders for testing the request.
+ */
+static NSString *const kTestDeletePasskeys = @"TestCredentialIDs";
+
 /** @var kReturnSecureTokenKey
     @brief The key for the "returnSecureToken" value in the request.
  */
@@ -271,6 +281,7 @@ static NSString *const kExpectedAPIURL =
   request.captchaResponse = kTestCaptchaResponse;
   request.deleteAttributes = @[ kTestDeleteAttributes ];
   request.deleteProviders = @[ kTestDeleteProviders ];
+  request.deletePasskeys = @[ kTestDeletePasskeys ];
 
   [FIRAuthBackend
       setAccountInfo:request
@@ -294,6 +305,7 @@ static NSString *const kExpectedAPIURL =
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDeleteAttributesKey],
                         @[ kTestDeleteAttributes ]);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDeleteProvidersKey], @[ kTestDeleteProviders ]);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kDeletePasskeysKey], @[ kTestDeletePasskeys ]);
   XCTAssertTrue([_RPCIssuer.decodedRequest[kReturnSecureTokenKey] boolValue]);
   XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
 }

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1073,7 +1073,7 @@ static NSString *const kAttestationObject =
 }
 
 /**
- @fn testStartPasskeyEnrollmentSuccess
+ @fn testUnenrollPasskeySuccess
  @brief Tests the flow of a successful @c unenrollPasskeyWithCredentialID:completion: call
  */
 - (void)testUnenrollPasskeySuccess {

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1072,7 +1072,7 @@ static NSString *const kAttestationObject =
   }
 }
 
-/** 
+/**
  @fn testStartPasskeyEnrollmentSuccess
  @brief Tests the flow of a successful @c unenrollPasskeyWithCredentialID:completion: call
  */

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -370,7 +370,7 @@ static NSTimeInterval const kLastSignInDateTimeIntervalInSeconds = 1505858583;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 2;
+static const NSTimeInterval kExpectationTimeout = 20;
 
 /** @var kPhoneInfo
     @brief The mock multi factor phone info.
@@ -1070,6 +1070,90 @@ static NSString *const kAttestationObject =
     [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
     OCMVerifyAll(_mockBackend);
   }
+}
+
+/** 
+ @fn testStartPasskeyEnrollmentSuccess
+ @brief Tests the flow of a successful @c unenrollPasskeyWithCredentialID:completion: call
+ */
+- (void)testUnenrollPasskeySuccess {
+  OCMExpect([_mockBackend setAccountInfo:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRSetAccountInfoRequest *_Nullable request,
+                       FIRSetAccountInfoResponseCallback callback) {
+        XCTAssertEqualObjects(request.APIKey, kAPIKey);
+        XCTAssertEqualObjects(request.accessToken, kAccessToken);
+        XCTAssertEqualObjects(request.deletePasskeys, @[ kCredentialID ]);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockSetAccountInfoResponse = OCMClassMock([FIRSetAccountInfoResponse class]);
+          OCMStub([mockSetAccountInfoResponse refreshToken]).andReturn(kRefreshToken);
+          OCMStub([mockSetAccountInfoResponse IDToken]).andReturn(kAccessToken);
+          OCMStub([mockSetAccountInfoResponse approximateExpirationDate])
+              .andReturn([NSDate dateWithTimeIntervalSinceNow:kAccessTokenTimeToLive]);
+          callback(mockSetAccountInfoResponse, nil);
+        });
+      });
+  id mockGetAccountInfoResponseUser = OCMClassMock([FIRGetAccountInfoResponseUser class]);
+  OCMStub([mockGetAccountInfoResponseUser localID]).andReturn(kLocalID);
+  OCMStub([mockGetAccountInfoResponseUser email]).andReturn(kEmail);
+  OCMStub([mockGetAccountInfoResponseUser enrolledPasskeys]).andReturn(@[ kCredentialID ]);
+  [self expectGetAccountInfoWithMockUserInfoResponse:mockGetAccountInfoResponseUser];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  id mockSecureTokenService = OCMClassMock([FIRSecureTokenService class]);
+  OCMStub([mockSecureTokenService hasValidAccessToken]).andReturn(YES);
+  [self signInWithEmailPasswordWithMockUserInfoResponse:mockGetAccountInfoResponseUser
+                                             completion:^(FIRUser *_Nonnull user) {
+                                               [user
+                                                   unenrollPasskeyWithCredentialID:kCredentialID
+                                                                        completion:^(
+                                                                            NSError
+                                                                                *_Nullable error) {
+                                                                          XCTAssertNil(error);
+                                                                          XCTAssertEqualObjects(
+                                                                              user.rawAccessToken,
+                                                                              kAccessToken);
+                                                                          XCTAssertEqualObjects(
+                                                                              user.refreshToken,
+                                                                              kRefreshToken);
+
+                                                                          [expectation fulfill];
+                                                                        }];
+                                             }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
+}
+
+/**
+ @fn testUnenrollPasskeyFailure
+ @brief Tests the flow of a failed @c unenrollPasskeyWithCredentialID:completion: call
+ */
+- (void)testUnenrollPasskeyFailure {
+  OCMExpect([_mockBackend setAccountInfo:[OCMArg any] callback:[OCMArg any]])
+      .andDispatchError2([FIRAuthErrorUtils operationNotAllowedErrorWithMessage:nil]);
+  id mockGetAccountInfoResponseUser = OCMClassMock([FIRGetAccountInfoResponseUser class]);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  id mockSecureTokenService = OCMClassMock([FIRSecureTokenService class]);
+  OCMStub([mockSecureTokenService hasValidAccessToken]).andReturn(YES);
+  [self
+      signInWithEmailPasswordWithMockUserInfoResponse:mockGetAccountInfoResponseUser
+                                           completion:^(FIRUser *_Nonnull user) {
+                                             [user
+                                                 unenrollPasskeyWithCredentialID:kCredentialID
+                                                                      completion:^(
+                                                                          NSError
+                                                                              *_Nullable error) {
+                                                                        XCTAssertTrue([NSThread
+                                                                            isMainThread]);
+                                                                        XCTAssertEqual(
+                                                                            error.code,
+                                                                            FIRAuthErrorCodeOperationNotAllowed);
+                                                                        XCTAssertNotNil(
+                                                                            error.userInfo
+                                                                                [NSLocalizedDescriptionKey]);
+                                                                        [expectation fulfill];
+                                                                      }];
+                                           }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
 }
 
 /** @fn testUpdateEmailAutoSignOut

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -370,7 +370,7 @@ static NSTimeInterval const kLastSignInDateTimeIntervalInSeconds = 1505858583;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 20;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @var kPhoneInfo
     @brief The mock multi factor phone info.


### PR DESCRIPTION
Added FIRUser level unenrollPasskeyWithCredentialID:completion: API.
This has been tested with backend staging endpoint.