### PR TITLE
[Release Tooling] Initial xcprivacy file generation tooling

### DIFF
--- a/ReleaseTooling/Package.swift
+++ b/ReleaseTooling/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     .executable(name: "zip-builder", targets: ["ZipBuilder"]),
     .executable(name: "podspecs-tester", targets: ["PodspecsTester"]),
     .executable(name: "manifest", targets: ["ManifestParser"]),
+    .executable(name: "privacy-manifest-generator", targets: ["PrivacyManifestGenerator"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.1.0")),
@@ -52,6 +53,13 @@ let package = Package(
     ),
     .target(
       name: "Utils"
+    ),
+    .target(
+      name: "PrivacyManifestGenerator",
+      dependencies: ["ArgumentParser", "PrivacyKit"]
+    ),
+    .target(
+      name: "PrivacyKit"
     ),
   ]
 )

--- a/ReleaseTooling/Sources/PrivacyKit/PrivacyManifest.swift
+++ b/ReleaseTooling/Sources/PrivacyKit/PrivacyManifest.swift
@@ -1,0 +1,21 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Represents a Privacy Manifest as described in
+///  https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+public struct PrivacyManifest {
+  public init() {}
+}

--- a/ReleaseTooling/Sources/PrivacyManifestGenerator/PrivacyManifestWizard.swift
+++ b/ReleaseTooling/Sources/PrivacyManifestGenerator/PrivacyManifestWizard.swift
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import PrivacyKit
+
+/// Provides an API to walk the client through the creation of a Privacy
+/// Manifest via a series of questions.
+final class PrivacyManifestWizard {
+  private let xcframework: URL
+
+  init(xcframework: URL) {
+    self.xcframework = xcframework
+  }
+
+  func nextQuestion() -> String? {
+    // TODO(ncooke3): Implement.
+    nil
+  }
+
+  func processAnswer(_ answer: String) throws {
+    // TODO(ncooke3): Implement.
+  }
+
+  func createManifest() throws -> PrivacyManifest {
+    // TODO(ncooke3): Implement.
+    return PrivacyManifest()
+  }
+}

--- a/ReleaseTooling/Sources/PrivacyManifestGenerator/main.swift
+++ b/ReleaseTooling/Sources/PrivacyManifestGenerator/main.swift
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+import Foundation
+
+struct PrivacyManifestGenerator: ParsableCommand {
+  @Argument(
+    help: ArgumentHelp("The xcframework to create the Privacy Manifest for."),
+    transform: URL.init(fileURLWithPath:)
+  )
+  var xcframework: URL
+
+  func validate() throws {
+    guard xcframework.pathExtension == "xcframework" else {
+      throw ValidationError("Given path does not end in `.xcframework`: \(xcframework.path)")
+    }
+  }
+
+  func run() throws {
+    let wizard = PrivacyManifestWizard(xcframework: xcframework)
+
+    while let question = wizard.nextQuestion() {
+      print(question)
+      if let answer = readLine() {
+        try wizard.processAnswer(answer)
+      }
+    }
+
+    let privacyManifest = try wizard.createManifest()
+    print(privacyManifest)
+  }
+}


### PR DESCRIPTION
### Context
- Add initial code for a tool that generates xcprivacy files 
- The idea is for the CLI to be like a "wizard" that walks you through a series of questions and generates a manifest with your answers.
- The tool requires a path to an xcframework. This will be the xcframework that the generated Privacy Manifest will be for.
- Locally, I'm a ways ahead, but will be opening smaller PRs that should be easy to review.

Structure:
- `privacy-manifest-generator` (executable target)
  - depends on `PrivacyKit` (source target) which will model the data types described in https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
  - The `PrivacyKit.PrivacyManifest` type will be encodable into a plist which will populate the .xcprivacy file.

### Follow-up Work
- [ ] Find or create an example Privacy Manifest to reference in doc comment.

#no-changelog