### PR TITLE
redeclare protocol method so it can be added to docs

### DIFF
--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
@@ -40,6 +40,19 @@ NS_SWIFT_NAME(AppAttestProvider)
 /// required parameters.
 - (nullable instancetype)initWithApp:(FIRApp *)app;
 
+/* Jazzy doesn't generate documentation for protocol-inherited
+ * methods, so this is copied over from the protocol declaration.
+ */
+/// Returns a new Firebase App Check token.
+/// When implementing this method for your custom provider, the token returned should be suitable
+/// for consumption in a limited-use scenario. If you do not implement this method, the
+/// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getLimitedUseTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h
@@ -44,6 +44,13 @@ NS_SWIFT_NAME(AppAttestProvider)
  * methods, so this is copied over from the protocol declaration.
  */
 /// Returns a new Firebase App Check token.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getToken(completion:));
+
+/// Returns a new Firebase App Check token.
 /// When implementing this method for your custom provider, the token returned should be suitable
 /// for consumption in a limited-use scenario. If you do not implement this method, the
 /// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
@@ -79,6 +79,19 @@ NS_SWIFT_NAME(AppCheckDebugProvider)
  */
 - (NSString *)currentDebugToken;
 
+/* Jazzy doesn't generate documentation for protocol-inherited
+ * methods, so this is copied over from the protocol declaration.
+ */
+/// Returns a new Firebase App Check token.
+/// When implementing this method for your custom provider, the token returned should be suitable
+/// for consumption in a limited-use scenario. If you do not implement this method, the
+/// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getLimitedUseTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
@@ -83,6 +83,13 @@ NS_SWIFT_NAME(AppCheckDebugProvider)
  * methods, so this is copied over from the protocol declaration.
  */
 /// Returns a new Firebase App Check token.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getToken(completion:));
+
+/// Returns a new Firebase App Check token.
 /// When implementing this method for your custom provider, the token returned should be suitable
 /// for consumption in a limited-use scenario. If you do not implement this method, the
 /// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
@@ -41,6 +41,19 @@ NS_SWIFT_NAME(DeviceCheckProvider)
 /// required parameters.
 - (nullable instancetype)initWithApp:(FIRApp *)app;
 
+/* Jazzy doesn't generate documentation for protocol-inherited
+ * methods, so this is copied over from the protocol declaration.
+ */
+/// Returns a new Firebase App Check token.
+/// When implementing this method for your custom provider, the token returned should be suitable
+/// for consumption in a limited-use scenario. If you do not implement this method, the
+/// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getLimitedUseTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getLimitedUseToken(completion:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRDeviceCheckProvider.h
@@ -45,6 +45,13 @@ NS_SWIFT_NAME(DeviceCheckProvider)
  * methods, so this is copied over from the protocol declaration.
  */
 /// Returns a new Firebase App Check token.
+/// @param handler The completion handler. Make sure to call the handler with either a token
+/// or an error.
+- (void)getTokenWithCompletion:
+    (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(getToken(completion:));
+
+/// Returns a new Firebase App Check token.
 /// When implementing this method for your custom provider, the token returned should be suitable
 /// for consumption in a limited-use scenario. If you do not implement this method, the
 /// getTokenWithCompletion will be invoked instead whenever a limited-use token is requested.


### PR DESCRIPTION
See cl/585793441 for docsgen (googlers only). Addresses the lack of doc in this comment: https://github.com/firebase/firebase-ios-sdk/issues/11284#issuecomment-1828405118

#no-changelog