### PR TITLE
[Release Tooling] Fix .bash_profile warning for when no .bash_profile exists

### DIFF
--- a/ReleaseTooling/Sources/Utils/ShellUtils.swift
+++ b/ReleaseTooling/Sources/Utils/ShellUtils.swift
@@ -62,6 +62,9 @@ public extension Shell {
       // Write the temporary script contents to the script's path. CocoaPods complains when LANG
       // isn't set in the environment, so explicitly set it here. The `/usr/local/git/current/bin`
       // is to allow the `sso` protocol if it's there.
+      // The user's .bash_profile, if it exists, is sourced to modify the
+      // shell's PATH with any configuration (e.g. adding Ruby to path)
+      // that may be needed to run the given command.
       let contents = """
       export PATH="/usr/local/bin:/usr/local/git/current/bin:$PATH"
       export LANG="en_US.UTF-8"

--- a/ReleaseTooling/Sources/Utils/ShellUtils.swift
+++ b/ReleaseTooling/Sources/Utils/ShellUtils.swift
@@ -65,7 +65,10 @@ public extension Shell {
       let contents = """
       export PATH="/usr/local/bin:/usr/local/git/current/bin:$PATH"
       export LANG="en_US.UTF-8"
-      source ~/.bash_profile
+      BASH_PROFILE_PATH="~/.bash_profile"
+      if [ -f "$BASH_PROFILE_PATH" ]; then
+        source $BASH_PROFILE_PATH
+      fi
       \(command)
       """
       try contents.write(to: scriptPath, atomically: true, encoding: .utf8)


### PR DESCRIPTION
This is a minor problem. I don't have a .bash_profile, so whenever I run the release tooling, any script it invokes prints a warning that the  `.bash_profile` it tries to source does not exist.

I could add an empty bash profile to my machine, but generalizing the script may be better.