### PR TITLE
[Release Tooling] Stop sourcing .bash_profile when running generated shell scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,3 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.14.3'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'
-# trigger global CI

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.14.3'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'
+# trigger global CI

--- a/ReleaseTooling/Sources/Utils/ShellUtils.swift
+++ b/ReleaseTooling/Sources/Utils/ShellUtils.swift
@@ -62,16 +62,9 @@ public extension Shell {
       // Write the temporary script contents to the script's path. CocoaPods complains when LANG
       // isn't set in the environment, so explicitly set it here. The `/usr/local/git/current/bin`
       // is to allow the `sso` protocol if it's there.
-      // The user's .bash_profile, if it exists, is sourced to modify the
-      // shell's PATH with any configuration (e.g. adding Ruby to path)
-      // that may be needed to run the given command.
       let contents = """
       export PATH="/usr/local/bin:/usr/local/git/current/bin:$PATH"
       export LANG="en_US.UTF-8"
-      BASH_PROFILE_PATH="~/.bash_profile"
-      if [ -f "$BASH_PROFILE_PATH" ]; then
-        source $BASH_PROFILE_PATH
-      fi
       \(command)
       """
       try contents.write(to: scriptPath, atomically: true, encoding: .utf8)


### PR DESCRIPTION
See comment here (https://github.com/firebase/firebase-ios-sdk/pull/12158#discussion_r1410917059).

Going to let a global CI run finish and will re-evaluate then if this PR is worth it.