### PR TITLE
[App Check] Remove unused forward declaration

### DIFF
--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
@@ -19,7 +19,6 @@
 #import "FIRAppCheckProvider.h"
 
 @class FIRApp;
-@protocol FIRAppCheckDebugProviderAPIServiceProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
This line has existed within the public header for a few years. The line forward declares a protocol that (1) does not exist, and (2) is not referenced elsewhere within the header. 

I don't think this is a breaking change because any client trying to reference the protocol from importing this header would need to provide an interface for the type themselves. But, I would appreciate feedback here on whether this sounds like a breaking change or not. And also if you think this needs a changelog entry.

#no-changelog