### PR TITLE
[Release] Carthage updates for 10.19.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseABTesting-19a21793fc54b22c.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseABTesting-077b2dc3bc28f19b.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseABTesting-60386b1807639d7f.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseABTesting-1a1916232af9cd1a.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseABTesting-3c0e5c9ddc52bccd.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseABTesting-e87c686cee02758a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseABTesting-6a65ab8b888172af.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/Google-Mobile-Ads-SDK-f3386ef46d3c5d3f.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/Google-Mobile-Ads-SDK-8ee12e09f91c521d.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/Google-Mobile-Ads-SDK-bdeb97bf3c25008b.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/Google-Mobile-Ads-SDK-db6e557426f37394.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/Google-Mobile-Ads-SDK-c8bc252ed3323212.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/Google-Mobile-Ads-SDK-8b0d1ce3d1162b67.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/Google-Mobile-Ads-SDK-046511c3fd0189eb.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseAnalytics-818e60d497e338e1.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseAnalytics-770e1f266115a486.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseAnalytics-a31cc40d8ff01594.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseAnalytics-040a907770027c1e.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAnalytics-6f8b70c8ee2efc85.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalytics-95669fcf109f74a2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalytics-c0db6cb0e858e397.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseAnalyticsOnDeviceConversion-d70c712fc988478d.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseAnalyticsOnDeviceConversion-3a7e89e62712e39d.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseAnalyticsOnDeviceConversion-17d27742d2da3a56.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseAnalyticsOnDeviceConversion-219e668e914bee4c.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAnalyticsOnDeviceConversion-37cf6277991d7d75.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalyticsOnDeviceConversion-091f5252d693a9f9.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalyticsOnDeviceConversion-7bbb73d46383a042.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseAppCheck-a535b6a20bb888aa.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseAppCheck-02cc161dfed9ca96.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseAppCheck-19e0aad072b96709.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseAppCheck-09ecedc08c2562d0.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAppCheck-b0ead84a126d24d4.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppCheck-d19e46a728b1ac4f.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppCheck-8339fde989fe8f24.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseAppDistribution-49b58003297ccb70.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseAppDistribution-32d7715b4e368ecd.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseAppDistribution-40a7981d53107dd8.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseAppDistribution-30aec5c329204ede.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAppDistribution-45b5c85bba08a85b.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppDistribution-cefc3327ddfceda6.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppDistribution-7931e42d39575534.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseAuth-03adb74b07d993d0.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseAuth-4038362324e7ba40.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseAuth-457adc38d20fc396.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseAuth-9b66f8a440352f9b.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAuth-2165e27f89d4959e.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAuth-e43e66353617f093.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAuth-8a9591e6daa7e207.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseCrashlytics-7a2e8bc5feec7e9c.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseCrashlytics-cdcd7d27d6bad014.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseCrashlytics-b6bcce010b638cff.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseCrashlytics-8126c26e6374c8b1.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseCrashlytics-054718c61ef054f9.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseCrashlytics-d29d3285a7d9fa1d.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseCrashlytics-165beb64483b4278.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseDatabase-9a3210234cd3e29f.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseDatabase-32428945bd6ec380.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseDatabase-bcf8e0a3091629be.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseDatabase-a62dd446dac4b89f.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseDatabase-8b7048f7890bb665.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDatabase-5b22f689cb66d83a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDatabase-e1a9d1f0c4222cf7.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseDynamicLinks-6af2f8bf23e4ada2.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseDynamicLinks-b8ae2a0b7699b635.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseDynamicLinks-fe77330a0c9267b7.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseDynamicLinks-a4f0deb13e7b39fd.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseDynamicLinks-bfdce6ac5d591ab3.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDynamicLinks-7cf4ae5e96882ca8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDynamicLinks-c3bdeb37651a5d5d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseFirestore-13ee20ea4baedb54.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseFirestore-da541c5b854cf63c.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseFirestore-c0e26a80058623cb.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseFirestore-b46da5ea686c3422.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseFirestore-4c3d1568e379a98c.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFirestore-73ba0700b1aa6d6a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFirestore-02eb8da05f81fca5.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseFunctions-45a3e9cd89bba832.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseFunctions-2a3e2dc8d18f710c.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseFunctions-9de21260bf5ac1cd.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseFunctions-8e91f34c0289f5ba.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseFunctions-b949cfeca4e7a80f.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFunctions-47189f2c99cdf806.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFunctions-17c4b760141e38ad.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/GoogleSignIn-fc27f2bcfc77abf7.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/GoogleSignIn-c4b45f53f5b9dcac.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/GoogleSignIn-e1d7f1f5e02bdb80.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/GoogleSignIn-7d252d83bad9f2b6.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/GoogleSignIn-c887dbc6bd07c787.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/GoogleSignIn-a5b49807be66100b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/GoogleSignIn-0d2e746eb3ff9f92.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseInAppMessaging-d96f33048696aab5.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseInAppMessaging-e5cd88e50540c195.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseInAppMessaging-0729150e08035b53.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseInAppMessaging-ab8486f9415476ca.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseInAppMessaging-f29d7b7839cda915.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseInAppMessaging-91e5426eade46bca.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseInAppMessaging-10801bd111df59de.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseMLModelDownloader-878bed89989c6881.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseMLModelDownloader-ec90500fc6359954.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseMLModelDownloader-e2d1f325f5000ac6.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseMLModelDownloader-865fc851458ff97e.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseMLModelDownloader-ee2af587027e74d3.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMLModelDownloader-559cb113c0cfd8f2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMLModelDownloader-9c909894999c92e4.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseMessaging-f4f6950ceaf17152.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseMessaging-a96ded484b5b6f2e.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseMessaging-c6e5b81bc953e88f.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseMessaging-536acbc043d0e42a.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseMessaging-289a04c85f7e771d.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMessaging-59ef1cc63c660712.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMessaging-76c02a69e3fe1008.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebasePerformance-19b921d6950279cf.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebasePerformance-08f67576cd79b422.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebasePerformance-28f3f8f88f887bd4.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebasePerformance-5ef59eac9e09086e.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebasePerformance-7a7398acc615dbb6.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebasePerformance-36ac6dfb99caa11b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebasePerformance-f9f5be8ffad5cbb0.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseRemoteConfig-c1b98613292e04f1.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseRemoteConfig-1e96adad926e160d.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseRemoteConfig-2d73f0e2258c7ac5.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseRemoteConfig-13b390a0fae2a496.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseRemoteConfig-45a7f541a654884c.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseRemoteConfig-edd1b427b8bbe782.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseRemoteConfig-10b62ee5663aaab3.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -10,6 +10,7 @@
   "10.16.0": "https://dl.google.com/dl/firebase/ios/carthage/10.16.0/FirebaseStorage-d960b46a547eef25.zip",
   "10.17.0": "https://dl.google.com/dl/firebase/ios/carthage/10.17.0/FirebaseStorage-84de3e4df69c0124.zip",
   "10.18.0": "https://dl.google.com/dl/firebase/ios/carthage/10.18.0/FirebaseStorage-05669862cf21ca8d.zip",
+  "10.19.0": "https://dl.google.com/dl/firebase/ios/carthage/10.19.0/FirebaseStorage-93e56fb9268ffd5f.zip",
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseStorage-347e6a3402706596.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseStorage-ac463d14593d10a8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseStorage-fdf8479115660ce6.zip",


### PR DESCRIPTION
Updated the Carthage artifacts for the 10.19.0 release. Verified with `carthage update`.

<details>
<summary>Cartfile.resolved</summary>

```
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppDistributionBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDynamicLinksBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLModelDownloaderBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" "10.19.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json" "10.19.0"
```

</details>