### PR TITLE
[Rollouts] RC interop implementation

### DIFF
--- a/ClientApp/Podfile
+++ b/ClientApp/Podfile
@@ -15,6 +15,7 @@ target 'ClientApp-CocoaPods' do
   pod 'FirebaseAppCheck', :path => '../'
   pod 'FirebaseRemoteConfig', :path => '../'
   pod 'FirebaseRemoteConfigSwift', :path => '../'
+  pod 'FirebaseRemoteConfigInterop', :path => '../'
   pod 'FirebaseAppDistribution', :path => '../'
   pod 'FirebaseAuth', :path => '../'
   pod 'FirebaseCrashlytics', :path => '../'

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Podfile
@@ -25,6 +25,7 @@ target 'CocoapodsIntegrationTest' do
   pod 'FirebaseInstallations', :path => '../'
   pod 'FirebaseMessaging', :path => '../'
   pod 'FirebaseMessagingInterop', :path => '../'
+  pod 'FirebaseRemoteConfigInterop', :path => '../'
   pod 'FirebasePerformance', :path => '../'
   pod 'FirebaseStorage', :path => '../'
 end

--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -33,6 +33,7 @@ target 'FirebasePodTest' do
   pod 'FirebaseAppCheckInterop', :path => '../../../'
   pod 'FirebaseAuthInterop', :path => '../../../'
   pod 'FirebaseMessagingInterop', :path => '../../../'
+  pod 'FirebaseRemoteConfigInterop', :path => '../../../'
   pod 'FirebaseCoreInternal', :path => '../../../'
   pod 'FirebaseCoreExtension', :path => '../../../'
   pod 'FirebaseSessions', :path => '../../../'

--- a/Example/watchOSSample/Podfile
+++ b/Example/watchOSSample/Podfile
@@ -19,6 +19,7 @@ target 'SampleWatchAppWatchKitExtension' do
   pod 'FirebaseDatabase', :path => '../../'
   pod 'FirebaseAppCheckInterop', :path => '../../'
   pod 'FirebaseAuthInterop', :path => '../../'
+  pod 'FirebaseRemoteConfigInterop', :path => '../../'
 
   pod 'Firebase/Messaging', :path => '../../'
   pod 'Firebase/Storage', :path => '../../'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -53,7 +53,7 @@ app update.
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.8'
-  s.dependency 'FirebaseRemoteConfigInterop', '~> 10.0'
+  s.dependency 'FirebaseRemoteConfigInterop', '~> 10.20'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -53,6 +53,7 @@ app update.
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.8'
+  s.dependency 'FirebaseRemoteConfigInterop', '~> 10.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }
@@ -77,7 +78,8 @@ app update.
         'FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.m',
         'FirebaseRemoteConfig/Tests/Unit/RCNUserDefaultsManagerTests.m',
         'FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h',
-        'FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m'
+        'FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m',
+        'FirebaseRemoteConfig/Tests/SwiftUnit/*.swift'
     # Supply plist custom plist testing.
     unit_tests.resources =
         'FirebaseRemoteConfig/Tests/Unit/Defaults-testInfo.plist',

--- a/FirebaseRemoteConfig/Interop/RemoteConfigInterop.swift
+++ b/FirebaseRemoteConfig/Interop/RemoteConfigInterop.swift
@@ -16,6 +16,6 @@ import Foundation
 
 @objc(FIRRemoteConfigInterop)
 public protocol RemoteConfigInterop {
-  func registerRolloutsStateSubscriber(_ subscriber: RolloutsStateSubscriber?,
+  func registerRolloutsStateSubscriber(_ subscriber: RolloutsStateSubscriber,
                                        for namespace: String)
 }

--- a/FirebaseRemoteConfig/Interop/RemoteConfigInterop.swift
+++ b/FirebaseRemoteConfig/Interop/RemoteConfigInterop.swift
@@ -1,0 +1,21 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@objc(FIRRemoteConfigInterop)
+public protocol RemoteConfigInterop {
+  func registerRolloutsStateSubscriber(_ subscriber: RolloutsStateSubscriber?,
+                                       for namespace: String)
+}

--- a/FirebaseRemoteConfig/Interop/RolloutAssignment.swift
+++ b/FirebaseRemoteConfig/Interop/RolloutAssignment.swift
@@ -1,0 +1,46 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@objc(FIRRolloutAssignment)
+public class RolloutAssignment: NSObject {
+  @objc public var rolloutId: String
+  @objc public var variantId: String
+  @objc public var templateVersion: Int64
+  @objc public var parameterKey: String
+  @objc public var parameterValue: String
+
+  public init(rolloutId: String, variantId: String, templateVersion: Int64, parameterKey: String,
+              parameterValue: String) {
+    self.rolloutId = rolloutId
+    self.variantId = variantId
+    self.templateVersion = templateVersion
+    self.parameterKey = parameterKey
+    self.parameterValue = parameterValue
+    super.init()
+  }
+}
+
+@objc(FIRRolloutsState)
+public class RolloutsState: NSObject {
+  @objc public var assignments: Set<RolloutAssignment> = Set()
+
+  public init(assignmentList: [RolloutAssignment]) {
+    for assignment in assignmentList {
+      assignments.insert(assignment)
+    }
+    super.init()
+  }
+}

--- a/FirebaseRemoteConfig/Interop/RolloutsStateSubscriber.swift
+++ b/FirebaseRemoteConfig/Interop/RolloutsStateSubscriber.swift
@@ -1,0 +1,20 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@objc(FIRRolloutsStateSubscriber)
+public protocol RolloutsStateSubscriber {
+  func rolloutsStateDidChange(_ rolloutsState: RolloutsState)
+}

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+@import FirebaseRemoteConfigInterop;
 
 @class FIRApp;
 @class FIRRemoteConfig;
@@ -37,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// A concrete implementation for FIRRemoteConfigInterop to create Remote Config instances and
 /// register with Core's component system.
-@interface FIRRemoteConfigComponent : NSObject <FIRRemoteConfigProvider, FIRLibrary>
+@interface FIRRemoteConfigComponent
+    : NSObject <FIRRemoteConfigProvider, FIRLibrary, FIRRemoteConfigInterop>
 
 /// The FIRApp that instances will be set up with.
 @property(nonatomic, weak, readonly) FIRApp *app;

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h
@@ -47,6 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// Cached instances of Remote Config objects.
 @property(nonatomic, strong) NSMutableDictionary<NSString *, FIRRemoteConfig *> *instances;
 
+/// Clear all the component instances from the singleton which created previously, this is for
+/// testing only
++ (void)clearAllComponentInstances;
+
 /// Default method for retrieving a Remote Config instance, or creating one if it doesn't exist.
 - (FIRRemoteConfig *)remoteConfigForNamespace:(NSString *)remoteConfigNamespace;
 

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.m
@@ -24,6 +24,9 @@
 
 @implementation FIRRemoteConfigComponent
 
+// Because Component now need to register two protocols (provider and interop), we need a way to
+// return the same component instance for both registered protocol, this singleton pattern allow us
+// to return the same component object for both registration callback.
 static NSMutableDictionary<NSString *, FIRRemoteConfigComponent *> *_componentInstances = nil;
 
 + (FIRRemoteConfigComponent *)getComponentForApp:(FIRApp *)app {
@@ -38,6 +41,12 @@ static NSMutableDictionary<NSString *, FIRRemoteConfigComponent *> *_componentIn
     return _componentInstances[app.name];
   }
   return nil;
+}
+
++ (void)clearAllComponentInstances {
+  @synchronized(_componentInstances) {
+    [_componentInstances removeAllObjects];
+  }
 }
 
 /// Default method for retrieving a Remote Config instance, or creating one if it doesn't exist.
@@ -137,7 +146,7 @@ static NSMutableDictionary<NSString *, FIRRemoteConfigComponent *> *_componentIn
 
 #pragma mark - Remote Config Interop Protocol
 
-- (void)registerRolloutsStateSubscriber:(id<FIRRolloutsStateSubscriber> _Nullable)subscriber
+- (void)registerRolloutsStateSubscriber:(id<FIRRolloutsStateSubscriber>)subscriber
                                     for:(NSString * _Nonnull)namespace {
   // TODO(Themisw): Adding the registered subscriber reference to the namespace instance
   // [self.instances[namespace] addRemoteConfigInteropSubscriber:subscriber];

--- a/FirebaseRemoteConfig/Tests/Sample/Podfile
+++ b/FirebaseRemoteConfig/Tests/Sample/Podfile
@@ -14,6 +14,7 @@ target 'RemoteConfigSampleApp' do
   pod 'FirebaseInstallations', :path => '../../../'
   pod 'FirebaseRemoteConfig', :path => '../../../'
   pod 'FirebaseABTesting', :path => '../../..'
+  pod 'FirebaseRemoteConfigInterop', :path => '../../..'
 
   # Pods for RemoteConfigSampleApp
 

--- a/FirebaseRemoteConfig/Tests/SwiftUnit/RemoteConfigInteropTests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftUnit/RemoteConfigInteropTests.swift
@@ -18,7 +18,7 @@ import XCTest
 class MockRCInterop: RemoteConfigInterop {
   weak var subscriber: FirebaseRemoteConfigInterop.RolloutsStateSubscriber?
   func registerRolloutsStateSubscriber(_ subscriber: FirebaseRemoteConfigInterop
-    .RolloutsStateSubscriber?,
+    .RolloutsStateSubscriber,
     for namespace: String) {
     self.subscriber = subscriber
   }

--- a/FirebaseRemoteConfig/Tests/SwiftUnit/RemoteConfigInteropTests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftUnit/RemoteConfigInteropTests.swift
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseRemoteConfigInterop
+import XCTest
+
+class MockRCInterop: RemoteConfigInterop {
+  weak var subscriber: FirebaseRemoteConfigInterop.RolloutsStateSubscriber?
+  func registerRolloutsStateSubscriber(_ subscriber: FirebaseRemoteConfigInterop
+    .RolloutsStateSubscriber?,
+    for namespace: String) {
+    self.subscriber = subscriber
+  }
+}
+
+class MockRolloutSubscriber: RolloutsStateSubscriber {
+  var isSubscriberCalled = false
+  var rolloutsState: RolloutsState?
+  func rolloutsStateDidChange(_ rolloutsState: FirebaseRemoteConfigInterop.RolloutsState) {
+    isSubscriberCalled = true
+    self.rolloutsState = rolloutsState
+  }
+}
+
+final class RemoteConfigInteropTests: XCTestCase {
+  let rollouts: RolloutsState = {
+    let assignment1 = RolloutAssignment(
+      rolloutId: "rollout_1",
+      variantId: "control",
+      templateVersion: 1,
+      parameterKey: "my_feature",
+      parameterValue: "false"
+    )
+    let assignment2 = RolloutAssignment(
+      rolloutId: "rollout_2",
+      variantId: "enabled",
+      templateVersion: 123,
+      parameterKey: "themis_big_feature",
+      parameterValue: "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    )
+    let rollouts = RolloutsState(assignmentList: [assignment1, assignment2])
+    return rollouts
+  }()
+
+  func testRemoteConfigIntegration() throws {
+    let rcSubscriber = MockRolloutSubscriber()
+    let rcInterop = MockRCInterop()
+    rcInterop.registerRolloutsStateSubscriber(rcSubscriber, for: "namespace")
+    rcInterop.subscriber?.rolloutsStateDidChange(rollouts)
+
+    XCTAssertTrue(rcSubscriber.isSubscriberCalled)
+    XCTAssertEqual(rcSubscriber.rolloutsState?.assignments.count, 2)
+  }
+}

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -32,6 +32,7 @@
 
   // Clear out any apps that were called with `configure`.
   [FIRApp resetApps];
+  [FIRRemoteConfigComponent clearAllComponentInstances];
 }
 
 - (void)testRCInstanceCreationAndCaching {
@@ -93,7 +94,7 @@
 }
 
 - (void)testRegistersAsLibrary {
-  // Now compoment has two register, one is provider and another one is Interop
+  // Now component has two register, one is provider and another one is Interop
   XCTAssertEqual([FIRRemoteConfigComponent componentsToRegister].count, 2);
 
   // Configure a test FIRApp for fetching an instance of the FIRRemoteConfigProvider.

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -20,6 +20,7 @@
 #import "FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
+@import FirebaseRemoteConfigInterop;
 
 @interface FIRRemoteConfigComponentTest : XCTestCase
 @end
@@ -92,7 +93,8 @@
 }
 
 - (void)testRegistersAsLibrary {
-  XCTAssertEqual([FIRRemoteConfigComponent componentsToRegister].count, 1);
+  // Now compoment has two register, one is provider and another one is Interop
+  XCTAssertEqual([FIRRemoteConfigComponent componentsToRegister].count, 2);
 
   // Configure a test FIRApp for fetching an instance of the FIRRemoteConfigProvider.
   NSString *appName = [self generatedTestAppName];
@@ -101,12 +103,50 @@
 
   // Attempt to fetch the component and verify it's a valid instance.
   id<FIRRemoteConfigProvider> provider = FIR_COMPONENT(FIRRemoteConfigProvider, app.container);
+  id<FIRRemoteConfigInterop> interop = FIR_COMPONENT(FIRRemoteConfigInterop, app.container);
   XCTAssertNotNil(provider);
+  XCTAssertNotNil(interop);
 
   // Ensure that the instance that comes from the container is cached.
   id<FIRRemoteConfigProvider> sameProvider = FIR_COMPONENT(FIRRemoteConfigProvider, app.container);
+  id<FIRRemoteConfigInterop> sameInterop = FIR_COMPONENT(FIRRemoteConfigInterop, app.container);
   XCTAssertNotNil(sameProvider);
+  XCTAssertNotNil(sameInterop);
   XCTAssertEqual(provider, sameProvider);
+  XCTAssertEqual(interop, sameInterop);
+
+  // Dynamic typing, both prototols are refering to the same component instance
+  id providerID = provider;
+  id interopID = interop;
+  XCTAssertEqualObjects(providerID, interopID);
+}
+
+- (void)testTwoAppsCreateTwoComponents {
+  NSString *appName = [self generatedTestAppName];
+  [FIRApp configureWithName:appName options:[self fakeOptions]];
+  FIRApp *app = [FIRApp appNamed:appName];
+
+  [FIRApp configureWithOptions:[self fakeOptions]];
+  FIRApp *defaultApp = [FIRApp defaultApp];
+  XCTAssertNotNil(defaultApp);
+  XCTAssertNotEqualObjects(app, defaultApp);
+
+  id<FIRRemoteConfigProvider> provider = FIR_COMPONENT(FIRRemoteConfigProvider, app.container);
+  id<FIRRemoteConfigInterop> interop = FIR_COMPONENT(FIRRemoteConfigInterop, app.container);
+  id<FIRRemoteConfigProvider> defaultAppProvider =
+      FIR_COMPONENT(FIRRemoteConfigProvider, defaultApp.container);
+  id<FIRRemoteConfigInterop> defaultAppInterop =
+      FIR_COMPONENT(FIRRemoteConfigInterop, defaultApp.container);
+
+  id providerID = provider;
+  id interopID = interop;
+  id defaultAppProviderID = defaultAppProvider;
+  id defaultAppInteropID = defaultAppInterop;
+
+  XCTAssertEqualObjects(providerID, interopID);
+  XCTAssertEqualObjects(defaultAppProviderID, defaultAppInteropID);
+  // Check two apps get their own component to register
+  XCTAssertNotEqualObjects(interopID, defaultAppInteropID);
 }
 
 - (void)testThrowsWithEmptyGoogleAppID {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -18,6 +18,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
@@ -286,6 +287,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
 
 - (void)tearDown {
   [_DBManager removeDatabaseOnDatabaseQueueAtPath:_DBPath];
+  [FIRRemoteConfigComponent clearAllComponentInstances];
   [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:_userDefaultsSuiteName];
   [_DBManagerMock stopMocking];
   _DBManagerMock = nil;

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1541,7 +1541,6 @@ static NSString *UTCToLocal(NSString *utcTime) {
   if (![FIRApp isDefaultAppConfigured]) {
     XCTAssertNoThrow([FIRApp configureWithOptions:[self firstAppOptions]]);
   }
-  XCTAssertNoThrow([FIRRemoteConfig remoteConfig]);
   FIRRemoteConfig *config = [FIRRemoteConfig remoteConfig];
   XCTAssertNotNil(config);
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1541,6 +1541,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
   if (![FIRApp isDefaultAppConfigured]) {
     XCTAssertNoThrow([FIRApp configureWithOptions:[self firstAppOptions]]);
   }
+  XCTAssertNoThrow([FIRRemoteConfig remoteConfig]);
   FIRRemoteConfig *config = [FIRRemoteConfig remoteConfig];
   XCTAssertNotNil(config);
 

--- a/FirebaseRemoteConfigInterop.podspec
+++ b/FirebaseRemoteConfigInterop.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name             = 'FirebaseRemoteConfigInterop'
+  s.version          = '10.19.0'
+  s.summary          = 'Interfaces that allow other Firebase SDKs to use Remote Config functionality.'
+
+  s.description      = <<-DESC
+  Not for public use.
+  A set of protocols that other Firebase SDKs can use to interoperate with FirebaseRemoetConfig in a safe
+  and reliable manner.
+                       DESC
+
+  s.homepage         = 'https://firebase.google.com'
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
+  s.authors          = 'Google, Inc.'
+
+  # NOTE that these should not be used externally, this is for Firebase pods to depend on each
+  # other.
+  s.source           = {
+    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+    :tag => 'CocoaPods-' + s.version.to_s
+  }
+  s.social_media_url = 'https://twitter.com/Firebase'
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
+
+  s.source_files = 'FirebaseRemoteConfig/Interop/*.swift'
+end

--- a/FirebaseRemoteConfigInterop.podspec
+++ b/FirebaseRemoteConfigInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfigInterop'
-  s.version          = '10.19.0'
+  s.version          = '10.20.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Remote Config functionality.'
 
   s.description      = <<-DESC
@@ -19,6 +19,11 @@ Pod::Spec.new do |s|
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
     :tag => 'CocoaPods-' + s.version.to_s
   }
+
+  s.swift_version = '5.3'
+  s.cocoapods_version = '>= 1.4.0'
+  s.prefix_header_file = false
+
   s.social_media_url = 'https://twitter.com/Firebase'
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'

--- a/Package.swift
+++ b/Package.swift
@@ -491,11 +491,16 @@ let package = Package(
     ),
     .target(
       name: "FirebaseCrashlytics",
-      dependencies: ["FirebaseCore", "FirebaseInstallations", "FirebaseSessions",
-                     .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
-                     .product(name: "GULEnvironment", package: "GoogleUtilities"),
-                     .product(name: "FBLPromises", package: "Promises"),
-                     .product(name: "nanopb", package: "nanopb")],
+      dependencies: [
+        "FirebaseCore",
+        "FirebaseInstallations",
+        "FirebaseSessions",
+        "FirebaseRemoteConfigInterop",
+        .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
+        .product(name: "GULEnvironment", package: "GoogleUtilities"),
+        .product(name: "FBLPromises", package: "Promises"),
+        .product(name: "nanopb", package: "nanopb"),
+      ],
       path: "Crashlytics",
       exclude: [
         "run",
@@ -957,6 +962,7 @@ let package = Package(
         "FirebaseCore",
         "FirebaseABTesting",
         "FirebaseInstallations",
+        "FirebaseRemoteConfigInterop",
         .product(name: "GULNSData", package: "GoogleUtilities"),
       ],
       path: "FirebaseRemoteConfig/Sources",
@@ -982,6 +988,14 @@ let package = Package(
         .process("Defaults-testInfo.plist"),
         .process("TestABTPayload.txt"),
       ],
+      cSettings: [
+        .headerSearchPath("../../.."),
+      ]
+    ),
+    .testTarget(
+      name: "RemoteConfigSwiftUnit",
+      dependencies: ["FirebaseRemoteConfigInternal"],
+      path: "FirebaseRemoteConfig/Tests/SwiftUnit",
       cSettings: [
         .headerSearchPath("../../.."),
       ]
@@ -1026,6 +1040,15 @@ let package = Package(
       publicHeadersPath: ".",
       cSettings: [
         .headerSearchPath("../../../"),
+      ]
+    ),
+    // Internal headers only for consuming from other SDK.
+    .target(
+      name: "FirebaseRemoteConfigInterop",
+      path: "FirebaseRemoteConfig/Interop",
+      publicHeadersPath: ".",
+      cSettings: [
+        .headerSearchPath("../../"),
       ]
     ),
 

--- a/scripts/localize_podfile.swift
+++ b/scripts/localize_podfile.swift
@@ -39,6 +39,7 @@ let implicitPods = [
   "FirebaseAppCheckInterop", "FirebaseAuthInterop",
   "FirebaseMessagingInterop", "FirebaseCoreInternal",
   "FirebaseSessions", "FirebaseSharedSwift",
+  "FirebaseRemoteConfigInterop",
 ]
 
 let binaryPods = [


### PR DESCRIPTION
RC interop Implementation

- This change is for interop and RCComponent.
- Interop and its unit tests are written in Swift under `FirebaseRemoteConfig/Interop` and `FirebaseRemoteConfig/Tests/SwiftUnit`
- Updated dependency for SPM and CocoaPod for the new Interop.

Note: this change will merge to our feature branch not master
#no-changelog