### PR TITLE
Firestore: Add test that verifies aggregate query error message when missing index

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -1093,4 +1093,45 @@
                  [[NSNumber numberWithDouble:5] doubleValue]);
 }
 
+- (void)testFailWithGoodMessageIfMissingIndex {
+  XCTSkipIf([FSTIntegrationTestCase isRunningAgainstEmulator],
+            "Skip this test when running against the Firestore emulator because the Firestore "
+            "emulator does not use indexes and never fails with a 'missing index' error.");
+
+  FIRCollectionReference* testCollection = [self collectionRef];
+  FIRQuery* compositeIndexQuery = [[testCollection queryWhereField:@"field1"
+                                                         isEqualTo:@42] queryWhereField:@"field2"
+                                                                             isLessThan:@99];
+  FIRAggregateQuery* compositeIndexAggregateQuery = [compositeIndexQuery aggregate:@[
+    [FIRAggregateField aggregateFieldForCount],
+    [FIRAggregateField aggregateFieldForSumOfField:@"pages"],
+    [FIRAggregateField aggregateFieldForAverageOfField:@"pages"]
+  ]];
+
+  XCTestExpectation* queryCompletion = [self expectationWithDescription:@"query"];
+  [compositeIndexAggregateQuery
+      aggregationWithSource:FIRAggregateSourceServer
+                 completion:^(FIRAggregateQuerySnapshot* snapshot, NSError* error) {
+                   XCTAssertNotNil(error);
+                   if (error) {
+                     NSString* errorDescription = [error localizedDescription];
+                     XCTAssertTrue([errorDescription.lowercaseString containsString:@"index"],
+                                   "The NSError should have contained the word 'index' "
+                                   "(case-insensitive), but got: %@",
+                                   errorDescription);
+                     // TODO(b/316359394) Remove this check for the default databases once
+                     // cl/582465034 is rolled out to production.
+                     if ([[FSTIntegrationTestCase databaseID] isEqualToString:@"(default)"]) {
+                       XCTAssertTrue(
+                           [errorDescription containsString:@"https://console.firebase.google.com"],
+                           "The NSError should have contained the string "
+                           "'https://console.firebase.google.com', but got: %@",
+                           errorDescription);
+                     }
+                   }
+                   XCTAssertNil(snapshot);
+                   [queryCompletion fulfill];
+                 }];
+  [self awaitExpectations];
+}
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -1093,7 +1093,7 @@
                  [[NSNumber numberWithDouble:5] doubleValue]);
 }
 
-- (void)testFailWithGoodMessageIfMissingIndex {
+- (void)testFailWithMessageWithConsoleLinkIfMissingIndex {
   XCTSkipIf([FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test when running against the Firestore emulator because the Firestore "
             "emulator does not use indexes and never fails with a 'missing index' error.");

--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -227,7 +227,7 @@
   XCTAssertEqual(snapshot.count, [NSNumber numberWithLong:3L]);
 }
 
-- (void)testFailWithGoodMessageIfMissingIndex {
+- (void)testFailWithMessageWithConsoleLinkIfMissingIndex {
   XCTSkipIf([FSTIntegrationTestCase isRunningAgainstEmulator],
             "Skip this test when running against the Firestore emulator because the Firestore "
             "emulator does not use indexes and never fails with a 'missing index' error.");

--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -233,24 +233,31 @@
             "emulator does not use indexes and never fails with a 'missing index' error.");
 
   FIRCollectionReference* testCollection = [self collectionRef];
-  FIRQuery* compositeIndexQuery = [[testCollection queryWhereField:@"field1" isEqualTo:@42] queryWhereField:@"field2" isLessThan:@99];
+  FIRQuery* compositeIndexQuery = [[testCollection queryWhereField:@"field1"
+                                                         isEqualTo:@42] queryWhereField:@"field2"
+                                                                             isLessThan:@99];
   FIRAggregateQuery* compositeIndexCountQuery = [compositeIndexQuery count];
 
-  XCTestExpectation *queryCompletion = [self expectationWithDescription:@"query"];
-  [compositeIndexCountQuery aggregationWithSource:FIRAggregateSourceServer completion:^(FIRAggregateQuerySnapshot* snapshot, NSError* error) {
-    XCTAssertNotNil(error);
-    if (error) {
-      NSString* errorDescription = [error localizedDescription];
-      XCTAssertTrue([errorDescription.lowercaseString containsString:@"index"],
-        "The NSError should have contained the word 'index' (case-insensitive), but got: %@",
-        errorDescription);
-      XCTAssertTrue([errorDescription containsString:@"https://console.firebase.google.com"],
-        "The NSError should have contained the 'https://console.firebase.google.com', but got: %@",
-        errorDescription);
-    }
-    XCTAssertNil(snapshot);
-    [queryCompletion fulfill];
-  }];
+  XCTestExpectation* queryCompletion = [self expectationWithDescription:@"query"];
+  [compositeIndexCountQuery
+      aggregationWithSource:FIRAggregateSourceServer
+                 completion:^(FIRAggregateQuerySnapshot* snapshot, NSError* error) {
+                   XCTAssertNotNil(error);
+                   if (error) {
+                     NSString* errorDescription = [error localizedDescription];
+                     XCTAssertTrue([errorDescription.lowercaseString containsString:@"index"],
+                                   "The NSError should have contained the word 'index' "
+                                   "(case-insensitive), but got: %@",
+                                   errorDescription);
+                     XCTAssertTrue(
+                         [errorDescription containsString:@"https://console.firebase.google.com"],
+                         "The NSError should have contained the string "
+                         "'https://console.firebase.google.com', but got: %@",
+                         errorDescription);
+                   }
+                   XCTAssertNil(snapshot);
+                   [queryCompletion fulfill];
+                 }];
   [self awaitExpectations];
 }
 

--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -249,11 +249,15 @@
                                    "The NSError should have contained the word 'index' "
                                    "(case-insensitive), but got: %@",
                                    errorDescription);
-                     XCTAssertTrue(
-                         [errorDescription containsString:@"https://console.firebase.google.com"],
-                         "The NSError should have contained the string "
-                         "'https://console.firebase.google.com', but got: %@",
-                         errorDescription);
+                     // TODO(b/316359394) Remove this check for the default databases once
+                     // cl/582465034 is rolled out to production.
+                     if ([[FSTIntegrationTestCase databaseID] isEqualToString:@"(default)"]) {
+                       XCTAssertTrue(
+                           [errorDescription containsString:@"https://console.firebase.google.com"],
+                           "The NSError should have contained the string "
+                           "'https://console.firebase.google.com', but got: %@",
+                           errorDescription);
+                     }
                    }
                    XCTAssertNil(snapshot);
                    [queryCompletion fulfill];

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -61,6 +61,8 @@ eg. `scripts/upload-symbols`, and make sure that the file is executable:
 This script can be used to manually upload dSYM files (for usage notes and
 additional instructions, run with the `--help` parameter).
 
+If you're getting `error: Could not get GOOGLE_APP_ID in Google Services file from build environment` on the Crashlytics run script step and you're using Xcode 15 and specifically `User Script Sandboxing = YES`, make sure to include all input files referenced [here](https://github.com/firebase/firebase-ios-sdk/pull/11463) in the Crashlytics run script.
+
 ---
 
 ### Alternatively, add Firebase to a `Package.swift` manifest


### PR DESCRIPTION
This verifies that the descriptive error message that occurs when the server does not have the required index has the URL that customers can follow to create the index.

This is a port of the "getCountFromServer error message is good if missing index" integration test from https://github.com/firebase/firebase-js-sdk/blob/42bfb0b8243a6c36b66a0bbedf61436e70591062/packages/firestore/test/integration/api/aggregation.test.ts#L130-L155 and https://github.com/firebase/firebase-android-sdk/pull/4232.

Googlers see b/254063570 for details.

#no-changelog