### PR TITLE
Firestore: Increase clock skew tolerance in FIRServerTimestampTests.mm

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
@@ -123,13 +123,8 @@
 
 /** Verifies a snapshot containing _setData but with resolved server timestamps. */
 - (void)verifySnapshotWithResolvedTimestamps:(FIRDocumentSnapshot *)snapshot {
-  // Tolerate up to 10 seconds of clock skew between client and server.
-  NSInteger tolerance = 10;
-
-  // Somehow the skew is much worse in nightly
-  if ([self.db.settings.host isEqualToString:@"test-firestore.sandbox.googleapis.com"]) {
-    tolerance = 200;
-  }
+  // Tolerate up to 200 seconds of clock skew between client and server.
+  NSInteger tolerance = 200;
 
   XCTAssertTrue(snapshot.exists);
   FIRTimestamp *when = snapshot[@"when"];


### PR DESCRIPTION
In `FIRServerTimestampTests.mm` there is a check to verify that the server timestamp values generated by the backend are within 10 seconds of the time on the local device. This, however, appears to be too aggressive, even for production. Therefore, increase the tolerance to 200 seconds.

#no-changelog