### PR TITLE
[Rollouts] Crashlytics Rollouts interop Integration

### DIFF
--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -173,6 +173,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       FIRCLSDebugLog(@"Registering RemoteConfig SDK subscription for rollouts data");
 
       _remoteConfigManager = [[FIRCLSRemoteConfigManager alloc] initWithRemoteConfig:remoteConfig];
+
+      // TODO(themisw): Import "firebase" from the interop in the future.
       [remoteConfig registerRolloutsStateSubscriber:self for:@"firebase"];
     }
 

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -58,6 +58,12 @@
 #import <GoogleDataTransport/GoogleDataTransport.h>
 
 @import FirebaseSessions;
+@import FirebaseRemoteConfigInterop;
+#if SWIFT_PACKAGE
+@import FirebaseCrashlyticsSwift;
+#else  // Swift Package Manager
+#import "FirebaseCrashlytics/FirebaseCrashlytics-Swift.h"
+#endif  // Cocoapod
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -76,7 +82,10 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 @protocol FIRCrashlyticsInstanceProvider <NSObject>
 @end
 
-@interface FIRCrashlytics () <FIRLibrary, FIRCrashlyticsInstanceProvider, FIRSessionsSubscriber>
+@interface FIRCrashlytics () <FIRLibrary,
+                              FIRCrashlyticsInstanceProvider,
+                              FIRSessionsSubscriber,
+                              FIRRolloutsStateSubscriber>
 
 @property(nonatomic) BOOL didPreviouslyCrash;
 @property(nonatomic, copy) NSString *googleAppID;
@@ -91,6 +100,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 @property(nonatomic, strong) FIRCLSAnalyticsManager *analyticsManager;
 
+@property(nonatomic, strong) FIRCLSRemoteConfigManager *remoteConfigManager;
+
 // Dependencies common to each of the Controllers
 @property(nonatomic, strong) FIRCLSManagerData *managerData;
 
@@ -104,7 +115,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
                     appInfo:(NSDictionary *)appInfo
               installations:(FIRInstallations *)installations
                   analytics:(id<FIRAnalyticsInterop>)analytics
-                   sessions:(id<FIRSessionsProvider>)sessions {
+                   sessions:(id<FIRSessionsProvider>)sessions
+               remoteConfig:(id<FIRRemoteConfigInterop>)remoteConfig {
   self = [super init];
 
   if (self) {
@@ -155,6 +167,13 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       // It should also be made after managerData is initialized so
       // that the ContextManager can accept data
       [sessions registerWithSubscriber:self];
+    }
+
+    if (remoteConfig) {
+      FIRCLSDebugLog(@"Registering RemoteConfig SDK subscription for rollouts data");
+
+      _remoteConfigManager = [[FIRCLSRemoteConfigManager alloc] initWithRemoteConfig:remoteConfig];
+      [remoteConfig registerRolloutsStateSubscriber:self for:@"firebase"];
     }
 
     _reportUploader = [[FIRCLSReportUploader alloc] initWithManagerData:_managerData];
@@ -215,6 +234,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
     id<FIRSessionsProvider> sessions = FIR_COMPONENT(FIRSessionsProvider, container);
+    id<FIRRemoteConfigInterop> remoteConfig = FIR_COMPONENT(FIRRemoteConfigInterop, container);
 
     FIRInstallations *installations = [FIRInstallations installationsWithApp:container.app];
 
@@ -224,7 +244,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
                                        appInfo:NSBundle.mainBundle.infoDictionary
                                  installations:installations
                                      analytics:analytics
-                                      sessions:sessions];
+                                      sessions:sessions
+                                  remoteConfig:remoteConfig];
   };
 
   FIRComponent *component =
@@ -405,6 +426,12 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 - (FIRSessionsSubscriberName)sessionsSubscriberName {
   return FIRSessionsSubscriberNameCrashlytics;
+}
+
+#pragma mark - FIRRolloutsStateSubscriber
+- (void)rolloutsStateDidChange:(FIRRolloutsState *_Nonnull)rolloutsState {
+  [_remoteConfigManager updateRolloutsStateWithRolloutsState:rolloutsState];
+  // TODO(themisw): writing the rollout state change to persistence
 }
 
 @end

--- a/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
+++ b/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
@@ -1,0 +1,61 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseRemoteConfigInterop
+import Foundation
+
+protocol CrashlyticsPersistentLog: NSObject {
+  func updateRolloutsStateToPersistence(rolloutAssignments: [RolloutAssignment])
+}
+
+@objc(FIRCLSRemoteConfigManager)
+public class CrashlyticsRemoteConfigManager: NSObject {
+  public static let maxRolloutAssignment = 128
+  public static let maxParameterValueLength = 256
+
+  var remoteConfig: RemoteConfigInterop
+  public private(set) var rolloutAssignment: [RolloutAssignment] = []
+  weak var persistenceDelegate: CrashlyticsPersistentLog?
+
+  @objc public init(remoteConfig: RemoteConfigInterop) {
+    self.remoteConfig = remoteConfig
+  }
+
+  @objc public func updateRolloutsState(rolloutsState: RolloutsState) {
+    rolloutAssignment = validateRolloutAssignment(assignments: Array(rolloutsState.assignments))
+  }
+}
+
+private extension CrashlyticsRemoteConfigManager {
+  func validateRolloutAssignment(assignments: [RolloutAssignment]) -> [RolloutAssignment] {
+    var validatedAssignments = assignments
+    if assignments.count > CrashlyticsRemoteConfigManager.maxRolloutAssignment {
+      validatedAssignments =
+        Array(assignments[..<CrashlyticsRemoteConfigManager.maxRolloutAssignment])
+    }
+
+    _ = validatedAssignments.map { assignment in
+      if assignment.parameterValue.count > CrashlyticsRemoteConfigManager.maxParameterValueLength {
+        let upperBound = String.Index(
+          utf16Offset: CrashlyticsRemoteConfigManager.maxParameterValueLength,
+          in: assignment.parameterValue
+        )
+        let slicedParameterValue = assignment.parameterValue[..<upperBound]
+        assignment.parameterValue = String(slicedParameterValue)
+      }
+    }
+
+    return validatedAssignments
+  }
+}

--- a/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
+++ b/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
@@ -21,7 +21,7 @@ protocol CrashlyticsPersistentLog: NSObject {
 
 @objc(FIRCLSRemoteConfigManager)
 public class CrashlyticsRemoteConfigManager: NSObject {
-  public static let maxRolloutAssignment = 128
+  public static let maxRolloutAssignments = 128
   public static let maxParameterValueLength = 256
 
   var remoteConfig: RemoteConfigInterop
@@ -33,20 +33,25 @@ public class CrashlyticsRemoteConfigManager: NSObject {
   }
 
   @objc public func updateRolloutsState(rolloutsState: RolloutsState) {
-    rolloutAssignment = validateRolloutAssignment(assignments: Array(rolloutsState.assignments))
+    rolloutAssignment = normalizeRolloutAssignment(assignments: Array(rolloutsState.assignments))
   }
 }
 
 private extension CrashlyticsRemoteConfigManager {
-  func validateRolloutAssignment(assignments: [RolloutAssignment]) -> [RolloutAssignment] {
+  func normalizeRolloutAssignment(assignments: [RolloutAssignment]) -> [RolloutAssignment] {
     var validatedAssignments = assignments
-    if assignments.count > CrashlyticsRemoteConfigManager.maxRolloutAssignment {
+    if assignments.count > CrashlyticsRemoteConfigManager.maxRolloutAssignments {
+      debugPrint("Rollouts excess the maximum number of assignments can pass to Crashlytics")
       validatedAssignments =
-        Array(assignments[..<CrashlyticsRemoteConfigManager.maxRolloutAssignment])
+        Array(assignments[..<CrashlyticsRemoteConfigManager.maxRolloutAssignments])
     }
 
     _ = validatedAssignments.map { assignment in
       if assignment.parameterValue.count > CrashlyticsRemoteConfigManager.maxParameterValueLength {
+        debugPrint(
+          "Rollouts excess the maximum length of parameter value can pass to Crashlytics",
+          assignment.parameterValue
+        )
         let upperBound = String.Index(
           utf16Offset: CrashlyticsRemoteConfigManager.maxParameterValueLength,
           in: assignment.parameterValue

--- a/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
+++ b/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#if SWIFT_PACKAGE
+  @testable import FirebaseCrashlyticsSwift
+#else
+  @testable import FirebaseCrashlytics
+#endif
+import FirebaseRemoteConfigInterop
+import XCTest
+
+class RemoteConfigConfigMock: RemoteConfigInterop {
+  func registerRolloutsStateSubscriber(_ subscriber: FirebaseRemoteConfigInterop
+    .RolloutsStateSubscriber,
+    for namespace: String) {}
+}
+
+final class CrashlyticsRemoteConfigManagerTests: XCTestCase {
+  let rollouts: RolloutsState = {
+    let assignment1 = RolloutAssignment(
+      rolloutId: "rollout_1",
+      variantId: "control",
+      templateVersion: 1,
+      parameterKey: "my_feature",
+      parameterValue: "false"
+    )
+    let assignment2 = RolloutAssignment(
+      rolloutId: "rollout_2",
+      variantId: "enabled",
+      templateVersion: 1,
+      parameterKey: "themis_big_feature",
+      parameterValue: "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    )
+    let rollouts = RolloutsState(assignmentList: [assignment1, assignment2])
+    return rollouts
+  }()
+
+  let rcInterop = RemoteConfigConfigMock()
+
+  func testRemoteConfigManagerProperlyProcessRolloutsState() throws {
+    let rcManager = CrashlyticsRemoteConfigManager(remoteConfig: rcInterop)
+    rcManager.updateRolloutsState(rolloutsState: rollouts)
+    XCTAssertEqual(rcManager.rolloutAssignment.count, 2)
+
+    for assignment in rollouts.assignments {
+      if assignment.parameterKey == "themis_big_feature" {
+        XCTAssertEqual(
+          assignment.parameterValue.count,
+          CrashlyticsRemoteConfigManager.maxParameterValueLength
+        )
+      }
+    }
+  }
+}

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.prefix_header_file = false
 
   s.source_files = [
-    'Crashlytics/Crashlytics/**/*.{c,h,m,mm}',
+    'Crashlytics/Crashlytics/**/*.{c,h,m,mm,swift}',
     'Crashlytics/Protogen/**/*.{c,h,m,mm}',
     'Crashlytics/Shared/**/*.{c,h,m,mm}',
     'Crashlytics/third_party/**/*.{c,h,m,mm}',
@@ -58,6 +58,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseCore', '~> 10.5'
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'FirebaseSessions', '~> 10.5'
+  s.dependency 'FirebaseRemoteConfigInterop', '~> 10.20'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
@@ -115,7 +116,8 @@ Pod::Spec.new do |s|
       :tvos => tvos_deployment_target
     }
     unit_tests.source_files = 'Crashlytics/UnitTests/*.[mh]',
-                              'Crashlytics/UnitTests/*/*.[mh]'
+                              'Crashlytics/UnitTests/*/*.[mh]',
+                              'Crashlytics/UnitTestsSwift/*.swift'
     unit_tests.resources = 'Crashlytics/UnitTests/Data/*',
                            'Crashlytics/UnitTests/*.clsrecord',
                            'Crashlytics/UnitTests/FIRCLSMachO/machO_data/*'

--- a/Package.swift
+++ b/Package.swift
@@ -496,6 +496,7 @@ let package = Package(
         "FirebaseInstallations",
         "FirebaseSessions",
         "FirebaseRemoteConfigInterop",
+        "FirebaseCrashlyticsSwift",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "FBLPromises", package: "Promises"),
@@ -513,6 +514,7 @@ let package = Package(
         "upload-symbols",
         "CrashlyticsInputFiles.xcfilelist",
         "third_party/libunwind/LICENSE",
+        "Crashlytics/Rollouts/",
       ],
       sources: [
         "Crashlytics/",
@@ -540,6 +542,19 @@ let package = Package(
         .linkedFramework("Security"),
         .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
       ]
+    ),
+    .target(
+      name: "FirebaseCrashlyticsSwift",
+      dependencies: ["FirebaseRemoteConfigInterop"],
+      path: "Crashlytics",
+      sources: [
+        "Crashlytics/Rollouts/",
+      ]
+    ),
+    .testTarget(
+      name: "FirebaseCrashlyticsSwiftUnit",
+      dependencies: ["FirebaseCrashlyticsSwift"],
+      path: "Crashlytics/UnitTestsSwift/"
     ),
     .testTarget(
       name: "FirebaseCrashlyticsUnit",


### PR DESCRIPTION
- Adding interop dependency to Crashlytics SDK
- Validate the rollouts data on Crash side(maxNumOfAssignments, maxLengthOfParamValue)
- Adding support for Crashlytics writing swift code
- Unit tests

#no-changelog