### PR TITLE
MFA Integration Testing fixes

### DIFF
--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -274,14 +274,13 @@ import Foundation
       let startMFARequestInfo = AuthProtoStartMFAPhoneRequestInfo(phoneNumber: phoneNumber,
                                                                   codeIdentity: codeIdentity)
       do {
-        switch codeIdentity {
-        case .credential:
-          let request = StartMFAEnrollmentRequest(idToken: session.idToken,
+        if let idToken = session.idToken {
+          let request = StartMFAEnrollmentRequest(idToken: idToken,
                                                   enrollmentInfo: startMFARequestInfo,
                                                   requestConfiguration: auth.requestConfiguration)
           let response = try await AuthBackend.call(with: request)
           return response.phoneSessionInfo?.sessionInfo
-        case .recaptcha:
+        } else {
           let request = StartMFASignInRequest(MFAPendingCredential: session.mfaPendingCredential,
                                               MFAEnrollmentID: session.multiFactorInfo?.uid,
                                               signInInfo: startMFARequestInfo,
@@ -289,8 +288,6 @@ import Foundation
 
           let response = try await AuthBackend.call(with: request)
           return response.responseInfo?.sessionInfo
-        case .empty:
-          return nil
         }
       } catch {
         return try await handleVerifyErrorWithRetry(

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -186,7 +186,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
   #if os(iOS)
     private class func generateMFAError(response: AuthRPCResponse, auth: Auth) -> Error? {
       if let mfaResponse = response as? AuthMFAResponse,
-         mfaResponse.nilIDToken(),
+         mfaResponse.idToken == nil,
          let enrollments = mfaResponse.mfaInfo {
         var info: [MultiFactorInfo] = []
         for enrollment in enrollments {

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -185,24 +185,22 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
 
   #if os(iOS)
     private class func generateMFAError(response: AuthRPCResponse, auth: Auth) -> Error? {
-      if let mfaResponse = response as? EmailLinkSignInResponse,
-         mfaResponse.idToken == nil,
-         let enrollments = mfaResponse.mfaInfo {
+      if let mfaResponse = response as? AuthMFAResponse,
+         mfaResponse.nilIDToken(),
+         let enrollments = mfaResponse.mfaInfo() {
         var info: [MultiFactorInfo] = []
         for enrollment in enrollments {
           // check which MFA factors are enabled.
           if let _ = enrollment.phoneInfo {
-            info.append(MultiFactorInfo(proto: enrollment,
-                                        factorID: PhoneMultiFactorInfo.PhoneMultiFactorID))
+            info.append(PhoneMultiFactorInfo(proto: enrollment))
           } else if let _ = enrollment.totpInfo {
-            info.append(MultiFactorInfo(proto: enrollment,
-                                        factorID: PhoneMultiFactorInfo.TOTPMultiFactorID))
+            info.append(TOTPMultiFactorInfo(proto: enrollment))
           } else {
             AuthLog.logError(code: "I-AUT000021", message: "Multifactor type is not supported")
           }
         }
         return AuthErrorUtils.secondFactorRequiredError(
-          pendingCredential: mfaResponse.mfaPendingCredential,
+          pendingCredential: mfaResponse.mfaPendingCredential(),
           hints: info,
           auth: auth
         )

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -187,7 +187,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
     private class func generateMFAError(response: AuthRPCResponse, auth: Auth) -> Error? {
       if let mfaResponse = response as? AuthMFAResponse,
          mfaResponse.nilIDToken(),
-         let enrollments = mfaResponse.mfaInfo() {
+         let enrollments = mfaResponse.mfaInfo {
         var info: [MultiFactorInfo] = []
         for enrollment in enrollments {
           // check which MFA factors are enabled.
@@ -200,7 +200,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
           }
         }
         return AuthErrorUtils.secondFactorRequiredError(
-          pendingCredential: mfaResponse.mfaPendingCredential(),
+          pendingCredential: mfaResponse.mfaPendingCredential,
           hints: info,
           auth: auth
         )

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
@@ -1,0 +1,28 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Protocol for responses that support Multi-Factor Authentication.
+protocol AuthMFAResponse {
+  /// An opaque string that functions as proof that the user has successfully passed the first
+  /// factor check.
+  func mfaPendingCredential() -> String?
+
+  /// Info on which multi-factor authentication providers are enabled.
+  func mfaInfo() -> [AuthProtoMFAEnrollment]?
+
+  /// MFA is only done when the idToken is nil.
+  func nilIDToken() -> Bool
+}

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
@@ -18,10 +18,10 @@ import Foundation
 protocol AuthMFAResponse {
   /// An opaque string that functions as proof that the user has successfully passed the first
   /// factor check.
-  func mfaPendingCredential() -> String?
+  var mfaPendingCredential: String? { get }
 
   /// Info on which multi-factor authentication providers are enabled.
-  func mfaInfo() -> [AuthProtoMFAEnrollment]?
+  var mfaInfo: [AuthProtoMFAEnrollment]? { get }
 
   /// MFA is only done when the idToken is nil.
   func nilIDToken() -> Bool

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/AuthMFAResponse.swift
@@ -24,5 +24,5 @@ protocol AuthMFAResponse {
   var mfaInfo: [AuthProtoMFAEnrollment]? { get }
 
   /// MFA is only done when the idToken is nil.
-  func nilIDToken() -> Bool
+  var idToken: String? { get }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -23,7 +23,7 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
   /** @property IDToken
    @brief The ID token in the email link sign-in response.
    */
-  var idToken: String?
+  private var _idToken: String?
 
   /** @property email
    @brief The email returned by the IdP.
@@ -51,9 +51,7 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
 
   var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
-  func nilIDToken() -> Bool {
-    return idToken == nil
-  }
+  var idToken: String? { return _idToken }
 
   /** @property MFAPendingCredential
        @brief An opaque string that functions as proof that the user has successfully passed the first
@@ -68,7 +66,7 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
-    idToken = dictionary["idToken"] as? String
+    _idToken = dictionary["idToken"] as? String
     isNewUser = dictionary["isNewUser"] as? Bool ?? false
     refreshToken = dictionary["refreshToken"] as? String
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -23,7 +23,7 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
   /** @property IDToken
    @brief The ID token in the email link sign-in response.
    */
-  private var _idToken: String?
+  private(set) var idToken: String?
 
   /** @property email
    @brief The email returned by the IdP.
@@ -47,26 +47,20 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  var mfaPendingCredential: String? { return _mfaPendingCredential }
-
-  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
-
-  var idToken: String? { return _idToken }
-
   /** @property MFAPendingCredential
        @brief An opaque string that functions as proof that the user has successfully passed the first
       factor check.
    */
-  private var _mfaPendingCredential: String?
+  private(set) var mfaPendingCredential: String?
 
   /** @property MFAInfo
        @brief Info on which multi-factor authentication providers are enabled.
    */
-  private var _mfaInfo: [AuthProtoMFAEnrollment]?
+  private(set) var mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
-    _idToken = dictionary["idToken"] as? String
+    idToken = dictionary["idToken"] as? String
     isNewUser = dictionary["isNewUser"] as? Bool ?? false
     refreshToken = dictionary["refreshToken"] as? String
 
@@ -80,8 +74,8 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
         let enrollment = AuthProtoMFAEnrollment(dictionary: entry)
         mfaInfo.append(enrollment)
       }
-      _mfaInfo = mfaInfo
+      self.mfaInfo = mfaInfo
     }
-    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
+    mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -47,13 +47,9 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  func mfaPendingCredential() -> String? {
-    return _mfaPendingCredential
-  }
+  var mfaPendingCredential: String? { return _mfaPendingCredential }
 
-  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
-    return _mfaInfo
-  }
+  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
   func nilIDToken() -> Bool {
     return idToken == nil

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -17,7 +17,7 @@ import Foundation
 /** @class FIRVerifyAssertionResponse
     @brief Represents the response from the emailLinkSignin endpoint.
  */
-class EmailLinkSignInResponse: NSObject, AuthRPCResponse {
+class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
   override required init() {}
 
   /** @property IDToken
@@ -45,16 +45,30 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse {
    */
   var isNewUser: Bool = false
 
+  // MARK: - AuthMFAResponse
+
+  func mfaPendingCredential() -> String? {
+    return _mfaPendingCredential
+  }
+
+  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
+    return _mfaInfo
+  }
+
+  func nilIDToken() -> Bool {
+    return idToken == nil
+  }
+
   /** @property MFAPendingCredential
        @brief An opaque string that functions as proof that the user has successfully passed the first
       factor check.
    */
-  var mfaPendingCredential: String?
+  private var _mfaPendingCredential: String?
 
   /** @property MFAInfo
        @brief Info on which multi-factor authentication providers are enabled.
    */
-  var mfaInfo: [AuthProtoMFAEnrollment]?
+  private var _mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     email = dictionary["email"] as? String
@@ -72,8 +86,8 @@ class EmailLinkSignInResponse: NSObject, AuthRPCResponse {
         let enrollment = AuthProtoMFAEnrollment(dictionary: entry)
         mfaInfo.append(enrollment)
       }
-      self.mfaInfo = mfaInfo
+      _mfaInfo = mfaInfo
     }
-    mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
+    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -203,13 +203,9 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  func mfaPendingCredential() -> String? {
-    return _mfaPendingCredential
-  }
+  var mfaPendingCredential: String? { return _mfaPendingCredential }
 
-  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
-    return _mfaInfo
-  }
+  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
   func nilIDToken() -> Bool {
     return idToken == nil

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -97,7 +97,7 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
    access token from Secure Token Service, depending on whether @c returnSecureToken is set
    on the request.
    */
-  var idToken: String?
+  private var _idToken: String?
 
   /** @property approximateExpirationDate
    @brief The approximate expiration date of the access token.
@@ -207,9 +207,7 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
 
   var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
-  func nilIDToken() -> Bool {
-    return idToken == nil
-  }
+  var idToken: String? { return _idToken }
 
   private var _mfaPendingCredential: String?
 
@@ -231,7 +229,7 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
     fullName = dictionary["fullName"] as? String
     nickName = dictionary["nickName"] as? String
     displayName = dictionary["displayName"] as? String
-    idToken = dictionary["idToken"] as? String
+    _idToken = dictionary["idToken"] as? String
     if let expiresIn = dictionary["expiresIn"] as? String {
       approximateExpirationDate = Date(timeIntervalSinceNow: (expiresIn as NSString)
         .doubleValue)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -97,7 +97,7 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
    access token from Secure Token Service, depending on whether @c returnSecureToken is set
    on the request.
    */
-  private var _idToken: String?
+  private(set) var idToken: String?
 
   /** @property approximateExpirationDate
    @brief The approximate expiration date of the access token.
@@ -203,15 +203,9 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  var mfaPendingCredential: String? { return _mfaPendingCredential }
+  private(set) var mfaPendingCredential: String?
 
-  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
-
-  var idToken: String? { return _idToken }
-
-  private var _mfaPendingCredential: String?
-
-  private var _mfaInfo: [AuthProtoMFAEnrollment]?
+  private(set) var mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     federatedID = dictionary["federatedId"] as? String
@@ -229,7 +223,7 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
     fullName = dictionary["fullName"] as? String
     nickName = dictionary["nickName"] as? String
     displayName = dictionary["displayName"] as? String
-    _idToken = dictionary["idToken"] as? String
+    idToken = dictionary["idToken"] as? String
     if let expiresIn = dictionary["expiresIn"] as? String {
       approximateExpirationDate = Date(timeIntervalSinceNow: (expiresIn as NSString)
         .doubleValue)
@@ -275,10 +269,10 @@ class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
     pendingToken = dictionary["pendingToken"] as? String
 
     if let mfaInfoDicts = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
-      _mfaInfo = mfaInfoDicts.map {
+      mfaInfo = mfaInfoDicts.map {
         AuthProtoMFAEnrollment(dictionary: $0)
       }
     }
-    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
+    mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -18,7 +18,7 @@ import Foundation
  @brief Represents the response from the verifyAssertion endpoint.
  @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/verifyAssertion
  */
-class VerifyAssertionResponse: AuthRPCResponse {
+class VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
   required init() {}
 
   /** @property federatedID
@@ -201,9 +201,23 @@ class VerifyAssertionResponse: AuthRPCResponse {
    */
   var pendingToken: String?
 
-  var MFAPendingCredential: String?
+  // MARK: - AuthMFAResponse
 
-  var MFAInfo: [AuthProtoMFAEnrollment]?
+  func mfaPendingCredential() -> String? {
+    return _mfaPendingCredential
+  }
+
+  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
+    return _mfaInfo
+  }
+
+  func nilIDToken() -> Bool {
+    return idToken == nil
+  }
+
+  private var _mfaPendingCredential: String?
+
+  private var _mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     federatedID = dictionary["federatedId"] as? String
@@ -267,10 +281,10 @@ class VerifyAssertionResponse: AuthRPCResponse {
     pendingToken = dictionary["pendingToken"] as? String
 
     if let mfaInfoDicts = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
-      MFAInfo = mfaInfoDicts.map {
+      _mfaInfo = mfaInfoDicts.map {
         AuthProtoMFAEnrollment(dictionary: $0)
       }
     }
-    MFAPendingCredential = dictionary["mfaPendingCredential"] as? String
+    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
@@ -64,13 +64,9 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  func mfaPendingCredential() -> String? {
-    return _mfaPendingCredential
-  }
+  var mfaPendingCredential: String? { return _mfaPendingCredential }
 
-  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
-    return _mfaInfo
-  }
+  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
   func nilIDToken() -> Bool {
     return idToken == nil

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
@@ -21,7 +21,7 @@ import Foundation
        - FIRAuthInternalErrorCodeEmailNotFound
     @see https://developers.google.com/identity/toolkit/web/reference/relyingparty/verifyPassword
  */
-class VerifyPasswordResponse: AuthRPCResponse {
+class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
   required init() {}
 
   /** @property localID
@@ -62,9 +62,23 @@ class VerifyPasswordResponse: AuthRPCResponse {
    */
   var photoURL: URL?
 
-  var mfaPendingCredential: String?
+  // MARK: - AuthMFAResponse
 
-  var mfaInfo: [AuthProtoMFAEnrollment]?
+  func mfaPendingCredential() -> String? {
+    return _mfaPendingCredential
+  }
+
+  func mfaInfo() -> [AuthProtoMFAEnrollment]? {
+    return _mfaInfo
+  }
+
+  func nilIDToken() -> Bool {
+    return idToken == nil
+  }
+
+  private var _mfaPendingCredential: String?
+
+  private var _mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     localID = dictionary["localId"] as? String
@@ -79,8 +93,8 @@ class VerifyPasswordResponse: AuthRPCResponse {
     photoURL = (dictionary["photoUrl"] as? String).flatMap { URL(string: $0) }
 
     if let mfaInfo = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
-      self.mfaInfo = mfaInfo.map { AuthProtoMFAEnrollment(dictionary: $0) }
+      _mfaInfo = mfaInfo.map { AuthProtoMFAEnrollment(dictionary: $0) }
     }
-    mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
+    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
@@ -45,7 +45,7 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
           access token from Secure Token Service, depending on whether @c returnSecureToken is set
           on the request.
    */
-  private var _idToken: String?
+  private(set) var idToken: String?
 
   /** @property approximateExpirationDate
       @brief The approximate expiration date of the access token.
@@ -64,21 +64,15 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
 
   // MARK: - AuthMFAResponse
 
-  var mfaPendingCredential: String? { return _mfaPendingCredential }
+  private(set) var mfaPendingCredential: String?
 
-  var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
-
-  var idToken: String? { return _idToken }
-
-  private var _mfaPendingCredential: String?
-
-  private var _mfaInfo: [AuthProtoMFAEnrollment]?
+  private(set) var mfaInfo: [AuthProtoMFAEnrollment]?
 
   func setFields(dictionary: [String: AnyHashable]) throws {
     localID = dictionary["localId"] as? String
     email = dictionary["email"] as? String
     displayName = dictionary["displayName"] as? String
-    _idToken = dictionary["idToken"] as? String
+    idToken = dictionary["idToken"] as? String
     if let expiresIn = dictionary["expiresIn"] as? String {
       approximateExpirationDate = Date(timeIntervalSinceNow: (expiresIn as NSString)
         .doubleValue)
@@ -87,8 +81,8 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
     photoURL = (dictionary["photoUrl"] as? String).flatMap { URL(string: $0) }
 
     if let mfaInfo = dictionary["mfaInfo"] as? [[String: AnyHashable]] {
-      _mfaInfo = mfaInfo.map { AuthProtoMFAEnrollment(dictionary: $0) }
+      self.mfaInfo = mfaInfo.map { AuthProtoMFAEnrollment(dictionary: $0) }
     }
-    _mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
+    mfaPendingCredential = dictionary["mfaPendingCredential"] as? String
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordResponse.swift
@@ -45,7 +45,7 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
           access token from Secure Token Service, depending on whether @c returnSecureToken is set
           on the request.
    */
-  var idToken: String?
+  private var _idToken: String?
 
   /** @property approximateExpirationDate
       @brief The approximate expiration date of the access token.
@@ -68,9 +68,7 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
 
   var mfaInfo: [AuthProtoMFAEnrollment]? { return _mfaInfo }
 
-  func nilIDToken() -> Bool {
-    return idToken == nil
-  }
+  var idToken: String? { return _idToken }
 
   private var _mfaPendingCredential: String?
 
@@ -80,7 +78,7 @@ class VerifyPasswordResponse: AuthRPCResponse, AuthMFAResponse {
     localID = dictionary["localId"] as? String
     email = dictionary["email"] as? String
     displayName = dictionary["displayName"] as? String
-    idToken = dictionary["idToken"] as? String
+    _idToken = dictionary["idToken"] as? String
     if let expiresIn = dictionary["expiresIn"] as? String {
       approximateExpirationDate = Date(timeIntervalSinceNow: (expiresIn as NSString)
         .doubleValue)

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -334,7 +334,7 @@ extension User: NSSecureCoding {}
 
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func reload(withCompletion completion: ((Error?) -> Void)? = nil) {
+  @objc public func reload(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.getAccountInfoRefreshingCache { user, error in
         User.callInMainThreadWithError(callback: completion, error: error)
@@ -1023,7 +1023,7 @@ extension User: NSSecureCoding {}
    */
   @objc(sendEmailVerificationWithCompletion:)
   public func __sendEmailVerification(withCompletion completion: ((Error?) -> Void)?) {
-    sendEmailVerification(withCompletion: completion)
+    sendEmailVerification(completion: completion)
   }
 
   /** @fn sendEmailVerificationWithActionCodeSettings:completion:
@@ -1052,7 +1052,7 @@ extension User: NSSecureCoding {}
    */
   @objc(sendEmailVerificationWithActionCodeSettings:completion:)
   public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings? = nil,
-                                    withCompletion completion: ((Error?) -> Void)? = nil) {
+                                    completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.internalGetToken { accessToken, error in
         if let error {
@@ -1136,7 +1136,7 @@ extension User: NSSecureCoding {}
 
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
-  @objc public func delete(withCompletion completion: ((Error?) -> Void)? = nil) {
+  @objc public func delete(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.internalGetToken { accessToken, error in
         if let error {

--- a/FirebaseAuth/Sources/Swift/User/UserProfileChangeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserProfileChangeRequest.swift
@@ -65,7 +65,7 @@ import Foundation
    @param completion Optionally; the block invoked when the user profile change has been applied.
    Invoked asynchronously on the main thread in the future.
    */
-  @objc public func commitChanges(withCompletion completion: ((Error?) -> Void)? = nil) {
+  @objc public func commitChanges(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       if self.consumed {
         fatalError("Internal Auth Error: commitChanges should only be called once.")


### PR DESCRIPTION
Fix four issues integration testing Multi-Factor Authentication thanks to the test case from #11079 

- Build issue from using `withCompletion:` instead of  `completion:` in some APIs
- Created an `AuthMFAResponse` protocol for responses that need AuthBackend's checking of MFA error throwing
- Fixed the type of `MultiFactorInfo` hint arrays. They should be `PhoneMultiFactorInfo` and `TOTPMultiFactorInfo` instead of the common base type.
- Fixed a logic error in PhoneAuthProvider.swift: `idToken` can be non-nil for both the `recaptcha` and `credential` cases.