### PR TITLE
Add build tests for Auth globals

### DIFF
--- a/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+@import FirebaseAuth;
+
+@interface ObjCAPIGlobalTests : XCTestCase
+@end
+
+@implementation ObjCAPIGlobalTests
+
+- (void)GlobalSymbolBuildTest {
+  NSNotificationName n = FIRAuthStateDidChangeNotification;
+  NSString *s = FIRAuthErrorDomain;
+  s = FIRAuthErrorUserInfoNameKey;
+  s = FIRAuthErrorUserInfoEmailKey;
+  s = FIRAuthErrorUserInfoUpdatedCredentialKey;
+  s = FIRAuthErrorUserInfoMultiFactorResolverKey;
+  s = FIREmailAuthProviderID;
+  s = FIREmailLinkAuthSignInMethod;
+  s = FIREmailPasswordAuthSignInMethod;
+  s = FIRFacebookAuthProviderID;
+  s = FIRFacebookAuthSignInMethod;
+  s = FIRGameCenterAuthProviderID;
+  s = FIRGameCenterAuthSignInMethod;
+  s = FIRGitHubAuthProviderID;
+  s = FIRGitHubAuthSignInMethod;
+  s = FIRGoogleAuthProviderID;
+  s = FIRGoogleAuthSignInMethod;
+  s = FIRPhoneMultiFactorID;
+  s = FIRTOTPMultiFactorID;
+  s = FIRPhoneAuthProviderID;
+  s = FIRPhoneAuthSignInMethod;
+  s = FIRTwitterAuthProviderID;
+  s = FIRTwitterAuthSignInMethod;
+}
+@end

--- a/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
@@ -22,7 +22,7 @@
 @implementation ObjCAPIGlobalTests
 
 - (void)GlobalSymbolBuildTest {
-  NSNotificationName n = FIRAuthStateDidChangeNotification;
+  __unused NSNotificationName n = FIRAuthStateDidChangeNotification;
   NSString *s = FIRAuthErrorDomain;
   s = FIRAuthErrorUserInfoNameKey;
   s = FIRAuthErrorUserInfoEmailKey;

--- a/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCGlobalTests.m
@@ -39,10 +39,12 @@
   s = FIRGitHubAuthSignInMethod;
   s = FIRGoogleAuthProviderID;
   s = FIRGoogleAuthSignInMethod;
+#if TARGET_OS_IOS
   s = FIRPhoneMultiFactorID;
   s = FIRTOTPMultiFactorID;
   s = FIRPhoneAuthProviderID;
   s = FIRPhoneAuthSignInMethod;
+#endif
   s = FIRTwitterAuthProviderID;
   s = FIRTwitterAuthSignInMethod;
 }

--- a/FirebaseAuth/Tests/Unit/SwiftGlobalTests.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftGlobalTests.swift
@@ -38,10 +38,12 @@ class SwiftGlobalTests: XCTestCase {
     let _: String = GitHubAuthSignInMethod
     let _: String = GoogleAuthProviderID
     let _: String = GoogleAuthSignInMethod
-    let _: String = PhoneMultiFactorID
-    let _: String = TOTPMultiFactorID
-    let _: String = PhoneAuthProviderID
-    let _: String = PhoneAuthSignInMethod
+    #if os(iOS)
+      let _: String = PhoneMultiFactorID
+      let _: String = TOTPMultiFactorID
+      let _: String = PhoneAuthProviderID
+      let _: String = PhoneAuthSignInMethod
+    #endif
     let _: String = TwitterAuthProviderID
     let _: String = TwitterAuthSignInMethod
   }

--- a/FirebaseAuth/Tests/Unit/SwiftGlobalTests.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftGlobalTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import XCTest
+
+import FirebaseAuth
+
+/// Tests globals defined in Objective C sources.  These globals are for backward compatibility and
+/// should not be used in new code.
+class SwiftGlobalTests: XCTestCase {
+  func GlobalSymbolBuildTest() {
+    let _ = NSNotification.Name.AuthStateDidChange
+    let _: String = AuthErrorDomain
+    let _: String = AuthErrorUserInfoNameKey
+    let _: String = AuthErrorUserInfoEmailKey
+    let _: String = AuthErrorUserInfoUpdatedCredentialKey
+    let _: String = AuthErrorUserInfoMultiFactorResolverKey
+    let _: String = EmailAuthProviderID
+    let _: String = EmailLinkAuthSignInMethod
+    let _: String = EmailPasswordAuthSignInMethod
+    let _: String = FacebookAuthProviderID
+    let _: String = FacebookAuthSignInMethod
+    let _: String = GameCenterAuthProviderID
+    let _: String = GameCenterAuthSignInMethod
+    let _: String = GitHubAuthProviderID
+    let _: String = GitHubAuthSignInMethod
+    let _: String = GoogleAuthProviderID
+    let _: String = GoogleAuthSignInMethod
+    let _: String = PhoneMultiFactorID
+    let _: String = TOTPMultiFactorID
+    let _: String = PhoneAuthProviderID
+    let _: String = PhoneAuthSignInMethod
+    let _: String = TwitterAuthProviderID
+    let _: String = TwitterAuthSignInMethod
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -464,6 +464,7 @@ let package = Package(
         "FIRAuthTests.m",
         "FIRUserTests.m",
         "SwiftAPI.swift", // Only builds via CocoaPods testing until Swift source update.
+        "SwiftGlobalTests.swift", // Only builds via CocoaPods testing until Swift source update.
       ],
       cSettings: [
         .headerSearchPath("../../.."),


### PR DESCRIPTION
Global list generated from grepping for `extern` in public header files.

The new tests are also included in the corresponding [auth-swift] PR #12228 

The health-metrics CI failure is not reproducible. I suspect it will go away after main merge and tag update.