### PR TITLE
Remove unnecessary compiler checks for Concurrency support

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -63,7 +63,6 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -74,7 +73,6 @@ final class AppCheckAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Set `AppCheckProviderFactory`
     AppCheck.setAppCheckProviderFactory(DummyAppCheckProviderFactory())
@@ -97,7 +95,6 @@ final class AppCheckAPITests {
       }
 
       // Get token (async/await)
-      #if compiler(>=5.5.2) && canImport(_Concurrency)
         if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
@@ -108,7 +105,6 @@ final class AppCheckAPITests {
             }
           }
         }
-      #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
       _ = debugProvider.localDebugToken()
       _ = debugProvider.currentDebugToken()
@@ -170,7 +166,6 @@ final class AppCheckAPITests {
             }
           }
           // Get token (async/await)
-          #if compiler(>=5.5.2) && canImport(_Concurrency)
             if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
               // async/await is a Swift 5.5+ feature available on iOS 15+
               Task {
@@ -183,7 +178,6 @@ final class AppCheckAPITests {
                 }
               }
             }
-          #endif // compiler(>=5.5.2) && canImport(_Concurrency)
         }
       }
     #endif // !os(watchOS)

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -63,16 +63,16 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            try await AppCheck.appCheck().token(forcingRefresh: false)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          try await AppCheck.appCheck().token(forcingRefresh: false)
+        } catch {
+          // ...
         }
       }
+    }
 
     // Set `AppCheckProviderFactory`
     AppCheck.setAppCheckProviderFactory(DummyAppCheckProviderFactory())
@@ -95,16 +95,16 @@ final class AppCheckAPITests {
       }
 
       // Get token (async/await)
-        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-          // async/await is a Swift 5.5+ feature available on iOS 15+
-          Task {
-            do {
-              _ = try await debugProvider.getToken()
-            } catch {
-              // ...
-            }
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+        // async/await is a Swift 5.5+ feature available on iOS 15+
+        Task {
+          do {
+            _ = try await debugProvider.getToken()
+          } catch {
+            // ...
           }
         }
+      }
 
       _ = debugProvider.localDebugToken()
       _ = debugProvider.currentDebugToken()
@@ -166,18 +166,18 @@ final class AppCheckAPITests {
             }
           }
           // Get token (async/await)
-            if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-              // async/await is a Swift 5.5+ feature available on iOS 15+
-              Task {
-                do {
-                  _ = try await deviceCheckProvider.getToken()
-                } catch AppCheckErrorCode.unsupported {
-                  // ...
-                } catch {
-                  // ...
-                }
+          if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // async/await is a Swift 5.5+ feature available on iOS 15+
+            Task {
+              do {
+                _ = try await deviceCheckProvider.getToken()
+              } catch AppCheckErrorCode.unsupported {
+                // ...
+              } catch {
+                // ...
               }
             }
+          }
         }
       }
     #endif // !os(watchOS)

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -75,27 +75,27 @@ class AccountInfoTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 7, *)
-    func testUpdatingUsersEmailAsync() async throws {
-      let auth = Auth.auth()
-      do {
-        _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
-        XCTFail("Did not get error for recreating a user")
-      } catch {
-        XCTAssertEqual((error as NSError).code,
-                       AuthErrorCode.emailAlreadyInUse.rawValue,
-                       "Created a user despite it already exiting.")
-      }
-
-      let user = try await auth.signIn(withEmail: kOldUserEmail, password: "password")
-      XCTAssertEqual(user.user.email, kOldUserEmail)
-      XCTAssertEqual(auth.currentUser?.email,
-                     kOldUserEmail,
-                     "Signed user does not match request.")
-
-      try await auth.currentUser?.updateEmail(to: kNewUserEmail)
-      XCTAssertEqual(auth.currentUser?.email,
-                     kNewUserEmail,
-                     "Signed user does not match change.")
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 7, *)
+  func testUpdatingUsersEmailAsync() async throws {
+    let auth = Auth.auth()
+    do {
+      _ = try await auth.createUser(withEmail: kOldUserEmail, password: "password")
+      XCTFail("Did not get error for recreating a user")
+    } catch {
+      XCTAssertEqual((error as NSError).code,
+                     AuthErrorCode.emailAlreadyInUse.rawValue,
+                     "Created a user despite it already exiting.")
     }
+
+    let user = try await auth.signIn(withEmail: kOldUserEmail, password: "password")
+    XCTAssertEqual(user.user.email, kOldUserEmail)
+    XCTAssertEqual(auth.currentUser?.email,
+                   kOldUserEmail,
+                   "Signed user does not match request.")
+
+    try await auth.currentUser?.updateEmail(to: kNewUserEmail)
+    XCTAssertEqual(auth.currentUser?.email,
+                   kNewUserEmail,
+                   "Signed user does not match change.")
+  }
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AccountInfoTests.swift
@@ -75,7 +75,6 @@ class AccountInfoTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 7, *)
     func testUpdatingUsersEmailAsync() async throws {
       let auth = Auth.auth()
@@ -99,5 +98,4 @@ class AccountInfoTests: TestsBase {
                      kNewUserEmail,
                      "Signed user does not match change.")
     }
-  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -29,14 +29,14 @@ class AnonymousTests: TestsBase {
     deleteCurrentUser()
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testUpdatingUsersEmailAsync() async throws {
-      try await signInAnonymouslyAsync()
-      if let isAnonymous = Auth.auth().currentUser?.isAnonymous {
-        XCTAssertTrue(isAnonymous)
-      } else {
-        XCTFail("Missing currentUser after anonymous sign in")
-      }
-      try await deleteCurrentUserAsync()
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testUpdatingUsersEmailAsync() async throws {
+    try await signInAnonymouslyAsync()
+    if let isAnonymous = Auth.auth().currentUser?.isAnonymous {
+      XCTAssertTrue(isAnonymous)
+    } else {
+      XCTFail("Missing currentUser after anonymous sign in")
     }
+    try await deleteCurrentUserAsync()
+  }
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/AnonymousTests.swift
@@ -29,7 +29,6 @@ class AnonymousTests: TestsBase {
     deleteCurrentUser()
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUpdatingUsersEmailAsync() async throws {
       try await signInAnonymouslyAsync()
@@ -40,5 +39,4 @@ class AnonymousTests: TestsBase {
       }
       try await deleteCurrentUserAsync()
     }
-  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -39,7 +39,6 @@ class EmailPasswordTests: TestsBase {
     deleteCurrentUser()
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testCreateAccountWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
@@ -47,7 +46,6 @@ class EmailPasswordTests: TestsBase {
       XCTAssertEqual(auth.currentUser?.email, kNewEmailToCreateUser, "Expected email doesn't match")
       try await deleteCurrentUserAsync()
     }
-  #endif
 
   func testSignInExistingUserWithEmailAndPassword() {
     let auth = Auth.auth()
@@ -63,7 +61,6 @@ class EmailPasswordTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
       let auth = Auth.auth()
@@ -72,5 +69,4 @@ class EmailPasswordTests: TestsBase {
                      kExistingEmailToSignIn,
                      "Signed user does not match request.")
     }
-  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/EmailPasswordTests.swift
@@ -39,13 +39,13 @@ class EmailPasswordTests: TestsBase {
     deleteCurrentUser()
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testCreateAccountWithEmailAndPasswordAsync() async throws {
-      let auth = Auth.auth()
-      try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
-      XCTAssertEqual(auth.currentUser?.email, kNewEmailToCreateUser, "Expected email doesn't match")
-      try await deleteCurrentUserAsync()
-    }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testCreateAccountWithEmailAndPasswordAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.createUser(withEmail: kNewEmailToCreateUser, password: "password")
+    XCTAssertEqual(auth.currentUser?.email, kNewEmailToCreateUser, "Expected email doesn't match")
+    try await deleteCurrentUserAsync()
+  }
 
   func testSignInExistingUserWithEmailAndPassword() {
     let auth = Auth.auth()
@@ -61,12 +61,12 @@ class EmailPasswordTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
-      let auth = Auth.auth()
-      try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")
-      XCTAssertEqual(auth.currentUser?.email,
-                     kExistingEmailToSignIn,
-                     "Signed user does not match request.")
-    }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")
+    XCTAssertEqual(auth.currentUser?.email,
+                   kExistingEmailToSignIn,
+                   "Signed user does not match request.")
+  }
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/FacebookTests.swift
@@ -44,7 +44,6 @@ import XCTest
 //    deleteFacebookTestingAccountbyID(facebookAccountID)
 //  }
 //
-//  #if compiler(>=5.5.2) && canImport(_Concurrency)
 //    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 //    func testSignInWithFacebookAsync() async throws {
 //      let auth = Auth.auth()
@@ -60,7 +59,6 @@ import XCTest
 //      try await deleteCurrentUserAsync()
 //      try await deleteFacebookTestingAccountbyIDAsync(facebookAccountID)
 //    }
-//  #endif
 //
 //  func testLinkAnonymousAccountToFacebookAccount() throws {
 //    let auth = Auth.auth()
@@ -90,7 +88,6 @@ import XCTest
 //    deleteFacebookTestingAccountbyID(facebookAccountID)
 //  }
 //
-//  #if compiler(>=5.5.2) && canImport(_Concurrency)
 //    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 //    func testLinkAnonymousAccountToFacebookAccountAsync() async throws {
 //      let auth = Auth.auth()
@@ -111,7 +108,6 @@ import XCTest
 //      try await deleteCurrentUserAsync()
 //      try await deleteFacebookTestingAccountbyIDAsync(facebookAccountID)
 //    }
-//  #endif
 //
 //  /// Creates a Facebook testing account using Facebook Graph API and return a dictionary that
 //  /// constrains "id", "access_token", "login_url", "email" and "password" of the created account.
@@ -151,7 +147,6 @@ import XCTest
 //    return returnValue
 //  }
 //
-//  #if compiler(>=5.5.2) && canImport(_Concurrency)
 //    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 //    /// Creates a Facebook testing account using Facebook Graph API and return a dictionary that
 //    /// constains "id", "access_token", "login_url", "email" and "password" of the created
@@ -174,7 +169,6 @@ import XCTest
 //      }
 //      return returnValue
 //    }
-//  #endif
 //
 //  // ** Delete a Facebook testing account by account Id using Facebook Graph API. */
 //  func deleteFacebookTestingAccountbyID(_ accountID: String) {
@@ -195,7 +189,6 @@ import XCTest
 //    waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
 //  }
 //
-//  #if compiler(>=5.5.2) && canImport(_Concurrency)
 //    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 //    // ** Delete a Facebook testing account by account Id using Facebook Graph API. */
 //    func deleteFacebookTestingAccountbyIDAsync(_ accountID: String) async throws {
@@ -208,5 +201,4 @@ import XCTest
 //      fetcher.setRequestValue("text/plain", forHTTPHeaderField: "Content-Type")
 //      try await fetcher.beginFetch()
 //    }
-//  #endif
 // }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -37,7 +37,6 @@ class GoogleTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testSignInWithGoogleAsync() async throws {
       let auth = Auth.auth()
@@ -48,7 +47,6 @@ class GoogleTests: TestsBase {
                                                      accessToken: googleAccessToken)
       _ = try await auth.signIn(with: credential)
     }
-  #endif
 
   /// Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
   /// access token.
@@ -84,7 +82,6 @@ class GoogleTests: TestsBase {
     return returnValue
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     /// Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
     /// access token.
@@ -111,5 +108,4 @@ class GoogleTests: TestsBase {
       }
       return returnValue
     }
-  #endif
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/GoogleTests.swift
@@ -37,16 +37,16 @@ class GoogleTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testSignInWithGoogleAsync() async throws {
-      let auth = Auth.auth()
-      let userInfoDict = try await getGoogleAccessTokenAsync()
-      let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
-      let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
-      let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
-                                                     accessToken: googleAccessToken)
-      _ = try await auth.signIn(with: credential)
-    }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testSignInWithGoogleAsync() async throws {
+    let auth = Auth.auth()
+    let userInfoDict = try await getGoogleAccessTokenAsync()
+    let googleAccessToken: String = try XCTUnwrap(userInfoDict["access_token"] as? String)
+    let googleIDToken: String = try XCTUnwrap(userInfoDict["id_token"] as? String)
+    let credential = GoogleAuthProvider.credential(withIDToken: googleIDToken,
+                                                   accessToken: googleAccessToken)
+    _ = try await auth.signIn(with: credential)
+  }
 
   /// Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
   /// access token.
@@ -82,30 +82,30 @@ class GoogleTests: TestsBase {
     return returnValue
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    /// Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
-    /// access token.
-    /// Returns a dictionary that constains "access_token", "token_type", "expires_in" and sometimes
-    /// the "id_token". (The id_token is not guaranteed to be returned during a refresh exchange;
-    /// see https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse)
-    func getGoogleAccessTokenAsync() async throws -> [String: Any] {
-      let googleOauth2TokenServerUrl = "https://www.googleapis.com/oauth2/v4/token"
-      let bodyString = "client_id=\(Credentials.kGoogleClientID)&grant_type=refresh_token" +
-        "&refresh_token=\(Credentials.kGoogleTestAccountRefreshToken)"
-      let postData = bodyString.data(using: .utf8)
-      let service = GTMSessionFetcherService()
-      let fetcher = service.fetcher(withURLString: googleOauth2TokenServerUrl)
-      fetcher.bodyData = postData
-      fetcher.setRequestValue(
-        "application/x-www-form-urlencoded",
-        forHTTPHeaderField: "Content-Type"
-      )
-      let data = try await fetcher.beginFetch()
-      guard let returnValue = try JSONSerialization.jsonObject(with: data, options: [])
-        as? [String: Any] else {
-        XCTFail("Failed to serialize userInfo as a Dictionary")
-        fatalError()
-      }
-      return returnValue
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  /// Sends http request to Google OAuth2 token server to use refresh token to exchange for Google
+  /// access token.
+  /// Returns a dictionary that constains "access_token", "token_type", "expires_in" and sometimes
+  /// the "id_token". (The id_token is not guaranteed to be returned during a refresh exchange;
+  /// see https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse)
+  func getGoogleAccessTokenAsync() async throws -> [String: Any] {
+    let googleOauth2TokenServerUrl = "https://www.googleapis.com/oauth2/v4/token"
+    let bodyString = "client_id=\(Credentials.kGoogleClientID)&grant_type=refresh_token" +
+      "&refresh_token=\(Credentials.kGoogleTestAccountRefreshToken)"
+    let postData = bodyString.data(using: .utf8)
+    let service = GTMSessionFetcherService()
+    let fetcher = service.fetcher(withURLString: googleOauth2TokenServerUrl)
+    fetcher.bodyData = postData
+    fetcher.setRequestValue(
+      "application/x-www-form-urlencoded",
+      forHTTPHeaderField: "Content-Type"
+    )
+    let data = try await fetcher.beginFetch()
+    guard let returnValue = try JSONSerialization.jsonObject(with: data, options: [])
+      as? [String: Any] else {
+      XCTFail("Failed to serialize userInfo as a Dictionary")
+      fatalError()
     }
+    return returnValue
+  }
 }

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -21,7 +21,6 @@ import XCTest
 class TestsBase: XCTestCase {
   static let kExpectationsTimeout = 10.0
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func signInAnonymouslyAsync() async throws {
       let auth = Auth.auth()
@@ -33,7 +32,6 @@ class TestsBase: XCTestCase {
       let auth = Auth.auth()
       try await auth.currentUser?.delete()
     }
-  #endif
 
   func signInAnonymously() {
     let auth = Auth.auth()

--- a/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
+++ b/FirebaseAuth/Tests/Sample/SwiftApiTests/TestsBase.swift
@@ -21,17 +21,17 @@ import XCTest
 class TestsBase: XCTestCase {
   static let kExpectationsTimeout = 10.0
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func signInAnonymouslyAsync() async throws {
-      let auth = Auth.auth()
-      try await auth.signInAnonymously()
-    }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func signInAnonymouslyAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.signInAnonymously()
+  }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func deleteCurrentUserAsync() async throws {
-      let auth = Auth.auth()
-      try await auth.currentUser?.delete()
-    }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func deleteCurrentUserAsync() async throws {
+    let auth = Auth.auth()
+    try await auth.currentUser?.delete()
+  }
 
   func signInAnonymously() {
     let auth = Auth.auth()

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -51,14 +51,12 @@ final class CoreAPITests {
         // ...
       }
 
-      #if compiler(>=5.5.2) && canImport(_Concurrency)
         if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
           // async/await is a Swift 5.5+ feature available on iOS 15+
           Task {
             await app.delete()
           }
         }
-      #endif // compiler(>=5.5.2) && canImport(_Concurrency)
     }
 
     // Properties

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -51,12 +51,12 @@ final class CoreAPITests {
         // ...
       }
 
-        if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-          // async/await is a Swift 5.5+ feature available on iOS 15+
-          Task {
-            await app.delete()
-          }
+      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+        // async/await is a Swift 5.5+ feature available on iOS 15+
+        Task {
+          await app.delete()
         }
+      }
     }
 
     // Properties

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -112,16 +112,16 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot? = dataSnapshot
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let /* dataSnapshot */ _: DataSnapshot = try await DatabaseQuery().getData()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let /* dataSnapshot */ _: DataSnapshot = try await DatabaseQuery().getData()
+        } catch {
+          // ...
         }
       }
+    }
 
     // Observe Single Event
 
@@ -136,14 +136,14 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          // observeSingleEvent(of eventType:)
-          let _: (DataSnapshot, String?) = await DatabaseQuery()
-            .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
-        }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        // observeSingleEvent(of eventType:)
+        let _: (DataSnapshot, String?) = await DatabaseQuery()
+          .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
       }
+    }
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseQuery.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -206,17 +206,17 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // setValue(_ value:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference().setValue(value)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // setValue(_ value:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference().setValue(value)
+        } catch {
+          // ...
         }
       }
+    }
 
     databaseReference.setValue(value, andPriority: priority)
 
@@ -226,18 +226,18 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // setValue(_ value:andPriority priority:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .setValue(value, andPriority: priority)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // setValue(_ value:andPriority priority:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .setValue(value, andPriority: priority)
+        } catch {
+          // ...
         }
       }
+    }
 
     // Remove value
     databaseReference.removeValue()
@@ -248,16 +248,16 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let /* ref */ _: DatabaseReference = try await DatabaseReference().removeValue()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let /* ref */ _: DatabaseReference = try await DatabaseReference().removeValue()
+        } catch {
+          // ...
         }
       }
+    }
 
     // Set priority
     databaseReference.setPriority(priority)
@@ -268,17 +268,17 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // setPriority(_ priority:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference().setPriority(priority)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // setPriority(_ priority:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference().setPriority(priority)
+        } catch {
+          // ...
         }
       }
+    }
 
     // Update child values
     databaseReference.updateChildValues(values)
@@ -289,18 +289,18 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // updateChildValues(_ values:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .updateChildValues(values)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // updateChildValues(_ values:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .updateChildValues(values)
+        } catch {
+          // ...
         }
       }
+    }
 
     // Observe for data
 
@@ -343,14 +343,14 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          // observeSingleEvent(of eventType:)
-          let _: (DataSnapshot, String?) = await DatabaseReference()
-            .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
-        }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        // observeSingleEvent(of eventType:)
+        let _: (DataSnapshot, String?) = await DatabaseReference()
+          .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
       }
+    }
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseReference.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -375,16 +375,16 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot? = dataSnapshot
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let /* dataSnapshot */ _: DataSnapshot = try await DatabaseReference().getData()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let /* dataSnapshot */ _: DataSnapshot = try await DatabaseReference().getData()
+        } catch {
+          // ...
         }
       }
+    }
 
     // Remove Observers
     databaseReference.removeObserver(withHandle: databaseHandle)
@@ -417,18 +417,18 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // onDisconnectSetValue(_ value:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .onDisconnectSetValue(value)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // onDisconnectSetValue(_ value:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .onDisconnectSetValue(value)
+        } catch {
+          // ...
         }
       }
+    }
 
     databaseReference.onDisconnectSetValue(value, andPriority: priorityAny)
 
@@ -439,20 +439,20 @@ final class DatabaseAPITests {
         let /* databaseReference */ _: DatabaseReference = databaseReference
       }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // onDisconnectSetValue(_ value:andPriority priority:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference().onDisconnectSetValue(
-              value,
-              andPriority: priority
-            )
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // onDisconnectSetValue(_ value:andPriority priority:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference().onDisconnectSetValue(
+            value,
+            andPriority: priority
+          )
+        } catch {
+          // ...
         }
       }
+    }
 
     // onDisconnectRemoveValue
     databaseReference.onDisconnectRemoveValue()
@@ -463,17 +463,17 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .onDisconnectRemoveValue()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .onDisconnectRemoveValue()
+        } catch {
+          // ...
         }
       }
+    }
 
     // onDisconnectUpdateChildValues
     databaseReference.onDisconnectUpdateChildValues(values)
@@ -484,18 +484,18 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // onDisconnectUpdateChildValues(_ values:)
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .onDisconnectUpdateChildValues(values)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // onDisconnectUpdateChildValues(_ values:)
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .onDisconnectUpdateChildValues(values)
+        } catch {
+          // ...
         }
       }
+    }
 
     // cancelDisconnectOperations
     databaseReference.cancelDisconnectOperations()
@@ -506,17 +506,17 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let /* ref */ _: DatabaseReference = try await DatabaseReference()
-              .cancelDisconnectOperations()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let /* ref */ _: DatabaseReference = try await DatabaseReference()
+            .cancelDisconnectOperations()
+        } catch {
+          // ...
         }
       }
+    }
 
     // runTransactionBlock
 
@@ -536,21 +536,21 @@ final class DatabaseAPITests {
       let /* optionalDataSnapshot */ _: DataSnapshot? = optionalDataSnapshot
     }
 
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            // runTransactionBlock(_ block:)
-            let _: (Bool, DataSnapshot) = try await DatabaseReference()
-              .runTransactionBlock { mutableData in
-                let /* mutableData */ _: MutableData = mutableData
-                return TransactionResult()
-              }
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          // runTransactionBlock(_ block:)
+          let _: (Bool, DataSnapshot) = try await DatabaseReference()
+            .runTransactionBlock { mutableData in
+              let /* mutableData */ _: MutableData = mutableData
+              return TransactionResult()
+            }
+        } catch {
+          // ...
         }
       }
+    }
 
     // runTransactionBlock(_ block:andCompletionBlock completionBlock:withLocalEvents localEvents:)
     databaseReference.runTransactionBlock({ mutableData in

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -112,7 +112,6 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot? = dataSnapshot
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -123,7 +122,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Observe Single Event
 
@@ -138,7 +136,6 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -147,7 +144,6 @@ final class DatabaseAPITests {
             .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseQuery.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -210,7 +206,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -222,7 +217,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     databaseReference.setValue(value, andPriority: priority)
 
@@ -232,7 +226,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -245,7 +238,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Remove value
     databaseReference.removeValue()
@@ -256,7 +248,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -267,7 +258,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Set priority
     databaseReference.setPriority(priority)
@@ -278,7 +268,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -290,7 +279,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Update child values
     databaseReference.updateChildValues(values)
@@ -301,7 +289,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -314,7 +301,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Observe for data
 
@@ -357,7 +343,6 @@ final class DatabaseAPITests {
       let /* optionalString */ _: String? = optionalString
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -366,7 +351,6 @@ final class DatabaseAPITests {
             .observeSingleEventAndPreviousSiblingKey(of: dataEventType)
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // observeSingleEvent(of eventType:with block:withCancel cancelBlock:)
     databaseReference.observeSingleEvent(of: dataEventType) { dataSnapshot in
@@ -391,7 +375,6 @@ final class DatabaseAPITests {
       let /* dataSnapshot */ _: DataSnapshot? = dataSnapshot
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -402,7 +385,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Remove Observers
     databaseReference.removeObserver(withHandle: databaseHandle)
@@ -435,7 +417,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -448,7 +429,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     databaseReference.onDisconnectSetValue(value, andPriority: priorityAny)
 
@@ -459,7 +439,6 @@ final class DatabaseAPITests {
         let /* databaseReference */ _: DatabaseReference = databaseReference
       }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -474,7 +453,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // onDisconnectRemoveValue
     databaseReference.onDisconnectRemoveValue()
@@ -485,7 +463,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -497,7 +474,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // onDisconnectUpdateChildValues
     databaseReference.onDisconnectUpdateChildValues(values)
@@ -508,7 +484,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -521,7 +496,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // cancelDisconnectOperations
     databaseReference.cancelDisconnectOperations()
@@ -532,7 +506,6 @@ final class DatabaseAPITests {
       let /* databaseReference */ _: DatabaseReference = databaseReference
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -544,7 +517,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // runTransactionBlock
 
@@ -564,7 +536,6 @@ final class DatabaseAPITests {
       let /* optionalDataSnapshot */ _: DataSnapshot? = optionalDataSnapshot
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -580,7 +551,6 @@ final class DatabaseAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // runTransactionBlock(_ block:andCompletionBlock completionBlock:withLocalEvents localEvents:)
     databaseReference.runTransactionBlock({ mutableData in

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -109,7 +109,6 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     call(data, completion: completion)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Executes this Callable HTTPS trigger asynchronously.
     ///
     /// The data passed into the trigger must be of the generic `Request` type:
@@ -160,5 +159,4 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     public func callAsFunction(_ data: Request) async throws -> Response {
       return try await call(data)
     }
-  #endif
 }

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -109,54 +109,54 @@ public struct Callable<Request: Encodable, Response: Decodable> {
     call(data, completion: completion)
   }
 
-    /// Executes this Callable HTTPS trigger asynchronously.
-    ///
-    /// The data passed into the trigger must be of the generic `Request` type:
-    ///
-    /// The request to the Cloud Functions backend made by this method automatically includes a
-    /// FCM token to identify the app instance. If a user is logged in with Firebase
-    /// Auth, an auth ID token for the user is also automatically included.
-    ///
-    /// Firebase Cloud Messaging sends data to the Firebase backend periodically to collect
-    /// information
-    /// regarding the app instance. To stop this, see `Messaging.deleteData()`. It
-    /// resumes with a new FCM Token the next time you call this method.
-    ///
-    /// - Parameter data: The `Request` representing the data to pass to the trigger.
-    ///
-    /// - Throws: An error if any value throws an error during encoding or decoding.
-    /// - Throws: An error if the callable fails to complete
-    ///
-    /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func call(_ data: Request) async throws -> Response {
-      let encoded = try encoder.encode(data)
-      let result = try await callable.call(encoded)
-      return try decoder.decode(Response.self, from: result.data)
-    }
+  /// Executes this Callable HTTPS trigger asynchronously.
+  ///
+  /// The data passed into the trigger must be of the generic `Request` type:
+  ///
+  /// The request to the Cloud Functions backend made by this method automatically includes a
+  /// FCM token to identify the app instance. If a user is logged in with Firebase
+  /// Auth, an auth ID token for the user is also automatically included.
+  ///
+  /// Firebase Cloud Messaging sends data to the Firebase backend periodically to collect
+  /// information
+  /// regarding the app instance. To stop this, see `Messaging.deleteData()`. It
+  /// resumes with a new FCM Token the next time you call this method.
+  ///
+  /// - Parameter data: The `Request` representing the data to pass to the trigger.
+  ///
+  /// - Throws: An error if any value throws an error during encoding or decoding.
+  /// - Throws: An error if the callable fails to complete
+  ///
+  /// - Returns: The decoded `Response` value
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  public func call(_ data: Request) async throws -> Response {
+    let encoded = try encoder.encode(data)
+    let result = try await callable.call(encoded)
+    return try decoder.decode(Response.self, from: result.data)
+  }
 
-    /// Creates a directly callable function.
-    ///
-    /// This allows users to call a HTTPS Callable Function like a normal Swift function:
-    /// ```swift
-    ///     let greeter = functions.httpsCallable("greeter",
-    ///                                           requestType: GreetingRequest.self,
-    ///                                           responseType: GreetingResponse.self)
-    ///     let result = try await greeter(data)
-    ///     print(result.greeting)
-    /// ```
-    /// You can also call a HTTPS Callable function using the following syntax:
-    /// ```swift
-    ///     let greeter: Callable<GreetingRequest, GreetingResponse> =
-    /// functions.httpsCallable("greeter")
-    ///     let result = try await greeter(data)
-    ///     print(result.greeting)
-    /// ```
-    /// - Parameters:
-    ///   - data: Parameters to pass to the trigger.
-    /// - Returns: The decoded `Response` value
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func callAsFunction(_ data: Request) async throws -> Response {
-      return try await call(data)
-    }
+  /// Creates a directly callable function.
+  ///
+  /// This allows users to call a HTTPS Callable Function like a normal Swift function:
+  /// ```swift
+  ///     let greeter = functions.httpsCallable("greeter",
+  ///                                           requestType: GreetingRequest.self,
+  ///                                           responseType: GreetingResponse.self)
+  ///     let result = try await greeter(data)
+  ///     print(result.greeting)
+  /// ```
+  /// You can also call a HTTPS Callable function using the following syntax:
+  /// ```swift
+  ///     let greeter: Callable<GreetingRequest, GreetingResponse> =
+  /// functions.httpsCallable("greeter")
+  ///     let result = try await greeter(data)
+  ///     print(result.greeting)
+  /// ```
+  /// - Parameters:
+  ///   - data: Parameters to pass to the trigger.
+  /// - Returns: The decoded `Response` value
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  public func callAsFunction(_ data: Request) async throws -> Response {
+    return try await call(data)
+  }
 }

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -139,32 +139,32 @@ open class HTTPSCallable: NSObject {
     call(nil, completion: completion)
   }
 
-    /**
-     * Executes this Callable HTTPS trigger asynchronously.
-     *
-     * The request to the Cloud Functions backend made by this method automatically includes a
-     * FCM token to identify the app instance. If a user is logged in with Firebase
-     * Auth, an auth ID token for the user is also automatically included.
-     *
-     * Firebase Cloud Messaging sends data to the Firebase backend periodically to collect information
-     * regarding the app instance. To stop this, see `Messaging.deleteData()`. It
-     * resumes with a new FCM Token the next time you call this method.
-     *
-     * - Parameter data Parameters to pass to the trigger.
-     * - Throws: An error if the Cloud Functions invocation failed.
-     * - Returns: The result of the call.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
-      return try await withCheckedThrowingContinuation { continuation in
-        // TODO(bonus): Use task to handle and cancellation.
-        self.call(data) { callableResult, error in
-          if let callableResult = callableResult {
-            continuation.resume(returning: callableResult)
-          } else {
-            continuation.resume(throwing: error!)
-          }
+  /**
+   * Executes this Callable HTTPS trigger asynchronously.
+   *
+   * The request to the Cloud Functions backend made by this method automatically includes a
+   * FCM token to identify the app instance. If a user is logged in with Firebase
+   * Auth, an auth ID token for the user is also automatically included.
+   *
+   * Firebase Cloud Messaging sends data to the Firebase backend periodically to collect information
+   * regarding the app instance. To stop this, see `Messaging.deleteData()`. It
+   * resumes with a new FCM Token the next time you call this method.
+   *
+   * - Parameter data Parameters to pass to the trigger.
+   * - Throws: An error if the Cloud Functions invocation failed.
+   * - Returns: The result of the call.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
+    return try await withCheckedThrowingContinuation { continuation in
+      // TODO(bonus): Use task to handle and cancellation.
+      self.call(data) { callableResult, error in
+        if let callableResult = callableResult {
+          continuation.resume(returning: callableResult)
+        } else {
+          continuation.resume(throwing: error!)
         }
       }
     }
+  }
 }

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -139,7 +139,6 @@ open class HTTPSCallable: NSObject {
     call(nil, completion: completion)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /**
      * Executes this Callable HTTPS trigger asynchronously.
      *
@@ -168,5 +167,4 @@ open class HTTPSCallable: NSObject {
         }
       }
     }
-  #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 }

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -118,34 +118,34 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testDataAsync() async throws {
-      let data = DataTestRequest(
-        bool: true,
-        int: 2,
-        long: 9_876_543_210,
-        string: "four",
-        array: [5, 6],
-        null: nil
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testDataAsync() async throws {
+    let data = DataTestRequest(
+      bool: true,
+      int: 2,
+      long: 9_876_543_210,
+      string: "four",
+      array: [5, 6],
+      null: nil
+    )
+
+    let byName = functions.httpsCallable("dataTest",
+                                         requestAs: DataTestRequest.self,
+                                         responseAs: DataTestResponse.self)
+    let byUrl = functions.httpsCallable(emulatorURL("dataTest"),
+                                        requestAs: DataTestRequest.self,
+                                        responseAs: DataTestResponse.self)
+
+    for function in [byName, byUrl] {
+      let response = try await function.call(data)
+      let expected = DataTestResponse(
+        message: "stub response",
+        long: 420,
+        code: 42
       )
-
-      let byName = functions.httpsCallable("dataTest",
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
-      let byUrl = functions.httpsCallable(emulatorURL("dataTest"),
-                                          requestAs: DataTestRequest.self,
-                                          responseAs: DataTestResponse.self)
-
-      for function in [byName, byUrl] {
-        let response = try await function.call(data)
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-      }
+      XCTAssertEqual(response, expected)
     }
+  }
 
   func testScalar() {
     let byName = functions.httpsCallable(
@@ -173,35 +173,34 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testScalarAsync() async throws {
-      let byName = functions.httpsCallable(
-        "scalarTest",
-        requestAs: Int16.self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("scalarTest"),
-        requestAs: Int16.self,
-        responseAs: Int.self
-      )
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testScalarAsync() async throws {
+    let byName = functions.httpsCallable(
+      "scalarTest",
+      requestAs: Int16.self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("scalarTest"),
+      requestAs: Int16.self,
+      responseAs: Int.self
+    )
 
-      for function in [byName, byURL] {
-        let result = try await function.call(17)
-        XCTAssertEqual(result, 76)
-      }
+    for function in [byName, byURL] {
+      let result = try await function.call(17)
+      XCTAssertEqual(result, 76)
     }
+  }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testScalarAsyncAlternateSignature() async throws {
-      let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
-      let byURL: Callable<Int16, Int> = functions.httpsCallable(emulatorURL("scalarTest"))
-      for function in [byName, byURL] {
-        let result = try await function.call(17)
-        XCTAssertEqual(result, 76)
-      }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testScalarAsyncAlternateSignature() async throws {
+    let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
+    let byURL: Callable<Int16, Int> = functions.httpsCallable(emulatorURL("scalarTest"))
+    for function in [byName, byURL] {
+      let result = try await function.call(17)
+      XCTAssertEqual(result, 76)
     }
-
+  }
 
   func testToken() {
     // Recreate functions with a token.
@@ -241,35 +240,35 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testTokenAsync() async throws {
-      // Recreate functions with a token.
-      let functions = Functions(
-        projectID: "functions-integration-test",
-        region: "us-central1",
-        customDomain: nil,
-        auth: AuthTokenProvider(token: "token"),
-        messaging: MessagingTokenProvider(),
-        appCheck: nil
-      )
-      functions.useEmulator(withHost: "localhost", port: 5005)
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testTokenAsync() async throws {
+    // Recreate functions with a token.
+    let functions = Functions(
+      projectID: "functions-integration-test",
+      region: "us-central1",
+      customDomain: nil,
+      auth: AuthTokenProvider(token: "token"),
+      messaging: MessagingTokenProvider(),
+      appCheck: nil
+    )
+    functions.useEmulator(withHost: "localhost", port: 5005)
 
-      let byName = functions.httpsCallable(
-        "tokenTest",
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("tokenTest"),
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
+    let byName = functions.httpsCallable(
+      "tokenTest",
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("tokenTest"),
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
 
-      for function in [byName, byURL] {
-        let data = try await function.call([:])
-        XCTAssertEqual(data, [:])
-      }
+    for function in [byName, byURL] {
+      let data = try await function.call([:])
+      XCTAssertEqual(data, [:])
     }
+  }
 
   func testFCMToken() {
     let byName = functions.httpsCallable(
@@ -297,24 +296,24 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testFCMTokenAsync() async throws {
-      let byName = functions.httpsCallable(
-        "FCMTokenTest",
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("FCMTokenTest"),
-        requestAs: [String: Int].self,
-        responseAs: [String: Int].self
-      )
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testFCMTokenAsync() async throws {
+    let byName = functions.httpsCallable(
+      "FCMTokenTest",
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("FCMTokenTest"),
+      requestAs: [String: Int].self,
+      responseAs: [String: Int].self
+    )
 
-      for function in [byName, byURL] {
-        let data = try await function.call([:])
-        XCTAssertEqual(data, [:])
-      }
+    for function in [byName, byURL] {
+      let data = try await function.call([:])
+      XCTAssertEqual(data, [:])
     }
+  }
 
   func testNull() {
     let byName = functions.httpsCallable(
@@ -342,24 +341,24 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testNullAsync() async throws {
-      let byName = functions.httpsCallable(
-        "nullTest",
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("nullTest"),
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testNullAsync() async throws {
+    let byName = functions.httpsCallable(
+      "nullTest",
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("nullTest"),
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
 
-      for function in [byName, byURL] {
-        let data = try await function.call(nil)
-        XCTAssertEqual(data, nil)
-      }
+    for function in [byName, byURL] {
+      let data = try await function.call(nil)
+      XCTAssertEqual(data, nil)
     }
+  }
 
   func testMissingResult() {
     let byName = functions.httpsCallable(
@@ -391,29 +390,29 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testMissingResultAsync() async {
-      let byName = functions.httpsCallable(
-        "missingResultTest",
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("missingResultTest"),
-        requestAs: Int?.self,
-        responseAs: Int?.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call(nil)
-          XCTFail("Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-          XCTAssertEqual("Response is missing data field.", error.localizedDescription)
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testMissingResultAsync() async {
+    let byName = functions.httpsCallable(
+      "missingResultTest",
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("missingResultTest"),
+      requestAs: Int?.self,
+      responseAs: Int?.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call(nil)
+        XCTFail("Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("Response is missing data field.", error.localizedDescription)
       }
     }
+  }
 
   func testUnhandledError() {
     let byName = functions.httpsCallable(
@@ -445,29 +444,29 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testUnhandledErrorAsync() async {
-      let byName = functions.httpsCallable(
-        "unhandledErrorTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        "unhandledErrorTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTFail("Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-          XCTAssertEqual("INTERNAL", error.localizedDescription)
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testUnhandledErrorAsync() async {
+    let byName = functions.httpsCallable(
+      "unhandledErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      "unhandledErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTFail("Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("INTERNAL", error.localizedDescription)
       }
     }
+  }
 
   func testUnknownError() {
     let byName = functions.httpsCallable(
@@ -498,29 +497,29 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testUnknownErrorAsync() async {
-      let byName = functions.httpsCallable(
-        "unknownErrorTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("unknownErrorTest"),
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTAssertFalse(true, "Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
-          XCTAssertEqual("INTERNAL", error.localizedDescription)
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testUnknownErrorAsync() async {
+    let byName = functions.httpsCallable(
+      "unknownErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("unknownErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTAssertFalse(true, "Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
+        XCTAssertEqual("INTERNAL", error.localizedDescription)
       }
     }
+  }
 
   func testExplicitError() {
     let byName = functions.httpsCallable(
@@ -553,31 +552,31 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testExplicitErrorAsync() async {
-      let byName = functions.httpsCallable(
-        "explicitErrorTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("explicitErrorTest"),
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTAssertFalse(true, "Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
-          XCTAssertEqual("explicit nope", error.localizedDescription)
-          XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
-                         error.userInfo["details"] as? [String: Int32])
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testExplicitErrorAsync() async {
+    let byName = functions.httpsCallable(
+      "explicitErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("explicitErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTAssertFalse(true, "Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.outOfRange.rawValue, error.code)
+        XCTAssertEqual("explicit nope", error.localizedDescription)
+        XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
+                       error.userInfo["details"] as? [String: Int32])
       }
     }
+  }
 
   func testHttpError() {
     let byName = functions.httpsCallable(
@@ -608,28 +607,28 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testHttpErrorAsync() async {
-      let byName = functions.httpsCallable(
-        "httpErrorTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("httpErrorTest"),
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTAssertFalse(true, "Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testHttpErrorAsync() async {
+    let byName = functions.httpsCallable(
+      "httpErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("httpErrorTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTAssertFalse(true, "Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
       }
     }
+  }
 
   func testThrowError() {
     let byName = functions.httpsCallable(
@@ -661,29 +660,29 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testThrowErrorAsync() async {
-      let byName = functions.httpsCallable(
-        "throwTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      let byURL = functions.httpsCallable(
-        emulatorURL("throwTest"),
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTAssertFalse(true, "Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
-          XCTAssertEqual(error.localizedDescription, "Invalid test requested.")
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testThrowErrorAsync() async {
+    let byName = functions.httpsCallable(
+      "throwTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    let byURL = functions.httpsCallable(
+      emulatorURL("throwTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTAssertFalse(true, "Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
+        XCTAssertEqual(error.localizedDescription, "Invalid test requested.")
       }
     }
+  }
 
   func testTimeout() {
     let byName = functions.httpsCallable(
@@ -716,32 +715,32 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testTimeoutAsync() async {
-      var byName = functions.httpsCallable(
-        "timeoutTest",
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      byName.timeoutInterval = 0.05
-      var byURL = functions.httpsCallable(
-        emulatorURL("timeoutTest"),
-        requestAs: [Int].self,
-        responseAs: Int.self
-      )
-      byURL.timeoutInterval = 0.05
-      for function in [byName, byURL] {
-        do {
-          _ = try await function.call([])
-          XCTAssertFalse(true, "Failed to throw error for missing result")
-        } catch {
-          let error = error as NSError
-          XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
-          XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
-          XCTAssertNil(error.userInfo["details"])
-        }
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testTimeoutAsync() async {
+    var byName = functions.httpsCallable(
+      "timeoutTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    byName.timeoutInterval = 0.05
+    var byURL = functions.httpsCallable(
+      emulatorURL("timeoutTest"),
+      requestAs: [Int].self,
+      responseAs: Int.self
+    )
+    byURL.timeoutInterval = 0.05
+    for function in [byName, byURL] {
+      do {
+        _ = try await function.call([])
+        XCTAssertFalse(true, "Failed to throw error for missing result")
+      } catch {
+        let error = error as NSError
+        XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
+        XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
+        XCTAssertNil(error.userInfo["details"])
       }
     }
+  }
 
   func testCallAsFunction() {
     let data = DataTestRequest(
@@ -778,35 +777,35 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testCallAsFunctionAsync() async throws {
-      let data = DataTestRequest(
-        bool: true,
-        int: 2,
-        long: 9_876_543_210,
-        string: "four",
-        array: [5, 6],
-        null: nil
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testCallAsFunctionAsync() async throws {
+    let data = DataTestRequest(
+      bool: true,
+      int: 2,
+      long: 9_876_543_210,
+      string: "four",
+      array: [5, 6],
+      null: nil
+    )
+
+    let byName = functions.httpsCallable("dataTest",
+                                         requestAs: DataTestRequest.self,
+                                         responseAs: DataTestResponse.self)
+
+    let byURL = functions.httpsCallable(emulatorURL("dataTest"),
+                                        requestAs: DataTestRequest.self,
+                                        responseAs: DataTestResponse.self)
+
+    for function in [byName, byURL] {
+      let response = try await function(data)
+      let expected = DataTestResponse(
+        message: "stub response",
+        long: 420,
+        code: 42
       )
-
-      let byName = functions.httpsCallable("dataTest",
-                                           requestAs: DataTestRequest.self,
-                                           responseAs: DataTestResponse.self)
-
-      let byURL = functions.httpsCallable(emulatorURL("dataTest"),
-                                          requestAs: DataTestRequest.self,
-                                          responseAs: DataTestResponse.self)
-
-      for function in [byName, byURL] {
-        let response = try await function(data)
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-      }
+      XCTAssertEqual(response, expected)
     }
+  }
 
   func testInferredTypes() {
     let data = DataTestRequest(
@@ -841,32 +840,32 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func testInferredTyesAsync() async throws {
-      let data = DataTestRequest(
-        bool: true,
-        int: 2,
-        long: 9_876_543_210,
-        string: "four",
-        array: [5, 6],
-        null: nil
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func testInferredTyesAsync() async throws {
+    let data = DataTestRequest(
+      bool: true,
+      int: 2,
+      long: 9_876_543_210,
+      string: "four",
+      array: [5, 6],
+      null: nil
+    )
+
+    let byName: Callable<DataTestRequest, DataTestResponse> = functions
+      .httpsCallable("dataTest")
+    let byURL: Callable<DataTestRequest, DataTestResponse> = functions
+      .httpsCallable(emulatorURL("dataTest"))
+
+    for function in [byName, byURL] {
+      let response = try await function(data)
+      let expected = DataTestResponse(
+        message: "stub response",
+        long: 420,
+        code: 42
       )
-
-      let byName: Callable<DataTestRequest, DataTestResponse> = functions
-        .httpsCallable("dataTest")
-      let byURL: Callable<DataTestRequest, DataTestResponse> = functions
-        .httpsCallable(emulatorURL("dataTest"))
-
-      for function in [byName, byURL] {
-        let response = try await function(data)
-        let expected = DataTestResponse(
-          message: "stub response",
-          long: 420,
-          code: 42
-        )
-        XCTAssertEqual(response, expected)
-      }
+      XCTAssertEqual(response, expected)
     }
+  }
 }
 
 private class AuthTokenProvider: AuthInterop {

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -118,7 +118,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testDataAsync() async throws {
       let data = DataTestRequest(
@@ -147,7 +146,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(response, expected)
       }
     }
-  #endif
 
   func testScalar() {
     let byName = functions.httpsCallable(
@@ -175,7 +173,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testScalarAsync() async throws {
       let byName = functions.httpsCallable(
@@ -205,7 +202,6 @@ class IntegrationTests: XCTestCase {
       }
     }
 
-  #endif
 
   func testToken() {
     // Recreate functions with a token.
@@ -245,7 +241,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testTokenAsync() async throws {
       // Recreate functions with a token.
@@ -275,7 +270,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, [:])
       }
     }
-  #endif
 
   func testFCMToken() {
     let byName = functions.httpsCallable(
@@ -303,7 +297,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testFCMTokenAsync() async throws {
       let byName = functions.httpsCallable(
@@ -322,7 +315,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, [:])
       }
     }
-  #endif
 
   func testNull() {
     let byName = functions.httpsCallable(
@@ -350,7 +342,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testNullAsync() async throws {
       let byName = functions.httpsCallable(
@@ -369,7 +360,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(data, nil)
       }
     }
-  #endif
 
   func testMissingResult() {
     let byName = functions.httpsCallable(
@@ -401,7 +391,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testMissingResultAsync() async {
       let byName = functions.httpsCallable(
@@ -425,7 +414,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testUnhandledError() {
     let byName = functions.httpsCallable(
@@ -457,7 +445,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnhandledErrorAsync() async {
       let byName = functions.httpsCallable(
@@ -481,7 +468,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testUnknownError() {
     let byName = functions.httpsCallable(
@@ -512,7 +498,6 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testUnknownErrorAsync() async {
       let byName = functions.httpsCallable(
@@ -536,7 +521,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testExplicitError() {
     let byName = functions.httpsCallable(
@@ -569,7 +553,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testExplicitErrorAsync() async {
       let byName = functions.httpsCallable(
@@ -595,7 +578,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testHttpError() {
     let byName = functions.httpsCallable(
@@ -626,7 +608,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testHttpErrorAsync() async {
       let byName = functions.httpsCallable(
@@ -649,7 +630,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testThrowError() {
     let byName = functions.httpsCallable(
@@ -681,7 +661,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testThrowErrorAsync() async {
       let byName = functions.httpsCallable(
@@ -705,7 +684,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testTimeout() {
     let byName = functions.httpsCallable(
@@ -738,7 +716,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testTimeoutAsync() async {
       var byName = functions.httpsCallable(
@@ -765,7 +742,6 @@ class IntegrationTests: XCTestCase {
         }
       }
     }
-  #endif
 
   func testCallAsFunction() {
     let data = DataTestRequest(
@@ -802,7 +778,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testCallAsFunctionAsync() async throws {
       let data = DataTestRequest(
@@ -832,7 +807,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(response, expected)
       }
     }
-  #endif
 
   func testInferredTypes() {
     let data = DataTestRequest(
@@ -867,7 +841,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func testInferredTyesAsync() async throws {
       let data = DataTestRequest(
@@ -894,7 +867,6 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(response, expected)
       }
     }
-  #endif
 }
 
 private class AuthTokenProvider: AuthInterop {

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -85,17 +85,17 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let result = try await callableRef.call(data)
-            _ = result.data
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let result = try await callableRef.call(data)
+          _ = result.data
+        } catch {
+          // ...
         }
       }
+    }
 
     callableRef.call { result, error in
       if let result = result {
@@ -105,17 +105,17 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            let result = try await callableRef.call()
-            _ = result.data
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          let result = try await callableRef.call()
+          _ = result.data
+        } catch {
+          // ...
         }
       }
+    }
 
     // MARK: - FunctionsErrorCode
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -85,7 +85,6 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -97,7 +96,6 @@ final class FunctionsAPITests: XCTestCase {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     callableRef.call { result, error in
       if let result = result {
@@ -107,7 +105,6 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -119,7 +116,6 @@ final class FunctionsAPITests: XCTestCase {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // MARK: - FunctionsErrorCode
 

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -51,16 +51,16 @@ final class InstallationsAPITests {
       }
     }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            try await Installations.installations().installationID()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          try await Installations.installations().installationID()
+        } catch {
+          // ...
         }
       }
+    }
 
     // Retrieves an installation auth token
     Installations.installations().authToken { result, error in
@@ -71,16 +71,16 @@ final class InstallationsAPITests {
       }
     }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            _ = try await Installations.installations().authToken()
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          _ = try await Installations.installations().authToken()
+        } catch {
+          // ...
         }
       }
+    }
 
     // Retrieves an installation auth token with forcing refresh parameter
     Installations.installations().authTokenForcingRefresh(true) { result, error in
@@ -91,16 +91,16 @@ final class InstallationsAPITests {
       }
     }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
-        Task {
-          do {
-            _ = try await Installations.installations().authTokenForcingRefresh(true)
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift 5.5+ feature available on iOS 15+
+      Task {
+        do {
+          _ = try await Installations.installations().authTokenForcingRefresh(true)
+        } catch {
+          // ...
         }
       }
+    }
 
     // Delete installation data
     Installations.installations().delete { error in

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -51,7 +51,6 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -62,7 +61,6 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Retrieves an installation auth token
     Installations.installations().authToken { result, error in
@@ -73,7 +71,6 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -84,7 +81,6 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Retrieves an installation auth token with forcing refresh parameter
     Installations.installations().authTokenForcingRefresh(true) { result, error in
@@ -95,7 +91,6 @@ final class InstallationsAPITests {
       }
     }
 
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift 5.5+ feature available on iOS 15+
         Task {
@@ -106,7 +101,6 @@ final class InstallationsAPITests {
           }
         }
       }
-    #endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
     // Delete installation data
     Installations.installations().delete { error in

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -127,7 +127,6 @@ class CustomDelegate: NSObject, MessagingDelegate {
 func apiAsync() async throws {
   let messaging = Messaging.messaging()
   let topic = "cat_video"
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     try await messaging.subscribe(toTopic: topic)
 
     try await messaging.unsubscribe(fromTopic: topic)
@@ -147,5 +146,4 @@ func apiAsync() async throws {
       try await messaging.unsubscribe(fromTopic: topic)
     } catch MessagingError.timeout {
     } catch {}
-  #endif
 }

--- a/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
+++ b/FirebaseMessaging/Tests/UnitTestsSwift/FIRMessagingAPITest.swift
@@ -127,23 +127,23 @@ class CustomDelegate: NSObject, MessagingDelegate {
 func apiAsync() async throws {
   let messaging = Messaging.messaging()
   let topic = "cat_video"
-    try await messaging.subscribe(toTopic: topic)
+  try await messaging.subscribe(toTopic: topic)
 
+  try await messaging.unsubscribe(fromTopic: topic)
+
+  try await messaging.token()
+
+  try await messaging.retrieveFCMToken(forSenderID: "fakeSenderID")
+
+  try await messaging.deleteToken()
+
+  try await messaging.deleteFCMToken(forSenderID: "fakeSenderID")
+
+  try await messaging.deleteData()
+
+  // Test new handling of errors
+  do {
     try await messaging.unsubscribe(fromTopic: topic)
-
-    try await messaging.token()
-
-    try await messaging.retrieveFCMToken(forSenderID: "fakeSenderID")
-
-    try await messaging.deleteToken()
-
-    try await messaging.deleteFCMToken(forSenderID: "fakeSenderID")
-
-    try await messaging.deleteData()
-
-    // Test new handling of errors
-    do {
-      try await messaging.unsubscribe(fromTopic: topic)
-    } catch MessagingError.timeout {
-    } catch {}
+  } catch MessagingError.timeout {
+  } catch {}
 }

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -17,116 +17,116 @@ import FirebaseCore
 
 import XCTest
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AsyncAwaitTests: APITestBase {
-    func testFetchThenActivate() async throws {
-      let status = try await config.fetch()
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      let success = try await config.activate()
-      XCTAssertTrue(success)
-    }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class AsyncAwaitTests: APITestBase {
+  func testFetchThenActivate() async throws {
+    let status = try await config.fetch()
+    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+    let success = try await config.activate()
+    XCTAssertTrue(success)
+  }
 
-    func testFetchWithExpirationThenActivate() async throws {
-      let status = try await config.fetch(withExpirationDuration: 0)
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      _ = try await config.activate()
-      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-    }
+  func testFetchWithExpirationThenActivate() async throws {
+    let status = try await config.fetch(withExpirationDuration: 0)
+    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+    _ = try await config.activate()
+    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+  }
 
-    func testFetchAndActivate() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-    }
+  func testFetchAndActivate() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+  }
 
-    func testFetchAndActivateGenericValue() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-    }
+  func testFetchAndActivateGenericValue() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+  }
 
-    // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
-    func testUnchangedActivateWillFlag() async throws {
-      let status = try await config.fetch()
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      let changed = try await config.activate()
-      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-      XCTAssertTrue(!APITests.useFakeConfig || changed)
-      XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
-    }
+  // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
+  func testUnchangedActivateWillFlag() async throws {
+    let status = try await config.fetch()
+    XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+    let changed = try await config.activate()
+    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+    XCTAssertTrue(!APITests.useFakeConfig || changed)
+    XCTAssertEqual(config[Constants.key1].stringValue, Constants.value1)
+  }
 
-    func testFetchAndActivateUnchangedConfig() async throws {
-      guard APITests.useFakeConfig == false else { return }
+  func testFetchAndActivateUnchangedConfig() async throws {
+    guard APITests.useFakeConfig == false else { return }
 
-      XCTAssertEqual(config.settings.minimumFetchInterval, 0)
+    XCTAssertEqual(config.settings.minimumFetchInterval, 0)
 
-      // Represents pre-fetch occurring sometime in past.
-      let status = try await config.fetch()
-      XCTAssertEqual(status, .success)
+    // Represents pre-fetch occurring sometime in past.
+    let status = try await config.fetch()
+    XCTAssertEqual(status, .success)
 
-      // Represents a `fetchAndActivate` being made to pull latest changes from Remote Config.
-      let status2 = try await config.fetchAndActivate()
-      // Since no updates to remote config have occurred we use the `.successUsingPreFetchedData`.
-      // The behavior of the next test changed in Firebase 7.0.0.
-      // It's an open question which is correct, but it should only
-      // be changed in a major release.
-      // See https://github.com/firebase/firebase-ios-sdk/pull/8788
-      // XCTAssertEqual(status, .successUsingPreFetchedData)
-      XCTAssertEqual(status2, .successFetchedFromRemote)
-      // The `lastETagUpdateTime` should either be older or the same time as `lastFetchTime`.
-      if let lastFetchTime = try? XCTUnwrap(config.lastFetchTime) {
-        XCTAssertLessThanOrEqual(Double(config.settings.lastETagUpdateTime),
-                                 Double(lastFetchTime.timeIntervalSince1970))
-      } else {
-        XCTFail("Could not unwrap lastFetchTime.")
-      }
-    }
-
-    // MARK: - RemoteConfigConsole Tests
-
-    func testFetchConfigThenUpdateConsoleThenFetchAgain() async throws {
-      guard APITests.useFakeConfig == false else { return }
-
-      _ = try await config.fetchAndActivate()
-      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-      XCTAssertEqual(configValue, Constants.obiwan)
-
-      // Synchronously update the console.
-      console.updateRemoteConfigValue(Constants.yoda, forKey: Constants.jedi)
-
-      _ = try await config.fetchAndActivate()
-      let configValue2 = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-      XCTAssertEqual(configValue2, Constants.yoda)
-    }
-
-    func testFetchConfigThenAddValueOnConsoleThenFetchAgain() async throws {
-      guard APITests.useFakeConfig == false else { return }
-
-      // Ensure no Sith Lord has been written to Remote Config yet.
-      _ = try await config.fetchAndActivate()
-      XCTAssertTrue(config.configValue(forKey: Constants.sith).dataValue.isEmpty)
-
-      // Synchronously update the console
-      console.updateRemoteConfigValue(Constants.darthSidious, forKey: Constants.sith)
-
-      // Verify the Sith Lord can now be fetched from Remote Config
-      _ = try await config.fetchAndActivate()
-      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.sith).stringValue)
-      XCTAssertEqual(configValue, Constants.darthSidious)
-    }
-
-    func testFetchConfigThenDeleteValueOnConsoleThenFetchAgain() async throws {
-      guard APITests.useFakeConfig == false else { return }
-
-      _ = try await config.fetchAndActivate()
-      let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
-      XCTAssertEqual(configValue, Constants.obiwan)
-
-      // Synchronously delete value on the console.
-      console.removeRemoteConfigValue(forKey: Constants.jedi)
-
-      _ = try await config.fetchAndActivate()
-      XCTAssertTrue(config.configValue(forKey: Constants.jedi).dataValue.isEmpty,
-                    "Remote config should have been deleted.")
+    // Represents a `fetchAndActivate` being made to pull latest changes from Remote Config.
+    let status2 = try await config.fetchAndActivate()
+    // Since no updates to remote config have occurred we use the `.successUsingPreFetchedData`.
+    // The behavior of the next test changed in Firebase 7.0.0.
+    // It's an open question which is correct, but it should only
+    // be changed in a major release.
+    // See https://github.com/firebase/firebase-ios-sdk/pull/8788
+    // XCTAssertEqual(status, .successUsingPreFetchedData)
+    XCTAssertEqual(status2, .successFetchedFromRemote)
+    // The `lastETagUpdateTime` should either be older or the same time as `lastFetchTime`.
+    if let lastFetchTime = try? XCTUnwrap(config.lastFetchTime) {
+      XCTAssertLessThanOrEqual(Double(config.settings.lastETagUpdateTime),
+                               Double(lastFetchTime.timeIntervalSince1970))
+    } else {
+      XCTFail("Could not unwrap lastFetchTime.")
     }
   }
+
+  // MARK: - RemoteConfigConsole Tests
+
+  func testFetchConfigThenUpdateConsoleThenFetchAgain() async throws {
+    guard APITests.useFakeConfig == false else { return }
+
+    _ = try await config.fetchAndActivate()
+    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+    XCTAssertEqual(configValue, Constants.obiwan)
+
+    // Synchronously update the console.
+    console.updateRemoteConfigValue(Constants.yoda, forKey: Constants.jedi)
+
+    _ = try await config.fetchAndActivate()
+    let configValue2 = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+    XCTAssertEqual(configValue2, Constants.yoda)
+  }
+
+  func testFetchConfigThenAddValueOnConsoleThenFetchAgain() async throws {
+    guard APITests.useFakeConfig == false else { return }
+
+    // Ensure no Sith Lord has been written to Remote Config yet.
+    _ = try await config.fetchAndActivate()
+    XCTAssertTrue(config.configValue(forKey: Constants.sith).dataValue.isEmpty)
+
+    // Synchronously update the console
+    console.updateRemoteConfigValue(Constants.darthSidious, forKey: Constants.sith)
+
+    // Verify the Sith Lord can now be fetched from Remote Config
+    _ = try await config.fetchAndActivate()
+    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.sith).stringValue)
+    XCTAssertEqual(configValue, Constants.darthSidious)
+  }
+
+  func testFetchConfigThenDeleteValueOnConsoleThenFetchAgain() async throws {
+    guard APITests.useFakeConfig == false else { return }
+
+    _ = try await config.fetchAndActivate()
+    let configValue = try? XCTUnwrap(config.configValue(forKey: Constants.jedi).stringValue)
+    XCTAssertEqual(configValue, Constants.obiwan)
+
+    // Synchronously delete value on the console.
+    console.removeRemoteConfigValue(forKey: Constants.jedi)
+
+    _ = try await config.fetchAndActivate()
+    XCTAssertTrue(config.configValue(forKey: Constants.jedi).dataValue.isEmpty,
+                  "Remote config should have been deleted.")
+  }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/AsyncAwaitTests.swift
@@ -17,7 +17,6 @@ import FirebaseCore
 
 import XCTest
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class AsyncAwaitTests: APITestBase {
     func testFetchThenActivate() async throws {
@@ -131,4 +130,3 @@ import XCTest
                     "Remote config should have been deleted.")
     }
   }
-#endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -16,7 +16,6 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class CodableTests: APITestBase {
     // MARK: - Test decoding Remote Config JSON values
@@ -208,4 +207,3 @@ import XCTest
       XCTAssertEqual(readDefaults.arrayIntValue, [1, 2, 0, 3])
     }
   }
-#endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Codable.swift
@@ -16,194 +16,194 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class CodableTests: APITestBase {
-    // MARK: - Test decoding Remote Config JSON values
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class CodableTests: APITestBase {
+  // MARK: - Test decoding Remote Config JSON values
 
-    // Contrast this test with the subsequent one to see the value of the Codable API.
-    func testFetchAndActivateWithoutCodable() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let dict = try XCTUnwrap(config[Constants.jsonKey].jsonValue as? [String: AnyHashable])
-      XCTAssertEqual(dict["recipeName"], "PB&J")
-      XCTAssertEqual(dict["ingredients"], ["bread", "peanut butter", "jelly"])
-      XCTAssertEqual(dict["cookTime"], 7)
-      XCTAssertEqual(
-        config[Constants.jsonKey].jsonValue as! [String: AnyHashable],
-        Constants.jsonValue
-      )
-    }
-
-    struct Recipe: Decodable {
-      var recipeName: String
-      var ingredients: [String]
-      var cookTime: Int
-    }
-
-    func testFetchAndActivateWithCodable() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
-      XCTAssertEqual(recipe.recipeName, "PB&J")
-      XCTAssertEqual(recipe.ingredients, ["bread", "peanut butter", "jelly"])
-      XCTAssertEqual(recipe.cookTime, 7)
-    }
-
-    func testFetchAndActivateWithCodableAlternativeAPI() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let recipe: Recipe = try XCTUnwrap(config[Constants.jsonKey].decoded())
-      XCTAssertEqual(recipe.recipeName, "PB&J")
-      XCTAssertEqual(recipe.ingredients, ["bread", "peanut butter", "jelly"])
-      XCTAssertEqual(recipe.cookTime, 7)
-    }
-
-    func testFetchAndActivateWithCodableBadJson() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      do {
-        _ = try config[Constants.nonJsonKey].decoded(asType: Recipe.self)
-      } catch let DecodingError.typeMismatch(_, context) {
-        XCTAssertEqual(context.debugDescription,
-                       "Expected to decode Dictionary<String, Any> but found " +
-                         "FirebaseRemoteConfigValueDecoderHelper instead.")
-        return
-      }
-      XCTFail("Failed to catch trying to decode non-JSON key as JSON")
-    }
-
-    // MARK: - Test setting Remote Config defaults via an encodable struct
-
-    struct DataTestDefaults: Encodable {
-      var bool: Bool
-      var int: Int32
-      var long: Int64
-      var string: String
-    }
-
-    func testSetEncodeableDefaults() throws {
-      let data = DataTestDefaults(
-        bool: true,
-        int: 2,
-        long: 9_876_543_210,
-        string: "four"
-      )
-      try config.setDefaults(from: data)
-      let boolValue = try XCTUnwrap(config.defaultValue(forKey: "bool")).numberValue.boolValue
-      XCTAssertTrue(boolValue)
-      let intValue = try XCTUnwrap(config.defaultValue(forKey: "int")).numberValue.intValue
-      XCTAssertEqual(intValue, 2)
-      let longValue = try XCTUnwrap(config.defaultValue(forKey: "long")).numberValue.int64Value
-      XCTAssertEqual(longValue, 9_876_543_210)
-      let stringValue = try XCTUnwrap(config.defaultValue(forKey: "string")).stringValue
-      XCTAssertEqual(stringValue, "four")
-    }
-
-    func testSetEncodeableDefaultsInvalid() throws {
-      do {
-        _ = try config.setDefaults(from: 7)
-      } catch let RemoteConfigCodableError.invalidSetDefaultsInput(message) {
-        XCTAssertEqual(message,
-                       "The setDefaults input: 7, must be a Struct that encodes to a Dictionary")
-        return
-      }
-      XCTFail("Failed to catch trying to encode an invalid input to setDefaults.")
-    }
-
-    // MARK: - Test extracting config to an decodable struct.
-
-    struct MyConfig: Decodable {
-      var Recipe: Recipe
-      var notJSON: String
-      var myInt: Int
-      var myFloat: Float
-      var myDecimal: Decimal
-      var myTrue: Bool
-      var myData: Data
-    }
-
-    func testExtractConfig() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let myConfig: MyConfig = try config.decoded()
-      XCTAssertEqual(myConfig.notJSON, Constants.nonJsonValue)
-      XCTAssertEqual(myConfig.myInt, Constants.intValue)
-      XCTAssertEqual(myConfig.myTrue, true)
-      XCTAssertEqual(myConfig.myFloat, Constants.floatValue)
-      XCTAssertEqual(myConfig.myDecimal, Constants.decimalValue)
-      XCTAssertEqual(myConfig.myData, Constants.dataValue)
-      XCTAssertEqual(myConfig.Recipe.recipeName, "PB&J")
-      XCTAssertEqual(myConfig.Recipe.ingredients, ["bread", "peanut butter", "jelly"])
-      XCTAssertEqual(myConfig.Recipe.cookTime, 7)
-    }
-
-    // Additional fields in config are ignored.
-    func testExtractConfigExtra() async throws {
-      guard APITests.useFakeConfig else { return }
-      fakeConsole.config["extra"] = "extra Value"
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let myConfig: MyConfig = try config.decoded()
-      XCTAssertEqual(myConfig.notJSON, Constants.nonJsonValue)
-      XCTAssertEqual(myConfig.Recipe.recipeName, "PB&J")
-      XCTAssertEqual(myConfig.Recipe.ingredients, ["bread", "peanut butter", "jelly"])
-      XCTAssertEqual(myConfig.Recipe.cookTime, 7)
-    }
-
-    // Failure if requested field does not exist.
-    func testExtractConfigMissing() async throws {
-      struct MyConfig: Decodable {
-        var missing: String
-        var Recipe: String
-        var notJSON: String
-      }
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      do {
-        let _: MyConfig = try config.decoded()
-      } catch let DecodingError.keyNotFound(codingKey, context) {
-        XCTAssertEqual(codingKey.stringValue, "missing")
-        print(codingKey, context)
-        return
-      }
-      XCTFail("Failed to throw on missing field")
-    }
-
-    func testCodableAfterPlistDefaults() throws {
-      struct Defaults: Codable {
-        let format: String
-        let isPaidUser: Bool
-        let newItem: Double
-        let Languages: String
-        let dictValue: [String: String]
-        let arrayValue: [String]
-        let arrayIntValue: [Int]
-      }
-      // setDefaults(fromPlist:) doesn't work because of dynamic linking.
-      // More details in RCNRemoteConfigTest.m
-      var findPlist: String?
-      #if SWIFT_PACKAGE
-        findPlist = Bundle.module.path(forResource: "Defaults-testInfo", ofType: "plist")
-      #else
-        for b in Bundle.allBundles {
-          findPlist = b.path(forResource: "Defaults-testInfo", ofType: "plist")
-          if findPlist != nil {
-            break
-          }
-        }
-      #endif
-      let plistFile = try XCTUnwrap(findPlist)
-      let defaults = NSDictionary(contentsOfFile: plistFile)
-      config.setDefaults(defaults as? [String: NSObject])
-      let readDefaults: Defaults = try config.decoded()
-      XCTAssertEqual(readDefaults.format, "key to value.")
-      XCTAssertEqual(readDefaults.isPaidUser, true)
-      XCTAssertEqual(readDefaults.newItem, 2.4)
-      XCTAssertEqual(readDefaults.Languages, "English")
-      XCTAssertEqual(readDefaults.dictValue, ["foo": "foo",
-                                              "bar": "bar",
-                                              "baz": "baz"])
-      XCTAssertEqual(readDefaults.arrayValue, ["foo", "bar", "baz"])
-      XCTAssertEqual(readDefaults.arrayIntValue, [1, 2, 0, 3])
-    }
+  // Contrast this test with the subsequent one to see the value of the Codable API.
+  func testFetchAndActivateWithoutCodable() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let dict = try XCTUnwrap(config[Constants.jsonKey].jsonValue as? [String: AnyHashable])
+    XCTAssertEqual(dict["recipeName"], "PB&J")
+    XCTAssertEqual(dict["ingredients"], ["bread", "peanut butter", "jelly"])
+    XCTAssertEqual(dict["cookTime"], 7)
+    XCTAssertEqual(
+      config[Constants.jsonKey].jsonValue as! [String: AnyHashable],
+      Constants.jsonValue
+    )
   }
+
+  struct Recipe: Decodable {
+    var recipeName: String
+    var ingredients: [String]
+    var cookTime: Int
+  }
+
+  func testFetchAndActivateWithCodable() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
+    XCTAssertEqual(recipe.recipeName, "PB&J")
+    XCTAssertEqual(recipe.ingredients, ["bread", "peanut butter", "jelly"])
+    XCTAssertEqual(recipe.cookTime, 7)
+  }
+
+  func testFetchAndActivateWithCodableAlternativeAPI() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let recipe: Recipe = try XCTUnwrap(config[Constants.jsonKey].decoded())
+    XCTAssertEqual(recipe.recipeName, "PB&J")
+    XCTAssertEqual(recipe.ingredients, ["bread", "peanut butter", "jelly"])
+    XCTAssertEqual(recipe.cookTime, 7)
+  }
+
+  func testFetchAndActivateWithCodableBadJson() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    do {
+      _ = try config[Constants.nonJsonKey].decoded(asType: Recipe.self)
+    } catch let DecodingError.typeMismatch(_, context) {
+      XCTAssertEqual(context.debugDescription,
+                     "Expected to decode Dictionary<String, Any> but found " +
+                       "FirebaseRemoteConfigValueDecoderHelper instead.")
+      return
+    }
+    XCTFail("Failed to catch trying to decode non-JSON key as JSON")
+  }
+
+  // MARK: - Test setting Remote Config defaults via an encodable struct
+
+  struct DataTestDefaults: Encodable {
+    var bool: Bool
+    var int: Int32
+    var long: Int64
+    var string: String
+  }
+
+  func testSetEncodeableDefaults() throws {
+    let data = DataTestDefaults(
+      bool: true,
+      int: 2,
+      long: 9_876_543_210,
+      string: "four"
+    )
+    try config.setDefaults(from: data)
+    let boolValue = try XCTUnwrap(config.defaultValue(forKey: "bool")).numberValue.boolValue
+    XCTAssertTrue(boolValue)
+    let intValue = try XCTUnwrap(config.defaultValue(forKey: "int")).numberValue.intValue
+    XCTAssertEqual(intValue, 2)
+    let longValue = try XCTUnwrap(config.defaultValue(forKey: "long")).numberValue.int64Value
+    XCTAssertEqual(longValue, 9_876_543_210)
+    let stringValue = try XCTUnwrap(config.defaultValue(forKey: "string")).stringValue
+    XCTAssertEqual(stringValue, "four")
+  }
+
+  func testSetEncodeableDefaultsInvalid() throws {
+    do {
+      _ = try config.setDefaults(from: 7)
+    } catch let RemoteConfigCodableError.invalidSetDefaultsInput(message) {
+      XCTAssertEqual(message,
+                     "The setDefaults input: 7, must be a Struct that encodes to a Dictionary")
+      return
+    }
+    XCTFail("Failed to catch trying to encode an invalid input to setDefaults.")
+  }
+
+  // MARK: - Test extracting config to an decodable struct.
+
+  struct MyConfig: Decodable {
+    var Recipe: Recipe
+    var notJSON: String
+    var myInt: Int
+    var myFloat: Float
+    var myDecimal: Decimal
+    var myTrue: Bool
+    var myData: Data
+  }
+
+  func testExtractConfig() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let myConfig: MyConfig = try config.decoded()
+    XCTAssertEqual(myConfig.notJSON, Constants.nonJsonValue)
+    XCTAssertEqual(myConfig.myInt, Constants.intValue)
+    XCTAssertEqual(myConfig.myTrue, true)
+    XCTAssertEqual(myConfig.myFloat, Constants.floatValue)
+    XCTAssertEqual(myConfig.myDecimal, Constants.decimalValue)
+    XCTAssertEqual(myConfig.myData, Constants.dataValue)
+    XCTAssertEqual(myConfig.Recipe.recipeName, "PB&J")
+    XCTAssertEqual(myConfig.Recipe.ingredients, ["bread", "peanut butter", "jelly"])
+    XCTAssertEqual(myConfig.Recipe.cookTime, 7)
+  }
+
+  // Additional fields in config are ignored.
+  func testExtractConfigExtra() async throws {
+    guard APITests.useFakeConfig else { return }
+    fakeConsole.config["extra"] = "extra Value"
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let myConfig: MyConfig = try config.decoded()
+    XCTAssertEqual(myConfig.notJSON, Constants.nonJsonValue)
+    XCTAssertEqual(myConfig.Recipe.recipeName, "PB&J")
+    XCTAssertEqual(myConfig.Recipe.ingredients, ["bread", "peanut butter", "jelly"])
+    XCTAssertEqual(myConfig.Recipe.cookTime, 7)
+  }
+
+  // Failure if requested field does not exist.
+  func testExtractConfigMissing() async throws {
+    struct MyConfig: Decodable {
+      var missing: String
+      var Recipe: String
+      var notJSON: String
+    }
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    do {
+      let _: MyConfig = try config.decoded()
+    } catch let DecodingError.keyNotFound(codingKey, context) {
+      XCTAssertEqual(codingKey.stringValue, "missing")
+      print(codingKey, context)
+      return
+    }
+    XCTFail("Failed to throw on missing field")
+  }
+
+  func testCodableAfterPlistDefaults() throws {
+    struct Defaults: Codable {
+      let format: String
+      let isPaidUser: Bool
+      let newItem: Double
+      let Languages: String
+      let dictValue: [String: String]
+      let arrayValue: [String]
+      let arrayIntValue: [Int]
+    }
+    // setDefaults(fromPlist:) doesn't work because of dynamic linking.
+    // More details in RCNRemoteConfigTest.m
+    var findPlist: String?
+    #if SWIFT_PACKAGE
+      findPlist = Bundle.module.path(forResource: "Defaults-testInfo", ofType: "plist")
+    #else
+      for b in Bundle.allBundles {
+        findPlist = b.path(forResource: "Defaults-testInfo", ofType: "plist")
+        if findPlist != nil {
+          break
+        }
+      }
+    #endif
+    let plistFile = try XCTUnwrap(findPlist)
+    let defaults = NSDictionary(contentsOfFile: plistFile)
+    config.setDefaults(defaults as? [String: NSObject])
+    let readDefaults: Defaults = try config.decoded()
+    XCTAssertEqual(readDefaults.format, "key to value.")
+    XCTAssertEqual(readDefaults.isPaidUser, true)
+    XCTAssertEqual(readDefaults.newItem, 2.4)
+    XCTAssertEqual(readDefaults.Languages, "English")
+    XCTAssertEqual(readDefaults.dictValue, ["foo": "foo",
+                                            "bar": "bar",
+                                            "baz": "baz"])
+    XCTAssertEqual(readDefaults.arrayValue, ["foo", "bar", "baz"])
+    XCTAssertEqual(readDefaults.arrayIntValue, [1, 2, 0, 3])
+  }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
@@ -21,48 +21,48 @@ import XCTest
 
 let ConfigKeyForThisTestOnly = "PropertyWrapperDefaultConfigsTestsKey"
 
-  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
-  class PropertyWrapperDefaultConfigsTests: XCTestCase {
-    struct Recipe: Decodable, Encodable {
-      var recipeName: String
-      var ingredients: [String]
-      var cookTime: Int
-    }
+@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+class PropertyWrapperDefaultConfigsTests: XCTestCase {
+  struct Recipe: Decodable, Encodable {
+    var recipeName: String
+    var ingredients: [String]
+    var cookTime: Int
+  }
 
-    static let defaultRecipe = Recipe(
-      recipeName: "muffin", ingredients: ["flour", "sugar"], cookTime: 45
+  static let defaultRecipe = Recipe(
+    recipeName: "muffin", ingredients: ["flour", "sugar"], cookTime: 45
+  )
+
+  // MARK: - Test Remote Config default values with property wrapper
+
+  struct DefaultsValuesTester {
+    @RemoteConfigProperty(
+      key: ConfigKeyForThisTestOnly,
+      fallback: Recipe(recipeName: "test", ingredients: [], cookTime: 0)
     )
+    var dictValue: Recipe
+  }
 
-    // MARK: - Test Remote Config default values with property wrapper
-
-    struct DefaultsValuesTester {
-      @RemoteConfigProperty(
-        key: ConfigKeyForThisTestOnly,
-        fallback: Recipe(recipeName: "test", ingredients: [], cookTime: 0)
-      )
-      var dictValue: Recipe
-    }
-
-    override class func setUp() {
-      if FirebaseApp.app() == nil {
-        let options = FirebaseOptions(googleAppID: "1:123:ios:123abc",
-                                      gcmSenderID: "correct_gcm_sender_id")
-        options.apiKey = "A23456789012345678901234567890123456789"
-        options.projectID = "Fake Project"
-        FirebaseApp.configure(options: options)
-      }
-    }
-
-    func testDefaultValues() async throws {
-      try? RemoteConfig.remoteConfig().setDefaults(
-        from: [ConfigKeyForThisTestOnly: PropertyWrapperDefaultConfigsTests.defaultRecipe]
-      )
-
-      let tester = await DefaultsValuesTester()
-      let dictValue = await tester.dictValue
-
-      XCTAssertEqual(dictValue.recipeName, "muffin")
-      XCTAssertEqual(dictValue.cookTime, 45)
-      XCTAssertEqual(dictValue.ingredients, ["flour", "sugar"])
+  override class func setUp() {
+    if FirebaseApp.app() == nil {
+      let options = FirebaseOptions(googleAppID: "1:123:ios:123abc",
+                                    gcmSenderID: "correct_gcm_sender_id")
+      options.apiKey = "A23456789012345678901234567890123456789"
+      options.projectID = "Fake Project"
+      FirebaseApp.configure(options: options)
     }
   }
+
+  func testDefaultValues() async throws {
+    try? RemoteConfig.remoteConfig().setDefaults(
+      from: [ConfigKeyForThisTestOnly: PropertyWrapperDefaultConfigsTests.defaultRecipe]
+    )
+
+    let tester = await DefaultsValuesTester()
+    let dictValue = await tester.dictValue
+
+    XCTAssertEqual(dictValue.recipeName, "muffin")
+    XCTAssertEqual(dictValue.cookTime, 45)
+    XCTAssertEqual(dictValue.ingredients, ["flour", "sugar"])
+  }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperDefaultConfigsTests.swift
@@ -21,7 +21,6 @@ import XCTest
 
 let ConfigKeyForThisTestOnly = "PropertyWrapperDefaultConfigsTestsKey"
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
   class PropertyWrapperDefaultConfigsTests: XCTestCase {
     struct Recipe: Decodable, Encodable {
@@ -67,4 +66,3 @@ let ConfigKeyForThisTestOnly = "PropertyWrapperDefaultConfigsTestsKey"
       XCTAssertEqual(dictValue.ingredients, ["flour", "sugar"])
     }
   }
-#endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
@@ -18,280 +18,280 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
-  class PropertyWrapperTests: APITestBase {
-    // MARK: - Test fetching Remote Config JSON values into struct property
+@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+class PropertyWrapperTests: APITestBase {
+  // MARK: - Test fetching Remote Config JSON values into struct property
 
-    struct Recipe: Decodable {
-      var recipeName: String
-      var ingredients: [String]
-      var cookTime: Int
+  struct Recipe: Decodable {
+    var recipeName: String
+    var ingredients: [String]
+    var cookTime: Int
+  }
+
+  static let fallbackString = "fallback"
+  static let fallbackInt = 50
+  static let fallbackFloat: Float = 50.2
+  static let fallbackDouble: Double = 16_777_216.333921
+  static let fallbackDecimal: Decimal = 235
+  static let fallbackData = "hello".data(using: .utf8)!
+  static let fallbackArray = ["mango", "pineapple", "papaya"]
+  static let fallbackDict = [
+    "session 0": "breakfast", "session 1": "keynote", "session 2": "state of union",
+  ]
+  static let fallbackJSON = Recipe(
+    recipeName: "muffin", ingredients: ["flour", "sugar"], cookTime: 45
+  )
+
+  struct PropertyWrapperTester {
+    @RemoteConfigProperty(key: Constants.stringKey, fallback: "")
+    var stringValue: String!
+
+    var stringKeyName: String {
+      return _stringValue.key
     }
 
-    static let fallbackString = "fallback"
-    static let fallbackInt = 50
-    static let fallbackFloat: Float = 50.2
-    static let fallbackDouble: Double = 16_777_216.333921
-    static let fallbackDecimal: Decimal = 235
-    static let fallbackData = "hello".data(using: .utf8)!
-    static let fallbackArray = ["mango", "pineapple", "papaya"]
-    static let fallbackDict = [
-      "session 0": "breakfast", "session 1": "keynote", "session 2": "state of union",
-    ]
-    static let fallbackJSON = Recipe(
-      recipeName: "muffin", ingredients: ["flour", "sugar"], cookTime: 45
-    )
+    @RemoteConfigProperty(key: Constants.intKey, fallback: 0)
+    var intValue: Int!
 
-    struct PropertyWrapperTester {
-      @RemoteConfigProperty(key: Constants.stringKey, fallback: "")
-      var stringValue: String!
-
-      var stringKeyName: String {
-        return _stringValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.intKey, fallback: 0)
-      var intValue: Int!
-
-      var intKeyName: String {
-        return _intValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.floatKey, fallback: 0)
-      var floatValue: Float!
-
-      var floatKeyName: String {
-        return _floatValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.floatKey, fallback: 0)
-      var doubleValue: Double!
-
-      var doubleKeyName: String {
-        return _doubleValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.decimalKey, fallback: 0)
-      var decimalValue: Decimal!
-
-      var decimalKeyName: String {
-        return _decimalValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.trueKey, fallback: false)
-      var trueValue: Bool!
-
-      var trueKeyName: String {
-        return _trueValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.falseKey, fallback: false)
-      var falseValue: Bool!
-
-      var falseKeyName: String {
-        return _falseValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.dataKey, fallback: Data())
-      var dataValue: Data!
-
-      var dataKeyName: String {
-        return _dataValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.jsonKey, fallback: nil)
-      var recipeValue: Recipe!
-
-      var recipeKeyName: String {
-        _recipeValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.arrayKey, fallback: [])
-      var arrayValue: [String]!
-
-      var arrayKeyName: String {
-        _arrayValue.key
-      }
-
-      @RemoteConfigProperty(key: Constants.dictKey, fallback: [:])
-      var dictValue: [String: String]!
-
-      var dictKeyName: String {
-        _dictValue.key
-      }
+    var intKeyName: String {
+      return _intValue.key
     }
 
-    struct PlaceholderValueTester {
-      @RemoteConfigProperty(key: "NewKeyNotInSystem", fallback: fallbackString)
-      var stringValue: String
+    @RemoteConfigProperty(key: Constants.floatKey, fallback: 0)
+    var floatValue: Float!
 
-      @RemoteConfigProperty(key: "NewIntKeyNotInSystem", fallback: fallbackInt)
-      var intValue: Int!
-
-      @RemoteConfigProperty(key: "NewZeroKey", fallback: 0)
-      var zeroIntValue: Int!
-
-      @RemoteConfigProperty(key: "newFloatKey", fallback: fallbackFloat)
-      var floatValue: Float!
-
-      @RemoteConfigProperty(key: "newDoubleKey", fallback: fallbackDouble)
-      var doubleValue: Double!
-
-      @RemoteConfigProperty(key: "newDecimalKey", fallback: fallbackDecimal)
-      var decimalValue: Decimal!
-
-      @RemoteConfigProperty(key: "newTrueKey", fallback: false)
-      var trueKeyFalseValue: Bool!
-
-      @RemoteConfigProperty(key: "newTrueKey2", fallback: true)
-      var trueKeyTrueValue: Bool!
-
-      @RemoteConfigProperty(key: "newFalseKey", fallback: true)
-      var falseKeyTrueValue: Bool!
-
-      @RemoteConfigProperty(key: "newFalseKey2", fallback: false)
-      var falseKeyFalseValue: Bool!
-
-      @RemoteConfigProperty(key: "newDataKey", fallback: fallbackData)
-      var dataValue: Data
-
-      @RemoteConfigProperty(key: "newJSONKey", fallback: fallbackJSON)
-      var recipeValue: Recipe!
-
-      @RemoteConfigProperty(key: "newArrayKey", fallback: fallbackArray)
-      var arrayValue: [String]!
-
-      @RemoteConfigProperty(key: "newDictKey", fallback: fallbackDict)
-      var dictValue: [String: String]!
+    var floatKeyName: String {
+      return _floatValue.key
     }
 
-    func testFetchAndActivateWithPropertyWrapper() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
+    @RemoteConfigProperty(key: Constants.floatKey, fallback: 0)
+    var doubleValue: Double!
 
-      let tester = await PropertyWrapperTester()
-
-      let stringValue = await tester.stringValue
-      XCTAssertEqual(stringValue, Constants.stringValue)
-
-      let intValue = await tester.intValue
-      XCTAssertEqual(intValue, Constants.intValue)
-
-      let floatValue = await tester.floatValue
-      XCTAssertEqual(floatValue, Constants.floatValue)
-
-      let doubleValue = await tester.doubleValue
-      XCTAssertEqual(doubleValue, Constants.doubleValue)
-
-      let decimalValue = await tester.decimalValue
-      XCTAssertEqual(decimalValue, Constants.decimalValue)
-
-      let trueValue = await tester.trueValue
-      XCTAssertEqual(trueValue, true)
-
-      let falseValue = await tester.falseValue
-      XCTAssertEqual(falseValue, false)
-
-      let dataValue = await tester.dataValue
-      XCTAssertEqual(dataValue, Constants.dataValue)
-
-      let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
-      let recipeValue = await tester.recipeValue
-      XCTAssertEqual(recipeValue?.recipeName, recipe.recipeName)
-      XCTAssertEqual(recipeValue?.ingredients, recipe.ingredients)
-      XCTAssertEqual(recipeValue?.cookTime, recipe.cookTime)
-
-      let arrayValue = await tester.arrayValue
-      XCTAssertEqual(arrayValue, Constants.arrayValue)
-
-      let dictValue = await tester.dictValue
-      XCTAssertEqual(dictValue, Constants.dictValue)
+    var doubleKeyName: String {
+      return _doubleValue.key
     }
 
-    func testPropertyWrapperInstanceValues() async {
-      let tester = await PropertyWrapperTester()
+    @RemoteConfigProperty(key: Constants.decimalKey, fallback: 0)
+    var decimalValue: Decimal!
 
-      let stringKeyName = await tester.stringKeyName
-      XCTAssertEqual(Constants.stringKey, stringKeyName)
-
-      let intKeyName = await tester.intKeyName
-      XCTAssertEqual(Constants.intKey, intKeyName)
-
-      let floatKeyName = await tester.floatKeyName
-      XCTAssertEqual(Constants.floatKey, floatKeyName)
-
-      let doubleKeyName = await tester.doubleKeyName
-      XCTAssertEqual(Constants.floatKey, doubleKeyName)
-
-      let decimalKeyName = await tester.decimalKeyName
-      XCTAssertEqual(Constants.decimalKey, decimalKeyName)
-
-      let trueKeyName = await tester.trueKeyName
-      XCTAssertEqual(Constants.trueKey, trueKeyName)
-
-      let falseKeyName = await tester.falseKeyName
-      XCTAssertEqual(Constants.falseKey, falseKeyName)
-
-      let dataKeyName = await tester.dataKeyName
-      XCTAssertEqual(Constants.dataKey, dataKeyName)
-
-      let recipeKeyName = await tester.recipeKeyName
-      XCTAssertEqual(Constants.jsonKey, recipeKeyName)
-
-      let arrayKeyName = await tester.arrayKeyName
-      XCTAssertEqual(Constants.arrayKey, arrayKeyName)
-
-      let dictKeyName = await tester.dictKeyName
-      XCTAssertEqual(Constants.dictKey, dictKeyName)
+    var decimalKeyName: String {
+      return _decimalValue.key
     }
 
-    func testPlaceHolderValues() async throws {
-      // Make sure the values below are consistent with the property wrapper
-      // in PlaceholderValueTester
-      let tester = await PlaceholderValueTester()
+    @RemoteConfigProperty(key: Constants.trueKey, fallback: false)
+    var trueValue: Bool!
 
-      let stringValue = await tester.stringValue
-      XCTAssertEqual(stringValue, PropertyWrapperTests.fallbackString)
+    var trueKeyName: String {
+      return _trueValue.key
+    }
 
-      let intValue = await tester.intValue
-      XCTAssertEqual(intValue, PropertyWrapperTests.fallbackInt)
+    @RemoteConfigProperty(key: Constants.falseKey, fallback: false)
+    var falseValue: Bool!
 
-      let zeroValue = await tester.zeroIntValue
-      XCTAssertEqual(zeroValue, 0)
+    var falseKeyName: String {
+      return _falseValue.key
+    }
 
-      let floatValue = await tester.floatValue
-      XCTAssertEqual(floatValue, PropertyWrapperTests.fallbackFloat)
+    @RemoteConfigProperty(key: Constants.dataKey, fallback: Data())
+    var dataValue: Data!
 
-      let doubleValue = await tester.doubleValue
-      XCTAssertEqual(doubleValue, PropertyWrapperTests.fallbackDouble)
+    var dataKeyName: String {
+      return _dataValue.key
+    }
 
-      let decimalValue = await tester.decimalValue
-      XCTAssertEqual(decimalValue, PropertyWrapperTests.fallbackDecimal)
+    @RemoteConfigProperty(key: Constants.jsonKey, fallback: nil)
+    var recipeValue: Recipe!
 
-      let trueKeyFalseValue = await tester.trueKeyFalseValue
-      XCTAssertEqual(trueKeyFalseValue, false)
+    var recipeKeyName: String {
+      _recipeValue.key
+    }
 
-      let trueKeyTrueValue = await tester.trueKeyTrueValue
-      XCTAssertEqual(trueKeyTrueValue, true)
+    @RemoteConfigProperty(key: Constants.arrayKey, fallback: [])
+    var arrayValue: [String]!
 
-      let falseKeyTrueValue = await tester.falseKeyTrueValue
-      XCTAssertEqual(falseKeyTrueValue, true)
+    var arrayKeyName: String {
+      _arrayValue.key
+    }
 
-      let falseKeyFalseValue = await tester.falseKeyFalseValue
-      XCTAssertEqual(falseKeyFalseValue, false)
+    @RemoteConfigProperty(key: Constants.dictKey, fallback: [:])
+    var dictValue: [String: String]!
 
-      let dataValue = await tester.dataValue
-      XCTAssertEqual(dataValue, PropertyWrapperTests.fallbackData)
-
-      let arrayValue = await tester.arrayValue
-      XCTAssertEqual(arrayValue, PropertyWrapperTests.fallbackArray)
-
-      let dictValue = await tester.dictValue
-      XCTAssertEqual(dictValue, PropertyWrapperTests.fallbackDict)
-
-      let recipeValue = await tester.recipeValue
-      XCTAssertEqual(recipeValue?.recipeName, "muffin")
-      XCTAssertEqual(recipeValue?.ingredients, ["flour", "sugar"])
-      XCTAssertEqual(recipeValue?.cookTime, 45)
+    var dictKeyName: String {
+      _dictValue.key
     }
   }
+
+  struct PlaceholderValueTester {
+    @RemoteConfigProperty(key: "NewKeyNotInSystem", fallback: fallbackString)
+    var stringValue: String
+
+    @RemoteConfigProperty(key: "NewIntKeyNotInSystem", fallback: fallbackInt)
+    var intValue: Int!
+
+    @RemoteConfigProperty(key: "NewZeroKey", fallback: 0)
+    var zeroIntValue: Int!
+
+    @RemoteConfigProperty(key: "newFloatKey", fallback: fallbackFloat)
+    var floatValue: Float!
+
+    @RemoteConfigProperty(key: "newDoubleKey", fallback: fallbackDouble)
+    var doubleValue: Double!
+
+    @RemoteConfigProperty(key: "newDecimalKey", fallback: fallbackDecimal)
+    var decimalValue: Decimal!
+
+    @RemoteConfigProperty(key: "newTrueKey", fallback: false)
+    var trueKeyFalseValue: Bool!
+
+    @RemoteConfigProperty(key: "newTrueKey2", fallback: true)
+    var trueKeyTrueValue: Bool!
+
+    @RemoteConfigProperty(key: "newFalseKey", fallback: true)
+    var falseKeyTrueValue: Bool!
+
+    @RemoteConfigProperty(key: "newFalseKey2", fallback: false)
+    var falseKeyFalseValue: Bool!
+
+    @RemoteConfigProperty(key: "newDataKey", fallback: fallbackData)
+    var dataValue: Data
+
+    @RemoteConfigProperty(key: "newJSONKey", fallback: fallbackJSON)
+    var recipeValue: Recipe!
+
+    @RemoteConfigProperty(key: "newArrayKey", fallback: fallbackArray)
+    var arrayValue: [String]!
+
+    @RemoteConfigProperty(key: "newDictKey", fallback: fallbackDict)
+    var dictValue: [String: String]!
+  }
+
+  func testFetchAndActivateWithPropertyWrapper() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+
+    let tester = await PropertyWrapperTester()
+
+    let stringValue = await tester.stringValue
+    XCTAssertEqual(stringValue, Constants.stringValue)
+
+    let intValue = await tester.intValue
+    XCTAssertEqual(intValue, Constants.intValue)
+
+    let floatValue = await tester.floatValue
+    XCTAssertEqual(floatValue, Constants.floatValue)
+
+    let doubleValue = await tester.doubleValue
+    XCTAssertEqual(doubleValue, Constants.doubleValue)
+
+    let decimalValue = await tester.decimalValue
+    XCTAssertEqual(decimalValue, Constants.decimalValue)
+
+    let trueValue = await tester.trueValue
+    XCTAssertEqual(trueValue, true)
+
+    let falseValue = await tester.falseValue
+    XCTAssertEqual(falseValue, false)
+
+    let dataValue = await tester.dataValue
+    XCTAssertEqual(dataValue, Constants.dataValue)
+
+    let recipe = try XCTUnwrap(config[Constants.jsonKey].decoded(asType: Recipe.self))
+    let recipeValue = await tester.recipeValue
+    XCTAssertEqual(recipeValue?.recipeName, recipe.recipeName)
+    XCTAssertEqual(recipeValue?.ingredients, recipe.ingredients)
+    XCTAssertEqual(recipeValue?.cookTime, recipe.cookTime)
+
+    let arrayValue = await tester.arrayValue
+    XCTAssertEqual(arrayValue, Constants.arrayValue)
+
+    let dictValue = await tester.dictValue
+    XCTAssertEqual(dictValue, Constants.dictValue)
+  }
+
+  func testPropertyWrapperInstanceValues() async {
+    let tester = await PropertyWrapperTester()
+
+    let stringKeyName = await tester.stringKeyName
+    XCTAssertEqual(Constants.stringKey, stringKeyName)
+
+    let intKeyName = await tester.intKeyName
+    XCTAssertEqual(Constants.intKey, intKeyName)
+
+    let floatKeyName = await tester.floatKeyName
+    XCTAssertEqual(Constants.floatKey, floatKeyName)
+
+    let doubleKeyName = await tester.doubleKeyName
+    XCTAssertEqual(Constants.floatKey, doubleKeyName)
+
+    let decimalKeyName = await tester.decimalKeyName
+    XCTAssertEqual(Constants.decimalKey, decimalKeyName)
+
+    let trueKeyName = await tester.trueKeyName
+    XCTAssertEqual(Constants.trueKey, trueKeyName)
+
+    let falseKeyName = await tester.falseKeyName
+    XCTAssertEqual(Constants.falseKey, falseKeyName)
+
+    let dataKeyName = await tester.dataKeyName
+    XCTAssertEqual(Constants.dataKey, dataKeyName)
+
+    let recipeKeyName = await tester.recipeKeyName
+    XCTAssertEqual(Constants.jsonKey, recipeKeyName)
+
+    let arrayKeyName = await tester.arrayKeyName
+    XCTAssertEqual(Constants.arrayKey, arrayKeyName)
+
+    let dictKeyName = await tester.dictKeyName
+    XCTAssertEqual(Constants.dictKey, dictKeyName)
+  }
+
+  func testPlaceHolderValues() async throws {
+    // Make sure the values below are consistent with the property wrapper
+    // in PlaceholderValueTester
+    let tester = await PlaceholderValueTester()
+
+    let stringValue = await tester.stringValue
+    XCTAssertEqual(stringValue, PropertyWrapperTests.fallbackString)
+
+    let intValue = await tester.intValue
+    XCTAssertEqual(intValue, PropertyWrapperTests.fallbackInt)
+
+    let zeroValue = await tester.zeroIntValue
+    XCTAssertEqual(zeroValue, 0)
+
+    let floatValue = await tester.floatValue
+    XCTAssertEqual(floatValue, PropertyWrapperTests.fallbackFloat)
+
+    let doubleValue = await tester.doubleValue
+    XCTAssertEqual(doubleValue, PropertyWrapperTests.fallbackDouble)
+
+    let decimalValue = await tester.decimalValue
+    XCTAssertEqual(decimalValue, PropertyWrapperTests.fallbackDecimal)
+
+    let trueKeyFalseValue = await tester.trueKeyFalseValue
+    XCTAssertEqual(trueKeyFalseValue, false)
+
+    let trueKeyTrueValue = await tester.trueKeyTrueValue
+    XCTAssertEqual(trueKeyTrueValue, true)
+
+    let falseKeyTrueValue = await tester.falseKeyTrueValue
+    XCTAssertEqual(falseKeyTrueValue, true)
+
+    let falseKeyFalseValue = await tester.falseKeyFalseValue
+    XCTAssertEqual(falseKeyFalseValue, false)
+
+    let dataValue = await tester.dataValue
+    XCTAssertEqual(dataValue, PropertyWrapperTests.fallbackData)
+
+    let arrayValue = await tester.arrayValue
+    XCTAssertEqual(arrayValue, PropertyWrapperTests.fallbackArray)
+
+    let dictValue = await tester.dictValue
+    XCTAssertEqual(dictValue, PropertyWrapperTests.fallbackDict)
+
+    let recipeValue = await tester.recipeValue
+    XCTAssertEqual(recipeValue?.recipeName, "muffin")
+    XCTAssertEqual(recipeValue?.ingredients, ["flour", "sugar"])
+    XCTAssertEqual(recipeValue?.cookTime, 45)
+  }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/PropertyWrapperTests.swift
@@ -18,7 +18,6 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
   class PropertyWrapperTests: APITestBase {
     // MARK: - Test fetching Remote Config JSON values into struct property
@@ -296,4 +295,3 @@ import XCTest
       XCTAssertEqual(recipeValue?.cookTime, 45)
     }
   }
-#endif

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -16,179 +16,179 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class ValueTests: APITestBase {
-    func testFetchAndActivateAllTypes() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      XCTAssertEqual(config[Constants.stringKey].stringValue, Constants.stringValue)
-      XCTAssertEqual(config[Constants.intKey].numberValue.intValue, Constants.intValue)
-      XCTAssertEqual(config[Constants.intKey].numberValue.int8Value, Int8(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.int16Value, Int16(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.int32Value, Int32(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.int64Value, Int64(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.uintValue, UInt(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.uint8Value, UInt8(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.uint16Value, UInt16(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.uint32Value, UInt32(Constants.intValue))
-      XCTAssertEqual(config[Constants.intKey].numberValue.uint64Value, UInt64(Constants.intValue))
-      XCTAssertEqual(
-        config[Constants.floatKey].numberValue.decimalValue,
-        Decimal(Constants.doubleValue)
-      )
-      XCTAssertEqual(config[Constants.floatKey].numberValue.floatValue, Constants.floatValue)
-      XCTAssertEqual(config[Constants.floatKey].numberValue.doubleValue, Constants.doubleValue)
-      XCTAssertEqual(config[Constants.trueKey].boolValue, true)
-      XCTAssertEqual(config[Constants.falseKey].boolValue, false)
-      XCTAssertEqual(
-        config[Constants.stringKey].dataValue,
-        Constants.stringValue.data(using: .utf8)
-      )
-      XCTAssertEqual(
-        config[Constants.jsonKey].jsonValue as! [String: AnyHashable],
-        Constants.jsonValue
-      )
-    }
-
-    func testStrongTypingViaSubscriptApi() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      XCTAssertEqual(config[decodedValue: Constants.stringKey], Constants.stringValue)
-      XCTAssertEqual(config[decodedValue: Constants.intKey], Constants.intValue)
-      XCTAssertEqual(config[decodedValue: Constants.floatKey], Constants.floatValue)
-      XCTAssertEqual(config[decodedValue: Constants.floatKey], Constants.doubleValue)
-      XCTAssertEqual(config[decodedValue: Constants.trueKey], true)
-      XCTAssertEqual(config[decodedValue: Constants.falseKey], false)
-      XCTAssertEqual(
-        config[decodedValue: Constants.stringKey],
-        Constants.stringValue.data(using: .utf8)
-      )
-      XCTAssertEqual(try XCTUnwrap(config[jsonValue: Constants.jsonKey]), Constants.jsonValue)
-    }
-
-    func testStrongTypingViaDecoder() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      XCTAssertEqual(
-        try config[Constants.stringKey].decoded(asType: String.self),
-        Constants.stringValue
-      )
-      XCTAssertEqual(try config[Constants.intKey].decoded(asType: Int.self), Constants.intValue)
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int8.self),
-        Int8(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int16.self),
-        Int16(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int32.self),
-        Int32(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: Int64.self),
-        Int64(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt.self),
-        UInt(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt8.self),
-        UInt8(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt16.self),
-        UInt16(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt32.self),
-        UInt32(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.intKey].decoded(asType: UInt64.self),
-        UInt64(Constants.intValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Decimal.self),
-        Decimal(Constants.doubleValue)
-      )
-      XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Float.self),
-        Constants.floatValue
-      )
-      XCTAssertEqual(
-        try config[Constants.floatKey].decoded(asType: Double.self),
-        Constants.doubleValue
-      )
-      XCTAssertEqual(try config[Constants.trueKey].decoded(asType: Bool.self), true)
-      XCTAssertEqual(try config[Constants.falseKey].decoded(asType: Bool.self), false)
-      XCTAssertEqual(
-        try config[Constants.stringKey].decoded(asType: Data.self),
-        Constants.stringValue.data(using: .utf8)
-      )
-    }
-
-    func testStrongTypingViaDecoderAlternateDecoderApi() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      let myString: String = try config[Constants.stringKey].decoded()
-      XCTAssertEqual(myString, Constants.stringValue)
-      let myInt: Int = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myInt, Constants.intValue)
-      let myInt8: Int8 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myInt8, Int8(Constants.intValue))
-      let myInt16: Int16 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myInt16, Int16(Constants.intValue))
-      let myInt32: Int32 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myInt32, Int32(Constants.intValue))
-      let myInt64: Int64 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myInt64, Int64(Constants.intValue))
-      let myUInt: UInt = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myUInt, UInt(Constants.intValue))
-      let myUInt8: UInt8 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myUInt8, UInt8(Constants.intValue))
-      let myUInt16: UInt16 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myUInt16, UInt16(Constants.intValue))
-      let myUInt32: UInt32 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myUInt32, UInt32(Constants.intValue))
-      let myUInt64: UInt64 = try config[Constants.intKey].decoded()
-      XCTAssertEqual(myUInt64, UInt64(Constants.intValue))
-      let myDecimal: Decimal = try config[Constants.floatKey].decoded()
-      XCTAssertEqual(myDecimal, Decimal(Constants.doubleValue))
-      let myFloat: Float = try config[Constants.floatKey].decoded()
-      XCTAssertEqual(myFloat, Constants.floatValue)
-      let myDouble: Double = try config[Constants.floatKey].decoded()
-      XCTAssertEqual(myDouble, Constants.doubleValue)
-      let myTrue: Bool = try config[Constants.trueKey].decoded()
-      XCTAssertEqual(myTrue, true)
-      let myFalse: Bool = try config[Constants.falseKey].decoded()
-      XCTAssertEqual(myFalse, false)
-      let myData: Data = try config[Constants.stringKey].decoded()
-      XCTAssertEqual(myData, Constants.stringValue.data(using: .utf8))
-    }
-
-    func testStringFails() {
-      XCTAssertEqual(config[decodedValue: "UndefinedKey"], "")
-    }
-
-    func testJSONFails() {
-      XCTAssertNil(config[jsonValue: "UndefinedKey"])
-      XCTAssertNil(config[jsonValue: Constants.stringKey])
-    }
-
-    func testDateDecodingNotYetSupported() async throws {
-      let status = try await config.fetchAndActivate()
-      XCTAssertEqual(status, .successFetchedFromRemote)
-      do {
-        let _: Date = try config[Constants.stringKey].decoded()
-      } catch let RemoteConfigValueCodableError.unsupportedType(message) {
-        XCTAssertEqual(message,
-                       "Date type is not currently supported for  Remote Config Value decoding. " +
-                         "Please file a feature request")
-        return
-      }
-      XCTFail("Failed to throw unsupported Date error.")
-    }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class ValueTests: APITestBase {
+  func testFetchAndActivateAllTypes() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    XCTAssertEqual(config[Constants.stringKey].stringValue, Constants.stringValue)
+    XCTAssertEqual(config[Constants.intKey].numberValue.intValue, Constants.intValue)
+    XCTAssertEqual(config[Constants.intKey].numberValue.int8Value, Int8(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.int16Value, Int16(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.int32Value, Int32(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.int64Value, Int64(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.uintValue, UInt(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.uint8Value, UInt8(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.uint16Value, UInt16(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.uint32Value, UInt32(Constants.intValue))
+    XCTAssertEqual(config[Constants.intKey].numberValue.uint64Value, UInt64(Constants.intValue))
+    XCTAssertEqual(
+      config[Constants.floatKey].numberValue.decimalValue,
+      Decimal(Constants.doubleValue)
+    )
+    XCTAssertEqual(config[Constants.floatKey].numberValue.floatValue, Constants.floatValue)
+    XCTAssertEqual(config[Constants.floatKey].numberValue.doubleValue, Constants.doubleValue)
+    XCTAssertEqual(config[Constants.trueKey].boolValue, true)
+    XCTAssertEqual(config[Constants.falseKey].boolValue, false)
+    XCTAssertEqual(
+      config[Constants.stringKey].dataValue,
+      Constants.stringValue.data(using: .utf8)
+    )
+    XCTAssertEqual(
+      config[Constants.jsonKey].jsonValue as! [String: AnyHashable],
+      Constants.jsonValue
+    )
   }
+
+  func testStrongTypingViaSubscriptApi() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    XCTAssertEqual(config[decodedValue: Constants.stringKey], Constants.stringValue)
+    XCTAssertEqual(config[decodedValue: Constants.intKey], Constants.intValue)
+    XCTAssertEqual(config[decodedValue: Constants.floatKey], Constants.floatValue)
+    XCTAssertEqual(config[decodedValue: Constants.floatKey], Constants.doubleValue)
+    XCTAssertEqual(config[decodedValue: Constants.trueKey], true)
+    XCTAssertEqual(config[decodedValue: Constants.falseKey], false)
+    XCTAssertEqual(
+      config[decodedValue: Constants.stringKey],
+      Constants.stringValue.data(using: .utf8)
+    )
+    XCTAssertEqual(try XCTUnwrap(config[jsonValue: Constants.jsonKey]), Constants.jsonValue)
+  }
+
+  func testStrongTypingViaDecoder() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    XCTAssertEqual(
+      try config[Constants.stringKey].decoded(asType: String.self),
+      Constants.stringValue
+    )
+    XCTAssertEqual(try config[Constants.intKey].decoded(asType: Int.self), Constants.intValue)
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: Int8.self),
+      Int8(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: Int16.self),
+      Int16(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: Int32.self),
+      Int32(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: Int64.self),
+      Int64(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: UInt.self),
+      UInt(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: UInt8.self),
+      UInt8(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: UInt16.self),
+      UInt16(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: UInt32.self),
+      UInt32(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.intKey].decoded(asType: UInt64.self),
+      UInt64(Constants.intValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.floatKey].decoded(asType: Decimal.self),
+      Decimal(Constants.doubleValue)
+    )
+    XCTAssertEqual(
+      try config[Constants.floatKey].decoded(asType: Float.self),
+      Constants.floatValue
+    )
+    XCTAssertEqual(
+      try config[Constants.floatKey].decoded(asType: Double.self),
+      Constants.doubleValue
+    )
+    XCTAssertEqual(try config[Constants.trueKey].decoded(asType: Bool.self), true)
+    XCTAssertEqual(try config[Constants.falseKey].decoded(asType: Bool.self), false)
+    XCTAssertEqual(
+      try config[Constants.stringKey].decoded(asType: Data.self),
+      Constants.stringValue.data(using: .utf8)
+    )
+  }
+
+  func testStrongTypingViaDecoderAlternateDecoderApi() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    let myString: String = try config[Constants.stringKey].decoded()
+    XCTAssertEqual(myString, Constants.stringValue)
+    let myInt: Int = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myInt, Constants.intValue)
+    let myInt8: Int8 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myInt8, Int8(Constants.intValue))
+    let myInt16: Int16 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myInt16, Int16(Constants.intValue))
+    let myInt32: Int32 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myInt32, Int32(Constants.intValue))
+    let myInt64: Int64 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myInt64, Int64(Constants.intValue))
+    let myUInt: UInt = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myUInt, UInt(Constants.intValue))
+    let myUInt8: UInt8 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myUInt8, UInt8(Constants.intValue))
+    let myUInt16: UInt16 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myUInt16, UInt16(Constants.intValue))
+    let myUInt32: UInt32 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myUInt32, UInt32(Constants.intValue))
+    let myUInt64: UInt64 = try config[Constants.intKey].decoded()
+    XCTAssertEqual(myUInt64, UInt64(Constants.intValue))
+    let myDecimal: Decimal = try config[Constants.floatKey].decoded()
+    XCTAssertEqual(myDecimal, Decimal(Constants.doubleValue))
+    let myFloat: Float = try config[Constants.floatKey].decoded()
+    XCTAssertEqual(myFloat, Constants.floatValue)
+    let myDouble: Double = try config[Constants.floatKey].decoded()
+    XCTAssertEqual(myDouble, Constants.doubleValue)
+    let myTrue: Bool = try config[Constants.trueKey].decoded()
+    XCTAssertEqual(myTrue, true)
+    let myFalse: Bool = try config[Constants.falseKey].decoded()
+    XCTAssertEqual(myFalse, false)
+    let myData: Data = try config[Constants.stringKey].decoded()
+    XCTAssertEqual(myData, Constants.stringValue.data(using: .utf8))
+  }
+
+  func testStringFails() {
+    XCTAssertEqual(config[decodedValue: "UndefinedKey"], "")
+  }
+
+  func testJSONFails() {
+    XCTAssertNil(config[jsonValue: "UndefinedKey"])
+    XCTAssertNil(config[jsonValue: Constants.stringKey])
+  }
+
+  func testDateDecodingNotYetSupported() async throws {
+    let status = try await config.fetchAndActivate()
+    XCTAssertEqual(status, .successFetchedFromRemote)
+    do {
+      let _: Date = try config[Constants.stringKey].decoded()
+    } catch let RemoteConfigValueCodableError.unsupportedType(message) {
+      XCTAssertEqual(message,
+                     "Date type is not currently supported for  Remote Config Value decoding. " +
+                       "Please file a feature request")
+      return
+    }
+    XCTFail("Failed to throw unsupported Date error.")
+  }
+}

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/Value.swift
@@ -16,7 +16,6 @@ import FirebaseRemoteConfig
 
 import XCTest
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   class ValueTests: APITestBase {
     func testFetchAndActivateAllTypes() async throws {
@@ -193,4 +192,3 @@ import XCTest
       XCTFail("Failed to throw unsupported Date error.")
     }
   }
-#endif

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -14,7 +14,6 @@
 
 import Foundation
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension StorageReference {
     /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
@@ -200,5 +199,3 @@ import Foundation
       }
     }
   }
-
-#endif

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -14,188 +14,188 @@
 
 import Foundation
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public extension StorageReference {
-    /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
-    /// A Data object of the provided max size will be allocated, so ensure that the device has
-    /// enough free memory to complete the download. For downloading large files, the `write`
-    /// API may be a better option.
-    ///
-    /// - Parameters:
-    ///   - size: The maximum size in bytes to download. If the download exceeds this size,
-    ///           the task will be cancelled and an error will be thrown.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if the data exceeded `maxSize`.
-    /// - Returns: Data object.
-    func data(maxSize: Int64) async throws -> Data {
-      return try await withCheckedThrowingContinuation { continuation in
-        _ = self.getData(maxSize: maxSize) { result in
-          continuation.resume(with: result)
-        }
-      }
-    }
-
-    /// Asynchronously uploads data to the currently specified StorageReference.
-    /// This is not recommended for large files, and one should instead upload a file from disk
-    /// from the Firebase Console.
-    ///
-    /// - Parameters:
-    ///   - uploadData: The Data to upload.
-    ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
-    ///              about the object being uploaded.
-    ///   - onProgress: An optional closure function to return a `Progress` instance while the
-    /// upload proceeds.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if Storage was unreachable.
-    /// - Returns: StorageMetadata with additional information about the object being uploaded.
-    func putDataAsync(_ uploadData: Data,
-                      metadata: StorageMetadata? = nil,
-                      onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
-      guard let onProgress = onProgress else {
-        return try await withCheckedThrowingContinuation { continuation in
-          self.putData(uploadData, metadata: metadata) { result in
-            continuation.resume(with: result)
-          }
-        }
-      }
-      let uploadTask = putData(uploadData, metadata: metadata)
-      return try await withCheckedThrowingContinuation { continuation in
-        uploadTask.observe(.progress) {
-          onProgress($0.progress)
-        }
-        uploadTask.observe(.success) { _ in
-          continuation.resume(with: .success(uploadTask.metadata!))
-        }
-        uploadTask.observe(.failure) { snapshot in
-          continuation.resume(with: .failure(
-            snapshot.error ?? StorageError.internalError("Internal Storage Error in putDataAsync")
-          ))
-        }
-      }
-    }
-
-    /// Asynchronously uploads a file to the currently specified StorageReference.
-    /// `putDataAsync` should be used instead of `putFileAsync` in Extensions.
-    ///
-    /// - Parameters:
-    ///   - url: A URL representing the system file path of the object to be uploaded.
-    ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
-    ///              about the object being uploaded.
-    ///   - onProgress: An optional closure function to return a `Progress` instance while the
-    /// upload proceeds.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if no file was present at the specified
-    /// `url`.
-    /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
-    func putFileAsync(from url: URL,
-                      metadata: StorageMetadata? = nil,
-                      onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
-      guard let onProgress = onProgress else {
-        return try await withCheckedThrowingContinuation { continuation in
-          self.putFile(from: url, metadata: metadata) { result in
-            continuation.resume(with: result)
-          }
-        }
-      }
-      let uploadTask = putFile(from: url, metadata: metadata)
-      return try await withCheckedThrowingContinuation { continuation in
-        uploadTask.observe(.progress) {
-          onProgress($0.progress)
-        }
-        uploadTask.observe(.success) { _ in
-          continuation.resume(with: .success(uploadTask.metadata!))
-        }
-        uploadTask.observe(.failure) { snapshot in
-          continuation.resume(with: .failure(
-            snapshot.error ?? StorageError.internalError("Internal Storage Error in putFileAsync")
-          ))
-        }
-      }
-    }
-
-    /// Asynchronously downloads the object at the current path to a specified system filepath.
-    ///
-    /// - Parameters:
-    ///   - fileUrl: A URL representing the system file path of the object to be uploaded.
-    ///   - onProgress: An optional closure function to return a `Progress` instance while the
-    /// download proceeds.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if Storage was unreachable
-    ///   or `fileURL` did not reference a valid path on disk.
-    /// - Returns: A `URL` pointing to the file path of the downloaded file.
-    func writeAsync(toFile fileURL: URL,
-                    onProgress: ((Progress?) -> Void)? = nil) async throws -> URL {
-      guard let onProgress = onProgress else {
-        return try await withCheckedThrowingContinuation { continuation in
-          _ = self.write(toFile: fileURL) { result in
-            continuation.resume(with: result)
-          }
-        }
-      }
-      let downloadTask = write(toFile: fileURL)
-      return try await withCheckedThrowingContinuation { continuation in
-        downloadTask.observe(.progress) {
-          onProgress($0.progress)
-        }
-        downloadTask.observe(.success) { _ in
-          continuation.resume(with: .success(fileURL))
-        }
-        downloadTask.observe(.failure) { snapshot in
-          continuation.resume(with: .failure(
-            snapshot.error ?? StorageError.internalError("Internal Storage Error in writeAsync")
-          ))
-        }
-      }
-    }
-
-    /// List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
-    ///
-    /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-    /// filtered.
-    ///
-    /// Only available for projects using Firebase Rules Version 2.
-    ///
-    /// - Parameters:
-    ///   - maxResults The maximum number of results to return in a single page. Must be
-    ///                greater than 0 and at most 1000.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if Storage was unreachable
-    ///   or the storage reference referenced an invalid path.
-    /// - Returns:
-    ///   - A `StorageListResult` containing the contents of the storage reference.
-    func list(maxResults: Int64) async throws -> StorageListResult {
-      typealias ListContinuation = CheckedContinuation<StorageListResult, Error>
-      return try await withCheckedThrowingContinuation { (continuation: ListContinuation) in
-        self.list(maxResults: maxResults) { result in
-          continuation.resume(with: result)
-        }
-      }
-    }
-
-    /// List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
-    ///
-    /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-    /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-    /// filtered.
-    ///
-    /// Only available for projects using Firebase Rules Version 2.
-    ///
-    /// - Parameters:
-    ///   - maxResults The maximum number of results to return in a single page. Must be
-    ///                greater than 0 and at most 1000.
-    ///   - pageToken A page token from a previous call to list.
-    /// - Throws:
-    ///   - An error if the operation failed, for example if Storage was unreachable
-    ///   or the storage reference referenced an invalid path.
-    /// - Returns:
-    ///   - completion A `Result` enum with either the list or an `Error`.
-    func list(maxResults: Int64, pageToken: String) async throws -> StorageListResult {
-      typealias ListContinuation = CheckedContinuation<StorageListResult, Error>
-      return try await withCheckedThrowingContinuation { (continuation: ListContinuation) in
-        self.list(maxResults: maxResults, pageToken: pageToken) { result in
-          continuation.resume(with: result)
-        }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+public extension StorageReference {
+  /// Asynchronously downloads the object at the StorageReference to a Data object in memory.
+  /// A Data object of the provided max size will be allocated, so ensure that the device has
+  /// enough free memory to complete the download. For downloading large files, the `write`
+  /// API may be a better option.
+  ///
+  /// - Parameters:
+  ///   - size: The maximum size in bytes to download. If the download exceeds this size,
+  ///           the task will be cancelled and an error will be thrown.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if the data exceeded `maxSize`.
+  /// - Returns: Data object.
+  func data(maxSize: Int64) async throws -> Data {
+    return try await withCheckedThrowingContinuation { continuation in
+      _ = self.getData(maxSize: maxSize) { result in
+        continuation.resume(with: result)
       }
     }
   }
+
+  /// Asynchronously uploads data to the currently specified StorageReference.
+  /// This is not recommended for large files, and one should instead upload a file from disk
+  /// from the Firebase Console.
+  ///
+  /// - Parameters:
+  ///   - uploadData: The Data to upload.
+  ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
+  ///              about the object being uploaded.
+  ///   - onProgress: An optional closure function to return a `Progress` instance while the
+  /// upload proceeds.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if Storage was unreachable.
+  /// - Returns: StorageMetadata with additional information about the object being uploaded.
+  func putDataAsync(_ uploadData: Data,
+                    metadata: StorageMetadata? = nil,
+                    onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
+    guard let onProgress = onProgress else {
+      return try await withCheckedThrowingContinuation { continuation in
+        self.putData(uploadData, metadata: metadata) { result in
+          continuation.resume(with: result)
+        }
+      }
+    }
+    let uploadTask = putData(uploadData, metadata: metadata)
+    return try await withCheckedThrowingContinuation { continuation in
+      uploadTask.observe(.progress) {
+        onProgress($0.progress)
+      }
+      uploadTask.observe(.success) { _ in
+        continuation.resume(with: .success(uploadTask.metadata!))
+      }
+      uploadTask.observe(.failure) { snapshot in
+        continuation.resume(with: .failure(
+          snapshot.error ?? StorageError.internalError("Internal Storage Error in putDataAsync")
+        ))
+      }
+    }
+  }
+
+  /// Asynchronously uploads a file to the currently specified StorageReference.
+  /// `putDataAsync` should be used instead of `putFileAsync` in Extensions.
+  ///
+  /// - Parameters:
+  ///   - url: A URL representing the system file path of the object to be uploaded.
+  ///   - metadata: Optional StorageMetadata containing additional information (MIME type, etc.)
+  ///              about the object being uploaded.
+  ///   - onProgress: An optional closure function to return a `Progress` instance while the
+  /// upload proceeds.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if no file was present at the specified
+  /// `url`.
+  /// - Returns: `StorageMetadata` with additional information about the object being uploaded.
+  func putFileAsync(from url: URL,
+                    metadata: StorageMetadata? = nil,
+                    onProgress: ((Progress?) -> Void)? = nil) async throws -> StorageMetadata {
+    guard let onProgress = onProgress else {
+      return try await withCheckedThrowingContinuation { continuation in
+        self.putFile(from: url, metadata: metadata) { result in
+          continuation.resume(with: result)
+        }
+      }
+    }
+    let uploadTask = putFile(from: url, metadata: metadata)
+    return try await withCheckedThrowingContinuation { continuation in
+      uploadTask.observe(.progress) {
+        onProgress($0.progress)
+      }
+      uploadTask.observe(.success) { _ in
+        continuation.resume(with: .success(uploadTask.metadata!))
+      }
+      uploadTask.observe(.failure) { snapshot in
+        continuation.resume(with: .failure(
+          snapshot.error ?? StorageError.internalError("Internal Storage Error in putFileAsync")
+        ))
+      }
+    }
+  }
+
+  /// Asynchronously downloads the object at the current path to a specified system filepath.
+  ///
+  /// - Parameters:
+  ///   - fileUrl: A URL representing the system file path of the object to be uploaded.
+  ///   - onProgress: An optional closure function to return a `Progress` instance while the
+  /// download proceeds.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if Storage was unreachable
+  ///   or `fileURL` did not reference a valid path on disk.
+  /// - Returns: A `URL` pointing to the file path of the downloaded file.
+  func writeAsync(toFile fileURL: URL,
+                  onProgress: ((Progress?) -> Void)? = nil) async throws -> URL {
+    guard let onProgress = onProgress else {
+      return try await withCheckedThrowingContinuation { continuation in
+        _ = self.write(toFile: fileURL) { result in
+          continuation.resume(with: result)
+        }
+      }
+    }
+    let downloadTask = write(toFile: fileURL)
+    return try await withCheckedThrowingContinuation { continuation in
+      downloadTask.observe(.progress) {
+        onProgress($0.progress)
+      }
+      downloadTask.observe(.success) { _ in
+        continuation.resume(with: .success(fileURL))
+      }
+      downloadTask.observe(.failure) { snapshot in
+        continuation.resume(with: .failure(
+          snapshot.error ?? StorageError.internalError("Internal Storage Error in writeAsync")
+        ))
+      }
+    }
+  }
+
+  /// List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+  ///
+  /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+  /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  /// filtered.
+  ///
+  /// Only available for projects using Firebase Rules Version 2.
+  ///
+  /// - Parameters:
+  ///   - maxResults The maximum number of results to return in a single page. Must be
+  ///                greater than 0 and at most 1000.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if Storage was unreachable
+  ///   or the storage reference referenced an invalid path.
+  /// - Returns:
+  ///   - A `StorageListResult` containing the contents of the storage reference.
+  func list(maxResults: Int64) async throws -> StorageListResult {
+    typealias ListContinuation = CheckedContinuation<StorageListResult, Error>
+    return try await withCheckedThrowingContinuation { (continuation: ListContinuation) in
+      self.list(maxResults: maxResults) { result in
+        continuation.resume(with: result)
+      }
+    }
+  }
+
+  /// List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+  ///
+  /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+  /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  /// filtered.
+  ///
+  /// Only available for projects using Firebase Rules Version 2.
+  ///
+  /// - Parameters:
+  ///   - maxResults The maximum number of results to return in a single page. Must be
+  ///                greater than 0 and at most 1000.
+  ///   - pageToken A page token from a previous call to list.
+  /// - Throws:
+  ///   - An error if the operation failed, for example if Storage was unreachable
+  ///   or the storage reference referenced an invalid path.
+  /// - Returns:
+  ///   - completion A `Result` enum with either the list or an `Error`.
+  func list(maxResults: Int64, pageToken: String) async throws -> StorageListResult {
+    typealias ListContinuation = CheckedContinuation<StorageListResult, Error>
+    return try await withCheckedThrowingContinuation { (continuation: ListContinuation) in
+      self.list(maxResults: maxResults, pageToken: pageToken) { result in
+        continuation.resume(with: result)
+      }
+    }
+  }
+}

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -270,7 +270,6 @@ import Foundation
     task.enqueue()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      * Asynchronously retrieves a long lived download URL with a revokable token.
      * This can be used to share the file with others, but can be revoked by a developer
@@ -286,7 +285,6 @@ import Foundation
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
 
   /**
    * Asynchronously downloads the object at the current path to a specified system filepath.
@@ -398,7 +396,6 @@ import Foundation
     task.enqueue()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      * Lists all items (files) and prefixes (folders) under this StorageReference.
      *
@@ -419,7 +416,6 @@ import Foundation
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
 
   /**
    * List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
@@ -514,7 +510,6 @@ import Foundation
     task.enqueue()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      * Retrieves metadata associated with an object at the current path.
      * - Throws: An error if the object metadata could not be retrieved.
@@ -528,7 +523,6 @@ import Foundation
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
 
   /**
    * Updates the metadata associated with an object at the current path.
@@ -549,7 +543,6 @@ import Foundation
     task.enqueue()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      * Updates the metadata associated with an object at the current path.
      * - Parameter metadata A `StorageMetadata` object with the metadata to update.
@@ -564,7 +557,6 @@ import Foundation
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
 
   // MARK: - Delete
 
@@ -582,7 +574,6 @@ import Foundation
     task.enqueue()
   }
 
-  #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      * Deletes the object at the current path.
      * - Throws: An error if the delete operation failed.
@@ -599,7 +590,6 @@ import Foundation
         }
       }
     }
-  #endif // compiler(>=5.5) && canImport(_Concurrency)
 
   // MARK: - NSObject overrides
 

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -270,21 +270,21 @@ import Foundation
     task.enqueue()
   }
 
-    /**
-     * Asynchronously retrieves a long lived download URL with a revokable token.
-     * This can be used to share the file with others, but can be revoked by a developer
-     * in the Firebase Console.
-     * - Throws: An error if the download URL could not be retrieved.
-     * - Returns: The URL on success.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    open func downloadURL() async throws -> URL {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.downloadURL { result in
-          continuation.resume(with: result)
-        }
+  /**
+   * Asynchronously retrieves a long lived download URL with a revokable token.
+   * This can be used to share the file with others, but can be revoked by a developer
+   * in the Firebase Console.
+   * - Throws: An error if the download URL could not be retrieved.
+   * - Returns: The URL on success.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+  open func downloadURL() async throws -> URL {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.downloadURL { result in
+        continuation.resume(with: result)
       }
     }
+  }
 
   /**
    * Asynchronously downloads the object at the current path to a specified system filepath.
@@ -396,26 +396,26 @@ import Foundation
     task.enqueue()
   }
 
-    /**
-     * Lists all items (files) and prefixes (folders) under this StorageReference.
-     *
-     * This is a helper method for calling list() repeatedly until there are no more results.
-     * Consistency of the result is not guaranteed if objects are inserted or removed while this
-     * operation is executing. All results are buffered in memory.
-     *
-     * `listAll()` is only available for projects using Firebase Rules Version 2.
-     *
-     * - Throws: An error if the list operation failed.
-     * - Returns: All items and prefixes under the current `StorageReference`.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    open func listAll() async throws -> StorageListResult {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.listAll { result in
-          continuation.resume(with: result)
-        }
+  /**
+   * Lists all items (files) and prefixes (folders) under this StorageReference.
+   *
+   * This is a helper method for calling list() repeatedly until there are no more results.
+   * Consistency of the result is not guaranteed if objects are inserted or removed while this
+   * operation is executing. All results are buffered in memory.
+   *
+   * `listAll()` is only available for projects using Firebase Rules Version 2.
+   *
+   * - Throws: An error if the list operation failed.
+   * - Returns: All items and prefixes under the current `StorageReference`.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+  open func listAll() async throws -> StorageListResult {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.listAll { result in
+        continuation.resume(with: result)
       }
     }
+  }
 
   /**
    * List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
@@ -510,19 +510,19 @@ import Foundation
     task.enqueue()
   }
 
-    /**
-     * Retrieves metadata associated with an object at the current path.
-     * - Throws: An error if the object metadata could not be retrieved.
-     * - Returns: The object metadata on success.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    open func getMetadata() async throws -> StorageMetadata {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.getMetadata { result in
-          continuation.resume(with: result)
-        }
+  /**
+   * Retrieves metadata associated with an object at the current path.
+   * - Throws: An error if the object metadata could not be retrieved.
+   * - Returns: The object metadata on success.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+  open func getMetadata() async throws -> StorageMetadata {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.getMetadata { result in
+        continuation.resume(with: result)
       }
     }
+  }
 
   /**
    * Updates the metadata associated with an object at the current path.
@@ -543,20 +543,20 @@ import Foundation
     task.enqueue()
   }
 
-    /**
-     * Updates the metadata associated with an object at the current path.
-     * - Parameter metadata A `StorageMetadata` object with the metadata to update.
-     * - Throws: An error if the metadata update operation failed.
-     * - Returns: The object metadata on success.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    open func updateMetadata(_ metadata: StorageMetadata) async throws -> StorageMetadata {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.updateMetadata(metadata) { result in
-          continuation.resume(with: result)
-        }
+  /**
+   * Updates the metadata associated with an object at the current path.
+   * - Parameter metadata A `StorageMetadata` object with the metadata to update.
+   * - Throws: An error if the metadata update operation failed.
+   * - Returns: The object metadata on success.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+  open func updateMetadata(_ metadata: StorageMetadata) async throws -> StorageMetadata {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.updateMetadata(metadata) { result in
+        continuation.resume(with: result)
       }
     }
+  }
 
   // MARK: - Delete
 
@@ -574,22 +574,22 @@ import Foundation
     task.enqueue()
   }
 
-    /**
-     * Deletes the object at the current path.
-     * - Throws: An error if the delete operation failed.
-     */
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    open func delete() async throws {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.delete { error in
-          if let error = error {
-            continuation.resume(throwing: error)
-          } else {
-            continuation.resume()
-          }
+  /**
+   * Deletes the object at the current path.
+   * - Throws: An error if the delete operation failed.
+   */
+  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+  open func delete() async throws {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.delete { error in
+        if let error = error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
         }
       }
     }
+  }
 
   // MARK: - NSObject overrides
 

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -17,405 +17,405 @@ import FirebaseCore
 import FirebaseStorage
 import XCTest
 
-  @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
-  class StorageAsyncAwait: StorageIntegrationCommon {
-    func testGetMetadata() async throws {
-      let ref = storage.reference().child("ios/public/1mb2")
-      let result = try await ref.getMetadata()
-      XCTAssertNotNil(result)
-    }
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
+class StorageAsyncAwait: StorageIntegrationCommon {
+  func testGetMetadata() async throws {
+    let ref = storage.reference().child("ios/public/1mb2")
+    let result = try await ref.getMetadata()
+    XCTAssertNotNil(result)
+  }
 
-    func testUpdateMetadata() async throws {
-      let meta = StorageMetadata()
-      meta.contentType = "lol/custom"
-      meta.customMetadata = ["lol": "custom metadata is neat",
-                             "ちかてつ": "🚇",
-                             "shinkansen": "新幹線"]
+  func testUpdateMetadata() async throws {
+    let meta = StorageMetadata()
+    meta.contentType = "lol/custom"
+    meta.customMetadata = ["lol": "custom metadata is neat",
+                           "ちかてつ": "🚇",
+                           "shinkansen": "新幹線"]
 
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-      let metadata = try await ref.updateMetadata(meta)
-      XCTAssertEqual(meta.contentType, metadata.contentType)
-      XCTAssertEqual(meta.customMetadata!["lol"], metadata.customMetadata!["lol"])
-      XCTAssertEqual(meta.customMetadata!["ちかてつ"], metadata.customMetadata!["ちかてつ"])
-      XCTAssertEqual(meta.customMetadata!["shinkansen"],
-                     metadata.customMetadata!["shinkansen"])
-    }
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let metadata = try await ref.updateMetadata(meta)
+    XCTAssertEqual(meta.contentType, metadata.contentType)
+    XCTAssertEqual(meta.customMetadata!["lol"], metadata.customMetadata!["lol"])
+    XCTAssertEqual(meta.customMetadata!["ちかてつ"], metadata.customMetadata!["ちかてつ"])
+    XCTAssertEqual(meta.customMetadata!["shinkansen"],
+                   metadata.customMetadata!["shinkansen"])
+  }
 
-    func testDelete() async throws {
-      let objectLocation = "ios/public/fileToDelete"
-      let ref = storage.reference(withPath: objectLocation)
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
+  func testDelete() async throws {
+    let objectLocation = "ios/public/fileToDelete"
+    let ref = storage.reference(withPath: objectLocation)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+    _ = try await ref.delete()
+    // Next delete should fail and verify the first delete succeeded.
+    var caughtError = false
+    do {
       _ = try await ref.delete()
-      // Next delete should fail and verify the first delete succeeded.
-      var caughtError = false
-      do {
-        _ = try await ref.delete()
-      } catch {
-        caughtError = true
-        let nsError = error as NSError
-        XCTAssertEqual(nsError.code, StorageErrorCode.objectNotFound.rawValue)
-        XCTAssertEqual(nsError.userInfo["ResponseErrorCode"] as? Int, 404)
-        let underlyingError = try XCTUnwrap(nsError.userInfo[NSUnderlyingErrorKey] as? NSError)
-        XCTAssertEqual(underlyingError.code, 404)
-        XCTAssertEqual(underlyingError.domain, "com.google.HTTPStatus")
-      }
-      XCTAssertTrue(caughtError)
+    } catch {
+      caughtError = true
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.code, StorageErrorCode.objectNotFound.rawValue)
+      XCTAssertEqual(nsError.userInfo["ResponseErrorCode"] as? Int, 404)
+      let underlyingError = try XCTUnwrap(nsError.userInfo[NSUnderlyingErrorKey] as? NSError)
+      XCTAssertEqual(underlyingError.code, 404)
+      XCTAssertEqual(underlyingError.domain, "com.google.HTTPStatus")
     }
+    XCTAssertTrue(caughtError)
+  }
 
-    func testDeleteAfterPut() async throws {
-      let ref = storage.reference(withPath: "ios/public/fileToDelete")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
-      let result2: Void = try await ref.delete()
-      XCTAssertNotNil(result2)
-    }
+  func testDeleteAfterPut() async throws {
+    let ref = storage.reference(withPath: "ios/public/fileToDelete")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+    let result2: Void = try await ref.delete()
+    XCTAssertNotNil(result2)
+  }
 
-    func testSimplePutData() async throws {
-      let ref = storage.reference(withPath: "ios/public/testBytesUpload")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
-    }
+  func testSimplePutData() async throws {
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+  }
 
-    func testSimplePutSpecialCharacter() async throws {
-      let ref = storage.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
-      let data = try XCTUnwrap("Hello Swift World-._~!$'()*,=:@&+;".data(using: .utf8),
-                               "Data construction failed")
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
-    }
+  func testSimplePutSpecialCharacter() async throws {
+    let ref = storage.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
+    let data = try XCTUnwrap("Hello Swift World-._~!$'()*,=:@&+;".data(using: .utf8),
+                             "Data construction failed")
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+  }
 
-    func testSimplePutDataInBackgroundQueue() async throws {
-      actor Background {
-        func uploadData(_ ref: StorageReference) async throws -> StorageMetadata {
-          let data = try XCTUnwrap(
-            "Hello Swift World".data(using: .utf8),
-            "Data construction failed"
-          )
-          XCTAssertFalse(Thread.isMainThread)
-          return try await ref.putDataAsync(data)
-        }
-      }
-      let ref = storage.reference(withPath: "ios/public/testBytesUpload")
-      let result = try await Background().uploadData(ref)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimplePutEmptyData() async throws {
-      let ref = storage.reference(withPath: "ios/public/testSimplePutEmptyData")
-      let data = Data()
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimplePutDataUnauthorized() async throws {
-      let objectLocation = "ios/private/secretfile.txt"
-      let ref = storage.reference(withPath: objectLocation)
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      do {
-        _ = try await ref.putDataAsync(data)
-        XCTFail("Unexpected success from unauthorized putData")
-      } catch let StorageError.unauthorized(bucket, object) {
-        XCTAssertEqual(bucket, "ios-opensource-samples.appspot.com")
-        XCTAssertEqual(object, objectLocation)
-      } catch {
-        XCTFail("error failed to convert to StorageError.unauthorized")
+  func testSimplePutDataInBackgroundQueue() async throws {
+    actor Background {
+      func uploadData(_ ref: StorageReference) async throws -> StorageMetadata {
+        let data = try XCTUnwrap(
+          "Hello Swift World".data(using: .utf8),
+          "Data construction failed"
+        )
+        XCTAssertFalse(Thread.isMainThread)
+        return try await ref.putDataAsync(data)
       }
     }
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
+    let result = try await Background().uploadData(ref)
+    XCTAssertNotNil(result)
+  }
 
-    func testAttemptToUploadDirectoryShouldFail() async throws {
-      // This `.numbers` file is actually a directory.
-      let fileName = "HomeImprovement.numbers"
-      let bundle = Bundle(for: StorageIntegrationCommon.self)
-      let fileURL = try XCTUnwrap(bundle.url(forResource: fileName, withExtension: ""),
-                                  "Failed to get filePath")
-      let ref = storage.reference(withPath: "ios/public/" + fileName)
-      do {
-        _ = try await ref.putFileAsync(from: fileURL)
-        XCTFail("Unexpected success from putFile of a directory")
-      } catch let StorageError.unknown(reason) {
-        XCTAssertTrue(reason.starts(with: "File at URL:"))
-        XCTAssertTrue(reason.hasSuffix(
-          "is not reachable. Ensure file URL is not a directory, symbolic link, or invalid url."
-        ))
-      } catch {
-        XCTFail("error failed to convert to StorageError.unknown")
-      }
-    }
+  func testSimplePutEmptyData() async throws {
+    let ref = storage.reference(withPath: "ios/public/testSimplePutEmptyData")
+    let data = Data()
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+  }
 
-    func testPutFileWithSpecialCharacters() async throws {
-      let fileName = "hello&+@_ .txt"
-      let ref = storage.reference(withPath: "ios/public/" + fileName)
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-      let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-      try data.write(to: fileURL, options: .atomicWrite)
-      let metadata = try await ref.putFileAsync(from: fileURL)
-      XCTAssertEqual(fileName, metadata.name)
-      let result = try await ref.getMetadata()
-      XCTAssertNotNil(result)
-    }
-
-    func testSimplePutDataNoMetadata() async throws {
-      let ref = storage.reference(withPath: "ios/public/testSimplePutDataNoMetadata")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let result = try await ref.putDataAsync(data)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimplePutFileNoMetadata() async throws {
-      let fileName = "hello&+@_ .txt"
-      let ref = storage.reference(withPath: "ios/public/" + fileName)
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-      let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-      try data.write(to: fileURL, options: .atomicWrite)
-      let result = try await ref.putFileAsync(from: fileURL)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimplePutFileWithAsyncProgress() async throws {
-      var checkedProgress = false
-      let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-      let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-      let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-      try data.write(to: fileURL, options: .atomicWrite)
-      var uploadedBytes: Int64 = -1
-      let successMetadata = try await ref.putFileAsync(from: fileURL) { progress in
-        if let completed = progress?.completedUnitCount {
-          checkedProgress = true
-          XCTAssertGreaterThanOrEqual(completed, uploadedBytes)
-          uploadedBytes = completed
-        }
-      }
-      XCTAssertEqual(successMetadata.size, 17)
-      XCTAssertTrue(checkedProgress)
-    }
-
-    func testSimpleGetData() async throws {
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-      let result = try await ref.data(maxSize: 1024 * 1024)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimpleGetDataWithTask() async throws {
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-      let result = try await ref.data(maxSize: 1024 * 1024)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimpleGetDataInBackgroundQueue() async throws {
-      actor Background {
-        func data(from ref: StorageReference) async throws -> Data {
-          XCTAssertFalse(Thread.isMainThread)
-          return try await ref.data(maxSize: 1024 * 1024)
-        }
-      }
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-      let result = try await Background().data(from: ref)
-      XCTAssertNotNil(result)
-    }
-
-    func testSimpleGetDataTooSmall() async {
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-      let max: Int64 = 1024
-      do {
-        _ = try await ref.data(maxSize: max)
-        XCTFail("Unexpected success from getData too small")
-      } catch let StorageError.downloadSizeExceeded(total, maxSize) {
-        XCTAssertEqual(total, 1_048_576)
-        XCTAssertEqual(maxSize, max)
-      } catch {
-        XCTFail("error failed to convert to StorageError.downloadSizeExceeded")
-      }
-    }
-
-    func testSimpleGetDownloadURL() async throws {
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-
-      // Download URL format is
-      // "https://firebasestorage.googleapis.com:443/v0/b/{bucket}/o/{path}?alt=media&token={token}"
-      let downloadURLPattern =
-        "^https:\\/\\/firebasestorage.googleapis.com:443\\/v0\\/b\\/[^\\/]*\\/o\\/" +
-        "ios%2Fpublic%2F1mb2\\?alt=media&token=[a-z0-9-]*$"
-
-      let downloadURL = try await ref.downloadURL()
-      let testRegex = try NSRegularExpression(pattern: downloadURLPattern)
-      let urlString = downloadURL.absoluteString
-      let range = NSRange(location: 0, length: urlString.count)
-      XCTAssertNotNil(testRegex.firstMatch(in: urlString, options: [], range: range))
-    }
-
-    func testAsyncWrite() async throws {
-      let ref = storage.reference(withPath: "ios/public/helloworld")
-      let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-      let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-
+  func testSimplePutDataUnauthorized() async throws {
+    let objectLocation = "ios/private/secretfile.txt"
+    let ref = storage.reference(withPath: objectLocation)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    do {
       _ = try await ref.putDataAsync(data)
-      let url = try await ref.writeAsync(toFile: fileURL)
-      XCTAssertEqual(url.lastPathComponent, "hello.txt")
-    }
-
-    func testSimpleGetFile() throws {
-      let expectation = self.expectation(description: #function)
-      let ref = storage.reference(withPath: "ios/public/helloworld")
-      let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-      let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-      let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-
-      Task {
-        _ = try await ref.putDataAsync(data)
-        let task = ref.write(toFile: fileURL)
-
-        task.observe(StorageTaskStatus.success) { snapshot in
-          do {
-            let stringData = try String(contentsOf: fileURL, encoding: .utf8)
-            XCTAssertEqual(stringData, "Hello Swift World")
-            XCTAssertEqual(snapshot.description, "<State: Success>")
-          } catch {
-            XCTFail("Error processing success snapshot")
-          }
-          expectation.fulfill()
-        }
-
-        task.observe(StorageTaskStatus.progress) { snapshot in
-          XCTAssertNil(snapshot.error, "Error should be nil")
-          guard snapshot.progress != nil else {
-            XCTFail("Missing progress")
-            return
-          }
-        }
-        task.observe(StorageTaskStatus.failure) { snapshot in
-          XCTAssertNil(snapshot.error, "Error should be nil")
-        }
-      }
-      waitForExpectations()
-    }
-
-    func testSimpleGetFileWithAsyncProgressCallbackAPI() async throws {
-      var checkedProgress = false
-      let ref = storage.reference().child("ios/public/1mb")
-      let url = URL(fileURLWithPath: "\(NSTemporaryDirectory())/hello.txt")
-      let fileURL = url
-      var downloadedBytes: Int64 = 0
-      var resumeAtBytes = 256 * 1024
-      let successURL = try await ref.writeAsync(toFile: fileURL) { progress in
-        if let completed = progress?.completedUnitCount {
-          checkedProgress = true
-          XCTAssertGreaterThanOrEqual(completed, downloadedBytes)
-          downloadedBytes = completed
-          if completed > resumeAtBytes {
-            resumeAtBytes = Int.max
-          }
-        }
-      }
-      XCTAssertTrue(checkedProgress)
-      XCTAssertEqual(successURL, url)
-      XCTAssertEqual(resumeAtBytes, Int.max)
-    }
-
-    private func assertMetadata(actualMetadata: StorageMetadata,
-                                expectedContentType: String,
-                                expectedCustomMetadata: [String: String]) {
-      XCTAssertEqual(actualMetadata.cacheControl, "cache-control")
-      XCTAssertEqual(actualMetadata.contentDisposition, "content-disposition")
-      XCTAssertEqual(actualMetadata.contentEncoding, "gzip")
-      XCTAssertEqual(actualMetadata.contentLanguage, "de")
-      XCTAssertEqual(actualMetadata.contentType, expectedContentType)
-      XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
-      for (key, value) in expectedCustomMetadata {
-        XCTAssertEqual(actualMetadata.customMetadata![key], value)
-      }
-    }
-
-    private func assertMetadataNil(actualMetadata: StorageMetadata) {
-      XCTAssertNil(actualMetadata.cacheControl)
-      XCTAssertNil(actualMetadata.contentDisposition)
-      XCTAssertEqual(actualMetadata.contentEncoding, "identity")
-      XCTAssertNil(actualMetadata.contentLanguage)
-      XCTAssertNil(actualMetadata.contentType)
-      XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
-      XCTAssertNil(actualMetadata.customMetadata)
-    }
-
-    func testUpdateMetadata2() async throws {
-      let ref = storage.reference(withPath: "ios/public/1mb2")
-
-      let metadata = StorageMetadata()
-      metadata.cacheControl = "cache-control"
-      metadata.contentDisposition = "content-disposition"
-      metadata.contentEncoding = "gzip"
-      metadata.contentLanguage = "de"
-      metadata.contentType = "content-type-a"
-      metadata.customMetadata = ["a": "b"]
-
-      let updatedMetadata = try await ref.updateMetadata(metadata)
-      assertMetadata(actualMetadata: updatedMetadata,
-                     expectedContentType: "content-type-a",
-                     expectedCustomMetadata: ["a": "b"])
-
-      let metadata2 = updatedMetadata
-      metadata2.contentType = "content-type-b"
-      metadata2.customMetadata = ["a": "b", "c": "d"]
-
-      let metadata3 = try await ref.updateMetadata(metadata2)
-      assertMetadata(actualMetadata: metadata3,
-                     expectedContentType: "content-type-b",
-                     expectedCustomMetadata: ["a": "b", "c": "d"])
-      metadata.cacheControl = nil
-      metadata.contentDisposition = nil
-      metadata.contentEncoding = nil
-      metadata.contentLanguage = nil
-      metadata.contentType = nil
-      metadata.customMetadata = nil
-      let metadata4 = try await ref.updateMetadata(metadata)
-      XCTAssertNotNil(metadata4)
-    }
-
-    func testPagedListFiles() async throws {
-      let ref = storage.reference(withPath: "ios/public/list")
-      let listResult = try await ref.list(maxResults: 2)
-      XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
-      XCTAssertEqual(listResult.prefixes, [])
-      let pageToken = try XCTUnwrap(listResult.pageToken)
-      let listResult2 = try await ref.list(maxResults: 2, pageToken: pageToken)
-      XCTAssertEqual(listResult2.items, [])
-      XCTAssertEqual(listResult2.prefixes, [ref.child("prefix")])
-      XCTAssertNil(listResult2.pageToken, "pageToken should be nil")
-    }
-
-    func testPagedListFilesError() async throws {
-      let ref = storage.reference(withPath: "ios/public/list")
-      do {
-        let _: StorageListResult = try await ref.list(maxResults: 22222)
-        XCTFail("Unexpected success from ref.list")
-      } catch let StorageError.invalidArgument(message) {
-        XCTAssertEqual(message, "Argument 'maxResults' must be between 1 and 1000 inclusive.")
-      } catch {
-        XCTFail("Unexpected error")
-      }
-    }
-
-    func testListAllFiles() async throws {
-      let ref = storage.reference(withPath: "ios/public/list")
-      let listResult = try await ref.listAll()
-      XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
-      XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
-      XCTAssertNil(listResult.pageToken, "pageToken should be nil")
-    }
-
-    private func waitForExpectations() {
-      let kTestTimeout = 60.0
-      waitForExpectations(timeout: kTestTimeout,
-                          handler: { error in
-                            if let error = error {
-                              print(error)
-                            }
-                          })
+      XCTFail("Unexpected success from unauthorized putData")
+    } catch let StorageError.unauthorized(bucket, object) {
+      XCTAssertEqual(bucket, "ios-opensource-samples.appspot.com")
+      XCTAssertEqual(object, objectLocation)
+    } catch {
+      XCTFail("error failed to convert to StorageError.unauthorized")
     }
   }
+
+  func testAttemptToUploadDirectoryShouldFail() async throws {
+    // This `.numbers` file is actually a directory.
+    let fileName = "HomeImprovement.numbers"
+    let bundle = Bundle(for: StorageIntegrationCommon.self)
+    let fileURL = try XCTUnwrap(bundle.url(forResource: fileName, withExtension: ""),
+                                "Failed to get filePath")
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
+    do {
+      _ = try await ref.putFileAsync(from: fileURL)
+      XCTFail("Unexpected success from putFile of a directory")
+    } catch let StorageError.unknown(reason) {
+      XCTAssertTrue(reason.starts(with: "File at URL:"))
+      XCTAssertTrue(reason.hasSuffix(
+        "is not reachable. Ensure file URL is not a directory, symbolic link, or invalid url."
+      ))
+    } catch {
+      XCTFail("error failed to convert to StorageError.unknown")
+    }
+  }
+
+  func testPutFileWithSpecialCharacters() async throws {
+    let fileName = "hello&+@_ .txt"
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    let metadata = try await ref.putFileAsync(from: fileURL)
+    XCTAssertEqual(fileName, metadata.name)
+    let result = try await ref.getMetadata()
+    XCTAssertNotNil(result)
+  }
+
+  func testSimplePutDataNoMetadata() async throws {
+    let ref = storage.reference(withPath: "ios/public/testSimplePutDataNoMetadata")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let result = try await ref.putDataAsync(data)
+    XCTAssertNotNil(result)
+  }
+
+  func testSimplePutFileNoMetadata() async throws {
+    let fileName = "hello&+@_ .txt"
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    let result = try await ref.putFileAsync(from: fileURL)
+    XCTAssertNotNil(result)
+  }
+
+  func testSimplePutFileWithAsyncProgress() async throws {
+    var checkedProgress = false
+    let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    var uploadedBytes: Int64 = -1
+    let successMetadata = try await ref.putFileAsync(from: fileURL) { progress in
+      if let completed = progress?.completedUnitCount {
+        checkedProgress = true
+        XCTAssertGreaterThanOrEqual(completed, uploadedBytes)
+        uploadedBytes = completed
+      }
+    }
+    XCTAssertEqual(successMetadata.size, 17)
+    XCTAssertTrue(checkedProgress)
+  }
+
+  func testSimpleGetData() async throws {
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let result = try await ref.data(maxSize: 1024 * 1024)
+    XCTAssertNotNil(result)
+  }
+
+  func testSimpleGetDataWithTask() async throws {
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let result = try await ref.data(maxSize: 1024 * 1024)
+    XCTAssertNotNil(result)
+  }
+
+  func testSimpleGetDataInBackgroundQueue() async throws {
+    actor Background {
+      func data(from ref: StorageReference) async throws -> Data {
+        XCTAssertFalse(Thread.isMainThread)
+        return try await ref.data(maxSize: 1024 * 1024)
+      }
+    }
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let result = try await Background().data(from: ref)
+    XCTAssertNotNil(result)
+  }
+
+  func testSimpleGetDataTooSmall() async {
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+    let max: Int64 = 1024
+    do {
+      _ = try await ref.data(maxSize: max)
+      XCTFail("Unexpected success from getData too small")
+    } catch let StorageError.downloadSizeExceeded(total, maxSize) {
+      XCTAssertEqual(total, 1_048_576)
+      XCTAssertEqual(maxSize, max)
+    } catch {
+      XCTFail("error failed to convert to StorageError.downloadSizeExceeded")
+    }
+  }
+
+  func testSimpleGetDownloadURL() async throws {
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+
+    // Download URL format is
+    // "https://firebasestorage.googleapis.com:443/v0/b/{bucket}/o/{path}?alt=media&token={token}"
+    let downloadURLPattern =
+      "^https:\\/\\/firebasestorage.googleapis.com:443\\/v0\\/b\\/[^\\/]*\\/o\\/" +
+      "ios%2Fpublic%2F1mb2\\?alt=media&token=[a-z0-9-]*$"
+
+    let downloadURL = try await ref.downloadURL()
+    let testRegex = try NSRegularExpression(pattern: downloadURLPattern)
+    let urlString = downloadURL.absoluteString
+    let range = NSRange(location: 0, length: urlString.count)
+    XCTAssertNotNil(testRegex.firstMatch(in: urlString, options: [], range: range))
+  }
+
+  func testAsyncWrite() async throws {
+    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+
+    _ = try await ref.putDataAsync(data)
+    let url = try await ref.writeAsync(toFile: fileURL)
+    XCTAssertEqual(url.lastPathComponent, "hello.txt")
+  }
+
+  func testSimpleGetFile() throws {
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+
+    Task {
+      _ = try await ref.putDataAsync(data)
+      let task = ref.write(toFile: fileURL)
+
+      task.observe(StorageTaskStatus.success) { snapshot in
+        do {
+          let stringData = try String(contentsOf: fileURL, encoding: .utf8)
+          XCTAssertEqual(stringData, "Hello Swift World")
+          XCTAssertEqual(snapshot.description, "<State: Success>")
+        } catch {
+          XCTFail("Error processing success snapshot")
+        }
+        expectation.fulfill()
+      }
+
+      task.observe(StorageTaskStatus.progress) { snapshot in
+        XCTAssertNil(snapshot.error, "Error should be nil")
+        guard snapshot.progress != nil else {
+          XCTFail("Missing progress")
+          return
+        }
+      }
+      task.observe(StorageTaskStatus.failure) { snapshot in
+        XCTAssertNil(snapshot.error, "Error should be nil")
+      }
+    }
+    waitForExpectations()
+  }
+
+  func testSimpleGetFileWithAsyncProgressCallbackAPI() async throws {
+    var checkedProgress = false
+    let ref = storage.reference().child("ios/public/1mb")
+    let url = URL(fileURLWithPath: "\(NSTemporaryDirectory())/hello.txt")
+    let fileURL = url
+    var downloadedBytes: Int64 = 0
+    var resumeAtBytes = 256 * 1024
+    let successURL = try await ref.writeAsync(toFile: fileURL) { progress in
+      if let completed = progress?.completedUnitCount {
+        checkedProgress = true
+        XCTAssertGreaterThanOrEqual(completed, downloadedBytes)
+        downloadedBytes = completed
+        if completed > resumeAtBytes {
+          resumeAtBytes = Int.max
+        }
+      }
+    }
+    XCTAssertTrue(checkedProgress)
+    XCTAssertEqual(successURL, url)
+    XCTAssertEqual(resumeAtBytes, Int.max)
+  }
+
+  private func assertMetadata(actualMetadata: StorageMetadata,
+                              expectedContentType: String,
+                              expectedCustomMetadata: [String: String]) {
+    XCTAssertEqual(actualMetadata.cacheControl, "cache-control")
+    XCTAssertEqual(actualMetadata.contentDisposition, "content-disposition")
+    XCTAssertEqual(actualMetadata.contentEncoding, "gzip")
+    XCTAssertEqual(actualMetadata.contentLanguage, "de")
+    XCTAssertEqual(actualMetadata.contentType, expectedContentType)
+    XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
+    for (key, value) in expectedCustomMetadata {
+      XCTAssertEqual(actualMetadata.customMetadata![key], value)
+    }
+  }
+
+  private func assertMetadataNil(actualMetadata: StorageMetadata) {
+    XCTAssertNil(actualMetadata.cacheControl)
+    XCTAssertNil(actualMetadata.contentDisposition)
+    XCTAssertEqual(actualMetadata.contentEncoding, "identity")
+    XCTAssertNil(actualMetadata.contentLanguage)
+    XCTAssertNil(actualMetadata.contentType)
+    XCTAssertEqual(actualMetadata.md5Hash?.count, 24)
+    XCTAssertNil(actualMetadata.customMetadata)
+  }
+
+  func testUpdateMetadata2() async throws {
+    let ref = storage.reference(withPath: "ios/public/1mb2")
+
+    let metadata = StorageMetadata()
+    metadata.cacheControl = "cache-control"
+    metadata.contentDisposition = "content-disposition"
+    metadata.contentEncoding = "gzip"
+    metadata.contentLanguage = "de"
+    metadata.contentType = "content-type-a"
+    metadata.customMetadata = ["a": "b"]
+
+    let updatedMetadata = try await ref.updateMetadata(metadata)
+    assertMetadata(actualMetadata: updatedMetadata,
+                   expectedContentType: "content-type-a",
+                   expectedCustomMetadata: ["a": "b"])
+
+    let metadata2 = updatedMetadata
+    metadata2.contentType = "content-type-b"
+    metadata2.customMetadata = ["a": "b", "c": "d"]
+
+    let metadata3 = try await ref.updateMetadata(metadata2)
+    assertMetadata(actualMetadata: metadata3,
+                   expectedContentType: "content-type-b",
+                   expectedCustomMetadata: ["a": "b", "c": "d"])
+    metadata.cacheControl = nil
+    metadata.contentDisposition = nil
+    metadata.contentEncoding = nil
+    metadata.contentLanguage = nil
+    metadata.contentType = nil
+    metadata.customMetadata = nil
+    let metadata4 = try await ref.updateMetadata(metadata)
+    XCTAssertNotNil(metadata4)
+  }
+
+  func testPagedListFiles() async throws {
+    let ref = storage.reference(withPath: "ios/public/list")
+    let listResult = try await ref.list(maxResults: 2)
+    XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
+    XCTAssertEqual(listResult.prefixes, [])
+    let pageToken = try XCTUnwrap(listResult.pageToken)
+    let listResult2 = try await ref.list(maxResults: 2, pageToken: pageToken)
+    XCTAssertEqual(listResult2.items, [])
+    XCTAssertEqual(listResult2.prefixes, [ref.child("prefix")])
+    XCTAssertNil(listResult2.pageToken, "pageToken should be nil")
+  }
+
+  func testPagedListFilesError() async throws {
+    let ref = storage.reference(withPath: "ios/public/list")
+    do {
+      let _: StorageListResult = try await ref.list(maxResults: 22222)
+      XCTFail("Unexpected success from ref.list")
+    } catch let StorageError.invalidArgument(message) {
+      XCTAssertEqual(message, "Argument 'maxResults' must be between 1 and 1000 inclusive.")
+    } catch {
+      XCTFail("Unexpected error")
+    }
+  }
+
+  func testListAllFiles() async throws {
+    let ref = storage.reference(withPath: "ios/public/list")
+    let listResult = try await ref.listAll()
+    XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
+    XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
+    XCTAssertNil(listResult.pageToken, "pageToken should be nil")
+  }
+
+  private func waitForExpectations() {
+    let kTestTimeout = 60.0
+    waitForExpectations(timeout: kTestTimeout,
+                        handler: { error in
+                          if let error = error {
+                            print(error)
+                          }
+                        })
+  }
+}

--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -17,7 +17,6 @@ import FirebaseCore
 import FirebaseStorage
 import XCTest
 
-#if swift(>=5.5) && canImport(_Concurrency)
   @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
   class StorageAsyncAwait: StorageIntegrationCommon {
     func testGetMetadata() async throws {
@@ -420,4 +419,3 @@ import XCTest
                           })
     }
   }
-#endif

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -21,25 +21,25 @@
 #endif // SWIFT_PACKAGE
 import Foundation
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public extension CollectionReference {
-    /// Adds a new document to this collection with the specified data, assigning it a document ID
-    /// automatically.
-    /// - Parameter data: A `Dictionary` containing the data for the new document.
-    /// - Throws: `Error` if the backend rejected the write.
-    /// - Returns: A `DocumentReference` pointing to the newly created document.
-    @discardableResult
-    func addDocument(data: [String: Any]) async throws -> DocumentReference {
-      return try await withCheckedThrowingContinuation { continuation in
-        var document: DocumentReference?
-        document = self.addDocument(data: data) { error in
-          if let err = error {
-            continuation.resume(throwing: err)
-          } else {
-            // Our callbacks guarantee that we either return an error or a document.
-            continuation.resume(returning: document!)
-          }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+public extension CollectionReference {
+  /// Adds a new document to this collection with the specified data, assigning it a document ID
+  /// automatically.
+  /// - Parameter data: A `Dictionary` containing the data for the new document.
+  /// - Throws: `Error` if the backend rejected the write.
+  /// - Returns: A `DocumentReference` pointing to the newly created document.
+  @discardableResult
+  func addDocument(data: [String: Any]) async throws -> DocumentReference {
+    return try await withCheckedThrowingContinuation { continuation in
+      var document: DocumentReference?
+      document = self.addDocument(data: data) { error in
+        if let err = error {
+          continuation.resume(throwing: err)
+        } else {
+          // Our callbacks guarantee that we either return an error or a document.
+          continuation.resume(returning: document!)
         }
       }
     }
   }
+}

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -21,7 +21,6 @@
 #endif // SWIFT_PACKAGE
 import Foundation
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension CollectionReference {
     /// Adds a new document to this collection with the specified data, assigning it a document ID
@@ -44,4 +43,3 @@ import Foundation
       }
     }
   }
-#endif

--- a/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
@@ -21,7 +21,6 @@
 #endif // SWIFT_PACKAGE
 import Foundation
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public extension Firestore {
     /// Loads a Firestore bundle into the local cache.
@@ -117,4 +116,3 @@ import Foundation
       }
     }
   }
-#endif

--- a/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/Firestore+AsyncAwait.swift
@@ -21,98 +21,98 @@
 #endif // SWIFT_PACKAGE
 import Foundation
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public extension Firestore {
-    /// Loads a Firestore bundle into the local cache.
-    /// - Parameter bundleData: Data from the bundle to be loaded.
-    /// - Throws: `Error` if the bundle data cannot be parsed.
-    /// - Returns: The final `LoadBundleTaskProgress` that contains the total number of documents
-    /// loaded.
-    func loadBundle(_ bundleData: Data) async throws -> LoadBundleTaskProgress {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.loadBundle(bundleData) { progress, error in
-          if let err = error {
-            continuation.resume(throwing: err)
-          } else {
-            // Our callbacks guarantee that we either return an error or a progress event.
-            continuation.resume(returning: progress!)
-          }
-        }
-      }
-    }
-
-    /// Loads a Firestore bundle into the local cache.
-    /// - Parameter bundleStream: An input stream from which the bundle can be read.
-    /// - Throws: `Error` if the bundle stream cannot be parsed.
-    /// - Returns: The final `LoadBundleTaskProgress` that contains the total number of documents
-    /// loaded.
-    func loadBundle(_ bundleStream: InputStream) async throws -> LoadBundleTaskProgress {
-      return try await withCheckedThrowingContinuation { continuation in
-        self.loadBundle(bundleStream) { progress, error in
-          if let err = error {
-            continuation.resume(throwing: err)
-          } else {
-            // Our callbacks guarantee that we either return an error or a progress event.
-            continuation.resume(returning: progress!)
-          }
-        }
-      }
-    }
-
-    /// Executes the given updateBlock and then attempts to commit the changes applied within an
-    /// atomic
-    /// transaction.
-    ///
-    /// The maximum number of writes allowed in a single transaction is 500, but note that each
-    /// usage of
-    /// `FieldValue.serverTimestamp()`, `FieldValue.arrayUnion()`, `FieldValue.arrayRemove()`, or
-    /// `FieldValue.increment()` inside a transaction counts as an additional write.
-    ///
-    /// In the `updateBlock`, a set of reads and writes can be performed atomically using the
-    /// `Transaction` object passed to the block. After the `updateBlock` is run, Firestore will
-    /// attempt
-    /// to apply the changes to the server. If any of the data read has been modified outside of
-    /// this
-    /// transaction since being read, then the transaction will be retried by executing the
-    /// `updateBlock`
-    /// again. If the transaction still fails after 5 retries, then the transaction will fail.
-    ///
-    /// Since the `updateBlock` may be executed multiple times, it should avoiding doing anything
-    /// that
-    /// would cause side effects.
-    ///
-    /// Any value maybe be returned from the `updateBlock`. If the transaction is successfully
-    /// committed,
-    /// then the completion block will be passed that value. The `updateBlock` also has an `NSError`
-    /// out
-    /// parameter. If this is set, then the transaction will not attempt to commit, and the given
-    /// error
-    /// will be returned.
-    ///
-    /// The `Transaction` object passed to the `updateBlock` contains methods for accessing
-    /// documents
-    /// and collections. Unlike other firestore access, data accessed with the transaction will not
-    /// reflect local changes that have not been committed. For this reason, it is required that all
-    /// reads are performed before any writes. Transactions must be performed while online.
-    /// Otherwise,
-    /// reads will fail, the final commit will fail, and this function will return an error.
-    ///
-    /// - Parameter updateBlock The block to execute within the transaction context.
-    /// - Throws Throws an error if the transaction could not be committed, or if an error was
-    /// explicitly specified in the `updateBlock` parameter.
-    /// - Returns Returns the value returned in the `updateBlock` parameter if no errors occurred.
-    func runTransaction(_ updateBlock: @escaping (Transaction, NSErrorPointer)
-      -> Any?) async throws -> Any? {
-      // This needs to be wrapped in order to express a nullable return value upon success.
-      // See https://github.com/firebase/firebase-ios-sdk/issues/9426 for more details.
-      return try await withCheckedThrowingContinuation { continuation in
-        self.runTransaction(updateBlock) { anyValue, error in
-          if let err = error {
-            continuation.resume(throwing: err)
-          } else {
-            continuation.resume(returning: anyValue)
-          }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+public extension Firestore {
+  /// Loads a Firestore bundle into the local cache.
+  /// - Parameter bundleData: Data from the bundle to be loaded.
+  /// - Throws: `Error` if the bundle data cannot be parsed.
+  /// - Returns: The final `LoadBundleTaskProgress` that contains the total number of documents
+  /// loaded.
+  func loadBundle(_ bundleData: Data) async throws -> LoadBundleTaskProgress {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.loadBundle(bundleData) { progress, error in
+        if let err = error {
+          continuation.resume(throwing: err)
+        } else {
+          // Our callbacks guarantee that we either return an error or a progress event.
+          continuation.resume(returning: progress!)
         }
       }
     }
   }
+
+  /// Loads a Firestore bundle into the local cache.
+  /// - Parameter bundleStream: An input stream from which the bundle can be read.
+  /// - Throws: `Error` if the bundle stream cannot be parsed.
+  /// - Returns: The final `LoadBundleTaskProgress` that contains the total number of documents
+  /// loaded.
+  func loadBundle(_ bundleStream: InputStream) async throws -> LoadBundleTaskProgress {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.loadBundle(bundleStream) { progress, error in
+        if let err = error {
+          continuation.resume(throwing: err)
+        } else {
+          // Our callbacks guarantee that we either return an error or a progress event.
+          continuation.resume(returning: progress!)
+        }
+      }
+    }
+  }
+
+  /// Executes the given updateBlock and then attempts to commit the changes applied within an
+  /// atomic
+  /// transaction.
+  ///
+  /// The maximum number of writes allowed in a single transaction is 500, but note that each
+  /// usage of
+  /// `FieldValue.serverTimestamp()`, `FieldValue.arrayUnion()`, `FieldValue.arrayRemove()`, or
+  /// `FieldValue.increment()` inside a transaction counts as an additional write.
+  ///
+  /// In the `updateBlock`, a set of reads and writes can be performed atomically using the
+  /// `Transaction` object passed to the block. After the `updateBlock` is run, Firestore will
+  /// attempt
+  /// to apply the changes to the server. If any of the data read has been modified outside of
+  /// this
+  /// transaction since being read, then the transaction will be retried by executing the
+  /// `updateBlock`
+  /// again. If the transaction still fails after 5 retries, then the transaction will fail.
+  ///
+  /// Since the `updateBlock` may be executed multiple times, it should avoiding doing anything
+  /// that
+  /// would cause side effects.
+  ///
+  /// Any value maybe be returned from the `updateBlock`. If the transaction is successfully
+  /// committed,
+  /// then the completion block will be passed that value. The `updateBlock` also has an `NSError`
+  /// out
+  /// parameter. If this is set, then the transaction will not attempt to commit, and the given
+  /// error
+  /// will be returned.
+  ///
+  /// The `Transaction` object passed to the `updateBlock` contains methods for accessing
+  /// documents
+  /// and collections. Unlike other firestore access, data accessed with the transaction will not
+  /// reflect local changes that have not been committed. For this reason, it is required that all
+  /// reads are performed before any writes. Transactions must be performed while online.
+  /// Otherwise,
+  /// reads will fail, the final commit will fail, and this function will return an error.
+  ///
+  /// - Parameter updateBlock The block to execute within the transaction context.
+  /// - Throws Throws an error if the transaction could not be committed, or if an error was
+  /// explicitly specified in the `updateBlock` parameter.
+  /// - Returns Returns the value returned in the `updateBlock` parameter if no errors occurred.
+  func runTransaction(_ updateBlock: @escaping (Transaction, NSErrorPointer)
+    -> Any?) async throws -> Any? {
+    // This needs to be wrapped in order to express a nullable return value upon success.
+    // See https://github.com/firebase/firebase-ios-sdk/issues/9426 for more details.
+    return try await withCheckedThrowingContinuation { continuation in
+      self.runTransaction(updateBlock) { anyValue, error in
+        if let err = error {
+          continuation.resume(throwing: err)
+        } else {
+          continuation.resume(returning: anyValue)
+        }
+      }
+    }
+  }
+}

--- a/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
@@ -76,40 +76,40 @@ public extension DocumentReference {
     }
   }
 
-    /// Fetches and decodes the document referenced by this `DocumentReference`.
-    ///
-    /// This allows users to retrieve a Firestore document and have it decoded
-    /// to an instance of caller-specified type as follows:
-    /// ```swift
-    /// do {
-    ///   let book = try await ref.getDocument(as: Book.self)
-    /// } catch {
-    ///   // Handle error
-    /// }
-    /// ```
-    ///
-    /// This method attempts to provide up-to-date data when possible by waiting
-    /// for data from the server, but it may return cached data or fail if you
-    /// are offline and the server cannot be reached. If `T` denotes
-    /// an optional type, the method returns a successful status with a value
-    /// of `nil` for non-existing documents.
-    ///
-    /// - Parameters:
-    ///   - as: A `Decodable` type to convert the document fields to.
-    ///   - serverTimestampBehavior: Configures how server timestamps that have
-    ///     not yet been set to their final value are returned from the
-    ///     snapshot.
-    ///   - decoder: The decoder to use to convert the document. Defaults to use
-    ///     the default decoder.
-    /// - Returns: This instance of the supplied `Decodable` type `T`.
-    @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    func getDocument<T: Decodable>(as type: T.Type,
-                                   with serverTimestampBehavior: ServerTimestampBehavior =
-                                     .none,
-                                   decoder: Firestore.Decoder = .init()) async throws -> T {
-      let snapshot = try await getDocument()
-      return try snapshot.data(as: T.self,
-                               with: serverTimestampBehavior,
-                               decoder: decoder)
-    }
+  /// Fetches and decodes the document referenced by this `DocumentReference`.
+  ///
+  /// This allows users to retrieve a Firestore document and have it decoded
+  /// to an instance of caller-specified type as follows:
+  /// ```swift
+  /// do {
+  ///   let book = try await ref.getDocument(as: Book.self)
+  /// } catch {
+  ///   // Handle error
+  /// }
+  /// ```
+  ///
+  /// This method attempts to provide up-to-date data when possible by waiting
+  /// for data from the server, but it may return cached data or fail if you
+  /// are offline and the server cannot be reached. If `T` denotes
+  /// an optional type, the method returns a successful status with a value
+  /// of `nil` for non-existing documents.
+  ///
+  /// - Parameters:
+  ///   - as: A `Decodable` type to convert the document fields to.
+  ///   - serverTimestampBehavior: Configures how server timestamps that have
+  ///     not yet been set to their final value are returned from the
+  ///     snapshot.
+  ///   - decoder: The decoder to use to convert the document. Defaults to use
+  ///     the default decoder.
+  /// - Returns: This instance of the supplied `Decodable` type `T`.
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  func getDocument<T: Decodable>(as type: T.Type,
+                                 with serverTimestampBehavior: ServerTimestampBehavior =
+                                   .none,
+                                 decoder: Firestore.Decoder = .init()) async throws -> T {
+    let snapshot = try await getDocument()
+    return try snapshot.data(as: T.self,
+                             with: serverTimestampBehavior,
+                             decoder: decoder)
+  }
 }

--- a/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+ReadDecodable.swift
@@ -76,7 +76,6 @@ public extension DocumentReference {
     }
   }
 
-  #if compiler(>=5.5.2) && canImport(_Concurrency)
     /// Fetches and decodes the document referenced by this `DocumentReference`.
     ///
     /// This allows users to retrieve a Firestore document and have it decoded
@@ -113,5 +112,4 @@ public extension DocumentReference {
                                with: serverTimestampBehavior,
                                decoder: decoder)
     }
-  #endif
 }


### PR DESCRIPTION
Remove unnecessary checks for Swift compiler Concurrency support.

Concurrency is always available in the currently supported minimum Xcode 14.1 and above.