### PR TITLE
Storage Integration Test flakiness

### DIFF
--- a/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
+++ b/FirebaseStorage/Tests/Integration/StorageAsyncAwait.swift
@@ -151,7 +151,7 @@ class StorageAsyncAwait: StorageIntegrationCommon {
     let ref = storage.reference(withPath: "ios/public/" + fileName)
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
     let metadata = try await ref.putFileAsync(from: fileURL)
     XCTAssertEqual(fileName, metadata.name)
@@ -182,7 +182,7 @@ class StorageAsyncAwait: StorageIntegrationCommon {
     let ref = storage.reference(withPath: "ios/public/testSimplePutFile")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
     var uploadedBytes: Int64 = -1
     let successMetadata = try await ref.putFileAsync(from: fileURL) { progress in
@@ -251,21 +251,21 @@ class StorageAsyncAwait: StorageIntegrationCommon {
   }
 
   func testAsyncWrite() async throws {
-    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let ref = storage.reference(withPath: "ios/public/helloworld" + #function)
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
     _ = try await ref.putDataAsync(data)
     let url = try await ref.writeAsync(toFile: fileURL)
-    XCTAssertEqual(url.lastPathComponent, "hello.txt")
+    XCTAssertEqual(url.lastPathComponent, #function + "hello.txt")
   }
 
   func testSimpleGetFile() throws {
     let expectation = self.expectation(description: #function)
-    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let ref = storage.reference(withPath: "ios/public/helloworld" + #function)
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
     Task {

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -535,9 +535,9 @@ class StorageResultTests: StorageIntegrationCommon {
 
   func testSimpleGetFile() throws {
     let expectation = self.expectation(description: #function)
-    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let ref = storage.reference(withPath: "ios/public/helloworld" + #function)
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
     ref.putData(data) { result in
@@ -577,16 +577,15 @@ class StorageResultTests: StorageIntegrationCommon {
 
   func testCancelErrorCode() throws {
     let expectation = self.expectation(description: #function)
-    let ref = storage.reference(withPath: "ios/public/helloworld")
+    let ref = storage.reference(withPath: "ios/public/helloworld" + #function)
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
     ref.putData(data) { result in
       switch result {
       case .success:
         let task = ref.write(toFile: fileURL)
-        task.cancel()
 
         task.observe(StorageTaskStatus.success) { snapshot in
           XCTFail("Error processing success snapshot")
@@ -603,6 +602,7 @@ class StorageResultTests: StorageIntegrationCommon {
           }
           expectation.fulfill()
         }
+        task.cancel()
       case let .failure(error):
         XCTFail("Unexpected error \(error) from putData")
         expectation.fulfill()


### PR DESCRIPTION
Use unique names to try to address recent storage integration test flakiness

Also move task.cancel after task.observe to address another possible flake