### PR TITLE
[auth-swift] Fix heartbeats for SPM

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRHeartbeatLogger+AppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRHeartbeatLogger+AppCheck.m
@@ -23,8 +23,7 @@ static NSString *const kFIRHeartbeatLoggerPayloadHeaderKey = @"X-firebase-client
 
 - (GACAppCheckAPIRequestHook)requestHook {
   return ^(NSMutableURLRequest *request) {
-    NSString *heartbeatsValue =
-        FIRHeaderValueFromHeartbeatsPayload([self flushHeartbeatsIntoPayload]);
+    NSString *heartbeatsValue = [self headerValue];
     if (heartbeatsValue) {
       [request setValue:heartbeatsValue forHTTPHeaderField:kFIRHeartbeatLoggerPayloadHeaderKey];
     }

--- a/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
@@ -41,17 +41,15 @@ import Foundation
   private let kUserCodingKey = "user"
   private let kCredentialCodingKey = "credential"
 
-  // TODO: All below here should be internal
-
   /** @fn initWithUser:additionalUserInfo:
    @brief Designated initializer.
    @param user The signed in user reference.
    @param additionalUserInfo The additional user info.
    @param credential The updated OAuth credential if available.
    */
-  @objc public init(withUser user: User,
-                    additionalUserInfo: AdditionalUserInfo?,
-                    credential: OAuthCredential? = nil) {
+  init(withUser user: User,
+       additionalUserInfo: AdditionalUserInfo?,
+       credential: OAuthCredential? = nil) {
     self.user = user
     self.additionalUserInfo = additionalUserInfo
     self.credential = credential

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -112,15 +112,9 @@ class AuthBackend: NSObject {
     request.setValue(clientVersion, forHTTPHeaderField: "X-Client-Version")
     request.setValue(Bundle.main.bundleIdentifier, forHTTPHeaderField: "X-Ios-Bundle-Identifier")
     request.setValue(requestConfiguration.appID, forHTTPHeaderField: "X-Firebase-GMPID")
-    // TODO: Enable for SPM. Can we directly call the Swift library?
-    #if COCOAPODS
-      if let heartbeatLogger = requestConfiguration.heartbeatLogger {
-        request.setValue(
-          FIRHeaderValueFromHeartbeatsPayload(heartbeatLogger.flushHeartbeatsIntoPayload()),
-          forHTTPHeaderField: "X-Firebase-Client"
-        )
-      }
-    #endif
+    if let heartbeatLogger = requestConfiguration.heartbeatLogger {
+      request.setValue(heartbeatLogger.headerValue(), forHTTPHeaderField: "X-Firebase-Client")
+    }
     request.httpMethod = requestConfiguration.httpMethod
     let preferredLocalizations = Bundle.main.preferredLocalizations
     if preferredLocalizations.count > 0 {

--- a/FirebaseCore/Extension/FIRHeartbeatLogger.h
+++ b/FirebaseCore/Extension/FIRHeartbeatLogger.h
@@ -36,8 +36,8 @@ typedef NS_ENUM(NSInteger, FIRDailyHeartbeatCode) {
 - (void)log;
 
 #ifndef FIREBASE_BUILD_CMAKE
-/// Flushes heartbeats from storage into a structured payload of heartbeats.
-- (FIRHeartbeatsPayload *)flushHeartbeatsIntoPayload;
+/// Return the headerValue for the HeartbeatLogger.
+- (NSString *_Nullable)headerValue;
 #endif  // FIREBASE_BUILD_CMAKE
 
 /// Gets the heartbeat code for today.

--- a/FirebaseCore/Sources/FIRHeartbeatLogger.m
+++ b/FirebaseCore/Sources/FIRHeartbeatLogger.m
@@ -70,6 +70,10 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 }
 
 #ifndef FIREBASE_BUILD_CMAKE
+- (NSString *_Nullable)headerValue {
+  return FIRHeaderValueFromHeartbeatsPayload([self flushHeartbeatsIntoPayload]);
+}
+
 - (FIRHeartbeatsPayload *)flushHeartbeatsIntoPayload {
   FIRHeartbeatsPayload *payload = [_heartbeatController flush];
   return payload;

--- a/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
+++ b/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
@@ -278,8 +278,7 @@ NS_ASSUME_NONNULL_END
                [request setValue:authHeader forHTTPHeaderField:@"Authorization"];
              }
              // Heartbeat Header.
-             [request setValue:FIRHeaderValueFromHeartbeatsPayload(
-                                   [self.heartbeatLogger flushHeartbeatsIntoPayload])
+             [request setValue:[self.heartbeatLogger headerValue]
                  forHTTPHeaderField:kFIRInstallationsHeartbeatKey];
 
              [additionalHeaders

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -95,8 +95,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   // from the above Installations API call.
   [self addTeardownBlock:^{
     FBLWaitForPromisesWithTimeout(20);
-    XCTAssertNil(FIRHeaderValueFromHeartbeatsPayload(
-        [FIRApp.defaultApp.heartbeatLogger flushHeartbeatsIntoPayload]));
+    XCTAssertNil(FIRHeaderValueFromHeartbeatsPayload([self.heartbeatLogger headerValue]));
   }];
 }
 
@@ -126,8 +125,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   // from the above Installations API call.
   [self addTeardownBlock:^{
     FBLWaitForPromisesWithTimeout(20);
-    XCTAssertNil(FIRHeaderValueFromHeartbeatsPayload(
-        [FIRApp.defaultApp.heartbeatLogger flushHeartbeatsIntoPayload]));
+    XCTAssertNil([FIRApp.defaultApp.heartbeatLogger headerValue]);
   }];
 }
 
@@ -158,8 +156,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   // from the above Installations API call.
   [self addTeardownBlock:^{
     FBLWaitForPromisesWithTimeout(20);
-    XCTAssertNil(FIRHeaderValueFromHeartbeatsPayload(
-        [FIRApp.defaultApp.heartbeatLogger flushHeartbeatsIntoPayload]));
+    XCTAssertNil([FIRApp.defaultApp.heartbeatLogger headerValue]);
   }];
 }
 


### PR DESCRIPTION
Restore HeartbeatLogger support for the SPM build

SPM failed to recognize the FIRHeartbeatLoggerProtocol because it included the method `flushHeartbeatsIntoPayload` that returns a Objective C type that maps a Swift implementation type.

Since the `flushHeartbeatsIntoPayload` isn't actually needed in the protocol versus a more concise `headerValue` method, the issue is resolved by switching to `headerValue`.