### PR TITLE
[Release Tooling] Stop including 'Info.plist's in static xcframeworks

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- In preparation for supporting Privacy Manifests, remove `Info.plist` files
+  from static xcframeworks (#12243).
+
 # Firebase 10.14.0
 - For developers building for visionOS, Xcode 15 beta 6 or later is required.
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
-- In preparation for supporting Privacy Manifests, remove `Info.plist` files
-  from static xcframeworks (#12243).
+- The following change only applies to those using a binary distribution of
+  a Firebase SDK(s). In preparation for supporting Privacy Manifests, each
+  platform framework directory within a static xcframewok no longer contains
+  an `Info.plist` file (#12243).
 
 # Firebase 10.14.0
 - For developers building for visionOS, Xcode 15 beta 6 or later is required.

--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -241,9 +241,6 @@ extension CarthageUtils {
     } catch {
       fatalError("Couldn't copy dummy library for Firebase framework in Carthage. \(error)")
     }
-
-    // Write the Info.plist.
-    generatePlistContents(forName: "Firebase", withVersion: version, to: frameworkDir)
   }
 
   static func generatePlistContents(forName name: String,

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -380,10 +380,6 @@ struct FrameworkBuilder {
       }
       umbrellaHeader = umbrellaHeaderURL.lastPathComponent
     }
-    // Add an Info.plist. Required by Carthage and SPM binary xcframeworks.
-    CarthageUtils.generatePlistContents(forName: frameworkName,
-                                        withVersion: podInfo.version,
-                                        to: frameworkDir)
 
     // TODO: copy PrivateHeaders directory as well if it exists. SDWebImage is an example pod.
 
@@ -594,8 +590,8 @@ struct FrameworkBuilder {
   /// Groups slices for each platform into a minimal set of frameworks.
   /// - Parameter withName: The framework name.
   /// - Parameter isCarthage: Name the temp directory differently for Carthage.
-  /// - Parameter fromFolder: The almost complete framework folder. Includes Headers, Info.plist,
-  /// and Resources.
+  /// - Parameter fromFolder: The almost complete framework folder. Includes
+  /// Headers, and Resources.
   /// - Parameter slicedFrameworks: All the frameworks sliced by platform.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
   private func groupFrameworks(withName framework: String,
@@ -656,15 +652,6 @@ struct FrameworkBuilder {
           at: headersSrc,
           to: platformFrameworkDir.appendingPathComponent("Headers")
         )
-      } catch {
-        fatalError("Could not create framework directory needed to build \(framework): \(error)")
-      }
-
-      // Info.plist from `fromFolder`
-      do {
-        let infoPlistSrc = fromFolder.appendingPathComponent("Info.plist").resolvingSymlinksInPath()
-        let infoPlistDst = platformFrameworkDir.appendingPathComponent("Info.plist")
-        try fileManager.copyItem(at: infoPlistSrc, to: infoPlistDst)
       } catch {
         fatalError("Could not create framework directory needed to build \(framework): \(error)")
       }


### PR DESCRIPTION
Static xcframeworks containing privacy manifests should be embedded in Xcode 15. The `Info.plist`s that have been historically included in our static xcframeworks should therefore be removed.

Note, only the `Info.plist`s within the _platform_ frameworks (`.framework`) need to be removed. The root level `Info.plist` in the xcframework (`.xcframework`) does not seem to cause issues.

---

### Testing

Locally built a `FirebaseSharedSwift.xcframework` with and without these changes:
```
diff --color <(tree FrameworkWithPlist) <(tree FrameworkWithoutPlist)
1c1
< FrameworkWithoutPlist
---
> FrameworkWithPlist
9a10
>     │       ├── Info.plist
24a26
>     │       ├── Info.plist
44a47
>     │       ├── Info.plist
64a68
>     │       ├── Info.plist
84a89
>     │       ├── Info.plist
99a105
>             ├── Info.plist
115c121
< 38 directories, 75 files
---
> 38 directories, 81 files
```

#### Additional Tasks Before Merging
- [x] Diff the `Firebase.zip` created from this PR's CI with the 10.19.0 zip.
- [x] Ensure that `.bundle`s still contain an `Info.plist`.