### PR TITLE
Decode old fcmToken format

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.20.0
+- [fixed] Fix 10.19.0 regression where the FCM registration token was nil at first app start
+  after update from 10.19.0 or earlier. (#12245)
+
 # 10.19.0
 - [changed] Adopt NSSecureCoding for internal classes. (#12075)
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// the cacheTime would be updated.
 @property(nonatomic, copy, nullable) NSDate *cacheTime;
 
+/// Indicates the info was stored on the keychain by version 10.18.0 or earlier.
+@property(nonatomic, readonly) BOOL needsMigration;
+
 /**
  *  Initializes a FIRMessagingTokenInfo object with the required parameters. These
  *  parameters represent all the relevant associated data with a token.

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -175,6 +175,8 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   if (rawAPNSInfo && ![rawAPNSInfo isKindOfClass:[FIRMessagingAPNSInfo class]]) {
     // If the decoder fails to decode a FIRMessagingAPNSInfo, check if this was archived by a
     // FirebaseMessaging 10.18.0 or earlier.
+    // TODO(#12246) This block may be replaced with `rawAPNSInfo = nil` once we're confident all users
+    // have upgraded to at least 10.19.0. Perhaps, after privacy manifests have been required for awhile?
     @try {
       [NSKeyedUnarchiver setClass:[FIRMessagingAPNSInfo class]
                      forClassName:@"FIRInstanceIDAPNSInfo"];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -175,8 +175,9 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
   if (rawAPNSInfo && ![rawAPNSInfo isKindOfClass:[FIRMessagingAPNSInfo class]]) {
     // If the decoder fails to decode a FIRMessagingAPNSInfo, check if this was archived by a
     // FirebaseMessaging 10.18.0 or earlier.
-    // TODO(#12246) This block may be replaced with `rawAPNSInfo = nil` once we're confident all users
-    // have upgraded to at least 10.19.0. Perhaps, after privacy manifests have been required for awhile?
+    // TODO(#12246) This block may be replaced with `rawAPNSInfo = nil` once we're confident all
+    // users have upgraded to at least 10.19.0. Perhaps, after privacy manifests have been required
+    // for awhile?
     @try {
       [NSKeyedUnarchiver setClass:[FIRMessagingAPNSInfo class]
                      forClassName:@"FIRInstanceIDAPNSInfo"];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -140,6 +140,7 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
 }
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+  BOOL needsMigration = NO;
   // These value cannot be nil
 
   id authorizedEntity = [aDecoder decodeObjectForKey:kFIRInstanceIDAuthorizedEntityKey];
@@ -180,6 +181,7 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       rawAPNSInfo = [NSKeyedUnarchiver unarchiveObjectWithData:(NSData *)rawAPNSInfo];
+      needsMigration = YES;
 #pragma clang diagnostic pop
     } @catch (NSException *exception) {
       FIRMessagingLoggerInfo(kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
@@ -203,6 +205,7 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
     _firebaseAppID = [firebaseAppID copy];
     _APNSInfo = [rawAPNSInfo copy];
     _cacheTime = cacheTime;
+    _needsMigration = needsMigration;
   }
   return self;
 }


### PR DESCRIPTION
Fix #12245. 

If decoding of the FIRMessagingTokenInfo fails, fallback to the pre-10.19.0 code and migrate the keychain to the NSSecure encode.

Summary from @ncooke3:
1. developer onboards to 10.20.0+ → secure tokens are always read and written
2. developer updates to 10.20.0+ from 10.18.0 or below → initial read of an unsecure token, write back a secured token, and always read secure tokens afterwards
3. developer updates to 10.20.0+ from 10.19.0 → two subcases:
    a. the unsecure token was overwritten by the secure token & always read later as a secure token
    b. the unsecure token was NOT overwritten yet and the fallback decode code path kicks into effect