### PR TITLE
[auth-swift] Use open instead of public for classes, vars, and funcs

### DIFF
--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
@@ -17,7 +17,7 @@ import Foundation
 /** @class ActionCodeInfo
     @brief Manages information regarding action codes.
  */
-@objc(FIRActionCodeInfo) public class ActionCodeInfo: NSObject {
+@objc(FIRActionCodeInfo) open class ActionCodeInfo: NSObject {
   /**
       @brief The operation being performed.
    */
@@ -50,7 +50,6 @@ import Foundation
       @param requestType Request type returned in in the server response.
       @return The corresponding ActionCodeOperation for the supplied request type.
    */
-  @objc public
   class func actionCodeOperation(forRequestType requestType: String?) -> ActionCodeOperation {
     switch requestType {
     case "PASSWORD_RESET": return .passwordReset

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
@@ -17,46 +17,46 @@ import Foundation
 /** @class FIRActionCodeSettings
     @brief Used to set and retrieve settings related to handling action codes.
  */
-@objc(FIRActionCodeSettings) public class ActionCodeSettings: NSObject {
+@objc(FIRActionCodeSettings) open class ActionCodeSettings: NSObject {
   /** @property URL
       @brief This URL represents the state/Continue URL in the form of a universal link.
       @remarks This URL can should be constructed as a universal link that would either directly open
           the app where the action code would be handled or continue to the app after the action code
           is handled by Firebase.
    */
-  @objc(URL) public var url: URL?
+  @objc(URL) open var url: URL?
 
   /** @property handleCodeInApp
       @brief Indicates whether the action code link will open the app directly or after being
           redirected from a Firebase owned web widget.
    */
-  @objc public var handleCodeInApp: Bool = false
+  @objc open var handleCodeInApp: Bool = false
 
   /** @property iOSBundleID
       @brief The iOS bundle ID, if available. The default value is the current app's bundle ID.
    */
-  @objc public var iOSBundleID: String?
+  @objc open var iOSBundleID: String?
 
   /** @property androidPackageName
       @brief The Android package name, if available.
    */
-  @objc public var androidPackageName: String?
+  @objc open var androidPackageName: String?
 
   /** @property androidMinimumVersion
       @brief The minimum Android version supported, if available.
    */
-  @objc public var androidMinimumVersion: String?
+  @objc open var androidMinimumVersion: String?
 
   /** @property androidInstallIfNotAvailable
       @brief Indicates whether the Android app should be installed on a device where it is not
          available.
    */
-  @objc public var androidInstallIfNotAvailable: Bool = false
+  @objc open var androidInstallIfNotAvailable: Bool = false
 
   /** @property dynamicLinkDomain
       @brief The Firebase Dynamic Link domain used for out of band code flow.
    */
-  @objc public var dynamicLinkDomain: String?
+  @objc open var dynamicLinkDomain: String?
 
   /** @fn
       @brief Sets the iOS bundle Id.
@@ -76,7 +76,7 @@ import Foundation
       @remarks If installIfNotAvailable is set to YES and the link is opened on an android device, it
           will try to install the app if not already available. Otherwise the web URL is used.
    */
-  @objc public func setAndroidPackageName(_ androidPackageName: String,
+  @objc open func setAndroidPackageName(_ androidPackageName: String,
                                           installIfNotAvailable: Bool,
                                           minimumVersion: String?) {
     self.androidPackageName = androidPackageName
@@ -84,7 +84,7 @@ import Foundation
     androidMinimumVersion = minimumVersion
   }
 
-  public func setIOSBundleID(_ bundleID: String) {
+  open func setIOSBundleID(_ bundleID: String) {
     iOSBundleID = bundleID
   }
 }

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
@@ -17,7 +17,7 @@ import Foundation
 /** @class FIRActionCodeURL
     @brief This class will allow developers to easily extract information about out of band links.
  */
-@objc(FIRActionCodeURL) public class ActionCodeURL: NSObject {
+@objc(FIRActionCodeURL) open class ActionCodeURL: NSObject {
   /** @property APIKey
       @brief Returns the API key from the link. nil, if not provided.
    */

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -37,7 +37,7 @@ import FirebaseCoreExtension
 #if os(iOS)
   @available(iOS 13.0, *)
   extension Auth: UISceneDelegate {
-    public func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    open func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
       for urlContext in URLContexts {
         let _ = canHandle(urlContext.url)
       }
@@ -46,19 +46,19 @@ import FirebaseCoreExtension
 
   @available(iOS 13.0, *)
   extension Auth: UIApplicationDelegate {
-    public func application(_ application: UIApplication,
+    open func application(_ application: UIApplication,
                             didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
       setAPNSToken(deviceToken, type: .unknown)
     }
 
-    public func application(_ application: UIApplication,
+    open func application(_ application: UIApplication,
                             didFailToRegisterForRemoteNotificationsWithError error: Error) {
       kAuthGlobalWorkQueue.sync {
         self.tokenManager.cancel(withError: error)
       }
     }
 
-    public func application(_ application: UIApplication,
+    open func application(_ application: UIApplication,
                             didReceiveRemoteNotification userInfo: [AnyHashable: Any],
                             fetchCompletionHandler completionHandler:
                             @escaping (UIBackgroundFetchResult) -> Void) {
@@ -67,12 +67,12 @@ import FirebaseCoreExtension
     }
 
     // TODO(#11693): This deprecated API is temporarily needed for Phone Auth.
-    public func application(_ application: UIApplication,
+    open func application(_ application: UIApplication,
                             didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
       _ = canHandleNotification(userInfo)
     }
 
-    public func application(_ application: UIApplication,
+    open func application(_ application: UIApplication,
                             open url: URL,
                             options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
       return canHandle(url)
@@ -83,7 +83,7 @@ import FirebaseCoreExtension
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 extension Auth: AuthInterop {
   @objc(getTokenForcingRefresh:withCallback:)
-  public func getToken(forcingRefresh forceRefresh: Bool,
+  open func getToken(forcingRefresh forceRefresh: Bool,
                        completion callback: @escaping (String?, Error?) -> Void) {
     kAuthGlobalWorkQueue.async { [weak self] in
       if let strongSelf = self {
@@ -134,7 +134,7 @@ extension Auth: AuthInterop {
     }
   }
 
-  public func getUserID() -> String? {
+  open func getUserID() -> String? {
     return currentUser?.uid
   }
 }
@@ -150,7 +150,7 @@ extension Auth: AuthInterop {
    @remarks The default Firebase app must have already been configured or an exception will be
    raised.
    */
-  @objc public class func auth() -> Auth {
+  @objc open class func auth() -> Auth {
     guard let defaultApp = FirebaseApp.app() else {
       fatalError("The default FirebaseApp instance must be configured before the default Auth " +
         "instance can be initialized. One way to ensure this is to call " +
@@ -167,7 +167,7 @@ extension Auth: AuthInterop {
    @param app The app for which to retrieve the associated `Auth` instance.
    @return The `Auth` instance associated with the given app.
    */
-  @objc public class func auth(app: FirebaseApp) -> Auth {
+  @objc open class func auth(app: FirebaseApp) -> Auth {
     return ComponentType<AuthProvider>.instance(for: AuthProvider.self, in: app.container) as! Auth
   }
 
@@ -187,7 +187,7 @@ extension Auth: AuthInterop {
 
    @remarks The string used to set this property must be a language code that follows BCP 47.
    */
-  @objc public var languageCode: String? {
+  @objc open var languageCode: String? {
     get {
       kAuthGlobalWorkQueue.sync {
         requestConfiguration.languageCode
@@ -203,7 +203,7 @@ extension Auth: AuthInterop {
   /** @property settings
    @brief Contains settings related to the auth object.
    */
-  @NSCopying @objc public var settings: AuthSettings?
+  @NSCopying @objc open var settings: AuthSettings?
 
   /** @property userAccessGroup
    @brief The current user access group that the Auth instance is using. Default is nil.
@@ -216,19 +216,19 @@ extension Auth: AuthInterop {
    have no effect. You should set shareAuthStateAcrossDevices to it's desired
    state and then set the userAccessGroup after.
    */
-  @objc public var shareAuthStateAcrossDevices: Bool = false
+  @objc open var shareAuthStateAcrossDevices: Bool = false
 
   /** @property tenantID
    @brief The tenant ID of the auth instance. nil if none is available.
    */
-  @objc public var tenantID: String?
+  @objc open var tenantID: String?
 
   /**
    * @property customAuthDomain
    * @brief The custom authentication domain used to handle all sign-in redirects. End-users will see
    * this domain when signing in. This domain must be allowlisted in the Firebase Console.
    */
-  @objc public var customAuthDomain: String?
+  @objc open var customAuthDomain: String?
 
   /** @fn updateCurrentUser:completion:
    @brief Sets the `currentUser` on the receiver to the provided user object.
@@ -236,7 +236,7 @@ extension Auth: AuthInterop {
    @param completion Optionally; a block invoked after the user of the calling Auth instance has
    been updated or an error was encountered.
    */
-  @objc public func updateCurrentUser(_ user: User?, completion: ((Error?) -> Void)? = nil) {
+  @objc open func updateCurrentUser(_ user: User?, completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       guard let user else {
         let error = AuthErrorUtils.nullUserError(message: nil)
@@ -275,7 +275,7 @@ extension Auth: AuthInterop {
    been updated or an error was encountered.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func updateCurrentUser(_ user: User) async throws {
+  open func updateCurrentUser(_ user: User) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.updateCurrentUser(user) { error in
         if let error {
@@ -308,7 +308,7 @@ extension Auth: AuthInterop {
     deprecated,
     message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
   )
-  @objc public func fetchSignInMethods(forEmail email: String,
+  @objc open func fetchSignInMethods(forEmail email: String,
                                        completion: (([String]?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       let request = CreateAuthURIRequest(identifier: email,
@@ -343,7 +343,7 @@ extension Auth: AuthInterop {
     deprecated,
     message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
   )
-  public func fetchSignInMethods(forEmail email: String) async throws -> [String] {
+  open func fetchSignInMethods(forEmail email: String) async throws -> [String] {
     return try await withCheckedThrowingContinuation { continuation in
       self.fetchSignInMethods(forEmail: email) { methods, error in
         if let methods {
@@ -378,7 +378,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func signIn(withEmail email: String,
+  @objc open func signIn(withEmail email: String,
                            password: String,
                            completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
@@ -451,7 +451,7 @@ extension Auth: AuthInterop {
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func signIn(withEmail email: String, password: String) async throws -> AuthDataResult {
+  open func signIn(withEmail email: String, password: String) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.signIn(withEmail: email, password: password) { authData, error in
         if let authData {
@@ -481,7 +481,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func signIn(withEmail email: String,
+  @objc open func signIn(withEmail email: String,
                            link: String,
                            completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
@@ -518,7 +518,7 @@ extension Auth: AuthInterop {
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func signIn(withEmail email: String, link: String) async throws -> AuthDataResult {
+  open func signIn(withEmail email: String, link: String) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.signIn(withEmail: email, link: link) { result, error in
         if let result {
@@ -580,7 +580,7 @@ extension Auth: AuthInterop {
      @remarks See @c AuthErrors for a list of error codes that are common to all API methods.
      */
     @objc(signInWithProvider:UIDelegate:completion:)
-    public func signIn(with provider: FederatedAuthProvider,
+    open func signIn(with provider: FederatedAuthProvider,
                        uiDelegate: AuthUIDelegate?,
                        completion: ((AuthDataResult?, Error?) -> Void)?) {
       kAuthGlobalWorkQueue.async {
@@ -648,7 +648,7 @@ extension Auth: AuthInterop {
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @discardableResult
-    public func signIn(with provider: FederatedAuthProvider,
+    open func signIn(with provider: FederatedAuthProvider,
                        uiDelegate: AuthUIDelegate?) async throws -> AuthDataResult {
       return try await withCheckedThrowingContinuation { continuation in
         self.signIn(with: provider, uiDelegate: uiDelegate) { result, error in
@@ -701,7 +701,7 @@ extension Auth: AuthInterop {
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods
    */
   @objc(signInWithCredential:completion:)
-  public func signIn(with credential: AuthCredential,
+  open func signIn(with credential: AuthCredential,
                      completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       let decoratedCallback = self.signInFlowAuthDataResultCallback(byDecorating: completion)
@@ -757,7 +757,7 @@ extension Auth: AuthInterop {
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func signIn(with credential: AuthCredential) async throws -> AuthDataResult {
+  open func signIn(with credential: AuthCredential) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.signIn(with: credential) { result, error in
         if let result {
@@ -784,7 +784,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func signInAnonymously(completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
+  @objc open func signInAnonymously(completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       let decoratedCallback = self.signInFlowAuthDataResultCallback(byDecorating: completion)
       if let currentUser = self.currentUser, currentUser.isAnonymous {
@@ -831,7 +831,7 @@ extension Auth: AuthInterop {
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  @objc public func signInAnonymously() async throws -> AuthDataResult {
+  @objc open func signInAnonymously() async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.signInAnonymously { result, error in
         if let result {
@@ -859,7 +859,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func signIn(withCustomToken token: String,
+  @objc open func signIn(withCustomToken token: String,
                            completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       let decoratedCallback = self.signInFlowAuthDataResultCallback(byDecorating: completion)
@@ -906,7 +906,7 @@ extension Auth: AuthInterop {
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func signIn(withCustomToken token: String) async throws -> AuthDataResult {
+  open func signIn(withCustomToken token: String) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.signIn(withCustomToken: token) { result, error in
         if let result {
@@ -940,7 +940,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func createUser(withEmail email: String,
+  @objc open func createUser(withEmail email: String,
                                password: String,
                                completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     guard password.count > 0 else {
@@ -1035,7 +1035,7 @@ extension Auth: AuthInterop {
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func createUser(withEmail email: String, password: String) async throws -> AuthDataResult {
+  open func createUser(withEmail email: String, password: String) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.createUser(withEmail: email, password: password) { result, error in
         if let result {
@@ -1066,7 +1066,7 @@ extension Auth: AuthInterop {
 
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func confirmPasswordReset(withCode code: String, newPassword: String,
+  @objc open func confirmPasswordReset(withCode code: String, newPassword: String,
                                          completion: @escaping (Error?) -> Void) {
     kAuthGlobalWorkQueue.async {
       let request = ResetPasswordRequest(oobCode: code,
@@ -1096,7 +1096,7 @@ extension Auth: AuthInterop {
    @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func confirmPasswordReset(withCode code: String, newPassword: String) async throws {
+  open func confirmPasswordReset(withCode code: String, newPassword: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.confirmPasswordReset(withCode: code, newPassword: newPassword) { error in
         if let error {
@@ -1115,7 +1115,7 @@ extension Auth: AuthInterop {
    @param completion Optionally; a block which is invoked when the request finishes. Invoked
    asynchronously on the main thread in the future.
    */
-  @objc public func checkActionCode(_ code: String,
+  @objc open func checkActionCode(_ code: String,
                                     completion: @escaping (ActionCodeInfo?, Error?) -> Void) {
     kAuthGlobalWorkQueue.async {
       let request = ResetPasswordRequest(oobCode: code,
@@ -1148,7 +1148,7 @@ extension Auth: AuthInterop {
    asynchronously on the main thread in the future.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func checkActionCode(_ code: String) async throws -> ActionCodeInfo {
+  open func checkActionCode(_ code: String) async throws -> ActionCodeInfo {
     return try await withCheckedThrowingContinuation { continuation in
       self.checkActionCode(code) { info, error in
         if let info {
@@ -1167,7 +1167,7 @@ extension Auth: AuthInterop {
    @param completion Optionally; a block which is invoked when the request finishes. Invoked
    asynchronously on the main thread in the future.
    */
-  @objc public func verifyPasswordResetCode(_ code: String,
+  @objc open func verifyPasswordResetCode(_ code: String,
                                             completion: @escaping (String?, Error?) -> Void) {
     checkActionCode(code) { info, error in
       if let error {
@@ -1186,7 +1186,7 @@ extension Auth: AuthInterop {
    asynchronously on the main thread in the future.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func verifyPasswordResetCode(_ code: String) async throws -> String {
+  open func verifyPasswordResetCode(_ code: String) async throws -> String {
     return try await withCheckedThrowingContinuation { continuation in
       self.verifyPasswordResetCode(code) { code, error in
         if let code {
@@ -1208,7 +1208,7 @@ extension Auth: AuthInterop {
    @remarks This method will not work for out of band codes which require an additional parameter,
    such as password reset code.
    */
-  @objc public func applyActionCode(_ code: String, completion: @escaping (Error?) -> Void) {
+  @objc open func applyActionCode(_ code: String, completion: @escaping (Error?) -> Void) {
     kAuthGlobalWorkQueue.async {
       let request = SetAccountInfoRequest(requestConfiguration: self.requestConfiguration)
       request.oobCode = code
@@ -1227,7 +1227,7 @@ extension Auth: AuthInterop {
    such as password reset code.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func applyActionCode(_ code: String) async throws {
+  open func applyActionCode(_ code: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.applyActionCode(code) { error in
         if let error {
@@ -1259,7 +1259,7 @@ extension Auth: AuthInterop {
    sending update email.
 
    */
-  @objc public func sendPasswordReset(withEmail email: String,
+  @objc open func sendPasswordReset(withEmail email: String,
                                       completion: ((Error?) -> Void)? = nil) {
     sendPasswordReset(withEmail: email, actionCodeSettings: nil, completion: completion)
   }
@@ -1291,7 +1291,7 @@ extension Auth: AuthInterop {
    continue URL is not valid.
 
    */
-  @objc public func sendPasswordReset(withEmail email: String,
+  @objc open func sendPasswordReset(withEmail email: String,
                                       actionCodeSettings: ActionCodeSettings?,
                                       completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
@@ -1347,7 +1347,7 @@ extension Auth: AuthInterop {
 
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func sendPasswordReset(withEmail email: String,
+  open func sendPasswordReset(withEmail email: String,
                                 actionCodeSettings: ActionCodeSettings? = nil) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.sendPasswordReset(withEmail: email, actionCodeSettings: actionCodeSettings) { error in
@@ -1369,7 +1369,7 @@ extension Auth: AuthInterop {
    @param completion Optionally; a block which is invoked when the request finishes. Invoked
    asynchronously on the main thread in the future.
    */
-  @objc public func sendSignInLink(toEmail email: String,
+  @objc open func sendSignInLink(toEmail email: String,
                                    actionCodeSettings: ActionCodeSettings,
                                    completion: ((Error?) -> Void)? = nil) {
     if !actionCodeSettings.handleCodeInApp {
@@ -1407,7 +1407,7 @@ extension Auth: AuthInterop {
    asynchronously on the main thread in the future.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func sendSignInLink(toEmail email: String,
+  open func sendSignInLink(toEmail email: String,
                              actionCodeSettings: ActionCodeSettings) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in
@@ -1434,7 +1434,7 @@ extension Auth: AuthInterop {
    dictionary will contain more information about the error encountered.
 
    */
-  @objc(signOut:) public func signOut() throws {
+  @objc(signOut:) open func signOut() throws {
     try kAuthGlobalWorkQueue.sync {
       guard self.currentUser != nil else {
         return
@@ -1449,7 +1449,7 @@ extension Auth: AuthInterop {
    @param link The email sign-in link.
    @return Returns true when the link passed matches the expected format of an email sign-in link.
    */
-  @objc public func isSignIn(withEmailLink link: String) -> Bool {
+  @objc open func isSignIn(withEmailLink link: String) -> Bool {
     guard link.count > 0 else {
       return false
     }
@@ -1471,7 +1471,7 @@ extension Auth: AuthInterop {
         reloaded.
      */
     @objc(initializeRecaptchaConfigWithCompletion:)
-    public func initializeRecaptchaConfig(completion: ((Error?) -> Void)?) {
+    open func initializeRecaptchaConfig(completion: ((Error?) -> Void)?) {
       Task {
         do {
           try await initializeRecaptchaConfig()
@@ -1493,7 +1493,7 @@ extension Auth: AuthInterop {
         If you change the tenant ID of the `Auth` instance, the configuration will be
         reloaded.
      */
-    public func initializeRecaptchaConfig() async throws {
+    open func initializeRecaptchaConfig() async throws {
       // Trigger recaptcha verification flow to initialize the recaptcha client and
       // config. Recaptcha token will be returned.
       let verifier = AuthRecaptchaVerifier.shared(auth: self)
@@ -1520,7 +1520,7 @@ extension Auth: AuthInterop {
    @return A handle useful for manually unregistering the block as a listener.
    */
   @objc(addAuthStateDidChangeListener:)
-  public func addStateDidChangeListener(_ listener: @escaping (Auth, User?) -> Void)
+  open func addStateDidChangeListener(_ listener: @escaping (Auth, User?) -> Void)
     -> NSObjectProtocol {
     var firstInvocation = true
     var previousUserID: String?
@@ -1540,7 +1540,7 @@ extension Auth: AuthInterop {
    @param listenerHandle The handle for the listener.
    */
   @objc(removeAuthStateDidChangeListener:)
-  public func removeStateDidChangeListener(_ listenerHandle: NSObjectProtocol) {
+  open func removeStateDidChangeListener(_ listenerHandle: NSObjectProtocol) {
     NotificationCenter.default.removeObserver(listenerHandle)
     objc_sync_enter(Auth.self)
     defer { objc_sync_exit(Auth.self) }
@@ -1592,7 +1592,7 @@ extension Auth: AuthInterop {
 
    @param listenerHandle The handle for the listener.
    */
-  @objc public func removeIDTokenDidChangeListener(_ listenerHandle: NSObjectProtocol) {
+  @objc open func removeIDTokenDidChangeListener(_ listenerHandle: NSObjectProtocol) {
     NotificationCenter.default.removeObserver(listenerHandle)
     objc_sync_enter(Auth.self)
     listenerHandles.remove(listenerHandle)
@@ -1602,7 +1602,7 @@ extension Auth: AuthInterop {
   /** @fn useAppLanguage
    @brief Sets `languageCode` to the app's current language.
    */
-  @objc public func useAppLanguage() {
+  @objc open func useAppLanguage() {
     kAuthGlobalWorkQueue.sync {
       self.requestConfiguration.languageCode = Locale.preferredLanguages.first
     }
@@ -1611,7 +1611,7 @@ extension Auth: AuthInterop {
   /** @fn useEmulatorWithHost:port
    @brief Configures Firebase Auth to connect to an emulated host instead of the remote backend.
    */
-  @objc public func useEmulator(withHost host: String, port: Int) {
+  @objc open func useEmulator(withHost host: String, port: Int) {
     guard host.count > 0 else {
       fatalError("Cannot connect to empty host")
     }
@@ -1630,7 +1630,7 @@ extension Auth: AuthInterop {
    @param completion (Optional) the block invoked when the request to revoke the token is
    complete, or fails. Invoked asynchronously on the main thread in the future.
    */
-  @objc public func revokeToken(withAuthorizationCode authorizationCode: String,
+  @objc open func revokeToken(withAuthorizationCode authorizationCode: String,
                                 completion: ((Error?) -> Void)? = nil) {
     currentUser?.internalGetToken { idToken, error in
       if let error {
@@ -1653,7 +1653,7 @@ extension Auth: AuthInterop {
    complete, or fails. Invoked asynchronously on the main thread in the future.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func revokeToken(withAuthorizationCode authorizationCode: String) async throws {
+  open func revokeToken(withAuthorizationCode authorizationCode: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.revokeToken(withAuthorizationCode: authorizationCode) { error in
         if let error {
@@ -1669,7 +1669,7 @@ extension Auth: AuthInterop {
    @brief Switch userAccessGroup and current user to the given accessGroup and the user stored in
    it.
    */
-  @objc public func useUserAccessGroup(_ accessGroup: String?) throws {
+  @objc open func useUserAccessGroup(_ accessGroup: String?) throws {
     // self.storedUserManager is initialized asynchronously. Make sure it is done.
     kAuthGlobalWorkQueue.sync {}
     return try internalUseUserAccessGroup(accessGroup)
@@ -1695,7 +1695,7 @@ extension Auth: AuthInterop {
    */
   @available(swift 1000.0) // Objective-C only API
   @objc(getStoredUserForAccessGroup:error:)
-  public func __getStoredUser(forAccessGroup accessGroup: String?,
+  open func __getStoredUser(forAccessGroup accessGroup: String?,
                               error outError: NSErrorPointer) -> User? {
     do {
       return try getStoredUser(forAccessGroup: accessGroup)
@@ -1711,7 +1711,7 @@ extension Auth: AuthInterop {
    This case will return `nil`.
    Please refer to https://github.com/firebase/firebase-ios-sdk/issues/8878 for details.
    */
-  public func getStoredUser(forAccessGroup accessGroup: String?) throws -> User? {
+  open func getStoredUser(forAccessGroup accessGroup: String?) throws -> User? {
     var user: User?
     if let accessGroup {
       #if os(tvOS)
@@ -1743,25 +1743,25 @@ extension Auth: AuthInterop {
   }
 
   #if os(iOS)
-    @objc(APNSToken) public var apnsToken: Data? {
+    @objc(APNSToken) open var apnsToken: Data? {
       kAuthGlobalWorkQueue.sync {
         self.tokenManager.token?.data
       }
     }
 
-    @objc public func setAPNSToken(_ token: Data, type: AuthAPNSTokenType) {
+    @objc open func setAPNSToken(_ token: Data, type: AuthAPNSTokenType) {
       kAuthGlobalWorkQueue.sync {
         self.tokenManager.token = AuthAPNSToken(withData: token, type: type)
       }
     }
 
-    @objc public func canHandleNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
+    @objc open func canHandleNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
       kAuthGlobalWorkQueue.sync {
         self.notificationManager.canHandle(notification: userInfo)
       }
     }
 
-    @objc(canHandleURL:) public func canHandle(_ url: URL) -> Bool {
+    @objc(canHandleURL:) open func canHandle(_ url: URL) -> Bool {
       kAuthGlobalWorkQueue.sync {
         guard let authURLPresenter = self.authURLPresenter as? AuthURLPresenter else {
           return false

--- a/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
@@ -19,7 +19,7 @@ import Foundation
         action. It contains references to a `User` instance and a `AdditionalUserInfo` instance.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthDataResult) public class AuthDataResult: NSObject, NSSecureCoding {
+@objc(FIRAuthDataResult) open class AuthDataResult: NSObject, NSSecureCoding {
   /** @property user
       @brief The signed in user.
    */
@@ -59,7 +59,7 @@ import Foundation
     return true
   }
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(user, forKey: kUserCodingKey)
     coder.encode(additionalUserInfo, forKey: kAdditionalUserInfoCodingKey)
     coder.encode(credential, forKey: kCredentialCodingKey)

--- a/FirebaseAuth/Sources/Swift/Auth/AuthSettings.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthSettings.swift
@@ -17,12 +17,12 @@ import Foundation
 /** @class AuthSettings
     @brief Determines settings related to an auth object.
  */
-@objc(FIRAuthSettings) public class AuthSettings: NSObject, NSCopying {
+@objc(FIRAuthSettings) open class AuthSettings: NSObject, NSCopying {
   /** @property appVerificationDisabledForTesting
       @brief Flag to determine whether app verification should be disabled for testing or not.
    */
-  @objc public var appVerificationDisabledForTesting: Bool
-  @objc public var isAppVerificationDisabledForTesting: Bool {
+  @objc open var appVerificationDisabledForTesting: Bool
+  @objc open var isAppVerificationDisabledForTesting: Bool {
     get {
       return appVerificationDisabledForTesting
     }
@@ -37,7 +37,7 @@ import Foundation
 
   // MARK: NSCopying
 
-  public func copy(with zone: NSZone? = nil) -> Any {
+  open func copy(with zone: NSZone? = nil) -> Any {
     let settings = AuthSettings()
     settings.appVerificationDisabledForTesting = appVerificationDisabledForTesting
     return settings

--- a/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
@@ -54,52 +54,52 @@ private let kClaimsKey = "claims"
     @brief A data class containing the ID token JWT string and other properties associated with the
     token including the decoded payload claims.
  */
-@objc(FIRAuthTokenResult) public class AuthTokenResult: NSObject {
+@objc(FIRAuthTokenResult) open class AuthTokenResult: NSObject {
   /** @property token
       @brief Stores the JWT string of the ID token.
    */
-  @objc public var token: String
+  @objc open var token: String
 
   /** @property expirationDate
       @brief Stores the ID token's expiration date.
    */
-  @objc public var expirationDate: Date
+  @objc open var expirationDate: Date
 
   /** @property authDate
       @brief Stores the ID token's authentication date.
       @remarks This is the date the user was signed in and NOT the date the token was refreshed.
    */
-  @objc public var authDate: Date
+  @objc open var authDate: Date
 
   /** @property issuedAtDate
       @brief Stores the date that the ID token was issued.
       @remarks This is the date last refreshed and NOT the last authentication date.
    */
-  @objc public var issuedAtDate: Date
+  @objc open var issuedAtDate: Date
 
   /** @property signInProvider
       @brief Stores sign-in provider through which the token was obtained.
       @remarks This does not necessarily map to provider IDs.
    */
-  @objc public var signInProvider: String
+  @objc open var signInProvider: String
 
   /** @property signInSecondFactor
       @brief Stores sign-in second factor through which the token was obtained.
    */
-  @objc public var signInSecondFactor: String
+  @objc open var signInSecondFactor: String
 
   /** @property claims
       @brief Stores the entire payload of claims found on the ID token. This includes the standard
           reserved claims as well as custom claims set by the developer via the Admin SDK.
    */
-  @objc public var claims: [String: Any]
+  @objc open var claims: [String: Any]
 
   /** @fn tokenResultWithToken:
        @brief Parse a token string to a structured token.
        @param token The token string to parse.
        @return A structured token result.
    */
-  @objc public class func tokenResult(token: String) -> AuthTokenResult? {
+  @objc open class func tokenResult(token: String) -> AuthTokenResult? {
     let tokenStringArray = token.components(separatedBy: ".")
 
     // The JWT should have three parts, though we only use the second in this method.

--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -28,7 +28,7 @@ import Foundation
       @param password The user's password.
       @return An `AuthCredential` containing the email & password credential.
    */
-  @objc public class func credential(withEmail email: String, password: String) -> AuthCredential {
+  @objc open class func credential(withEmail email: String, password: String) -> AuthCredential {
     return EmailAuthCredential(withEmail: email, password: password)
   }
 
@@ -39,7 +39,7 @@ import Foundation
       @param link The email sign-in link.
       @return An `AuthCredential` containing the email & link credential.
    */
-  @objc public class func credential(withEmail email: String, link: String) -> AuthCredential {
+  @objc open class func credential(withEmail email: String, link: String) -> AuthCredential {
     return EmailAuthCredential(withEmail: email, link: link)
   }
 }
@@ -69,7 +69,7 @@ class EmailAuthCredential: AuthCredential, NSSecureCoding {
 
   public static var supportsSecureCoding = true
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(email, forKey: "email")
     switch emailType {
     case let .password(password): coder.encode(password, forKey: "password")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -27,7 +27,7 @@ import Foundation
       @param accessToken The Access Token from Facebook.
       @return An AuthCredential containing the Facebook credentials.
    */
-  @objc public class func credential(withAccessToken accessToken: String) -> AuthCredential {
+  @objc open class func credential(withAccessToken accessToken: String) -> AuthCredential {
     return FacebookAuthCredential(withAccessToken: accessToken)
   }
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -38,7 +38,7 @@
     /** @fn
         @brief Creates an `AuthCredential` for a Game Center sign in.
      */
-    @objc public class func getCredential(completion: @escaping (AuthCredential?, Error?) -> Void) {
+    @objc open class func getCredential(completion: @escaping (AuthCredential?, Error?) -> Void) {
       /**
        Linking GameKit.framework without using it on macOS results in App Store rejection.
        Thus we don't link GameKit.framework to our SDK directly. `optionalLocalPlayer` is used for

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
@@ -27,7 +27,7 @@ import Foundation
       @param token The GitHub OAuth access token.
       @return An AuthCredential containing the GitHub credentials.
    */
-  @objc public class func credential(withToken token: String) -> AuthCredential {
+  @objc open class func credential(withToken token: String) -> AuthCredential {
     return GitHubAuthCredential(withToken: token)
   }
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -28,7 +28,7 @@ import Foundation
       @param accessToken The Access Token from Google.
       @return An AuthCredential containing the Google credentials.
    */
-  @objc public class func credential(withIDToken IDToken: String,
+  @objc open class func credential(withIDToken IDToken: String,
                                      accessToken: String) -> AuthCredential {
     return GoogleAuthCredential(withIDToken: IDToken, accessToken: accessToken)
   }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIROAuthCredential) public class OAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIROAuthCredential) open class OAuthCredential: AuthCredential, NSSecureCoding {
   /** @property IDToken
       @brief The ID Token associated with this credential.
    */
@@ -103,7 +103,7 @@ import Foundation
 
   public static var supportsSecureCoding: Bool = true
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(idToken, forKey: "IDToken")
     coder.encode(rawNonce, forKey: "rawNonce")
     coder.encode(accessToken, forKey: "accessToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -25,12 +25,12 @@ import Foundation
   /** @property scopes
       @brief Array used to configure the OAuth scopes.
    */
-  @objc public var scopes: [String]?
+  @objc open var scopes: [String]?
 
   /** @property customParameters
       @brief Dictionary used to configure the OAuth custom parameters.
    */
-  @objc public var customParameters: [String: String]?
+  @objc open var customParameters: [String: String]?
 
   /** @property providerID
       @brief The provider ID indicating the specific OAuth provider this OAuthProvider instance
@@ -43,7 +43,7 @@ import Foundation
           configured.
       @return An instance of `OAuthProvider` corresponding to the specified provider ID.
    */
-  @objc(providerWithProviderID:) public class func provider(providerID: String) -> OAuthProvider {
+  @objc(providerWithProviderID:) open class func provider(providerID: String) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: Auth.auth())
   }
 
@@ -53,7 +53,7 @@ import Foundation
       @param auth The auth instance to be associated with the `OAuthProvider` instance.
       @return An instance of `OAuthProvider` corresponding to the specified provider ID.
    */
-  @objc(providerWithProviderID:auth:) public class func provider(providerID: String,
+  @objc(providerWithProviderID:auth:) open class func provider(providerID: String,
                                                                  auth: Auth) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: auth)
   }
@@ -185,7 +185,7 @@ import Foundation
         @param completion Optionally; a block which is invoked asynchronously on the main thread when
             the mobile web flow is completed.
      */
-    public func getCredentialWith(_ uiDelegate: AuthUIDelegate?,
+    open func getCredentialWith(_ uiDelegate: AuthUIDelegate?,
                                   completion: ((AuthCredential?, Error?) -> Void)? = nil) {
       guard let urlTypes = auth.mainBundleUrlTypes,
             AuthWebUtils.isCallbackSchemeRegistered(forCustomURLScheme: callbackScheme,
@@ -259,7 +259,7 @@ import Foundation
      */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
     @objc(getCredentialWithUIDelegate:completion:)
-    public func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
+    open func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
       return try await withCheckedThrowingContinuation { continuation in
         getCredentialWith(uiDelegate) { credential, error in
           if let credential = credential {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
@@ -19,7 +19,7 @@ import Foundation
         This class is available on iOS only.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRPhoneAuthCredential) public class PhoneAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRPhoneAuthCredential) open class PhoneAuthCredential: AuthCredential, NSSecureCoding {
   enum CredentialKind {
     case phoneNumber(_ phoneNumber: String, _ temporaryProof: String)
     case verification(_ id: String, _ code: String)
@@ -40,7 +40,7 @@ import Foundation
 
   public static var supportsSecureCoding = true
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     switch credentialKind {
     case let .phoneNumber(phoneNumber, temporaryProof):
       coder.encode(phoneNumber, forKey: "phoneNumber")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -26,7 +26,7 @@ import Foundation
     /**
      @brief Returns an instance of `PhoneAuthProvider` for the default `Auth` object.
      */
-    @objc(provider) public class func provider() -> PhoneAuthProvider {
+    @objc(provider) open class func provider() -> PhoneAuthProvider {
       return PhoneAuthProvider(auth: Auth.auth())
     }
 
@@ -35,7 +35,7 @@ import Foundation
      @param auth The auth object to associate with the phone auth provider instance.
      */
     @objc(providerWithAuth:)
-    public class func provider(auth: Auth) -> PhoneAuthProvider {
+    open class func provider(auth: Auth) -> PhoneAuthProvider {
       return PhoneAuthProvider(auth: auth)
     }
 
@@ -57,7 +57,7 @@ import Foundation
      + `AuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
      */
     @objc(verifyPhoneNumber:UIDelegate:completion:)
-    public func verifyPhoneNumber(_ phoneNumber: String,
+    open func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   completion: ((_: String?, _: Error?) -> Void)?) {
       verifyPhoneNumber(phoneNumber,
@@ -77,7 +77,7 @@ import Foundation
      @param completion The callback to be invoked when the verification flow is finished.
      */
     @objc(verifyPhoneNumber:UIDelegate:multiFactorSession:completion:)
-    public func verifyPhoneNumber(_ phoneNumber: String,
+    open func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession? = nil,
                                   completion: ((_: String?, _: Error?) -> Void)?) {
@@ -114,7 +114,7 @@ import Foundation
      @returns The verification ID
      */
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    public func verifyPhoneNumber(_ phoneNumber: String,
+    open func verifyPhoneNumber(_ phoneNumber: String,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession? = nil) async throws
       -> String {
@@ -142,7 +142,7 @@ import Foundation
          @param completion The callback to be invoked when the verification flow is finished.
      */
     @objc(verifyPhoneNumberWithMultiFactorInfo:UIDelegate:multiFactorSession:completion:)
-    public func verifyPhoneNumber(with multiFactorInfo: PhoneMultiFactorInfo,
+    open func verifyPhoneNumber(with multiFactorInfo: PhoneMultiFactorInfo,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession?,
                                   completion: ((_: String?, _: Error?) -> Void)?) {
@@ -154,7 +154,7 @@ import Foundation
     }
 
     @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    public func verifyPhoneNumber(with multiFactorInfo: PhoneMultiFactorInfo,
+    open func verifyPhoneNumber(with multiFactorInfo: PhoneMultiFactorInfo,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession?) async throws -> String {
       return try await withCheckedThrowingContinuation { continuation in
@@ -181,7 +181,7 @@ import Foundation
             provided.
      */
     @objc(credentialWithVerificationID:verificationCode:)
-    public func credential(withVerificationID verificationID: String,
+    open func credential(withVerificationID verificationID: String,
                            verificationCode: String) -> PhoneAuthCredential {
       return PhoneAuthCredential(withProviderID: PhoneAuthProvider.id,
                                  verificationID: verificationID,

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -28,7 +28,7 @@ import Foundation
       @param secret The Twitter OAuth secret.
       @return An AuthCredential containing the Twitter credentials.
    */
-  @objc public class func credential(withToken token: String, secret: String) -> AuthCredential {
+  @objc open class func credential(withToken token: String, secret: String) -> AuthCredential {
     return TwitterAuthCredential(withToken: token, secret: secret)
   }
 

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
@@ -22,8 +22,8 @@ import Foundation
        This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRMultiFactor) public class MultiFactor: NSObject, NSSecureCoding {
-    @objc public var enrolledFactors: [MultiFactorInfo]
+  @objc(FIRMultiFactor) open class MultiFactor: NSObject, NSSecureCoding {
+    @objc open var enrolledFactors: [MultiFactorInfo]
 
     /** @fn getSessionWithCompletion:
      @brief Get a session for a second factor enrollment operation.
@@ -31,7 +31,7 @@ import Foundation
      This is used to identify the current user trying to enroll a second factor.
      */
     @objc(getSessionWithCompletion:)
-    public func getSessionWithCompletion(_ completion: ((MultiFactorSession?, Error?) -> Void)?) {
+    open func getSessionWithCompletion(_ completion: ((MultiFactorSession?, Error?) -> Void)?) {
       let session = MultiFactorSession.sessionForCurrentUser
       if let completion {
         completion(session, nil)
@@ -44,7 +44,7 @@ import Foundation
      This is used to identify the current user trying to enroll a second factor.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func session() async throws -> MultiFactorSession {
+    open func session() async throws -> MultiFactorSession {
       return try await withCheckedThrowingContinuation { continuation in
         self.getSessionWithCompletion { session, error in
           if let session {
@@ -63,7 +63,7 @@ import Foundation
      @param completion The block invoked when the request is complete, or fails.
      */
     @objc(enrollWithAssertion:displayName:completion:)
-    public func enroll(with assertion: MultiFactorAssertion,
+    open func enroll(with assertion: MultiFactorAssertion,
                        displayName: String?,
                        completion: ((Error?) -> Void)?) {
       // TODO: Refactor classes so this duplicated code isn't necessary for phone and totp.
@@ -173,7 +173,7 @@ import Foundation
      @param completion The block invoked when the request is complete, or fails.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func enroll(with assertion: MultiFactorAssertion, displayName: String?) async throws {
+    open func enroll(with assertion: MultiFactorAssertion, displayName: String?) async throws {
       return try await withCheckedThrowingContinuation { continuation in
         self.enroll(with: assertion, displayName: displayName) { error in
           if let error {
@@ -191,7 +191,7 @@ import Foundation
      or fails.
      */
     @objc(unenrollWithInfo:completion:)
-    public func unenroll(with factorInfo: MultiFactorInfo,
+    open func unenroll(with factorInfo: MultiFactorInfo,
                          completion: ((Error?) -> Void)?) {
       unenroll(withFactorUID: factorInfo.uid, completion: completion)
     }
@@ -202,7 +202,7 @@ import Foundation
      or fails.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func unenroll(with factorInfo: MultiFactorInfo) async throws {
+    open func unenroll(with factorInfo: MultiFactorInfo) async throws {
       try await unenroll(withFactorUID: factorInfo.uid)
     }
 
@@ -212,7 +212,7 @@ import Foundation
      or fails.
      */
     @objc(unenrollWithFactorUID:completion:)
-    public func unenroll(withFactorUID factorUID: String,
+    open func unenroll(withFactorUID factorUID: String,
                          completion: ((Error?) -> Void)?) {
       guard let user = user, let auth = user.auth else {
         fatalError("Internal Auth error: failed to get user unenrolling in MultiFactor")
@@ -251,7 +251,7 @@ import Foundation
     }
 
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func unenroll(withFactorUID factorUID: String) async throws {
+    open func unenroll(withFactorUID factorUID: String) async throws {
       return try await withCheckedThrowingContinuation { continuation in
         self.unenroll(withFactorUID: factorUID) { error in
           if let error {
@@ -292,7 +292,7 @@ import Foundation
       true
     }
 
-    public func encode(with coder: NSCoder) {
+    open func encode(with coder: NSCoder) {
       coder.encode(enrolledFactors, forKey: kEnrolledFactorsCodingKey)
       // Do not encode `user` weak property.
     }

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorAssertion.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorAssertion.swift
@@ -21,11 +21,11 @@ import Foundation
        AuthCredential class.
        This class is available on iOS only.
    */
-  @objc(FIRMultiFactorAssertion) public class MultiFactorAssertion: NSObject {
+  @objc(FIRMultiFactorAssertion) open class MultiFactorAssertion: NSObject {
     /**
         @brief The second factor identifier for this opaque object asserting a second factor.
      */
-    @objc public var factorID: String
+    @objc open var factorID: String
 
     init(factorID: String) {
       self.factorID = factorID

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
@@ -27,7 +27,7 @@ import Foundation
    @brief Safe public structure used to represent a second factor entity from a client perspective.
        This class is available on iOS only.
    */
-  @objc(FIRMultiFactorInfo) public class MultiFactorInfo: NSObject {
+  @objc(FIRMultiFactorInfo) open class MultiFactorInfo: NSObject {
     /**
         @brief The multi-factor enrollment ID.
      */
@@ -79,9 +79,9 @@ import Foundation
 
   extension MultiFactorInfo: NSSecureCoding {
     private static var secureCodingWorkaround = true
-    public class var supportsSecureCoding: Bool { return secureCodingWorkaround }
+    open class var supportsSecureCoding: Bool { return secureCodingWorkaround }
 
-    public func encode(with coder: NSCoder) {
+    open func encode(with coder: NSCoder) {
       coder.encode(uid, forKey: kUIDCodingKey)
       coder.encode(displayName, forKey: kDisplayNameCodingKey)
       coder.encode(enrollmentDate, forKey: kEnrollmentDateCodingKey)

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorResolver.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorResolver.swift
@@ -22,7 +22,7 @@ import Foundation
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc(FIRMultiFactorResolver)
-  public class MultiFactorResolver: NSObject {
+  open class MultiFactorResolver: NSObject {
     /**
         @brief The opaque session identifier for the current sign-in flow.
      */
@@ -46,7 +46,7 @@ import Foundation
          @param completion The block invoked when the request is complete, or fails.
      */
     @objc(resolveSignInWithAssertion:completion:)
-    public func resolveSignIn(with assertion: MultiFactorAssertion,
+    open func resolveSignIn(with assertion: MultiFactorAssertion,
                               completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
       var finalizedMFARequestInfo: AuthProto?
       if let totpAssertion = assertion as? TOTPMultiFactorAssertion {
@@ -104,7 +104,7 @@ import Foundation
          @param completion The block invoked when the request is complete, or fails.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func resolveSignIn(with assertion: MultiFactorAssertion) async throws -> AuthDataResult {
+    open func resolveSignIn(with assertion: MultiFactorAssertion) async throws -> AuthDataResult {
       return try await withCheckedThrowingContinuation { continuation in
         self.resolveSignIn(with: assertion) { result, error in
           if let result {

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorSession.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorSession.swift
@@ -23,7 +23,7 @@ import Foundation
           This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRMultiFactorSession) public class MultiFactorSession: NSObject {
+  @objc(FIRMultiFactorSession) open class MultiFactorSession: NSObject {
     /**
      @brief The ID token for an enroll flow. This has to be retrieved after recent authentication.
      */

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorAssertion.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorAssertion.swift
@@ -22,7 +22,7 @@ import Foundation
        This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRPhoneMultiFactorAssertion) public class PhoneMultiFactorAssertion: MultiFactorAssertion {
+  @objc(FIRPhoneMultiFactorAssertion) open class PhoneMultiFactorAssertion: MultiFactorAssertion {
     var authCredential: PhoneAuthCredential?
 
     init() {

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorGenerator.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorGenerator.swift
@@ -24,14 +24,14 @@ import Foundation
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc(FIRPhoneMultiFactorGenerator)
-  public class PhoneMultiFactorGenerator: NSObject {
+  open class PhoneMultiFactorGenerator: NSObject {
     /** @fn assertionWithCredential:
          @brief Initializes the MFA assertion to confirm ownership of the phone second factor. Note that
              this API is used for both enrolling and signing in with a phone second factor.
          @param phoneAuthCredential The phone auth credential used for multi factor flows.
      */
     @objc(assertionWithCredential:)
-    public class func assertion(with phoneAuthCredential: PhoneAuthCredential)
+    open class func assertion(with phoneAuthCredential: PhoneAuthCredential)
       -> PhoneMultiFactorAssertion {
       let assertion = PhoneMultiFactorAssertion()
       assertion.authCredential = phoneAuthCredential

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
@@ -21,7 +21,7 @@ import Foundation
        The identifier of this second factor is "phone".
        This class is available on iOS only.
    */
-  @objc(FIRPhoneMultiFactorInfo) public class PhoneMultiFactorInfo: MultiFactorInfo {
+  @objc(FIRPhoneMultiFactorInfo) open class PhoneMultiFactorInfo: MultiFactorInfo {
     /**
         @brief The string identifier for using phone as a second factor.
              This constant is available on iOS only.
@@ -37,7 +37,7 @@ import Foundation
     /**
         @brief This is the phone number associated with the current second factor.
      */
-    @objc public var phoneNumber: String
+    @objc open var phoneNumber: String
 
     init(proto: AuthProtoMFAEnrollment) {
       guard let phoneInfo = proto.phoneInfo else {
@@ -52,7 +52,7 @@ import Foundation
     private let kPhoneNumberCodingKey = "phoneNumber"
 
     private static var secureCodingWorkaround = true
-    override public class var supportsSecureCoding: Bool { return secureCodingWorkaround }
+    override open class var supportsSecureCoding: Bool { return secureCodingWorkaround }
 
     public required init?(coder: NSCoder) {
       guard let phoneNumber = coder.decodeObject(of: NSString.self,
@@ -63,7 +63,7 @@ import Foundation
       super.init(coder: coder)
     }
 
-    override public func encode(with coder: NSCoder) {
+    override open func encode(with coder: NSCoder) {
       super.encode(with: coder)
       coder.encode(phoneNumber, forKey: kPhoneNumberCodingKey)
     }

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultFactorAssertion.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultFactorAssertion.swift
@@ -26,7 +26,7 @@ import Foundation
    (Time-based One Time Password) second factor.
    This class is available on iOS only.
    */
-  @objc(FIRTOTPMultiFactorAssertion) public class TOTPMultiFactorAssertion: MultiFactorAssertion {
+  @objc(FIRTOTPMultiFactorAssertion) open class TOTPMultiFactorAssertion: MultiFactorAssertion {
     let oneTimePassword: String
     let secretOrID: SecretOrID
 

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorGenerator.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorGenerator.swift
@@ -23,7 +23,7 @@ import Foundation
    This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRTOTPMultiFactorGenerator) public class TOTPMultiFactorGenerator: NSObject {
+  @objc(FIRTOTPMultiFactorGenerator) open class TOTPMultiFactorGenerator: NSObject {
     /**
      @fn generateSecretWithMultiFactorSession
      @brief Creates a TOTP secret as part of enrolling a TOTP second factor. Used for generating a
@@ -33,7 +33,7 @@ import Foundation
      @param completion Completion block
      */
     @objc(generateSecretWithMultiFactorSession:completion:)
-    public class func generateSecret(with session: MultiFactorSession,
+    open class func generateSecret(with session: MultiFactorSession,
                                      completion: @escaping (TOTPSecret?, Error?) -> Void) {
       guard let currentUser = session.currentUser,
             let requestConfiguration = currentUser.auth?.requestConfiguration else {
@@ -72,7 +72,7 @@ import Foundation
     }
 
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public class func generateSecret(with session: MultiFactorSession) async throws
+    open class func generateSecret(with session: MultiFactorSession) async throws
       -> TOTPSecret {
       return try await withCheckedThrowingContinuation { continuation in
         self.generateSecret(with: session) { secret, error in
@@ -93,7 +93,7 @@ import Foundation
      @param oneTimePassword one time password string.
      */
     @objc(assertionForEnrollmentWithSecret:oneTimePassword:)
-    public class func assertionForEnrollment(with secret: TOTPSecret,
+    open class func assertionForEnrollment(with secret: TOTPSecret,
                                              oneTimePassword: String) -> TOTPMultiFactorAssertion {
       return TOTPMultiFactorAssertion(secretOrID: SecretOrID.secret(secret),
                                       oneTimePassword: oneTimePassword)
@@ -107,7 +107,7 @@ import Foundation
       @param oneTimePassword one time password string.
      */
     @objc(assertionForSignInWithEnrollmentID:oneTimePassword:)
-    public class func assertionForSignIn(withEnrollmentID enrollmentID: String,
+    open class func assertionForSignIn(withEnrollmentID enrollmentID: String,
                                          oneTimePassword: String) -> TOTPMultiFactorAssertion {
       return TOTPMultiFactorAssertion(secretOrID: SecretOrID.enrollmentID(enrollmentID),
                                       oneTimePassword: oneTimePassword)

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPSecret.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPSecret.swift
@@ -27,11 +27,11 @@ import Foundation
    (Time-based One Time Password) second factor.
    This class is available on iOS only.
    */
-  @objc(FIRTOTPSecret) public class TOTPSecret: NSObject {
+  @objc(FIRTOTPSecret) open class TOTPSecret: NSObject {
     /**
      @brief Returns the shared secret key/seed used to generate time-based one-time passwords.
      */
-    @objc public func sharedSecretKey() -> String {
+    @objc open func sharedSecretKey() -> String {
       return secretKey
     }
 
@@ -45,7 +45,7 @@ import Foundation
      @returns A QRCode URL string.
      */
     @objc(generateQRCodeURLWithAccountName:issuer:)
-    public func generateQRCodeURL(withAccountName accountName: String,
+    open func generateQRCodeURL(withAccountName accountName: String,
                                   issuer: String) -> String {
       guard let hashingAlgorithm, codeLength > 0 else {
         return ""
@@ -60,7 +60,7 @@ import Foundation
      https://developer.apple.com/documentation/authenticationservices/securing_logins_with_icloud_keychain_verification_codes
      */
     @objc(openInOTPAppWithQRCodeURL:)
-    public func openInOTPApp(withQRCodeURL qrCodeURL: String) {
+    open func openInOTPApp(withQRCodeURL qrCodeURL: String) {
       if GULAppEnvironmentUtil.isAppExtension() {
         // iOS App extensions should not call [UIApplication sharedApplication], even if
         // UIApplication responds to it.

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
@@ -64,7 +64,7 @@ class AuthAppCredential: NSObject, NSSecureCoding {
     self.init(receipt: receipt, secret: secret)
   }
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(receipt, forKey: kReceiptKey)
     coder.encode(secret, forKey: kSecretKey)
   }

--- a/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
+++ b/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@objc(FIRAdditionalUserInfo) public class AdditionalUserInfo: NSObject, NSSecureCoding {
+@objc(FIRAdditionalUserInfo) open class AdditionalUserInfo: NSObject, NSSecureCoding {
   private static let providerIDCodingKey = "providerID"
   private static let profileCodingKey = "profile"
   private static let usernameCodingKey = "username"
@@ -41,7 +41,7 @@ import Foundation
   @objc public let isNewUser: Bool
 
   // Maintain newUser for Objective C API.
-  @objc public func newUser() -> Bool {
+  @objc open func newUser() -> Bool {
     return isNewUser
   }
 
@@ -82,7 +82,7 @@ import Foundation
     }
   }
 
-  public func encode(with aCoder: NSCoder) {
+  open func encode(with aCoder: NSCoder) {
     aCoder.encode(providerID, forKey: AdditionalUserInfo.providerIDCodingKey)
     aCoder.encode(profile, forKey: AdditionalUserInfo.profileCodingKey)
     aCoder.encode(username, forKey: AdditionalUserInfo.usernameCodingKey)

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -26,24 +26,24 @@ extension User: NSSecureCoding {}
     @remarks This class is thread-safe.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRUser) public class User: NSObject, UserInfo {
+@objc(FIRUser) open class User: NSObject, UserInfo {
   /** @property anonymous
       @brief Indicates the user represents an anonymous user.
    */
   @objc public private(set) var isAnonymous: Bool
-  @objc public func anonymous() -> Bool { return isAnonymous }
+  @objc open func anonymous() -> Bool { return isAnonymous }
 
   /** @property emailVerified
       @brief Indicates the email address associated with this user has been verified.
    */
   @objc public private(set) var isEmailVerified: Bool
-  @objc public func emailVerified() -> Bool { return isEmailVerified }
+  @objc open func emailVerified() -> Bool { return isEmailVerified }
 
   /** @property providerData
       @brief Profile data for each identity provider, if any.
       @remarks This data is cached on sign-in and updated when linking or unlinking.
    */
-  @objc public var providerData: [UserInfo] {
+  @objc open var providerData: [UserInfo] {
     return Array(providerDataRaw.values)
   }
 
@@ -103,7 +103,7 @@ extension User: NSSecureCoding {}
     message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
   )
   @objc(updateEmail:completion:)
-  public func updateEmail(to email: String, completion: ((Error?) -> Void)? = nil) {
+  open func updateEmail(to email: String, completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.updateEmail(email: email, password: nil) { error in
         User.callInMainThreadWithError(callback: completion, error: error)
@@ -146,7 +146,7 @@ extension User: NSSecureCoding {}
     message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
   )
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func updateEmail(to email: String) async throws {
+  open func updateEmail(to email: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.updateEmail(to: email) { error in
         if let error {
@@ -180,7 +180,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @objc(updatePassword:completion:)
-  public func updatePassword(to password: String, completion: ((Error?) -> Void)? = nil) {
+  open func updatePassword(to password: String, completion: ((Error?) -> Void)? = nil) {
     guard password.count > 0 else {
       if let completion {
         completion(AuthErrorUtils.weakPasswordError(serverResponseReason: "Missing Password"))
@@ -215,7 +215,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func updatePassword(to password: String) async throws {
+  open func updatePassword(to password: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.updatePassword(to: password) { error in
         if let error {
@@ -249,7 +249,7 @@ extension User: NSSecureCoding {}
         @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
      */
     @objc(updatePhoneNumberCredential:completion:)
-    public func updatePhoneNumber(_ credential: PhoneAuthCredential,
+    open func updatePhoneNumber(_ credential: PhoneAuthCredential,
                                   completion: ((Error?) -> Void)? = nil) {
       kAuthGlobalWorkQueue.async {
         self.internalUpdateOrLinkPhoneNumber(credential: credential,
@@ -279,7 +279,7 @@ extension User: NSSecureCoding {}
         @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-    public func updatePhoneNumber(_ credential: PhoneAuthCredential) async throws {
+    open func updatePhoneNumber(_ credential: PhoneAuthCredential) async throws {
       return try await withCheckedThrowingContinuation { continuation in
         self.updatePhoneNumber(credential) { error in
           if let error {
@@ -301,7 +301,7 @@ extension User: NSSecureCoding {}
       @return An object which may be used to change the user's profile data atomically.
    */
   @objc(profileChangeRequest)
-  public func createProfileChangeRequest() -> UserProfileChangeRequest {
+  open func createProfileChangeRequest() -> UserProfileChangeRequest {
     var result: UserProfileChangeRequest!
     kAuthGlobalWorkQueue.sync {
       result = UserProfileChangeRequest(self)
@@ -313,7 +313,7 @@ extension User: NSSecureCoding {}
       @brief A refresh token; useful for obtaining new access tokens independently.
       @remarks This property should only be used for advanced scenarios, and is not typically needed.
    */
-  @objc public var refreshToken: String? {
+  @objc open var refreshToken: String? {
     var result: String?
     kAuthGlobalWorkQueue.sync {
       result = self.tokenService.refreshToken
@@ -333,7 +333,7 @@ extension User: NSSecureCoding {}
 
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
-  @objc public func reload(completion: ((Error?) -> Void)? = nil) {
+  @objc open func reload(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.getAccountInfoRefreshingCache { user, error in
         User.callInMainThreadWithError(callback: completion, error: error)
@@ -354,7 +354,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func reload() async throws {
+  open func reload() async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.reload { error in
         if let error {
@@ -402,7 +402,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @objc(reauthenticateWithCredential:completion:)
-  public func reauthenticate(with credential: AuthCredential,
+  open func reauthenticate(with credential: AuthCredential,
                              completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       Task {
@@ -478,7 +478,7 @@ extension User: NSSecureCoding {}
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func reauthenticate(with credential: AuthCredential) async throws -> AuthDataResult {
+  open func reauthenticate(with credential: AuthCredential) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.reauthenticate(with: credential) { result, error in
         if let result {
@@ -503,7 +503,7 @@ extension User: NSSecureCoding {}
             is canceled. Invoked asynchronously on the main thread in the future.
      */
     @objc(reauthenticateWithProvider:UIDelegate:completion:)
-    public func reauthenticate(with provider: FederatedAuthProvider,
+    open func reauthenticate(with provider: FederatedAuthProvider,
                                uiDelegate: AuthUIDelegate?,
                                completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
       kAuthGlobalWorkQueue.async {
@@ -532,7 +532,7 @@ extension User: NSSecureCoding {}
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     @discardableResult
-    public func reauthenticate(with provider: FederatedAuthProvider,
+    open func reauthenticate(with provider: FederatedAuthProvider,
                                uiDelegate: AuthUIDelegate?) async throws -> AuthDataResult {
       return try await withCheckedThrowingContinuation { continuation in
         self.reauthenticate(with: provider, uiDelegate: uiDelegate) { result, error in
@@ -555,7 +555,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @objc(getIDTokenWithCompletion:)
-  public func getIDToken(completion: ((String?, Error?) -> Void)?) {
+  open func getIDToken(completion: ((String?, Error?) -> Void)?) {
     // |getIDTokenForcingRefresh:completion:| is also a public API so there is no need to dispatch to
     // global work queue here.
     getIDTokenForcingRefresh(false, completion: completion)
@@ -575,7 +575,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @objc(getIDTokenForcingRefresh:completion:)
-  public func getIDTokenForcingRefresh(_ forceRefresh: Bool,
+  open func getIDTokenForcingRefresh(_ forceRefresh: Bool,
                                        completion: ((String?, Error?) -> Void)?) {
     getIDTokenResult(forcingRefresh: forceRefresh) { tokenResult, error in
       if let completion {
@@ -599,7 +599,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func getIDToken() async throws -> String {
+  open func getIDToken() async throws -> String {
     return try await withCheckedThrowingContinuation { continuation in
       self.getIDTokenForcingRefresh(false) { tokenResult, error in
         if let tokenResult {
@@ -620,7 +620,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @objc(getIDTokenResultWithCompletion:)
-  public func getIDTokenResult(completion: ((AuthTokenResult?, Error?) -> Void)?) {
+  open func getIDTokenResult(completion: ((AuthTokenResult?, Error?) -> Void)?) {
     getIDTokenResult(forcingRefresh: false) { tokenResult, error in
       if let completion {
         DispatchQueue.main.async {
@@ -644,7 +644,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @objc(getIDTokenResultForcingRefresh:completion:)
-  public func getIDTokenResult(forcingRefresh: Bool,
+  open func getIDTokenResult(forcingRefresh: Bool,
                                completion: ((AuthTokenResult?, Error?) -> Void)?) {
     kAuthGlobalWorkQueue.async {
       self.internalGetToken(forceRefresh: forcingRefresh) { token, error in
@@ -677,7 +677,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all API methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func getIDTokenResult(forcingRefresh forceRefresh: Bool = false) async throws
+  open func getIDTokenResult(forcingRefresh forceRefresh: Bool = false) async throws
     -> AuthTokenResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.getIDTokenResult(forcingRefresh: forceRefresh) { tokenResult, error in
@@ -714,7 +714,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @objc(linkWithCredential:completion:)
-  public func link(with credential: AuthCredential,
+  open func link(with credential: AuthCredential,
                    completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       if self.providerDataRaw[credential.provider] != nil {
@@ -818,7 +818,7 @@ extension User: NSSecureCoding {}
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @discardableResult
-  public func link(with credential: AuthCredential) async throws -> AuthDataResult {
+  open func link(with credential: AuthCredential) async throws -> AuthDataResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.link(with: credential) { result, error in
         if let result {
@@ -843,7 +843,7 @@ extension User: NSSecureCoding {}
             is canceled. Invoked asynchronously on the main thread in the future.
      */
     @objc(linkWithProvider:UIDelegate:completion:)
-    public func link(with provider: FederatedAuthProvider,
+    open func link(with provider: FederatedAuthProvider,
                      uiDelegate: AuthUIDelegate?,
                      completion: ((AuthDataResult?, Error?) -> Void)? = nil) {
       kAuthGlobalWorkQueue.async {
@@ -872,7 +872,7 @@ extension User: NSSecureCoding {}
      */
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     @discardableResult
-    public func link(with provider: FederatedAuthProvider,
+    open func link(with provider: FederatedAuthProvider,
                      uiDelegate: AuthUIDelegate?) async throws -> AuthDataResult {
       return try await withCheckedThrowingContinuation { continuation in
         self.link(with: provider, uiDelegate: uiDelegate) { result, error in
@@ -904,7 +904,7 @@ extension User: NSSecureCoding {}
 
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
-  @objc public func unlink(fromProvider provider: String,
+  @objc open func unlink(fromProvider provider: String,
                            completion: ((User?, Error?) -> Void)? = nil) {
     taskQueue.enqueueTask { complete in
       let completeAndCallbackWithError = { error in
@@ -990,7 +990,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func unlink(fromProvider provider: String) async throws -> User {
+  open func unlink(fromProvider provider: String) async throws -> User {
     return try await withCheckedThrowingContinuation { continuation in
       self.unlink(fromProvider: provider) { result, error in
         if let result {
@@ -1021,7 +1021,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @objc(sendEmailVerificationWithCompletion:)
-  public func __sendEmailVerification(withCompletion completion: ((Error?) -> Void)?) {
+  open func __sendEmailVerification(withCompletion completion: ((Error?) -> Void)?) {
     sendEmailVerification(completion: completion)
   }
 
@@ -1050,7 +1050,7 @@ extension User: NSSecureCoding {}
               continue URL is not valid.
    */
   @objc(sendEmailVerificationWithActionCodeSettings:completion:)
-  public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings? = nil,
+  open func sendEmailVerification(with actionCodeSettings: ActionCodeSettings? = nil,
                                     completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.internalGetToken { accessToken, error in
@@ -1107,7 +1107,7 @@ extension User: NSSecureCoding {}
               continue URL is not valid.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func sendEmailVerification(with actionCodeSettings: ActionCodeSettings? = nil) async throws
+  open func sendEmailVerification(with actionCodeSettings: ActionCodeSettings? = nil) async throws
   {
     return try await withCheckedThrowingContinuation { continuation in
       self.sendEmailVerification(with: actionCodeSettings) { error in
@@ -1135,7 +1135,7 @@ extension User: NSSecureCoding {}
 
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
-  @objc public func delete(completion: ((Error?) -> Void)? = nil) {
+  @objc open func delete(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       self.internalGetToken { accessToken, error in
         if let error {
@@ -1179,7 +1179,7 @@ extension User: NSSecureCoding {}
       @remarks See `AuthErrors` for a list of error codes that are common to all `User` methods.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func delete() async throws {
+  open func delete() async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.delete { error in
         if let error {
@@ -1198,7 +1198,7 @@ extension User: NSSecureCoding {}
            email is complete, or fails.
    */
   @objc(sendEmailVerificationBeforeUpdatingEmail:completion:)
-  public func __sendEmailVerificationBeforeUpdating(email: String,
+  open func __sendEmailVerificationBeforeUpdating(email: String,
                                                     completion: ((Error?) -> Void)?) {
     sendEmailVerification(beforeUpdatingEmail: email, completion: completion)
   }
@@ -1211,7 +1211,7 @@ extension User: NSSecureCoding {}
        @param completion Optionally; the block invoked when the request to send the verification
            email is complete, or fails.
    */
-  @objc public func sendEmailVerification(beforeUpdatingEmail email: String,
+  @objc open func sendEmailVerification(beforeUpdatingEmail email: String,
                                           actionCodeSettings: ActionCodeSettings? =
                                             nil,
                                           completion: ((Error?) -> Void)? = nil) {
@@ -1253,7 +1253,7 @@ extension User: NSSecureCoding {}
        @throws on failure.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func sendEmailVerification(beforeUpdatingEmail newEmail: String,
+  open func sendEmailVerification(beforeUpdatingEmail newEmail: String,
                                     actionCodeSettings: ActionCodeSettings? = nil) async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.sendEmailVerification(beforeUpdatingEmail: newEmail,
@@ -1267,11 +1267,11 @@ extension User: NSSecureCoding {}
     }
   }
 
-  @objc public func rawAccessToken() -> String {
+  @objc open func rawAccessToken() -> String {
     return tokenService.accessToken
   }
 
-  @objc public func accessTokenExpirationDate() -> Date? {
+  @objc open func accessTokenExpirationDate() -> Date? {
     return tokenService.accessTokenExpirationDate
   }
 
@@ -1321,35 +1321,35 @@ extension User: NSSecureCoding {}
     return user
   }
 
-  @objc public var providerID: String {
+  @objc open var providerID: String {
     return "Firebase"
   }
 
   /** @property uid
       @brief The provider's user ID for the user.
    */
-  @objc public var uid: String
+  @objc open var uid: String
 
   /** @property displayName
       @brief The name of the user.
    */
-  @objc public var displayName: String?
+  @objc open var displayName: String?
 
   /** @property photoURL
       @brief The URL of the user's profile photo.
    */
-  @objc public var photoURL: URL?
+  @objc open var photoURL: URL?
 
   /** @property email
       @brief The user's email address.
    */
-  @objc public var email: String?
+  @objc open var email: String?
 
   /** @property phoneNumber
       @brief A phone number associated with the user.
       @remarks This property is only available for users authenticated via phone number auth.
    */
-  @objc public var phoneNumber: String?
+  @objc open var phoneNumber: String?
 
   /** @var hasEmailPasswordCredential
       @brief Whether or not the user can be authenticated by using Firebase email and password.
@@ -2076,7 +2076,7 @@ extension User: NSSecureCoding {}
 
   public static var supportsSecureCoding = true
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(uid, forKey: kUserIDCodingKey)
     coder.encode(isAnonymous, forKey: kAnonymousCodingKey)
     coder.encode(hasEmailPasswordCredential, forKey: kHasEmailPasswordCredentialCodingKey)

--- a/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
@@ -18,7 +18,7 @@ import Foundation
     @brief A data class representing the metadata corresponding to a Firebase user.
  */
 
-@objc(FIRUserMetadata) public class UserMetadata: NSObject, NSSecureCoding {
+@objc(FIRUserMetadata) open class UserMetadata: NSObject, NSSecureCoding {
   /** @property lastSignInDate
       @brief Stores the last sign in date for the corresponding Firebase user.
    */
@@ -43,7 +43,7 @@ import Foundation
     return true
   }
 
-  public func encode(with coder: NSCoder) {
+  open func encode(with coder: NSCoder) {
     coder.encode(creationDate, forKey: UserMetadata.kCreationDateCodingKey)
     coder.encode(lastSignInDate, forKey: UserMetadata.kLastSignInDateCodingKey)
   }

--- a/FirebaseAuth/Sources/Swift/User/UserProfileChangeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserProfileChangeRequest.swift
@@ -20,11 +20,11 @@ import Foundation
         property value to nil is not the same as leaving the property unassigned.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRUserProfileChangeRequest) public class UserProfileChangeRequest: NSObject {
+@objc(FIRUserProfileChangeRequest) open class UserProfileChangeRequest: NSObject {
   /** @property displayName
    @brief The name of the user.
    */
-  @objc public var displayName: String? {
+  @objc open var displayName: String? {
     get { return _displayName }
     set(newDisplayName) {
       kAuthGlobalWorkQueue.async {
@@ -42,7 +42,7 @@ import Foundation
   /** @property photoURL
    @brief The URL of the user's profile photo.
    */
-  @objc public var photoURL: URL? {
+  @objc open var photoURL: URL? {
     get { return _photoURL }
     set(newPhotoURL) {
       kAuthGlobalWorkQueue.async {
@@ -65,7 +65,7 @@ import Foundation
    @param completion Optionally; the block invoked when the user profile change has been applied.
    Invoked asynchronously on the main thread in the future.
    */
-  @objc public func commitChanges(completion: ((Error?) -> Void)? = nil) {
+  @objc open func commitChanges(completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       if self.consumed {
         fatalError("Internal Auth Error: commitChanges should only be called once.")
@@ -115,7 +115,7 @@ import Foundation
    @throws on error.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  public func commitChanges() async throws {
+  open func commitChanges() async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.commitChanges { error in
         if let error {

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -33,7 +33,7 @@ import Foundation
  */
 
 // TODO: Keep the original global strings as deprecated, at least for CocoaPods, like we do in Storage.
-@objc(FIRAuthErrors) public class AuthErrors: NSObject {
+@objc(FIRAuthErrors) open class AuthErrors: NSObject {
   @objc public static let domain: String = "FIRAuthErrorDomain"
 
   @objc public static let userInfoNameKey: String = "FIRAuthErrorUserInfoNameKey"


### PR DESCRIPTION
#no-changelog