### PR TITLE
[#11887] Removed `NSLog` Calls from FirebaseAuth

### DIFF
--- a/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPSecret.m
+++ b/FirebaseAuth/Sources/MultiFactor/TOTP/FIRTOTPSecret.m
@@ -79,13 +79,14 @@ NS_ASSUME_NONNULL_BEGIN
         void (*func)(id, SEL, NSURL *, NSDictionary *, void (^)(BOOL)) = (void *)imp;
         func(application, selector, url, @{}, nil);
       } else {
-        NSLog(@"Cannot access openURL:options:completionHandler: method");
+        FIRLogError(kFIRLoggerAuth, @"I-AUT000023",
+                    @"Cannot access openURL:options:completionHandler: method");
       }
     } else {
-      NSLog(@"URL cannot be opened");
+      FIRLogError(kFIRLoggerAuth, @"I-AUT000024", @"URL cannot be opened");
     }
   } else {
-    NSLog(@"sharedApplication cannot be accessed");
+    FIRLogError(kFIRLoggerAuth, @"I-AUT000025", @"sharedApplication cannot be accessed");
   }
 }
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthRecaptchaVerifier.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthRecaptchaVerifier.m
@@ -123,14 +123,14 @@ static NSString *const kFakeToken = @"NO_RECAPTCHA";
                                            });
                                      } else {
                                        FIRLogError(kFIRLoggerAuth, @"I-AUT000026",
-                                                   @"reCAPTCHA verification faled because "
+                                                   @"reCAPTCHA verification failed because "
                                                    @"reCAPTCHA SDK not linked.");
                                        completion(nil,
                                                   [FIRAuthErrorUtils recaptchaSDKNotLinkedError]);
                                      }
                                    } else {
                                      FIRLogError(kFIRLoggerAuth, @"I-AUT000026",
-                                                 @"reCAPTCHA verification faled because reCAPTCHA "
+                                                 @"reCAPTCHA verification failed because reCAPTCHA "
                                                  @"SDK not linked.");
                                      completion(nil,
                                                 [FIRAuthErrorUtils recaptchaSDKNotLinkedError]);

--- a/FirebaseAuth/Sources/Utilities/FIRAuthRecaptchaVerifier.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthRecaptchaVerifier.m
@@ -122,19 +122,22 @@ static NSString *const kFakeToken = @"NO_RECAPTCHA";
                                              }
                                            });
                                      } else {
-                                       NSLog(@"reCAPTCHA verification faled because reCAPTCHA SDK "
-                                             @"not linked.");
+                                       FIRLogError(kFIRLoggerAuth, @"I-AUT000026",
+                                                   @"reCAPTCHA verification faled because "
+                                                   @"reCAPTCHA SDK not linked.");
                                        completion(nil,
                                                   [FIRAuthErrorUtils recaptchaSDKNotLinkedError]);
                                      }
                                    } else {
-                                     NSLog(@"reCAPTCHA verification faled because reCAPTCHA SDK "
-                                           @"not linked.");
+                                     FIRLogError(kFIRLoggerAuth, @"I-AUT000026",
+                                                 @"reCAPTCHA verification faled because reCAPTCHA "
+                                                 @"SDK not linked.");
                                      completion(nil,
                                                 [FIRAuthErrorUtils recaptchaSDKNotLinkedError]);
                                    }
                                  } else {
-                                   NSLog(@"reCAPTCHA verification succeeded.");
+                                   FIRLogInfo(kFIRLoggerAuth, @"I-AUT000027",
+                                              @"reCAPTCHA verification succeeded.");
                                    [self retrieveRecaptchaTokenWithAction:action
                                                                completion:completion];
                                  }
@@ -160,10 +163,12 @@ static NSString *const kFakeToken = @"NO_RECAPTCHA";
                 callback:^(FIRGetRecaptchaConfigResponse *_Nullable response,
                            NSError *_Nullable error) {
                   if (error) {
-                    NSLog(@"reCAPTCHA config retrieval failed.");
+                    FIRLogError(kFIRLoggerAuth, @"I-AUT000028",
+                                @"reCAPTCHA config retrieval failed.");
                     completion(error);
                   }
-                  NSLog(@"reCAPTCHA config retrieval succeeded.");
+                  FIRLogInfo(kFIRLoggerAuth, @"I-AUT000029",
+                             @"reCAPTCHA config retrieval succeeded.");
                   FIRAuthRecaptchaConfig *config = [[FIRAuthRecaptchaConfig alloc] init];
                   // Response's site key is of the format projects/<project-id>/keys/<site-key>'
                   config.siteKey = [response.recaptchaKey componentsSeparatedByString:@"/"][3];
@@ -218,11 +223,13 @@ static NSString *const kFakeToken = @"NO_RECAPTCHA";
                execute:customAction
             completion:^(NSString *_Nullable token, NSError *_Nullable error) {
               if (!error) {
-                NSLog(@"reCAPTCHA token retrieval succeeded.");
+                FIRLogInfo(kFIRLoggerAuth, @"I-AUT000030", @"reCAPTCHA token retrieval succeeded.");
                 completion(token, nil);
                 return;
               } else {
-                NSLog(@"reCAPTCHA token retrieval failed. NO_RECAPTCHA sent as the fake code.");
+                FIRLogError(
+                    kFIRLoggerAuth, @"I-AUT000031",
+                    @"reCAPTCHA token retrieval failed. NO_RECAPTCHA sent as the fake code.");
                 completion(kFakeToken, nil);
               }
             }];


### PR DESCRIPTION
[Closes #11887]

* Replaced `NSLog` calls in `FIRTOTPSecret.m` and `FIRAuthRecaptchaVerifier.m` with `FIRLogger` invocations
* This commit introduces message codes `I-AUT000023`, `I-AUT000024`, `I-AUT000025`, `I-AUT000026`, `I-AUT000027`, `I-AUT000028`, `I-AUT000029`, `I-AUT000030`, and `I-AUT000031`