### PR TITLE
Firestore: Remove obsolete special case from tests when verifying "missing index" error message in non-default DB

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -1119,15 +1119,11 @@
                                    "The NSError should have contained the word 'index' "
                                    "(case-insensitive), but got: %@",
                                    errorDescription);
-                     // TODO(b/316359394) Remove this check for the default databases once
-                     // cl/582465034 is rolled out to production.
-                     if ([[FSTIntegrationTestCase databaseID] isEqualToString:@"(default)"]) {
-                       XCTAssertTrue(
-                           [errorDescription containsString:@"https://console.firebase.google.com"],
-                           "The NSError should have contained the string "
-                           "'https://console.firebase.google.com', but got: %@",
-                           errorDescription);
-                     }
+                     XCTAssertTrue(
+                         [errorDescription containsString:@"https://console.firebase.google.com"],
+                         "The NSError should have contained the string "
+                         "'https://console.firebase.google.com', but got: %@",
+                         errorDescription);
                    }
                    XCTAssertNil(snapshot);
                    [queryCompletion fulfill];

--- a/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCountTests.mm
@@ -249,15 +249,11 @@
                                    "The NSError should have contained the word 'index' "
                                    "(case-insensitive), but got: %@",
                                    errorDescription);
-                     // TODO(b/316359394) Remove this check for the default databases once
-                     // cl/582465034 is rolled out to production.
-                     if ([[FSTIntegrationTestCase databaseID] isEqualToString:@"(default)"]) {
-                       XCTAssertTrue(
-                           [errorDescription containsString:@"https://console.firebase.google.com"],
-                           "The NSError should have contained the string "
-                           "'https://console.firebase.google.com', but got: %@",
-                           errorDescription);
-                     }
+                     XCTAssertTrue(
+                         [errorDescription containsString:@"https://console.firebase.google.com"],
+                         "The NSError should have contained the string "
+                         "'https://console.firebase.google.com', but got: %@",
+                         errorDescription);
                    }
                    XCTAssertNil(snapshot);
                    [queryCompletion fulfill];


### PR DESCRIPTION
This PR removes a special case from the integration tests (https://github.com/firebase/firebase-ios-sdk/pull/12189) that verifies the "missing index" error message returned from the server. Previously, a non-default database would result in a different, less descriptive error message; however, the backend was updated to use the same, descriptive error message for both default and non-default databases. The tests, therefore, should have to the special case removed to increase the coverage of the tests.

Googlers see b/316359394 for more information.