### PR TITLE
[Rollouts] Rollouts serialization

### DIFF
--- a/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
+++ b/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
@@ -25,7 +25,7 @@ public class CrashlyticsRemoteConfigManager: NSObject {
   public static let maxParameterValueLength = 256
 
   var remoteConfig: RemoteConfigInterop
-  public private(set) var rolloutAssignment: [RolloutAssignment] = []
+  @objc public private(set) var rolloutAssignment: [RolloutAssignment] = []
   weak var persistenceDelegate: CrashlyticsPersistentLog?
 
   @objc public init(remoteConfig: RemoteConfigInterop) {
@@ -34,6 +34,24 @@ public class CrashlyticsRemoteConfigManager: NSObject {
 
   @objc public func updateRolloutsState(rolloutsState: RolloutsState) {
     rolloutAssignment = normalizeRolloutAssignment(assignments: Array(rolloutsState.assignments))
+  }
+
+  @objc public func getRolloutAssignmentsEncodedJson() -> String? {
+    let contentEncodedRolloutAssignments = rolloutAssignment.map { assignment in
+      EncodedRolloutAssignment(assignment: assignment)
+    }
+
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    encoder.outputFormatting = .sortedKeys
+    let encodeData = try? encoder.encode(contentEncodedRolloutAssignments)
+    if let data = encodeData, let returnString = String(data: data, encoding: .utf8) {
+      return returnString
+    }
+
+    // TODO(themisw): Hook into core logging functions
+    debugPrint("Failed to serialize rollouts", encodeData ?? "nil")
+    return nil
   }
 }
 

--- a/Crashlytics/Crashlytics/Rollouts/EncodedRolloutAssignment.swift
+++ b/Crashlytics/Crashlytics/Rollouts/EncodedRolloutAssignment.swift
@@ -1,0 +1,34 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseRemoteConfigInterop
+import Foundation
+
+@objc(FIRCLSEncodedRolloutAssignment)
+class EncodedRolloutAssignment: NSObject, Codable {
+  @objc public private(set) var rolloutId: String
+  @objc public private(set) var variantId: String
+  @objc public private(set) var templateVersion: Int64
+  @objc public private(set) var parameterKey: String
+  @objc public private(set) var parameterValue: String
+
+  public init(assignment: RolloutAssignment) {
+    rolloutId = FileUtility.stringToHexConverter(for: assignment.rolloutId)
+    variantId = FileUtility.stringToHexConverter(for: assignment.variantId)
+    templateVersion = assignment.templateVersion
+    parameterKey = FileUtility.stringToHexConverter(for: assignment.parameterKey)
+    parameterValue = FileUtility.stringToHexConverter(for: assignment.parameterValue)
+    super.init()
+  }
+}

--- a/Crashlytics/Crashlytics/Rollouts/StringToHexConverter.swift
+++ b/Crashlytics/Crashlytics/Rollouts/StringToHexConverter.swift
@@ -1,0 +1,38 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// This is a swift rewrite for the logic in FIRCLSFile for the function FIRCLSFileHexEncodeString()
+@objc(FIRCLSwiftFileUtility)
+public class FileUtility: NSObject {
+  @objc public static func stringToHexConverter(for string: String) -> String {
+    let hexMap = "0123456789abcdef"
+
+    var processedString = ""
+    let utf8Array = string.utf8.map { UInt8($0) }
+    for c in utf8Array {
+      let index1 = String.Index(
+        utf16Offset: Int(c >> 4),
+        in: hexMap
+      )
+      let index2 = String.Index(
+        utf16Offset: Int(c & 0x0F),
+        in: hexMap
+      )
+      processedString = processedString + String(hexMap[index1]) + String(hexMap[index2])
+    }
+    return processedString
+  }
+}

--- a/Crashlytics/UnitTests/FIRCLSFileTests.m
+++ b/Crashlytics/UnitTests/FIRCLSFileTests.m
@@ -14,6 +14,12 @@
 
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFile.h"
 
+#if SWIFT_PACKAGE
+@import FirebaseCrashlyticsSwift;
+#else  // Swift Package Manager
+#import <FirebaseCrashlytics/FirebaseCrashlytics-Swift.h>
+#endif  // Cocoapod
+
 #import <XCTest/XCTest.h>
 
 @interface FIRCLSFileTests : XCTestCase
@@ -167,6 +173,31 @@
                         @"Hex encoded string written to and retrieved from file does not match "
                         @"input in %@buffered case",
                         buffered ? @"" : @"un");
+}
+
+// This is the test to compare FIRCLSwiftFileUtility.stringToHexConverter(for:) and
+// FIRCLSFileWriteHexEncodedString return the same hex encoding value
+- (void)testHexEncodingStringObjcAndSwiftResultsSame {
+  NSString *testedValueString = @"是themis的测试数据，输入中文";
+
+  FIRCLSFile *unbufferedFile = &_unbufferedFile;
+  FIRCLSFileWriteHashStart(unbufferedFile);
+  FIRCLSFileWriteHashEntryHexEncodedString(unbufferedFile, "hex", [testedValueString UTF8String]);
+  FIRCLSFileWriteHashEnd(unbufferedFile);
+  NSString *contentsFromObjcHexEncoding = [self contentsOfFileAtPath:self.unbufferedPath];
+
+  FIRCLSFile *bufferedFile = &_bufferedFile;
+  NSString *encodedValue = [FIRCLSwiftFileUtility stringToHexConverterFor:testedValueString];
+  FIRCLSFileWriteHashStart(bufferedFile);
+  FIRCLSFileWriteHashKey(bufferedFile, "hex");
+  FIRCLSFileWriteStringUnquoted(bufferedFile, "\"");
+  FIRCLSFileWriteStringUnquoted(bufferedFile, [encodedValue UTF8String]);
+  FIRCLSFileWriteStringUnquoted(bufferedFile, "\"");
+  FIRCLSFileWriteHashEnd(bufferedFile);
+  FIRCLSFileFlushWriteBuffer(bufferedFile);
+  NSString *contentsFromSwiftHexEncoding = [self contentsOfFileAtPath:self.bufferedPath];
+
+  XCTAssertTrue([contentsFromObjcHexEncoding isEqualToString:contentsFromSwiftHexEncoding]);
 }
 
 #pragma mark -

--- a/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
+++ b/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
@@ -45,6 +45,18 @@ final class CrashlyticsRemoteConfigManagerTests: XCTestCase {
     return rollouts
   }()
 
+  let singleRollout: RolloutsState = {
+    let assignment1 = RolloutAssignment(
+      rolloutId: "rollout_1",
+      variantId: "control",
+      templateVersion: 1,
+      parameterKey: "my_feature",
+      parameterValue: "这是themis的测试数据，输入中文" // check unicode
+    )
+    let rollouts = RolloutsState(assignmentList: [assignment1])
+    return rollouts
+  }()
+
   let rcInterop = RemoteConfigConfigMock()
 
   func testRemoteConfigManagerProperlyProcessRolloutsState() throws {
@@ -60,5 +72,16 @@ final class CrashlyticsRemoteConfigManagerTests: XCTestCase {
         )
       }
     }
+  }
+
+  func testRemoteConfigManagerGenerateEncodedRolloutAssignmentsJson() throws {
+    let expectedString =
+      "[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\",\"rollout_id\":\"726f6c6c6f75745f31\",\"template_version\":1,\"variant_id\":\"636f6e74726f6c\"}]"
+
+    let rcManager = CrashlyticsRemoteConfigManager(remoteConfig: rcInterop)
+    rcManager.updateRolloutsState(rolloutsState: singleRollout)
+
+    let string = rcManager.getRolloutAssignmentsEncodedJson()
+    XCTAssertEqual(string, expectedString)
   }
 }

--- a/FirebaseRemoteConfig/Interop/RolloutAssignment.swift
+++ b/FirebaseRemoteConfig/Interop/RolloutAssignment.swift
@@ -22,8 +22,9 @@ public class RolloutAssignment: NSObject {
   @objc public var parameterKey: String
   @objc public var parameterValue: String
 
-  public init(rolloutId: String, variantId: String, templateVersion: Int64, parameterKey: String,
-              parameterValue: String) {
+  @objc public init(rolloutId: String, variantId: String, templateVersion: Int64,
+                    parameterKey: String,
+                    parameterValue: String) {
     self.rolloutId = rolloutId
     self.variantId = variantId
     self.templateVersion = templateVersion
@@ -37,7 +38,7 @@ public class RolloutAssignment: NSObject {
 public class RolloutsState: NSObject {
   @objc public var assignments: Set<RolloutAssignment> = Set()
 
-  public init(assignmentList: [RolloutAssignment]) {
+  @objc public init(assignmentList: [RolloutAssignment]) {
     for assignment in assignmentList {
       assignments.insert(assignment)
     }


### PR DESCRIPTION
- Adding a intermediate data object `EncodedRolloutAssignment` to process string value hex encoding and serialization
- Re-write [`FIRCLSFileHexEncodeString`](https://github.com/firebase/firebase-ios-sdk/blob/a8d753baf0f76ead89dc3fd3138431a162722d5b/Crashlytics/Crashlytics/Helpers/FIRCLSFile.m#L660) logic to swift
- Unit testing

Checked rollouts are successfully attached to non-fatals after integration:
<img width="794" alt="Screenshot 2024-01-09 at 6 11 40 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/16548721/2420d8e2-8547-4e02-bf99-5d78638bc3b3">

#no-changelog
