### PR TITLE
Update async/await availability comments to "iOS 13+"

### DIFF
--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -63,7 +63,7 @@ final class AppCheckAPITests {
     }
 
     // Get token (async/await)
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -95,7 +95,7 @@ final class AppCheckAPITests {
       }
 
       // Get token (async/await)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           do {
@@ -166,7 +166,7 @@ final class AppCheckAPITests {
             }
           }
           // Get token (async/await)
-          if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+          if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
             // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
             Task {
               do {

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -64,7 +64,7 @@ final class AppCheckAPITests {
 
     // Get token (async/await)
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           try await AppCheck.appCheck().token(forcingRefresh: false)
@@ -96,7 +96,7 @@ final class AppCheckAPITests {
 
       // Get token (async/await)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
+        // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           do {
             _ = try await debugProvider.getToken()
@@ -167,7 +167,7 @@ final class AppCheckAPITests {
           }
           // Get token (async/await)
           if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // async/await is a Swift 5.5+ feature available on iOS 15+
+            // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
             Task {
               do {
                 _ = try await deviceCheckProvider.getToken()

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -51,7 +51,7 @@ final class CoreAPITests {
         // ...
       }
 
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           await app.delete()

--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -52,7 +52,7 @@ final class CoreAPITests {
       }
 
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
+        // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           await app.delete()
         }

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -113,7 +113,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let /* dataSnapshot */ _: DataSnapshot = try await DatabaseQuery().getData()
@@ -137,7 +137,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         // observeSingleEvent(of eventType:)
         let _: (DataSnapshot, String?) = await DatabaseQuery()
@@ -207,7 +207,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // setValue(_ value:)
@@ -227,7 +227,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // setValue(_ value:andPriority priority:)
@@ -249,7 +249,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let /* ref */ _: DatabaseReference = try await DatabaseReference().removeValue()
@@ -269,7 +269,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // setPriority(_ priority:)
@@ -290,7 +290,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // updateChildValues(_ values:)
@@ -344,7 +344,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         // observeSingleEvent(of eventType:)
         let _: (DataSnapshot, String?) = await DatabaseReference()
@@ -376,7 +376,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let /* dataSnapshot */ _: DataSnapshot = try await DatabaseReference().getData()
@@ -418,7 +418,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // onDisconnectSetValue(_ value:)
@@ -440,7 +440,7 @@ final class DatabaseAPITests {
       }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // onDisconnectSetValue(_ value:andPriority priority:)
@@ -464,7 +464,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let /* ref */ _: DatabaseReference = try await DatabaseReference()
@@ -485,7 +485,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // onDisconnectUpdateChildValues(_ values:)
@@ -507,7 +507,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let /* ref */ _: DatabaseReference = try await DatabaseReference()
@@ -537,7 +537,7 @@ final class DatabaseAPITests {
     }
 
     if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           // runTransactionBlock(_ block:)

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -85,7 +85,7 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -105,7 +105,7 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -86,7 +86,7 @@ final class FunctionsAPITests: XCTestCase {
     }
 
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let result = try await callableRef.call(data)
@@ -106,7 +106,7 @@ final class FunctionsAPITests: XCTestCase {
     }
 
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           let result = try await callableRef.call()

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -51,7 +51,7 @@ final class InstallationsAPITests {
       }
     }
 
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -71,7 +71,7 @@ final class InstallationsAPITests {
       }
     }
 
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -91,7 +91,7 @@ final class InstallationsAPITests {
       }
     }
 
-    if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -110,7 +110,7 @@ final class InstallationsAPITests {
     }
 
     #if swift(>=5.5)
-      if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
         // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           do {

--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -52,7 +52,7 @@ final class InstallationsAPITests {
     }
 
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           try await Installations.installations().installationID()
@@ -72,7 +72,7 @@ final class InstallationsAPITests {
     }
 
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           _ = try await Installations.installations().authToken()
@@ -92,7 +92,7 @@ final class InstallationsAPITests {
     }
 
     if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift 5.5+ feature available on iOS 15+
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
           _ = try await Installations.installations().authTokenForcingRefresh(true)
@@ -111,7 +111,7 @@ final class InstallationsAPITests {
 
     #if swift(>=5.5)
       if #available(iOS 13.0, macOS 11.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift 5.5+ feature available on iOS 15+
+        // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
         Task {
           do {
             _ = try await Installations.installations().delete()


### PR DESCRIPTION
- Updated comments to say async/await is available on iOS 13+ (from 15+ and macOS 10.15+) since it was backported in Xcode 13.2+ / Swift 5.5.2+
- Removed mention of Swift 5.5+ in the comments since we only support 5.6+
- Fixed macOS 11.15 typos (version doesn't exist -- assumed 10.15 since that's the minimum for async/await)

#no-changelog