### PR TITLE
[Rollouts] Implement insert and load logic for rollout metadata in RC

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -121,33 +121,30 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
   _isDatabaseLoadAlreadyInitiated = true;
 
   dispatch_group_enter(_dispatch_group);
-  [_DBManager
-      loadMainWithBundleIdentifier:_bundleIdentifier
-                 completionHandler:^(BOOL success, NSDictionary *fetchedConfig,
-                                     NSDictionary *activeConfig, NSDictionary *defaultConfig) {
-                   self->_fetchedConfig = [fetchedConfig mutableCopy];
-                   self->_activeConfig = [activeConfig mutableCopy];
-                   self->_defaultConfig = [defaultConfig mutableCopy];
-                   dispatch_group_leave(self->_dispatch_group);
-                 }];
+  [_DBManager loadMainWithBundleIdentifier:_bundleIdentifier
+                         completionHandler:^(
+                             BOOL success, NSDictionary *fetchedConfig, NSDictionary *activeConfig,
+                             NSDictionary *defaultConfig, NSDictionary *rolloutMetadata) {
+                           self->_fetchedConfig = [fetchedConfig mutableCopy];
+                           self->_activeConfig = [activeConfig mutableCopy];
+                           self->_defaultConfig = [defaultConfig mutableCopy];
+                           self->_fetchedRolloutMetadata =
+                               [rolloutMetadata[@RCNRolloutTableKeyFetchedMetadata] copy];
+                           self->_activeRolloutMetadata =
+                               [rolloutMetadata[@RCNRolloutTableKeyActiveMetadata] copy];
+                           dispatch_group_leave(self->_dispatch_group);
+                         }];
 
   // TODO(karenzeng): Refactor personalization to be returned in loadMainWithBundleIdentifier above
   dispatch_group_enter(_dispatch_group);
-  [_DBManager loadPersonalizationWithCompletionHandler:^(
-                  BOOL success, NSDictionary *fetchedPersonalization,
-                  NSDictionary *activePersonalization, NSDictionary *defaultConfig) {
-    self->_fetchedPersonalization = [fetchedPersonalization copy];
-    self->_activePersonalization = [activePersonalization copy];
-    dispatch_group_leave(self->_dispatch_group);
-  }];
-
-  dispatch_group_enter(_dispatch_group);
-  [_DBManager loadRolloutMetadataWithCompletionHandler:^(BOOL success,
-                                                         NSDictionary<NSString *, id> *result) {
-    self->_fetchedRolloutMetadata = [result[@RCNRolloutTableKeyFetchedMetadata] copy];
-    self->_activeRolloutMetadata = [result[@RCNRolloutTableKeyActiveMetadata] copy];
-    dispatch_group_leave(self->_dispatch_group);
-  }];
+  [_DBManager
+      loadPersonalizationWithCompletionHandler:^(
+          BOOL success, NSDictionary *fetchedPersonalization, NSDictionary *activePersonalization,
+          NSDictionary *defaultConfig, NSDictionary *rolloutMetadata) {
+        self->_fetchedPersonalization = [fetchedPersonalization copy];
+        self->_activePersonalization = [activePersonalization copy];
+        dispatch_group_leave(self->_dispatch_group);
+      }];
 }
 
 /// Update the current config result to main table.

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -39,9 +39,9 @@
   /// applied.
   NSDictionary *_fetchedPersonalization;
   /// Active Rollout metadata that is currently used.
-  NSArray *_activeRolloutMetadata;
+  NSArray<NSDictionary *> *_activeRolloutMetadata;
   /// Pending Rollout metadata that is latest data from server that might or might not be applied.
-  NSArray *_fetchedRolloutMetadata;
+  NSArray<NSDictionary *> *_fetchedRolloutMetadata;
   /// DBManager
   RCNConfigDBManager *_DBManager;
   /// Current bundle identifier;

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -38,6 +38,10 @@
   /// Pending Personalization metadata that is latest data from server that might or might not be
   /// applied.
   NSDictionary *_fetchedPersonalization;
+  /// Active Rollout metadata that is currently used.
+  NSArray *_activeRollout;
+  /// Pending Rollout metadata that is latest data from server that might or might not be applied.
+  NSArray *_fetchedRollout;
   /// DBManager
   RCNConfigDBManager *_DBManager;
   /// Current bundle identifier;
@@ -80,6 +84,8 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
     _defaultConfig = [[NSMutableDictionary alloc] init];
     _activePersonalization = [[NSDictionary alloc] init];
     _fetchedPersonalization = [[NSDictionary alloc] init];
+    _activeRollout = [[NSArray alloc] init];
+    _fetchedRollout = [[NSArray alloc] init];
     _bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     if (!_bundleIdentifier) {
       FIRLogNotice(kFIRLoggerRemoteConfig, @"I-RCN000038",
@@ -134,6 +140,14 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
     self->_activePersonalization = [activePersonalization copy];
     dispatch_group_leave(self->_dispatch_group);
   }];
+
+  dispatch_group_enter(_dispatch_group);
+  [_DBManager
+      loadRolloutWithCompletionHandler:^(BOOL success, NSDictionary<NSString *, id> *result) {
+        self->_fetchedRollout = [result[@RCNRolloutTableKeyFetchedMetadata] copy];
+        self->_activeRollout = [result[@RCNRolloutTableKeyActiveMetadata] copy];
+        dispatch_group_leave(self->_dispatch_group);
+      }];
 }
 
 /// Update the current config result to main table.

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -39,9 +39,9 @@
   /// applied.
   NSDictionary *_fetchedPersonalization;
   /// Active Rollout metadata that is currently used.
-  NSArray *_activeRollout;
+  NSArray *_activeRolloutMetadata;
   /// Pending Rollout metadata that is latest data from server that might or might not be applied.
-  NSArray *_fetchedRollout;
+  NSArray *_fetchedRolloutMetadata;
   /// DBManager
   RCNConfigDBManager *_DBManager;
   /// Current bundle identifier;
@@ -84,8 +84,8 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
     _defaultConfig = [[NSMutableDictionary alloc] init];
     _activePersonalization = [[NSDictionary alloc] init];
     _fetchedPersonalization = [[NSDictionary alloc] init];
-    _activeRollout = [[NSArray alloc] init];
-    _fetchedRollout = [[NSArray alloc] init];
+    _activeRolloutMetadata = [[NSArray alloc] init];
+    _fetchedRolloutMetadata = [[NSArray alloc] init];
     _bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
     if (!_bundleIdentifier) {
       FIRLogNotice(kFIRLoggerRemoteConfig, @"I-RCN000038",
@@ -142,12 +142,12 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
   }];
 
   dispatch_group_enter(_dispatch_group);
-  [_DBManager
-      loadRolloutWithCompletionHandler:^(BOOL success, NSDictionary<NSString *, id> *result) {
-        self->_fetchedRollout = [result[@RCNRolloutTableKeyFetchedMetadata] copy];
-        self->_activeRollout = [result[@RCNRolloutTableKeyActiveMetadata] copy];
-        dispatch_group_leave(self->_dispatch_group);
-      }];
+  [_DBManager loadRolloutMetadataWithCompletionHandler:^(BOOL success,
+                                                         NSDictionary<NSString *, id> *result) {
+    self->_fetchedRolloutMetadata = [result[@RCNRolloutTableKeyFetchedMetadata] copy];
+    self->_activeRolloutMetadata = [result[@RCNRolloutTableKeyActiveMetadata] copy];
+    dispatch_group_leave(self->_dispatch_group);
+  }];
 }
 
 /// Update the current config result to main table.

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -117,9 +117,9 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 ///                   RCNConfigDefines.h.
 /// @param value      The value that rollout metadata array.
 /// @param handler    The callback.
-- (void)insertRolloutTableWithKey:(NSString *)key
-                            value:(NSData *)value
-                completionHandler:(RCNDBCompletion)handler;
+- (void)insertOrUpdateRolloutTableWithKey:(NSString *)key
+                                    value:(NSArray *)value
+                        completionHandler:(RCNDBCompletion)handler;
 
 /// Clear the record of given namespace and package name
 /// before updating the table.

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -112,8 +112,8 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 - (BOOL)insertOrUpdatePersonalizationConfig:(NSDictionary *)metadata fromSource:(RCNDBSource)source;
 
 /// Insert rollout metadata in rollout table.
-/// @param key        The string as a key of rollout metadata belongs to, which indicates whether
-/// the metadata is fetched or active and defined in RCNConfigDefines.h.
+/// @param key        Key indicating whether rollout metadata is fetched or active and defined in
+/// RCNConfigDefines.h.
 /// @param value      The value that rollout metadata array.
 /// @param handler    The callback.
 - (void)insertOrUpdateRolloutTableWithKey:(NSString *)key

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -117,7 +117,7 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 /// @param value      The value that rollout metadata array.
 /// @param handler    The callback.
 - (void)insertOrUpdateRolloutTableWithKey:(NSString *)key
-                                    value:(NSArray *)value
+                                    value:(NSArray<NSDictionary *> *)value
                         completionHandler:(RCNDBCompletion)handler;
 
 /// Clear the record of given namespace and package name

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -78,7 +78,9 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 /// Load Personalization from table.
 /// @param handler    The callback when reading from DB is complete.
 - (void)loadPersonalizationWithCompletionHandler:(RCNDBLoadCompletion)handler;
-
+/// Load Rollout metadata from table
+/// @param handler   The callback when reading from DB is complete.
+- (void)loadRolloutWithCompletionHandler:(RCNDBCompletion)handler;
 /// Insert a record in metadata table.
 /// @param columnNameToValue The column name and its value to be inserted in metadata table.
 /// @param handler           The callback.
@@ -109,6 +111,15 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 
 /// Insert or update the data in Personalization config.
 - (BOOL)insertOrUpdatePersonalizationConfig:(NSDictionary *)metadata fromSource:(RCNDBSource)source;
+
+/// Insert rollout metadata in rollout table.
+/// @param key        The key of rollout metadata belongs to, which are defined in
+///                   RCNConfigDefines.h.
+/// @param value      The value that rollout metadata array.
+/// @param handler    The callback.
+- (void)insertRolloutTableWithKey:(NSString *)key
+                            value:(NSData *)value
+                completionHandler:(RCNDBCompletion)handler;
 
 /// Clear the record of given namespace and package name
 /// before updating the table.

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -78,9 +78,11 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 /// Load Personalization from table.
 /// @param handler    The callback when reading from DB is complete.
 - (void)loadPersonalizationWithCompletionHandler:(RCNDBLoadCompletion)handler;
+
 /// Load Rollout metadata from table
 /// @param handler   The callback when reading from DB is complete.
-- (void)loadRolloutWithCompletionHandler:(RCNDBCompletion)handler;
+- (void)loadRolloutMetadataWithCompletionHandler:(RCNDBCompletion)handler;
+
 /// Insert a record in metadata table.
 /// @param columnNameToValue The column name and its value to be inserted in metadata table.
 /// @param handler           The callback.
@@ -113,8 +115,8 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 - (BOOL)insertOrUpdatePersonalizationConfig:(NSDictionary *)metadata fromSource:(RCNDBSource)source;
 
 /// Insert rollout metadata in rollout table.
-/// @param key        The key of rollout metadata belongs to, which are defined in
-///                   RCNConfigDefines.h.
+/// @param key        The string as a key of rollout metadata belongs to, which indicates whether
+/// the metadata is fetched or active and defined in RCNConfigDefines.h.
 /// @param value      The value that rollout metadata array.
 /// @param handler    The callback.
 - (void)insertOrUpdateRolloutTableWithKey:(NSString *)key

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -53,10 +53,12 @@ typedef void (^RCNDBCompletion)(BOOL success, NSDictionary *result);
 /// @param fetchedConfig  Return fetchedConfig loaded from DB
 /// @param activeConfig  Return activeConfig loaded from DB
 /// @param defaultConfig  Return defaultConfig loaded from DB
+/// @param rolloutMetadata  Return fetched and active RolloutMetadata loaded from DB
 typedef void (^RCNDBLoadCompletion)(BOOL success,
                                     NSDictionary *fetchedConfig,
                                     NSDictionary *activeConfig,
-                                    NSDictionary *defaultConfig);
+                                    NSDictionary *defaultConfig,
+                                    NSDictionary *rolloutMetadata);
 
 /// Returns the current version of the Remote Config database.
 + (NSString *)remoteConfigPathForDatabase;
@@ -78,11 +80,6 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 /// Load Personalization from table.
 /// @param handler    The callback when reading from DB is complete.
 - (void)loadPersonalizationWithCompletionHandler:(RCNDBLoadCompletion)handler;
-
-/// Load Rollout metadata from table
-/// @param handler   The callback when reading from DB is complete.
-- (void)loadRolloutMetadataWithCompletionHandler:(RCNDBCompletion)handler;
-
 /// Insert a record in metadata table.
 /// @param columnNameToValue The column name and its value to be inserted in metadata table.
 /// @param handler           The callback.

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -918,9 +918,6 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder(void) {
   dispatch_async(_databaseOperationQueue, ^{
     RCNConfigDBManager *strongSelf = weakSelf;
     if (!strongSelf) {
-      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        handler(NO, [NSMutableDictionary new]);
-      });
       return;
     }
     NSArray *activeRollout = [strongSelf loadRolloutTableFromKey:@RCNRolloutTableKeyActiveMetadata];

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -913,7 +913,7 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder(void) {
   return results;
 }
 
-- (void)loadRolloutWithCompletionHandler:(RCNDBCompletion)handler {
+- (void)loadRolloutMetadataWithCompletionHandler:(RCNDBCompletion)handler {
   __weak RCNConfigDBManager *weakSelf = self;
   dispatch_async(_databaseOperationQueue, ^{
     RCNConfigDBManager *strongSelf = weakSelf;

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -628,7 +628,7 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder(void) {
   dispatch_async(_databaseOperationQueue, ^{
     BOOL success = [self insertOrUpdateRolloutTableWithKey:key value:value];
     if (handler) {
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         handler(success, nil);
       });
     }

--- a/FirebaseRemoteConfig/Sources/RCNConfigDefines.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDefines.h
@@ -31,5 +31,7 @@
 #define RCNExperimentTableKeyPayload "experiment_payload"
 #define RCNExperimentTableKeyMetadata "experiment_metadata"
 #define RCNExperimentTableKeyActivePayload "experiment_active_payload"
+#define RCNRolloutTableKeyActiveMetadata "active_rollout_metadata"
+#define RCNRolloutTableKeyFetchedMetadata "fetched_rollout_metadata"
 
 #endif

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -44,7 +44,7 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(justSmallDelay * NSEC_PER_SEC)),
                  dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                    self.isLoadMainCompleted = YES;
-                   handler(YES, nil, nil, nil);
+                   handler(YES, nil, nil, nil, nil);
                  });
 }
 - (void)loadPersonalizationWithCompletionHandler:(RCNDBLoadCompletion)handler {
@@ -53,7 +53,7 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(justOtherSmallDelay * NSEC_PER_SEC)),
                  dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                    self.isLoadPersonalizationCompleted = YES;
-                   handler(YES, nil, nil, nil);
+                   handler(YES, nil, nil, nil, nil);
                  });
 }
 @end

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
@@ -628,7 +628,7 @@
 
       [writeAndLoadFetchedRolloutExpectation fulfill];
     };
-    [self->_DBManager loadRolloutWithCompletionHandler:readCompletion];
+    [self->_DBManager loadRolloutMetadataWithCompletionHandler:readCompletion];
   };
   [_DBManager insertOrUpdateRolloutTableWithKey:@RCNRolloutTableKeyFetchedMetadata
                                           value:fetchedRollout
@@ -673,7 +673,7 @@
 
       [updateAndLoadFetchedRolloutExpectation fulfill];
     };
-    [self->_DBManager loadRolloutWithCompletionHandler:readCompletion];
+    [self->_DBManager loadRolloutMetadataWithCompletionHandler:readCompletion];
   };
   [_DBManager insertOrUpdateRolloutTableWithKey:@RCNRolloutTableKeyFetchedMetadata
                                           value:fetchedRollout
@@ -697,7 +697,7 @@
 
     [updateAndLoadFetchedRolloutExpectation fulfill];
   };
-  [self->_DBManager loadRolloutWithCompletionHandler:readCompletion];
+  [self->_DBManager loadRolloutMetadataWithCompletionHandler:readCompletion];
   [self waitForExpectationsWithTimeout:_expectionTimeout handler:nil];
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1350,7 +1350,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
     return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: appMeasurementURL, branch: "main")
+  return .package(url: appMeasurementURL, exact: "10.17.0")
 }
 
 func abseilDependency() -> Package.Dependency {

--- a/Package.swift
+++ b/Package.swift
@@ -1350,7 +1350,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
     return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: appMeasurementURL, exact: "10.17.0")
+  return .package(url: appMeasurementURL, branch: "main")
 }
 
 func abseilDependency() -> Package.Dependency {


### PR DESCRIPTION
Add insertOrUpdate method to persist rollout metadata in sqlite db
Add load method to load rollout metadata from sqlite db

Note: this change will merge to our feature branch not master
#no-changelog
