### PR TITLE
[auth-swift] Consistent NSSecureCoding decode

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
@@ -14,12 +14,15 @@
 
 import Foundation
 
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+extension AuthDataResult: NSSecureCoding {}
+
 /** @class AuthDataResult
     @brief Helper object that contains the result of a successful sign-in, link and reauthenticate
         action. It contains references to a `User` instance and a `AdditionalUserInfo` instance.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthDataResult) open class AuthDataResult: NSObject, NSSecureCoding {
+@objc(FIRAuthDataResult) open class AuthDataResult: NSObject {
   /** @property user
       @brief The signed in user.
    */
@@ -37,10 +40,6 @@ import Foundation
    */
   @objc public let credential: OAuthCredential?
 
-  private let kAdditionalUserInfoCodingKey = "additionalUserInfo"
-  private let kUserCodingKey = "user"
-  private let kCredentialCodingKey = "credential"
-
   /** @fn initWithUser:additionalUserInfo:
    @brief Designated initializer.
    @param user The signed in user reference.
@@ -55,9 +54,13 @@ import Foundation
     self.credential = credential
   }
 
-  public static var supportsSecureCoding: Bool {
-    return true
-  }
+  // MARK: Secure Coding
+
+  private let kAdditionalUserInfoCodingKey = "additionalUserInfo"
+  private let kUserCodingKey = "user"
+  private let kCredentialCodingKey = "credential"
+
+  public static var supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(user, forKey: kUserCodingKey)
@@ -66,12 +69,12 @@ import Foundation
   }
 
   public required init?(coder: NSCoder) {
-    guard let user = coder.decodeObject(forKey: kUserCodingKey) as? User else {
+    guard let user = coder.decodeObject(of: User.self, forKey: kUserCodingKey) else {
       return nil
     }
     self.user = user
-    additionalUserInfo = coder.decodeObject(forKey: kAdditionalUserInfoCodingKey)
-      as? AdditionalUserInfo
-    credential = coder.decodeObject(forKey: kCredentialCodingKey) as? OAuthCredential
+    additionalUserInfo = coder.decodeObject(of: AdditionalUserInfo.self,
+                                            forKey: kAdditionalUserInfoCodingKey)
+    credential = coder.decodeObject(of: OAuthCredential.self, forKey: kCredentialCodingKey)
   }
 }

--- a/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
@@ -14,56 +14,53 @@
 
 import Foundation
 
+extension AuthTokenResult: NSSecureCoding {}
+
 /** @class FIRAuthTokenResult
     @brief A data class containing the ID token JWT string and other properties associated with the
     token including the decoded payload claims.
  */
 @objc(FIRAuthTokenResult) open class AuthTokenResult: NSObject {
   /** @property token
-      @brief Stores the JWT string of the ID token.
+   @brief Stores the JWT string of the ID token.
    */
   @objc open var token: String
 
   /** @property expirationDate
-      @brief Stores the ID token's expiration date.
+   @brief Stores the ID token's expiration date.
    */
   @objc open var expirationDate: Date
 
   /** @property authDate
-      @brief Stores the ID token's authentication date.
-      @remarks This is the date the user was signed in and NOT the date the token was refreshed.
+   @brief Stores the ID token's authentication date.
+   @remarks This is the date the user was signed in and NOT the date the token was refreshed.
    */
   @objc open var authDate: Date
 
   /** @property issuedAtDate
-      @brief Stores the date that the ID token was issued.
-      @remarks This is the date last refreshed and NOT the last authentication date.
+   @brief Stores the date that the ID token was issued.
+   @remarks This is the date last refreshed and NOT the last authentication date.
    */
   @objc open var issuedAtDate: Date
 
   /** @property signInProvider
-      @brief Stores sign-in provider through which the token was obtained.
-      @remarks This does not necessarily map to provider IDs.
+   @brief Stores sign-in provider through which the token was obtained.
+   @remarks This does not necessarily map to provider IDs.
    */
   @objc open var signInProvider: String
 
   /** @property signInSecondFactor
-      @brief Stores sign-in second factor through which the token was obtained.
+   @brief Stores sign-in second factor through which the token was obtained.
    */
   @objc open var signInSecondFactor: String
 
   /** @property claims
-      @brief Stores the entire payload of claims found on the ID token. This includes the standard
-          reserved claims as well as custom claims set by the developer via the Admin SDK.
+   @brief Stores the entire payload of claims found on the ID token. This includes the standard
+   reserved claims as well as custom claims set by the developer via the Admin SDK.
    */
   @objc open var claims: [String: Any]
 
-  /** @fn tokenResultWithToken:
-       @brief Parse a token string to a structured token.
-       @param token The token string to parse.
-       @return A structured token result.
-   */
-  @objc open class func tokenResult(token: String) -> AuthTokenResult? {
+  private class func getTokenPayloadData(_ token: String) -> Data? {
     let tokenStringArray = token.components(separatedBy: ".")
 
     // The JWT should have three parts, though we only use the second in this method.
@@ -85,56 +82,81 @@ import Foundation
       let length = tokenPayload.count + (4 - tokenPayload.count % 4)
       tokenPayload = tokenPayload.padding(toLength: length, withPad: "=", startingAt: 0)
     }
+    return Data(base64Encoded: tokenPayload, options: [.ignoreUnknownCharacters])
+  }
 
-    guard let decodedTokenPayloadData = Data(
-      base64Encoded: tokenPayload,
-      options: [.ignoreUnknownCharacters]
-    ) else {
-      return nil
-    }
-    guard let tokenPayloadDictionary = try? JSONSerialization.jsonObject(
-      with: decodedTokenPayloadData,
+  private class func getTokenPayloadDictionary(_ payloadData: Data) -> [String: Any]? {
+    return try? JSONSerialization.jsonObject(
+      with: payloadData,
       options: [.mutableContainers, .allowFragments]
-    ) as? [String: Any] else {
-      return nil
-    }
+    ) as? [String: Any]
+  }
+
+  private class func getJWT(_ payloadData: Data) -> JWT? {
     // These are dates since 00:00:00 January 1 1970, as described by the Terminology section in
     // the JWT spec. https://tools.ietf.org/html/rfc7519
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .secondsSince1970
     decoder.keyDecodingStrategy = .convertFromSnakeCase
-    guard let jwt = try? decoder.decode(JWT.self, from: decodedTokenPayloadData) else {
+    guard let jwt = try? decoder.decode(JWT.self, from: payloadData) else {
       return nil
     }
-
-    let tokenResult = AuthTokenResult(token: token,
-                                      expirationDate: jwt.exp,
-                                      authDate: jwt.authTime,
-                                      issuedAtDate: jwt.iat,
-                                      signInProvider: jwt.firebase.signInProvider,
-                                      signInSecondFactor: jwt.firebase.signInSecondFactor,
-                                      claims: tokenPayloadDictionary)
-    return tokenResult
+    return jwt
   }
 
-  init(token: String,
-       expirationDate: Date,
-       authDate: Date,
-       issuedAtDate: Date,
-       signInProvider: String,
-       signInSecondFactor: String?,
-       claims: [String: Any]) {
+  /** @fn tokenResultWithToken:
+       @brief Parse a token string to a structured token.
+       @param token The token string to parse.
+       @return A structured token result.
+   */
+  @objc open class func tokenResult(token: String) -> AuthTokenResult? {
+    guard let payloadData = getTokenPayloadData(token),
+          let claims = getTokenPayloadDictionary(payloadData),
+          let jwt = getJWT(payloadData) else {
+      return nil
+    }
+    return AuthTokenResult(token: token, jwt: jwt, claims: claims)
+  }
+
+  private init(token: String, jwt: JWT, claims: [String: Any]) {
     self.token = token
-    self.expirationDate = expirationDate
-    self.authDate = authDate
-    self.issuedAtDate = issuedAtDate
-    self.signInProvider = signInProvider
-    self.signInSecondFactor = signInSecondFactor ?? ""
+    expirationDate = jwt.exp
+    authDate = jwt.authTime
+    issuedAtDate = jwt.iat
+    signInProvider = jwt.firebase.signInProvider
+    signInSecondFactor = jwt.firebase.signInSecondFactor ?? ""
     self.claims = claims
+  }
+
+  // MARK: Secure Coding
+
+  private static let kTokenKey = "token"
+
+  public static var supportsSecureCoding: Bool {
+    return true
+  }
+
+  public func encode(with coder: NSCoder) {
+    coder.encode(token, forKey: AuthTokenResult.kTokenKey)
+  }
+
+  public required convenience init?(coder: NSCoder) {
+    guard let token = coder.decodeObject(
+      of: [NSString.self],
+      forKey: AuthTokenResult.kTokenKey
+    ) as? String else {
+      return nil
+    }
+    guard let payloadData = AuthTokenResult.getTokenPayloadData(token),
+          let claims = AuthTokenResult.getTokenPayloadDictionary(payloadData),
+          let jwt = AuthTokenResult.getJWT(payloadData) else {
+      return nil
+    }
+    self.init(token: token, jwt: jwt, claims: claims)
   }
 }
 
-struct JWT: Decodable {
+private struct JWT: Decodable {
   struct FirebasePayload: Decodable {
     let signInProvider: String
     let signInSecondFactor: String?

--- a/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
@@ -14,42 +14,6 @@
 
 import Foundation
 
-/** @var kExpirationDateKey
-    @brief The key used to encode the expirationDate property for NSSecureCoding.
- */
-// XXX TODO: TYPO IN ORIGINAL KEY. TO FIX OR NOT?
-private let kExpirationDateKey = "expiratinDate"
-
-/** @var kTokenKey
-    @brief The key used to encode the token property for NSSecureCoding.
- */
-private let kTokenKey = "token"
-
-/** @var kAuthDateKey
-    @brief The key used to encode the authDate property for NSSecureCoding.
- */
-private let kAuthDateKey = "authDate"
-
-/** @var kIssuedDateKey
-    @brief The key used to encode the issuedDate property for NSSecureCoding.
- */
-private let kIssuedDateKey = "issuedDate"
-
-/** @var kSignInProviderKey
-    @brief The key used to encode the signInProvider property for NSSecureCoding.
- */
-private let kSignInProviderKey = "signInProvider"
-
-/** @var kSignInSecondFactorKey
- @brief The key used to encode the signInSecondFactor property for NSSecureCoding.
- */
-private let kSignInSecondFactorKey = "signInSecondFactor"
-
-/** @var kClaimsKey
-    @brief The key used to encode the claims property for NSSecureCoding.
- */
-private let kClaimsKey = "claims"
-
 /** @class FIRAuthTokenResult
     @brief A data class containing the ID token JWT string and other properties associated with the
     token including the decoded payload claims.
@@ -181,29 +145,3 @@ struct JWT: Decodable {
   let iat: Date
   let firebase: FirebasePayload
 }
-
-/*
- @implementation FIRAuthTokenResult
-
- + (nullable FIRAuthTokenResult *)tokenResultWithToken:(NSString *)token {
-
- }
-
- #pragma mark - NSSecureCoding
-
- + (BOOL)supportsSecureCoding {
-   return YES;
- }
-
- - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
-   NSString *token = [aDecoder decodeObjectOfClass:[NSDate class] forKey:kTokenKey];
-   return [FIRAuthTokenResult tokenResultWithToken:token];
- }
-
- - (void)encodeWithCoder:(NSCoder *)aCoder {
-   [aCoder encodeObject:_token forKey:kTokenKey];
- }
-
- @end
-
- */

--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -45,7 +45,7 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class EmailAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIREmailPasswordAuthCredential) class EmailAuthCredential: AuthCredential, NSSecureCoding {
   let email: String
 
   enum EmailType {
@@ -66,6 +66,8 @@ class EmailAuthCredential: AuthCredential, NSSecureCoding {
     emailType = .link(link)
     super.init(provider: EmailAuthProvider.id)
   }
+
+  // MARK: Secure Coding
 
   public static var supportsSecureCoding = true
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -69,9 +69,9 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  static var supportsSecureCoding = true
 
-  public func encode(with coder: NSCoder) {
+  func encode(with coder: NSCoder) {
     coder.encode(email, forKey: "email")
     switch emailType {
     case let .password(password): coder.encode(password, forKey: "password")
@@ -79,7 +79,7 @@ import Foundation
     }
   }
 
-  public required init?(coder: NSCoder) {
+  required init?(coder: NSCoder) {
     guard let email = coder.decodeObject(of: NSString.self, forKey: "email") as? String else {
       return nil
     }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -52,7 +52,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(accessToken, forKey: "accessToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -38,7 +38,7 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc class FacebookAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRFacebookAuthCredential) class FacebookAuthCredential: AuthCredential, NSSecureCoding {
   let accessToken: String
 
   init(withAccessToken accessToken: String) {
@@ -50,7 +50,9 @@ import Foundation
     request.providerAccessToken = accessToken
   }
 
-  static var supportsSecureCoding = true
+  // MARK: Secure Coding
+
+  public static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(accessToken, forKey: "accessToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -171,7 +171,7 @@
 
     // MARK: Secure Coding
 
-    public static var supportsSecureCoding = true
+    static var supportsSecureCoding = true
 
     func encode(with coder: NSCoder) {
       coder.encode(playerID, forKey: "playerID")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -133,7 +133,8 @@
   }
 
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class GameCenterAuthCredential: AuthCredential, NSSecureCoding {
+  @objc(FIRGameCenterAuthCredential) class GameCenterAuthCredential: AuthCredential,
+    NSSecureCoding {
     let playerID: String
     let teamPlayerID: String?
     let gamePlayerID: String?
@@ -168,7 +169,9 @@
       super.init(provider: GameCenterAuthProvider.id)
     }
 
-    static var supportsSecureCoding = true
+    // MARK: Secure Coding
+
+    public static var supportsSecureCoding = true
 
     func encode(with coder: NSCoder) {
       coder.encode(playerID, forKey: "playerID")
@@ -191,7 +194,7 @@
               of: NSString.self,
               forKey: "gamePlayerID"
             ) as? String,
-            let timestamp = coder.decodeObject(forKey: "timestamp") as? UInt64,
+            let timestamp = coder.decodeObject(of: NSNumber.self, forKey: "timestamp") as? UInt64,
             let displayName = coder.decodeObject(
               of: NSString.self,
               forKey: "displayName"

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
@@ -38,7 +38,7 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class GitHubAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRGitHubAuthCredential) class GitHubAuthCredential: AuthCredential, NSSecureCoding {
   let token: String
 
   init(withToken token: String) {
@@ -50,7 +50,9 @@ class GitHubAuthCredential: AuthCredential, NSSecureCoding {
     request.providerAccessToken = token
   }
 
-  static var supportsSecureCoding = true
+  // MARK: Secure Coding
+
+  public static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(token, forKey: "token")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -57,7 +57,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(idToken, forKey: "idToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -55,7 +55,9 @@ import Foundation
     request.providerAccessToken = accessToken
   }
 
-  static var supportsSecureCoding = true
+  // MARK: Secure Coding
+
+  public static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(idToken, forKey: "idToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -117,7 +117,8 @@ import Foundation
     accessToken = coder.decodeObject(of: NSString.self, forKey: "accessToken") as? String
     pendingToken = coder.decodeObject(of: NSString.self, forKey: "pendingToken") as? String
     secret = coder.decodeObject(of: NSString.self, forKey: "secret") as? String
-    fullName = coder.decodeObject(forKey: "fullName") as? PersonNameComponents
+    fullName = coder.decodeObject(of: NSPersonNameComponents.self, forKey: "fullName")
+      as? PersonNameComponents
     OAuthResponseURLString = nil
     sessionID = nil
     super.init(provider: OAuthProvider.id)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
@@ -38,6 +38,8 @@ import Foundation
     super.init(provider: providerID)
   }
 
+  // MARK: Secure Coding
+
   public static var supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -56,7 +56,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(token, forKey: "token")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -39,7 +39,7 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class TwitterAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRTwitterAuthCredential) class TwitterAuthCredential: AuthCredential, NSSecureCoding {
   let token: String
   let secret: String
 
@@ -54,7 +54,9 @@ class TwitterAuthCredential: AuthCredential, NSSecureCoding {
     request.providerOAuthTokenSecret = secret
   }
 
-  static var supportsSecureCoding = true
+  // MARK: Secure Coding
+
+  public static var supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(token, forKey: "token")

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
@@ -16,13 +16,15 @@ import Foundation
 
 #if os(iOS)
 
+  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+extension MultiFactor: NSSecureCoding {}
   /** @class FIRMultiFactor
    @brief The interface defining the multi factor related properties and operations pertaining to a
        user.
        This class is available on iOS only.
    */
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  @objc(FIRMultiFactor) open class MultiFactor: NSObject, NSSecureCoding {
+  @objc(FIRMultiFactor) open class MultiFactor: NSObject {
     @objc open var enrolledFactors: [MultiFactorInfo]
 
     /** @fn getSessionWithCompletion:

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
@@ -17,7 +17,7 @@ import Foundation
 #if os(iOS)
 
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-extension MultiFactor: NSSecureCoding {}
+  extension MultiFactor: NSSecureCoding {}
   /** @class FIRMultiFactor
    @brief The interface defining the multi factor related properties and operations pertaining to a
        user.

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
@@ -15,10 +15,7 @@
 import Foundation
 
 #if os(iOS)
-  private let kUIDCodingKey = "uid"
-  private let kDisplayNameCodingKey = "displayName"
-  private let kEnrollmentDateCodingKey = "enrollmentDate"
-  private let kFactorIDCodingKey = "factorID"
+  extension MultiFactorInfo: NSSecureCoding {}
 
   /** @class FIRMultiFactorInfo
    @brief Safe public structure used to represent a second factor entity from a client perspective.
@@ -55,6 +52,22 @@ import Foundation
       enrollmentDate = proto.enrolledAt ?? Date()
     }
 
+    // MARK: NSSecureCoding
+
+    private let kUIDCodingKey = "uid"
+    private let kDisplayNameCodingKey = "displayName"
+    private let kEnrollmentDateCodingKey = "enrollmentDate"
+    private let kFactorIDCodingKey = "factorID"
+
+    public class var supportsSecureCoding: Bool { return true }
+
+    public func encode(with coder: NSCoder) {
+      coder.encode(uid, forKey: kUIDCodingKey)
+      coder.encode(displayName, forKey: kDisplayNameCodingKey)
+      coder.encode(enrollmentDate, forKey: kEnrollmentDateCodingKey)
+      coder.encode(factorID, forKey: kFactorIDCodingKey)
+    }
+
     public required init?(coder: NSCoder) {
       guard let uid = coder.decodeObject(of: [NSString.self], forKey: kUIDCodingKey) as? String,
             let factorID = coder.decodeObject(of: [NSString.self],
@@ -71,18 +84,6 @@ import Foundation
         of: [NSString.self],
         forKey: kDisplayNameCodingKey
       ) as? String
-    }
-  }
-
-  extension MultiFactorInfo: NSSecureCoding {
-    private static var secureCodingWorkaround = true
-    open class var supportsSecureCoding: Bool { return secureCodingWorkaround }
-
-    public func encode(with coder: NSCoder) {
-      coder.encode(uid, forKey: kUIDCodingKey)
-      coder.encode(displayName, forKey: kDisplayNameCodingKey)
-      coder.encode(enrollmentDate, forKey: kEnrollmentDateCodingKey)
-      coder.encode(factorID, forKey: kFactorIDCodingKey)
     }
   }
 #endif

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
@@ -16,11 +16,8 @@ import Foundation
 
 #if os(iOS)
   private let kUIDCodingKey = "uid"
-
   private let kDisplayNameCodingKey = "displayName"
-
   private let kEnrollmentDateCodingKey = "enrollmentDate"
-
   private let kFactorIDCodingKey = "factorID"
 
   /** @class FIRMultiFactorInfo

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
@@ -51,6 +51,7 @@ import Foundation
 
     private let kPhoneNumberCodingKey = "phoneNumber"
 
+    // Workaround Cannot override mutable property with read-only property 'supportsSecureCoding'
     private static var secureCodingWorkaround = true
     override open class var supportsSecureCoding: Bool { return secureCodingWorkaround }
 

--- a/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/Phone/PhoneMultiFactorInfo.swift
@@ -51,9 +51,7 @@ import Foundation
 
     private let kPhoneNumberCodingKey = "phoneNumber"
 
-    // Workaround Cannot override mutable property with read-only property 'supportsSecureCoding'
-    private static var secureCodingWorkaround = true
-    override open class var supportsSecureCoding: Bool { return secureCodingWorkaround }
+    override public class var supportsSecureCoding: Bool { return true }
 
     public required init?(coder: NSCoder) {
       guard let phoneNumber = coder.decodeObject(of: NSString.self,

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
@@ -44,11 +44,11 @@ import Foundation
   private static let kReceiptKey = "receipt"
   private static let kSecretKey = "secret"
 
-  public static var supportsSecureCoding: Bool {
+  static var supportsSecureCoding: Bool {
     true
   }
 
-  public required convenience init?(coder: NSCoder) {
+  required convenience init?(coder: NSCoder) {
     guard let receipt = coder.decodeObject(of: NSString.self,
                                            forKey: AuthAppCredential.kReceiptKey) as? String
     else {
@@ -59,7 +59,7 @@ import Foundation
     self.init(receipt: receipt, secret: secret)
   }
 
-  public func encode(with coder: NSCoder) {
+  func encode(with coder: NSCoder) {
     coder.encode(receipt, forKey: AuthAppCredential.kReceiptKey)
     coder.encode(secret, forKey: AuthAppCredential.kSecretKey)
   }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
@@ -14,20 +14,10 @@
 
 import Foundation
 
-/** @var kReceiptKey
-    @brief The key used to encode the receipt property for NSSecureCoding.
- */
-private let kReceiptKey = "receipt"
-
-/** @var kSecretKey
-    @brief The key used to encode the secret property for NSSecureCoding.
- */
-private let kSecretKey = "secret"
-
 /** @class FIRAuthAppCredential
     @brief A class represents a credential that proves the identity of the app.
  */
-class AuthAppCredential: NSObject, NSSecureCoding {
+@objc(FIRAuthAppCredential) class AuthAppCredential: NSObject, NSSecureCoding {
   /** @property receipt
       @brief The server acknowledgement of receiving client's claim of identity.
    */
@@ -51,21 +41,26 @@ class AuthAppCredential: NSObject, NSSecureCoding {
 
   // MARK: NSSecureCoding
 
-  static var supportsSecureCoding: Bool {
+  private static let kReceiptKey = "receipt"
+  private static let kSecretKey = "secret"
+
+  public static var supportsSecureCoding: Bool {
     true
   }
 
-  required convenience init?(coder: NSCoder) {
-    guard let receipt = coder.decodeObject(of: [NSString.self], forKey: kReceiptKey) as? String
+  public required convenience init?(coder: NSCoder) {
+    guard let receipt = coder.decodeObject(of: NSString.self,
+                                           forKey: AuthAppCredential.kReceiptKey) as? String
     else {
       return nil
     }
-    let secret = coder.decodeObject(of: [NSString.self], forKey: kSecretKey) as? String
+    let secret = coder.decodeObject(of: NSString.self,
+                                    forKey: AuthAppCredential.kSecretKey) as? String
     self.init(receipt: receipt, secret: secret)
   }
 
-  func encode(with coder: NSCoder) {
-    coder.encode(receipt, forKey: kReceiptKey)
-    coder.encode(secret, forKey: kSecretKey)
+  public func encode(with coder: NSCoder) {
+    coder.encode(receipt, forKey: AuthAppCredential.kReceiptKey)
+    coder.encode(secret, forKey: AuthAppCredential.kSecretKey)
   }
 }

--- a/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
@@ -14,16 +14,6 @@
 
 import Foundation
 
-/** @var kReceiptKey
-    @brief The key used to encode the receipt property for NSSecureCoding.
- */
-private let kReceiptKey = "receipt"
-
-/** @var kSecretKey
-    @brief The key used to encode the secret property for NSSecureCoding.
- */
-private let kSecretKey = "secret"
-
 private let kFiveMinutes = 5 * 60.0
 
 /** @class FIRAuthAppCredential

--- a/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
+++ b/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
@@ -14,12 +14,8 @@
 
 import Foundation
 
-@objc(FIRAdditionalUserInfo) open class AdditionalUserInfo: NSObject, NSSecureCoding {
-  private static let providerIDCodingKey = "providerID"
-  private static let profileCodingKey = "profile"
-  private static let usernameCodingKey = "username"
-  private static let newUserKey = "newUser"
-
+extension AdditionalUserInfo: NSSecureCoding {}
+@objc(FIRAdditionalUserInfo) open class AdditionalUserInfo: NSObject {
   /** @property providerID
       @brief The provider identifier.
    */
@@ -51,6 +47,13 @@ import Foundation
     self.username = username
     self.isNewUser = isNewUser
   }
+
+  // MARK: Secure Coding
+
+  private static let providerIDCodingKey = "providerID"
+  private static let profileCodingKey = "profile"
+  private static let usernameCodingKey = "username"
+  private static let newUserKey = "newUser"
 
   public static var supportsSecureCoding: Bool {
     return true

--- a/FirebaseAuth/Sources/Swift/User/UserInfo.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfo.swift
@@ -26,7 +26,7 @@ import Foundation
   /** @property uid
    @brief The provider's user ID for the user.
    */
-  var uid: String { get }
+  var uid: String? { get }
 
   /** @property displayName
    @brief The name of the user.

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -48,12 +48,12 @@ class UserInfoImpl: NSObject, UserInfo {
       @param email The user's email address.
       @param phoneNumber The user's phone number.
    */
-  init(withProviderID providerID: String,
-       userID: String,
-       displayName: String?,
-       photoURL: URL?,
-       email: String?,
-       phoneNumber: String?) {
+  private init(withProviderID providerID: String,
+               userID: String,
+               displayName: String?,
+               photoURL: URL?,
+               email: String?,
+               phoneNumber: String?) {
     self.providerID = providerID
     uid = userID
     self.displayName = displayName

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension UserInfoImpl: NSSecureCoding {}
 
-class UserInfoImpl: NSObject, UserInfo {
+@objc(FIRUserInfoImpl) class UserInfoImpl: NSObject, UserInfo {
   /** @fn userInfoWithGetAccountInfoResponseProviderUserInfo:
       @brief A convenience factory method for constructing a @c FIRUserInfo instance from data
           returned by the getAccountInfo endpoint.
@@ -25,14 +25,12 @@ class UserInfoImpl: NSObject, UserInfo {
    */
   class func userInfo(withGetAccountInfoResponseProviderUserInfo providerUserInfo: GetAccountInfoResponseProviderUserInfo)
     -> UserInfoImpl {
-    guard let providerID = providerUserInfo.providerID,
-          let userID = providerUserInfo.federatedID else {
+    guard let providerID = providerUserInfo.providerID else {
       // This was a crash in ObjC implementation. Should providerID be not nullable?
-      // federatedID is nil on initial Phone Auth.
-      fatalError("Missing userID or providerID from GetAccountInfoResponseProviderUserInfo")
+      fatalError("Missing providerID from GetAccountInfoResponseProviderUserInfo")
     }
     return UserInfoImpl(withProviderID: providerID,
-                        userID: userID,
+                        userID: providerUserInfo.federatedID,
                         displayName: providerUserInfo.displayName,
                         photoURL: providerUserInfo.photoURL,
                         email: providerUserInfo.email,
@@ -49,7 +47,7 @@ class UserInfoImpl: NSObject, UserInfo {
       @param phoneNumber The user's phone number.
    */
   private init(withProviderID providerID: String,
-               userID: String,
+               userID: String?,
                displayName: String?,
                photoURL: URL?,
                email: String?,
@@ -63,7 +61,7 @@ class UserInfoImpl: NSObject, UserInfo {
   }
 
   var providerID: String
-  var uid: String
+  var uid: String?
   var displayName: String?
   var photoURL: URL?
   var email: String?

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -91,15 +91,14 @@ extension UserInfoImpl: NSSecureCoding {}
 
   required convenience init?(coder: NSCoder) {
     guard let providerID = coder.decodeObject(of: [NSString.self],
-                                              forKey: UserInfoImpl.kProviderIDCodingKey) as? String,
-      let uid = coder.decodeObject(
-        of: [NSString.self],
-        forKey: UserInfoImpl.kUserIDCodingKey
-      ) as? String
+                                              forKey: UserInfoImpl.kProviderIDCodingKey) as? String
     else {
       return nil
     }
-
+    let uid = coder.decodeObject(
+      of: [NSString.self],
+      forKey: UserInfoImpl.kUserIDCodingKey
+    ) as? String
     let displayName = coder.decodeObject(
       of: [NSString.self],
       forKey: UserInfoImpl.kDisplayNameCodingKey

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -14,7 +14,9 @@
 
 import Foundation
 
-class UserInfoImpl: NSObject, UserInfo, NSSecureCoding {
+extension UserInfoImpl: NSSecureCoding {}
+
+class UserInfoImpl: NSObject, UserInfo {
   /** @fn userInfoWithGetAccountInfoResponseProviderUserInfo:
       @brief A convenience factory method for constructing a @c FIRUserInfo instance from data
           returned by the getAccountInfo endpoint.

--- a/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
@@ -19,7 +19,10 @@ import Foundation
  */
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRUserMetadata) open class UserMetadata: NSObject, NSSecureCoding {
+extension UserMetadata: NSSecureCoding {}
+
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+@objc(FIRUserMetadata) open class UserMetadata: NSObject {
   /** @property lastSignInDate
       @brief Stores the last sign in date for the corresponding Firebase user.
    */

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -614,8 +614,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     changeRequest.commitChanges { _ in
     }
     let _: String = user.providerID
-    let _: String = user.uid
-    if let _: String = user.displayName,
+    if let _: String = user.uid,
+       let _: String = user.displayName,
        let _: URL = user.photoURL,
        let _: String = user.email,
        let _: String = user.phoneNumber {}
@@ -671,8 +671,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
 
   func userInfoProperties(userInfo: UserInfo) {
     let _: String = userInfo.providerID
-    let _: String = userInfo.uid
-    if let _: String = userInfo.displayName,
+    if let _: String = userInfo.uid,
+       let _: String = userInfo.displayName,
        let _: URL = userInfo.photoURL,
        let _: String = userInfo.email,
        let _: String = userInfo.phoneNumber {}


### PR DESCRIPTION
After discoveries about NSSecureCoding and decoding from the keychain, this PR rolls out the learnings across all the relevant classes in Auth and addresses a few other issues:

- In the ObjC implementation, NSSecureCoding is only `public` for OAuthCredential and PhoneAuthCredential, therefore move NSSecureCoding on all other `open` classes to an extension
- Move key declarations into `MARK: Secure Coding` sections
- Use `of` parameter to specify allowed types on all `decodeObject` calls.
- Implement NSSecureCoding commented code from AuthTokenResult.swift. 
- Even thought the UserInfo.uid was not nullable in the ObjC implementation, after linking email auth to phone number auth in the quickstart, it will be nil and crash at the now updated fatalError in [FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift](https://github.com/firebase/firebase-ios-sdk/pull/12263/files#diff-e100fcf22ae33b33263910388058595cdfa524fbfdcf69ac3ee7a72b9c136996)

#no-changelog