### PR TITLE
[NFC] Fix typos `occured` → `occurred`

### DIFF
--- a/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
@@ -42,7 +42,7 @@ void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid) {
   FIRCLSHostWriteDiskUsage(file);
 
   // This is the first common point where various crash handlers call into
-  // Store a crash file marker to indicate that a crash has occured
+  // Store a crash file marker to indicate that a crash has occurred
   FIRCLSCreateCrashedMarkerFile();
 
   FIRCLSProcessResumeAllOtherThreads(&process);

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -84,7 +84,7 @@
   high precision to be stored correctly in our persistence layer. (#4108)
 
 # 6.1.1
-- [fixed] Fixed an iOS 13 crash that occured in our WebSocket error handling. (#3950)
+- [fixed] Fixed an iOS 13 crash that occurred in our WebSocket error handling. (#3950)
 
 # 6.1.0
 - [fixed] Fix Catalyst Build issue. (#3512)

--- a/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRNetworkTraceTest.m
@@ -237,7 +237,7 @@
   NSDictionary<NSString *, NSNumber *> *states = [trace checkpointStates];
   XCTAssertEqual(states.count, 1);
 
-  // Validate if the first checkpoint occured before the second checkpoint time.
+  // Validate if the first checkpoint occurred before the second checkpoint time.
   XCTAssertLessThan(firstCheckpointTime, secondCheckpointTime);
   // Validate if the time has not changed even after rec checkpointing.
   XCTAssertEqual(firstInitiatedTime, secondInitiatedTime);


### PR DESCRIPTION
#no-changelog