### PR TITLE
[auth-swift] Fix Component warning

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -139,13 +139,6 @@ extension Auth: AuthInterop {
   }
 }
 
-// This prevents FIRComponentContainer from warning when instantiating from the protocol.
-extension Auth: AuthProvider {
-  func auth() -> Auth {
-    return self
-  }
-}
-
 /** @class Auth
     @brief Manages authentication for Firebase apps.
     @remarks This class is thread-safe.
@@ -175,7 +168,7 @@ extension Auth: AuthProvider {
    @return The `Auth` instance associated with the given app.
    */
   @objc open class func auth(app: FirebaseApp) -> Auth {
-    return ComponentType<AuthProvider>.instance(for: AuthProvider.self, in: app.container) as! Auth
+    return ComponentType<AuthProvider>.instance(for: AuthProvider.self, in: app.container).auth()
   }
 
   /** @property app

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -139,6 +139,13 @@ extension Auth: AuthInterop {
   }
 }
 
+// This prevents FIRComponentContainer from warning when instantiating from the protocol.
+extension Auth: AuthProvider {
+  func auth() -> Auth {
+    return self
+  }
+}
+
 /** @class Auth
     @brief Manages authentication for Firebase apps.
     @remarks This class is thread-safe.

--- a/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
@@ -53,13 +53,16 @@ class AuthComponent: NSObject, Library, AuthProvider, ComponentLifecycleMaintain
                       dependencies: [appCheckInterop]) { container, isCacheable in
         guard let app = container.app else { return nil }
         isCacheable.pointee = true
-        return Auth(app: app)
+        let newComponent = AuthComponent(app: app)
+        // Set up instances early enough so User on keychain will be decoded.
+        newComponent.auth()
+        return newComponent
       }]
   }
 
   // MARK: - AuthProvider conformance
 
-  func auth() -> Auth {
+  @discardableResult func auth() -> Auth {
     os_unfair_lock_lock(&instancesLock)
 
     // Unlock before the function returns.


### PR DESCRIPTION
This fixes the following console log warning:

10.20.0 - [FirebaseCore][I-COR000030] An instance conforming to FIRAuthProvider was requested, but the instance provided does not conform to the protocol
