### PR TITLE
[Firestore] Add warning when building Firestore's binary SPM distro for visionOS

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- Add warning when trying to build Firestore's binary SPM distribution for
+  visionOS (#12279). See Firestore's 10.12.0 release note for supported
+  workaround.
+
 # 10.19.0
 - [fixed] Made an optimization to the synchronization logic for resumed queries
   to only re-download locally-cached documents that are known to be out-of-sync. (#12044)

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - Add warning when trying to build Firestore's binary SPM distribution for
-  visionOS (#12279). See Firestore's 10.12.0 release note for supported
+  visionOS (#12279). See Firestore's 10.12.0 release note for a supported
   workaround.
 
 # 10.19.0

--- a/Package.swift
+++ b/Package.swift
@@ -1495,8 +1495,16 @@ func firestoreTargets() -> [Target] {
           name: "FirebaseFirestoreInternalWrapper",
           condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
         ),
-        .product(name: "abseil", package: "abseil-cpp-binary", condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS])),
-        .product(name: "gRPC-C++", package: "grpc-binary",  condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS])),
+        .product(
+          name: "abseil",
+          package: "abseil-cpp-binary",
+          condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
+        ),
+        .product(
+          name: "gRPC-C++",
+          package: "grpc-binary",
+          condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
+        ),
         .product(name: "nanopb", package: "nanopb"),
         "FirebaseAppCheckInterop",
         "FirebaseCore",
@@ -1513,7 +1521,10 @@ func firestoreTargets() -> [Target] {
     ),
     .target(
       name: "FirebaseFirestoreInternalWrapper",
-      dependencies: [.target(name: "FirebaseFirestoreInternal", condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS]))],
+      dependencies: [.target(
+        name: "FirebaseFirestoreInternal",
+        condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
+      )],
       path: "FirebaseFirestoreInternal",
       publicHeadersPath: "."
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1495,8 +1495,8 @@ func firestoreTargets() -> [Target] {
           name: "FirebaseFirestoreInternalWrapper",
           condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
         ),
-        .product(name: "abseil", package: "abseil-cpp-binary"),
-        .product(name: "gRPC-C++", package: "grpc-binary"),
+        .product(name: "abseil", package: "abseil-cpp-binary", condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS])),
+        .product(name: "gRPC-C++", package: "grpc-binary",  condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS])),
         .product(name: "nanopb", package: "nanopb"),
         "FirebaseAppCheckInterop",
         "FirebaseCore",
@@ -1513,7 +1513,7 @@ func firestoreTargets() -> [Target] {
     ),
     .target(
       name: "FirebaseFirestoreInternalWrapper",
-      dependencies: ["FirebaseFirestoreInternal"],
+      dependencies: [.target(name: "FirebaseFirestoreInternal", condition: .when(platforms: [.iOS,  .macCatalyst, .tvOS, .macOS]))],
       path: "FirebaseFirestoreInternal",
       publicHeadersPath: "."
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -1364,7 +1364,8 @@ func firestoreWrapperTarget() -> Target {
     name: "FirebaseFirestoreTarget",
     dependencies: [.target(name: "FirebaseFirestore",
                            condition: .when(platforms: [.iOS, .tvOS, .macOS, .macCatalyst]))],
-    path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
+    path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap",
+    cSettings: [.define("FIREBASE_BINARY_FIRESTORE", to: "1")]
   )
 }
 

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -16,3 +16,10 @@
 #if TARGET_OS_WATCH
 #warning "Firebase Firestore does not support watchOS"
 #endif
+
+#if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
+#warning \
+"Firebase Firestore's binary SPM distribution does not support \
+visionOS. See workaround documented in the 10.12.0 release notes: \
+https://firebase.google.com/support/release-notes/ios#version_10120_-_july_11_2023"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -19,6 +19,9 @@
 
 #if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
 #warning "Firebase Firestore's binary SPM distribution does not support \
-visionOS. See workaround documented in the 10.12.0 release notes: \
-https://firebase.google.com/support/release-notes/ios#version_10120_-_july_11_2023"
+visionOS. To enable the source distribution, quit Xcode and open the desired \
+project from the command line with the FIREBASE_SOURCE_FIRESTORE environment \
+variable: `open --env FIREBASE_SOURCE_FIRESTORE /path/to/project.xcodeproj`. \
+To go back to using the binary distribution of Firestore, quit Xcode and open \
+Xcode like normal, without the environment variable."
 #endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -18,8 +18,7 @@
 #endif
 
 #if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
-#warning \
-"Firebase Firestore's binary SPM distribution does not support \
+#warning "Firebase Firestore's binary SPM distribution does not support \
 visionOS. See workaround documented in the 10.12.0 release notes: \
 https://firebase.google.com/support/release-notes/ios#version_10120_-_july_11_2023"
 #endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -18,7 +18,7 @@
 #endif
 
 #if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
-#warning "Firebase Firestore's binary SPM distribution does not support \
+#error "Firebase Firestore's binary SPM distribution does not support \
 visionOS. To enable the source distribution, quit Xcode and open the desired \
 project from the command line with the FIREBASE_SOURCE_FIRESTORE environment \
 variable: `open --env FIREBASE_SOURCE_FIRESTORE /path/to/project.xcodeproj`. \

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
@@ -16,9 +16,3 @@
 #if TARGET_OS_WATCH
 #warning "Firebase Firestore does not support watchOS"
 #endif
-
-#if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
-#warning "Firebase Firestore's binary SPM distribution does not support \
-          visionOS. See workaround documented in the 10.12.0 release notes: \
-          https://firebase.google.com/support/release-notes/ios#version_10120_-_july_11_2023"
-#endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
@@ -16,3 +16,9 @@
 #if TARGET_OS_WATCH
 #warning "Firebase Firestore does not support watchOS"
 #endif
+
+#if (defined(TARGET_OS_VISION) && TARGET_OS_VISION) && FIREBASE_BINARY_FIRESTORE
+#warning "Firebase Firestore's binary SPM distribution does not support \
+          visionOS. See workaround documented in the 10.12.0 release notes: \
+          https://firebase.google.com/support/release-notes/ios#version_10120_-_july_11_2023"
+#endif


### PR DESCRIPTION
The proposed consists of two parts:
1. Change the Package.swift to only build Firestore's binary targets on platforms that support the binary distribution (e.g. !visionOS)
    - This shifts the problem from the package loading phase to the compilation phase.
2. Add a warning in the source wrapper target to issue a warning only on visionOS and only when it is detected that the client is using the binary distro*.
    - *: We can determine this by configuring the wrapper target in the binary distro code path to define a preprocessor directive.

