### PR TITLE
Firestore: Remove unnecessary brace initialization in call to AlphaNum

### DIFF
--- a/Firestore/core/src/util/string_format.h
+++ b/Firestore/core/src/util/string_format.h
@@ -80,7 +80,7 @@ class FormatArg : public absl::AlphaNum {
   template <typename T,
             typename = typename std::enable_if<std::is_same<bool, T>{}>::type>
   FormatArg(T bool_value, internal::FormatChoice<0>)
-      : AlphaNum{bool_value ? "true" : "false"} {
+      : AlphaNum(bool_value ? "true" : "false") {
   }
 
 #if __OBJC__
@@ -91,7 +91,7 @@ class FormatArg : public absl::AlphaNum {
       typename T,
       typename = typename std::enable_if<objc::is_objc_pointer<T>{}>::type>
   FormatArg(T object, internal::FormatChoice<1>)
-      : AlphaNum{MakeStringView([object description])} {
+      : AlphaNum(MakeStringView([object description])) {
   }
 
   /**
@@ -99,7 +99,7 @@ class FormatArg : public absl::AlphaNum {
    * types are a special struct that aren't of a type derived from NSObject.
    */
   FormatArg(Class object, internal::FormatChoice<1>)
-      : AlphaNum{MakeStringView(NSStringFromClass(object))} {
+      : AlphaNum(MakeStringView(NSStringFromClass(object))) {
   }
 #endif
 
@@ -108,7 +108,7 @@ class FormatArg : public absl::AlphaNum {
    * handled specially to avoid ambiguity with generic pointers, which are
    * handled differently.
    */
-  FormatArg(std::nullptr_t, internal::FormatChoice<2>) : AlphaNum{"null"} {
+  FormatArg(std::nullptr_t, internal::FormatChoice<2>) : AlphaNum("null") {
   }
 
   /**
@@ -117,7 +117,7 @@ class FormatArg : public absl::AlphaNum {
    * handled differently.
    */
   FormatArg(const char* string_value, internal::FormatChoice<3>)
-      : AlphaNum{string_value == nullptr ? "null" : string_value} {
+      : AlphaNum(string_value == nullptr ? "null" : string_value) {
   }
 
   /**
@@ -126,7 +126,7 @@ class FormatArg : public absl::AlphaNum {
    */
   template <typename T>
   FormatArg(T* pointer_value, internal::FormatChoice<4>)
-      : AlphaNum{absl::Hex{reinterpret_cast<uintptr_t>(pointer_value)}} {
+      : AlphaNum(absl::Hex(reinterpret_cast<uintptr_t>(pointer_value))) {
   }
 
   /**
@@ -135,7 +135,7 @@ class FormatArg : public absl::AlphaNum {
    */
   template <typename T>
   FormatArg(T&& value, internal::FormatChoice<5>)
-      : AlphaNum{std::forward<T>(value)} {
+      : AlphaNum(std::forward<T>(value)) {
   }
 };
 


### PR DESCRIPTION
Remove unnecessary brace initialization in call to AlphaNum. This does not change any functionality, but merely improves the code quality to use AlphaNum in the intended manner.

Brace-initialized calls to AlphaNum are unsupported, and are misused as function parameters, which cause problems when attempts are made to modify the implementations of functions such as StrCat. While this particular usage (inside a base-class constructor call) itself isn't problematic, it does blocking brace initialization in the future in Google's internal source code repository, hence this change. Googlers see cl/598865604 for details.

#no-changelog