### PR TITLE
[Rollouts]Writing Rollouts to persistence

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -81,7 +81,9 @@ void FIRCLSUserLoggingRecordUserKeysAndValues(NSDictionary* keysAndValues);
 void FIRCLSUserLoggingRecordInternalKeyValue(NSString* key, id value);
 void FIRCLSUserLoggingWriteInternalKeyValue(NSString* key, NSString* value);
 
-void FIRCLSUserLoggingRecordError(NSError* error, NSDictionary<NSString*, id>* additionalUserInfo);
+void FIRCLSUserLoggingRecordError(NSError* error,
+                                  NSDictionary<NSString*, id>* additionalUserInfo,
+                                  NSString* rolloutsInfo);
 
 NSDictionary* FIRCLSUserLoggingGetCompactedKVEntries(FIRCLSUserLoggingKVStorage* storage,
                                                      bool decodeHex);

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -83,7 +83,7 @@ void FIRCLSUserLoggingWriteInternalKeyValue(NSString* key, NSString* value);
 
 void FIRCLSUserLoggingRecordError(NSError* error,
                                   NSDictionary<NSString*, id>* additionalUserInfo,
-                                  NSString* rolloutsInfo);
+                                  NSString* rolloutsInfoJSON);
 
 NSDictionary* FIRCLSUserLoggingGetCompactedKVEntries(FIRCLSUserLoggingKVStorage* storage,
                                                      bool decodeHex);

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -355,7 +355,8 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
                                         NSError *error,
                                         NSDictionary<NSString *, id> *additionalUserInfo,
                                         NSArray *addresses,
-                                        uint64_t timestamp) {
+                                        uint64_t timestamp,
+                                        NSString *rolloutsInfo) {
   FIRCLSFileWriteSectionStart(file, "error");
   FIRCLSFileWriteHashStart(file);
   FIRCLSFileWriteHashEntryHexEncodedString(file, "domain", [[error domain] UTF8String]);
@@ -374,12 +375,20 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
   FIRCLSUserLoggingRecordErrorUserInfo(file, "info", [error userInfo]);
   FIRCLSUserLoggingRecordErrorUserInfo(file, "extra_info", additionalUserInfo);
 
+  // rollouts
+  if (rolloutsInfo) {
+    FIRCLSFileWriteHashKey(file, "rollouts");
+    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfo UTF8String]);
+    FIRCLSFileWriteHashEnd(file);
+  }
+
   FIRCLSFileWriteHashEnd(file);
   FIRCLSFileWriteSectionEnd(file);
 }
 
 void FIRCLSUserLoggingRecordError(NSError *error,
-                                  NSDictionary<NSString *, id> *additionalUserInfo) {
+                                  NSDictionary<NSString *, id> *additionalUserInfo,
+                                  NSString *rolloutsInfo) {
   if (!error) {
     return;
   }
@@ -396,7 +405,8 @@ void FIRCLSUserLoggingRecordError(NSError *error,
   FIRCLSUserLoggingWriteAndCheckABFiles(
       &_firclsContext.readonly->logging.errorStorage,
       &_firclsContext.writable->logging.activeErrorLogPath, ^(FIRCLSFile *file) {
-        FIRCLSUserLoggingWriteError(file, error, additionalUserInfo, addresses, timestamp);
+        FIRCLSUserLoggingWriteError(file, error, additionalUserInfo, addresses, timestamp,
+                                    rolloutsInfo);
       });
 }
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -356,7 +356,7 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
                                         NSDictionary<NSString *, id> *additionalUserInfo,
                                         NSArray *addresses,
                                         uint64_t timestamp,
-                                        NSString *rolloutsInfo) {
+                                        NSString *rolloutsInfoJSON) {
   FIRCLSFileWriteSectionStart(file, "error");
   FIRCLSFileWriteHashStart(file);
   FIRCLSFileWriteHashEntryHexEncodedString(file, "domain", [[error domain] UTF8String]);
@@ -376,9 +376,9 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
   FIRCLSUserLoggingRecordErrorUserInfo(file, "extra_info", additionalUserInfo);
 
   // rollouts
-  if (rolloutsInfo) {
+  if (rolloutsInfoJSON) {
     FIRCLSFileWriteHashKey(file, "rollouts");
-    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfo UTF8String]);
+    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfoJSON UTF8String]);
     FIRCLSFileWriteHashEnd(file);
   }
 
@@ -388,7 +388,7 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
 
 void FIRCLSUserLoggingRecordError(NSError *error,
                                   NSDictionary<NSString *, id> *additionalUserInfo,
-                                  NSString *rolloutsInfo) {
+                                  NSString *rolloutsInfoJSON) {
   if (!error) {
     return;
   }
@@ -406,7 +406,7 @@ void FIRCLSUserLoggingRecordError(NSError *error,
       &_firclsContext.readonly->logging.errorStorage,
       &_firclsContext.writable->logging.activeErrorLogPath, ^(FIRCLSFile *file) {
         FIRCLSUserLoggingWriteError(file, error, additionalUserInfo, addresses, timestamp,
-                                    rolloutsInfo);
+                                    rolloutsInfoJSON);
       });
 }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if SWIFT_PACKAGE
+@import FirebaseCrashlyticsSwift;
+#else  // Swift Package Manager
+#import <FirebaseCrashlytics/FirebaseCrashlytics-Swift.h>
+#endif  // Cocoapod
+
+@interface FIRCLSRolloutsPersistenceManager : NSObject <FIRCLSPersistenceLog>
+
+- (instancetype _Nullable)initWithFileManager:(FIRCLSFileManager *_Nonnull)fileManager;
+- (instancetype _Nonnull)init NS_UNAVAILABLE;
++ (instancetype _Nonnull)new NS_UNAVAILABLE;
+
+- (void)updateRolloutsStateToPersistenceWithRollouts:(NSData *_Nonnull)rollouts
+                                            reportID:(NSString *_Nonnull)reportID;
+@end

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#include "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
+#include "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
+#import "Crashlytics/Crashlytics/Helpers/FIRCLSLogger.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSFileManager.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
+#if SWIFT_PACKAGE
+@import FirebaseCrashlyticsSwift;
+#else  // Swift Package Manager
+#import <FirebaseCrashlytics/FirebaseCrashlytics-Swift.h>
+#endif  // Cocoapod
+
+@interface FIRCLSRolloutsPersistenceManager : NSObject <FIRCLSPersistenceLog>
+@property(nonatomic, readonly) FIRCLSFileManager *fileManager;
+@end
+
+@implementation FIRCLSRolloutsPersistenceManager
+- (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager {
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+  _fileManager = fileManager;
+  return self;
+}
+
+- (void)updateRolloutsStateToPersistenceWithRollouts:(NSData *_Nonnull)rollouts
+                                            reportID:(NSString *_Nonnull)reportID {
+  NSString *rolloutsPath = [[[_fileManager activePath] stringByAppendingPathComponent:reportID]
+      stringByAppendingPathComponent:FIRCLSReportRolloutsFile];
+  if (![_fileManager fileExistsAtPath:rolloutsPath]) {
+    if (![_fileManager createFileAtPath:rolloutsPath contents:nil attributes:nil]) {
+      FIRCLSDebugLog(@"Could not create rollouts.clsrecord file. Error was code: %d - message: %s",
+                     errno, strerror(errno));
+    }
+  }
+
+  NSFileHandle *rolloutsFile = [NSFileHandle fileHandleForUpdatingAtPath:rolloutsPath];
+
+  dispatch_sync(FIRCLSGetLoggingQueue(), ^{
+    [rolloutsFile seekToEndOfFile];
+    [rolloutsFile writeData:rollouts];
+    NSData *newLineData = [@"\n" dataUsingEncoding:NSUTF8StringEncoding];
+    [rolloutsFile writeData:newLineData];
+  });
+}
+@end

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -406,13 +406,13 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
-  NSString *rolloutsInfo = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
-  FIRCLSUserLoggingRecordError(error, userInfo, rolloutsInfo);
+  NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
+  FIRCLSUserLoggingRecordError(error, userInfo, rolloutsInfoJSON);
 }
 
 - (void)recordExceptionModel:(FIRExceptionModel *)exceptionModel {
-  NSString *rolloutsInfo = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
-  FIRCLSExceptionRecordModel(exceptionModel, rolloutsInfo);
+  NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
+  FIRCLSExceptionRecordModel(exceptionModel, rolloutsInfoJSON);
 }
 
 - (void)recordOnDemandExceptionModel:(FIRExceptionModel *)exceptionModel {

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -444,7 +444,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     FIRCLSDebugLog(@"rolloutsStateDidChange gets called without init the rc manager.");
     return;
   }
-  NSString *currenReportID = _managerData.executionIDModel.executionID;
-  [_remoteConfigManager updateRolloutsStateWithRolloutsState:rolloutsState reportID:currenReportID];
+  NSString *currentReportID = _managerData.executionIDModel.executionID;
+  [_remoteConfigManager updateRolloutsStateWithRolloutsState:rolloutsState
+                                                    reportID:currentReportID];
 }
 @end

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.h
@@ -60,7 +60,7 @@ void FIRCLSExceptionRaiseTestObjCException(void) __attribute((noreturn));
 void FIRCLSExceptionRaiseTestCppException(void) __attribute((noreturn));
 
 #ifdef __OBJC__
-void FIRCLSExceptionRecordModel(FIRExceptionModel* exceptionModel);
+void FIRCLSExceptionRecordModel(FIRExceptionModel* exceptionModel, NSString* rolloutsInfo);
 NSString* FIRCLSExceptionRecordOnDemandModel(FIRExceptionModel* exceptionModel,
                                              int previousRecordedOnDemandExceptions,
                                              int previousDroppedOnDemandExceptions);
@@ -68,7 +68,8 @@ void FIRCLSExceptionRecordNSException(NSException* exception);
 void FIRCLSExceptionRecord(FIRCLSExceptionType type,
                            const char* name,
                            const char* reason,
-                           NSArray<FIRStackFrame*>* frames);
+                           NSArray<FIRStackFrame*>* frames,
+                           NSString* rolloutsInfo);
 NSString* FIRCLSExceptionRecordOnDemand(FIRCLSExceptionType type,
                                         const char* name,
                                         const char* reason,

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.h
@@ -60,7 +60,7 @@ void FIRCLSExceptionRaiseTestObjCException(void) __attribute((noreturn));
 void FIRCLSExceptionRaiseTestCppException(void) __attribute((noreturn));
 
 #ifdef __OBJC__
-void FIRCLSExceptionRecordModel(FIRExceptionModel* exceptionModel, NSString* rolloutsInfo);
+void FIRCLSExceptionRecordModel(FIRExceptionModel* exceptionModel, NSString* rolloutsInfoJSON);
 NSString* FIRCLSExceptionRecordOnDemandModel(FIRExceptionModel* exceptionModel,
                                              int previousRecordedOnDemandExceptions,
                                              int previousDroppedOnDemandExceptions);
@@ -69,7 +69,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
                            const char* name,
                            const char* reason,
                            NSArray<FIRStackFrame*>* frames,
-                           NSString* rolloutsInfo);
+                           NSString* rolloutsInfoJSON);
 NSString* FIRCLSExceptionRecordOnDemand(FIRCLSExceptionType type,
                                         const char* name,
                                         const char* reason,

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -82,11 +82,11 @@ void FIRCLSExceptionInitialize(FIRCLSExceptionReadOnlyContext *roContext,
   rwContext->customExceptionCount = 0;
 }
 
-void FIRCLSExceptionRecordModel(FIRExceptionModel *exceptionModel) {
+void FIRCLSExceptionRecordModel(FIRExceptionModel *exceptionModel, NSString *rolloutsInfo) {
   const char *name = [[exceptionModel.name copy] UTF8String];
   const char *reason = [[exceptionModel.reason copy] UTF8String] ?: "";
-
-  FIRCLSExceptionRecord(FIRCLSExceptionTypeCustom, name, reason, [exceptionModel.stackTrace copy]);
+  FIRCLSExceptionRecord(FIRCLSExceptionTypeCustom, name, reason, [exceptionModel.stackTrace copy],
+                        rolloutsInfo);
 }
 
 NSString *FIRCLSExceptionRecordOnDemandModel(FIRExceptionModel *exceptionModel,
@@ -122,7 +122,7 @@ void FIRCLSExceptionRecordNSException(NSException *exception) {
   }
 
   FIRCLSExceptionRecord(FIRCLSExceptionTypeObjectiveC, [name UTF8String], [reason UTF8String],
-                        frames);
+                        frames, nil);
 }
 
 static void FIRCLSExceptionRecordFrame(FIRCLSFile *file, FIRStackFrame *frame) {
@@ -175,7 +175,8 @@ void FIRCLSExceptionWrite(FIRCLSFile *file,
                           FIRCLSExceptionType type,
                           const char *name,
                           const char *reason,
-                          NSArray<FIRStackFrame *> *frames) {
+                          NSArray<FIRStackFrame *> *frames,
+                          NSString *rolloutsInfo) {
   FIRCLSFileWriteSectionStart(file, "exception");
 
   FIRCLSFileWriteHashStart(file);
@@ -196,6 +197,12 @@ void FIRCLSExceptionWrite(FIRCLSFile *file,
     FIRCLSFileWriteArrayEnd(file);
   }
 
+  if (rolloutsInfo) {
+    FIRCLSFileWriteHashKey(file, "rollouts");
+    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfo UTF8String]);
+    FIRCLSFileWriteHashEnd(file);
+  }
+
   FIRCLSFileWriteHashEnd(file);
 
   FIRCLSFileWriteSectionEnd(file);
@@ -204,7 +211,8 @@ void FIRCLSExceptionWrite(FIRCLSFile *file,
 void FIRCLSExceptionRecord(FIRCLSExceptionType type,
                            const char *name,
                            const char *reason,
-                           NSArray<FIRStackFrame *> *frames) {
+                           NSArray<FIRStackFrame *> *frames,
+                           NSString *rolloutsInfo) {
   if (!FIRCLSContextIsInitialized()) {
     return;
   }
@@ -224,7 +232,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
         return;
       }
 
-      FIRCLSExceptionWrite(&file, type, name, reason, frames);
+      FIRCLSExceptionWrite(&file, type, name, reason, frames, nil);
 
       // We only want to do this work if we have the expectation that we'll actually crash
       FIRCLSHandler(&file, mach_thread_self(), NULL);
@@ -235,7 +243,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
     FIRCLSUserLoggingWriteAndCheckABFiles(
         &_firclsContext.readonly->logging.customExceptionStorage,
         &_firclsContext.writable->logging.activeCustomExceptionPath, ^(FIRCLSFile *file) {
-          FIRCLSExceptionWrite(file, type, name, reason, frames);
+          FIRCLSExceptionWrite(file, type, name, reason, frames, rolloutsInfo);
         });
   }
 
@@ -271,6 +279,7 @@ NSString *FIRCLSExceptionRecordOnDemand(FIRCLSExceptionType type,
 
   // Create new report and copy into it the current state of custom keys and log and the sdk.log,
   // binary_images.clsrecord, and metadata.clsrecord files.
+  // also copy rollouts.clsrecord if applicable.
   NSError *error = nil;
   BOOL copied = [fileManager.underlyingFileManager copyItemAtPath:currentReportPath
                                                            toPath:newReportPath
@@ -343,7 +352,7 @@ NSString *FIRCLSExceptionRecordOnDemand(FIRCLSExceptionType type,
     FIRCLSSDKLog("Unable to open log file for on demand custom exception\n");
     return nil;
   }
-  FIRCLSExceptionWrite(&file, type, name, reason, frames);
+  FIRCLSExceptionWrite(&file, type, name, reason, frames, nil);
   FIRCLSHandler(&file, mach_thread_self(), NULL);
   FIRCLSFileClose(&file);
 
@@ -397,19 +406,21 @@ static void FIRCLSCatchAndRecordActiveException(std::type_info *typeInfo) {
 #endif
     }
   } catch (const char *exc) {
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "const char *", exc, nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "const char *", exc, nil, nil);
   } catch (const std::string &exc) {
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "std::string", exc.c_str(), nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "std::string", exc.c_str(), nil, nil);
   } catch (const std::exception &exc) {
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), exc.what(), nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), exc.what(), nil,
+                          nil);
   } catch (const std::exception *exc) {
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), exc->what(), nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), exc->what(), nil,
+                          nil);
   } catch (const std::bad_alloc &exc) {
     // it is especially important to avoid demangling in this case, because the expetation at this
     // point is that all allocations could fail
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "std::bad_alloc", exc.what(), nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "std::bad_alloc", exc.what(), nil, nil);
   } catch (...) {
-    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), "", nil);
+    FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), "", nil, nil);
   }
 }
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -82,11 +82,11 @@ void FIRCLSExceptionInitialize(FIRCLSExceptionReadOnlyContext *roContext,
   rwContext->customExceptionCount = 0;
 }
 
-void FIRCLSExceptionRecordModel(FIRExceptionModel *exceptionModel, NSString *rolloutsInfo) {
+void FIRCLSExceptionRecordModel(FIRExceptionModel *exceptionModel, NSString *rolloutsInfoJSON) {
   const char *name = [[exceptionModel.name copy] UTF8String];
   const char *reason = [[exceptionModel.reason copy] UTF8String] ?: "";
   FIRCLSExceptionRecord(FIRCLSExceptionTypeCustom, name, reason, [exceptionModel.stackTrace copy],
-                        rolloutsInfo);
+                        rolloutsInfoJSON);
 }
 
 NSString *FIRCLSExceptionRecordOnDemandModel(FIRExceptionModel *exceptionModel,
@@ -176,7 +176,7 @@ void FIRCLSExceptionWrite(FIRCLSFile *file,
                           const char *name,
                           const char *reason,
                           NSArray<FIRStackFrame *> *frames,
-                          NSString *rolloutsInfo) {
+                          NSString *rolloutsInfoJSON) {
   FIRCLSFileWriteSectionStart(file, "exception");
 
   FIRCLSFileWriteHashStart(file);
@@ -197,9 +197,9 @@ void FIRCLSExceptionWrite(FIRCLSFile *file,
     FIRCLSFileWriteArrayEnd(file);
   }
 
-  if (rolloutsInfo) {
+  if (rolloutsInfoJSON) {
     FIRCLSFileWriteHashKey(file, "rollouts");
-    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfo UTF8String]);
+    FIRCLSFileWriteStringUnquoted(file, [rolloutsInfoJSON UTF8String]);
     FIRCLSFileWriteHashEnd(file);
   }
 
@@ -212,7 +212,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
                            const char *name,
                            const char *reason,
                            NSArray<FIRStackFrame *> *frames,
-                           NSString *rolloutsInfo) {
+                           NSString *rolloutsInfoJSON) {
   if (!FIRCLSContextIsInitialized()) {
     return;
   }
@@ -243,7 +243,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
     FIRCLSUserLoggingWriteAndCheckABFiles(
         &_firclsContext.readonly->logging.customExceptionStorage,
         &_firclsContext.writable->logging.activeCustomExceptionPath, ^(FIRCLSFile *file) {
-          FIRCLSExceptionWrite(file, type, name, reason, frames, rolloutsInfo);
+          FIRCLSExceptionWrite(file, type, name, reason, frames, rolloutsInfoJSON);
         });
   }
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
@@ -36,6 +36,7 @@ extern NSString *const FIRCLSReportInternalIncrementalKVFile;
 extern NSString *const FIRCLSReportInternalCompactedKVFile;
 extern NSString *const FIRCLSReportUserIncrementalKVFile;
 extern NSString *const FIRCLSReportUserCompactedKVFile;
+extern NSString *const FIRCLSReportRolloutsFile;
 
 @class FIRCLSFileManager;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
@@ -41,6 +41,7 @@ NSString *const FIRCLSReportInternalIncrementalKVFile = @"internal_incremental_k
 NSString *const FIRCLSReportInternalCompactedKVFile = @"internal_compacted_kv.clsrecord";
 NSString *const FIRCLSReportUserIncrementalKVFile = @"user_incremental_kv.clsrecord";
 NSString *const FIRCLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
+NSString *const FIRCLSReportRolloutsFile = @"rollouts.clsrecord";
 
 @interface FIRCLSInternalReport () {
   NSString *_identifier;

--- a/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
+++ b/Crashlytics/Crashlytics/Rollouts/CrashlyticsRemoteConfigManager.swift
@@ -60,7 +60,8 @@ public class CrashlyticsRemoteConfigManager: NSObject {
   }
 
   /// Return string format: [{RolloutAssignment1}, {RolloutAssignment2}, {RolloutAssignment3}...]
-  /// This will get insert into each clsrcord for non-fatal events
+  /// This will get insert into each clsrcord for non-fatal events.
+  /// Return a string type because later `FIRCLSFileWriteStringUnquoted` takes string as input
   @objc public func getRolloutAssignmentsEncodedJsonString() -> String? {
     let encodeData = getRolloutAssignmentsEncodedJsonData()
     if let data = encodeData {
@@ -100,6 +101,8 @@ private extension CrashlyticsRemoteConfigManager {
     return validatedAssignments
   }
 
+  // Helper for later convert Data to String. Because `FIRCLSFileWriteStringUnquoted` takes string
+  // as input
   func getRolloutAssignmentsEncodedJsonData() -> Data? {
     let contentEncodedRolloutAssignments = rolloutAssignment.map { assignment in
       EncodedRolloutAssignment(assignment: assignment)
@@ -115,6 +118,7 @@ private extension CrashlyticsRemoteConfigManager {
   /// Return string format: {"rollouts": [{RolloutAssignment1}, {RolloutAssignment2},
   /// {RolloutAssignment3}...]}
   /// This will get stored in the separate rollouts.clsrecord
+  /// Return a data  type because later `[NSFileHandler writeData:]` takes data as input
   func getRolloutsStateEncodedJsonData() -> Data? {
     let contentEncodedRolloutAssignments = rolloutAssignment.map { assignment in
       EncodedRolloutAssignment(assignment: assignment)

--- a/Crashlytics/Crashlytics/Rollouts/EncodedRolloutAssignment.swift
+++ b/Crashlytics/Crashlytics/Rollouts/EncodedRolloutAssignment.swift
@@ -15,6 +15,16 @@
 import FirebaseRemoteConfigInterop
 import Foundation
 
+@objc(FIRCLSEncodedRolloutsState)
+class EncodedRolloutsState: NSObject, Codable {
+  @objc public private(set) var rollouts: [EncodedRolloutAssignment]
+
+  @objc public init(assignments: [EncodedRolloutAssignment]) {
+    rollouts = assignments
+    super.init()
+  }
+}
+
 @objc(FIRCLSEncodedRolloutAssignment)
 class EncodedRolloutAssignment: NSObject, Codable {
   @objc public private(set) var rolloutId: String

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -365,7 +365,7 @@
                                        code:-1
                                    userInfo:@{@"key1" : @"value", @"key2" : @"value2"}];
 
-  FIRCLSUserLoggingRecordError(error, @{@"additional" : @"key"});
+  FIRCLSUserLoggingRecordError(error, @{@"additional" : @"key"}, nil);
 
   NSArray* errors = [self errorAContents];
 
@@ -405,7 +405,7 @@
                                    userInfo:@{@"key1" : @"value", @"key2" : @"value2"}];
 
   for (size_t i = 0; i < _firclsContext.readonly->logging.errorStorage.maxEntries; ++i) {
-    FIRCLSUserLoggingRecordError(error, nil);
+    FIRCLSUserLoggingRecordError(error, nil, nil);
   }
 
   NSArray* errors = [self errorAContents];
@@ -414,7 +414,7 @@
 
   // at this point, if we log one more, we should expect a roll over to the next file
 
-  FIRCLSUserLoggingRecordError(error, nil);
+  FIRCLSUserLoggingRecordError(error, nil, nil);
 
   XCTAssertEqual([[self errorAContents] count], 8, @"");
   XCTAssertEqual([[self errorBContents] count], 1, @"");
@@ -422,7 +422,7 @@
 
   // and our next entry should continue into the B file
 
-  FIRCLSUserLoggingRecordError(error, nil);
+  FIRCLSUserLoggingRecordError(error, nil, nil);
 
   XCTAssertEqual([[self errorAContents] count], 8, @"");
   XCTAssertEqual([[self errorBContents] count], 2, @"");
@@ -432,7 +432,7 @@
 - (void)testLoggedErrorWithNullsInAdditionalInfo {
   NSError* error = [NSError errorWithDomain:@"Domain" code:-1 userInfo:nil];
 
-  FIRCLSUserLoggingRecordError(error, @{@"null-key" : [NSNull null]});
+  FIRCLSUserLoggingRecordError(error, @{@"null-key" : [NSNull null]}, nil);
 
   NSArray* errors = [self errorAContents];
 

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -1,0 +1,70 @@
+// Copyright 2024 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+#import "Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
+#import "Crashlytics/UnitTests/Mocks/FIRCLSTempMockFileManager.h"
+#if SWIFT_PACKAGE
+@import FirebaseCrashlyticsSwift;
+#else  // Swift Package Manager
+#import <FirebaseCrashlytics/FirebaseCrashlytics-Swift.h>
+#endif  // Cocoapod
+
+NSString *reportId = @"1234567";
+
+@interface FIRCLSRolloutsPersistenceManagerTests : XCTestCase
+@property(nonatomic, strong) FIRCLSTempMockFileManager *fileManager;
+@property(nonatomic, strong) FIRCLSRolloutsPersistenceManager *rolloutsPersistenceManager;
+@end
+
+@implementation FIRCLSRolloutsPersistenceManagerTests
+- (void)setUp {
+  [super setUp];
+  FIRCLSContextBaseInit();
+  self.fileManager = [[FIRCLSTempMockFileManager alloc] init];
+  [self.fileManager createReportDirectories];
+  [self.fileManager setupNewPathForExecutionIdentifier:reportId];
+
+  self.rolloutsPersistenceManager =
+      [[FIRCLSRolloutsPersistenceManager alloc] initWithFileManager:self.fileManager];
+}
+
+- (void)tearDown {
+  [self.fileManager removeItemAtPath:_fileManager.rootPath];
+  FIRCLSContextBaseDeinit();
+  [super tearDown];
+}
+
+- (void)testUpdateRolloutsStateToPersistenceWithRollouts {
+  NSString *encodedStateString =
+      @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
+      @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
+      @"\"rollout_id\":\"726f6c6c6f75745f31\",\"template_version\":1,\"variant_id\":"
+      @"\"636f6e74726f6c\"}]}";
+
+  NSData *data = [encodedStateString dataUsingEncoding:NSUTF8StringEncoding];
+  NSString *rolloutsFilePath =
+      [[[self.fileManager activePath] stringByAppendingPathComponent:reportId]
+          stringByAppendingPathComponent:FIRCLSReportRolloutsFile];
+
+  [self.rolloutsPersistenceManager updateRolloutsStateToPersistenceWithRollouts:data
+                                                                       reportID:reportId];
+  XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:rolloutsFilePath]);
+}
+
+@end

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -75,7 +75,7 @@
   FIRExceptionModel *exceptionModel = [FIRExceptionModel exceptionModelWithName:name reason:reason];
   exceptionModel.stackTrace = stackTrace;
 
-  FIRCLSExceptionRecordModel(exceptionModel);
+  FIRCLSExceptionRecordModel(exceptionModel, nil);
 
   NSData *data = [NSData
       dataWithContentsOfFile:[self.reportPath

--- a/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
+++ b/Crashlytics/UnitTestsSwift/CrashlyticsRemoteConfigManagerTests.swift
@@ -95,7 +95,7 @@ final class CrashlyticsRemoteConfigManagerTests: XCTestCase {
     XCTAssertEqual(string, expectedString)
   }
 
-  func testMutiThreadsUpdateRolloutAssignments() throws {
+  func testMultiThreadsUpdateRolloutAssignments() throws {
     let rcManager = CrashlyticsRemoteConfigManager(
       remoteConfig: rcInterop,
       persistenceDelegate: PersistanceManagerMock()
@@ -113,5 +113,23 @@ final class CrashlyticsRemoteConfigManagerTests: XCTestCase {
         XCTAssertEqual(rcManager.rolloutAssignment.count, 2)
       }
     }
+  }
+
+  func testMultiThreadsReadAndWriteRolloutAssignments() throws {
+    let rcManager = CrashlyticsRemoteConfigManager(
+      remoteConfig: rcInterop,
+      persistenceDelegate: PersistanceManagerMock()
+    )
+    rcManager.updateRolloutsState(rolloutsState: singleRollout, reportID: "456")
+
+    DispatchQueue.main.async { [weak self] in
+      if let rollouts = self?.rollouts {
+        let oldAssignments = rcManager.rolloutAssignment
+        rcManager.updateRolloutsState(rolloutsState: rollouts, reportID: "456")
+        XCTAssertEqual(rcManager.rolloutAssignment.count, 2)
+        XCTAssertEqual(oldAssignments.count, 1)
+      }
+    }
+    XCTAssertEqual(rcManager.rolloutAssignment.count, 1)
   }
 }


### PR DESCRIPTION
Base on this summary of events crashlytics record:
|  Events |  API |  Persistence File(s) |  Will Crash?  | 
|---|---|---|---|
| non-fatal  | recordError()  | error_a/b |  No  |  
| native-fatal  |  N/A | exception, signal, mach_exception  |  YES | 
|  custom exception |  recordExceptionModel() |  custom_exception_a/b |  No | 
| on-demand fatal |  recordOnDemandExceptionModel() | exception(if we consider it's fatal), custom_exception_a/b(if we consider it's non-fatal) |  No |

Here is how we read rollouts info:
|  File | SDK log for rollouts |  Backend Process | 
|---|---|---|
| error_a/b (.clsrecord) | each error entry will attach the rollouts state with the entry  | read rollouts from each entry | 
| exception, signal, mach_exception (.clsrecord)|  write rollouts separately - `rollout.clsrecord` | read rollouts from  `rollout.clsrecord` | 
|  custom_exception (.clsrecord) | for `recordExceptionModel()` we add rollouts to each exception entry, for on-demand fatal it will read rollouts from  `rollout.clsrecord`  |  for each entry check if has rollouts attach, if `YES` then read rollouts info from entry, if `NO`, read rollouts from `rollout.clsrecord`| 

Changes include in this PR:
- write rollouts to  `rollouts.clsrecord`
- write rollouts to `error.clsrecord`
- write rollouts to `custom_exception.clsrecord`
- unit tests

#no-changelog