### PR TITLE
Fix Client App build issue

### DIFF
--- a/IntegrationTesting/ClientApp/Podfile
+++ b/IntegrationTesting/ClientApp/Podfile
@@ -8,6 +8,8 @@ target 'ClientApp-CocoaPods' do
   use_frameworks!
 
   pod 'FirebaseCore', :path => '../../'
+  pod 'FirebaseCoreInternal', :path => '../../'
+  pod 'FirebaseCoreExtension', :path => '../../'
   pod 'FirebaseInstallations', :path => '../../'
   pod 'FirebaseAnalytics' # Binary pods don't work with `:path`.
   pod 'FirebaseAnalyticsOnDeviceConversion', :path => '../../'


### PR DESCRIPTION
The Client App Podfile was missing local paths for CoreInternal and CoreExtension. This can cause build failures when those change locally like https://github.com/firebase/firebase-ios-sdk/actions/runs/7595950042/job/20689094685 