### PR TITLE
Firestore: Another use foundation API instead of C API

### DIFF
--- a/Firestore/core/src/util/filesystem_apple.mm
+++ b/Firestore/core/src/util/filesystem_apple.mm
@@ -123,7 +123,10 @@ StatusOr<int64_t> Filesystem::FileSize(const Path& path) {
   }
 
   NSNumber* fileSizeNumber = [attributes objectForKey:NSFileSize];
-  return [fileSizeNumber longLongValue];
+
+  // Use brace initialization of the in64_t return value so that compilation
+  // will fail if the conversion from long long is narrowing.
+  return {[fileSizeNumber longLongValue]};
 }
 
 }  // namespace util

--- a/Firestore/core/src/util/filesystem_apple.mm
+++ b/Firestore/core/src/util/filesystem_apple.mm
@@ -109,6 +109,23 @@ Status Filesystem::IsDirectory(const Path& path) {
   return Status::OK();
 }
 
+StatusOr<int64_t> Filesystem::FileSize(const Path& path) {
+  NSFileManager* file_manager = NSFileManager.defaultManager;
+  NSString* ns_path_str = path.ToNSString();
+  NSError* error = nil;
+
+  NSDictionary* attributes = [file_manager attributesOfItemAtPath:ns_path_str
+                                                            error:&error];
+
+  if (attributes == nil) {
+    return Status{Error::kErrorInternal, "attributesOfItemAtPath failed"}
+        .CausedBy(Status::FromNSError(error));
+  }
+
+  NSNumber* fileSizeNumber = [attributes objectForKey:NSFileSize];
+  return [fileSizeNumber longLongValue];
+}
+
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/util/filesystem_posix.cc
+++ b/Firestore/core/src/util/filesystem_posix.cc
@@ -166,7 +166,6 @@ Status Filesystem::IsDirectory(const Path& path) {
 
   return Status::OK();
 }
-#endif  // !__APPLE__
 
 StatusOr<int64_t> Filesystem::FileSize(const Path& path) {
   struct stat st {};
@@ -177,6 +176,7 @@ StatusOr<int64_t> Filesystem::FileSize(const Path& path) {
         errno, StringFormat("Failed to stat file: %s", path.ToUtf8String()));
   }
 }
+#endif  // !__APPLE__
 
 Status Filesystem::CreateDir(const Path& path) {
   if (::mkdir(path.c_str(), 0777)) {


### PR DESCRIPTION
This is a follow-up to https://github.com/firebase/firebase-ios-sdk/pull/12264.

#no-changelog