### PR TITLE
Delete unnecessary file system API usages.

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.m
@@ -24,8 +24,6 @@
 #import "FirebaseMessaging/Sources/FIRMessagingUtilities.h"
 
 static const int64_t kDefaultSyncMessageTTL = 4 * 7 * 24 * 60 * 60;  // 4 weeks
-// 4 MB of free space is required to persist Sync messages
-static const uint64_t kMinFreeDiskSpaceInMB = 1;
 
 @interface FIRMessagingSyncMessageManager ()
 
@@ -63,12 +61,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
       [self.rmqManager querySyncMessageWithRmqID:rmqID];
 
   if (!persistentMessage) {
-    // Do not persist the new message if we don't have enough disk space
-    uint64_t freeDiskSpace = FIRMessagingGetFreeDiskSpaceInMB();
-    if (freeDiskSpace < kMinFreeDiskSpaceInMB) {
-      return NO;
-    }
-
     int64_t expirationTime = [[self class] expirationTimeForSyncMessage:message];
     [self.rmqManager saveSyncMessageWithRmqID:rmqID expirationTime:expirationTime];
     return NO;

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.h
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.h
@@ -34,7 +34,6 @@ FOUNDATION_EXPORT BOOL FIRMessagingIsWatchKitExtension(void);
 
 #pragma mark - Others
 
-FOUNDATION_EXPORT uint64_t FIRMessagingGetFreeDiskSpaceInMB(void);
 FOUNDATION_EXPORT NSSearchPathDirectory FIRMessagingSupportedDirectory(void);
 
 #pragma mark - Device Info

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -114,28 +114,6 @@ BOOL FIRMessagingIsWatchKitExtension(void) {
 #endif
 }
 
-uint64_t FIRMessagingGetFreeDiskSpaceInMB(void) {
-  NSError *error;
-  NSArray *paths =
-      NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(), NSUserDomainMask, YES);
-
-  NSDictionary *attributesMap =
-      [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject]
-                                                              error:&error];
-  if (attributesMap) {
-    uint64_t totalSizeInBytes __unused = [attributesMap[NSFileSystemSize] longLongValue];
-    uint64_t freeSizeInBytes = [attributesMap[NSFileSystemFreeSize] longLongValue];
-    FIRMessagingLoggerDebug(
-        kFIRMessagingMessageCodeUtilities001, @"Device has capacity %llu MB with %llu MB free.",
-        totalSizeInBytes / kBytesToMegabytesDivisor, freeSizeInBytes / kBytesToMegabytesDivisor);
-    return ((double)freeSizeInBytes) / kBytesToMegabytesDivisor;
-  } else {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeUtilities002,
-                            @"Error in retreiving device's free memory %@", error);
-    return 0;
-  }
-}
-
 NSSearchPathDirectory FIRMessagingSupportedDirectory(void) {
 #if TARGET_OS_TV
   return NSCachesDirectory;

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -21,7 +21,6 @@
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingLogger.h"
 
-static const uint64_t kBytesToMegabytesDivisor = 1024 * 1024LL;
 NSString *const kFIRMessagingInstanceIDUserDefaultsKeyLocale =
     @"com.firebase.instanceid.user_defaults.locale";  // locale key stored in GULUserDefaults
 static NSString *const kFIRMessagingAPNSSandboxPrefix = @"s_";


### PR DESCRIPTION
Before storing a new message to the message database, we check whether there is enough free disk space. If there is no enough disk space, nothing will be stored. 

This check is not necessary. Because when there is no enough disk space, sqlite will return SQLITE_FULL and abort the transaction.

#no-changelog