### PR TITLE
Require at least CocoaPods version 1.12.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ To learn more about running tests with Swift Package Manager, visit the
 #### **[CocoaPods]**
 
 [CocoaPods] is another popular dependency manager used in Apple development.
-Firebase supports development with CocoaPods 1.10.0 (or later). If you choose to
+Firebase supports development with CocoaPods 1.12.0 (or later). If you choose to
 develop using CocoaPods, it's recommend to use
 [`cocoapods-generate`][cocoapods-generate], a plugin that generates a
 [workspace] from a [podspec]. This plugin allows you to quickly generate a

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -26,7 +26,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '12.0'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
 
   s.swift_version = '5.3'
 

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -32,7 +32,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.swift_version = '5.3'

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
         :http => 'https://dl.google.com/firebase/ios/analytics/0199e7929b47e2d9/FirebaseAnalytics-10.20.0.tar.gz'
     }
 
-    s.cocoapods_version = '>= 1.10.0'
+    s.cocoapods_version = '>= 1.12.0'
     s.swift_version     = '5.3'
 
     s.ios.deployment_target  = '10.0'

--- a/FirebaseAnalyticsOnDeviceConversion.podspec
+++ b/FirebaseAnalyticsOnDeviceConversion.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
       :tag => 'CocoaPods-' + s.version.to_s
     }
 
-    s.cocoapods_version = '>= 1.10.2'
+    s.cocoapods_version = '>= 1.12.0'
 
     s.dependency 'GoogleAppMeasurementOnDeviceConversion', '10.21.0'
 

--- a/FirebaseAnalyticsSwift.podspec
+++ b/FirebaseAnalyticsSwift.podspec
@@ -27,7 +27,7 @@ Firebase Analytics is a free, out-of-the-box analytics solution that inspires ac
   s.osx.deployment_target   = osx_deployment_target
   s.tvos.deployment_target  = tvos_deployment_target
 
-  s.cocoapods_version       = '>= 1.10.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.source_files = [

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseAppCheck/"

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -19,7 +19,7 @@ iOS SDK for App Distribution for Firebase.
 
   s.swift_version = '5.3'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseAppDistribution/Sources/"

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -31,7 +31,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   source = 'FirebaseAuth/Sources/'

--- a/FirebaseAuthTestingSupport.podspec
+++ b/FirebaseAuthTestingSupport.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
   s.requires_arc            = true
 

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -31,7 +31,7 @@ for internal testing only. It should not be published.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   source = 'FirebaseCombineSwift/Sources/'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -28,7 +28,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.source_files = [

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 10.21.0
+- Firebase now requires at least CocoaPods version 1.12.0 to enable privacy
+  manifest support.
+
 # Firebase 10.20.0
 - The following change only applies to those using a binary distribution of
   a Firebase SDK(s): In preparation for supporting Privacy Manifests, each

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.source_files = [

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -29,7 +29,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseDatabase/Sources/"

--- a/FirebaseDatabaseSwift.podspec
+++ b/FirebaseDatabaseSwift.podspec
@@ -21,7 +21,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.osx.deployment_target   = '10.13'
   s.tvos.deployment_target  = '12.0'
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.source_files = [

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -20,7 +20,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
 
   s.swift_version = '5.3'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.source_files = [

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -21,7 +21,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.weak_framework = 'FirebaseFirestoreInternal'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.public_header_files = 'FirebaseFirestoreInternal/**/*.h'

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -22,7 +22,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.swift_version = '5.3'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   # Header files that constitute the interface to this module. Only Objective-C

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -26,7 +26,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.osx.deployment_target   = '10.13'
   s.tvos.deployment_target  = '12.0'
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.requires_arc            = true

--- a/FirebaseFirestoreTestingSupport.podspec
+++ b/FirebaseFirestoreTestingSupport.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
   s.requires_arc            = true
 

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -28,7 +28,7 @@ Cloud Functions for Firebase.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.swift_version = '5.3'

--- a/FirebaseFunctions/README.md
+++ b/FirebaseFunctions/README.md
@@ -7,7 +7,7 @@ integration test FirebaseFunctions:
 
 ### Prereqs
 
-- At least CocoaPods 1.10.0
+- At least CocoaPods 1.12.0
 - Install [cocoapods-generate](https://github.com/square/cocoapods-generate)
 
 ### To Develop

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -22,7 +22,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.swift_version = '5.3'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseInAppMessaging/"

--- a/FirebaseInAppMessagingSwift.podspec
+++ b/FirebaseInAppMessagingSwift.podspec
@@ -20,7 +20,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.swift_version           = '5.3'
   s.ios.deployment_target   = '13.0'
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.source_files = [

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseInstallations/Source/"

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.source_files = [

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -32,7 +32,7 @@ device, and it is completely free.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseMessaging/"

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -25,7 +25,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.ios.deployment_target = ios_deployment_target
   s.tvos.deployment_target = tvos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebasePerformance/"

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -30,7 +30,7 @@ app update.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseRemoteConfig/Sources/"

--- a/FirebaseRemoteConfigSwift.podspec
+++ b/FirebaseRemoteConfigSwift.podspec
@@ -31,7 +31,7 @@ app update.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.source_files = [

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   base_dir = "FirebaseSessions/"

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -30,7 +30,7 @@ Firebase products. FirebaseSharedSwift is not supported for non-Firebase usage.
   s.tvos.deployment_target = tvos_deployment_target
   s.watchos.deployment_target = watchos_deployment_target
 
-  s.cocoapods_version       = '>= 1.4.0'
+  s.cocoapods_version       = '>= 1.12.0'
   s.prefix_header_file      = false
 
   s.source_files = [

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -29,7 +29,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
 
   s.swift_version = '5.3'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
 
   s.source_files = [

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
         :http => 'https://dl.google.com/firebase/ios/analytics/3fcc7b954e5d5458/GoogleAppMeasurement-10.20.0.tar.gz'
     }
 
-    s.cocoapods_version = '>= 1.10.2'
+    s.cocoapods_version = '>= 1.12.0'
 
     s.ios.deployment_target  = '10.0'
     s.osx.deployment_target  = '10.13'

--- a/GoogleAppMeasurementOnDeviceConversion.podspec
+++ b/GoogleAppMeasurementOnDeviceConversion.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
         :http => 'https://dl.google.com/firebase/ios/analytics/4ab453c686c6aac4/GoogleAppMeasurementOnDeviceConversion-10.20.0.tar.gz'
     }
 
-    s.cocoapods_version = '>= 1.10.2'
+    s.cocoapods_version = '>= 1.12.0'
 
     s.ios.deployment_target  = '10.0'
 

--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -22,7 +22,7 @@ Not intended for direct public usage.
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '12.0'
 
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
   s.static_framework = true
 

--- a/IntegrationTesting/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Gemfile
+++ b/IntegrationTesting/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem 'cocoapods', '1.12.0'
+gem 'cocoapods', '1.14.3'

--- a/IntegrationTesting/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Gemfile
+++ b/IntegrationTesting/CocoapodsIntegrationTest/TestEnvironments/Cocoapods_multiprojects_frameworks/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem 'cocoapods', '1.10.0.rc.1'
+gem 'cocoapods', '1.12.0'

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ development with Swift Package Manager.
 ### CocoaPods
 
 Install the following:
-* CocoaPods 1.10.0 (or later)
+* CocoaPods 1.12.0 (or later)
 * [CocoaPods generate](https://github.com/square/cocoapods-generate)
 
 For the pod that you want to develop:


### PR DESCRIPTION
At least CocoaPods version 1.12.0 is required to support privacy manifests. This change will enforce the requirement at installation time.

More context at  https://github.com/google/gtm-session-fetcher/issues/375