### PR TITLE
[Release Tooling] Only embed bundles containing privacy manifests

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -635,6 +635,65 @@ struct FrameworkBuilder {
           "\(framework): \(error)")
       }
 
+      // TODO(ncooke3): ZipBuilder should fail if pod does not contain manifest.
+      // Idea: Add command flag with allowlist for pods that don't need a manifest
+
+      // Move any privacy manifest-containing resource bundles into the platform framework (if any).
+      try? fileManager.contentsOfDirectory(
+        at: frameworkPath.deletingLastPathComponent(),
+        includingPropertiesForKeys: nil
+      )
+      .filter { $0.pathExtension == "bundle" }
+      // TODO(ncooke3): Once the zip is built with Xcode 15, the following
+      // `filter` an be removed. The following block exists to preserve
+      // how resources (e.g. like FIAM's) are packaged for use in Xcode 14.
+      .filter { bundleURL in
+        // Bundle should contain only a `Info.plist` and a `PrivacyInfo.xcprivacy`.
+        if platform == .macOS || platform == .catalyst {
+          let bundleURL = bundleURL.appendingPathComponents(["Contents"])
+          let bundleContents = try? fileManager.contentsOfDirectory(
+            at: bundleURL,
+            includingPropertiesForKeys: nil
+          )
+          guard
+            let bundleContents = bundleContents,
+            Set(bundleContents.map(\.lastPathComponent)) == Set(["Info.plist", "Resources"])
+          else {
+            return false
+          }
+          let bundleResourcesContents = try? fileManager.contentsOfDirectory(
+            at: bundleURL.appendingPathComponents(["Resources"]),
+            includingPropertiesForKeys: nil
+          )
+          guard
+            let bundleResourcesContents = bundleResourcesContents,
+            bundleResourcesContents.map(\.lastPathComponent) == ["PrivacyInfo.xcprivacy"]
+          else {
+            return false
+          }
+        } else {
+          let bundleContents = try? fileManager.contentsOfDirectory(
+            at: bundleURL,
+            includingPropertiesForKeys: nil
+          )
+          guard
+            let bundleContents = bundleContents,
+            Set(bundleContents.map(\.lastPathComponent)) == Set([
+              "Info.plist",
+              "PrivacyInfo.xcprivacy",
+            ])
+          else {
+            return false
+          }
+        }
+
+        return true
+      }
+      .forEach { try! fileManager.moveItem(
+        at: $0,
+        to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
+      ) }
+
       // Headers from slice
       do {
         let headersSrc: URL = frameworkPath.appendingPathComponent("Headers")


### PR DESCRIPTION
Xcode 14 friendly version of #12114. 

The first commit was something I had stashed a few weeks back. Revisiting it now, I simplified it with the file enumerator approach.

```console
FirebaseInAppMessaging.xcframework
├── Info.plist
├── Resources ← 🎯 Non-privacy manifest bundles are NOT embedded for Xcode 14 users.
│   └── InAppMessagingDisplayResources.bundle
│       ├── FIRInAppMessageDisplayStoryboard.storyboard
│       │   ├── Info.plist
│       │   ├── banner-view-vc.nib
│       │   ├── card-view-vc.nib
│       │   ├── image-only-vc.nib
│       │   ├── lGH-bl-7Xw-view-ef6-R8-q1S.nib
│       │   ├── lbb-HM-tHJ-view-vRb-yf-OWE.nib
│       │   ├── modal-view-vc.nib
│       │   ├── oTF-1C-LZP-view-SM1-hn-m3n.nib
│       │   └── x01-lq-3r6-view-1pz-BP-O6T.nib
│       ├── Info.plist
│       ├── close-with-transparency.png
│       └── close-with-transparency@2x.png
├── ios-arm64
│   └── FirebaseInAppMessaging.framework
│       ├── FirebaseInAppMessaging
│       ├── FirebaseInAppMessaging_Privacy.bundle  ← 🎯 Privacy manifest bundles are embedded.
│       │   ├── Info.plist
│       │   └── PrivacyInfo.xcprivacy
│       ├── Headers
│       │   ├── FIRInAppMessaging.h
│       │   ├── FIRInAppMessagingRendering.h
│       │   ├── FirebaseInAppMessaging-Swift.h
│       │   ├── FirebaseInAppMessaging-umbrella.h
│       │   └── FirebaseInAppMessaging.h
│       └── Modules
│           ├── FirebaseInAppMessaging.swiftmodule
│           │   ├── Project
│           │   │   └── arm64-apple-ios.swiftsourceinfo
│           │   ├── arm64-apple-ios.abi.json
│           │   ├── arm64-apple-ios.private.swiftinterface
│           │   ├── arm64-apple-ios.swiftdoc
│           │   └── arm64-apple-ios.swiftinterface
│           └── module.modulemap
```