### PR TITLE
[Rollouts] Diff rollout metadata for updatedKeys in RemoteConfigUpdater

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
@@ -39,6 +39,12 @@ static NSString *const RCNFetchResponseKeyExperimentDescriptions = @"experimentD
 static NSString *const RCNFetchResponseKeyPersonalizationMetadata = @"personalizationMetadata";
 /// Key that includes data for Rollout metadata.
 static NSString *const RCNFetchResponseKeyRolloutMetadata = @"rolloutMetadata";
+/// Key that indicates rollout id in Rollout metadata.
+static NSString *const RCNFetchResponseKeyRolloutID = @"rollout_id";
+/// Key that indicates variant id in Rollout metadata.
+static NSString *const RCNFetchResponseKeyVariantID = @"variant_id";
+/// Key that indicates affected parameter keys in Rollout Metadata.
+static NSString *const RCNFetchResponseKeyAffectedParameterKeys = @"affected_parameter_keys";
 /// Error key.
 static NSString *const RCNFetchResponseKeyError = @"error";
 /// Error code.

--- a/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
@@ -40,11 +40,11 @@ static NSString *const RCNFetchResponseKeyPersonalizationMetadata = @"personaliz
 /// Key that includes data for Rollout metadata.
 static NSString *const RCNFetchResponseKeyRolloutMetadata = @"rolloutMetadata";
 /// Key that indicates rollout id in Rollout metadata.
-static NSString *const RCNFetchResponseKeyRolloutID = @"rollout_id";
+static NSString *const RCNFetchResponseKeyRolloutID = @"rolloutId";
 /// Key that indicates variant id in Rollout metadata.
-static NSString *const RCNFetchResponseKeyVariantID = @"variant_id";
+static NSString *const RCNFetchResponseKeyVariantID = @"variantId";
 /// Key that indicates affected parameter keys in Rollout Metadata.
-static NSString *const RCNFetchResponseKeyAffectedParameterKeys = @"affected_parameter_keys";
+static NSString *const RCNFetchResponseKeyAffectedParameterKeys = @"affectedParameterKeys";
 /// Error key.
 static NSString *const RCNFetchResponseKeyError = @"error";
 /// Error code.

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -471,21 +471,21 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
     }
   }
 
-  NSMutableDictionary<NSString *, NSMutableDictionary *> *fetchedRollout =
-      [self getParameterKeyToRolloutMetadataDic:fetchedRolloutMetadata];
-  NSMutableDictionary<NSString *, NSMutableDictionary *> *activeRollout =
-      [self getParameterKeyToRolloutMetadataDic:activeRolloutMetadata];
+  NSDictionary<NSString *, NSDictionary *> *fetchedRollouts =
+      [self getParameterKeyToRolloutMetadata:fetchedRolloutMetadata];
+  NSDictionary<NSString *, NSDictionary *> *activeRollouts =
+      [self getParameterKeyToRolloutMetadata:activeRolloutMetadata];
 
   // add params with new/updated rollout metadata
-  for (NSString *key in [fetchedRollout allKeys]) {
-    if (activeRollout[key] == nil ||
-        ![activeRollout[key] isEqualToDictionary:fetchedRollout[key]]) {
+  for (NSString *key in [fetchedRollouts allKeys]) {
+    if (activeRollouts[key] == nil ||
+        ![activeRollouts[key] isEqualToDictionary:fetchedRollouts[key]]) {
       [updatedKeys addObject:key];
     }
   }
   // add params with deleted rollout metadata
-  for (NSString *key in [activeRollout allKeys]) {
-    if (fetchedRollout[key] == nil) {
+  for (NSString *key in [activeRollouts allKeys]) {
+    if (fetchedRollouts[key] == nil) {
       [updatedKeys addObject:key];
     }
   }
@@ -494,7 +494,7 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
   return configUpdate;
 }
 
-- (NSMutableDictionary<NSString *, NSMutableDictionary *> *)getParameterKeyToRolloutMetadataDic:
+- (NSDictionary<NSString *, NSDictionary *> *)getParameterKeyToRolloutMetadata:
     (NSArray<NSDictionary *> *)rolloutMetadata {
   NSMutableDictionary<NSString *, NSMutableDictionary *> *result =
       [[NSMutableDictionary alloc] init];
@@ -514,7 +514,7 @@ const NSTimeInterval kDatabaseLoadTimeoutSecs = 30.0;
       }
     }
   }
-  return result;
+  return [result copy];
 }
 
 @end

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -472,8 +472,7 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
 - (void)testConfigUpdate_rolloutMetadataUpdated_returnsKey {
   NSString *namespace = @"test_namespace";
   NSString *key = @"key1";
-  NSString *value1 = @"value1";
-  NSString *value2 = @"value2";
+  NSString *value = @"value";
   NSString *rolloutId1 = @"1";
   NSString *variantId1 = @"A";
   NSString *variantId2 = @"B";
@@ -486,27 +485,24 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
   ];
 
   // Populate fetched config
-  NSMutableDictionary *fetchResponse = [self createFetchResponseWithConfigEntries:@{key : value1}
+  NSMutableDictionary *fetchResponse = [self createFetchResponseWithConfigEntries:@{key : value}
                                                                      p13nMetadata:nil
                                                                   rolloutMetadata:rolloutMetadata];
   [_configContent updateConfigContentWithResponse:fetchResponse forNamespace:namespace];
   // populate active config with the same content
   NSArray<NSDictionary *> *result = [_configContent activateRolloutMetadata];
   XCTAssertEqualObjects(rolloutMetadata, result);
-  FIRRemoteConfigValue *rcValue1 =
-      [[FIRRemoteConfigValue alloc] initWithData:[value1 dataUsingEncoding:NSUTF8StringEncoding]
+  FIRRemoteConfigValue *rcValue =
+      [[FIRRemoteConfigValue alloc] initWithData:[value dataUsingEncoding:NSUTF8StringEncoding]
                                           source:FIRRemoteConfigSourceRemote];
 
-  NSDictionary *namespaceToConfig = @{namespace : @{key : rcValue1}};
+  NSDictionary *namespaceToConfig = @{namespace : @{key : rcValue}};
   [_configContent copyFromDictionary:namespaceToConfig
                             toSource:RCNDBSourceActive
                         forNamespace:namespace];
   // New fetch response has updated rollout metadata
-  NSMutableDictionary *fetchResponse2 =
-      [self createFetchResponseWithConfigEntries:@{key : value2}
-                                    p13nMetadata:nil
-                                 rolloutMetadata:updatedRolloutMetadata];
-  [_configContent updateConfigContentWithResponse:fetchResponse2 forNamespace:namespace];
+  [fetchResponse setValue:updatedRolloutMetadata forKey:RCNFetchResponseKeyRolloutMetadata];
+  [_configContent updateConfigContentWithResponse:fetchResponse forNamespace:namespace];
 
   FIRRemoteConfigUpdate *update = [_configContent getConfigUpdateForNamespace:namespace];
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -493,7 +493,7 @@ extern const NSTimeInterval kDatabaseLoadTimeoutSecs;
     @{
       RCNFetchResponseKeyRolloutID : rolloutId2,
       RCNFetchResponseKeyVariantID : variantId1,
-      RCNFetchResponseKeyAffectedParameterKeys : @[ key1, key2 ]
+      RCNFetchResponseKeyAffectedParameterKeys : @[ key2 ]
     },
   ];
   // Populate fetched config


### PR DESCRIPTION
Diff rollout metadata for updatedKeys in RemoteConfigUpdater

Before diffing, convert rollout metadata NSArray into a NSDictionary with the parameter key string as key and  a Dictionary (rollout id as key and variant id as value) as value.

Note: this change will merge to our feature branch not master
#no-changelog
