### PR TITLE
Add setDiskSpaceImplementation public API for developer-supplied disk space implementation

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
@@ -17,6 +17,7 @@
 __BEGIN_DECLS
 
 extern FIRCLSContext _firclsContext;
+extern int (*diskSpaceFunction) (const char *, struct statfs *);
 extern dispatch_queue_t _firclsLoggingQueue;
 extern dispatch_queue_t _firclsBinaryImageQueue;
 extern dispatch_queue_t _firclsExceptionQueue;

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.h
@@ -16,12 +16,14 @@
 
 #include <mach/vm_types.h>
 #include <sys/cdefs.h>
+#include <sys/mount.h>
 
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFile.h"
 
 typedef struct {
   const char* documentDirectoryPath;
   vm_size_t pageSize;
+  int (*diskSpaceFunction) (const char *, struct statfs *);
 } FIRCLSHostReadOnlyContext;
 
 __BEGIN_DECLS

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -52,6 +52,7 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file);
 void FIRCLSHostInitialize(FIRCLSHostReadOnlyContext* roContext) {
   _firclsContext.readonly->host.pageSize = FIRCLSHostGetPageSize();
   _firclsContext.readonly->host.documentDirectoryPath = NULL;
+  _firclsContext.readonly->host.diskSpaceFunction = diskSpaceFunction;
 
   // determine where the document directory is mounted, so we can get file system statistics later
   NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
@@ -186,12 +187,42 @@ void FIRCLSHostWriteDiskUsage(FIRCLSFile* file) {
 
   FIRCLSFileWriteHashStart(file);
 
-  if (statfs(_firclsContext.readonly->host.documentDirectoryPath, &tStats) == 0) {
+  FIRCLSFileWriteHashEntryUint64(file, "statfs_point", _firclsContext.readonly->host.diskSpaceFunction);
+
+
+  if (_firclsContext.readonly->host.diskSpaceFunction &&
+      _firclsContext.readonly->host.diskSpaceFunction(_firclsContext.readonly->host.documentDirectoryPath, &tStats) == 0) {
     FIRCLSFileWriteHashEntryUint64(file, "free", tStats.f_bavail * tStats.f_bsize);
     FIRCLSFileWriteHashEntryUint64(file, "total", tStats.f_blocks * tStats.f_bsize);
+
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
+    FIRCLSFileWriteHashEntryUint64(file, "wrote_using_statfs", 1);
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
+
+  } else {
+    FIRCLSFileWriteHashEntryUint64(file, "free", UINT64_MAX);
+    FIRCLSFileWriteHashEntryUint64(file, "total", UINT64_MAX);
+
+
+
+
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
+    FIRCLSFileWriteHashEntryUint64(file, "wrote_using_statfs", 0);
+    // TODO REMOVE
+    // TODO REMOVE
+    // TODO REMOVE
   }
 
   FIRCLSFileWriteHashEnd(file);
 
   FIRCLSFileWriteSectionEnd(file);
 }
+

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -187,38 +187,16 @@ void FIRCLSHostWriteDiskUsage(FIRCLSFile* file) {
 
   FIRCLSFileWriteHashStart(file);
 
-  FIRCLSFileWriteHashEntryUint64(file, "statfs_point", _firclsContext.readonly->host.diskSpaceFunction);
-
-
+  // Developers can optionally supply a function pointer to statfs
+  // that we can use here. Otherwise, set the disk space to 0 so the backend
+  // knows to hide this field in the crash report.
   if (_firclsContext.readonly->host.diskSpaceFunction &&
       _firclsContext.readonly->host.diskSpaceFunction(_firclsContext.readonly->host.documentDirectoryPath, &tStats) == 0) {
     FIRCLSFileWriteHashEntryUint64(file, "free", tStats.f_bavail * tStats.f_bsize);
     FIRCLSFileWriteHashEntryUint64(file, "total", tStats.f_blocks * tStats.f_bsize);
-
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
-    FIRCLSFileWriteHashEntryUint64(file, "wrote_using_statfs", 1);
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
-
   } else {
-    FIRCLSFileWriteHashEntryUint64(file, "free", UINT64_MAX);
-    FIRCLSFileWriteHashEntryUint64(file, "total", UINT64_MAX);
-
-
-
-
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
-    FIRCLSFileWriteHashEntryUint64(file, "wrote_using_statfs", 0);
-    // TODO REMOVE
-    // TODO REMOVE
-    // TODO REMOVE
+    FIRCLSFileWriteHashEntryUint64(file, "free", 0);
+    FIRCLSFileWriteHashEntryUint64(file, "total", 0);
   }
 
   FIRCLSFileWriteHashEnd(file);

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include <sys/mount.h>
+
 #import "FIRCrashlyticsReport.h"
 #import "FIRExceptionModel.h"
 
@@ -242,6 +244,28 @@ NS_SWIFT_NAME(Crashlytics)
  * This method only applies if automatic data collection is disabled.
  */
 - (void)deleteUnsentReports;
+
+
+/**
+ * Sets the function to be used for reading the remaining disk space on the device to support
+ * Apple Privacy Manifests.
+ *
+ * This method must be called before Crashlytics starts up so that Crashlytics has the disk space implementation during SDK startup.
+ *
+ * You can use this method by using the following code snippets:
+ * ```swift
+ * Crashlytics.setDiskSpaceImplementation(statfs)
+ * FirebaseApp.configure()
+ * ```
+ *
+ * ```objective-c
+ * #include <sys/mount.h>
+ * ...
+ * [FIRCrashlytics setDiskSpaceImplementation:statfs];
+ * [FIRApp configure];
+ * ```
+ */
++ (void)setDiskSpaceImplementation:(int (*) (const char *_Nullable, struct statfs *_Nullable))implementation;
 
 @end
 


### PR DESCRIPTION
### Description

The intent behind this PR is to comply with Apple Privacy Manifests, while also giving developers the option to comply themselves and provide us the `statfs` function implementation.

### TODO

- [ ] Decide if this is an approach we want to take. There's some risk that Apple is also scanning for the `struct statfs` type, in addition to the `statfs` function, but nothing in their docs says they do. If that's the case, we can add more onus on the developer to implement a function that returns free and total disk space at the time of the crash.
- [ ] Go through API review
- [ ] Test in a testapp (Swift, ObjC, and other non-iOS platforms)
- [ ] Add Changelog

### API

What's interesting about this API is it introduces a static method, and it must be called before FIRApp configure. I think we could make this more future-proof by making this category of APIs fall under a single method call. See the code comments for why this requirement exists.

Eg. we could call it `[Crashlytics setStartupDependencies:...]`, and it could take a dictionary or NSObject. One of the fields in this dictionary or NSObject could be `statfs` or `diskSpaceFunction`.