### PR TITLE
Try GHA retry

### DIFF
--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -51,8 +51,12 @@ jobs:
           FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage${{ matrix.language }} all)
+      uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: error
+          command: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage${{ matrix.language }} all)
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -51,7 +51,7 @@ jobs:
           FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - uses: nick-fields/retry@v4
+    - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 30
         max_attempts: 3

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -53,10 +53,10 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 30
+        timeout_minutes: 120
         max_attempts: 3
         retry_on: error
-        command: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage${{ matrix.language }} all)
+        command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -56,6 +56,7 @@ jobs:
         timeout_minutes: 120
         max_attempts: 3
         retry_on: error
+        retry_wait_seconds: 120
         command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
 
   spm:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -52,11 +52,11 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_on: error
-          command: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage${{ matrix.language }} all)
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage${{ matrix.language }} all)
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -51,7 +51,7 @@ jobs:
           FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-      uses: nick-fields/retry@v4
+    - uses: nick-fields/retry@v4
         with:
           timeout_minutes: 30
           max_attempts: 3


### PR DESCRIPTION
This validates a proof of concept of using GHA retry (#11253) instead of travis retry. 

It doesn't address the Storage Integration flake, but it successfully retries it.

#no-changelog