### PR TITLE
Fix health-metrics

### DIFF
--- a/.github/workflows/health-metrics-presubmit.yml
+++ b/.github/workflows/health-metrics-presubmit.yml
@@ -72,7 +72,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseABTesting --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -92,7 +92,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseAuth --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -115,7 +115,9 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseDatabase --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+      # TODO: Make sure that https://github.com/actions/upload-artifact/issues/478 is resolved
+      # before going to actions/upload-artifact@v4.
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -138,7 +140,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseDynamicLinks --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -164,7 +166,7 @@ jobs:
       run: |
         export EXPERIMENTAL_MODE=true
         ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseFirestore --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -187,7 +189,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseFunctions --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -210,7 +212,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseInAppMessaging --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -233,7 +235,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseMessaging --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -258,7 +260,7 @@ jobs:
       run: gem install xcpretty
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebasePerformance --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -281,7 +283,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseRemoteConfig --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -304,7 +306,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh --sdk=FirebaseStorage --platform=${{ matrix.target }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: codecoverage
         path: /Users/runner/*.xcresult
@@ -331,7 +333,7 @@ jobs:
           scripts/decrypt_gha_secret.sh scripts/gha-encrypted/metrics_service_access.json.gpg \
           metrics-access.json "${{ env.METRICS_SERVICE_SECRET }}"
           gcloud auth activate-service-account --key-file metrics-access.json
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         id: download
         with:
           path: /Users/runner/test

--- a/scripts/health_metrics/README.md
+++ b/scripts/health_metrics/README.md
@@ -33,8 +33,7 @@ pod-lib-lint-newsdk:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh FirebaseNewSDK "${{ matrix.target }}"
-    - uses: actions/upload-artifact@v2
-      with:
+    - uses: actions/upload-artifact@v3
         name: codecoverage
         path: /Users/runner/*.xcresult
 ```

--- a/scripts/health_metrics/README.md
+++ b/scripts/health_metrics/README.md
@@ -34,6 +34,7 @@ pod-lib-lint-newsdk:
     - name: Build and test
       run: ./scripts/health_metrics/pod_test_code_coverage_report.sh FirebaseNewSDK "${{ matrix.target }}"
     - uses: actions/upload-artifact@v3
+      with:
         name: codecoverage
         path: /Users/runner/*.xcresult
 ```


### PR DESCRIPTION
Downversion to actions/upload-artifact@v3

The new upload-artifact version from #12337 broke the health metrics presubmit job - https://github.com/firebase/firebase-ios-sdk/actions/runs/7748205614/job/21130380583

```
With the provided path, there will be 41 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

The failures are related to https://github.com/actions/upload-artifact/issues/478. We need a resolution before going to actions/upload-artifact@v4