### PR TITLE
Demo minimum platform version issue for SPM dependencies

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -27,12 +27,8 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13]
         include:
-          - os: macos-12
-            xcode: Xcode_14.2
-            test: spm
-          # The integration tests are slow and flaky on Xcode 15, so just build.
           - os: macos-13
             xcode: Xcode_15.2
             test: spmbuildonly
@@ -57,10 +53,8 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13]
         include:
-          - os: macos-12
-            xcode: Xcode_14.2
           - os: macos-13
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -84,10 +84,8 @@ jobs:
       matrix:
         # Full set of Firebase-Package tests only run on iOS. Run subset on other platforms.
         target: [tvOS, macOS, catalyst]
-        os: [macos-12, macos-13]
+        os: [macos-13]
         include:
-          - os: macos-12
-            xcode: Xcode_14.2
           - os: macos-13
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -84,8 +84,10 @@ jobs:
       matrix:
         # Full set of Firebase-Package tests only run on iOS. Run subset on other platforms.
         target: [tvOS, macOS, catalyst]
-        os: [macos-13]
+        os: [macos-12, macos-13]
         include:
+          - os: macos-12
+            xcode: Xcode_14.2
           - os: macos-13
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -27,8 +27,12 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-12, macos-13]
         include:
+          - os: macos-12
+            xcode: Xcode_14.2
+            test: spm
+          # The integration tests are slow and flaky on Xcode 15, so just build.
           - os: macos-13
             xcode: Xcode_15.2
             test: spmbuildonly
@@ -53,8 +57,10 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-12, macos-13]
         include:
+          - os: macos-12
+            xcode: Xcode_14.2
           - os: macos-13
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 
@@ -183,7 +183,7 @@ let package = Package(
       "100.0.0" ..< "101.0.0"
     ),
     .package(url: "https://github.com/google/app-check.git", "10.18.0" ..< "11.0.0"),
-    .package(url: "https://github.com/google/generative-ai-swift.git", "0.4.7" ..< "0.5.0"),
+    .package(url: "https://github.com/google/generative-ai-swift.git", branch: "ah/supported-platforms"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -183,6 +183,7 @@ let package = Package(
       "100.0.0" ..< "101.0.0"
     ),
     .package(url: "https://github.com/google/app-check.git", "10.18.0" ..< "11.0.0"),
+    .package(url: "https://github.com/google/generative-ai-swift.git", "0.4.7" ..< "0.5.0"),
   ],
   targets: [
     .target(
@@ -429,6 +430,7 @@ let package = Package(
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
         .product(name: "RecaptchaInterop", package: "interop-ios-for-google-sdks"),
+        .product(name: "GoogleGenerativeAI", package: "generative-ai-swift"),
       ],
       path: "FirebaseAuth/Sources",
       publicHeadersPath: "Public",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 


### PR DESCRIPTION
Do not merge. Added a dependency on `GoogleGenerativeAI` in `FirebaseAuth` as an example.

#no-changelog