### PR TITLE
Increase `swift-tools-version` to `5.7.1`

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [changed] Firebase now requires the Swift 5.7.1 toolchain or newer;
-  already included in Xcode 14.1+. (#12350)
+- [Swift Package Manager] Firebase now enforces a Swift 5.7.1 minimum version,
+  which is aligned with the Xcode 14.1 minimum. (#12350)
 
 # Firebase 10.21.0
 - Firebase now requires at least CocoaPods version 1.12.0 to enable privacy

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Firebase now requires the Swift 5.7.1 toolchain or newer;
+  already included in Xcode 14.1+. (#12350)
+
 # Firebase 10.21.0
 - Firebase now requires at least CocoaPods version 1.12.0 to enable privacy
   manifest support.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7.1
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 


### PR DESCRIPTION
- Increased to `swift-tools-version:5.7.1` in `Package.swift`
  - This aligns with the minimum version of Xcode supported by the SDK (14.1)