### PR TITLE
Fix auth integration test build issue

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -55,7 +55,7 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -82,7 +82,8 @@ jobs:
           FirebaseAuth/Tests/Sample/Sample/Sample.entitlements "$plist_secret"
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
           FirebaseAuth/Tests/Sample/SwiftApiTests/Credentials.swift "$plist_secret"
-
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.1.app/Contents/Developer
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Auth iOS)
 


### PR DESCRIPTION
The auth Objective C integration tests stopped building when the default Xcode became 14.3 yesterday. See https://github.com/firebase/firebase-ios-sdk/actions/runs/7797150970/job/21271664663

Since we don't need to support Xcode 14.3 for too much longer, moving these tests to Xcode 15.

Fix #12360