### PR TITLE
Remove placeholder token constant from Firebase App Check

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -48,8 +48,6 @@ NSString *const kFIRAppCheckAppNameNotificationKey = @"FIRAppCheckAppNameNotific
 
 static id<FIRAppCheckProviderFactory> _providerFactory;
 
-static NSString *const kDummyFACTokenValue = @"eyJlcnJvciI6IlVOS05PV05fRVJST1IifQ==";
-
 @interface FIRAppCheck () <FIRAppCheckInterop, GACAppCheckTokenDelegate>
 @property(class, nullable) id<FIRAppCheckProviderFactory> providerFactory;
 


### PR DESCRIPTION
The private `kDummyFACTokenValue` constant is no longer used in Firebase App Check. The replacement constant now lives in App Check Core: https://github.com/google/app-check/blob/3e464dad87dad2d29bb29a97836789bf0f8f67d2/AppCheckCore/Sources/Core/GACAppCheckTokenResult.m#L21-L23

#no-changelog