### PR TITLE
Bug fix for flaky behaviour when using Map in arrayRemove

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix the flaky offline behaviour when using `arrayRemove` on `Map` object. (#12378)
+
 # 10.21.0
 - Add an error when trying to build Firestore's binary SPM distribution for
   visionOS (#12279). See Firestore's 10.12.0 release note for a supported

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -183,6 +183,10 @@ nanopb::Message<google_firestore_v1_Value> DeepClone(
 nanopb::Message<google_firestore_v1_ArrayValue> DeepClone(
     const google_firestore_v1_ArrayValue& source);
 
+/** Creates a copy of the contents of the MapValue proto. */
+nanopb::Message<google_firestore_v1_MapValue> DeepClone(
+    const google_firestore_v1_MapValue& source);
+
 /** Returns true if `value` is a INTEGER_VALUE. */
 inline bool IsInteger(const absl::optional<google_firestore_v1_Value>& value) {
   return value &&

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -545,10 +545,22 @@ TEST_F(ValueUtilTest, DeepClone) {
   VerifyDeepClone(Map("a", Array("b", Map("c", GeoPoint(30, 60)))));
 }
 
-TEST_F(ValueUtilTest, CompareMapsWithDifferentKeyOrders) {
-  auto left = Map("a", 3, "b", 5);
-  auto right = Map("b", 5, "a", 3);
-  EXPECT_EQ(model::Compare(*left, *right), ComparisonResult::Same);
+TEST_F(ValueUtilTest, CompareMaps) {
+  auto left_1 = Map("a", 7, "b", 0);
+  auto right_1 = Map("a", 7, "b", 0);
+  EXPECT_EQ(model::Compare(*left_1, *right_1), ComparisonResult::Same);
+
+  auto left_2 = Map("a", 3, "b", 5);
+  auto right_2 = Map("b", 5, "a", 3);
+  EXPECT_EQ(model::Compare(*left_2, *right_2), ComparisonResult::Same);
+
+  auto left_3 = Map("a", 8, "b", 10, "c", 5);
+  auto right_3 = Map("a", 8, "b", 10);
+  EXPECT_EQ(model::Compare(*left_3, *right_3), ComparisonResult::Descending);
+
+  auto left_4 = Map("a", 7, "b", 0);
+  auto right_4 = Map("a", 7, "b", 10);
+  EXPECT_EQ(model::Compare(*left_4, *right_4), ComparisonResult::Ascending);
 }
 
 }  // namespace

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -545,6 +545,12 @@ TEST_F(ValueUtilTest, DeepClone) {
   VerifyDeepClone(Map("a", Array("b", Map("c", GeoPoint(30, 60)))));
 }
 
+TEST_F(ValueUtilTest, CompareMapsWithDifferentKeyOrders) {
+  auto left = Map("a", 3, "b", 5);
+  auto right = Map("b", 5, "a", 3);
+  EXPECT_EQ(model::Compare(*left, *right), ComparisonResult::Same);
+}
+
 }  // namespace
 
 }  // namespace model


### PR DESCRIPTION
When user calls `arrayRemove` on map object, since the key order in mutation is not necessary align with the order in document and the SDK falsely assume for hash map the item is always sorted by keys, sometimes `arrayRemove` doesn't work. 