### PR TITLE
[auth-swift] Include Swift-generated ObjC Auth types via Firebase.h

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -32,6 +32,8 @@
 
   #if __has_include(<FirebaseAuth/FirebaseAuth.h>)
     #import <FirebaseAuth/FirebaseAuth.h>
+    #import <FirebaseAuthInterop/FIRAuthInterop.h>
+    #import <FirebaseAuth/FirebaseAuth-Swift.h>
   #endif
 
   #if __has_include(<FirebaseCrashlytics/FirebaseCrashlytics.h>)


### PR DESCRIPTION
Fixes 

<img width="982" alt="Screenshot 2024-02-09 at 3 40 44 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/73870/2ffadb84-1edd-457a-9803-410a1c19c570">

and the Interop import fixes the next failure:

<img width="993" alt="Screenshot 2024-02-09 at 3 43 03 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/73870/80ced469-3dc8-40db-aa00-2c9834b8d99e">
