### PR TITLE
Make `AuthInterop` and `AppCheckInterop` properties optional in Storage

### DIFF
--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -306,8 +306,8 @@ import FirebaseCore
 
   private static func initFetcherServiceForApp(_ app: FirebaseApp,
                                                _ bucket: String,
-                                               _ auth: AuthInterop,
-                                               _ appCheck: AppCheckInterop)
+                                               _ auth: AuthInterop?,
+                                               _ appCheck: AppCheckInterop?)
     -> GTMSessionFetcherService {
     objc_sync_enter(fetcherServiceLock)
     defer { objc_sync_exit(fetcherServiceLock) }
@@ -334,8 +334,8 @@ import FirebaseCore
     return fetcherService!
   }
 
-  private let auth: AuthInterop
-  private let appCheck: AppCheckInterop
+  private let auth: AuthInterop?
+  private let appCheck: AppCheckInterop?
   private let storageBucket: String
   private var usesEmulator: Bool = false
   var host: String


### PR DESCRIPTION
The `AuthInterop` and `AppCheckInterop` instances returned by `ComponentType<ProtocolName>.instance(for: ProtocolName.self, in: app.container)` are nullable (e.g., if AppCheck or Auth aren't added to an app). This hasn't broken the Storage SDK because the instances are only used in [`StorageTokenAuthorizer`](https://github.com/firebase/firebase-ios-sdk/blob/2c76938316df35db9f8f5aa69bfeacfac40a8a07/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift#L117-L118), where they're nullable parameters.

#no-changelog