### PR TITLE
Make `instanceForProtocol:inContainer:` return `nullable T`

### DIFF
--- a/FirebaseCore/Extension/FIRComponentType.h
+++ b/FirebaseCore/Extension/FIRComponentType.h
@@ -27,7 +27,8 @@ NS_SWIFT_NAME(ComponentType)
 
 /// Do not use directly. A factory method to retrieve an instance that provides a specific
 /// functionality.
-+ (T)instanceForProtocol:(Protocol *)protocol inContainer:(FIRComponentContainer *)container;
++ (nullable T)instanceForProtocol:(Protocol *)protocol
+                      inContainer:(FIRComponentContainer *)container;
 
 @end
 

--- a/FirebaseCore/Sources/FIRComponentType.m
+++ b/FirebaseCore/Sources/FIRComponentType.m
@@ -20,7 +20,8 @@
 
 @implementation FIRComponentType
 
-+ (id)instanceForProtocol:(Protocol *)protocol inContainer:(FIRComponentContainer *)container {
++ (nullable id)instanceForProtocol:(Protocol *)protocol
+                       inContainer:(FIRComponentContainer *)container {
   // Forward the call to the container.
   return [container instanceForProtocol:protocol];
 }

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -61,8 +61,10 @@ import FirebaseCore
   /// - Parameter app: The custom `FirebaseApp` used for initialization.
   /// - Returns: A `Storage` instance, configured with the custom `FirebaseApp`.
   @objc(storageForApp:) open class func storage(app: FirebaseApp) -> Storage {
-    let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
-                                                           in: app.container)
+    guard let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
+                                                                 in: app.container) else {
+      fatalError("No \(StorageProvider.self) instance found for Firebase app: \(app.name)")
+    }
     return provider.storage(for: Storage.bucket(for: app))
   }
 
@@ -75,8 +77,10 @@ import FirebaseCore
   /// URL.
   @objc(storageForApp:URL:)
   open class func storage(app: FirebaseApp, url: String) -> Storage {
-    let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
-                                                           in: app.container)
+    guard let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
+                                                                 in: app.container) else {
+      fatalError("No \(StorageProvider.self) instance found for Firebase app: \(app.name)")
+    }
     return provider.storage(for: Storage.bucket(for: app, urlString: url))
   }
 

--- a/FirebaseStorage/Tests/Unit/StorageComponentTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageComponentTests.swift
@@ -70,14 +70,14 @@ class StorageComponentTests: StorageTestHelpers {
                                                            in: container)
     XCTAssertNotNil(provider)
 
-    let storage1 = provider.storage(for: "randomBucket")
-    let storage2 = provider.storage(for: "randomBucket")
+    let storage1 = provider?.storage(for: "randomBucket")
+    let storage2 = provider?.storage(for: "randomBucket")
     XCTAssertNotNil(storage1)
 
     // Ensure they're the same instance.
     XCTAssert(storage1 === storage2)
 
-    let storage3 = provider.storage(for: "differentBucket")
+    let storage3 = provider?.storage(for: "differentBucket")
     XCTAssertNotNil(storage3)
 
     XCTAssert(storage1 !== storage3)

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-# TODO: Remove this comment after testing
-
 gem 'cocoapods', '1.15.2'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
+# TODO: Remove this comment after testing
+
 gem 'cocoapods', '1.15.2'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'


### PR DESCRIPTION
Updated [`+ (T)instanceForProtocol:inContainer:`](https://github.com/firebase/firebase-ios-sdk/blob/2c76938316df35db9f8f5aa69bfeacfac40a8a07/FirebaseCore/Extension/FIRComponentType.h#L30) in `FIRComponentType` to return a `nullable T` instead of `T`. The [underlying call](https://github.com/firebase/firebase-ios-sdk/blob/ab0d0854a3682f14c0ee26859469cb4b1636d5e1/FirebaseCore/Sources/FIRComponentType.m#L25) to [`instanceForProtocol:`](https://github.com/firebase/firebase-ios-sdk/blob/ab0d0854a3682f14c0ee26859469cb4b1636d5e1/FirebaseCore/Sources/FIRComponentContainer.m#L189-L203) in `FIRComponentContainer` can return `nil`.

This is a follow-up that addresses https://github.com/firebase/firebase-ios-sdk/pull/12387#issuecomment-1942408448.

#no-changelog