### PR TITLE
Revert "[Release Tooling] Stop including 'Info.plist's in static xcframeworks (#12243)"

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [Swift Package Manager] Firebase now enforces a Swift 5.7.1 minimum version,
   which is aligned with the Xcode 14.1 minimum. (#12350)
+- Revert Firebase 10.20.0 change that removed `Info.plist` files from
+  static xcframeworks (#12390).
 
 # Firebase 10.21.0
 - Firebase now requires at least CocoaPods version 1.12.0 to enable privacy
@@ -9,7 +11,7 @@
 # Firebase 10.20.0
 - The following change only applies to those using a binary distribution of
   a Firebase SDK(s): In preparation for supporting Privacy Manifests, each
-  platform framework directory within a static xcframewok no longer contains
+  platform framework directory within a static xcframework no longer contains
   an `Info.plist` file (#12243).
 
 # Firebase 10.14.0

--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -241,6 +241,9 @@ extension CarthageUtils {
     } catch {
       fatalError("Couldn't copy dummy library for Firebase framework in Carthage. \(error)")
     }
+
+    // Write the Info.plist.
+    generatePlistContents(forName: "Firebase", withVersion: version, to: frameworkDir)
   }
 
   static func generatePlistContents(forName name: String,

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -380,6 +380,10 @@ struct FrameworkBuilder {
       }
       umbrellaHeader = umbrellaHeaderURL.lastPathComponent
     }
+    // Add an Info.plist. Required by Carthage and SPM binary xcframeworks.
+    CarthageUtils.generatePlistContents(forName: frameworkName,
+                                        withVersion: podInfo.version,
+                                        to: frameworkDir)
 
     // TODO: copy PrivateHeaders directory as well if it exists. SDWebImage is an example pod.
 
@@ -590,8 +594,8 @@ struct FrameworkBuilder {
   /// Groups slices for each platform into a minimal set of frameworks.
   /// - Parameter withName: The framework name.
   /// - Parameter isCarthage: Name the temp directory differently for Carthage.
-  /// - Parameter fromFolder: The almost complete framework folder. Includes
-  /// Headers, and Resources.
+  /// - Parameter fromFolder: The almost complete framework folder. Includes Headers, Info.plist,
+  /// and Resources.
   /// - Parameter slicedFrameworks: All the frameworks sliced by platform.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
   private func groupFrameworks(withName framework: String,
@@ -680,6 +684,15 @@ struct FrameworkBuilder {
           at: headersSrc,
           to: platformFrameworkDir.appendingPathComponent("Headers")
         )
+      } catch {
+        fatalError("Could not create framework directory needed to build \(framework): \(error)")
+      }
+
+      // Info.plist from `fromFolder`
+      do {
+        let infoPlistSrc = fromFolder.appendingPathComponent("Info.plist").resolvingSymlinksInPath()
+        let infoPlistDst = platformFrameworkDir.appendingPathComponent("Info.plist")
+        try fileManager.copyItem(at: infoPlistSrc, to: infoPlistDst)
       } catch {
         fatalError("Could not create framework directory needed to build \(framework): \(error)")
       }


### PR DESCRIPTION
This reverts commit 0fa8498f4b97e2ac1e550100e1996e13888d03fc.

Fix #12390 
