### PR TITLE
Disable flaky Storage ObjC quickstart on Xcode 15.2

### DIFF
--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -114,6 +114,7 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
+        swift: [swift, ""]
         include:
           - os: macos-12
             xcode: Xcode_14.2
@@ -134,10 +135,8 @@ jobs:
           quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Test objc quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage true)
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage true swift)
+    - name: Test quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage true ${{ matrix.swift }})
 
   quickstart-ftl-cron-only:
     # Don't run on private repo.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -112,13 +112,15 @@ jobs:
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    # TODO: See #12399 and restore Objective-C testing for Xcode 15 if GHA is fixed.
     strategy:
       matrix:
         swift: [swift, ""]
         include:
           - os: macos-12
             xcode: Xcode_14.2
-          - os: macos-13
+          - swift: swift
+            os: macos-13
             xcode: Xcode_15.2
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -115,10 +115,12 @@ jobs:
     # TODO: See #12399 and restore Objective-C testing for Xcode 15 if GHA is fixed.
     strategy:
       matrix:
-        swift: [swift, ""]
         include:
           - os: macos-12
             xcode: Xcode_14.2
+          - swift: swift
+            os: macos-13
+            xcode: Xcode_15.2
           - swift: swift
             os: macos-13
             xcode: Xcode_15.2


### PR DESCRIPTION
Disable ObjC quickstart on Xcode 15.2

GHA is flaking because with a redefinition of module 'SwiftBridging' error. See  https://github.com/firebase/firebase-ios-sdk/actions/runs/7908402675/job/21587502678

from a GHA configuration issue though:

https://forums.developer.apple.com/forums/thread/739510