### PR TITLE
[Release Tooling] Attempt to address zip failures

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -639,34 +639,6 @@ struct FrameworkBuilder {
           "\(framework): \(error)")
       }
 
-      // Move any privacy manifest-containing resource bundles into the
-      // platform framework.
-      try? fileManager.contentsOfDirectory(
-        at: frameworkPath.deletingLastPathComponent(),
-        includingPropertiesForKeys: nil
-      )
-      .filter { $0.pathExtension == "bundle" }
-      // TODO(ncooke3): Once the zip is built with Xcode 15, the following
-      // `filter` can be removed. The following block exists to preserve
-      // how resources (e.g. like FIAM's) are packaged for use in Xcode 14.
-      .filter { bundleURL in
-        let dirEnum = fileManager.enumerator(atPath: bundleURL.path)
-        var containsPrivacyManifest = false
-        while let relativeFilePath = dirEnum?.nextObject() as? String {
-          if relativeFilePath.hasSuffix("PrivacyInfo.xcprivacy") {
-            containsPrivacyManifest = true
-            break
-          }
-        }
-        return containsPrivacyManifest
-      }
-      // Bundles are moved rather than copied to prevent them from being
-      // packaged in a `Resources` directory at the root of the xcframework.
-      .forEach { try! fileManager.moveItem(
-        at: $0,
-        to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
-      ) }
-
       // Headers from slice
       do {
         let headersSrc: URL = frameworkPath.appendingPathComponent("Headers")

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -482,7 +482,19 @@ struct ZipBuilder {
             // Move all the bundles in the frameworks out to a common "Resources" directory to
             // match the existing Zip structure.
             let resourcesDir = productPath.appendingPathComponent("Resources")
-            try fileManager.moveItem(at: xcResourceDir, to: resourcesDir)
+            do {
+              try fileManager.moveItem(at: xcResourceDir, to: resourcesDir)
+            } catch {
+              // Couldn't copy directory because a directory with the same name
+              // already exists. Instead, copy each resource in the current
+              // directory to the existing Resources directory.
+              let resourcesDirectories = try fileManager.contentsOfDirectory(atPath: resourcesDir.path)
+              try resourcesDirectories.forEach { resourceDir in
+                let srcResourceDir = xcResourceDir.appendingPathComponent(resourceDir)
+                let dstResourceDir = resourcesDir.appendingPathComponent(resourceDir)
+                try fileManager.moveItem(at: srcResourceDir, to: dstResourceDir)
+              }
+            }
 
           } else {
             let xcContents = try fileManager.contentsOfDirectory(atPath: xcPath.path)


### PR DESCRIPTION
- Revert PR that embedded resource bundles. There will be a time for that work once the `Info.plist` issues are resolved in Xcode.
- Reverting the above PR will bring back the [CI failure](https://github.com/firebase/firebase-ios-sdk/actions/runs/7676201639/job/20923451837) a few weeks back that prompted the fix. Add a new code path to handle the error and add to product-level Resources/ directory instead of trying to re-write it.

#no-changelog