### PR TITLE
Privacy Manifests for named Firebase SDKs

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -7,6 +7,8 @@ on:
     - '.github/workflows/zip.yml'
     - 'scripts/build_non_firebase_sdks.sh'
     - 'Gemfile*'
+    # DELETE BEFORE pushing
+    - 'FirebaseCore.podspec'
     # Don't run based on any markdown only changes.
     - '!ReleaseTooling/*.md'
   schedule:

--- a/Crashlytics/Resources/PrivacyInfo.xcprivacy
+++ b/Crashlytics/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeCrashData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>35F9.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>CA92.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -43,6 +43,9 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
    'Interop/Analytics/Public/*.h',
    'FirebaseCore/Extension/*.h',
   ]
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseABTesting/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
   s.requires_arc = base_dir + '*.m'
   s.public_header_files = base_dir + 'Public/FirebaseABTesting/*.h'
   s.pod_target_xcconfig = {

--- a/FirebaseABTesting/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseABTesting/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -41,6 +41,9 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'FirebaseAuth/Interop/*.h',
   ]
   s.public_header_files = source + 'Public/FirebaseAuth/*.h'
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseAuth/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
   s.preserve_paths = [
     'FirebaseAuth/README.md',
     'FirebaseAuth/CHANGELOG.md'

--- a/FirebaseAuth/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseAuth/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeUserID</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <true/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>CA92.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -36,6 +36,10 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
     'FirebaseCore/Extension/*.h'
   ]
 
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseCore/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
+
   s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseCore/Sources/Public/FirebaseCore/*.h'

--- a/FirebaseCore/Extension/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseCore/Extension/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseCore/Internal/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseCore/Internal/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseCore/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseCore/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>CA92.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -30,5 +30,9 @@ Pod::Spec.new do |s|
     s.source_files = 'FirebaseCore/Extension/*.[hm]'
     s.public_header_files = 'FirebaseCore/Extension/*.h'
 
+    s.resource_bundles = {
+      "#{s.module_name}_Privacy" => 'FirebaseCore/Extension/Resources/PrivacyInfo.xcprivacy'
+    }
+
     s.dependency 'FirebaseCore', '~> 10.0'
   end

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -32,6 +32,10 @@ Pod::Spec.new do |s|
     'FirebaseCore/Internal/Sources/**/*.swift'
   ]
 
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseCore/Internal/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
+
   s.swift_version = '5.3'
 
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.8'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -36,6 +36,10 @@ Pod::Spec.new do |s|
     'Interop/Analytics/Public/*.h',
   ]
 
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'Crashlytics/Resources/PrivacyInfo.xcprivacy'
+  }
+
   s.public_header_files = [
     'Crashlytics/Crashlytics/Public/FirebaseCrashlytics/*.h'
   ]

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -29,6 +29,9 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
     'FirebaseCore/Extension/*.h',
   ]
   s.public_header_files = 'FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/*.h'
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseDynamicLinks/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
   s.frameworks = 'QuartzCore'
   s.weak_framework = 'WebKit'
   s.dependency 'FirebaseCore', '~> 10.0'

--- a/FirebaseDynamicLinks/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseDynamicLinks/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>C617.1</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -31,6 +31,9 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'FirebaseFirestoreInternal/**/*.[mh]',
     'Firestore/Swift/Source/**/*.swift',
   ]
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'Firestore/Swift/Source/Resources/PrivacyInfo.xcprivacy'
+  }
 
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -87,6 +87,10 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/core/src/util/secure_random_openssl.cc'
   ]
 
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'Firestore/Source/Resources/PrivacyInfo.xcprivacy'
+  }
+
   s.dependency 'FirebaseAppCheckInterop', '~> 10.17'
   s.dependency 'FirebaseCore', '~> 10.0'
 

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -40,6 +40,9 @@ Pod::Spec.new do |s|
   s.public_header_files = [
     base_dir + 'Library/Public/FirebaseInstallations/*.h',
   ]
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseInstallations/Source/Library/Resources/PrivacyInfo.xcprivacy'
+  }
 
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 10.0'

--- a/FirebaseInstallations/Source/Library/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseInstallations/Source/Library/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -45,6 +45,9 @@ device, and it is completely free.
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseMessaging/*.h'
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseMessaging/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
   s.library = 'sqlite3'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseMessaging/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseMessaging/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeDeviceID</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -44,7 +44,7 @@ app update.
   ]
   s.public_header_files = base_dir + 'Public/FirebaseRemoteConfig/*.h'
   s.resource_bundles = {
-    "#{s.module_name}_Privacy" => 'FirebaseRemoteConfig/Sources/Resources/PrivacyInfo.xcprivacy'
+    "#{s.module_name}_Privacy" => 'FirebaseRemoteConfig/Swift/Resources/PrivacyInfo.xcprivacy'
   }
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -43,6 +43,9 @@ app update.
     'FirebaseRemoteConfig/Swift/**/*.swift',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseRemoteConfig/*.h'
+  s.resource_bundles = {
+    "#{s.module_name}_Privacy" => 'FirebaseRemoteConfig/Sources/Resources/PrivacyInfo.xcprivacy'
+  }
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/FirebaseRemoteConfig/Swift/Resources/PrivacyInfo.xcprivacy
+++ b/FirebaseRemoteConfig/Swift/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyAccessedAPIType</key>
+                        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                        <key>NSPrivacyAccessedAPITypeReasons</key>
+                        <array>
+                                <string>1C8F.1</string>
+                        </array>
+                </dict>
+        </array>
+</dict>
+</plist>
+

--- a/Firestore/Source/Resources/PrivacyInfo.xcprivacy
+++ b/Firestore/Source/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/Firestore/Swift/Source/Resources/PrivacyInfo.xcprivacy
+++ b/Firestore/Swift/Source/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyTrackingDomains</key>
+        <array>
+        </array>
+        <key>NSPrivacyCollectedDataTypes</key>
+        <array>
+                <dict>
+                        <key>NSPrivacyCollectedDataType</key>
+                        <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+                        <key>NSPrivacyCollectedDataTypeLinked</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypeTracking</key>
+                        <false/>
+                        <key>NSPrivacyCollectedDataTypePurposes</key>
+                        <array>
+                                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                        </array>
+                </dict>
+        </array>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+        </array>
+</dict>
+</plist>
+

--- a/Package.swift
+++ b/Package.swift
@@ -653,6 +653,7 @@ let package = Package(
       name: "FirebaseDynamicLinks",
       dependencies: ["FirebaseCore"],
       path: "FirebaseDynamicLinks/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),

--- a/Package.swift
+++ b/Package.swift
@@ -199,6 +199,7 @@ let package = Package(
         .product(name: "GULLogger", package: "GoogleUtilities"),
       ],
       path: "FirebaseCore/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../.."),
@@ -232,6 +233,7 @@ let package = Package(
     .target(
       name: "FirebaseCoreExtension",
       path: "FirebaseCore/Extension",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: ".",
       cSettings: [
         .headerSearchPath("../../"),
@@ -246,7 +248,8 @@ let package = Package(
       dependencies: [
         .product(name: "GULNSData", package: "GoogleUtilities"),
       ],
-      path: "FirebaseCore/Internal/Sources"
+      path: "FirebaseCore/Internal/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
     ),
     .testTarget(
       name: "FirebaseCoreInternalTests",

--- a/Package.swift
+++ b/Package.swift
@@ -501,6 +501,7 @@ let package = Package(
                      .product(name: "FBLPromises", package: "Promises"),
                      .product(name: "nanopb", package: "nanopb")],
       path: "Crashlytics",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       exclude: [
         "run",
         "CHANGELOG.md",

--- a/Package.swift
+++ b/Package.swift
@@ -503,7 +503,6 @@ let package = Package(
                      .product(name: "FBLPromises", package: "Promises"),
                      .product(name: "nanopb", package: "nanopb")],
       path: "Crashlytics",
-      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       exclude: [
         "run",
         "CHANGELOG.md",
@@ -522,6 +521,7 @@ let package = Package(
         "Shared/",
         "third_party/libunwind/dwarf.h",
       ],
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Crashlytics/Public",
       cSettings: [
         .headerSearchPath(".."),

--- a/Package.swift
+++ b/Package.swift
@@ -845,6 +845,7 @@ let package = Package(
         .product(name: "nanopb", package: "nanopb"),
       ],
       path: "FirebaseMessaging/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),

--- a/Package.swift
+++ b/Package.swift
@@ -997,7 +997,8 @@ let package = Package(
         "FirebaseRemoteConfigInternal",
         "FirebaseSharedSwift",
       ],
-      path: "FirebaseRemoteConfig/Swift"
+      path: "FirebaseRemoteConfig/Swift",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
     ),
     .target(
       name: "FirebaseRemoteConfigSwift",

--- a/Package.swift
+++ b/Package.swift
@@ -263,6 +263,7 @@ let package = Package(
       name: "FirebaseABTesting",
       dependencies: ["FirebaseCore"],
       path: "FirebaseABTesting/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),

--- a/Package.swift
+++ b/Package.swift
@@ -1427,6 +1427,7 @@ func firestoreTargets() -> [Target] {
           "core/include/",
           "core/src",
         ],
+        resources: [.process("Resources/PrivacyInfo.xcprivacy")],
         publicHeadersPath: "Source/Public",
         cSettings: [
           .headerSearchPath("../"),

--- a/Package.swift
+++ b/Package.swift
@@ -1430,7 +1430,6 @@ func firestoreTargets() -> [Target] {
           "core/include/",
           "core/src",
         ],
-        resources: [.process("Resources/PrivacyInfo.xcprivacy")],
         publicHeadersPath: "Source/Public",
         cSettings: [
           .headerSearchPath("../"),
@@ -1477,7 +1476,7 @@ func firestoreTargets() -> [Target] {
         sources: [
           "Swift/Source/",
         ],
-        resources: [.process("Resources/PrivacyInfo.xcprivacy")]
+        resources: [.process("Source/Resources/PrivacyInfo.xcprivacy")]
       ),
     ]
   }
@@ -1525,6 +1524,7 @@ func firestoreTargets() -> [Target] {
         "FirebaseSharedSwift",
       ],
       path: "Firestore/Swift/Source",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       linkerSettings: [
         .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
         .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),

--- a/Package.swift
+++ b/Package.swift
@@ -1473,7 +1473,8 @@ func firestoreTargets() -> [Target] {
         ],
         sources: [
           "Swift/Source/",
-        ]
+        ],
+        resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       ),
     ]
   }

--- a/Package.swift
+++ b/Package.swift
@@ -249,7 +249,7 @@ let package = Package(
         .product(name: "GULNSData", package: "GoogleUtilities"),
       ],
       path: "FirebaseCore/Internal/Sources",
-      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .testTarget(
       name: "FirebaseCoreInternalTests",
@@ -1003,7 +1003,7 @@ let package = Package(
         "FirebaseSharedSwift",
       ],
       path: "FirebaseRemoteConfig/Swift",
-      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .target(
       name: "FirebaseRemoteConfigSwift",
@@ -1477,7 +1477,7 @@ func firestoreTargets() -> [Target] {
         sources: [
           "Swift/Source/",
         ],
-        resources: [.process("Resources/PrivacyInfo.xcprivacy")],
+        resources: [.process("Resources/PrivacyInfo.xcprivacy")]
       ),
     ]
   }

--- a/Package.swift
+++ b/Package.swift
@@ -434,6 +434,7 @@ let package = Package(
         .product(name: "RecaptchaInterop", package: "interop-ios-for-google-sdks"),
       ],
       path: "FirebaseAuth/Sources",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../"),

--- a/Package.swift
+++ b/Package.swift
@@ -801,6 +801,7 @@ let package = Package(
         .product(name: "GULUserDefaults", package: "GoogleUtilities"),
       ],
       path: "FirebaseInstallations/Source/Library",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../../../"),


### PR DESCRIPTION
Add privacy manifests for the Firebase SDKs named in https://developer.apple.com/support/third-party-SDK-requirements/

FirebaseCoreDiagnostics is not included because it is no longer part of the product.

Other non-named Firebase SDKs are still being investigated.