### PR TITLE
Enable nanopb version with privacy manifest

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -584,7 +584,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: quickstart_artifacts_ihappmessaging
+        name: quickstart_artifacts_inappmessaging
         path: quickstart-ios/
 
   quickstart_framework_messaging:

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.11'
     s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.11'
     s.dependency 'GoogleUtilities/Network', '~> 7.11'
-    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
     s.default_subspecs = 'AdIdSupport'
 

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -61,7 +61,7 @@ Pod::Spec.new do |s|
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
   s.libraries = 'c++', 'z'
   s.ios.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -102,7 +102,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'gRPC-C++', '~> 1.49.1'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
   s.ios.frameworks = 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -84,7 +84,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'FirebaseABTesting', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -65,7 +65,7 @@ device, and it is completely free.
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.8'
   s.dependency 'GoogleDataTransport', '~> 9.3'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -67,7 +67,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'GoogleUtilities/Environment', '~> 7.8'
   s.dependency 'GoogleUtilities/ISASwizzler', '~> 7.8'
   s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.8'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => ios_deployment_target, :tvos => tvos_deployment_target}

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'GoogleDataTransport', '~> 9.2'
   s.dependency 'GoogleUtilities/Environment', '~> 7.10'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
   s.dependency 'PromisesSwift', '~> 2.1'
 
   s.pod_target_xcconfig = {

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/MethodSwizzler', '~> 7.11'
     s.dependency 'GoogleUtilities/NSData+zlib', '~> 7.11'
     s.dependency 'GoogleUtilities/Network', '~> 7.11'
-    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
 
     s.default_subspecs = 'AdIdSupport'
 

--- a/Package.swift
+++ b/Package.swift
@@ -162,7 +162,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/firebase/nanopb.git",
-      "2.30909.0" ..< "2.30910.0"
+      "2.30909.0" ..< "2.30911.0"
     ),
     abseilDependency(),
     grpcDependency(),


### PR DESCRIPTION
nanopb 0.3.9.10 or 2.30910.0 introduces a privacy manifest for nanopb

Confirmed the Privacy manifest is being built into the zip after updating SpecsStaging

CI failures match main and are related to a zip builder issue with GoogleUtilities

![Screenshot 2024-02-22 at 3 51 03 PM](https://github.com/firebase/firebase-ios-sdk/assets/73870/59e16de0-9333-44c7-9e52-e9fb7833ecd2)

