### PR TITLE
[Binary] Add missing values to Info.plist generator

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CarthageUtils.swift
@@ -250,10 +250,15 @@ extension CarthageUtils {
                                     withVersion version: String,
                                     to location: URL) {
     let ver = version.components(separatedBy: "-")[0] // remove any version suffix.
+
+    // TODO(paulb777): Does MinimumOSVersion or anything else need
+    // to be adapted for other platforms?
     let plist: [String: String] = ["CFBundleIdentifier": "com.firebase.Firebase-\(name)",
                                    "CFBundleInfoDictionaryVersion": "6.0",
                                    "CFBundlePackageType": "FMWK",
                                    "CFBundleVersion": ver,
+                                   "CFBundleShortVersionString": ver,
+                                   "MinimumOSVersion": Platform.iOS.minimumVersion,
                                    "DTSDKName": "iphonesimulator11.2",
                                    "CFBundleExecutable": name,
                                    "CFBundleName": name]


### PR DESCRIPTION
Some internal testing showed errors for CFBundleShortVersionString and MinimumOSVersion missing from the Info.plist. This PR adds them.

Currently the implementation is iOS specific.

This PR is mostly moot after #12414, but is still relevant for the one case where generateInfoPlist is still used and if we ever need it in the future.

![Screenshot 2024-02-22 at 9 11 50 AM](https://github.com/firebase/firebase-ios-sdk/assets/73870/ea2b70e8-abf5-4da1-9d53-6b933728cbf7)
