### PR TITLE
Fix GoogleUtilities zip file structure

### DIFF
--- a/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
@@ -193,8 +193,7 @@ public extension FileManager {
         // The only thing of interest is the path extension being ".bundle", but not a privacy
         // bundle.
         if fileURL.pathExtension == "bundle",
-           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle"),
-           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle/") {
+           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
           matches.append(fileURL)
         }
       case .headers:

--- a/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
@@ -28,6 +28,9 @@ public extension FileManager {
     /// All folders with a `.bundle` extension.
     case bundles
 
+    /// All folders with a `.bundle` extension excluding privacy manifest bundles.
+    case nonPrivacyBundles
+
     /// A directory with an optional name. If name is `nil`, all directories will be matched.
     case directories(name: String?)
 
@@ -184,6 +187,13 @@ public extension FileManager {
       case .bundles:
         // The only thing of interest is the path extension being ".bundle".
         if fileURL.pathExtension == "bundle" {
+          matches.append(fileURL)
+        }
+      case .nonPrivacyBundles:
+        // The only thing of interest is the path extension being ".bundle", but not a privacy
+        // bundle.
+        if fileURL.pathExtension == "bundle",
+           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
           matches.append(fileURL)
         }
       case .headers:

--- a/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
@@ -193,7 +193,8 @@ public extension FileManager {
         // The only thing of interest is the path extension being ".bundle", but not a privacy
         // bundle.
         if fileURL.pathExtension == "bundle",
-           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
+           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle"),
+           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle/") {
           matches.append(fileURL)
         }
       case .headers:

--- a/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
@@ -30,7 +30,7 @@ extension ResourcesManager {
   static func directoryContainsResources(_ dir: URL) throws -> Bool {
     // First search for any .bundle files.
     let fileManager = FileManager.default
-    let bundles = try fileManager.recursivelySearch(for: .bundles, in: dir)
+    let bundles = try fileManager.recursivelySearch(for: .nonPrivacyBundles, in: dir)
 
     // Stop searching if there were any bundles found.
     if !bundles.isEmpty { return true }

--- a/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
@@ -168,7 +168,7 @@ extension ResourcesManager {
                              to resourceDir: URL,
                              keepOriginal: Bool = false) throws -> [URL] {
     let fileManager = FileManager.default
-    let allBundles = try fileManager.recursivelySearch(for: .bundles, in: dir)
+    let allBundles = try fileManager.recursivelySearch(for: .nonPrivacyBundles, in: dir)
 
     // If no bundles are found, return an empty array since nothing was done (but there wasn't an
     // error).


### PR DESCRIPTION
Fix #12385

This PR fixes the Resource organization issue in GoogleUtilities in the zip that's been causing the nightly zip build failures for the last week.

The issue isn't reproducible in Xcode 15 on macos 13. I suspect the root cause may have to do with file system repercussions of building GoogleUtilities a second time separately for Carthage.

I'll do a bit more investigation, but this should be ready for review, so we can unblock progress on #12407

Getting:

![Screenshot 2024-02-22 at 5 03 51 PM](https://github.com/firebase/firebase-ios-sdk/assets/73870/46cf2966-af35-4145-914c-25f9c616b92a)

Should be:

![Screenshot 2024-02-22 at 5 06 14 PM](https://github.com/firebase/firebase-ios-sdk/assets/73870/64f0e492-e4af-4aee-8d8d-32e4fd540620)
