### PR TITLE
Fix metadata.md generation

### DIFF
--- a/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
@@ -28,9 +28,6 @@ public extension FileManager {
     /// All folders with a `.bundle` extension.
     case bundles
 
-    /// All folders with a `.bundle` extension excluding privacy manifest bundles.
-    case nonPrivacyBundles
-
     /// A directory with an optional name. If name is `nil`, all directories will be matched.
     case directories(name: String?)
 
@@ -163,6 +160,11 @@ public extension FileManager {
     var matches: [URL] = []
     var foundXcframework = false // Ignore .frameworks after finding an xcframework.
     while let fileURL = dirEnumerator.nextObject() as? URL {
+      // Never mess with Privacy.bundles
+      if fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
+        continue
+      }
+
       switch type {
       case .allFiles:
         // Skip directories, include everything else.
@@ -187,13 +189,6 @@ public extension FileManager {
       case .bundles:
         // The only thing of interest is the path extension being ".bundle".
         if fileURL.pathExtension == "bundle" {
-          matches.append(fileURL)
-        }
-      case .nonPrivacyBundles:
-        // The only thing of interest is the path extension being ".bundle", but not a privacy
-        // bundle.
-        if fileURL.pathExtension == "bundle",
-           !fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
           matches.append(fileURL)
         }
       case .headers:

--- a/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
+++ b/ReleaseTooling/Sources/Utils/FileManager+Utils.swift
@@ -159,9 +159,10 @@ public extension FileManager {
     // Recursively search using the enumerator, adding any matches to the array.
     var matches: [URL] = []
     var foundXcframework = false // Ignore .frameworks after finding an xcframework.
-    while let fileURL = dirEnumerator.nextObject() as? URL {
+    for case let fileURL as URL in dirEnumerator {
       // Never mess with Privacy.bundles
       if fileURL.lastPathComponent.hasSuffix("_Privacy.bundle") {
+        dirEnumerator.skipDescendants()
         continue
       }
 

--- a/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
@@ -30,7 +30,7 @@ extension ResourcesManager {
   static func directoryContainsResources(_ dir: URL) throws -> Bool {
     // First search for any .bundle files.
     let fileManager = FileManager.default
-    let bundles = try fileManager.recursivelySearch(for: .nonPrivacyBundles, in: dir)
+    let bundles = try fileManager.recursivelySearch(for: .bundles, in: dir)
 
     // Stop searching if there were any bundles found.
     if !bundles.isEmpty { return true }
@@ -168,7 +168,7 @@ extension ResourcesManager {
                              to resourceDir: URL,
                              keepOriginal: Bool = false) throws -> [URL] {
     let fileManager = FileManager.default
-    let allBundles = try fileManager.recursivelySearch(for: .nonPrivacyBundles, in: dir)
+    let allBundles = try fileManager.recursivelySearch(for: .bundles, in: dir)
 
     // If no bundles are found, return an empty array since nothing was done (but there wasn't an
     // error).

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -244,12 +244,11 @@ struct ZipBuilder {
             carthageGoogleUtilitiesFrameworks += cdFrameworks
           }
           let fileManager = FileManager.default
-          if let resourceContents {
-            let path = resourceContents.absoluteString
-            if let contents = try? fileManager.contentsOfDirectory(atPath: path),
-               !contents.isEmpty {
-              resources[podName] = resourceContents
-            }
+          if let resourceContents,
+             let contents = try? fileManager.contentsOfDirectory(at: resourceContents,
+                                                                 includingPropertiesForKeys: nil),
+             !contents.isEmpty {
+            resources[podName] = resourceContents
           }
         } else if podsBuilt[podName] == nil {
           // Binary pods need to be collected once, since the platforms should already be merged.

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -243,8 +243,12 @@ struct ZipBuilder {
                                                                          podInfo: podInfo)
             carthageGoogleUtilitiesFrameworks += cdFrameworks
           }
-          if resourceContents != nil {
-            resources[podName] = resourceContents
+          let fileManager = FileManager.default
+          if let resourceContents {
+            let path = resourceContents.absoluteString
+            if try! !fileManager.contentsOfDirectory(atPath: path).isEmpty {
+              resources[podName] = resourceContents
+            }
           }
         } else if podsBuilt[podName] == nil {
           // Binary pods need to be collected once, since the platforms should already be merged.

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -246,7 +246,8 @@ struct ZipBuilder {
           let fileManager = FileManager.default
           if let resourceContents {
             let path = resourceContents.absoluteString
-            if try! !fileManager.contentsOfDirectory(atPath: path).isEmpty {
+            if let contents = try? fileManager.contentsOfDirectory(atPath: path),
+               !contents.isEmpty {
               resources[podName] = resourceContents
             }
           }


### PR DESCRIPTION
fix #12422

It turns out that Resources in macOS and catalyst are generated by xcodebuild in Privacy Manifest bundles. When xcodebuild creates a fat framework including Catalyst, the Resource structure is maintained.

This PR fixes the directory enumeration so that Privacy manifest bundles are always treated as atomic entities. Reference https://developer.apple.com/documentation/foundation/filemanager/2765464-enumerator

After more investigation, this PR only fixes the documentation. Everything else should be ready for further testing of privacy manifests.

#no-changelog