### PR TITLE
Fix FirebaseSessions release mode crash

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 10.22.0
 - [changed] Removed calls to statfs in the Crashlytics SDK to comply with Apple Privacy Manifests. This change removes support for collecting Disk Space Free in Crashlytics reports.
+- [fixed] Fixed FirebaseSessions crash on startup that occurs in release mode in Xcode 15.3 and other build configurations. (#11403)
 
 # 10.16.0
 - [fixed] Fixed a memory leak regression when generating session events (#11725).

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -150,18 +150,7 @@ class SessionStartEvent: NSObject, GDTCOREventDataObject {
   // MARK: - GDTCOREventDataObject
 
   func transportBytes() -> Data {
-    var fields = firebase_appquality_sessions_SessionEvent_fields
-    var error: NSError?
-    let data = FIRSESEncodeProto(&fields.0, &proto, &error)
-    if error != nil {
-      Logger
-        .logError("Session Event failed to encode as proto with error: \(error.debugDescription)")
-    }
-    guard let data = data else {
-      Logger.logError("Session Event generated nil transportBytes. Returning empty data.")
-      return Data()
-    }
-    return data
+    return FIRSESTransportBytes(&proto)
   }
 
   // MARK: - Data Conversion

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.h
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.h
@@ -91,6 +91,9 @@ pb_size_t FIRSESGetAppleApplicationInfoTag(void);
 /// private method in GULAppEnvironmentUtil.
 NSString* _Nullable FIRSESGetSysctlEntry(const char* sysctlKey);
 
+/// C function to bridge from Swift to do nanopb bytes transfer.
+NSData* FIRSESTransportBytes(const void* _Nonnull proto);
+
 NS_ASSUME_NONNULL_END
 
 #endif /* FIRSESNanoPBHelpers_h */

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
@@ -21,7 +21,7 @@
 
 #import "FirebaseSessions/SourcesObjC/Protogen/nanopb/sessions.nanopb.h"
 
-#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+@import FirebaseCoreExtension;
 
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
@@ -185,12 +185,14 @@ NSString *_Nullable FIRSESGetSysctlEntry(const char *sysctlKey) {
 }
 
 NSData *FIRSESTransportBytes(const void *_Nonnull proto) {
-  pb_field_t *const fields = firebase_appquality_sessions_SessionEvent_fields;
+  const pb_field_t *fields = firebase_appquality_sessions_SessionEvent_fields;
   NSError *error;
   NSData *data = FIRSESEncodeProto(fields, proto, &error);
   if (error != nil) {
-    FIRLogError(@"FirebaseSessions", @"I-SES000001",
-                @"Session Event failed to encode as proto with error: ", error.debugDescription);
+    FIRLogError(
+        @"FirebaseSessions", @"I-SES000001", @"%@",
+        [NSString stringWithFormat:@"Session Event failed to encode as proto with error: %@",
+                                   error.debugDescription]);
   }
   if (data == nil) {
     data = [NSData data];

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
@@ -21,6 +21,8 @@
 
 #import "FirebaseSessions/SourcesObjC/Protogen/nanopb/sessions.nanopb.h"
 
+#import "FirebaseCore/Extension/FirebaseCoreInternal.h"
+
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
@@ -180,6 +182,24 @@ NSString *_Nullable FIRSESGetSysctlEntry(const char *sysctlKey) {
   } else {
     return nil;
   }
+}
+
+NSData *FIRSESTransportBytes(const void *_Nonnull proto) {
+  pb_field_t *const fields = firebase_appquality_sessions_SessionEvent_fields;
+  NSError *error;
+  NSData *data = FIRSESEncodeProto(fields, proto, &error);
+  if (error != nil) {
+    NSString *errString =
+        [NSString stringWithFormat:@"Session Event failed to encode as proto with error: %@",
+                                   error.debugDescription];
+    FIRLogError(@"FirebaseSessions", @"I-SES000001", error.debugDescription);
+  }
+  if (data == nil) {
+    data = [NSData data];
+    FIRLogError(@"FirebaseSessions", @"I-SES000002",
+                @"Session Event generated nil transportBytes. Returning empty data.");
+  }
+  return data;
 }
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
+++ b/FirebaseSessions/SourcesObjC/NanoPB/FIRSESNanoPBHelpers.m
@@ -189,10 +189,8 @@ NSData *FIRSESTransportBytes(const void *_Nonnull proto) {
   NSError *error;
   NSData *data = FIRSESEncodeProto(fields, proto, &error);
   if (error != nil) {
-    NSString *errString =
-        [NSString stringWithFormat:@"Session Event failed to encode as proto with error: %@",
-                                   error.debugDescription];
-    FIRLogError(@"FirebaseSessions", @"I-SES000001", error.debugDescription);
+    FIRLogError(@"FirebaseSessions", @"I-SES000001",
+                @"Session Event failed to encode as proto with error: ", error.debugDescription);
   }
   if (data == nil) {
     data = [NSData data];

--- a/Package.swift
+++ b/Package.swift
@@ -1076,6 +1076,8 @@ let package = Package(
     .target(
       name: "FirebaseSessionsObjC",
       dependencies: [
+        "FirebaseCore",
+        "FirebaseCoreExtension",
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "nanopb", package: "nanopb"),
       ],


### PR DESCRIPTION
It's not clear to me how to reliably pass arrays of structures from Swift to C, so I changed the boundary so that only a pointer to a struct needs to be passed across the language barrier.

See an example of passing arrays at https://github.com/firebase/firebase-ios-sdk/issues/11403#issuecomment-1963020799. When passing to the Swift inout parameter, only the zeroth element of the array gets copied.

Fix #11403