### PR TITLE
Add Fireperf dependency to feature rollouts test app

### DIFF
--- a/FirebaseRemoteConfig/Tests/FeatureRolloutsTestApp/Podfile
+++ b/FirebaseRemoteConfig/Tests/FeatureRolloutsTestApp/Podfile
@@ -7,6 +7,7 @@ def shared_pods
   pod 'FirebaseCoreInternal', :path => '../../../'
   pod 'FirebaseCoreExtension', :path => '../../../'
   pod 'FirebaseRemoteConfigInterop', :path => '../../../'
+  pod 'FirebasePerformance', :path => '../../../'
 end
 
 target 'FeatureRolloutsTestApp_iOS' do


### PR DESCRIPTION
Add Fireperf dependency to feature rollouts test app

Note: this change will merge to our feature branch not master
#no-changelog
