### PR TITLE
[Release Tooling] Rename gRPC-C++ framework to grpcpp

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -283,6 +283,8 @@ struct FrameworkBuilder {
   /// - Returns: The corresponding framework/module name.
   private static func frameworkBuildName(_ framework: String) -> String {
     switch framework {
+    case "gRPC-C++":
+      return "grpcpp"
     case "PromisesObjC":
       return "FBLPromises"
     case "Protobuf":

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -51,7 +51,7 @@ struct ModuleMapBuilder {
         content += """
           link framework "BoringSSL-GRPC"
           link framework "gRPC-Core"
-          link framework "gRPC-C++"
+          link framework "grpcpp"
         """
       }
 


### PR DESCRIPTION
Updated the gRPC-C++ framework name to `grpcpp` to match the module name: https://github.com/grpc/grpc/blob/0d69f8dc7492507ed4280a55f97a06cc35a813d2/gRPC-C%2B%2B.podspec#L44-L47

#no-changelog