### PR TITLE
[Release Tooling] Validation workaround for Xcode 15.3b3

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -671,6 +671,8 @@ struct FrameworkBuilder {
         fatalError("Could not copy fat binary to framework directory for \(framework): \(error)")
       }
       do {
+        // The minimum OS version is set to 100.0 to work around b/327020913.
+        // TODO(ncooke3): Revert this logic once b/327020913 is fixed.
         var plistDictionary = try PropertyListSerialization.propertyList(
           from: Data(contentsOf: infoPlist), format: nil
         ) as! [AnyHashable: Any]

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -679,7 +679,8 @@ struct FrameworkBuilder {
         let updatedPlistData = try PropertyListSerialization.data(
           fromPropertyList: plistDictionary,
           format: .binary,
-          options: 0)
+          options: 0
+        )
 
         try updatedPlistData.write(to: infoPlistDestination)
       } catch {

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -671,7 +671,17 @@ struct FrameworkBuilder {
         fatalError("Could not copy fat binary to framework directory for \(framework): \(error)")
       }
       do {
-        try fileManager.copyItem(at: infoPlist, to: infoPlistDestination)
+        var plistDictionary = try PropertyListSerialization.propertyList(
+          from: Data(contentsOf: infoPlist), format: nil
+        ) as! [AnyHashable: Any]
+        plistDictionary["MinimumOSVersion"] = "100.0"
+
+        let updatedPlistData = try PropertyListSerialization.data(
+          fromPropertyList: plistDictionary,
+          format: .binary,
+          options: 0)
+
+        try updatedPlistData.write(to: infoPlistDestination)
       } catch {
         // The Catalyst and macos Info.plist's are in another location. Ignore failure.
       }


### PR DESCRIPTION
context in b/327020913

Validated locally by building one xcframework. It's possible this could blow up when building all of the xcframeworks, but hopefully not.