### PR TITLE
[Release Tooling] Rename frameworks to match modules

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -283,8 +283,16 @@ struct FrameworkBuilder {
   /// - Returns: The corresponding framework/module name.
   private static func frameworkBuildName(_ framework: String) -> String {
     switch framework {
+    case "abseil":
+      return "absl"
+    case "BoringSSL-gRPC":
+      return "openssl_grpc"
+    case "gRPC-Core":
+      return "grpc"
     case "gRPC-C++":
       return "grpcpp"
+    case "leveldb-library":
+      return "leveldb"
     case "PromisesObjC":
       return "FBLPromises"
     case "PromisesSwift":

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -285,7 +285,7 @@ struct FrameworkBuilder {
     switch framework {
     case "abseil":
       return "absl"
-    case "BoringSSL-gRPC":
+    case "BoringSSL-GRPC":
       return "openssl_grpc"
     case "gRPC-Core":
       return "grpc"

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -287,6 +287,8 @@ struct FrameworkBuilder {
       return "grpcpp"
     case "PromisesObjC":
       return "FBLPromises"
+    case "PromisesSwift":
+      return "Promises"
     case "Protobuf":
       return "protobuf"
     default:

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -49,8 +49,8 @@ struct ModuleMapBuilder {
 
       if module == "FirebaseFirestoreInternal" {
         content += """
-          link framework "BoringSSL-GRPC"
-          link framework "gRPC-Core"
+          link framework "openssl_grpc"
+          link framework "grpc"
           link framework "grpcpp"
         """
       }


### PR DESCRIPTION
Renamed several frameworks to match their module names (`CFBundleExecutable` name in their `Info.plist` files):
  - `abseil` --> `absl`: https://github.com/CocoaPods/Specs/blob/c51b98a526569c195efaa40f8b15c0c80ea05297/Specs/3/8/6/abseil/1.20240116.1/abseil.podspec.json#L17
  - `BoringSSL-GRPC` --> `openssl_grpc`: https://github.com/grpc/grpc/blob/00c01f395c01204fbd767abe7143bd1a49e82a20/src/objective-c/BoringSSL-GRPC.podspec#L87-L92
  - `gRPC-Core` --> `grpc`: https://github.com/grpc/grpc/blob/00c01f395c01204fbd767abe7143bd1a49e82a20/gRPC-Core.podspec#L48-L54
  - `leveldb-library` --> `leveldb`
  - `PromisesSwift` --> `Promises`: https://github.com/google/promises/blob/540318ecedd63d883069ae7f1ed811a2df00b6ac/PromisesSwift.podspec#L26

#no-changelog
