### PR TITLE
[Release Tooling] Prefer xml Info.plist

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -283,8 +283,16 @@ struct FrameworkBuilder {
   /// - Returns: The corresponding framework/module name.
   private static func frameworkBuildName(_ framework: String) -> String {
     switch framework {
+    case "abseil":
+      return "absl"
+    case "BoringSSL-gRPC":
+      return "openssl_grpc"
+    case "gRPC-Core":
+      return "grpc"
     case "gRPC-C++":
       return "grpcpp"
+    case "leveldb-library":
+      return "leveldb"
     case "PromisesObjC":
       return "FBLPromises"
     case "PromisesSwift":

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -692,7 +692,7 @@ struct FrameworkBuilder {
 
         let updatedPlistData = try PropertyListSerialization.data(
           fromPropertyList: plistDictionary,
-          format: .binary,
+          format: .xml,
           options: 0
         )
 

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -287,6 +287,8 @@ struct FrameworkBuilder {
       return "grpcpp"
     case "PromisesObjC":
       return "FBLPromises"
+    case "PromisesSwift":
+      return "Promises"
     case "Protobuf":
       return "protobuf"
     default:


### PR DESCRIPTION
I think binary plists are more performant, but I don't think xml plists will significantly worse since they are so small. I think making the switch is worth it so zip are easier to diff.

See https://github.com/firebase/firebase-ios-sdk/pull/12439#discussion_r1506141724