### PR TITLE
Add CHANGELOG entry for renamed frameworks

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -15,15 +15,15 @@
   `Firebase.zip` have been updated for Xcode 15 users. The updated instructions
   call for embedding SDKs dragged in from the `Firebase.zip`. This will enable
   Xcode's tooling to detect privacy manifests bundled within the xcframework.
-- [Zip Distribution] Several frameworks have been renamed to resolve the above
+- [Zip Distribution] Several xcframeworks have been renamed to resolve the above
   Xcode 15.3 validation issues. Please ensure that the following renamed
-  frameworks are removed from your project when upgrading (#12437, #12447):
-    - `abseil.xcframework` to `absl.framework`
-    - `BoringSSL-gRPC.framework` to `openssl_grpc`
-    - `gRPC-Core.framework` to `grpc.framework`
+  xcframeworks are removed from your project when upgrading (#12437, #12447):
+    - `abseil.xcframework` to `absl.xcframework`
+    - `BoringSSL-gRPC.xcframework` to `openssl_grpc.xcframework`
+    - `gRPC-Core.xcframework` to `grpc.xcframework`
     - `gRPC-C++.xcframework` to `grpcc.xcframework`
-    - `leveldb-library.framework` to `leveldb.framework`
-    - `PromisesSwift.framework` to `Promises.framework`
+    - `leveldb-library.xcframework` to `leveldb.xcframework`
+    - `PromisesSwift.xcframework` to `Promises.xcframework`
 
 # Firebase 10.21.0
 - Firebase now requires at least CocoaPods version 1.12.0 to enable privacy

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -15,7 +15,15 @@
   `Firebase.zip` have been updated for Xcode 15 users. The updated instructions
   call for embedding SDKs dragged in from the `Firebase.zip`. This will enable
   Xcode's tooling to detect privacy manifests bundled within the xcframework.
-
+- [Zip Distribution] Several frameworks have been renamed to resolve the above
+  Xcode 15.3 validation issues. Please ensure that the following renamed
+  frameworks are removed from your project when upgrading (#12437, #12447):
+    - `abseil.xcframework` to `absl.framework`
+    - `BoringSSL-gRPC.framework` to `openssl_grpc`
+    - `gRPC-Core.framework` to `grpc.framework`
+    - `gRPC-C++.xcframework` to `grpcc.xcframework`
+    - `leveldb-library.framework` to `leveldb.framework`
+    - `PromisesSwift.framework` to `Promises.framework`
 
 # Firebase 10.21.0
 - Firebase now requires at least CocoaPods version 1.12.0 to enable privacy

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,9 +1,5 @@
 # 10.22.0
 - [fixed] Fix the flaky offline behaviour when using `arrayRemove` on `Map` object. (#12378)
-- [Zip Distribution] Renamed `gRPC-C++.xcframework` to `grpcc.xcframework`,
-  matching the module name, to work around an issue introduced in Xcode 15.3
-  with `+` characters in framework names. (#12437)
-    - Please ensure that `gRPC-C++.xcframework` is removed when upgrading.
 
 # 10.21.0
 - Add an error when trying to build Firestore's binary SPM distribution for


### PR DESCRIPTION
Added a CHANGELOG entry that covers the framework renames in #12437 and #12447. Removed the entry from `Firestore/CHANGELOG.md` since it is now covered by this one.