### PR TITLE
[Release Tooling] Recommend -lc++ linker flag for manual integration

### DIFF
--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -54,13 +54,22 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-ObjC`
 
-10. Drag the `Firebase.h` header in this directory into your project. This will
+10. If using Add the `-lc++` flag to **Other Linker Settings**:
+
+   a. In your project settings, open the **Settings** panel for your target.
+
+   b. Go to the Build Settings tab and find the **Other Linker Flags** setting
+     in the **Linking** section.
+
+   c. Double-click the setting, click the '+' button, and add `-lc++`
+
+11. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-11. Drag `module.modulemap` into your project and update the
+12. Drag `module.modulemap` into your project and update the
    "User Header Search Paths" in your project's Build Settings to include the
    directory that contains the added module map.
-12. If your app does not include any Swift implementation, you may need to add
+13. If your app does not include any Swift implementation, you may need to add
    a dummy Swift file to the app to prevent Swift system library missing
    symbol linker errors. See
    https://forums.swift.org/t/using-binary-swift-sdks-from-non-swift-apps/55989.
@@ -68,7 +77,7 @@ To integrate a Firebase SDK with your app:
    > ⚠ If prompted with the option to create a corresponding bridging header
    > for the new Swift file, select **Don't create**.
 
-13. You're done! Build your target and start using Firebase.
+14. You're done! Build your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the xcframeworks for
 the new SDK. You only need to add each framework once, so if you've already

--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -54,7 +54,7 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-ObjC`
 
-10. If using Add the `-lc++` flag to **Other Linker Settings**:
+10. Add the `-lc++` flag to **Other Linker Settings**:
 
    a. In your project settings, open the **Settings** panel for your target.
 


### PR DESCRIPTION
I haven't fully investigated what is going on here. But when integrating `FirebaseCrashlytics.xcframework`, I see:


<img width="844" alt="Screenshot 2024-02-28 at 6 25 11 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/36927374/834bae1e-3544-4995-85e4-6db1673a2f2d">

Adding `-lc++` fixes the errors. 

Two observations:
1. The errors only appear after adding the `-ObjC` flag.
2. Crashlytics's `module.modulemap` includes  `link "c++"` and so does Analytics's. But, weirdly, this error does not surface when just depending on Analytics.

Steps to reproduce:
1. In Xcode 15, create app.
2. Drag in necessary xcframeworks for Crashlytics
3. Notice the build succeeds
4. Add -ObjC linker flag 
5. Notice build fails
6. Add -lc++ linker flag 
7. Notice build succeeds