### PR TITLE
[Release] Carthage updates for 10.22.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseABTesting-3c0e5c9ddc52bccd.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseABTesting-8dad3d6af34cb26c.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseABTesting-0ad6c6c2f729706c.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseABTesting-2823ac22562f1fbe.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseABTesting-e87c686cee02758a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseABTesting-6a65ab8b888172af.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseABTesting-197f0cb4125363b6.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/Google-Mobile-Ads-SDK-c8bc252ed3323212.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/Google-Mobile-Ads-SDK-5f8bb98bb2467b85.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/Google-Mobile-Ads-SDK-23be5a73a2ce3dcc.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/Google-Mobile-Ads-SDK-bf8077d30296e04a.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/Google-Mobile-Ads-SDK-8b0d1ce3d1162b67.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/Google-Mobile-Ads-SDK-046511c3fd0189eb.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/Google-Mobile-Ads-SDK-50008c143ad8f268.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAnalytics-6f8b70c8ee2efc85.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseAnalytics-4d7ca295e8b44c0c.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseAnalytics-620570dc24ce7d7b.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAnalytics-a121058bc5824bfa.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalytics-95669fcf109f74a2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalytics-c0db6cb0e858e397.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalytics-e8ebe991b5743f71.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAnalyticsOnDeviceConversion-37cf6277991d7d75.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseAnalyticsOnDeviceConversion-d3913995b7344202.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseAnalyticsOnDeviceConversion-202ed30074984af7.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAnalyticsOnDeviceConversion-4b5874979659af63.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalyticsOnDeviceConversion-091f5252d693a9f9.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalyticsOnDeviceConversion-7bbb73d46383a042.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalyticsOnDeviceConversion-eca2f83d40e0278d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAppCheck-b0ead84a126d24d4.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseAppCheck-8f7dfe411eeaccdf.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseAppCheck-a458ebf606a7b451.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAppCheck-2b52807979acf863.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppCheck-d19e46a728b1ac4f.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppCheck-8339fde989fe8f24.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppCheck-3ce0f074bfcd2596.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAppDistribution-45b5c85bba08a85b.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseAppDistribution-264a5e036b72a526.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseAppDistribution-e08ef26e391c7b0b.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAppDistribution-139211bb5dd3dbc3.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppDistribution-cefc3327ddfceda6.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppDistribution-7931e42d39575534.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppDistribution-79dc2b1348d9aee9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseAuth-2165e27f89d4959e.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseAuth-222a2417c3c21b41.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseAuth-da6796caf834f09f.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAuth-529e82147fbbd402.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAuth-e43e66353617f093.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAuth-8a9591e6daa7e207.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAuth-7e18a510d0a5b02e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseCrashlytics-054718c61ef054f9.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseCrashlytics-029c76d79754388c.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseCrashlytics-0f5ccfdbf0de85f7.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseCrashlytics-47c05619edb8ae9b.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseCrashlytics-d29d3285a7d9fa1d.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseCrashlytics-165beb64483b4278.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseCrashlytics-53604573442e756b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseDatabase-8b7048f7890bb665.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseDatabase-a7f5c6d032473b01.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseDatabase-a05cb524bec955b2.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseDatabase-f5156c8169b6358f.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDatabase-5b22f689cb66d83a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDatabase-e1a9d1f0c4222cf7.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDatabase-aea9249d81841ee1.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseDynamicLinks-bfdce6ac5d591ab3.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseDynamicLinks-693c6213bc87f8c0.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseDynamicLinks-ad0ac7b8fdf4c1b5.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseDynamicLinks-c17c59949b7cc573.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDynamicLinks-7cf4ae5e96882ca8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDynamicLinks-c3bdeb37651a5d5d.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDynamicLinks-bcb5df6ec32f6684.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseFirestore-4c3d1568e379a98c.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseFirestore-88b0aaac6fe277fe.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseFirestore-dcf15ce0975bfa3c.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseFirestore-e4570e4863fe2044.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFirestore-73ba0700b1aa6d6a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFirestore-02eb8da05f81fca5.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFirestore-46fa68ddf287f76e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseFunctions-b949cfeca4e7a80f.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseFunctions-23d6ba97d95db62c.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseFunctions-b77aca8c98dba58d.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseFunctions-d98d21836c2f2130.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFunctions-47189f2c99cdf806.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFunctions-17c4b760141e38ad.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFunctions-688a38b567392fcf.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/GoogleSignIn-c887dbc6bd07c787.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/GoogleSignIn-e55954e1a3ca9ee8.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/GoogleSignIn-82fc8f5e20a9345b.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/GoogleSignIn-a16b78c06ef8f77c.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/GoogleSignIn-a5b49807be66100b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/GoogleSignIn-0d2e746eb3ff9f92.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/GoogleSignIn-5cb2a2f1f74efd5e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseInAppMessaging-f29d7b7839cda915.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseInAppMessaging-c6a82f2dccc9a092.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseInAppMessaging-940786963f9ac384.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseInAppMessaging-fbb53083384bea1e.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseInAppMessaging-91e5426eade46bca.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseInAppMessaging-10801bd111df59de.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseInAppMessaging-91d4dd9878a06b7e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseMLModelDownloader-ee2af587027e74d3.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseMLModelDownloader-e45969e88bf879cd.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseMLModelDownloader-d779b84cfdf214f3.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseMLModelDownloader-b3bffe302a074d0e.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMLModelDownloader-559cb113c0cfd8f2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMLModelDownloader-9c909894999c92e4.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMLModelDownloader-9abf9b0e24bfb921.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseMessaging-289a04c85f7e771d.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseMessaging-236bb6f578c05ed1.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseMessaging-4a481ad8d3446844.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseMessaging-812bc4f1c2d27e93.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMessaging-59ef1cc63c660712.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMessaging-76c02a69e3fe1008.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMessaging-439a17dcc8b8172b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebasePerformance-7a7398acc615dbb6.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebasePerformance-6494eb8091be4e03.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebasePerformance-4b6c574e0645b449.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebasePerformance-2a39f03d02fcbc5f.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebasePerformance-36ac6dfb99caa11b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebasePerformance-f9f5be8ffad5cbb0.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebasePerformance-0ffe559f7554d8a5.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseRemoteConfig-45a7f541a654884c.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseRemoteConfig-44d640335ebdfea7.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseRemoteConfig-933eae5291c343cc.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseRemoteConfig-be4764f1b3e07c4f.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseRemoteConfig-edd1b427b8bbe782.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseRemoteConfig-10b62ee5663aaab3.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseRemoteConfig-2237eb5fcd4a4525.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -14,6 +14,7 @@
   "10.2.0": "https://dl.google.com/dl/firebase/ios/carthage/10.2.0/FirebaseStorage-347e6a3402706596.zip",
   "10.20.0": "https://dl.google.com/dl/firebase/ios/carthage/10.20.0/FirebaseStorage-fac47c17aae220e0.zip",
   "10.21.0": "https://dl.google.com/dl/firebase/ios/carthage/10.21.0/FirebaseStorage-6f3adc4f2b871f04.zip",
+  "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseStorage-e3b2849afc9f0f95.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseStorage-ac463d14593d10a8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseStorage-fdf8479115660ce6.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseStorage-04f255ea8c3a7420.zip",


### PR DESCRIPTION
Updated the Carthage artifacts for the 10.22.0 release. Verified with `carthage update`.

<details>
<summary>Cartfile.resolved</summary>

```
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppDistributionBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDynamicLinksBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLModelDownloaderBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" "10.22.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json" "10.22.0"
```

</details>

#no-changelog