### PR TITLE
Upgrade `clang-format` to v18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@17
+    brew install clang-format@18
     brew install mint
     ```
 

--- a/FirebaseDatabase/Tests/Integration/FData.m
+++ b/FirebaseDatabase/Tests/Integration/FData.m
@@ -314,9 +314,10 @@ This test flakes frequently on the emulator on travis and almost always on GHA w
           ios - sdk / firebase - ios -
           sdk / Example / Database / Tests / Helpers /
               FEventTester
-                  .m : 123 because it was raised inside test case -[FEventTester(null)] which has no
-                      associated XCTestRun object.This may happen when test cases are
-                          constructed and invoked independently of standard XCTest infrastructure,
+                  .m : 123 because it was raised inside test case -
+              [FEventTester(
+                  null)] which has no associated XCTestRun object.This may happen when test cases
+                  are constructed and invoked independently of standard XCTest infrastructure,
       or when the test has already finished
                       ." - Expected http://localhost:9000/-M8IJYWb68MuqQKKz2IY/a aa (0) to match "
                        "http://localhost:9000/-M8IJYWb68MuqQKKz2IY/a (null) (4)' from "

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
@@ -4192,9 +4192,7 @@
 
   [ref getDataWithCompletionBlock:^(NSError* err, FIRDataSnapshot* snapshot) {
     XCTAssertNil(err);
-    XCTAssertEqualObjects(
-        [snapshot value],
-        @{@"a" : @1});
+    XCTAssertEqualObjects([snapshot value], @{@"a" : @1});
     done = YES;
   }];
 }

--- a/FirebaseDatabase/Tests/Integration/FOrderByTests.m
+++ b/FirebaseDatabase/Tests/Integration/FOrderByTests.m
@@ -235,9 +235,7 @@
         moved = YES;
         XCTAssertEqualObjects(snapshot.key, @"greg", @"");
         XCTAssertEqualObjects(prevName, @"rob", @"");
-        XCTAssertEqualObjects(
-            snapshot.value,
-            @{@"nuggets" : @57}, @"");
+        XCTAssertEqualObjects(snapshot.value, @{@"nuggets" : @57}, @"");
       }];
 
   [ref setValue:initial];

--- a/Firestore/core/src/immutable/keys_view.h
+++ b/Firestore/core/src/immutable/keys_view.h
@@ -47,8 +47,8 @@ auto KeysView(const Range& range) -> KeysRange<decltype(std::begin(range))> {
 }
 
 template <typename Range, typename K>
-auto KeysViewFrom(const Range& range, const K& key)
-    -> KeysRange<decltype(range.lower_bound(key))> {
+auto KeysViewFrom(const Range& range,
+                  const K& key) -> KeysRange<decltype(range.lower_bound(key))> {
   auto keys_begin = util::make_iterator_first(range.lower_bound(key));
   auto keys_end = util::make_iterator_first(std::end(range));
   return util::make_range(keys_begin, keys_end);

--- a/Firestore/core/src/util/hashing.h
+++ b/Firestore/core/src/util/hashing.h
@@ -190,8 +190,8 @@ auto RankedInvokeHash(const Range& range, HashChoice<3>)
  * value can itself be hashed.
  */
 template <typename K>
-auto RankedInvokeHash(const absl::optional<K>& option, HashChoice<4>)
-    -> decltype(InvokeHash(*option)) {
+auto RankedInvokeHash(const absl::optional<K>& option,
+                      HashChoice<4>) -> decltype(InvokeHash(*option)) {
   return option ? InvokeHash(*option) : -1171;
 }
 
@@ -202,8 +202,8 @@ size_t RankedInvokeHash(K value, HashChoice<5>) {
 }
 
 template <typename K>
-auto RankedInvokeHash(const std::unique_ptr<K>& ptr, HashChoice<6>)
-    -> decltype(InvokeHash(*ptr)) {
+auto RankedInvokeHash(const std::unique_ptr<K>& ptr,
+                      HashChoice<6>) -> decltype(InvokeHash(*ptr)) {
   return ptr ? InvokeHash(*ptr) : 23631;
 }
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GitHub Actions will verify that any code changes are done in a style-compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@17
+brew install clang-format@18
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@17
+brew install clang-format@18
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -56,7 +56,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  17)
+  18)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -65,7 +65,7 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 17."
+    echo "Please upgrade to clang-format version 18."
     echo "If it's installed via homebrew you can run:"
     echo "brew upgrade clang-format"
     exit 1


### PR DESCRIPTION
`clang-format@17` is no longer available in Homebrew, upgraded to v18.

#no-changelog