### PR TITLE
Patch abseil-cpp to ignore deprecated errors in new Xcode.

### DIFF
--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -31,4 +31,5 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   TEST_COMMAND ""
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
+  PATCH_COMMAND patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/abseil-cpp.patch.txt
 )

--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -33,6 +33,5 @@ ExternalProject_Add(
   TEST_COMMAND ""
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
 
-  # Remove this patch command when gRPC is updated to 20230802.0 or later.
   PATCH_COMMAND patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/abseil-cpp.patch.txt
 )

--- a/cmake/external/abseil-cpp.cmake
+++ b/cmake/external/abseil-cpp.cmake
@@ -14,6 +14,7 @@
 
 include(ExternalProject)
 
+# Note: When updating to 20230802.0 or later, remove the PATCH_COMMAND below.
 set(version 20220623.0)
 
 ExternalProject_Add(
@@ -31,5 +32,7 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   TEST_COMMAND ""
   HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
+
+  # Remove this patch command when gRPC is updated to 20230802.0 or later.
   PATCH_COMMAND patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/abseil-cpp.patch.txt
 )

--- a/cmake/external/abseil-cpp.patch.txt
+++ b/cmake/external/abseil-cpp.patch.txt
@@ -1,22 +1,27 @@
 diff --git a/absl/meta/type_traits.h b/absl/meta/type_traits.h
-index d886cb30..9716c7b9 100644
+index d886cb30..de0ebda2 100644
 --- a/absl/meta/type_traits.h
 +++ b/absl/meta/type_traits.h
-@@ -35,6 +35,10 @@
+@@ -35,6 +35,12 @@
  #ifndef ABSL_META_TYPE_TRAITS_H_
  #define ABSL_META_TYPE_TRAITS_H_
  
 +// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
++#if __APPLE__
 +#pragma clang diagnostic push
 +#pragma clang diagnostic ignored "-Wdeprecated"
++#endif  // __APPLE__
 +
  #include <cstddef>
  #include <functional>
  #include <type_traits>
-@@ -794,4 +798,6 @@ using swap_internal::StdSwapIsUnconstrained;
+@@ -794,4 +800,9 @@ using swap_internal::StdSwapIsUnconstrained;
  ABSL_NAMESPACE_END
  }  // namespace absl
  
++// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
++#if __APPLE__
 +#pragma clang diagnostic pop
++#endif  // __APPLE__
 +
  #endif  // ABSL_META_TYPE_TRAITS_H_

--- a/cmake/external/abseil-cpp.patch.txt
+++ b/cmake/external/abseil-cpp.patch.txt
@@ -1,5 +1,5 @@
 diff --git a/absl/meta/type_traits.h b/absl/meta/type_traits.h
-index d886cb30..de0ebda2 100644
+index d886cb30..84c01e19 100644
 --- a/absl/meta/type_traits.h
 +++ b/absl/meta/type_traits.h
 @@ -35,6 +35,12 @@
@@ -7,10 +7,10 @@ index d886cb30..de0ebda2 100644
  #define ABSL_META_TYPE_TRAITS_H_
  
 +// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
-+#if __APPLE__
++#if __clang__
 +#pragma clang diagnostic push
 +#pragma clang diagnostic ignored "-Wdeprecated"
-+#endif  // __APPLE__
++#endif  // __clang__
 +
  #include <cstddef>
  #include <functional>
@@ -20,8 +20,8 @@ index d886cb30..de0ebda2 100644
  }  // namespace absl
  
 +// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
-+#if __APPLE__
++#if __clang__
 +#pragma clang diagnostic pop
-+#endif  // __APPLE__
++#endif  // __clang__
 +
  #endif  // ABSL_META_TYPE_TRAITS_H_

--- a/cmake/external/abseil-cpp.patch.txt
+++ b/cmake/external/abseil-cpp.patch.txt
@@ -1,0 +1,22 @@
+diff --git a/absl/meta/type_traits.h b/absl/meta/type_traits.h
+index d886cb30..9716c7b9 100644
+--- a/absl/meta/type_traits.h
++++ b/absl/meta/type_traits.h
+@@ -35,6 +35,10 @@
+ #ifndef ABSL_META_TYPE_TRAITS_H_
+ #define ABSL_META_TYPE_TRAITS_H_
+ 
++// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wdeprecated"
++
+ #include <cstddef>
+ #include <functional>
+ #include <type_traits>
+@@ -794,4 +798,6 @@ using swap_internal::StdSwapIsUnconstrained;
+ ABSL_NAMESPACE_END
+ }  // namespace absl
+ 
++#pragma clang diagnostic pop
++
+ #endif  // ABSL_META_TYPE_TRAITS_H_

--- a/cmake/external/abseil-cpp.patch.txt
+++ b/cmake/external/abseil-cpp.patch.txt
@@ -1,12 +1,12 @@
 diff --git a/absl/meta/type_traits.h b/absl/meta/type_traits.h
-index d886cb30..84c01e19 100644
+index d886cb30..c2a2d15e 100644
 --- a/absl/meta/type_traits.h
 +++ b/absl/meta/type_traits.h
 @@ -35,6 +35,12 @@
  #ifndef ABSL_META_TYPE_TRAITS_H_
  #define ABSL_META_TYPE_TRAITS_H_
  
-+// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
++// Added by firebase-ios-sdk/cmake/external/abseil-cpp.patch.txt
 +#if __clang__
 +#pragma clang diagnostic push
 +#pragma clang diagnostic ignored "-Wdeprecated"
@@ -19,7 +19,7 @@ index d886cb30..84c01e19 100644
  ABSL_NAMESPACE_END
  }  // namespace absl
  
-+// Added by firestore-ios-sdk/cmake/external/abseil-cpp.patch.txt.
++// Added by firebase-ios-sdk/cmake/external/abseil-cpp.patch.txt
 +#if __clang__
 +#pragma clang diagnostic pop
 +#endif  // __clang__


### PR DESCRIPTION
The current version of abseil-cpp (used by grpc) uses some deprecated builtins, which cause warnings that make the build fail on Xcode 15 (due to warnings-as-errors).

Until grpc is updated, this PR will work around the issue by adding a patch to abseil-cpp to turn off that warning for that file.