### PR TITLE
[Rollouts] Revert constants change in remote config public api test

### DIFF
--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -30,6 +30,7 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Sources/RCNDevice.h"
 #import "FirebaseRemoteConfig/Sources/RCNPersonalization.h"
+@import FirebaseRemoteConfigInterop;
 
 /// Remote Config Error Domain.
 /// TODO: Rename according to obj-c style for constants.

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -30,7 +30,6 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Sources/RCNDevice.h"
 #import "FirebaseRemoteConfig/Sources/RCNPersonalization.h"
-@import FirebaseRemoteConfigInterop;
 
 /// Remote Config Error Domain.
 /// TODO: Rename according to obj-c style for constants.

--- a/FirebaseRemoteConfig/Sources/RCNConstants3P.m
+++ b/FirebaseRemoteConfig/Sources/RCNConstants3P.m
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
+
+/// Firebase Remote Config service default namespace.
+NSString *const FIRNamespaceGoogleMobilePlatform = @"firebase";

--- a/FirebaseRemoteConfig/Sources/RCNConstants3P.m
+++ b/FirebaseRemoteConfig/Sources/RCNConstants3P.m
@@ -17,4 +17,6 @@
 #import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
 
 /// Firebase Remote Config service default namespace.
+/// TODO(doudounan): Change to use this namespace constant defined in RemoteConfigInterop
 NSString *const FIRNamespaceGoogleMobilePlatform = @"firebase";
+

--- a/FirebaseRemoteConfig/Sources/RCNConstants3P.m
+++ b/FirebaseRemoteConfig/Sources/RCNConstants3P.m
@@ -17,6 +17,5 @@
 #import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
 
 /// Firebase Remote Config service default namespace.
-/// TODO(doudounan): Change to use this namespace constant defined in RemoteConfigInterop
+/// TODO(doudounan): Change to use this namespace defined in RemoteConfigInterop.
 NSString *const FIRNamespaceGoogleMobilePlatform = @"firebase";
-

--- a/FirebaseRemoteConfigSwift/Tests/SwiftAPI/FirebaseRemoteConfigSwift_APIBuildTests.swift
+++ b/FirebaseRemoteConfigSwift/Tests/SwiftAPI/FirebaseRemoteConfigSwift_APIBuildTests.swift
@@ -24,7 +24,7 @@ final class FirebaseRemoteConfigSwift_APIBuildTests: XCTestCase {
     // MARK: - FirebaseRemoteConfig
 
     // TODO(ncooke3): These global constants should be lowercase.
-    let _: String = RemoteConfigConstants.NamespaceGoogleMobilePlatform
+    let _: String = FirebaseRemoteConfig.NamespaceGoogleMobilePlatform
     let _: String = FirebaseRemoteConfig.RemoteConfigThrottledEndTimeInSecondsKey
 
     // TODO(ncooke3): This should probably not be initializable.


### PR DESCRIPTION
Revert constants change in remote config public api test
Add back the firebase namespace constant in RC

Note: this change will merge to our feature branch not master
#no-changelog
