### PR TITLE
Resolved warning `no rule to process file 'PrivacyInfo.xcprivacy' of type 'text.xml' with CocoaPods`

### DIFF
--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -37,7 +37,7 @@ device, and it is completely free.
 
   base_dir = "FirebaseMessaging/"
   s.source_files = [
-    base_dir + 'Sources/**/*',
+    base_dir + 'Sources/**/*.{c,m,h}',
     base_dir + 'Sources/Protogen/nanopb/*.h',
     base_dir + 'Interop/*.h',
     'Interop/Analytics/Public/*.h',


### PR DESCRIPTION
Fix #12511 

### Testing
  * FirebaseMessaging-Unit-unit and FirebaseMessaging-Unit-integration tests passed


