### PR TITLE
[Firestore] Re-export public header added in #12370

### DIFF
--- a/FirebaseFirestoreInternal/FirebaseFirestore/FIRSnapshotListenOptions.h
+++ b/FirebaseFirestoreInternal/FirebaseFirestore/FIRSnapshotListenOptions.h
@@ -1,0 +1,15 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <FirebaseFirestoreInternal/FIRSnapshotListenOptions.h>


### PR DESCRIPTION
Working on a CI workflow to automate the detection of this... This is gtg though.

#no-changelog