### PR TITLE
Add CI workflow for Vertex AI

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -24,6 +24,8 @@ jobs:
           - os: macos-13
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
     - uses: actions/checkout@v4
     - name: Xcode

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -1,0 +1,35 @@
+name: vertexai
+
+on:
+  pull_request:
+    paths:
+        - 'FirebaseVertexAI**'
+        - '.github/workflows/vertexai.yml'
+        - 'Gemfile*'
+  schedule:
+    # Run every day at 11pm (PST) - cron uses UTC times
+    - cron:  '0 7 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spm:
+    strategy:
+      matrix:
+        target: [iOS, macOS, catalyst]
+        os: [macos-13]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Initialize xcodebuild
+      run: xcodebuild -list
+    # TODO: Add unit tests and switch from `spmbuildonly` to `spm`.
+    - name: Build
+      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseVertexAI ${{ matrix.target }} spmbuildonly


### PR DESCRIPTION
Runs `spmbuildonly` since the unit tests target is not yet ready.

#no-changelog
