### PR TITLE
[Release Tooling] Update XCFramework structure

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -156,7 +156,7 @@ jobs:
   quickstart_framework_auth:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,31 +25,31 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # package-release:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #   #   with:
-  #   #     cache_key: package-release
-  #   - name: Xcode 14.1
-  #     run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p release_zip_dir
-  #        sh -x scripts/build_zip.sh release_zip_dir \
-  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
-  #   - uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Firebase-release-zip-zip
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: release_zip_dir
+  package-release:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: package-release
+    - name: Xcode 14.1
+      run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p release_zip_dir
+         sh -x scripts/build_zip.sh release_zip_dir \
+           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Firebase-release-zip-zip
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: release_zip_dir
 
   build:
     # Don't run on private repo unless it is a PR.
@@ -64,99 +64,99 @@ jobs:
         cd ReleaseTooling
         swift build -v
 
-  # package-head:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: build
-  #   runs-on: macos-12
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #   #   with:
-  #   #     cache_key: package-head
-  #   - name: Xcode 14.1
-  #     run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p zip_output_dir
-  #        sh -x scripts/build_zip.sh \
-  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-  #          build-head
-  #   - uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: zip_output_dir
+  package-head:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: package-head
+    - name: Xcode 14.1
+      run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p zip_output_dir
+         sh -x scripts/build_zip.sh \
+           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+           build-head
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Firebase-actions-dir
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: zip_output_dir
 
-  # quickstart_framework_abtesting:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "ABTesting"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh abtesting
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_abtesting
-  #       path: quickstart-ios/
+  quickstart_framework_abtesting:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "ABTesting"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh abtesting
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_abtesting
+        path: quickstart-ios/
 
   quickstart_framework_auth:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -176,8 +176,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firebase-actions-dir
-        github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 8397031345
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
@@ -208,135 +206,135 @@ jobs:
         name: quickstart_artifacts_auth
         path: quickstart-ios/
 
-  # quickstart_framework_config:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Config"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup Swift Quickstart
+  quickstart_framework_config:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Config"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup Swift Quickstart
 
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh config
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_config
-  #       path: quickstart-ios/
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh config
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_config
+        path: quickstart-ios/
 
-  # quickstart_framework_crashlytics:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Crashlytics"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: |
-  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Setup swift quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: |
-  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Test Swift Quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh crashlytics
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_crashlytics
-  #       path: quickstart-ios/
+  quickstart_framework_crashlytics:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Crashlytics"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: |
+              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Setup swift quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: |
+    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Test Swift Quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh crashlytics
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_crashlytics
+        path: quickstart-ios/
 
   quickstart_framework_database:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -357,8 +355,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firebase-actions-dir
-        github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 8397031345
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
@@ -391,69 +387,69 @@ jobs:
         name: quickstart_artifacts database
         path: quickstart-ios/
 
-  # quickstart_framework_dynamiclinks:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "DynamicLinks"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Objc Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup Swift Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Update Environment Variable For DynamicLinks
-  #     run: |
-  #       sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
-  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
-  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
-  #       quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Objc Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh dynamiclinks
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_dynamiclinks
-  #       path: quickstart-ios/
+  quickstart_framework_dynamiclinks:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "DynamicLinks"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Objc Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup Swift Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Update Environment Variable For DynamicLinks
+      run: |
+        sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
+        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
+        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
+        quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
+    - name: Test Objc Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh dynamiclinks
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_dynamiclinks
+        path: quickstart-ios/
 
   quickstart_framework_firestore:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -474,8 +470,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firebase-actions-dir
-        github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 8397031345
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
@@ -506,152 +500,152 @@ jobs:
         name: quickstart_artifacts_firestore
         path: quickstart-ios/
 
-  # check_framework_firestore_symbols:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-  #   runs-on: macos-13
-  #   steps:
-  #     - name: Xcode 14.1
-  #       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-  #     - uses: actions/checkout@v4
-  #     - name: Get framework dir
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: Firebase-actions-dir
-  #     - uses: ruby/setup-ruby@v1
-  #     - name: Setup Bundler
-  #       run: ./scripts/setup_bundler.sh
-  #     - name: Install xcpretty
-  #       run: gem install xcpretty
-  #     - name: Move frameworks
-  #       run: |
-  #         mkdir -p "${HOME}"/ios_frameworks/
-  #         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #     - uses: actions/checkout@v4
-  #     - name: Check linked Firestore.xcframework for unlinked symbols.
-  #       run: |
-  #         scripts/check_firestore_symbols.sh \
-  #           $(pwd) \
-  #           "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
+  check_framework_firestore_symbols:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    runs-on: macos-13
+    steps:
+      - name: Xcode 14.1
+        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+      - uses: actions/checkout@v4
+      - name: Get framework dir
+        uses: actions/download-artifact@v4
+        with:
+          name: Firebase-actions-dir
+      - uses: ruby/setup-ruby@v1
+      - name: Setup Bundler
+        run: ./scripts/setup_bundler.sh
+      - name: Install xcpretty
+        run: gem install xcpretty
+      - name: Move frameworks
+        run: |
+          mkdir -p "${HOME}"/ios_frameworks/
+          find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      - uses: actions/checkout@v4
+      - name: Check linked Firestore.xcframework for unlinked symbols.
+        run: |
+          scripts/check_firestore_symbols.sh \
+            $(pwd) \
+            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
-  # quickstart_framework_inappmessaging:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "InAppMessaging"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh inappmessaging
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_inappmessaging
-  #       path: quickstart-ios/
+  quickstart_framework_inappmessaging:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "InAppMessaging"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh inappmessaging
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_inappmessaging
+        path: quickstart-ios/
 
-  # quickstart_framework_messaging:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Messaging"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh messaging
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_messaging
-  #       path: quickstart-ios/
+  quickstart_framework_messaging:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Messaging"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh messaging
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_messaging
+        path: quickstart-ios/
 
   quickstart_framework_storage:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -671,8 +665,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firebase-actions-dir
-        github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 8397031345
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,31 +25,31 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  package-release:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v4
-    # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-    #   with:
-    #     cache_key: package-release
-    - name: Xcode 14.1
-      run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p release_zip_dir
-         sh -x scripts/build_zip.sh release_zip_dir \
-           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Firebase-release-zip-zip
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: release_zip_dir
+  # package-release:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #   #   with:
+  #   #     cache_key: package-release
+  #   - name: Xcode 14.1
+  #     run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p release_zip_dir
+  #        sh -x scripts/build_zip.sh release_zip_dir \
+  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
+  #   - uses: actions/upload-artifact@v4
+  #     with:
+  #       name: Firebase-release-zip-zip
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: release_zip_dir
 
   build:
     # Don't run on private repo unless it is a PR.
@@ -64,94 +64,94 @@ jobs:
         cd ReleaseTooling
         swift build -v
 
-  package-head:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: build
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v4
-    # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-    #   with:
-    #     cache_key: package-head
-    - name: Xcode 14.1
-      run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh \
-           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-           build-head
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Firebase-actions-dir
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: zip_output_dir
+  # package-head:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: build
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #   #   with:
+  #   #     cache_key: package-head
+  #   - name: Xcode 14.1
+  #     run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p zip_output_dir
+  #        sh -x scripts/build_zip.sh \
+  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+  #          build-head
+  #   - uses: actions/upload-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: zip_output_dir
 
-  quickstart_framework_abtesting:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "ABTesting"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh abtesting
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_abtesting
-        path: quickstart-ios/
+  # quickstart_framework_abtesting:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "ABTesting"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh abtesting
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_abtesting
+  #       path: quickstart-ios/
 
   quickstart_framework_auth:
     # Don't run on private repo.
@@ -163,12 +163,13 @@ jobs:
       SDK:  "Authentication"
     strategy:
       matrix:
-        os: [macos-12, macos-13]
+        # os: [macos-12, macos-13]
+        os: [macos-12]
         include:
           - os: macos-12
             xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
+          # - os: macos-13
+          #   xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -176,6 +177,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: Firebase-actions-dir
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        run-id: 1352153065
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
@@ -206,130 +209,130 @@ jobs:
         name: quickstart_artifacts_auth
         path: quickstart-ios/
 
-  quickstart_framework_config:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Config"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup Swift Quickstart
+  # quickstart_framework_config:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Config"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup Swift Quickstart
 
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh config
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_config
-        path: quickstart-ios/
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh config
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_config
+  #       path: quickstart-ios/
 
-  quickstart_framework_crashlytics:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Crashlytics"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: |
-              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Setup swift quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: |
-    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Test Swift Quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh crashlytics
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_crashlytics
-        path: quickstart-ios/
+  # quickstart_framework_crashlytics:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Crashlytics"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: |
+  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Setup swift quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: |
+  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Test Swift Quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh crashlytics
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_crashlytics
+  #       path: quickstart-ios/
 
   quickstart_framework_database:
     # Don't run on private repo.
@@ -387,64 +390,64 @@ jobs:
         name: quickstart_artifacts database
         path: quickstart-ios/
 
-  quickstart_framework_dynamiclinks:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "DynamicLinks"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Objc Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Update Environment Variable For DynamicLinks
-      run: |
-        sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
-        quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
-    - name: Test Objc Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh dynamiclinks
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_dynamiclinks
-        path: quickstart-ios/
+  # quickstart_framework_dynamiclinks:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "DynamicLinks"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Objc Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup Swift Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Update Environment Variable For DynamicLinks
+  #     run: |
+  #       sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
+  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
+  #       sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
+  #       quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Objc Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh dynamiclinks
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_dynamiclinks
+  #       path: quickstart-ios/
 
   quickstart_framework_firestore:
     # Don't run on private repo.
@@ -500,147 +503,147 @@ jobs:
         name: quickstart_artifacts_firestore
         path: quickstart-ios/
 
-  check_framework_firestore_symbols:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-13
-    steps:
-      - name: Xcode 14.1
-        run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
-      - uses: actions/checkout@v4
-      - name: Get framework dir
-        uses: actions/download-artifact@v4
-        with:
-          name: Firebase-actions-dir
-      - uses: ruby/setup-ruby@v1
-      - name: Setup Bundler
-        run: ./scripts/setup_bundler.sh
-      - name: Install xcpretty
-        run: gem install xcpretty
-      - name: Move frameworks
-        run: |
-          mkdir -p "${HOME}"/ios_frameworks/
-          find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-      - uses: actions/checkout@v4
-      - name: Check linked Firestore.xcframework for unlinked symbols.
-        run: |
-          scripts/check_firestore_symbols.sh \
-            $(pwd) \
-            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
+  # check_framework_firestore_symbols:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+  #   runs-on: macos-13
+  #   steps:
+  #     - name: Xcode 14.1
+  #       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
+  #     - uses: actions/checkout@v4
+  #     - name: Get framework dir
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: Firebase-actions-dir
+  #     - uses: ruby/setup-ruby@v1
+  #     - name: Setup Bundler
+  #       run: ./scripts/setup_bundler.sh
+  #     - name: Install xcpretty
+  #       run: gem install xcpretty
+  #     - name: Move frameworks
+  #       run: |
+  #         mkdir -p "${HOME}"/ios_frameworks/
+  #         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #     - uses: actions/checkout@v4
+  #     - name: Check linked Firestore.xcframework for unlinked symbols.
+  #       run: |
+  #         scripts/check_firestore_symbols.sh \
+  #           $(pwd) \
+  #           "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
-  quickstart_framework_inappmessaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "InAppMessaging"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh inappmessaging
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_inappmessaging
-        path: quickstart-ios/
+  # quickstart_framework_inappmessaging:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "InAppMessaging"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh inappmessaging
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_inappmessaging
+  #       path: quickstart-ios/
 
-  quickstart_framework_messaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Messaging"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh messaging
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_messaging
-        path: quickstart-ios/
+  # quickstart_framework_messaging:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Messaging"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh messaging
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_messaging
+  #       path: quickstart-ios/
 
   quickstart_framework_storage:
     # Don't run on private repo.

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: package-release
+    # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+    #   with:
+    #     cache_key: package-release
     - name: Xcode 14.1
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
     - uses: ruby/setup-ruby@v1
@@ -71,9 +71,9 @@ jobs:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: package-head
+    # - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+    #   with:
+    #     cache_key: package-head
     - name: Xcode 14.1
       run: sudo xcode-select -s /Applications/Xcode_14.1.app/Contents/Developer
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -334,61 +334,61 @@ jobs:
   #       name: quickstart_artifacts_crashlytics
   #       path: quickstart-ios/
 
-  quickstart_framework_database:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Database"
-    strategy:
-      matrix:
-        os: [macos-12]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
-          # - os: macos-13
-          #   xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh database
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts database
-        path: quickstart-ios/
+  # quickstart_framework_database:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Database"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
+  #         # - os: macos-13
+  #         #   xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh database
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts database
+  #       path: quickstart-ios/
 
   # quickstart_framework_dynamiclinks:
   #   # Don't run on private repo.
@@ -449,59 +449,59 @@ jobs:
   #       name: quickstart_artifacts_dynamiclinks
   #       path: quickstart-ios/
 
-  quickstart_framework_firestore:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Firestore"
-    strategy:
-      matrix:
-        os: [macos-12]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
-          # - os: macos-13
-          #   xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh firestore
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_firestore
-        path: quickstart-ios/
+  # quickstart_framework_firestore:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Firestore"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
+  #         # - os: macos-13
+  #         #   xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh firestore
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_firestore
+  #       path: quickstart-ios/
 
   # check_framework_firestore_symbols:
   #   # Don't run on private repo.
@@ -645,68 +645,68 @@ jobs:
   #       name: quickstart_artifacts_messaging
   #       path: quickstart-ios/
 
-  quickstart_framework_storage:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Storage"
-    strategy:
-      matrix:
-        os: [macos-12, macos-13]
-        include:
-          - os: macos-12
-            xcode: Xcode_14.2
-          - os: macos-13
-            xcode: Xcode_15.2
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4
-      with:
-        name: Firebase-actions-dir
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup swift quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh storage
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_storage
-        path: quickstart-ios/
+  # quickstart_framework_storage:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: package-head
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Storage"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-12, macos-13]
+  #       include:
+  #         - os: macos-12
+  #           xcode: Xcode_14.2
+  #         - os: macos-13
+  #           xcode: Xcode_15.2
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Firebase-actions-dir
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup swift quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh storage
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_storage
+  #       path: quickstart-ios/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -178,7 +178,7 @@ jobs:
       with:
         name: Firebase-actions-dir
         github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 36927374
+        run-id: 8397031345
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -178,7 +178,7 @@ jobs:
       with:
         name: Firebase-actions-dir
         github-token: '${{ secrets.GITHUB_TOKEN }}'
-        run-id: 1352153065
+        run-id: 36927374
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -20,9 +20,9 @@ on:
         required: true
         default: 'https://github.com/firebase/SpecsStaging.git'
 
-# concurrency:
-#     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-#     cancel-in-progress: true
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 jobs:
   # package-release:
@@ -163,13 +163,12 @@ jobs:
       SDK:  "Authentication"
     strategy:
       matrix:
-        # os: [macos-12, macos-13]
-        os: [macos-12]
+        os: [macos-12, macos-13]
         include:
           - os: macos-12
             xcode: Xcode_14.2
-          # - os: macos-13
-          #   xcode: Xcode_15.2
+          - os: macos-13
+            xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -334,61 +333,63 @@ jobs:
   #       name: quickstart_artifacts_crashlytics
   #       path: quickstart-ios/
 
-  # quickstart_framework_database:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Database"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
-  #         # - os: macos-13
-  #         #   xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh database
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts database
-  #       path: quickstart-ios/
+  quickstart_framework_database:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Database"
+    strategy:
+      matrix:
+        os: [macos-12]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
+          # - os: macos-13
+          #   xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        run-id: 8397031345
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh database
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts database
+        path: quickstart-ios/
 
   # quickstart_framework_dynamiclinks:
   #   # Don't run on private repo.
@@ -449,59 +450,61 @@ jobs:
   #       name: quickstart_artifacts_dynamiclinks
   #       path: quickstart-ios/
 
-  # quickstart_framework_firestore:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Firestore"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
-  #         # - os: macos-13
-  #         #   xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh firestore
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_firestore
-  #       path: quickstart-ios/
+  quickstart_framework_firestore:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Firestore"
+    strategy:
+      matrix:
+        os: [macos-12]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          # TODO: Building FirebaseUI fails on Xcode 15 because it needs to sign the resources.
+          # - os: macos-13
+          #   xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        run-id: 8397031345
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh firestore
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_firestore
+        path: quickstart-ios/
 
   # check_framework_firestore_symbols:
   #   # Don't run on private repo.
@@ -645,68 +648,70 @@ jobs:
   #       name: quickstart_artifacts_messaging
   #       path: quickstart-ios/
 
-  # quickstart_framework_storage:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: package-head
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Storage"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-12, macos-13]
-  #       include:
-  #         - os: macos-12
-  #           xcode: Xcode_14.2
-  #         - os: macos-13
-  #           xcode: Xcode_15.2
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: Firebase-actions-dir
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup swift quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh storage
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_storage
-  #       path: quickstart-ios/
+  quickstart_framework_storage:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # needs: package-head
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Storage"
+    strategy:
+      matrix:
+        os: [macos-12, macos-13]
+        include:
+          - os: macos-12
+            xcode: Xcode_14.2
+          - os: macos-13
+            xcode: Xcode_15.2
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4
+      with:
+        name: Firebase-actions-dir
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        run-id: 8397031345
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup swift quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh storage
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_storage
+        path: quickstart-ios/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -20,9 +20,9 @@ on:
         required: true
         default: 'https://github.com/firebase/SpecsStaging.git'
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
+# concurrency:
+#     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#     cancel-in-progress: true
 
 jobs:
   # package-release:

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- Fix validation issue for macOS and macCatalyst XCFrameworks related to
+  framework directory structure. (#12557)
+
 # Firebase 10.23.0
 - Fix validation issue for macOS and macCatalyst XCFrameworks. (#12505)
 

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -492,65 +492,7 @@ struct FrameworkBuilder {
         } else if buildingCarthage {
           return true
         }
-        guard let first = swiftModules.first,
-              let swiftModule = URL(string: first) else {
-          fatalError("Failed to get swiftmodule in \(moduleDir).")
-        }
-        let destModuleDir = destination.appendingPathComponent("Modules")
-        // TODO(ncooke3): This case shouldn't ever be true I think.
-        if !fileManager.directoryExists(at: destModuleDir) {
-          do {
-            try fileManager.copyItem(at: moduleDir, to: destModuleDir)
-          } catch {
-            fatalError("Could not copy Modules from \(moduleDir) to " +
-              "\(destModuleDir): \(error)")
-          }
-        } else {
-          // If the Modules directory is already there, only copy in the architecture specific files
-          // from the *.swiftmodule subdirectory.
-//          do {
-//            let files = try fileManager.contentsOfDirectory(at: swiftModule,
-//                                                            includingPropertiesForKeys: nil)
-//              .compactMap { $0.path }
-//            let destSwiftModuleDir = destModuleDir
-//              .appendingPathComponent(swiftModule.lastPathComponent)
-//            for file in files {
-//              let fileURL = URL(fileURLWithPath: file)
-//              let projectDir = swiftModule.appendingPathComponent("Project")
-//              if fileURL.lastPathComponent == "Project",
-//                 fileManager.directoryExists(at: projectDir) {
-//                // The Project directory (introduced with Xcode 11.4) already exists, only copy in
-//                // new contents.
-//                let projectFiles = try fileManager.contentsOfDirectory(at: projectDir,
-//                                                                       includingPropertiesForKeys: nil)
-//                  .compactMap { $0.path }
-//                let destProjectDir = destSwiftModuleDir.appendingPathComponent("Project")
-//                for projectFile in projectFiles {
-//                  let projectFileURL = URL(fileURLWithPath: projectFile)
-//                  do {
-//                    try fileManager.copyItem(at: projectFileURL, to:
-//                      destProjectDir.appendingPathComponent(projectFileURL.lastPathComponent))
-//                  } catch {
-//                    fatalError("Could not copy Project file from \(projectFileURL) to " +
-//                      "\(destProjectDir): \(error)")
-//                  }
-//                }
-//              } else {
-//                do {
-//                  try fileManager.copyItem(at: fileURL, to:
-//                    destSwiftModuleDir
-//                      .appendingPathComponent(fileURL.lastPathComponent))
-//                } catch {
-//                  fatalError("Could not copy Swift module file from \(fileURL) to " +
-//                    "\(destSwiftModuleDir): \(error)")
-//                }
-//              }
-//            }
-//          } catch {
-//            fatalError("Failed to get Modules directory contents - \(moduleDir):" +
-//              "\(error.localizedDescription)")
-//          }
-        }
+
         do {
           // If this point is reached, the framework contains a Swift module,
           // so it's built from either Swift sources or Swift & C Family

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -635,9 +635,10 @@ struct FrameworkBuilder {
       // it here to avoid putting it in the zip or crashing the Carthage hash
       // generation. Because this will throw an error for cases where the file
       // does not exist, the error is ignored.
-      let headersDir = platformFrameworkDir.appendingPathComponent("PrivateHeaders")
-        .resolvingSymlinksInPath()
-      try? fileManager.removeItem(at: headersDir.appendingPathComponent("PrivateHeaders"))
+      let privateHeadersDir = platformFrameworkDir.appendingPathComponent("PrivateHeaders")
+      if !fileManager.directoryExists(at: privateHeadersDir.resolvingSymlinksInPath()) {
+        try? fileManager.removeItem(at: privateHeadersDir)
+      }
 
       // Move privacy manifest containing resource bundles into the framework.
       let resourceDir = platformFrameworkDir

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -708,7 +708,12 @@ struct FrameworkBuilder {
       try? fileManager.removeItem(at: headersDir.appendingPathComponent("Headers"))
       
       // Move privacy manifest containing resource bundles into the framework.
-      processPrivacyManifests(fileManager, frameworkPath, platformFrameworkDir)
+      let resourceDir = platformFrameworkDir
+        .appendingPathComponent(
+          platform == .catalyst || platform == .macOS ? "Resources" : ""
+        )
+        .resolvingSymlinksInPath()
+      processPrivacyManifests(fileManager, frameworkPath, resourceDir)
       
       // Use the appropriate moduleMaps
       packageModuleMaps(inFrameworks: [frameworkPath],

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -636,9 +636,16 @@ struct FrameworkBuilder {
       // generation. Because this will throw an error for cases where the file
       // does not exist, the error is ignored.
       let privateHeadersDir = platformFrameworkDir.appendingPathComponent("PrivateHeaders")
-      if !fileManager.directoryExists(at: privateHeadersDir.resolvingSymlinksInPath()) {
+      if fileManager.directoryExists(at: privateHeadersDir.resolvingSymlinksInPath()) {
+        try? fileManager
+          .removeItem(at: privateHeadersDir.resolvingSymlinksInPath()
+            .appendingPathComponent("PrivateHeaders"))
+      } else {
         try? fileManager.removeItem(at: privateHeadersDir)
       }
+      let headersDir = platformFrameworkDir.appendingPathComponent("Headers")
+        .resolvingSymlinksInPath()
+      try? fileManager.removeItem(at: headersDir.appendingPathComponent("Headers"))
 
       // Move privacy manifest containing resource bundles into the framework.
       let resourceDir = platformFrameworkDir

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -630,16 +630,14 @@ struct FrameworkBuilder {
         )
       }
 
-      // The macOS slice's `Headers` directory may have a `Headers` file in
-      // it that symbolically links to nowhere. For example, in the 8.0.0
-      // zip distribution, see the `Headers` directory in the macOS slice
-      // of the `PromisesObjC.xcframework`. Delete it here to avoid putting
-      // it in the zip or crashing the Carthage hash generation. Because
-      // this will throw an error for cases where the file does not exist,
-      // the error is ignored.
-      let headersDir = platformFrameworkDir.appendingPathComponent("Headers")
+      // The macOS slice's `PrivateHeaders` directory may have a
+      // `PrivateHeaders` file in it that symbolically links to nowhere. Delete
+      // it here to avoid putting it in the zip or crashing the Carthage hash
+      // generation. Because this will throw an error for cases where the file
+      // does not exist, the error is ignored.
+      let headersDir = platformFrameworkDir.appendingPathComponent("PrivateHeaders")
         .resolvingSymlinksInPath()
-      try? fileManager.removeItem(at: headersDir.appendingPathComponent("Headers"))
+      try? fileManager.removeItem(at: headersDir.appendingPathComponent("PrivateHeaders"))
 
       // Move privacy manifest containing resource bundles into the framework.
       let resourceDir = platformFrameworkDir

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -565,8 +565,6 @@ struct FrameworkBuilder {
         fatalError("Could not create a temp directory to store all thin frameworks: \(error)")
       }
     }
-    // Done – remove code sig dir, set OS min to 100 in plist, clean up symbolic link to avoid v8
-    // carthage crash, privacy manifest, module map,
 
     return slicedFrameworks.map { platform, frameworkPath in
       // Create the following structure in the platform frameworks directory:

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -581,7 +581,8 @@ struct FrameworkBuilder {
               requires objc
             }
             """
-            let modulemapURL = destination.appendingPathComponents(["Modules", "module.modulemap"]).resolvingSymlinksInPath()
+            let modulemapURL = destination.appendingPathComponents(["Modules", "module.modulemap"])
+              .resolvingSymlinksInPath()
             try newModuleMapContents.write(to: modulemapURL, atomically: true, encoding: .utf8)
           }
         } catch {
@@ -622,8 +623,9 @@ struct FrameworkBuilder {
         fatalError("Could not create a temp directory to store all thin frameworks: \(error)")
       }
     }
-    // Done – remove code sig dir, set OS min to 100 in plist, clean up symbolic link to avoid v8 carthage crash, privacy manifest, module map,
-    
+    // Done – remove code sig dir, set OS min to 100 in plist, clean up symbolic link to avoid v8
+    // carthage crash, privacy manifest, module map,
+
     return slicedFrameworks.map { platform, frameworkPath in
       // Create the following structure in the platform frameworks directory:
       // - platform_frameworks
@@ -632,7 +634,7 @@ struct FrameworkBuilder {
       let platformFrameworkDir = platformFrameworksDir
         .appendingPathComponent(platform.buildName)
         .appendingPathComponent(framework + ".framework")
-    
+
       do {
         // Create `platform_frameworks/$(PLATFORM)` subdirectory.
         try fileManager.createDirectory(
@@ -657,7 +659,7 @@ struct FrameworkBuilder {
         )
         .appendingPathComponent("_CodeSignature")
       try? fileManager.removeItem(at: codeSignatureDir)
-      
+
       // The minimum OS version is set to 100.0 to work around b/327020913.
       // TODO(ncooke3): Revert this logic once b/327020913 is fixed.
       // TODO(ncooke3): Does this need to happen on macOS?
@@ -685,7 +687,7 @@ struct FrameworkBuilder {
           "Could not modify framework-level plist for b/327020913 in framework directory \(framework): \(error)"
         )
       }
-      
+
       // The macOS slice's `Headers` directory may have a `Headers` file in
       // it that symbolically links to nowhere. For example, in the 8.0.0
       // zip distribution, see the `Headers` directory in the macOS slice
@@ -696,7 +698,7 @@ struct FrameworkBuilder {
       let headersDir = platformFrameworkDir.appendingPathComponent("Headers")
         .resolvingSymlinksInPath()
       try? fileManager.removeItem(at: headersDir.appendingPathComponent("Headers"))
-      
+
       // Move privacy manifest containing resource bundles into the framework.
       let resourceDir = platformFrameworkDir
         .appendingPathComponent(
@@ -704,13 +706,13 @@ struct FrameworkBuilder {
         )
         .resolvingSymlinksInPath()
       processPrivacyManifests(fileManager, frameworkPath, resourceDir)
-      
+
       // Use the appropriate moduleMaps
       packageModuleMaps(inFrameworks: [frameworkPath],
                         frameworkName: framework,
                         moduleMapContents: moduleMapContents,
                         destination: platformFrameworkDir)
-      
+
       return platformFrameworkDir
     }
   }

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -503,6 +503,11 @@ struct ZipBuilder {
                       frameworkPath.lastPathComponent.hasSuffix("framework") else { continue }
                 let resourcesDir = frameworkPath.appendingPathComponent("Resources")
                   .resolvingSymlinksInPath()
+                try? fileManager.createDirectory(
+                  at: resourcesDir,
+                  withIntermediateDirectories: true
+                )
+
                 let xcResourceDirContents = try fileManager.contentsOfDirectory(
                   at: xcResourceDir,
                   includingPropertiesForKeys: nil

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -501,8 +501,13 @@ struct ZipBuilder {
                 // Ignore anything that not a framework.
                 guard fileManager.isDirectory(at: frameworkPath),
                       frameworkPath.lastPathComponent.hasSuffix("framework") else { continue }
-                let resourcesDir = frameworkPath.appendingPathComponent("Resources")
-                try fileManager.copyItem(at: xcResourceDir, to: resourcesDir)
+                let resourcesDir = frameworkPath.appendingPathComponent("Resources").resolvingSymlinksInPath()
+                let xcResourceDirContents = try! fileManager.contentsOfDirectory(at: xcResourceDir, includingPropertiesForKeys: nil)
+                let resourcesDirContents = try! fileManager.contentsOfDirectory(at: resourcesDir, includingPropertiesForKeys: nil)
+
+                for file in Set(xcResourceDirContents).subtracting(resourcesDirContents) {
+                  try fileManager.copyItem(at: file, to: resourcesDir.appendingPathComponent(file.lastPathComponent))
+                }
               }
             }
             try fileManager.removeItem(at: xcResourceDir)

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -501,12 +501,22 @@ struct ZipBuilder {
                 // Ignore anything that not a framework.
                 guard fileManager.isDirectory(at: frameworkPath),
                       frameworkPath.lastPathComponent.hasSuffix("framework") else { continue }
-                let resourcesDir = frameworkPath.appendingPathComponent("Resources").resolvingSymlinksInPath()
-                let xcResourceDirContents = try! fileManager.contentsOfDirectory(at: xcResourceDir, includingPropertiesForKeys: nil)
-                let resourcesDirContents = try! fileManager.contentsOfDirectory(at: resourcesDir, includingPropertiesForKeys: nil)
+                let resourcesDir = frameworkPath.appendingPathComponent("Resources")
+                  .resolvingSymlinksInPath()
+                let xcResourceDirContents = try! fileManager.contentsOfDirectory(
+                  at: xcResourceDir,
+                  includingPropertiesForKeys: nil
+                )
+                let resourcesDirContents = try! fileManager.contentsOfDirectory(
+                  at: resourcesDir,
+                  includingPropertiesForKeys: nil
+                )
 
                 for file in Set(xcResourceDirContents).subtracting(resourcesDirContents) {
-                  try fileManager.copyItem(at: file, to: resourcesDir.appendingPathComponent(file.lastPathComponent))
+                  try fileManager.copyItem(
+                    at: file,
+                    to: resourcesDir.appendingPathComponent(file.lastPathComponent)
+                  )
                 }
               }
             }

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -503,11 +503,11 @@ struct ZipBuilder {
                       frameworkPath.lastPathComponent.hasSuffix("framework") else { continue }
                 let resourcesDir = frameworkPath.appendingPathComponent("Resources")
                   .resolvingSymlinksInPath()
-                let xcResourceDirContents = try! fileManager.contentsOfDirectory(
+                let xcResourceDirContents = try fileManager.contentsOfDirectory(
                   at: xcResourceDir,
                   includingPropertiesForKeys: nil
                 )
-                let resourcesDirContents = try! fileManager.contentsOfDirectory(
+                let resourcesDirContents = try fileManager.contentsOfDirectory(
                   at: resourcesDir,
                   includingPropertiesForKeys: nil
                 )

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -503,6 +503,8 @@ struct ZipBuilder {
                       frameworkPath.lastPathComponent.hasSuffix("framework") else { continue }
                 let resourcesDir = frameworkPath.appendingPathComponent("Resources")
                   .resolvingSymlinksInPath()
+                // On macOS platforms, this directory will already be there, so
+                // ignore error that it already exists.
                 try? fileManager.createDirectory(
                   at: resourcesDir,
                   withIntermediateDirectories: true

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -507,12 +507,8 @@ struct ZipBuilder {
                   at: xcResourceDir,
                   includingPropertiesForKeys: nil
                 )
-                let resourcesDirContents = try fileManager.contentsOfDirectory(
-                  at: resourcesDir,
-                  includingPropertiesForKeys: nil
-                )
 
-                for file in Set(xcResourceDirContents).subtracting(resourcesDirContents) {
+                for file in xcResourceDirContents {
                   try fileManager.copyItem(
                     at: file,
                     to: resourcesDir.appendingPathComponent(file.lastPathComponent)
@@ -524,7 +520,7 @@ struct ZipBuilder {
           }
         }
       } catch {
-        fatalError("Could not setup Resources for \(pod) for \(packageKind) \(error)")
+        fatalError("Could not setup Resources for \(pod.key) for \(packageKind) \(error)")
       }
 
       // Special case for Crashlytics:

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -44,8 +44,8 @@ fi
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
-    rm -rf "Firebase/$(basename ${file})"
-    cp -a ${file} Firebase/
+    # rm -rf "Firebase/$(basename ${file})"
+    rsync -a ${file} Firebase/
   fi
 done
 

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -41,6 +41,7 @@ fi
 if [ ! -f "Firebase/module.modulemap" ]; then
   cp "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 fi
+ls Firebase/
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -45,6 +45,8 @@ ls Firebase/
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
+    ls "Firebase/$(basename ${file})"
+    rm -rf "Firebase/$(basename ${file})"
     cp -a ${file} Firebase/
   fi
 done

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -44,6 +44,7 @@ fi
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
+    rm -rf "Firebase/$(basename ${file})"
     cp -R ${file} Firebase/
   fi
 done

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -41,6 +41,7 @@ fi
 if [ ! -f "Firebase/module.modulemap" ]; then
   cp "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 fi
+echo "$(ls Firebase/)"
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -41,11 +41,9 @@ fi
 if [ ! -f "Firebase/module.modulemap" ]; then
   cp "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 fi
-ls Firebase/
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
-    ls "Firebase/$(basename ${file})"
     rm -rf "Firebase/$(basename ${file})"
     cp -a ${file} Firebase/
   fi

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -43,7 +43,7 @@ if [ ! -f "Firebase/module.modulemap" ]; then
 fi
 for file in "$@"
 do
-  if [ ! -f "Firebase/$(basename ${file})" ]; then
+  if [ ! -d "Firebase/$(basename ${file})" ]; then
     cp -R ${file} Firebase/
   fi
 done

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -41,11 +41,9 @@ fi
 if [ ! -f "Firebase/module.modulemap" ]; then
   cp "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 fi
-echo "$(ls Firebase/)"
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
-    # rm -rf "Firebase/$(basename ${file})"
     rsync -a ${file} Firebase/
   fi
 done

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -44,8 +44,7 @@ fi
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
-    rm -rf "Firebase/$(basename ${file})"
-    cp -R ${file} Firebase/
+    cp -av ${file} Firebase/
   fi
 done
 

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -44,7 +44,7 @@ fi
 for file in "$@"
 do
   if [ ! -d "Firebase/$(basename ${file})" ]; then
-    cp -av ${file} Firebase/
+    cp -a ${file} Firebase/
   fi
 done
 


### PR DESCRIPTION
Fix #12557

Change zip builder to create macOS/macCatalyst frameworks with the following format:
```
CoreWaffleVarnishing.framework/
  CoreWaffleVarnishing -> Versions/Current/CoreWaffleVarnishing
  Resources -> Versions/Current/Resources
  Versions/
    Current -> A
    A/
      CoreWaffleVarnishing
      Resources/
        Info.plist
        … other resources …
```

CocoaPods already creates macOS/macCatalyst frameworks with the above structure, so CP frameworks are now copied rather than manually reconstructed.