### PR TITLE
[Release Tooling] Add case to address both issues with PrivateHeaders

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -636,7 +636,11 @@ struct FrameworkBuilder {
       // generation. Because this will throw an error for cases where the file
       // does not exist, the error is ignored.
       let privateHeadersDir = platformFrameworkDir.appendingPathComponent("PrivateHeaders")
-      if !fileManager.directoryExists(at: privateHeadersDir.resolvingSymlinksInPath()) {
+      if fileManager.directoryExists(at: privateHeadersDir.resolvingSymlinksInPath()) {
+        try? fileManager
+          .removeItem(at: privateHeadersDir.resolvingSymlinksInPath()
+            .appendingPathComponent("PrivateHeaders"))
+      } else {
         try? fileManager.removeItem(at: privateHeadersDir)
       }
 

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -643,6 +643,9 @@ struct FrameworkBuilder {
       } else {
         try? fileManager.removeItem(at: privateHeadersDir)
       }
+      let headersDir = platformFrameworkDir.appendingPathComponent("Headers")
+        .resolvingSymlinksInPath()
+      try? fileManager.removeItem(at: headersDir.appendingPathComponent("Headers"))
 
       // Move privacy manifest containing resource bundles into the framework.
       let resourceDir = platformFrameworkDir


### PR DESCRIPTION
Took awhile to pin down, but I'm finding there are **two** issues with private headers (I think it's a symptom of CocoaPods setup... not sure).

Affecting grpcpp, grpc, openssl_grpc:
```
grpcpp.framework/
├── Headers -> Versions/Current/Headers
├── Modules -> Versions/Current/Modules
├── PrivateHeaders -> Versions/Current/PrivateHeaders
├── Resources -> Versions/Current/Resources
├── Versions
│   ├── A
│   │   ├── Headers
│   │   ├── Modules
│   │   ├── PrivateHeaders
│   │   │          ├── PrivateHeaders -> Versions/A/PrivateHeaders ←⚠️ This is unexpected that this would be here. 
│   │   │          └── ...
│   │   ├── Resources
│   │   └── grpcpp
│   └── Current -> A
└── grpcpp -> Versions/Current/grpcpp

```

And affecting only abseil:

```
bsl.framework/
├── Headers -> Versions/Current/Headers
├── Modules -> Versions/Current/Modules
├── PrivateHeaders -> Versions/A/PrivateHeaders ←⚠️ This goes no where and breaks Carthage hash.
├── Resources -> Versions/Current/Resources
├── Versions
│   ├── A
│   └── Current -> A
└── absl -> Versions/Current/absl
```

#no-changelog