### PR TITLE
VertexAI Component tests; fix instance generation for different regions

### DIFF
--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -94,7 +94,7 @@ public class VertexAI: NSObject {
 
   private let appCheck: AppCheckInterop?
 
-  private let region: String
+  let region: String
 
   init(app: FirebaseApp, region: String) {
     self.app = app

--- a/FirebaseVertexAI/Sources/VertexAIComponent.swift
+++ b/FirebaseVertexAI/Sources/VertexAIComponent.swift
@@ -70,12 +70,11 @@ class VertexAIComponent: NSObject, Library, VertexAIProvider {
     // Unlock before the function returns.
     defer { os_unfair_lock_unlock(&instancesLock) }
 
-    if let instance = instances[app.name],
-       instance.region == region {
+    if let instance = instances[region] {
       return instance
     }
     let newInstance = VertexAI(app: app, region: region)
-    instances[app.name] = newInstance
+    instances[region] = newInstance
     return newInstance
   }
 }

--- a/FirebaseVertexAI/Sources/VertexAIComponent.swift
+++ b/FirebaseVertexAI/Sources/VertexAIComponent.swift
@@ -22,7 +22,7 @@ import Foundation
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 @objc(FIRVertexAIProvider)
 protocol VertexAIProvider {
-  @objc func vertexAI(_ location: String) -> VertexAI
+  @objc func vertexAI(_ region: String) -> VertexAI
 }
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
@@ -32,7 +32,7 @@ class VertexAIComponent: NSObject, Library, VertexAIProvider {
 
   /// The app associated with all `VertexAI` instances in this container.
   /// This is `unowned` instead of `weak` so it can be used without unwrapping in `vertexAI(...)`
-  private unowned let app: FirebaseApp
+  unowned let app: FirebaseApp
 
   /// A map of active  `VertexAI` instances for `app`, keyed by model resource names
   /// (e.g., "projects/my-project-id/locations/us-central1/publishers/google/models/gemini-pro").
@@ -70,7 +70,8 @@ class VertexAIComponent: NSObject, Library, VertexAIProvider {
     // Unlock before the function returns.
     defer { os_unfair_lock_unlock(&instancesLock) }
 
-    if let instance = instances[app.name] {
+    if let instance = instances[app.name],
+       instance.region == region {
       return instance
     }
     let newInstance = VertexAI(app: app, region: region)

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -15,10 +15,8 @@
 import Foundation
 
 import FirebaseCore
-import FirebaseCoreExtension
 @testable import FirebaseVertexAI
 
-// import FirebaseAppCheckInterop
 import SharedTestUtilities
 
 import XCTest

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -1,0 +1,117 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import FirebaseCore
+import FirebaseCoreExtension
+@testable import FirebaseVertexAI
+
+// import FirebaseAppCheckInterop
+import SharedTestUtilities
+
+import XCTest
+
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+class VertexComponentTests: XCTestCase {
+  static var app: FirebaseApp!
+
+  override class func setUp() {
+    super.setUp()
+    if app == nil {
+      let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
+                                    gcmSenderID: "00000000000000000-00000000000-000000000")
+      options.projectID = "myProjectID"
+      FirebaseApp.configure(options: options)
+      app = FirebaseApp(instanceWithName: "test", options: options)
+    }
+  }
+
+  // MARK: Interoperability Tests
+
+  /// Tests that the right number of components are being provided for the container.
+  func testComponentsBeingRegistered() throws {
+    let components = VertexAIComponent.componentsToRegister()
+    XCTAssert(components.count == 1)
+  }
+
+  /// Tests that a vertex instance can be created properly by the VertexAIComponent.
+  func testVertexInstanceCreation() throws {
+    let app = try XCTUnwrap(VertexComponentTests.app)
+    let component = VertexAIComponent(app: app)
+    let vertex = component.vertexAI("my-region")
+    XCTAssertNotNil(vertex)
+  }
+
+  /// Tests that the component container caches instances of VertexAIComponent.
+  func testMultipleComponentInstancesCreated() throws {
+    let registrants = NSMutableSet(array: [VertexAIComponent.self])
+    let container = FirebaseComponentContainer(
+      app: VertexComponentTests.app,
+      registrants: registrants
+    )
+
+    let provider1 = ComponentType<VertexAIProvider>.instance(for: VertexAIProvider.self,
+                                                             in: container)
+    XCTAssertNotNil(provider1)
+
+    let provider2 = ComponentType<VertexAIProvider>.instance(for: VertexAIProvider.self,
+                                                             in: container)
+    XCTAssertNotNil(provider2)
+
+    // Ensure they're the same instance.
+    XCTAssert(provider1 === provider2)
+  }
+
+  /// Tests that instances of vertex created are different.
+  func testMultipleVertexInstancesCreated() throws {
+    let app = try XCTUnwrap(VertexComponentTests.app)
+    let registrants = NSMutableSet(array: [VertexAIComponent.self])
+    let container = FirebaseComponentContainer(app: app, registrants: registrants)
+
+    let provider = ComponentType<VertexAIProvider>.instance(for: VertexAIProvider.self,
+                                                            in: container)
+    XCTAssertNotNil(provider)
+
+    let vertex1 = provider?.vertexAI("randomRegion")
+    let vertex2 = provider?.vertexAI("randomRegion")
+    XCTAssertNotNil(vertex1)
+
+    // Ensure they're the same instance.
+    XCTAssert(vertex1 === vertex2)
+
+    let vertex3 = provider?.vertexAI("differentRegion")
+    XCTAssertNotNil(vertex3)
+
+    XCTAssert(vertex1 !== vertex3)
+  }
+
+  /// Test that vertex instances get deallocated.
+  func testVertexLifecycle() throws {
+    weak var weakApp: FirebaseApp?
+    weak var weakVertex: VertexAI?
+    try autoreleasepool {
+      let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
+                                    gcmSenderID: "00000000000000000-00000000000-000000000")
+      options.projectID = "myProjectID"
+      let app1 = FirebaseApp(instanceWithName: "transitory app", options: options)
+      weakApp = try XCTUnwrap(app1)
+      let vertex = VertexAI(app: app1, region: "transitory bucket")
+      weakVertex = vertex
+      XCTAssertNotNil(weakVertex)
+    }
+    XCTAssertNil(weakApp)
+    XCTAssertNil(weakVertex)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -170,10 +170,16 @@ let package = Package(
     ),
     abseilDependency(),
     grpcDependency(),
+    // TODO: restore OCMock when https://github.com/erikdoe/ocmock/pull/537
+    // gets merged to fix Xcode 15.3 builds.
     .package(
-      url: "https://github.com/erikdoe/ocmock.git",
-      revision: "c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110"
+      url: "https://github.com/paulb777/ocmock.git",
+      revision: "173955e93e6ee6999a10729ab67e4b4efdd1db6d"
     ),
+//    .package(
+//      url: "https://github.com/erikdoe/ocmock.git",
+//      revision: "c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110"
+//    ),
     .package(
       url: "https://github.com/firebase/leveldb.git",
       "1.22.2" ..< "1.23.0"
@@ -1364,11 +1370,14 @@ let package = Package(
     ),
     .testTarget(
       name: "FirebaseVertexAIUnit",
-      dependencies: ["FirebaseVertexAI"],
+      dependencies: ["FirebaseVertexAI", "SharedTestUtilities"],
       path: "FirebaseVertexAI/Tests/Unit",
       resources: [
         .process("CountTokenResponses"),
         .process("GenerateContentResponses"),
+      ],
+      cSettings: [
+        .headerSearchPath("../../../"),
       ]
     ),
   ] + firestoreTargets(),


### PR DESCRIPTION
- Use StorageComponentTests as a template for VertexComponentTests
- Get a unique VertexAI instance for different regions.
- Enable OCMock testing on Xcode 15.3
