### PR TITLE
Fix model name in Vertex AI multi-modal sample

### DIFF
--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,8 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI(region: "us-central1").generativeModel(modelName: "gemini-1.0-pro")
+    let vertexAI = VertexAI.vertexAI(region: "us-central1")
+    model = vertexAI.generativeModel(modelName: "gemini-1.0-pro-vision")
   }
 
   func reason() async {


### PR DESCRIPTION
Changed `gemini-1.0-pro` to `gemini-1.0-pro-vision` in the GenerativeAIMultimodalSample (needs `-vision` for image support).

#no-changelog