### PR TITLE
Tweak release note

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 10.23.1
 - [Swift Package Manager / CocoaPods] Fixes the macOS/Catalyst xcframework
-  structure issue blocking submission via Xcode 15.3.
+  structure issue in Firebase Analytics blocking submission via Xcode 15.3.
 
 # Firebase 10.23.0
 - Fix validation issue for macOS and macCatalyst XCFrameworks. (#12505)


### PR DESCRIPTION
Clarify the release note to only Analytics since Firestore won't be fixed until 10.24.0.