### PR TITLE
[Release Tooling] Fix METADATA.md regression introduced in #12595

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -460,8 +460,6 @@ struct ZipBuilder {
                                        rootZipDir: zipDir,
                                        builtFrameworks: frameworksToAssemble,
                                        frameworksToIgnore: analyticsPods)
-        // Update the README.
-        metadataDeps += dependencyString(for: folder, in: productDir, frameworks: podFrameworks)
       } catch {
         fatalError("Could not copy frameworks from \(pod) into the zip file: \(error)")
       }
@@ -529,6 +527,9 @@ struct ZipBuilder {
       } catch {
         fatalError("Could not setup Resources for \(pod.key) for \(packageKind) \(error)")
       }
+
+      // Update the README.
+      metadataDeps += dependencyString(for: folder, in: productDir, frameworks: podFrameworks)
 
       // Special case for Crashlytics:
       // Copy additional tools to avoid users from downloading another artifact to upload symbols.

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -704,12 +704,12 @@ struct ZipBuilder {
         at: dir,
         includingPropertiesForKeys: [.isDirectoryKey]
       )
-      print("mango: \(resourceDirs1)")
+      print("papaya: \(resourceDirs1)")
       let resourceDirs2 = try fileManager.contentsOfDirectory(
         at: dir,
         includingPropertiesForKeys: nil
       )
-      print("mango: \(resourceDirs2)")
+      print("banana: \(resourceDirs2)")
 
       if !resourceDirs.isEmpty {
         result += Constants.resourcesRequiredText

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -693,8 +693,14 @@ struct ZipBuilder {
     // string.
     do {
       let fileManager = FileManager.default
-      let resourceDirs = try fileManager.recursivelySearch(for: .directories(name: "Resources"),
-                                                           in: dir)
+
+      let resourceDirs = try fileManager.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: [.isDirectoryKey]
+      ).filter {
+        $0.lastPathComponent == "Resources"
+      }
+
       if !resourceDirs.isEmpty {
         result += Constants.resourcesRequiredText
         result += "\n" // Separate from next pod in listing for text version.

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -699,6 +699,17 @@ struct ZipBuilder {
       ).filter {
         $0.lastPathComponent == "Resources"
       }
+      print("mango: \(resourceDirs)")
+      let resourceDirs1 = try fileManager.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: [.isDirectoryKey]
+      )
+      print("mango: \(resourceDirs1)")
+      let resourceDirs2 = try fileManager.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: nil
+      )
+      print("mango: \(resourceDirs2)")
 
       if !resourceDirs.isEmpty {
         result += Constants.resourcesRequiredText

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -696,7 +696,7 @@ struct ZipBuilder {
       let resourceDirs = try fileManager.contentsOfDirectory(
         at: dir,
         includingPropertiesForKeys: [.isDirectoryKey]
-      ).map {
+      ).flatMap {
         try fileManager.contentsOfDirectory(
           at: $0,
           includingPropertiesForKeys: [.isDirectoryKey]

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -460,7 +460,6 @@ struct ZipBuilder {
                                        rootZipDir: zipDir,
                                        builtFrameworks: frameworksToAssemble,
                                        frameworksToIgnore: analyticsPods)
-
         // Update the README.
         metadataDeps += dependencyString(for: folder, in: productDir, frameworks: podFrameworks)
       } catch {

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -693,7 +693,6 @@ struct ZipBuilder {
     // string.
     do {
       let fileManager = FileManager.default
-
       let resourceDirs = try fileManager.contentsOfDirectory(
         at: dir,
         includingPropertiesForKeys: [.isDirectoryKey]


### PR DESCRIPTION
#no-changelog

When the tooling looks for resources, it was doing a recursive search and finding the `Resources` directories in all of the macOS/macCatalyst directories (introduced in #12595). Since #12595, every macOS/macCatalyst framework has  a `Resources` directory to contain the framework-level Info.plist (this plist lives at the root of the .framework for other platforms). See below:

<img width="813" alt="Screenshot 2024-03-29 at 9 05 19 AM" src="https://github.com/firebase/firebase-ios-sdk/assets/36927374/87978cea-dc6e-4a4c-85ae-6ba6e4b46603">

_From [Apple Developer - Placing content in a bundle](https://developer.apple.com/documentation/bundleresources/placing_content_in_a_bundle?language=objc)_

So, to fix `METADATA.md` saying that everything product has resources, do a shallow search in each product directory at the root of the `Firebase.zip`. The resulting `METADATA.md` should match the 10.23.0 `METADATA.md`. 