### PR TITLE
Add platform tags in `x-goog-api-client`

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -829,7 +829,7 @@ static FIRApp *sDefaultApp;
     @"FIRSessions" : @"fire-ses",
     @"FIRFunctionsComponent" : @"fire-fun",
     @"FIRStorageComponent" : @"fire-str",
-    @"FIRVertexAIComponent" : @"fire-vtx",
+    @"FIRVertexAIComponent" : @"fire-vertex",
   };
   for (NSString *className in swiftComponents.allKeys) {
     Class klass = NSClassFromString(className);

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -18,6 +18,12 @@ import Foundation
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct GenerativeAIService {
+  /// The language of the SDK in the format "gl-<language>/<version>" where version may be blank.
+  static let languageTag = "gl-swift/"
+
+  /// The Firebase SDK version in the format "fire/<version>".
+  static let firebaseVersionTag = "fire/\(FirebaseVersion())"
+
   /// Gives permission to talk to the backend.
   private let apiKey: String
 
@@ -155,9 +161,10 @@ struct GenerativeAIService {
     var urlRequest = URLRequest(url: request.url)
     urlRequest.httpMethod = "POST"
     urlRequest.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
-    // TODO: Determine the right client header to use.
-    //    urlRequest.setValue("genai-swift/\(GenerativeAISwift.version))",
-    //                        forHTTPHeaderField: "x-goog-api-client")
+    urlRequest.setValue(
+      "\(GenerativeAIService.languageTag) \(GenerativeAIService.firebaseVersionTag)",
+      forHTTPHeaderField: "x-goog-api-client"
+    )
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
     if let appCheck {

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import FirebaseAppCheckInterop
+import FirebaseCore
 import XCTest
 
 @testable import FirebaseVertexAI
@@ -1058,6 +1059,10 @@ final class GenerativeModelTests: XCTestCase {
       let requestURL = try XCTUnwrap(request.url)
       XCTAssertEqual(requestURL.path.occurrenceCount(of: "models/"), 1)
       XCTAssertEqual(request.timeoutInterval, timeout)
+      let apiClientTags = try XCTUnwrap(request.value(forHTTPHeaderField: "x-goog-api-client"))
+        .components(separatedBy: " ")
+      XCTAssert(apiClientTags.contains(GenerativeAIService.languageTag))
+      XCTAssert(apiClientTags.contains(GenerativeAIService.firebaseVersionTag))
       XCTAssertEqual(request.value(forHTTPHeaderField: "X-Firebase-AppCheck"), appCheckToken)
       let response = try XCTUnwrap(HTTPURLResponse(
         url: requestURL,


### PR DESCRIPTION
- Updated component name to `fire-vertex`
- Added a `gl-swift/` language tag (omitted a language version based on `gl-objc/` [precedent](https://github.com/firebase/firebase-ios-sdk/blob/c8dadd00b476ca92444c0ff8cae1754a55c2e22c/Firestore/Source/API/FIRFirestore.mm#L120))
- Added a `fire/<firebase-version>` tag

#no-changelog
