### PR TITLE
fix passkey name caching issue

### DIFF
--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -611,6 +611,8 @@ static void callInMainThreadWithAuthDataResultAndError(
                     callback:^(FIRStartPasskeyEnrollmentResponse *_Nullable response,
                                NSError *_Nullable error) {
                       if (error) {
+                        // reset the passkey name cache.
+                        self.passkeyName = nil;
                         completion(nil, error);
                         return;
                       } else {
@@ -651,9 +653,9 @@ static void callInMainThreadWithAuthDataResultAndError(
         [platformCredential.rawClientDataJSON base64EncodedStringWithOptions:0];
     NSString *attestationObject =
         [platformCredential.rawAttestationObject base64EncodedStringWithOptions:0];
+    
     // If passkey name is not provided, we will provide a firebase formatted default name.
-
-    if (self.passkeyName != nil || [self.passkeyName isEqual:@""]) {
+    if (self.passkeyName == nil || [self.passkeyName isEqual:@""]) {
       self.passkeyName = @"Unnamed account (Apple)";
     }
     FIRFinalizePasskeyEnrollmentRequest *request =

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -619,6 +619,11 @@ static void callInMainThreadWithAuthDataResultAndError(
                         // cached the passkey name.  This is needed when calling
                         // finalizePasskeyEnrollment
                         self.passkeyName = name;
+                        // If passkey name is not provided, we will provide a firebase formatted
+                        // default name.
+                        if (self.passkeyName == nil || [self.passkeyName isEqual:@""]) {
+                          self.passkeyName = @"Unnamed account (Apple)";
+                        }
                         NSData *challengeInData =
                             [[NSData alloc] initWithBase64EncodedString:response.challenge
                                                                 options:0];
@@ -631,7 +636,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                         ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest *request =
                             [provider
                                 createCredentialRegistrationRequestWithChallenge:challengeInData
-                                                                            name:name
+                                                                            name:self.passkeyName
                                                                           userID:userIdInData];
                         completion(request, nil);
                       }
@@ -654,10 +659,6 @@ static void callInMainThreadWithAuthDataResultAndError(
     NSString *attestationObject =
         [platformCredential.rawAttestationObject base64EncodedStringWithOptions:0];
 
-    // If passkey name is not provided, we will provide a firebase formatted default name.
-    if (self.passkeyName == nil || [self.passkeyName isEqual:@""]) {
-      self.passkeyName = @"Unnamed account (Apple)";
-    }
     FIRFinalizePasskeyEnrollmentRequest *request =
         [[FIRFinalizePasskeyEnrollmentRequest alloc] initWithIDToken:self.rawAccessToken
                                                                 name:self.passkeyName

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -653,7 +653,7 @@ static void callInMainThreadWithAuthDataResultAndError(
         [platformCredential.rawClientDataJSON base64EncodedStringWithOptions:0];
     NSString *attestationObject =
         [platformCredential.rawAttestationObject base64EncodedStringWithOptions:0];
-    
+
     // If passkey name is not provided, we will provide a firebase formatted default name.
     if (self.passkeyName == nil || [self.passkeyName isEqual:@""]) {
       self.passkeyName = @"Unnamed account (Apple)";

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -413,7 +413,6 @@ static NSString *const kFakeWebSignInUserInteractionFailureReason = @"fake_reaso
  */
 static NSString *const kPasskeyName = @"mockPasskeyName";
 
-
 /** @var kDefaultPasskeyName
     @brief default passkey name.
  */
@@ -1027,7 +1026,7 @@ static NSString *const kAttestationObject =
                                                                          XCTAssertNil(error);
                                                                          XCTAssertEqualObjects(
                                                                              user.passkeyName,
-                                                                                               kDefaultPasskeyName);
+                                                                             kDefaultPasskeyName);
                                                                          XCTAssertEqualObjects(
                                                                              [[request challenge]
                                                                                  base64EncodedStringWithOptions:
@@ -1083,7 +1082,7 @@ static NSString *const kAttestationObject =
                                                                          XCTAssertNil(error);
                                                                          XCTAssertEqualObjects(
                                                                              user.passkeyName,
-                                                                                               kDefaultPasskeyName);
+                                                                             kDefaultPasskeyName);
                                                                          XCTAssertEqualObjects(
                                                                              [[request challenge]
                                                                                  base64EncodedStringWithOptions:
@@ -1126,7 +1125,8 @@ static NSString *const kAttestationObject =
                                                                            NSError
                                                                                *_Nullable error) {
                                                                          XCTAssertNil(request);
-                                                                         XCTAssertNil(user.passkeyName);
+                                                                         XCTAssertNil(
+                                                                             user.passkeyName);
                                                                          XCTAssertEqual(
                                                                              error.code,
                                                                              FIRAuthErrorCodeOperationNotAllowed);

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1028,6 +1028,9 @@ static NSString *const kAttestationObject =
                                                                              user.passkeyName,
                                                                              kDefaultPasskeyName);
                                                                          XCTAssertEqualObjects(
+                                                                             request.name,
+                                                                             kDefaultPasskeyName);
+                                                                         XCTAssertEqualObjects(
                                                                              [[request challenge]
                                                                                  base64EncodedStringWithOptions:
                                                                                      0],
@@ -1084,10 +1087,14 @@ static NSString *const kAttestationObject =
                                                                              user.passkeyName,
                                                                              kDefaultPasskeyName);
                                                                          XCTAssertEqualObjects(
+                                                                             request.name,
+                                                                             kDefaultPasskeyName);
+                                                                         XCTAssertEqualObjects(
                                                                              [[request challenge]
                                                                                  base64EncodedStringWithOptions:
                                                                                      0],
                                                                              kChallenge);
+
                                                                          XCTAssertEqualObjects(
                                                                              [request
                                                                                  relyingPartyIdentifier],


### PR DESCRIPTION
Fix the provided passkey name not being cached issue.  Added more unit tests to guard this.