### PR TITLE
Vertex AI preview versioning

### DIFF
--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -284,7 +284,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
     // The unit tests are set up to catch anything that does not properly convert.
     NSString *version = FIRFirebaseVersion();
     NSArray *components = [version componentsSeparatedByString:@"."];
-    NSString *major = [components objectAtIndex:0];
+    NSString *major = [NSString stringWithFormat:@"%02d", [[components objectAtIndex:0] intValue]];
     NSString *minor = [NSString stringWithFormat:@"%02d", [[components objectAtIndex:1] intValue]];
     NSString *patch = [NSString stringWithFormat:@"%02d", [[components objectAtIndex:2] intValue]];
     kFIRLibraryVersionID = [NSString stringWithFormat:@"%@%@%@000", major, minor, patch];

--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -624,7 +624,7 @@ extern NSString *const kFIRLibraryVersionID;
   int minor = (versionString[2] - '0') * 10 + versionString[3] - '0';
   int patch = (versionString[4] - '0') * 10 + versionString[5] - '0';
   NSString *str = [NSString stringWithFormat:@"%d.%d.%d", major, minor, patch];
-  XCTAssertEqualObjects(str, FIRFirebaseVersion());
+  XCTAssertTrue([FIRFirebaseVersion() hasPrefix:str]);
 }
 
 // Repeat test with more Objective-C.
@@ -639,10 +639,11 @@ extern NSString *const kFIRLibraryVersionID;
   NSRange minor = NSMakeRange(2, 2);
   NSRange patch = NSMakeRange(4, 2);
   NSString *str =
-      [NSString stringWithFormat:@"%@.%d.%d", [kFIRLibraryVersionID substringWithRange:major],
+      [NSString stringWithFormat:@"%d.%d.%d",
+                                 [[kFIRLibraryVersionID substringWithRange:major] intValue],
                                  [[kFIRLibraryVersionID substringWithRange:minor] intValue],
                                  [[kFIRLibraryVersionID substringWithRange:patch] intValue]];
-  XCTAssertEqualObjects(str, FIRFirebaseVersion());
+  XCTAssertTrue([FIRFirebaseVersion() hasPrefix:str]);
 }
 
 #pragma mark - Helpers

--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -638,11 +638,10 @@ extern NSString *const kFIRLibraryVersionID;
   NSRange major = NSMakeRange(0, 2);
   NSRange minor = NSMakeRange(2, 2);
   NSRange patch = NSMakeRange(4, 2);
-  NSString *str =
-      [NSString stringWithFormat:@"%d.%d.%d",
-                                 [[kFIRLibraryVersionID substringWithRange:major] intValue],
-                                 [[kFIRLibraryVersionID substringWithRange:minor] intValue],
-                                 [[kFIRLibraryVersionID substringWithRange:patch] intValue]];
+  NSString *str = [NSString
+      stringWithFormat:@"%d.%d.%d", [[kFIRLibraryVersionID substringWithRange:major] intValue],
+                       [[kFIRLibraryVersionID substringWithRange:minor] intValue],
+                       [[kFIRLibraryVersionID substringWithRange:patch] intValue]];
   XCTAssertTrue([FIRFirebaseVersion() hasPrefix:str]);
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-let firebaseVersion = "10.24.0-vertexai-preview.1"
+let firebaseVersion = "0.1.0-vertexai-preview"
 
 let package = Package(
   name: "Firebase",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-let firebaseVersion = "10.24.0"
+let firebaseVersion = "10.24.0-vertexai-preview.1"
 
 let package = Package(
   name: "Firebase",

--- a/SwiftPMTests/swift-test/all-imports.swift
+++ b/SwiftPMTests/swift-test/all-imports.swift
@@ -76,9 +76,8 @@ class importTest: XCTestCase {
 
     let versionParts = FirebaseVersion().split(separator: ".")
     XCTAssert(versionParts.count == 3)
-    XCTAssertEqual(Int(versionParts[0]), 10)
+    XCTAssertNotNil(Int(versionParts[0]))
     XCTAssertNotNil(Int(versionParts[1]))
-    XCTAssertNotNil(Int(versionParts[2]))
 
     print("System version? Answer: \(GULAppEnvironmentUtil.systemVersion())")
   }


### PR DESCRIPTION
Based on https://semver.org/#spec-item-9

- Start with `0.1.0-vertexai-preview`
- Fix some implementations and tests to handle both one and two digit major versions
- Update tests to handle string suffix

Confirmed that SPM Update to Latest will do an automatic update from https://github.com/paulb777/app-check/releases/tag/0.1.0-vertexai-preview to https://github.com/paulb777/app-check/releases/tag/0.2.0-vertexai-preview