### PR TITLE
Remove `location` from Vertex AI public API

### DIFF
--- a/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = VertexAI.vertexAI(location: "us-central1").generativeModel(modelName: "gemini-1.0-pro")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro")
     chat = model.startChat()
   }
 

--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,8 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    let vertexAI = VertexAI.vertexAI(location: "us-central1")
-    model = vertexAI.generativeModel(modelName: "gemini-1.0-pro-vision")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro-vision")
   }
 
   func reason() async {

--- a/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI(location: "us-central1").generativeModel(modelName: "gemini-1.0-pro")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro")
   }
 
   func summarize(inputText: String) async {

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -25,35 +25,27 @@ public class VertexAI: NSObject {
 
   /// The default `VertexAI` instance.
   ///
-  ///  - Parameter location: The region identifier, e.g., `us-central1`; see
-  ///     [Vertex AI
-  ///     regions](https://cloud.google.com/vertex-ai/docs/general/locations#vertex-ai-regions)
-  ///     for a list of supported regions.
   /// - Returns: An instance of `VertexAI`, configured with the default `FirebaseApp`.
-  public static func vertexAI(location: String) -> VertexAI {
+  public static func vertexAI() -> VertexAI {
     guard let app = FirebaseApp.app() else {
       fatalError("No instance of the default Firebase app was found.")
     }
 
-    return vertexAI(app: app, location: location)
+    return vertexAI(app: app)
   }
 
   /// Creates an instance of `VertexAI` configured with a custom `FirebaseApp`.
   ///
   ///  - Parameters:
   ///   - app: The custom `FirebaseApp` used for initialization.
-  ///   - location: The region identifier, e.g., `us-central1`; see
-  ///     [Vertex AI
-  ///     regions](https://cloud.google.com/vertex-ai/docs/general/locations#vertex-ai-regions)
-  ///     for a list of supported regions.
   /// - Returns: A `VertexAI` instance, configured with the custom `FirebaseApp`.
-  public static func vertexAI(app: FirebaseApp, location: String) -> VertexAI {
+  public static func vertexAI(app: FirebaseApp) -> VertexAI {
     guard let provider = ComponentType<VertexAIProvider>.instance(for: VertexAIProvider.self,
                                                                   in: app.container) else {
       fatalError("No \(VertexAIProvider.self) instance found for Firebase app: \(app.name)")
     }
 
-    return provider.vertexAI(location)
+    return provider.vertexAI("us-central1")
   }
 
   /// Initializes a generative model with the given parameters.

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -34,10 +34,10 @@ final class VertexAIAPITests: XCTestCase {
     let filters = [SafetySetting(harmCategory: .dangerousContent, threshold: .blockOnlyHigh)]
 
     // Instantiate Vertex AI SDK - Default App
-    let vertexAI = VertexAI.vertexAI(location: "my-location")
+    let vertexAI = VertexAI.vertexAI()
 
     // Instantiate Vertex AI SDK - Custom App
-    let _ = VertexAI.vertexAI(app: app!, location: "my-location")
+    let _ = VertexAI.vertexAI(app: app!)
 
     // Permutations without optional arguments.
 


### PR DESCRIPTION
Removed the `location` parameter from VertexAI public APIs -- now hardcoded to `us-central1`.

#no-changelog