### PR TITLE
fix the sign in with deleted passkey crash issue

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1281,6 +1281,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                 NSError *_Nullable error) {
                        if (error) {
                          decoratedCallback(nil, error);
+                         return;
                        }
                        [self completeSignInWithAccessToken:response.idToken
                                  accessTokenExpirationDate:nil

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -561,9 +561,15 @@ static NSString *const kInvalidRecaptchaVersion = @"INVALID_RECAPTCHA_VERSION";
 
 /** @var kInvalidLoginCredentials
     @brief This is the error message the server will respond with if the login credentials is
-   invalid. in the request.
+   invalid in the request.
  */
 static NSString *const kInvalidLoginCredentials = @"INVALID_LOGIN_CREDENTIALS";
+
+/** @var kPasskeyEnrollmentNotFound
+    @brief This is the error message the server will respond with if the passkey credentials is
+   invalid in the request.
+ */
+static NSString *const kPasskeyEnrollmentNotFound = @"PASSKEY_ENROLLMENT_NOT_FOUND";
 
 /** @var gBackendImplementation
     @brief The singleton FIRAuthBackendImplementation instance to use.
@@ -1400,7 +1406,6 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                                                                    underlyingError:error]);
                                return;
                              }
-
                              // Finally, we try to populate the response object with the JSON
                              // values.
                              if (![response setWithDictionary:dictionary error:&error]) {
@@ -1473,6 +1478,10 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
   if ([shortErrorMessage isEqualToString:kUserNotFoundErrorMessage]) {
     return [FIRAuthErrorUtils userNotFoundErrorWithMessage:serverDetailErrorMessage];
+  }
+
+  if ([shortErrorMessage isEqualToString:kPasskeyEnrollmentNotFound]) {
+    return [FIRAuthErrorUtils passkeyEnrollmentNotFoundError];
   }
 
   if ([shortErrorMessage isEqualToString:kUserDeletedErrorMessage]) {

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuthErrors.h
@@ -458,6 +458,10 @@ typedef NS_ERROR_ENUM(FIRAuthErrorDomain, FIRAuthErrorCode){
      */
     FIRAuthErrorCodeRecaptchaSDKNotLinked = 17208,
 
+    /** Indicates the user account was not found.
+     */
+    FIRAuthErrorCodePasskeyEnrollmentNotFound = 17209,
+
     /** Indicates an error occurred while attempting to access the keychain.
      */
     FIRAuthErrorCodeKeychainError = 17995,

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -673,6 +673,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                     NSError *_Nullable error) {
                            if (error) {
                              decoratedCallback(nil, error);
+                             return;
                            } else {
                              [FIRAuth.auth
                                  completeSignInWithAccessToken:response.idToken

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
@@ -489,6 +489,12 @@ static NSString *const kMissingRecaptchaTokenErrorPrefix = @"MISSING_RECAPTCHA_T
  */
 + (NSError *)notificationNotForwardedError;
 
+/** @fn passkeyEnrollmentNotFoundError
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeNotificationNotForwarded code.
+    @return The NSError instance associated with the given FIRAuthError.
+ */
++ (NSError *)passkeyEnrollmentNotFoundError;
+
 #if TARGET_OS_IOS
 /** @fn secondFactorRequiredError
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeSecondFactorRequired code.

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -630,6 +630,9 @@ static NSString *const kFIRAuthErrorMessageInvalidLoginCredentials =
     @"Login credentials invalid. It is possible that the email/password combination does not "
     @"exist.";
 
+static NSString *const kFIRAuthErrorMessageMissingPasskeyEnrollment =
+    @"Cannot find the passkey linked to the current account.";
+
 /** @var FIRAuthErrorDescription
     @brief The error descrioption, based on the error code.
     @remarks No default case so that we get a compiler warning if a new value was added to the enum.
@@ -814,6 +817,8 @@ static NSString *FIRAuthErrorDescription(FIRAuthErrorCode code) {
       return kFIRAuthErrorMessageInvalidReqType;
     case FIRAuthErrorCodeRecaptchaSDKNotLinked:
       return kFIRAuthErrorMessageRecaptchaSDKNotLinked;
+    case FIRAuthErrorCodePasskeyEnrollmentNotFound:
+      return kFIRAuthErrorMessageMissingPasskeyEnrollment;
   }
 }
 
@@ -1001,6 +1006,8 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
       return @"ERROR_INVALID_REQ_TYPE";
     case FIRAuthErrorCodeRecaptchaSDKNotLinked:
       return @"ERROR_RECAPTCHA_SDK_NOT_LINKED";
+    case FIRAuthErrorCodePasskeyEnrollmentNotFound:
+      return @"ERROR_PASSKEY_ENROLLMENT_NOT_FOUND";
   }
 }
 
@@ -1237,6 +1244,10 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
 
 + (NSError *)userNotFoundErrorWithMessage:(nullable NSString *)message {
   return [self errorWithCode:FIRAuthInternalErrorCodeUserNotFound message:message];
+}
+
++ (NSError *)passkeyEnrollmentNotFoundError {
+  return [self errorWithCode:FIRAuthInternalPasskeyEnrollmentNotFound];
 }
 
 + (NSError *)invalidAPIKeyError {

--- a/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
@@ -175,6 +175,12 @@ typedef NS_ENUM(NSInteger, FIRAuthInternalErrorCode) {
    */
   FIRAuthInternalErrorCodeUserNotFound = FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeUserNotFound,
 
+  /** @var FIRAuthInternalPasskeyEnrollmentNotFound
+      @brief Indicates the  given credential ID doesn't exist for passkey withdrawal.
+   */
+  FIRAuthInternalPasskeyEnrollmentNotFound = FIRAuthPublicErrorCodeFlag |
+                                             FIRAuthErrorCodePasskeyEnrollmentNotFound,
+
   /** @var FIRAuthInternalErrorCodeInvalidAPIKey
       @brief Indicates an invalid API Key was supplied in the request.
    */


### PR DESCRIPTION
Added the public facing ERROR_PASSKEY_ENROLLMENT_NOT_FOUND error
Fix the app crashing issue after sign in with a already removed passkey. The issue was due to after receiving the error, we kept going with the sign in.  Added the return statement after error has been received.