### PR TITLE
Handle `totalBillableCharacters` optional decoding in Vertex AI

### DIFF
--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -43,7 +43,10 @@ public struct CountTokensResponse {
   /// The total number of tokens in the input given to the model as a prompt.
   public let totalTokens: Int
 
-  /// The total number of billable characters in the input given to the model as a prompt.
+  /// The total number of billable characters in the text input given to the model as a prompt.
+  ///
+  /// > Important: This does not include billable image, video or other non-text input. See
+  /// [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
   public let totalBillableCharacters: Int
 }
 

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -39,10 +39,27 @@ extension CountTokensRequest: GenerativeAIRequest {
 
 /// The model's response to a count tokens request.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
-public struct CountTokensResponse: Decodable {
+public struct CountTokensResponse {
   /// The total number of tokens in the input given to the model as a prompt.
   public let totalTokens: Int
 
   /// The total number of billable characters in the input given to the model as a prompt.
-  public let totalBillableCharacters: Int?
+  public let totalBillableCharacters: Int
+}
+
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+extension CountTokensResponse: Decodable {
+  enum CodingKeys: CodingKey {
+    case totalTokens
+    case totalBillableCharacters
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    totalTokens = try container.decode(Int.self, forKey: .totalTokens)
+    totalBillableCharacters = try container.decodeIfPresent(
+      Int.self,
+      forKey: .totalBillableCharacters
+    ) ?? 0
+  }
 }

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -44,5 +44,5 @@ public struct CountTokensResponse: Decodable {
   public let totalTokens: Int
 
   /// The total number of billable characters in the input given to the model as a prompt.
-  public let totalBillableCharacters: Int
+  public let totalBillableCharacters: Int?
 }

--- a/FirebaseVertexAI/Tests/Unit/CountTokenResponses/success-no-billable-characters.json
+++ b/FirebaseVertexAI/Tests/Unit/CountTokenResponses/success-no-billable-characters.json
@@ -1,0 +1,3 @@
+{
+  "totalTokens": 258
+}

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -946,6 +946,21 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.totalBillableCharacters, 16)
   }
 
+  func testCountTokens_succeeds_noBillableCharacters() async throws {
+    MockURLProtocol.requestHandler = try httpRequestHandler(
+      forResource: "success-no-billable-characters",
+      withExtension: "json"
+    )
+
+    let response = try await model.countTokens(ModelContent.Part.data(
+      mimetype: "image/jpeg",
+      Data()
+    ))
+
+    XCTAssertEqual(response.totalTokens, 258)
+    XCTAssertNil(response.totalBillableCharacters)
+  }
+
   func testCountTokens_modelNotFound() async throws {
     MockURLProtocol.requestHandler = try httpRequestHandler(
       forResource: "failure-model-not-found", withExtension: "json",

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -958,7 +958,7 @@ final class GenerativeModelTests: XCTestCase {
     ))
 
     XCTAssertEqual(response.totalTokens, 258)
-    XCTAssertNil(response.totalBillableCharacters)
+    XCTAssertEqual(response.totalBillableCharacters, 0)
   }
 
   func testCountTokens_modelNotFound() async throws {


### PR DESCRIPTION
`CountTokensResponse` omits `totalBillableCharacters` on image-only prompts (no characters). Set `totalBillableCharacters` to `0` during decoding if the field is omitted from the JSON payload.

#no-changelog