### PR TITLE
Add placeholder `GoogleService-Info.plist` to Vertex AI sample

### DIFF
--- a/FirebaseVertexAI/Sample/GenerativeAISample.xcodeproj/project.pbxproj
+++ b/FirebaseVertexAI/Sample/GenerativeAISample.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.google.generativeai.GenerativeAISample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.VertexAISample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -517,7 +517,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.google.generativeai.GenerativeAISample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.VertexAISample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FirebaseVertexAI/Sample/GenerativeAISample/GenerativeAISampleApp.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAISample/GenerativeAISampleApp.swift
@@ -19,6 +19,14 @@ import SwiftUI
 struct GenerativeAISampleApp: App {
   init() {
     FirebaseApp.configure()
+
+    if let firebaseApp = FirebaseApp.app(), firebaseApp.options.projectID == "mockproject-1234" {
+      guard let bundleID = Bundle.main.bundleIdentifier else { fatalError() }
+      fatalError("You must create and/or download a valid `GoogleService-Info.plist` file for"
+        + " \(bundleID) from https://console.firebase.google.com to run this sample. Replace the"
+        + " existing `GoogleService-Info.plist` file in the `FirebaseVertexAI/Sample` directory"
+        + " with this new file.")
+    }
   }
 
   var body: some Scene {

--- a/FirebaseVertexAI/Sample/GoogleService-Info.plist
+++ b/FirebaseVertexAI/Sample/GoogleService-Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AD_UNIT_ID_FOR_BANNER_TEST</key>
+	<string>ca-app-pub-3940256099942544/2934735716</string>
+	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
+	<string>ca-app-pub-3940256099942544/4411468910</string>
+	<key>API_KEY</key>
+	<string>AIzaSyAzlj4APqi5S58nFtE52Da0fYBOHA2MhaY</string>
+	<key>BUNDLE_ID</key>
+	<string>com.google.firebase.VertexAISample</string>
+	<key>CLIENT_ID</key>
+	<string>123456789000-hjugbg6ud799v4c49dim8ce2usclthar.apps.googleusercontent.com</string>
+	<key>DATABASE_URL</key>
+	<string>https://mockproject-1234.firebaseio.com</string>
+	<key>GCM_SENDER_ID</key>
+	<string>123456789000</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:123456789000:ios:f1bf012572b04063</string>
+	<key>IS_ADS_ENABLED</key>
+	<true/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<true/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>PROJECT_ID</key>
+	<string>mockproject-1234</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.123456789000-hjugbg6ud799v4c49dim8ce2usclthar</string>
+	<key>STORAGE_BUCKET</key>
+	<string>mockproject-1234.appspot.com</string>
+</dict>
+</plist>

--- a/FirebaseVertexAI/Sample/README.md
+++ b/FirebaseVertexAI/Sample/README.md
@@ -1,0 +1,16 @@
+# Vertex AI for Firebase Sample App
+
+You can try out the SDK quickly, see a complete implementation of various use
+cases, or use the sample app if you don't have your own Apple platforms app. To
+use the sample app, you'll need to perform the following steps:
+1. Download
+   [vertexai-preview-0.1.0.zip](https://github.com/firebase/firebase-ios-sdk/archive/refs/heads/vertexai-preview-0.1.0.zip)
+   for the latest release of the SDK
+1. Extract the zip and open `GenerativeAISample.xcodeproj` in the
+   `FirebaseVertexAI/Sample` directory
+1. [Register the sample app](https://firebase.google.com/docs/ios/setup#register-app)
+   in your Firebase project
+   - The default bundle ID is `com.google.firebase.VertexAISample`
+1. [Download the `GoogleService-Info.plist`](https://firebase.google.com/docs/ios/setup#add-config-file)
+   to the `FirebaseVertexAI/Sample` directory, overwriting the placeholder file
+   with the same name


### PR DESCRIPTION
- Added a placeholder/fake `GoogleService-Info.plist` file to Vertex AI sample app to make it easier to see where to place a real one.
- Added a `projectID` check for `mockproject-1234`, printing instructions to the console if the placeholder file has not been replaced.
- Updated the sample's bundle ID to `com.google.firebase.VertexAISample`.
- Added a README for the sample directory.

#no-changelog