### PR TITLE
[Firestore] Remove DocumentID setter warning

### DIFF
--- a/Firestore/Swift/Source/Codable/DocumentID.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID.swift
@@ -121,12 +121,7 @@ public struct DocumentID<Value: DocumentIDWrappable & Codable>:
 
   public var wrappedValue: Value? {
     get { value }
-    set {
-      if let someNewValue = newValue {
-        logIgnoredValueWarning(value: someNewValue)
-      }
-      value = newValue
-    }
+    set { value = newValue }
   }
 
   private func logIgnoredValueWarning(value: Value) {


### PR DESCRIPTION
Passing a non-nil value to the `@DocumentID` property wrapper's setter no longer logs a warning.
- This warning discouraged some valid programming patterns, e.g., updating a document ID field in a local `Codable` object after the document is created in Firestore.

#no-changelog