### PR TITLE
Use declspec in Firestore on Windows machines

### DIFF
--- a/Firestore/core/src/util/string_format.cc
+++ b/Firestore/core/src/util/string_format.cc
@@ -26,7 +26,11 @@ static const char* kInvalid = "<invalid>";
 
 // Disable asan for this function because of the way it manages stack
 // (nested closure) is flaged with stack underflow by clang on Ubuntu.
+#if defined(_MSC_VER)
+__declspec(no_sanitize_address) std::string StringFormatPieces(
+#else
 __attribute__((no_sanitize_address)) std::string StringFormatPieces(
+#endif
     const char* format, std::initializer_list<absl::string_view> pieces) {
   std::string result;
 


### PR DESCRIPTION
The Visual Studio compiler doesn't support __attribute__((no_sanitize_address)), and instead expects __declspec(no_sanitize_address), so adjust the usage to swap between those two options based on which is being used.

This fixes the Firebase C++ SDK build.

#no-changelog