### PR TITLE
Fix some typos

### DIFF
--- a/.github/actions/notices_generation/app.rb
+++ b/.github/actions/notices_generation/app.rb
@@ -38,7 +38,7 @@ SEARCH_LOCAL_POD_VERSION=false
 begin
   OptionParser.new do |opts|
     opts.banner = "Usage: app.rb [options]"
-    opts.on('-p', '--pods PODS', 'Pods seperated by space or comma.') { |v| @options[:pods] = v.split(/[ ,]/) }
+    opts.on('-p', '--pods PODS', 'Pods separated by space or comma.') { |v| @options[:pods] = v.split(/[ ,]/) }
     opts.on('-s', '--sources SOURCES', 'Sources of Pods') { |v| @options[:sources] = v.split(/[ ,]/) }
     opts.on('-m', '--min_ios_version MIN_IOS_VERSION', 'Minimum iOS version') { |v| @options[:min_ios_version] = v }
     opts.on('-n', '--notices_path OUTPUT_PATH', 'The output path of NOTICES') { |v| @options[:output_path] = v }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,7 +361,7 @@ viewing the [documentation][xcode-debugging].
 ### Testing
 
 Tests are an essential part to building Firebase. Many of the tests
-for Firebase run as part of our continous integration (CI) setup with
+for Firebase run as part of our continuous integration (CI) setup with
 [GitHub Actions].
 
 * _Fixing a bug?_ Add a test to catch potential regressions in

--- a/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSApplication.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, FIRCLSApplicationInstallationSourceType) {
 };
 
 /**
- * Returns the application bundle identifier with occurences of "/" replaced by "_"
+ * Returns the application bundle identifier with occurrences of "/" replaced by "_"
  */
 NSString* FIRCLSApplicationGetBundleIdentifier(void);
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -29,7 +29,7 @@
 
 // The purpose of the crash context is to hold values that absolutely must be read and/or written at
 // crash time.  For robustness against memory corruption, they are protected with guard pages.
-// Further, the context is seperated into read-only and read-write sections.
+// Further, the context is separated into read-only and read-write sections.
 
 __BEGIN_DECLS
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
@@ -173,7 +173,7 @@ static bool FIRCLSProcessGetThreadState(FIRCLSProcess *process,
     return true;
   }
 
-  // Here's a wild trick: emulate what thread_get_state would do. It apppears that
+  // Here's a wild trick: emulate what thread_get_state would do. It appears that
   // we cannot reliably unwind out of thread_get_state. So, instead of trying, setup
   // a thread context that resembles what the real thing would look like
   if (FIRCLSProcessIsCurrentThread(process, thread)) {

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -93,7 +93,7 @@ static exception_mask_t FIRCLSMachExceptionMask(void) {
   // is a confirmed kernel bug.  Lacking access to EXC_CRASH means we must use signal handlers to
   // cover all types of crashes.
   // EXC_GUARD is relatively new, and isn't available on all OS versions. You have to be careful,
-  // because you cannot successfully register hanlders if there are any unrecognized masks. We've
+  // because you cannot successfully register handlers if there are any unrecognized masks. We've
   // dropped support for old OS versions that didn't have EXC_GUARD (iOS 5 and below, macOS 10.6 and
   // below) so we always add it now
 
@@ -192,7 +192,7 @@ static bool FIRCLSMachExceptionReadMessage(FIRCLSMachExceptionReadContext* conte
   r = mach_msg(&message->head, MACH_RCV_MSG | MACH_RCV_LARGE, 0, sizeof(MachExceptionMessage),
                context->port, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
   if (r != MACH_MSG_SUCCESS) {
-    FIRCLSSDKLog("Error receving mach_msg (%d)\n", r);
+    FIRCLSSDKLog("Error receiving mach_msg (%d)\n", r);
     return false;
   }
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -86,7 +86,7 @@ static void FIRCLSSignalInstallHandlers(FIRCLSSignalReadContext *roContext) {
     action.sa_sigaction = FIRCLSSignalHandler;
     // SA_RESETHAND seems like it would be great, but it doesn't appear to
     // work correctly.  After taking a signal, causing another identical signal in
-    // the handler will *not* cause the default handler to be invokved (which should
+    // the handler will *not* cause the default handler to be involved (which should
     // terminate the process).  I've found some evidence that others have seen this
     // behavior on MAC OS X.
     action.sa_flags = SA_SIGINFO | SA_ONSTACK;

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.c
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.c
@@ -55,7 +55,7 @@ FIRCLSAllocatorRef FIRCLSAllocatorCreate(size_t writableSpace, size_t readableSp
     readableRegion.size = ((readableSpace / pageSize) + 1) * pageSize;
   }
 
-  // Make one big, continous allocation, adding additional pages for our guards.  Note
+  // Make one big, continuous allocation, adding additional pages for our guards.  Note
   // that we cannot use malloc (or valloc) in this case, because we need to assert full
   // ownership over these allocations.  mmap is a much better choice.  We also mark these
   // pages as MAP_NOCACHE.

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.c
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.c
@@ -43,7 +43,7 @@ FIRCLSAllocatorRef FIRCLSAllocatorCreate(size_t writableSpace, size_t readableSp
   readableSpace += sizeof(FIRCLSAllocator);  // add the space for our allocator itself
 
   // we can only protect at the page level, so we need all of our regions to be
-  // exact multples of pages.  But, we don't need anything in the special-case of zero.
+  // exact multiples of pages.  But, we don't need anything in the special-case of zero.
 
   writableRegion.size = 0;
   if (writableSpace > 0) {

--- a/FirebaseMessaging/Sources/FIRMessagingPubSub.m
+++ b/FirebaseMessaging/Sources/FIRMessagingPubSub.m
@@ -310,7 +310,7 @@ static NSString *const kTopicRegexPattern = @"/topics/([a-zA-Z0-9-_.~%]+)";
 }
 
 /**
- *  Gets the class describing occurences of topic names and sender IDs in the sender.
+ *  Gets the class describing occurrences of topic names and sender IDs in the sender.
  *
  *  @param topic The topic expression used to generate a pubsub topic
  *

--- a/docs/AddNewPod.md
+++ b/docs/AddNewPod.md
@@ -52,7 +52,7 @@ explicit import by other Firebase pods)
 
 See [Headers and Imports](HeadersImports.md) for details on managing headers and imports.
 
-## Continous Integration
+## Continuous Integration
 
 Set up a GitHub Action workflow for the pod. A good example template is
 [storage.yml](.github/workflows/storage.yml).

--- a/docs/AddNewProduct.md
+++ b/docs/AddNewProduct.md
@@ -66,7 +66,7 @@ non-Google open source project should be nested under a `third_party` directory.
 * `FirebaseFoo/Tests/Sample` - Optional
 * `FirebaseFoo/Tests/{Other}` - Optional
 
-## Continous Integration
+## Continuous Integration
 
 Set up a GitHub Action workflow for the pod. A good example template is
 [storage.yml](.github/workflows/storage.yml).


### PR DESCRIPTION
Fixed typos. Mainly Crashlytics

1. sep `e` rated -> separated
2. contin ` ` ous -> continuous
3. occur ` ` ences -> occurrences
4. app `p` ears -> appears
5. han `ld` ers -> handlers
6. rece ` ` ving -> receiving
7. invo `k` ved -> involved
8. mult ` ` ples -> multiples