### PR TITLE
[Release] Update changelogs for user defaults migration PRs

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed usages of user defaults API to reduce required reason impact.
+
 # 10.24.0
 - [fixed] Fix `'FirebaseCrashlytics/FirebaseCrashlytics-Swift.h' file not found`
   errors (#12611).

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed usages of user defaults API to reduce required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.24.0
 - [fixed] Fix `'FirebaseCrashlytics/FirebaseCrashlytics-Swift.h' file not found`

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed usages of user defaults API to reduce required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.19.1
 - [fixed] Fix bug in apps using both AppCheck and ARCore where AppCheck

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed usages of user defaults API to reduce required reason impact.
+
 # 10.19.1
 - [fixed] Fix bug in apps using both AppCheck and ARCore where AppCheck
   unnecessarily tries to create tokens for the ARCore SDK. This results in

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed usages of user defaults API to reduce required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.17.0
 - [feature] The `FirebaseDatabase` module now contains Firebase Database's

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed usages of user defaults API to reduce required reason impact.
+
 # 10.17.0
 - [feature] The `FirebaseDatabase` module now contains Firebase Database's
   Swift-only APIs that were previously only available via the

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed usages of user defaults API to reduce required reason impact.
+
 # 10.22.0
 - [fixed] Fixed an `objc_retain` crash. (#12393)
 

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed usages of user defaults API to reduce required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.22.0
 - [fixed] Fixed an `objc_retain` crash. (#12393)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed usages of user defaults API to reduce required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.18.0
 - [fixed] Fix a Xcode 15.1 build warning (#12027).

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Removed usages of user defaults API to reduce required reason impact.
+
 # 10.18.0
 - [fixed] Fix a Xcode 15.1 build warning (#12027).
 


### PR DESCRIPTION
I recently merged PRs to migrate away from user defaults for the following SDKs:
- App Check
- Performance
- Sessions
- InAppMessaging
- Database

I'm updating each's changelog with the exception of Sessions because Sessions does not have a changelog. So, I'm ensuring that its clients, Crashlytics & Performance, mention this in their changelogs.

#no-changelog