### PR TITLE
Add `usageMetadata` to `GenerateContentResponse` in Vertex AI

### DIFF
--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -176,8 +176,7 @@ struct ErrorDetailsView: View {
       ],
       finishReason: FinishReason.maxTokens,
       citationMetadata: nil),
-    ],
-    promptFeedback: nil)
+    ])
   )
 
   return ErrorDetailsView(error: error)
@@ -200,8 +199,7 @@ struct ErrorDetailsView: View {
       ],
       finishReason: FinishReason.other,
       citationMetadata: nil),
-    ],
-    promptFeedback: nil)
+    ])
   )
 
   return ErrorDetailsView(error: error)

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
@@ -51,8 +51,7 @@ struct ErrorView: View {
         ],
         finishReason: FinishReason.other,
         citationMetadata: nil),
-      ],
-      promptFeedback: nil)
+      ])
     )
     List {
       MessageView(message: ChatMessage.samples[0])

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -66,8 +66,8 @@ public struct GenerateContentResponse {
   }
 
   /// Initializer for SwiftUI previews or tests.
-  public init(candidates: [CandidateResponse], promptFeedback: PromptFeedback?,
-              usageMetadata: UsageMetadata?) {
+  public init(candidates: [CandidateResponse], promptFeedback: PromptFeedback? = nil,
+              usageMetadata: UsageMetadata? = nil) {
     self.candidates = candidates
     self.promptFeedback = promptFeedback
     self.usageMetadata = usageMetadata

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -20,13 +20,13 @@ public struct GenerateContentResponse {
   /// Token usage metadata for processing the generate content request.
   public struct UsageMetadata {
     /// The number of tokens in the request prompt.
-    let promptTokenCount: Int
+    public let promptTokenCount: Int
 
     /// The total number of tokens across the generated response candidates.
-    let candidatesTokenCount: Int
+    public let candidatesTokenCount: Int
 
     /// The total number of tokens in both the request and response.
-    let totalTokenCount: Int
+    public let totalTokenCount: Int
   }
 
   /// A list of candidate response content, ordered from best to worst.


### PR DESCRIPTION
Added [`usageMetadata`](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/GenerateContentResponse#usagemetadata) to `GenerateContentResponse`.

#no-changelog
