### PR TITLE
Update Issue Xcode placeholder to a supported version

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Xcode Version
       description: What version of Xcode is being used?
-      placeholder: "14.3"
+      placeholder: "15.3"
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
After the 10.25.0 release, Xcode 15.2 will be the lowest supported Xcode version.

#no-changelog