### PR TITLE
[CI] Update grpc dependent jobs to macos-14

### DIFF
--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -46,29 +46,7 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         # These need to be on a single line or else the formatting won't validate.
-        pod: ["FirebaseABTesting", "FirebaseAuth", "FirebaseCore", "FirebaseCrashlytics", "FirebaseDatabase", "FirebaseFunctions", "FirebaseMessaging", "FirebaseRemoteConfig", "FirebaseStorage"]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: pods-${{ matrix.os }}
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Setup project and archive
-      run: scripts/test_archiving.sh ${{ matrix.pod }} ${{ matrix.target }} ArchiveOutputs/${{ matrix.target }}.xcarchive
-
-  # TODO(#12780: Merge Firestore back into above job after https://github.com/grpc/grpc/pull/36340
-  pods-ios-tvos-macos-cron-macos12:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule')
-
-    runs-on: macos-12
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-        # These need to be on a single line or else the formatting won't validate.
-        pod: ["FirebaseFirestore"]
+        pod: ["FirebaseABTesting", "FirebaseAuth", "FirebaseCore", "FirebaseCrashlytics", "FirebaseDatabase", "FirebaseFirestore", "FirebaseFunctions", "FirebaseMessaging", "FirebaseRemoteConfig", "FirebaseStorage"]
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -326,8 +326,7 @@ jobs:
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
-    # TODO(#12780): macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     needs: check
 
     strategy:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,8 +17,7 @@ jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
-    # TODO(#12780): macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       # The SDK repo will be cloned to this dir and podspecs from
@@ -112,8 +111,7 @@ jobs:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
-    # TODO(#12780): macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ jobs:
   specs_checking:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
-    # TODO(#12780): macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       # The SDK repo will be cloned to this dir and podspecs from
@@ -114,8 +113,7 @@ jobs:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
     if: github.repository == 'Firebase/firebase-ios-sdk'
-    # TODO(#12780): macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -44,8 +44,7 @@ jobs:
   specs_testing:
     needs: specs_checking
     if: ${{ needs.specs_checking.outputs.podspecs != '[]' }}
-    # TODO: macOS 14 blocked on https://github.com/grpc/grpc/pull/36340
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}


### PR DESCRIPTION
Fix #12780

Now that https://github.com/grpc/grpc/pull/36340 has been published in grpc 1.62.5, update dependent CI jobs to macos-14
