### PR TITLE
[Release Tooling] Consistent approach to resources when building on Xcode 15

### DIFF
--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
@@ -73,8 +73,9 @@
            // Dynamically linked.
            [NSBundle bundleForClass:myClass],
            // Embedded static framework (zip distribution).
-           [[NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"Frameworks"]
-               URLByAppendingPathComponent:@"FirebaseInAppMessaging.framework"]
+           [NSBundle bundleWithURL:[NSBundle.mainBundle.bundleURL
+                                       URLByAppendingPathComponent:
+                                           @"Frameworks/FirebaseInAppMessaging.framework"]]
          ]) {
       bundleURL = [containingBundle URLForResource:bundledResource withExtension:@"bundle"];
       if (bundleURL != nil) break;

--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
@@ -67,7 +67,15 @@
     NSBundle *containingBundle;
     NSURL *bundleURL;
     // The containing bundle is different whether FIAM is statically or dynamically linked.
-    for (containingBundle in @[ [NSBundle mainBundle], [NSBundle bundleForClass:myClass] ]) {
+    for (containingBundle in @[
+           // Statically linked.
+           [NSBundle mainBundle],
+           // Dynamically linked.
+           [NSBundle bundleForClass:myClass],
+           // Embedded static framework (zip distribution).
+           [[NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"Frameworks"]
+               URLByAppendingPathComponent:@"FirebaseInAppMessaging.framework"]
+         ]) {
       bundleURL = [containingBundle URLForResource:bundledResource withExtension:@"bundle"];
       if (bundleURL != nil) break;
     }

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -658,6 +658,8 @@ struct FrameworkBuilder {
         includingPropertiesForKeys: nil
       )
       .filter { $0.pathExtension == "bundle" }
+      // Filter out `gRPCCertificates-Cpp.bundle` since it is unused.
+      .filter { $0.lastPathComponent == "gRPCCertificates-Cpp.bundle" }
       // Bundles are moved rather than copied to prevent them from being
       // packaged in a `Resources` directory at the root of the xcframework.
       .forEach { try! fileManager.moveItem(

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -674,20 +674,6 @@ struct FrameworkBuilder {
       includingPropertiesForKeys: nil
     )
     .filter { $0.pathExtension == "bundle" }
-    // TODO(ncooke3): Once the zip is built with Xcode 15, the following
-    // `filter` can be removed. The following block exists to preserve
-    // how resources (e.g. like FIAM's) are packaged for use in Xcode 14.
-    .filter { bundleURL in
-      let dirEnum = fileManager.enumerator(atPath: bundleURL.path)
-      var containsPrivacyManifest = false
-      while let relativeFilePath = dirEnum?.nextObject() as? String {
-        if relativeFilePath.hasSuffix("PrivacyInfo.xcprivacy") {
-          containsPrivacyManifest = true
-          break
-        }
-      }
-      return containsPrivacyManifest
-    }
     // Bundles are moved rather than copied to prevent them from being
     // packaged in a `Resources` directory at the root of the xcframework.
     .forEach { try! fileManager.moveItem(

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -670,7 +670,7 @@ struct FrameworkBuilder {
 
           try fileManager.moveItem(
             at: $0,
-            to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
+            to: resourceDir.appendingPathComponent($0.lastPathComponent)
           )
         }
       } catch {

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -665,7 +665,6 @@ struct FrameworkBuilder {
         to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
       ) }
 
-
       // Use the appropriate moduleMaps
       packageModuleMaps(inFrameworks: [frameworkPath],
                         frameworkName: framework,

--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -651,7 +651,20 @@ struct FrameworkBuilder {
           platform == .catalyst || platform == .macOS ? "Resources" : ""
         )
         .resolvingSymlinksInPath()
-      processPrivacyManifests(fileManager, frameworkPath, resourceDir)
+
+      // Move resource bundles into the platform framework.
+      try? fileManager.contentsOfDirectory(
+        at: frameworkPath.deletingLastPathComponent(),
+        includingPropertiesForKeys: nil
+      )
+      .filter { $0.pathExtension == "bundle" }
+      // Bundles are moved rather than copied to prevent them from being
+      // packaged in a `Resources` directory at the root of the xcframework.
+      .forEach { try! fileManager.moveItem(
+        at: $0,
+        to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
+      ) }
+
 
       // Use the appropriate moduleMaps
       packageModuleMaps(inFrameworks: [frameworkPath],
@@ -661,25 +674,6 @@ struct FrameworkBuilder {
 
       return platformFrameworkDir
     }
-  }
-
-  /// Process privacy manifests.
-  ///
-  /// Move any privacy manifest-containing resource bundles into the platform framework.
-  func processPrivacyManifests(_ fileManager: FileManager,
-                               _ frameworkPath: URL,
-                               _ platformFrameworkDir: URL) {
-    try? fileManager.contentsOfDirectory(
-      at: frameworkPath.deletingLastPathComponent(),
-      includingPropertiesForKeys: nil
-    )
-    .filter { $0.pathExtension == "bundle" }
-    // Bundles are moved rather than copied to prevent them from being
-    // packaged in a `Resources` directory at the root of the xcframework.
-    .forEach { try! fileManager.moveItem(
-      at: $0,
-      to: platformFrameworkDir.appendingPathComponent($0.lastPathComponent)
-    ) }
   }
 
   /// Package the built frameworks into an XCFramework.

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -485,7 +485,7 @@ struct ZipBuilder {
           if packageKind == "Firebase" {
             // Move all the bundles in the frameworks out to a common "Resources" directory to
             // match the existing Zip structure.
-            let resourcesDir = productPath.appendingPathComponent("Resources-\(UUID().uuidString)")
+            let resourcesDir = productPath.appendingPathComponent("Resources")
             try fileManager.moveItem(at: xcResourceDir, to: resourcesDir)
 
           } else {

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -485,7 +485,7 @@ struct ZipBuilder {
           if packageKind == "Firebase" {
             // Move all the bundles in the frameworks out to a common "Resources" directory to
             // match the existing Zip structure.
-            let resourcesDir = productPath.appendingPathComponent("Resources")
+            let resourcesDir = productPath.appendingPathComponent("Resources-\(UUID().uuidString)")
             try fileManager.moveItem(at: xcResourceDir, to: resourcesDir)
 
           } else {

--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -24,11 +24,11 @@ Xcode 15.2 or newer is required.
 To integrate a Firebase SDK with your app:
 
 1. Find the desired SDK from the list within `METADATA.md`.
-2. Make sure you have an Xcode project open in Xcode.
-3. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
+1. Make sure you have an Xcode project open in Xcode.
+1. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
    left side of the Xcode window if it wasn't already open.
-4. Remove any existing Firebase xcframeworks from your project.
-5. Drag each xcframework from the "FirebaseAnalytics" directory into the Project
+1. Remove any existing Firebase xcframeworks from your project.
+1. Drag each xcframework from the "FirebaseAnalytics" directory into the Project
    Navigator pane. In the dialog box that appears, make sure the target you
    want the framework to be added to has a checkmark next to it, and that
    you've selected "Copy items if needed".
@@ -36,25 +36,20 @@ To integrate a Firebase SDK with your app:
    > ⚠ To disable AdId support, do not copy
    > `GoogleAppMeasurementIdentitySupport.xcframework`.
 
-6. Drag each framework from the directory named after the SDK into the Project
+1. Drag each framework from the directory named after the SDK into the Project
    Navigator pane. Note that there may be no additional frameworks, in which
    case this directory will be empty. For instance, if you want the Database
    SDK, look in the Database folder for the required frameworks. In the dialog
    box that appears, make sure the target you want this framework to be added to
    has a checkmark next to it, and that you've selected "Copy items if needed."
 
-7. If using Xcode 15, embed each framework that was dragged in. Navigate to the
+1. If using Xcode 15, embed each framework that was dragged in. Navigate to the
    target's _General_ settings and find _Frameworks, Libraries, & Embedded
    Content_. For each framework dragged in from the `Firebase.zip`, select
    **Embed & Sign**. This step will enable privacy manifests to be picked up by
    Xcode's tooling.
 
-8. If the SDK has resources, go into the Resources folders, which will be in
-   the SDK folder. Drag all of those resources into the Project Navigator, just
-   like the frameworks, again making sure that the target you want to add these
-   resources to has a checkmark next to it, and that you've selected "Copy items
-   if needed".
-9. Add the `-ObjC` flag to **Other Linker Settings**:
+1. Add the `-ObjC` flag to **Other Linker Settings**:
 
    a. In your project settings, open the **Settings** panel for your target.
 
@@ -63,7 +58,7 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-ObjC`
 
-10. Add the `-lc++` flag to **Other Linker Settings**:
+1. Add the `-lc++` flag to **Other Linker Settings**:
 
    a. In your project settings, open the **Settings** panel for your target.
 
@@ -72,13 +67,13 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-lc++`
 
-11. Drag the `Firebase.h` header in this directory into your project. This will
+1. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-12. Drag `module.modulemap` into your project and update the
+1. Drag `module.modulemap` into your project and update the
    "User Header Search Paths" in your project's Build Settings to include the
    directory that contains the added module map.
-13. If your app does not include any Swift implementation, you may need to add
+1. If your app does not include any Swift implementation, you may need to add
    a dummy Swift file to the app to prevent Swift system library missing
    symbol linker errors. See
    https://forums.swift.org/t/using-binary-swift-sdks-from-non-swift-apps/55989.
@@ -86,7 +81,7 @@ To integrate a Firebase SDK with your app:
    > ⚠ If prompted with the option to create a corresponding bridging header
    > for the new Swift file, select **Don't create**.
 
-14. You're done! Build your target and start using Firebase.
+1. You're done! Build your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the xcframeworks for
 the new SDK. You only need to add each framework once, so if you've already

--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -24,11 +24,11 @@ Xcode 15.2 or newer is required.
 To integrate a Firebase SDK with your app:
 
 1. Find the desired SDK from the list within `METADATA.md`.
-1. Make sure you have an Xcode project open in Xcode.
-1. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
+2. Make sure you have an Xcode project open in Xcode.
+3. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
    left side of the Xcode window if it wasn't already open.
-1. Remove any existing Firebase xcframeworks from your project.
-1. Drag each xcframework from the "FirebaseAnalytics" directory into the Project
+4. Remove any existing Firebase xcframeworks from your project.
+5. Drag each xcframework from the "FirebaseAnalytics" directory into the Project
    Navigator pane. In the dialog box that appears, make sure the target you
    want the framework to be added to has a checkmark next to it, and that
    you've selected "Copy items if needed".
@@ -36,20 +36,20 @@ To integrate a Firebase SDK with your app:
    > ⚠ To disable AdId support, do not copy
    > `GoogleAppMeasurementIdentitySupport.xcframework`.
 
-1. Drag each framework from the directory named after the SDK into the Project
+6. Drag each framework from the directory named after the SDK into the Project
    Navigator pane. Note that there may be no additional frameworks, in which
    case this directory will be empty. For instance, if you want the Database
    SDK, look in the Database folder for the required frameworks. In the dialog
    box that appears, make sure the target you want this framework to be added to
    has a checkmark next to it, and that you've selected "Copy items if needed."
 
-1. If using Xcode 15, embed each framework that was dragged in. Navigate to the
+7. If using Xcode 15, embed each framework that was dragged in. Navigate to the
    target's _General_ settings and find _Frameworks, Libraries, & Embedded
    Content_. For each framework dragged in from the `Firebase.zip`, select
    **Embed & Sign**. This step will enable privacy manifests to be picked up by
    Xcode's tooling.
 
-1. Add the `-ObjC` flag to **Other Linker Settings**:
+8. Add the `-ObjC` flag to **Other Linker Settings**:
 
    a. In your project settings, open the **Settings** panel for your target.
 
@@ -58,7 +58,7 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-ObjC`
 
-1. Add the `-lc++` flag to **Other Linker Settings**:
+9. Add the `-lc++` flag to **Other Linker Settings**:
 
    a. In your project settings, open the **Settings** panel for your target.
 
@@ -67,13 +67,13 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-lc++`
 
-1. Drag the `Firebase.h` header in this directory into your project. This will
+10. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-1. Drag `module.modulemap` into your project and update the
+11. Drag `module.modulemap` into your project and update the
    "User Header Search Paths" in your project's Build Settings to include the
    directory that contains the added module map.
-1. If your app does not include any Swift implementation, you may need to add
+12. If your app does not include any Swift implementation, you may need to add
    a dummy Swift file to the app to prevent Swift system library missing
    symbol linker errors. See
    https://forums.swift.org/t/using-binary-swift-sdks-from-non-swift-apps/55989.
@@ -81,7 +81,7 @@ To integrate a Firebase SDK with your app:
    > ⚠ If prompted with the option to create a corresponding bridging header
    > for the new Swift file, select **Don't create**.
 
-1. You're done! Build your target and start using Firebase.
+13. You're done! Build your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the xcframeworks for
 the new SDK. You only need to add each framework once, so if you've already


### PR DESCRIPTION
In practice, this PR will remove the gRPC-Certificates.bundle and add the FIAM UI resource bundle into the framework (rather than alongside it). 

Checks on green CI:
- [x] No more top-level resource directories.
- [x] Updated METADATA.md (no more resources outside of xcframeworks)
- [x] No more gRPC-Certificates.bundle (fix #9184)
- [x] Test embedded version of FIAM to ensure bundle is findable. (as of 09efe72)
- [ ] Test upload with all XCFrameworks (iOS, MacCatalyst, macOS)
  - I was able to validate that iOS and macOS apps archive, but am having certs trouble getting to the App Store Connect part.

#no-changelog