### PR TITLE
[Vertex AI] Add Swift major version to language tag

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -18,8 +18,8 @@ import Foundation
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 struct GenerativeAIService {
-  /// The language of the SDK in the format "gl-<language>/<version>" where version may be blank.
-  static let languageTag = "gl-swift/"
+  /// The language of the SDK in the format "gl-<language>/<version>".
+  static let languageTag = "gl-swift/5"
 
   /// The Firebase SDK version in the format "fire/<version>".
   static let firebaseVersionTag = "fire/\(FirebaseVersion())"


### PR DESCRIPTION
Cherry picking from commit a89224c028be0876afe6fb2cc0affcba958a715e / PR #12829 into `vertexai-preview-0.1.0`.

Added a version value to the language tag in Vertex AI. Blank values weren't being picked up by the backend. Picked version `5` (the Swift major version supported) since we don't need anything more specific.

#no-changelog
