### PR TITLE
Update unreleased changelog entries for 10.25.0

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [changed] Removed usages of user defaults API from internal Firebase Sessions
   dependency to eliminate required reason impact.
 

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.19.1

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Firebase 10.25.0
 - [changed] Firebase now requires at least Xcode 15.2. See
   https://developer.apple.com/news/?id=fxu2qp7b for more info.
 - [Zip Distribution] Update zip integration instructions with tips for

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.17.0

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.22.0

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 10.25.0
-- [changed] Removed usages of user defaults API to eliminate required reason impact.
+- [changed] Removed usages of user defaults API to eliminate required reason
+  impact.
+- [changed] When installing In App Messaging via the zip distribution, its UI
+  resource bundle is now embedded within the In App Messaging framework.
+  Choose _Embed & Sign_ when integrating the framework. See the zip
+  distribution's README.md for more instructions.
 
 # 10.22.0
 - [fixed] Fixed an `objc_retain` crash. (#12393)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.
 
 # 10.18.0

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [fixed] Fixed bug preventing Remote Config from working with a custom sqlite3
   dependency (#10884).
 

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.25.0
 - [fixed] Allow blob of data with zero length. (#11773, #12620)
 - [changed] Passing a non-nil value to the `@DocumentID` property wrapper's
   setter no longer logs a warning since it discouraged valid patterns,


### PR DESCRIPTION
Updated `Unreleased` changelog entries to `10.25.0`.

#no-changelog