### PR TITLE
Update `FIRAuthInterop` to use `_Nullable_result` annotation

### DIFF
--- a/FirebaseAuth/Interop/FIRAuthInterop.h
+++ b/FirebaseAuth/Interop/FIRAuthInterop.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** @typedef FIRTokenCallback
  @brief The type of block which gets called when a token is ready.
  */
-typedef void (^FIRTokenCallback)(NSString *_Nullable token, NSError *_Nullable error)
+typedef void (^FIRTokenCallback)(NSString *_Nullable_result token, NSError *_Nullable error)
     NS_SWIFT_UNAVAILABLE("Use Swift's closure syntax instead.");
 
 /// Common methods for Auth interoperability.
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(AuthInterop)
 /// Retrieves the Firebase authentication token, possibly refreshing it if it has expired.
 - (void)getTokenForcingRefresh:(BOOL)forceRefresh
                   withCallback:
-                      (void (^)(NSString *_Nullable token, NSError *_Nullable error))callback
+                      (void (^)(NSString *_Nullable_result token, NSError *_Nullable error))callback
     NS_SWIFT_NAME(getToken(forcingRefresh:completion:));
 
 /// Get the current Auth user's UID. Returns nil if there is no user signed in.

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -40,7 +40,7 @@ Cloud Functions for Firebase.
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'
   s.dependency 'FirebaseAppCheckInterop', '~> 10.10'
-  s.dependency 'FirebaseAuthInterop', '~> 10.0'
+  s.dependency 'FirebaseAuthInterop', '~> 10.25'
   s.dependency 'FirebaseMessagingInterop', '~> 10.0'
   s.dependency 'FirebaseSharedSwift', '~> 10.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -38,7 +38,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   ]
 
   s.dependency 'FirebaseAppCheckInterop', '~> 10.0'
-  s.dependency 'FirebaseAuthInterop', '~> 10.0'
+  s.dependency 'FirebaseAuthInterop', '~> 10.25'
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'


### PR DESCRIPTION
The `getTokenForcingRefresh:withCallback:` method in FirebaseAuthInterop can invoke the completion handler with [`nil, nil`](https://github.com/firebase/firebase-ios-sdk/blob/521cbcf3c17008ccc46509523e3a854d38749e41/FirebaseAuth/Sources/Auth/FIRAuth.m#L2546) but `(void (^)(SomeType *_Nullable value, NSError *_Nullable error))` completion blocks are translated to `async throws -> SomeType` in Swift async/await. The `_Nullable_result` annotation, instead of just `_Nullable`, signals that the return type may be `nil` even when no error is thrown; see Swift [SE-0297](https://github.com/apple/swift-evolution/blob/43b894b0c496b69dd8636bc97bb720212647bb7a/proposals/0297-concurrency-objc.md?plain=1#L259) for more details.

Before:
`func getToken(forcingRefresh forceRefresh: Bool) async throws -> String`

After:
`func getToken(forcingRefresh forceRefresh: Bool) async throws -> String?`

#no-changelog