### PR TITLE
Use Python 3.10 in `diff_report` job

### DIFF
--- a/.github/workflows/api_diff_report.yml
+++ b/.github/workflows/api_diff_report.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install Prerequisites
         run:  ~/api_diff_report/prerequisite.sh

--- a/.github/workflows/api_diff_report.yml
+++ b/.github/workflows/api_diff_report.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Install Prerequisites
         run:  ~/api_diff_report/prerequisite.sh

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -39,6 +39,11 @@ import FirebaseCore
 @objc(FIRStorage) open class Storage: NSObject {
   // MARK: - Public APIs
 
+  // TODO: Revert this change after testing
+  @objc open func fakeNewPublicAPI() -> String {
+    return "Hello, fake API!"
+  }
+
   /// The default `Storage` instance.
   /// - Returns: An instance of `Storage`, configured with the default `FirebaseApp`.
   @objc(storage) open class func storage() -> Storage {

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -39,11 +39,6 @@ import FirebaseCore
 @objc(FIRStorage) open class Storage: NSObject {
   // MARK: - Public APIs
 
-  // TODO: Revert this change after testing
-  @objc open func fakeNewPublicAPI() -> String {
-    return "Hello, fake API!"
-  }
-
   /// The default `Storage` instance.
   /// - Returns: An instance of `Storage`, configured with the default `FirebaseApp`.
   @objc(storage) open class func storage() -> Storage {


### PR DESCRIPTION
Updated to Python 3.10 since Python 3.7 [isn't available](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) on `arm64`.

#no-changelog
