### PR TITLE
Disable failing ObjC Performance quickstart on CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -79,7 +79,7 @@ jobs:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-12  # TODO: the legacy ObjC quickstarts don't run with Xcode 15.
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
@@ -90,8 +90,9 @@ jobs:
           quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
     - name: Test swift quickstart
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Performance true swift)
-    - name: Test objc quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Performance true)
+    # TODO: The legacy ObjC quickstarts don't run with Xcode 15, re-able if we get these working.
+    # - name: Test objc quickstart
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Performance true)
 
   quickstart-ftl-cron-only:
     if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'


### PR DESCRIPTION
Updated the Performance `quickstart` job to run on `macos-14` and disabled the legacy ObjC quickstart which doesn't build on Xcode 15.

#no-changelog