### PR TITLE
[Release] Carthage updates for 10.25.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseABTesting-2823ac22562f1fbe.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseABTesting-999c4183ee13b8d3.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseABTesting-f0810693c46fdadc.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseABTesting-7c24443801777936.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseABTesting-e87c686cee02758a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseABTesting-6a65ab8b888172af.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseABTesting-197f0cb4125363b6.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/Google-Mobile-Ads-SDK-bf8077d30296e04a.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/Google-Mobile-Ads-SDK-ea1e4524d0df93f6.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/Google-Mobile-Ads-SDK-28d9adec807e6c50.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/Google-Mobile-Ads-SDK-4088408e21a81c67.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/Google-Mobile-Ads-SDK-8b0d1ce3d1162b67.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/Google-Mobile-Ads-SDK-046511c3fd0189eb.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/Google-Mobile-Ads-SDK-50008c143ad8f268.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAnalytics-a121058bc5824bfa.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseAnalytics-ed7624b45fb9f7f1.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseAnalytics-e3194dd8c803ccd4.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAnalytics-8af4daf086589ec7.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalytics-95669fcf109f74a2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalytics-c0db6cb0e858e397.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalytics-e8ebe991b5743f71.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAnalyticsOnDeviceConversion-4b5874979659af63.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseAnalyticsOnDeviceConversion-8e03f5b073a147b0.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseAnalyticsOnDeviceConversion-8849e6e43cbbd3c0.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAnalyticsOnDeviceConversion-3ab4488b5238043b.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalyticsOnDeviceConversion-091f5252d693a9f9.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalyticsOnDeviceConversion-7bbb73d46383a042.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalyticsOnDeviceConversion-eca2f83d40e0278d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAppCheck-2b52807979acf863.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseAppCheck-24146838e19ccc61.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseAppCheck-e2e664c6ec135fc4.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAppCheck-81762cfe63fc1817.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppCheck-d19e46a728b1ac4f.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppCheck-8339fde989fe8f24.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppCheck-3ce0f074bfcd2596.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAppDistribution-139211bb5dd3dbc3.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseAppDistribution-fc3d9f20f693b734.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseAppDistribution-e38dad9115dff3af.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAppDistribution-cd27707b993aae9d.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppDistribution-cefc3327ddfceda6.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppDistribution-7931e42d39575534.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppDistribution-79dc2b1348d9aee9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseAuth-529e82147fbbd402.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseAuth-2bbb81f2b4cbac77.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseAuth-466e0e14d0c342e8.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAuth-a223b8ebda8fd2c2.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAuth-e43e66353617f093.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAuth-8a9591e6daa7e207.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAuth-7e18a510d0a5b02e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseCrashlytics-47c05619edb8ae9b.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseCrashlytics-913794b28b7424dc.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseCrashlytics-0805720ebb051475.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseCrashlytics-4035e9332410161e.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseCrashlytics-d29d3285a7d9fa1d.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseCrashlytics-165beb64483b4278.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseCrashlytics-53604573442e756b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseDatabase-f5156c8169b6358f.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseDatabase-61799b2e188bed5b.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseDatabase-a27e18a8a37d7d0a.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseDatabase-0ac7f999ddc3f338.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDatabase-5b22f689cb66d83a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDatabase-e1a9d1f0c4222cf7.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDatabase-aea9249d81841ee1.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseDynamicLinks-c17c59949b7cc573.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseDynamicLinks-ffffc66283665cc3.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseDynamicLinks-6aa708ba01e222f5.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseDynamicLinks-1c3a48e8f12fc824.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDynamicLinks-7cf4ae5e96882ca8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDynamicLinks-c3bdeb37651a5d5d.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDynamicLinks-bcb5df6ec32f6684.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseFirestore-e4570e4863fe2044.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseFirestore-7d1481e62eb86231.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseFirestore-aebec35b37a4feed.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseFirestore-c5fda3ae8ab62345.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFirestore-73ba0700b1aa6d6a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFirestore-02eb8da05f81fca5.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFirestore-46fa68ddf287f76e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseFunctions-d98d21836c2f2130.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseFunctions-30a434d6b70589d3.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseFunctions-56fc811f8293f2ec.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseFunctions-c143cedcb64ae0d6.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFunctions-47189f2c99cdf806.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFunctions-17c4b760141e38ad.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFunctions-688a38b567392fcf.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/GoogleSignIn-a16b78c06ef8f77c.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/GoogleSignIn-fa5daf30aae63bc6.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/GoogleSignIn-03314eec1dbb9708.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/GoogleSignIn-fb2542a2c86f843a.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/GoogleSignIn-a5b49807be66100b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/GoogleSignIn-0d2e746eb3ff9f92.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/GoogleSignIn-5cb2a2f1f74efd5e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseInAppMessaging-fbb53083384bea1e.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseInAppMessaging-0a6028f71dc4dad9.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseInAppMessaging-29ae2009ef1950b2.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseInAppMessaging-b90e8ce0168460cd.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseInAppMessaging-91e5426eade46bca.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseInAppMessaging-10801bd111df59de.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseInAppMessaging-91d4dd9878a06b7e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseMLModelDownloader-b3bffe302a074d0e.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseMLModelDownloader-acc3b6f7b4beb3d8.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseMLModelDownloader-7d8218cf3d3ef34e.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseMLModelDownloader-0373c9fd0cc9bd65.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMLModelDownloader-559cb113c0cfd8f2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMLModelDownloader-9c909894999c92e4.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMLModelDownloader-9abf9b0e24bfb921.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseMessaging-812bc4f1c2d27e93.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseMessaging-3289b9f5d636eda0.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseMessaging-d1e21fc776fa88ed.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseMessaging-e6c8a212895199fa.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMessaging-59ef1cc63c660712.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMessaging-76c02a69e3fe1008.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMessaging-439a17dcc8b8172b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebasePerformance-2a39f03d02fcbc5f.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebasePerformance-daf49762760bcd28.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebasePerformance-04ba5863cb67f726.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebasePerformance-bc7b306425147b0a.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebasePerformance-36ac6dfb99caa11b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebasePerformance-f9f5be8ffad5cbb0.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebasePerformance-0ffe559f7554d8a5.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseRemoteConfig-be4764f1b3e07c4f.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseRemoteConfig-33cb2acece724af5.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseRemoteConfig-8ebff21169280a12.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseRemoteConfig-93bad5de6b479bb5.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseRemoteConfig-edd1b427b8bbe782.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseRemoteConfig-10b62ee5663aaab3.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseRemoteConfig-2237eb5fcd4a4525.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -17,6 +17,7 @@
   "10.22.0": "https://dl.google.com/dl/firebase/ios/carthage/10.22.0/FirebaseStorage-e3b2849afc9f0f95.zip",
   "10.23.0": "https://dl.google.com/dl/firebase/ios/carthage/10.23.0/FirebaseStorage-251d7827e3fc52e4.zip",
   "10.24.0": "https://dl.google.com/dl/firebase/ios/carthage/10.24.0/FirebaseStorage-f4d55d7d55242a20.zip",
+  "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseStorage-472cc5950e16fed9.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseStorage-ac463d14593d10a8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseStorage-fdf8479115660ce6.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseStorage-04f255ea8c3a7420.zip",


### PR DESCRIPTION
Updated the Carthage artifacts for the https://github.com/firebase/firebase-ios-sdk/releases/tag/10.25.0. Verified with `carthage update`.

<details>
<summary>Cartfile.resolved</summary>

```
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppDistributionBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDynamicLinksBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLModelDownloaderBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" "10.25.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json" "10.25.0"
```

</details>

#no-changelog