### PR TITLE
Update versions for Release 10.27.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -36,14 +36,14 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '12.0'
-    ss.ios.dependency 'FirebaseAnalytics', '~> 10.25.0'
-    ss.osx.dependency 'FirebaseAnalytics', '~> 10.25.0'
-    ss.tvos.dependency 'FirebaseAnalytics', '~> 10.25.0'
+    ss.ios.dependency 'FirebaseAnalytics', '~> 10.27.0'
+    ss.osx.dependency 'FirebaseAnalytics', '~> 10.27.0'
+    ss.tvos.dependency 'FirebaseAnalytics', '~> 10.27.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '10.25.0'
+    ss.dependency 'FirebaseCore', '10.27.0'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -79,13 +79,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '12.0'
-    ss.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '~> 10.25.0'
+    ss.dependency 'FirebaseAnalytics/WithoutAdIdSupport', '~> 10.27.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 
   s.subspec 'ABTesting' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseABTesting', '~> 10.25.0'
+    ss.dependency 'FirebaseABTesting', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -95,13 +95,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseAppDistribution', '~> 10.25.0-beta'
+    ss.ios.dependency 'FirebaseAppDistribution', '~> 10.27.0-beta'
     ss.ios.deployment_target = '11.0'
   end
 
   s.subspec 'AppCheck' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAppCheck', '~> 10.25.0'
+    ss.dependency 'FirebaseAppCheck', '~> 10.27.0'
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '12.0'
@@ -110,7 +110,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Auth' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAuth', '~> 10.25.0'
+    ss.dependency 'FirebaseAuth', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -120,7 +120,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseCrashlytics', '~> 10.25.0'
+    ss.dependency 'FirebaseCrashlytics', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -130,7 +130,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Database' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseDatabase', '~> 10.25.0'
+    ss.dependency 'FirebaseDatabase', '~> 10.27.0'
     # Standard platforms PLUS watchOS 7.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -140,13 +140,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'DynamicLinks' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseDynamicLinks', '~> 10.25.0'
+    ss.ios.dependency 'FirebaseDynamicLinks', '~> 10.27.0'
     ss.ios.deployment_target = '11.0'
   end
 
   s.subspec 'Firestore' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFirestore', '~> 10.25.0'
+    ss.dependency 'FirebaseFirestore', '~> 10.27.0'
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '12.0'
@@ -154,7 +154,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Functions' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFunctions', '~> 10.25.0'
+    ss.dependency 'FirebaseFunctions', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -164,20 +164,20 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'InAppMessaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseInAppMessaging', '~> 10.25.0-beta'
-    ss.tvos.dependency 'FirebaseInAppMessaging', '~> 10.25.0-beta'
+    ss.ios.dependency 'FirebaseInAppMessaging', '~> 10.27.0-beta'
+    ss.tvos.dependency 'FirebaseInAppMessaging', '~> 10.27.0-beta'
     ss.ios.deployment_target = '11.0'
     ss.tvos.deployment_target = '12.0'
   end
 
   s.subspec 'Installations' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseInstallations', '~> 10.25.0'
+    ss.dependency 'FirebaseInstallations', '~> 10.27.0'
   end
 
   s.subspec 'Messaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMessaging', '~> 10.25.0'
+    ss.dependency 'FirebaseMessaging', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -187,7 +187,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'MLModelDownloader' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMLModelDownloader', '~> 10.25.0-beta'
+    ss.dependency 'FirebaseMLModelDownloader', '~> 10.27.0-beta'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -197,15 +197,15 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Performance' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebasePerformance', '~> 10.25.0'
-    ss.tvos.dependency 'FirebasePerformance', '~> 10.25.0'
+    ss.ios.dependency 'FirebasePerformance', '~> 10.27.0'
+    ss.tvos.dependency 'FirebasePerformance', '~> 10.27.0'
     ss.ios.deployment_target = '11.0'
     ss.tvos.deployment_target = '12.0'
   end
 
   s.subspec 'RemoteConfig' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseRemoteConfig', '~> 10.25.0'
+    ss.dependency 'FirebaseRemoteConfig', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'
@@ -215,7 +215,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Storage' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseStorage', '~> 10.25.0'
+    ss.dependency 'FirebaseStorage', '~> 10.27.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '11.0'
     ss.osx.deployment_target = '10.13'

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseAnalytics'
-    s.version          = '10.25.0'
+    s.version          = '10.27.0'
     s.summary          = 'Firebase Analytics for iOS'
 
     s.description      = <<-DESC
@@ -37,12 +37,12 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'AdIdSupport'
 
     s.subspec 'AdIdSupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement', '10.25.0'
+        ss.dependency 'GoogleAppMeasurement', '10.27.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 
     s.subspec 'WithoutAdIdSupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '10.25.0'
+        ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '10.27.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 

--- a/FirebaseAnalyticsOnDeviceConversion.podspec
+++ b/FirebaseAnalyticsOnDeviceConversion.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseAnalyticsOnDeviceConversion'
-    s.version          = '10.25.0'
+    s.version          = '10.27.0'
     s.summary          = 'On device conversion measurement plugin for FirebaseAnalytics. Not intended for direct use.'
 
     s.description      = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
     s.cocoapods_version = '>= 1.12.0'
 
-    s.dependency 'GoogleAppMeasurementOnDeviceConversion', '10.25.0'
+    s.dependency 'GoogleAppMeasurementOnDeviceConversion', '10.27.0'
 
     s.static_framework = true
 

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheck'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase App Check SDK.'
 
   s.description      = <<-DESC

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheckInterop'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use AppCheck functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppDistribution'
-  s.version          = '10.25.0-beta'
+  s.version          = '10.27.0-beta'
   s.summary          = 'App Distribution for Firebase iOS SDK.'
 
   s.description      = <<-DESC

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Apple platform client for Firebase Authentication'
 
   s.description      = <<-DESC

--- a/FirebaseAuthInterop.podspec
+++ b/FirebaseAuthInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuthInterop'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Auth functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseCoreExtension'
-    s.version          = '10.25.0'
+    s.version          = '10.27.0'
     s.summary          = 'Extended FirebaseCore APIs for Firebase product SDKs'
 
     s.description      = <<-DESC

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreInternal'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'APIs for internal FirebaseCore usage.'
 
   s.description      = <<-DESC

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCrashlytics'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Best and lightest-weight crash reporting for mobile, desktop and tvOS.'
   s.description      = 'Firebase Crashlytics helps you track, prioritize, and fix stability issues that erode app quality.'
   s.homepage         = 'https://firebase.google.com/'

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDatabase'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Realtime Database'
 
   s.description      = <<-DESC

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDynamicLinks'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Dynamic Links'
 
   s.description      = <<-DESC

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Google Cloud Firestore'
   s.description      = <<-DESC
 Google Cloud Firestore is a NoSQL document database built for automatic scaling, high performance, and ease of application development.
@@ -37,7 +37,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseCore', '~> 10.0'
   s.dependency 'FirebaseCoreExtension', '~> 10.0'
-  s.dependency 'FirebaseFirestoreInternal', '10.25.0'
+  s.dependency 'FirebaseFirestoreInternal', '10.27.0'
   s.dependency 'FirebaseSharedSwift', '~> 10.0'
 
 end

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestoreInternal'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Cloud Functions for Firebase'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '10.25.0-beta'
+  s.version          = '10.27.0-beta'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Installations'
 
   s.description      = <<-DESC

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMLModelDownloader'
-  s.version          = '10.25.0-beta'
+  s.version          = '10.27.0-beta'
   s.summary          = 'Firebase ML Model Downloader'
 
   s.description      = <<-DESC

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Messaging'
 
   s.description      = <<-DESC

--- a/FirebaseMessagingInterop.podspec
+++ b/FirebaseMessagingInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessagingInterop'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Messaging functionality.'
 
   s.description      = <<-DESC

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebasePerformance'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Performance'
 
   s.description      = <<-DESC

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Remote Config'
 
   s.description      = <<-DESC

--- a/FirebaseRemoteConfigInterop.podspec
+++ b/FirebaseRemoteConfigInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfigInterop'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Remote Config functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseSessions'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Sessions'
 
   s.description      = <<-DESC

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseSharedSwift'
-  s.version                 = '10.25.0'
+  s.version                 = '10.27.0'
   s.summary                 = 'Shared Swift Extensions for Firebase'
 
   s.description      = <<-DESC

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorage'
-  s.version          = '10.25.0'
+  s.version          = '10.27.0'
   s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'GoogleAppMeasurement'
-    s.version          = '10.25.0'
+    s.version          = '10.27.0'
     s.summary          = 'Shared measurement methods for Google libraries. Not intended for direct use.'
 
     s.description      = <<-DESC
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'AdIdSupport'
 
     s.subspec 'AdIdSupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '10.25.0'
+        ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '10.27.0'
         ss.vendored_frameworks = 'Frameworks/GoogleAppMeasurementIdentitySupport.xcframework'
     end
 

--- a/GoogleAppMeasurementOnDeviceConversion.podspec
+++ b/GoogleAppMeasurementOnDeviceConversion.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'GoogleAppMeasurementOnDeviceConversion'
-    s.version          = '10.25.0'
+    s.version          = '10.27.0'
     s.summary          = <<-SUMMARY
     On device conversion measurement plugin for Google App Measurement. Not
     intended for direct use.

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-let firebaseVersion = "10.25.0"
+let firebaseVersion = "10.27.0"
 
 let package = Package(
   name: "Firebase",

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "10.25.0",
+  version: "10.27.0",
   pods: [
     Pod("FirebaseSharedSwift"),
     Pod("FirebaseCoreInternal"),


### PR DESCRIPTION
Firebase 10.27.0 [pods](https://github.com/firebase/SpecsStaging/blob/main/Firebase/10.27.0/Firebase.podspec.json) staged in SpecsStaging.

Note: Intentionally skipped from 10.25.0 to 10.27.0 since 10.26.0 will be an SPM-only release; see https://github.com/firebase/firebase-ios-sdk/pull/12873 for context.

#no-changelog