### PR TITLE
Add SIGTERM support

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSMetricKitManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSMetricKitManager.m
@@ -438,6 +438,8 @@
       return @"SIGSYS";
     case SIGTRAP:
       return @"SIGTRAP";
+    case SIGTERM:
+      return @"SIGTERM";
     default:
       return @"UNKNOWN";
   }

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -150,6 +150,8 @@ exception_mask_t FIRCLSMachExceptionMaskForSignal(int signal) {
       return EXC_MASK_CRASH;
     case SIGFPE:
       return EXC_MASK_ARITHMETIC;
+    case SIGTERM:
+      return EXC_MASK_CRASH;
   }
 
   return 0;

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -24,7 +24,6 @@
 static const int FIRCLSFatalSignals[FIRCLSSignalCount] = {
     SIGABRT, SIGBUS, SIGFPE, SIGILL,
     SIGSEGV, SIGSYS, SIGTRAP,
-    
     // SIGTERM can be caught and is usually sent by iOS and variants
     // when Apple wants to try and gracefully shutdown the app
     // before sending a SIGKILL (which can't be caught).
@@ -32,8 +31,7 @@ static const int FIRCLSFatalSignals[FIRCLSSignalCount] = {
     // - When the OS updates an app.
     // - In some circumstances for Watchdog Events.
     // - Resource overuse (CPU, Disk, ...).
-    SIGTERM
-};
+    SIGTERM};
 
 #if CLS_USE_SIGALTSTACK
 static void FIRCLSSignalInstallAltStack(FIRCLSSignalReadContext *roContext);

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -21,8 +21,19 @@
 #include <stdlib.h>
 
 #if CLS_SIGNAL_SUPPORTED
-static const int FIRCLSFatalSignals[FIRCLSSignalCount] = {SIGABRT, SIGBUS, SIGFPE, SIGILL,
-                                                          SIGSEGV, SIGSYS, SIGTRAP};
+static const int FIRCLSFatalSignals[FIRCLSSignalCount] = {
+    SIGABRT, SIGBUS, SIGFPE, SIGILL,
+    SIGSEGV, SIGSYS, SIGTRAP,
+    
+    // SIGTERM can be caught and is usually sent by iOS and variants
+    // when Apple wants to try and gracefully shutdown the app
+    // before sending a SIGKILL (which can't be caught).
+    // Some areas I've seen this happen are:
+    // - When the OS updates an app.
+    // - In some circumstances for Watchdog Events.
+    // - Resource overuse (CPU, Disk, ...).
+    SIGTERM
+};
 
 #if CLS_USE_SIGALTSTACK
 static void FIRCLSSignalInstallAltStack(FIRCLSSignalReadContext *roContext);
@@ -236,6 +247,9 @@ void FIRCLSSignalNameLookup(int number, int code, const char **name, const char 
       break;
     case SIGTRAP:
       *name = "SIGTRAP";
+      break;
+    case SIGTERM:
+      *name = "SIGTERM";
       break;
     default:
       *name = "UNKNOWN";

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
@@ -30,7 +30,8 @@
 #endif
 
 #if CLS_SIGNAL_SUPPORTED
-#define FIRCLSSignalCount (7)
+// keep in sync with the list in _FIRCLSFatalSignals_.
+#define FIRCLSSignalCount (8)
 
 typedef struct {
   const char* path;


### PR DESCRIPTION
## Added support for catching the SIGTERM signal.

All Apple OS's send SIGTERM (like any good unix based system) when they want to request a graceful termination of an application, when the app doesn't quit in those circumstances, it'll receive a SIGKILL. This often gives us the opportunity to get a stack trace where we know Apple wants the app to be terminated but don't know why (watchdog events). This is just one more piece of information that can be added to the puzzle of figuring out unexplained app terminations.

Example in the Firebase Console:
<img width="964" alt="Screenshot 2024-05-01 at 3 13 13 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/221626/62f25feb-d8e8-44b9-9e83-546c9a857a6f">
