### PR TITLE
Stop CI on Swift podspecs

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -42,8 +42,6 @@ jobs:
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurement.podspec --platforms=${{ matrix.target }} --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/
     - name: FirebaseAnalytics
       run: scripts/third_party/travis/retry.sh pod spec lint FirebaseAnalytics.podspec --platforms=${{ matrix.target }} --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/
-    - name: FirebaseAnalyticsSwift
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAnalyticsSwift.podspec --allow-warnings --platforms=${{ matrix.target }}
     # The following steps are only run on `ios` due to product availability.
     - name: GoogleAppMeasurementOnDeviceConversion
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurementOnDeviceConversion.podspec --platforms=ios --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -135,7 +135,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        podspec: [FirebaseDatabase.podspec, FirebaseDatabaseSwift.podspec --allow-warnings]
+        podspec: [FirebaseDatabase.podspec]
         target: [ios, tvos, macos]
         flags: [
           '--skip-tests --use-static-frameworks'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -362,7 +362,6 @@ jobs:
         podspec: [
           'FirebaseFirestoreInternal.podspec',
           'FirebaseFirestore.podspec',
-          'FirebaseFirestoreSwift.podspec',
         ]
 
     steps:
@@ -391,7 +390,6 @@ jobs:
         podspec: [
           'FirebaseFirestoreInternal.podspec',
           'FirebaseFirestore.podspec',
-          'FirebaseFirestoreSwift.podspec',
         ]
         platforms: [
           'macos',

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        podspec: [FirebaseInAppMessaging.podspec, FirebaseInAppMessagingSwift.podspec --allow-warnings]
+        podspec: [FirebaseInAppMessaging.podspec]
         os: [macos-14, macos-13]
         include:
           - os: macos-14

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
         target: [ios, tvos, macos --skip-tests, watchos]
-        podspec: [FirebaseRemoteConfig.podspec, FirebaseRemoteConfigSwift.podspec --allow-warnings --skip-tests]
+        podspec: [FirebaseRemoteConfig.podspec]
         os: [macos-14, macos-13]
         include:
           - os: macos-14

--- a/scripts/health_metrics/file_patterns.json
+++ b/scripts/health_metrics/file_patterns.json
@@ -10,7 +10,7 @@
   },
   {
     "sdk": "analytics",
-    "podspecs": ["FirebaseAnalytics.podspec", "FirebaseAnalyticsSwift.podspec", "GoogleAppMeasurement.podspec"],
+    "podspecs": ["FirebaseAnalytics.podspec", "GoogleAppMeasurement.podspec"],
     "filePatterns": [
       "^FirebaseAnalytics.*",
       "^GoogleAppMeasurement.*"
@@ -58,7 +58,7 @@
   },
   {
     "sdk": "database",
-    "podspecs": ["FirebaseDatabase.podspec", "FirebaseDatabaseSwift.podspec"],
+    "podspecs": ["FirebaseDatabase.podspec"],
     "filePatterns": [
       "^FirebaseDatabase.*",
       "\\.github/workflows/database\\.yml",
@@ -85,7 +85,7 @@
   },
   {
     "sdk": "firestore",
-    "podspecs": ["FirebaseFirestore.podspec", "FirebaseFirestoreSwift.podspec"],
+    "podspecs": ["FirebaseFirestore.podspec"],
     "filePatterns": [
       "^Firestore/.*",
       "FirebaseAppCheck/Interop/[^/]+\\.h",
@@ -117,7 +117,7 @@
   },
   {
     "sdk": "inappmessaging",
-    "podspecs": ["FirebaseInAppMessaging.podspec", "FirebaseInAppMessagingSwift.podspec"],
+    "podspecs": ["FirebaseInAppMessaging.podspec"],
     "filePatterns": [
       "^FirebaseInAppMessaging.*",
       "Interop/Analytics/Public/[^/]+\\.h",
@@ -160,7 +160,7 @@
   },
   {
     "sdk": "remoteconfig",
-    "podspecs": ["FirebaseRemoteConfig.podspec", "FirebaseRemoteConfigSwift.podspec"],
+    "podspecs": ["FirebaseRemoteConfig.podspec"],
     "filePatterns": [
       "^FirebaseRemoteConfig.*",
       "Interop/Analytics/Public/[^/]+\\.h",


### PR DESCRIPTION
We have no plans to release these podspecs again and will remove them in the next major release.