### PR TITLE
[Vertex AI] Add default `nil` for `FunctionDeclaration` `requiredParameters`

### DIFF
--- a/FirebaseVertexAI/Sources/FunctionCalling.swift
+++ b/FirebaseVertexAI/Sources/FunctionCalling.swift
@@ -131,7 +131,7 @@ public struct FunctionDeclaration {
   ///   the values are ``Schema`` objects describing them.
   ///   - requiredParameters: A list of required parameters by name.
   public init(name: String, description: String, parameters: [String: Schema]?,
-              requiredParameters: [String]?) {
+              requiredParameters: [String]? = nil) {
     self.name = name
     self.description = description
     self.parameters = Schema(


### PR DESCRIPTION
Added a default value of `nil` for `requiredParameters` in the `FunctionDeclaration` constructor. This is a port of https://github.com/google-gemini/generative-ai-swift/pull/153.

#no-changelog