### PR TITLE
[Vertex AI] Make `Constants` file internal and fix typos

### DIFF
--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -18,9 +18,9 @@ import Foundation
   #warning("Only iOS, macOS, and Catalyst targets are currently fully supported.")
 #endif
 
-/// Constants associated with the GenerativeAISwift SDK.
+/// Constants associated with the Vertex AI for Firebase SDK.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
-public enum GenerativeAISwift {
+enum Constants {
   /// The Vertex AI backend endpoint URL.
   static let baseURL = "https://firebaseml.googleapis.com"
 }

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -26,7 +26,7 @@ extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
   var url: URL {
-    URL(string: "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model):countTokens")!
+    URL(string: "\(Constants.baseURL)/\(options.apiVersion)/\(model):countTokens")!
   }
 }
 

--- a/FirebaseVertexAI/Sources/GenerateContentRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentRequest.swift
@@ -45,7 +45,7 @@ extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 
   var url: URL {
-    let modelURL = "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model)"
+    let modelURL = "\(Constants.baseURL)/\(options.apiVersion)/\(model)"
     if isStreaming {
       return URL(string: "\(modelURL):streamGenerateContent?alt=sse")!
     } else {

--- a/FirebaseVertexAI/Sources/ModelContent.swift
+++ b/FirebaseVertexAI/Sources/ModelContent.swift
@@ -19,7 +19,7 @@ import Foundation
 /// may comprise multiple heterogeneous ``ModelContent/Part``s.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct ModelContent: Equatable {
-  /// A discrete piece of data in a media format intepretable by an AI model. Within a single value
+  /// A discrete piece of data in a media format interpretable by an AI model. Within a single value
   /// of ``Part``, different data types may not mix.
   public enum Part: Equatable {
     /// Text value.

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -24,9 +24,8 @@ public struct SafetyRating: Equatable, Hashable {
   public let category: SafetySetting.HarmCategory
 
   /// The model-generated probability that a given piece of content falls under the harm category
-  /// described in ``category``. This does not
-  /// indiciate the severity of harm for a piece of content. See ``HarmProbability`` for a list of
-  /// possible values.
+  /// described in ``SafetySetting/HarmCategory``. This does not indicate the severity of harm for a
+  /// piece of content. See ``HarmProbability`` for a list of possible values.
   public let probability: HarmProbability
 
   /// Initializes a new `SafetyRating` instance with the given category and probability.

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -20,7 +20,7 @@ import Foundation
 // Avoids exposing internal FirebaseCore APIs to Swift users.
 @_implementationOnly import FirebaseCoreExtension
 
-/// The Vertex AI service for Firebase.
+/// The Vertex AI for Firebase SDK provides access to Gemini models directly from your app.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public class VertexAI: NSObject {
   // MARK: - Public APIs


### PR DESCRIPTION
- Renamed `GenerativeAISwift` to `Constants` and made it `internal` instead of `public`.
  - Not needed for external use.
- Fixed `intepretable` and `indiciate` typos.
- Expanded on `VertexAI` class docs.

#no-changelog