### PR TITLE
[Release] Update FIAM changelog to reflect 10.26.0

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
-- [fixed] Fixed crash at app start that affected SwiftPM users and CocoaPods
-  users using static frameworks (#12882).
+- [fixed] Fixed crash at app start that affected CocoaPods users using static
+  frameworks (#12882).
+
+# 10.26.0
+- [fixed] Fixed crash at app start that affected SwiftPM users (#12882).
 
 # 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason

--- a/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/FIRIAMDefaultDisplayImpl.m
@@ -79,8 +79,6 @@
     }
     // When embedding static frameworks from the zip distribution, the Xcode
     // will copy the resources into the framework's directory.
-    // TODO(Firebase 11): Remove when Firebase.zip is composed of dynamic
-    // frameworks.
     NSBundle *frameworkBundle = [NSBundle
         bundleWithURL:
             [NSBundle.mainBundle.bundleURL


### PR DESCRIPTION
After merging, will cherry-pick this along with  #12910 and #12917 into the `release-10.26` branch (via PR).