### PR TITLE
Update FirebaseAppCheck's FirebaseCore dependency

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'AppCheckCore', '~> 10.19'
   s.dependency 'FirebaseAppCheckInterop', '~> 10.17'
-  s.dependency 'FirebaseCore', '~> 10.0'
+  s.dependency 'FirebaseCore', '~> 10.18'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.13'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.13'

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] [CocoaPods] missing symbol error for FIRGetLoggerLevel. (#12899)
+
 # 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.
 


### PR DESCRIPTION
Fix #12899

FirebaseAppCheck uses `FIRGetLoggerLevel` which was added to FirebaseCore in 10.18.0. Update the podspec dependency to reflect that.
