### PR TITLE
[Vertex AI] Add AppCheck, Auth and Storage frameworks to sample

### DIFF
--- a/FirebaseVertexAI/Sample/VertexAISample.xcodeproj/project.pbxproj
+++ b/FirebaseVertexAI/Sample/VertexAISample.xcodeproj/project.pbxproj
@@ -7,10 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		868A33682BB476FA00304BB1 /* FirebaseVertexAI-Preview in Frameworks */ = {isa = PBXBuildFile; productRef = 868A33672BB476FA00304BB1 /* FirebaseVertexAI-Preview */; };
 		869200B32B879C4F00482873 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 869200B22B879C4F00482873 /* GoogleService-Info.plist */; };
 		86C1F4832BC726150026816F /* FunctionCallingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C1F47E2BC726150026816F /* FunctionCallingScreen.swift */; };
 		86C1F4842BC726150026816F /* FunctionCallingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C1F4802BC726150026816F /* FunctionCallingViewModel.swift */; };
+		86D9CA8B2BED3EE1007D939E /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 86D9CA8A2BED3EE1007D939E /* FirebaseAppCheck */; };
+		86D9CA8F2BED3EE1007D939E /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 86D9CA8E2BED3EE1007D939E /* FirebaseAuth */; };
+		86D9CAB52BED3EE1007D939E /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 86D9CAB42BED3EE1007D939E /* FirebaseStorage */; };
+		86D9CAB92BED3EE1007D939E /* FirebaseVertexAI-Preview in Frameworks */ = {isa = PBXBuildFile; productRef = 86D9CAB82BED3EE1007D939E /* FirebaseVertexAI-Preview */; };
 		88263BF02B239C09008AB09B /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88263BEE2B239BFE008AB09B /* ErrorView.swift */; };
 		88263BF12B239C11008AB09B /* ErrorDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889873842B208563005B4896 /* ErrorDetailsView.swift */; };
 		8848C8332B0D04BC007B434F /* VertexAISampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8848C8322B0D04BC007B434F /* VertexAISampleApp.swift */; };
@@ -64,9 +67,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				868A33682BB476FA00304BB1 /* FirebaseVertexAI-Preview in Frameworks */,
 				886F95D82B17BA420036F07A /* MarkdownUI in Frameworks */,
+				86D9CAB52BED3EE1007D939E /* FirebaseStorage in Frameworks */,
+				86D9CA8F2BED3EE1007D939E /* FirebaseAuth in Frameworks */,
+				86D9CA8B2BED3EE1007D939E /* FirebaseAppCheck in Frameworks */,
 				886F95E32B17D6630036F07A /* GenerativeAIUIComponents in Frameworks */,
+				86D9CAB92BED3EE1007D939E /* FirebaseVertexAI-Preview in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -292,7 +298,10 @@
 			packageProductDependencies = (
 				886F95D72B17BA420036F07A /* MarkdownUI */,
 				886F95E22B17D6630036F07A /* GenerativeAIUIComponents */,
-				868A33672BB476FA00304BB1 /* FirebaseVertexAI-Preview */,
+				86D9CA8A2BED3EE1007D939E /* FirebaseAppCheck */,
+				86D9CA8E2BED3EE1007D939E /* FirebaseAuth */,
+				86D9CAB42BED3EE1007D939E /* FirebaseStorage */,
+				86D9CAB82BED3EE1007D939E /* FirebaseVertexAI-Preview */,
 			);
 			productName = GenerativeAISample;
 			productReference = 8848C82F2B0D04BC007B434F /* VertexAISample.app */;
@@ -325,7 +334,7 @@
 			packageReferences = (
 				88209C212B0FBDF700F64795 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				DEA09AC32B1FCE22001962D9 /* XCRemoteSwiftPackageReference "NetworkImage" */,
-				868A33642BB476FA00304BB1 /* XCLocalSwiftPackageReference "../.." */,
+				86D9CA892BED3EE1007D939E /* XCLocalSwiftPackageReference "../.." */,
 			);
 			productRefGroup = 8848C8302B0D04BC007B434F /* Products */;
 			projectDirPath = "";
@@ -578,7 +587,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		868A33642BB476FA00304BB1 /* XCLocalSwiftPackageReference "../.." */ = {
+		86D9CA892BED3EE1007D939E /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../..;
 		};
@@ -604,7 +613,19 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		868A33672BB476FA00304BB1 /* FirebaseVertexAI-Preview */ = {
+		86D9CA8A2BED3EE1007D939E /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAppCheck;
+		};
+		86D9CA8E2BED3EE1007D939E /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAuth;
+		};
+		86D9CAB42BED3EE1007D939E /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseStorage;
+		};
+		86D9CAB82BED3EE1007D939E /* FirebaseVertexAI-Preview */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = "FirebaseVertexAI-Preview";
 		};

--- a/FirebaseVertexAI/Sample/VertexAISample/VertexAISampleApp.swift
+++ b/FirebaseVertexAI/Sample/VertexAISample/VertexAISampleApp.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FirebaseAppCheck
 import FirebaseCore
 import SwiftUI
 
@@ -20,6 +21,7 @@ struct VertexAISampleApp: App {
   init() {
     // Recommendation: Protect your Vertex AI API resources from abuse by preventing unauthorized
     // clients using App Check; see https://firebase.google.com/docs/app-check#get_started.
+    AppCheck.setAppCheckProviderFactory(AppCheckNotConfiguredFactory())
 
     FirebaseApp.configure()
 
@@ -38,3 +40,19 @@ struct VertexAISampleApp: App {
     }
   }
 }
+
+/// Placeholder App Check provider factory that returns a simple ``AppCheckNotConfigured`` error.
+private class AppCheckNotConfiguredFactory: NSObject, AppCheckProviderFactory {
+  private class AppCheckNotConfiguredProvider: NSObject, AppCheckProvider {
+    func getToken() async throws -> AppCheckToken {
+      throw AppCheckNotConfigured()
+    }
+  }
+
+  func createProvider(with app: FirebaseApp) -> (any AppCheckProvider)? {
+    return AppCheckNotConfiguredProvider()
+  }
+}
+
+/// Error indicating that App Check is not configured in the sample app.
+struct AppCheckNotConfigured: Error {}

--- a/FirebaseVertexAI/Sample/VertexAISample/VertexAISampleApp.swift
+++ b/FirebaseVertexAI/Sample/VertexAISample/VertexAISampleApp.swift
@@ -16,9 +16,10 @@ import FirebaseAppCheck
 import FirebaseCore
 import SwiftUI
 
-@main
-struct VertexAISampleApp: App {
-  init() {
+class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions launchOptions: [UIApplication
+                     .LaunchOptionsKey: Any]? = nil) -> Bool {
     // Recommendation: Protect your Vertex AI API resources from abuse by preventing unauthorized
     // clients using App Check; see https://firebase.google.com/docs/app-check#get_started.
     AppCheck.setAppCheckProviderFactory(AppCheckNotConfiguredFactory())
@@ -27,12 +28,20 @@ struct VertexAISampleApp: App {
 
     if let firebaseApp = FirebaseApp.app(), firebaseApp.options.projectID == "mockproject-1234" {
       guard let bundleID = Bundle.main.bundleIdentifier else { fatalError() }
-      fatalError("You must create and/or download a valid `GoogleService-Info.plist` file for"
-        + " \(bundleID) from https://console.firebase.google.com to run this sample. Replace the"
-        + " existing `GoogleService-Info.plist` file in the `FirebaseVertexAI/Sample` directory"
-        + " with this new file.")
+      fatalError("""
+      You must create and/or download a valid `GoogleService-Info.plist` file for \(bundleID) from \
+      https://console.firebase.google.com to run this sample. Replace the existing \
+      `GoogleService-Info.plist` file in the `FirebaseVertexAI/Sample` directory with this new file.
+      """)
     }
+
+    return true
   }
+}
+
+@main
+struct VertexAISampleApp: App {
+  @UIApplicationDelegateAdaptor var appDelegate: AppDelegate
 
   var body: some Scene {
     WindowGroup {


### PR DESCRIPTION
- Added the FirebaseAppCheck, FirebaseAuth and FirebaseStorage frameworks to the sample app to make it easier for devs to try out related features.
- Added a placeholder `AppCheckProviderFactory` that returns a simple `AppCheckNotConfigured` error since `AppCheckDebugProviderFactory` and `DeviceCheckProviderFactory` are very noisy with `-FIRDebugEnabled` (if App Check is not configured on the Firebase app -- the more common situation for sample users).
- Switched from configuring Firebase in `init()` to a `UIApplicationDelegate` to silence a `[GoogleUtilities/AppDelegateSwizzler][I-SWZ001014] App Delegate does not conform to UIApplicationDelegate protocol.` warning with `-FIRDebugEnabled`.

#no-changelog