### PR TITLE
[Vertex AI] Update sample instructions for public preview

### DIFF
--- a/FirebaseVertexAI/Sample/README.md
+++ b/FirebaseVertexAI/Sample/README.md
@@ -1,16 +1,49 @@
 # Vertex AI for Firebase Sample App
 
-You can try out the SDK quickly, see a complete implementation of various use
-cases, or use the sample app if you don't have your own Apple platforms app. To
-use the sample app, you'll need to perform the following steps:
-1. Download
-   [vertexai-preview-0.1.0.zip](https://github.com/firebase/firebase-ios-sdk/archive/refs/heads/vertexai-preview-0.1.0.zip)
-   for the latest release of the SDK
-1. Extract the zip and open `VertexAISample.xcodeproj` in the
-   `FirebaseVertexAI/Sample` directory
-1. [Register the sample app](https://firebase.google.com/docs/ios/setup#register-app)
-   in your Firebase project
-   - The default bundle ID is `com.google.firebase.VertexAISample`
-1. [Download the `GoogleService-Info.plist`](https://firebase.google.com/docs/ios/setup#add-config-file)
-   to the `FirebaseVertexAI/Sample` directory, overwriting the placeholder file
-   with the same name
+This sample demonstrates how to make calls to the Vertex AI Gemini API directly
+from your app, rather than server-side, using the
+[Vertex AI for Firebase SDK](https://firebase.google.com/docs/vertex-ai/get-started?platform=ios).
+
+## Getting Started
+
+### Clone and open the sample project
+
+1. Clone this repo and checkout the `release-10.26` branch.
+1. Change into the `FirebaseVertexAI/Sample` directory.
+1. Open `VertexAISample.xcodeproj` using Xcode.
+
+```bash
+$ git clone https://github.com/firebase/firebase-ios-sdk.git
+$ cd firebase-ios-sdk
+$ git checkout release-10.26
+$ cd FirebaseVertexAI/Sample
+$ open VertexAISample.xcodeproj
+```
+
+### Connect the sample to your Firebase project
+
+- To have a functional application, you will need to connect the Vertex AI for
+  Firebase sample app to your Firebase project using the
+  [Firebase Console](https://console.firebase.google.com).
+- For an in-depth explanation, see
+  [Add Firebase to your Apple project](https://firebase.google.com/docs/ios/setup).
+  Below is a summary of the main steps:
+  1. Visit the [Firebase Console](https://console.firebase.google.com).
+  2. Add an iOS+ app to the project. Make sure the `Bundle Identifier` you set
+     matches that of the one in the sample.
+     - The default bundle ID is `com.google.firebase.VertexAISample`
+  3. Download the `GoogleService-Info.plist` when prompted and save it to the
+     `FirebaseVertexAI/Sample` directory, overwriting the placeholder file with
+     the same name.
+- Now you should be able to build and run the sample!
+
+## Documentation
+
+To learn more about the Vertex AI for Firebase SDK, check out the
+[documentation](https://firebase.google.com/docs/vertex-ai).
+
+## Support
+
+- [GitHub Issue](https://github.com/firebase/firebase-ios-sdk/issues/new/choose)
+  - File an issue in the `firebase-ios-sdk` repo, choosing the Vertex AI product.
+- [Firebase Support](https://firebase.google.com/support/)


### PR DESCRIPTION
Updated the instructions for running the sample app. These are linked from https://github.com/firebase/quickstart-ios/blob/main/vertexai/README.md.

Note: the `git checkout release-10.26` should be removed after merging into `main`.

#no-changelog