### PR TITLE
[Vertex AI] Switch to `gemini-1.5-pro-preview-0409` in sample app

### DIFF
--- a/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
     chat = model.startChat()
   }
 

--- a/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -39,7 +39,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init() {
     model = VertexAI.vertexAI().generativeModel(
-      modelName: "gemini-1.0-pro",
+      modelName: "gemini-1.5-pro-preview-0409",
       tools: [Tool(functionDeclarations: [
         FunctionDeclaration(
           name: "get_exchange_rate",

--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro-vision")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
   }
 
   func reason() async {

--- a/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.0-pro")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
   }
 
   func summarize(inputText: String) async {


### PR DESCRIPTION
Switched from `gemini-1.0-pro` / `gemini-1.0-pro-vision` to `gemini-1.5-pro-preview-0409` in the Vertex AI samples.

#no-changelog