### PR TITLE
[Vertex AI] Rename `FirebaseVertexAI-Docs.podspec` to avoid CI

### DIFF
--- a/FirebaseVertexAI-Docs.not_podspec
+++ b/FirebaseVertexAI-Docs.not_podspec
@@ -5,6 +5,9 @@ Pod::Spec.new do |s|
 
   s.description      = <<-DESC
   Placeholder podspec for docsgen only. Do not use this pod.
+
+  NOTE: Rename the file extension from `.not_podspec` to `.podspec` before
+        running `pod gen` for docs generation.
                         DESC
 
   s.homepage         = 'https://firebase.google.com'


### PR DESCRIPTION
Renamed the `FirebaseVertexAI-Docs.podspec` used for documentation generation to `FirebaseVertexAI-Docs.not_podspec`. This avoids including it in the `update_SpecsTesting_repo` job.

#no-changelog