### PR TITLE
Fix VisionOS and WatchOS CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 # To update, change version below, run bundle install, test,
 # commit Gemfile and Gemfile.lock.
+
 source 'https://rubygems.org'
 
 # To test CocoaPods pre-releases, update to a relevant commit or tag like below

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -169,9 +169,11 @@ tvos_flags=(
   -destination 'platform=tvOS Simulator,name=Apple TV'
 )
 watchos_flags=(
+  -sdk 'watchsimulator'
   -destination 'platform=watchOS Simulator,name=Apple Watch Series 7 (45mm)'
 )
 visionos_flags=(
+  -sdk 'xrsimulator'
   -destination 'platform=visionOS Simulator'
 )
 catalyst_flags=(


### PR DESCRIPTION
The `-sdk` option was for `xcodebuild` causing the builds and tests to run for macOS instead.