### PR TITLE
Crashlytics dispatch Rollouts writes async to prevent hangs

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [added] Added support for catching the SIGTERM signal (#12881).
+- [fixed] Fixed a hang when persisting Remote Config Rollouts to disk (#12913).
 
 # 10.25.0
 - [changed] Removed usages of user defaults API from internal Firebase Sessions

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -57,7 +57,7 @@
 
   NSFileHandle *rolloutsFile = [NSFileHandle fileHandleForUpdatingAtPath:rolloutsPath];
 
-  dispatch_sync(FIRCLSGetLoggingQueue(), ^{
+  dispatch_async(FIRCLSGetLoggingQueue(), ^{
     @try {
       [rolloutsFile seekToEndOfFile];
       NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -63,6 +63,7 @@
       NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];
       [rolloutsWithNewLineData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
       [rolloutsFile writeData:rolloutsWithNewLineData];
+      [rolloutsFile closeFile];
     } @catch (NSException *exception) {
       FIRCLSDebugLog(@"Failed to write new rollouts. Exception name: %s - message: %s",
                      exception.name, exception.reason);

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -16,6 +16,7 @@
 #import <XCTest/XCTest.h>
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
+#include "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h"
 #import "Crashlytics/UnitTests/Mocks/FIRCLSTempMockFileManager.h"
@@ -51,6 +52,9 @@ NSString *reportId = @"1234567";
 }
 
 - (void)testUpdateRolloutsStateToPersistenceWithRollouts {
+  XCTestExpectation *expectation = [[XCTestExpectation alloc]
+                                   initWithDescription:@"Expect updating rollouts to finish writing."];
+
   NSString *encodedStateString =
       @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
       @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
@@ -64,7 +68,46 @@ NSString *reportId = @"1234567";
 
   [self.rolloutsPersistenceManager updateRolloutsStateToPersistenceWithRollouts:data
                                                                        reportID:reportId];
+
+  // Wait for the logging queue to finish.
+  dispatch_async(FIRCLSGetLoggingQueue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectations:@[expectation] timeout:3];
+
   XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:rolloutsFilePath]);
+}
+
+- (void)testUpdateRolloutsStateToPersistenceEnsureNoHang {
+  dispatch_queue_t testQueue = dispatch_queue_create("TestQueue", DISPATCH_QUEUE_SERIAL);
+  XCTestExpectation *expectation = [[XCTestExpectation alloc]
+                                   initWithDescription:@"Expect updating rollouts to return."];
+  NSString *encodedStateString =
+      @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
+      @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
+      @"\"rollout_id\":\"726f6c6c6f75745f31\",\"template_version\":1,\"variant_id\":"
+      @"\"636f6e74726f6c\"}]}";
+
+  NSData *data = [encodedStateString dataUsingEncoding:NSUTF8StringEncoding];
+  NSString *rolloutsFilePath =
+      [[[self.fileManager activePath] stringByAppendingPathComponent:reportId]
+          stringByAppendingPathComponent:FIRCLSReportRolloutsFile];
+
+  // Clog up the queue with a long running operation. This sleep time
+  // must be longer than the expectation timeout.
+  dispatch_async(FIRCLSGetLoggingQueue(), ^{
+    sleep(10);
+  });
+
+  dispatch_async(testQueue, ^{
+    // Ensure that calling this returns quickly so we don't hang
+    [self.rolloutsPersistenceManager updateRolloutsStateToPersistenceWithRollouts:data
+                                                                         reportID:reportId];
+    [expectation fulfill];
+  });
+
+  [self waitForExpectations:@[expectation] timeout:3];
 }
 
 @end

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -52,6 +52,9 @@ NSString *reportId = @"1234567";
 }
 
 - (void)testUpdateRolloutsStateToPersistenceWithRollouts {
+  XCTestExpectation *expectation = [[XCTestExpectation alloc]
+      initWithDescription:@"Expect updating rollouts to finish writing."];
+
   NSString *encodedStateString =
       @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
       @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
@@ -65,6 +68,13 @@ NSString *reportId = @"1234567";
 
   [self.rolloutsPersistenceManager updateRolloutsStateToPersistenceWithRollouts:data
                                                                        reportID:reportId];
+
+  // Wait for the logging queue to finish.
+  dispatch_async(FIRCLSGetLoggingQueue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectations:@[ expectation ] timeout:3];
 
   XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:rolloutsFilePath]);
 }

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -52,9 +52,6 @@ NSString *reportId = @"1234567";
 }
 
 - (void)testUpdateRolloutsStateToPersistenceWithRollouts {
-  XCTestExpectation *expectation = [[XCTestExpectation alloc]
-      initWithDescription:@"Expect updating rollouts to finish writing."];
-
   NSString *encodedStateString =
       @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
       @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
@@ -68,13 +65,6 @@ NSString *reportId = @"1234567";
 
   [self.rolloutsPersistenceManager updateRolloutsStateToPersistenceWithRollouts:data
                                                                        reportID:reportId];
-
-  // Wait for the logging queue to finish.
-  dispatch_async(FIRCLSGetLoggingQueue(), ^{
-    [expectation fulfill];
-  });
-
-  [self waitForExpectations:@[ expectation ] timeout:3];
 
   XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:rolloutsFilePath]);
 }

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -90,9 +90,6 @@ NSString *reportId = @"1234567";
       @"\"636f6e74726f6c\"}]}";
 
   NSData *data = [encodedStateString dataUsingEncoding:NSUTF8StringEncoding];
-  NSString *rolloutsFilePath =
-      [[[self.fileManager activePath] stringByAppendingPathComponent:reportId]
-          stringByAppendingPathComponent:FIRCLSReportRolloutsFile];
 
   // Clog up the queue with a long running operation. This sleep time
   // must be longer than the expectation timeout.

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -53,7 +53,7 @@ NSString *reportId = @"1234567";
 
 - (void)testUpdateRolloutsStateToPersistenceWithRollouts {
   XCTestExpectation *expectation = [[XCTestExpectation alloc]
-                                   initWithDescription:@"Expect updating rollouts to finish writing."];
+      initWithDescription:@"Expect updating rollouts to finish writing."];
 
   NSString *encodedStateString =
       @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
@@ -74,15 +74,15 @@ NSString *reportId = @"1234567";
     [expectation fulfill];
   });
 
-  [self waitForExpectations:@[expectation] timeout:3];
+  [self waitForExpectations:@[ expectation ] timeout:3];
 
   XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:rolloutsFilePath]);
 }
 
 - (void)testUpdateRolloutsStateToPersistenceEnsureNoHang {
   dispatch_queue_t testQueue = dispatch_queue_create("TestQueue", DISPATCH_QUEUE_SERIAL);
-  XCTestExpectation *expectation = [[XCTestExpectation alloc]
-                                   initWithDescription:@"Expect updating rollouts to return."];
+  XCTestExpectation *expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Expect updating rollouts to return."];
   NSString *encodedStateString =
       @"{rollouts:[{\"parameter_key\":\"6d795f66656174757265\",\"parameter_value\":"
       @"\"e8bf99e698af7468656d6973e79a84e6b58be8af95e695b0e68daeefbc8ce8be93e585a5e4b8ade69687\","
@@ -107,7 +107,7 @@ NSString *reportId = @"1234567";
     [expectation fulfill];
   });
 
-  [self waitForExpectations:@[expectation] timeout:3];
+  [self waitForExpectations:@[ expectation ] timeout:3];
 }
 
 @end


### PR DESCRIPTION
https://github.com/firebase/firebase-ios-sdk/issues/12913 reports hangs writing to rollouts.

I was able to reproduce this in a test by putting a long running operation on the `FIRCLSGetLoggingQueue()`. Root cause is dispatching synchronously for writes to rollouts.

Added a test case to ensure `updateRolloutsStateToPersistenceWithRollouts` returns to the caller without blocking on the dispatch queue.