### PR TITLE
[Vertex AI] Update samples/docs to use `gemini-1.5-flash-preview-0514`

### DIFF
--- a/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
     chat = model.startChat()
   }
 

--- a/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -39,7 +39,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init() {
     model = VertexAI.vertexAI().generativeModel(
-      modelName: "gemini-1.5-pro-preview-0409",
+      modelName: "gemini-1.5-flash-preview-0514",
       tools: [Tool(functionDeclarations: [
         FunctionDeclaration(
           name: "get_exchange_rate",

--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
   }
 
   func reason() async {

--- a/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-pro-preview-0409")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
   }
 
   func summarize(inputText: String) async {

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -50,8 +50,7 @@ public final class GenerativeModel {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to use, for example `"gemini-1.0-pro"`; see
-  ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
+  ///   - name: The name of the model to use, for example `"gemini-1.0-pro"`.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -60,10 +60,14 @@ public class VertexAI: NSObject {
 
   /// Initializes a generative model with the given parameters.
   ///
+  /// - Note: Refer to [Gemini models](https://firebase.google.com/docs/vertex-ai/gemini-models) for
+  /// guidance on choosing an appropriate model for your use case.
+  ///
   /// - Parameters:
-  ///   - modelName: The name of the model to use, for example `"gemini-1.0-pro"`; see
-  ///     [Gemini models](https://firebase.google.com/docs/vertex-ai/gemini-model#available-models)
-  ///     for a list of supported model names.
+  ///   - modelName: The name of the model to use, for example `"gemini-1.5-flash-preview-0514"`;
+  ///     see [available model names
+  ///     ](https://firebase.google.com/docs/vertex-ai/gemini-models#available-model-names) for a
+  ///     list of supported model names.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.
   ///   - tools: A list of ``Tool`` objects that the model may use to generate the next response.


### PR DESCRIPTION
Updated the Vertex AI samples and docs to use the `gemini-1.5-flash-preview-0514` model.

Note: See [Gemini 1.5 Pro model names](https://firebase.google.com/docs/vertex-ai/gemini-models#model-names-gemini-1.5-pro) for the `gemini-1.5-pro-preview-0409` (previous model) discontinuation date.

#no-changelog