### PR TITLE
[auth-swift] Modernize Phone Auth Notification Implementation

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -66,12 +66,6 @@ import FirebaseCoreExtension
       completionHandler(UIBackgroundFetchResult.noData)
     }
 
-    // TODO(#11693): This deprecated API is temporarily needed for Phone Auth.
-    open func application(_ application: UIApplication,
-                          didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
-      _ = canHandleNotification(userInfo)
-    }
-
     open func application(_ application: UIApplication,
                           open url: URL,
                           options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -100,12 +100,6 @@
           delegate.application?(self.application,
                                 didReceiveRemoteNotification: proberNotification) { _ in
           }
-        } else if let delegate = self.application.delegate,
-                  delegate
-                  .responds(to: #selector(UIApplicationDelegate
-                      .application(_:didReceiveRemoteNotification:))) {
-          delegate.application?(self.application,
-                                didReceiveRemoteNotification: proberNotification)
         } else {
           AuthLog.logWarning(
             code: "I-AUT000015",

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1429,8 +1429,9 @@ extension User: NSSecureCoding {}
     var providerData: [String: UserInfoImpl] = [:]
     if let providerUserInfos = user.providerUserInfo {
       for providerUserInfo in providerUserInfos {
-        let userInfo = UserInfoImpl.userInfo(withGetAccountInfoResponseProviderUserInfo:
-          providerUserInfo)
+        let userInfo = UserInfoImpl.userInfo(
+          withGetAccountInfoResponseProviderUserInfo: providerUserInfo
+        )
         if let providerID = providerUserInfo.providerID {
           providerData[providerID] = userInfo
         }

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -23,13 +23,12 @@ extension UserInfoImpl: NSSecureCoding {}
   /// - Returns: A new instance of `UserInfo` using data from the getAccountInfo endpoint.
   class func userInfo(withGetAccountInfoResponseProviderUserInfo providerUserInfo: GetAccountInfoResponseProviderUserInfo)
     -> UserInfoImpl {
-    guard let providerID = providerUserInfo.providerID,
-          let uid = providerUserInfo.federatedID else {
+    guard let providerID = providerUserInfo.providerID else {
       // This was a crash in ObjC implementation. Should providerID be not nullable?
-      fatalError("Missing providerID or uid from GetAccountInfoResponseProviderUserInfo")
+      fatalError("Missing providerID from GetAccountInfoResponseProviderUserInfo")
     }
     return UserInfoImpl(withProviderID: providerID,
-                        userID: uid,
+                        userID: providerUserInfo.federatedID ?? "",
                         displayName: providerUserInfo.displayName,
                         photoURL: providerUserInfo.photoURL,
                         email: providerUserInfo.email,

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthUIDelegate.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthUIDelegate.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
   import Foundation
   import UIKit

--- a/Package.swift
+++ b/Package.swift
@@ -154,9 +154,9 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      branch: "pb-rm-deprecated-didReceive"
+      branch: "release-8.0"
       // TODO: Update to 8.0.0 when ready.
-      // "7.12.1" ..< "8.0.0"
+      // "8.0.0" ..< "9.0.0"
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",

--- a/Package.swift
+++ b/Package.swift
@@ -154,7 +154,9 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",
-      "7.12.1" ..< "8.0.0"
+      branch: "pb-rm-deprecated-didReceive"
+      // TODO: Update to 8.0.0 when ready.
+      // "7.12.1" ..< "8.0.0"
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",


### PR DESCRIPTION
Now only application:didReceiveRemoteNotification:fetchCompletionHandler: is supported unconditionally along with https://github.com/google/GoogleUtilities/pull/162.

This is part of fixing #11693.  FirebaseMessaging still needs review and updates.  GoogleUtilities needs to be updated to 8.0.0 for both CocoaPods and SPM.

This PR also fixes a regression in Phone Auth. (It depends on a nil uid at creation.)