### PR TITLE
[Vertex AI] Add error message for Firebase ML API not enabled

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -51,6 +51,8 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
     - uses: actions/checkout@v4
     - name: Xcode

--- a/FirebaseVertexAI/Sources/Errors.swift
+++ b/FirebaseVertexAI/Sources/Errors.swift
@@ -30,6 +30,10 @@ struct RPCError: Error {
     self.status = status
     self.details = details
   }
+
+  func isFirebaseMLServiceDisabledError() -> Bool {
+    return details.contains { $0.isFirebaseMLServiceDisabledErrorDetails() }
+  }
 }
 
 extension RPCError: Decodable {
@@ -76,9 +80,26 @@ struct ErrorDetails {
   let type: String
   let reason: String?
   let domain: String?
+  let metadata: [String: String]?
 
   func isErrorInfo() -> Bool {
     return type == ErrorDetails.errorInfoType
+  }
+
+  func isFirebaseMLServiceDisabledErrorDetails() -> Bool {
+    guard isErrorInfo() else {
+      return false
+    }
+    guard reason == "SERVICE_DISABLED" else {
+      return false
+    }
+    guard domain == "googleapis.com" else {
+      return false
+    }
+    guard let metadata, metadata["service"] == "firebaseml.googleapis.com" else {
+      return false
+    }
+    return true
   }
 }
 
@@ -87,6 +108,7 @@ extension ErrorDetails: Decodable, Equatable {
     case type = "@type"
     case reason
     case domain
+    case metadata
   }
 }
 

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -51,6 +51,7 @@ public final class GenerativeModel {
   ///
   /// - Parameters:
   ///   - name: The name of the model to use, for example `"gemini-1.0-pro"`.
+  ///   - projectID: The project ID from the Firebase console.
   ///   - apiKey: The API key for your project.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.
@@ -61,6 +62,7 @@ public final class GenerativeModel {
   ///   - requestOptions: Configuration parameters for sending requests to the backend.
   ///   - urlSession: The `URLSession` to use for requests; defaults to `URLSession.shared`.
   init(name: String,
+       projectID: String,
        apiKey: String,
        generationConfig: GenerationConfig? = nil,
        safetySettings: [SafetySetting]? = nil,
@@ -73,6 +75,7 @@ public final class GenerativeModel {
        urlSession: URLSession = .shared) {
     modelResourceName = GenerativeModel.modelResourceName(name: name)
     generativeAIService = GenerativeAIService(
+      projectID: projectID,
       apiKey: apiKey,
       appCheck: appCheck,
       auth: auth,

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -83,7 +83,15 @@ public class VertexAI: NSObject {
                               systemInstruction: ModelContent? = nil,
                               requestOptions: RequestOptions = RequestOptions())
     -> GenerativeModel {
-    let modelResourceName = modelResourceName(modelName: modelName, location: location)
+    guard let projectID = app.options.projectID else {
+      fatalError("The Firebase app named \"\(app.name)\" has no project ID in its configuration.")
+    }
+
+    let modelResourceName = modelResourceName(
+      modelName: modelName,
+      projectID: projectID,
+      location: location
+    )
 
     guard let apiKey = app.options.apiKey else {
       fatalError("The Firebase app named \"\(app.name)\" has no API key in its configuration.")
@@ -91,6 +99,7 @@ public class VertexAI: NSObject {
 
     return GenerativeModel(
       name: modelResourceName,
+      projectID: projectID,
       apiKey: apiKey,
       generationConfig: generationConfig,
       safetySettings: safetySettings,
@@ -121,10 +130,7 @@ public class VertexAI: NSObject {
     auth = ComponentType<AuthInterop>.instance(for: AuthInterop.self, in: app.container)
   }
 
-  private func modelResourceName(modelName: String, location: String) -> String {
-    guard let projectID = app.options.projectID else {
-      fatalError("The Firebase app named \"\(app.name)\" has no project ID in its configuration.")
-    }
+  private func modelResourceName(modelName: String, projectID: String, location: String) -> String {
     guard !modelName.isEmpty && modelName
       .allSatisfy({ !$0.isWhitespace && !$0.isNewline && $0 != "/" }) else {
       fatalError("""

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -49,6 +49,7 @@ final class ChatTests: XCTestCase {
 
     let model = GenerativeModel(
       name: "my-model",
+      projectID: "my-project-id",
       apiKey: "API_KEY",
       tools: nil,
       requestOptions: RequestOptions(),

--- a/FirebaseVertexAI/Tests/Unit/GenerateContentResponses/unary-failure-firebaseml-api-not-enabled.json
+++ b/FirebaseVertexAI/Tests/Unit/GenerateContentResponses/unary-failure-firebaseml-api-not-enabled.json
@@ -1,0 +1,27 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Firebase ML API has not been used in project 1234567890 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/firebaseml.googleapis.com/overview?project=1234567890 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/firebaseml.googleapis.com/overview?project=1234567890"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "SERVICE_DISABLED",
+        "domain": "googleapis.com",
+        "metadata": {
+          "service": "firebaseml.googleapis.com",
+          "consumer": "projects/1234567890"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
If a developer tries to use the Vertex AI SDK without going through the Firebase Console setup flow then they will receive an error saying:
> Firebase ML API has not been used in project 1234567890 before or it is disabled...

Since it may not be clear that the `firebaseml.googleapis.com` API is needed for Vertex AI, added a more detailed log message with direct links to the Firebase Console page:
> The Vertex AI for Firebase SDK requires the Firebase ML API `firebaseml.googleapis.com` to be enabled for your project. Get started in the Firebase Console (https://console.firebase.google.com/project/my-project-id/genai/vertex) or verify that the API is enabled in the Google Cloud Console (https://console.developers.google.com/apis/api/firebaseml.googleapis.com/overview?project=my-project-id).

#no-changelog