### PR TITLE
[auth-swift] Fix auth sample CI for latest analytics

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -60,6 +60,7 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix Sample build for pre-released Analytics SPM dependency like https://github.com/firebase/firebase-ios-sdk/actions/runs/9181564314/job/25248577833