### PR TITLE
[Vertex AI] Log server error responses without `-FIRDebugEnabled`

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -60,9 +60,9 @@ struct GenerativeAIService {
 
     // Verify the status code is 200
     guard response.statusCode == 200 else {
-      Logging.default.error("[FirebaseVertexAI] The server responded with an error: \(response)")
+      Logging.network.error("[FirebaseVertexAI] The server responded with an error: \(response)")
       if let responseString = String(data: data, encoding: .utf8) {
-        Logging.network.error("[FirebaseVertexAI] Response payload: \(responseString)")
+        Logging.default.error("[FirebaseVertexAI] Response payload: \(responseString)")
       }
 
       throw parseError(responseData: data)
@@ -108,14 +108,14 @@ struct GenerativeAIService {
 
         // Verify the status code is 200
         guard response.statusCode == 200 else {
-          Logging.default
+          Logging.network
             .error("[FirebaseVertexAI] The server responded with an error: \(response)")
           var responseBody = ""
           for try await line in stream.lines {
             responseBody += line + "\n"
           }
 
-          Logging.network.error("[FirebaseVertexAI] Response payload: \(responseBody)")
+          Logging.default.error("[FirebaseVertexAI] Response payload: \(responseBody)")
           continuation.finish(throwing: parseError(responseBody: responseBody))
 
           return


### PR DESCRIPTION
Updated logging to print response payloads even when `-FIRDebugEnabled` is _not_ enabled.

<details>
<summary>Example Error Response Log</summary>
If the Vertex AI API (aiplatform.googleapis.com) is not enabled:

```
[FirebaseVertexAI] Response payload: {
  "error": {
    "code": 403,
    "message": "Vertex AI API has not been used in project my-project-id before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/aiplatform.googleapis.com/overview?project=my-project-id then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.Help",
        "links": [
          {
            "description": "Google developers console API activation",
            "url": "https://console.developers.google.com/apis/api/aiplatform.googleapis.com/overview?project=my-project-id"
          }
        ]
      },
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "SERVICE_DISABLED",
        "domain": "googleapis.com",
        "metadata": {
          "service": "aiplatform.googleapis.com",
          "consumer": "projects/my-project-id"
        }
      }
    ]
  }
}
```

</details>

Updated logging to only print the `NSHTTPURLResponse` if `-FIRDebugEnabled` is enabled.

<details>
<summary>Example NSHTTPURLResponse Log</summary>

```
[FirebaseVertexAI] The server responded with an error: <NSHTTPURLResponse: 0x60000030a580> { URL: https://firebaseml.googleapis.com/v2beta/projects/my-project-id/locations/us-central1/publishers/google/models/gemini-1.5-flash-preview-0514:streamGenerateContent?alt=sse } { Status Code: 403, Headers {
    "Alt-Svc" =     (
        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
    );
    "Content-Length" =     (
        1048
    );
    "Content-Type" =     (
        "text/event-stream"
    );
    Date =     (
        "Tue, 21 May 2024 22:28:32 GMT"
    );
    Server =     (
        ESF
    );
    Vary =     (
        Origin,
        "X-Origin",
        Referer
    );
    "x-content-type-options" =     (
        nosniff
    );
    "x-frame-options" =     (
        SAMEORIGIN
    );
    "x-xss-protection" =     (
        0
    );
} }
```

</details>

These were swapped because the NSHTTPURLResponse is rarely useful for understanding an error on its own, whereas the response payload contains details to fix the problem.

#no-changelog