### PR TITLE
[Performance] Update Performance's use of GULObjectSwizzler

### DIFF
--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -24,7 +24,7 @@
 #import "FirebasePerformance/Sources/FPRDataUtils.h"
 #import "FirebasePerformance/Sources/FPRURLFilter.h"
 #import "FirebasePerformance/Sources/Gauges/FPRGaugeManager.h"
-# test
+// test
 #import <GoogleUtilities/GULObjectSwizzler.h>
 
 NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -24,7 +24,7 @@
 #import "FirebasePerformance/Sources/FPRDataUtils.h"
 #import "FirebasePerformance/Sources/FPRURLFilter.h"
 #import "FirebasePerformance/Sources/Gauges/FPRGaugeManager.h"
-
+# test
 #import <GoogleUtilities/GULObjectSwizzler.h>
 
 NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";


### PR DESCRIPTION
I _think_ this should result in a build warning. Will wait for CI to diagnose.

I did a grep and see no other uses of GULObjectSwizzler in Firebase.
#no-changelog