### PR TITLE
Removed Unused Availability Checks

### DIFF
--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -2938,19 +2938,15 @@ static NSString *const kFakeRecaptchaVersion = @"RecaptchaVersion";
 }
 
 - (void)testAppOpenURL_AuthPresenterCanHandleURL {
-  if (@available(iOS 9.0, *)) {
-    // 'application:openURL:options:' is only available on iOS 9.0 or newer.
-    NSURL *url = [NSURL URLWithString:@"https://localhost"];
+  NSURL *url = [NSURL URLWithString:@"https://localhost"];
 
-    OCMExpect([self.mockAuthURLPresenter canHandleURL:url]).andReturn(YES);
+  OCMExpect([self.mockAuthURLPresenter canHandleURL:url]).andReturn(YES);
 
-    XCTAssertTrue([self.fakeApplicationDelegate
-        application:[GULAppDelegateSwizzler sharedApplication]
-            openURL:url
-            options:@{}]);
+  XCTAssertTrue([self.fakeApplicationDelegate application:[GULAppDelegateSwizzler sharedApplication]
+                                                  openURL:url
+                                                  options:@{}]);
 
-    [self.mockAuthURLPresenter verify];
-  }
+  [self.mockAuthURLPresenter verify];
 }
 
 - (void)testAppOpenURLWithSourceApplication_AuthPresenterCanHandleURL {

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseTests.m
@@ -453,11 +453,7 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
   __block BOOL done = NO;
   [database.reference.childByAutoId observeSingleEventOfType:FIRDataEventTypeValue
                                                    withBlock:^(FIRDataSnapshot *snapshot) {
-                                                     if (@available(iOS 10.0, macOS 10.12, *)) {
-                                                       dispatch_assert_queue(callbackQueue);
-                                                     } else {
-                                                       NSAssert(YES, @"Test requires iOS 10");
-                                                     }
+                                                     dispatch_assert_queue(callbackQueue);
                                                      done = YES;
                                                    }];
   WAIT_FOR(done);

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -176,6 +176,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSURL *)uniqueMatchLinkToCheck {
   _clipboardContentAtMatchProcessStart = nil;
   NSString *pasteboardContents = [self retrievePasteboardContents];
+  if (!pasteboardContents) {
+    return nil;
+  }
   NSInteger linkStringMinimumLength =
       expectedCopiedLinkStringSuffix.length + /* ? or & */ 1 + /* http:// */ 7;
   if ((pasteboardContents.length >= linkStringMinimumLength) &&
@@ -201,21 +204,17 @@ NS_ASSUME_NONNULL_BEGIN
   return nil;
 }
 
-- (NSString *)retrievePasteboardContents {
+- (nullable NSString *)retrievePasteboardContents {
   if (![self isPasteboardRetrievalEnabled]) {
     // Pasteboard check for dynamic link is disabled by user.
-    return @"";
+    return nil;
   }
 
-  NSString *pasteboardContents = @"";
-  if (@available(iOS 10.0, *)) {
-    if ([[UIPasteboard generalPasteboard] hasURLs]) {
-      pasteboardContents = [UIPasteboard generalPasteboard].string;
-    }
+  if ([[UIPasteboard generalPasteboard] hasURLs]) {
+    return [UIPasteboard generalPasteboard].string;
   } else {
-    pasteboardContents = [UIPasteboard generalPasteboard].string;
+    return nil;
   }
-  return pasteboardContents;
 }
 
 /**

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutLogStorage.m
@@ -167,19 +167,11 @@ static NSString *const kEventExtensionJson = @"extension_js";
   id fetchedClearcutRetryRecords;
   NSData *data = [NSData dataWithContentsOfFile:filePath];
   if (data) {
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      fetchedClearcutRetryRecords = [NSKeyedUnarchiver
-          unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMClearcutLogRecord class],
-                                                          [NSMutableArray class], nil]
-                           fromData:data
-                              error:nil];
-    } else {
-      // Fallback on earlier versions
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      fetchedClearcutRetryRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-#pragma clang diagnostic pop
-    }
+    fetchedClearcutRetryRecords = [NSKeyedUnarchiver
+        unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMClearcutLogRecord class],
+                                                        [NSMutableArray class], nil]
+                         fromData:data
+                            error:nil];
   }
   if (fetchedClearcutRetryRecords) {
     @synchronized(self) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMActivityLogger.m
@@ -155,19 +155,11 @@ static NSString *const kDetailArchiveKey = @"detail";
   id fetchedActivityRecords;
   NSData *data = [NSData dataWithContentsOfFile:filePath];
   if (data) {
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      fetchedActivityRecords = [NSKeyedUnarchiver
-          unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMActivityRecord class],
-                                                          [NSMutableArray class], nil]
-                           fromData:data
-                              error:nil];
-    } else {
-      // Fallback on earlier versions
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      fetchedActivityRecords = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-#pragma clang diagnostic pop
-    }
+    fetchedActivityRecords = [NSKeyedUnarchiver
+        unarchivedObjectOfClasses:[NSSet setWithObjects:[FIRIAMActivityRecord class],
+                                                        [NSMutableArray class], nil]
+                         fromData:data
+                            error:nil];
   }
   if (fetchedActivityRecords) {
     @synchronized(self) {

--- a/FirebaseMLModelDownloader/Sources/FileDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/FileDownloader.swift
@@ -63,11 +63,9 @@ class ModelFileDownloader: NSObject, FileDownloader {
     self.conditions = conditions
     configuration = URLSessionConfiguration.ephemeral
     /// Wait for network connectivity.
-    if #available(iOS 11.0, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0, *) {
-      self.configuration.waitsForConnectivity = true
-      /// Wait for 10 minutes.
-      self.configuration.timeoutIntervalForResource = 600
-    }
+    configuration.waitsForConnectivity = true
+    /// Wait for 10 minutes.
+    configuration.timeoutIntervalForResource = 600
     configuration.allowsCellularAccess = conditions.allowsCellularAccess
   }
 

--- a/FirebaseMLModelDownloader/Sources/ModelInfoRetriever.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelInfoRetriever.swift
@@ -523,18 +523,10 @@ extension ModelInfoRetriever {
 
   /// Parse date from string - used to get download URL expiry time.
   private static func getDateFromString(_ strDate: String) -> Date? {
-    if #available(iOS 11, macOS 10.13, macCatalyst 13.0, tvOS 11.0, watchOS 4.0, *) {
-      let dateFormatter = ISO8601DateFormatter()
-      dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-      dateFormatter.formatOptions = [.withFractionalSeconds]
-      return dateFormatter.date(from: strDate)
-    } else {
-      let dateFormatter = DateFormatter()
-      dateFormatter.locale = Locale(identifier: "en-US_POSIX")
-      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-      dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-      return dateFormatter.date(from: strDate)
-    }
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    dateFormatter.formatOptions = [.withFractionalSeconds]
+    return dateFormatter.date(from: strDate)
   }
 
   /// Return model info created from server response.

--- a/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
+++ b/FirebaseSharedSwift/Sources/third_party/FirebaseDataEncoder/FirebaseDataEncoder.swift
@@ -122,7 +122,6 @@ public class FirebaseDataEncoder {
     case millisecondsSince1970
 
     /// Encode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     case iso8601
 
     /// Encode the `Date` as a string formatted by the given formatter.
@@ -823,11 +822,7 @@ extension __JSONEncoder {
       return NSNumber(value: 1000.0 * date.timeIntervalSince1970)
 
     case .iso8601:
-      if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
         return NSString(string: _iso8601Formatter.string(from: date))
-      } else {
-        fatalError("ISO8601DateFormatter is unavailable on this platform.")
-      }
 
     case .formatted(let formatter):
       return NSString(string: formatter.string(from: date))
@@ -1080,7 +1075,6 @@ public class FirebaseDataDecoder {
     case millisecondsSince1970
 
     /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
-    @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     case iso8601
 
     /// Decode the `Date` as a string parsed by the given formatter.
@@ -2443,16 +2437,12 @@ extension __JSONDecoder {
       return Date(timeIntervalSince1970: double / 1000.0)
 
     case .iso8601:
-      if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
         let string = try self.unbox(value, as: String.self)!
         guard let date = _iso8601Formatter.date(from: string) else {
           throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected date string to be ISO8601-formatted."))
         }
 
         return date
-      } else {
-        fatalError("ISO8601DateFormatter is unavailable on this platform.")
-      }
 
     case .formatted(let formatter):
       let string = try self.unbox(value, as: String.self)!
@@ -2621,7 +2611,6 @@ fileprivate struct _JSONKey : CodingKey {
 //===----------------------------------------------------------------------===//
 
 // NOTE: This value is implicitly lazy and _must_ be lazy. We're compiled against the latest SDK (w/ ISO8601DateFormatter), but linked against whichever Foundation the user has. ISO8601DateFormatter might not exist, so we better not hit this code path on an older OS.
-@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
   let formatter = ISO8601DateFormatter()
   formatter.formatOptions = .withInternetDateTime

--- a/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
+++ b/FirebaseSharedSwift/Tests/third_party/DataEncoderTests.swift
@@ -302,7 +302,6 @@ class TestFirebaseDataEncoder: XCTestCase {
   }
 
   func testEncodingDateISO8601() {
-    if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
       let formatter = ISO8601DateFormatter()
       formatter.formatOptions = .withInternetDateTime
 
@@ -319,7 +318,6 @@ class TestFirebaseDataEncoder: XCTestCase {
                      expected: expected,
                      dateEncodingStrategy: .iso8601,
                      dateDecodingStrategy: .iso8601)
-    }
   }
 
   func testEncodingDateFormatted() {

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -82,13 +82,10 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
       requestString = "<nil request returned from server>"
     }
     let invalidDataString = "Invalid data returned from the server:\(requestString)"
-    var localizedFailureKey: String
-    if #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
-      localizedFailureKey = NSLocalizedFailureErrorKey
-    } else {
-      localizedFailureKey = "NSLocalizedFailure"
-    }
-    return error(withCode: .unknown, infoDictionary: [localizedFailureKey: invalidDataString])
+    return error(
+      withCode: .unknown,
+      infoDictionary: [NSLocalizedFailureErrorKey: invalidDataString]
+    )
   }
 
   /**


### PR DESCRIPTION
* Removed redundant availability checks and attributes to match the deployment targets specified in `Package.swift` and `Firebase.podspec`
* Removed unused fallbacks for earlier versions
* Removed `_safariVC` from `FIRAppDistributionUIService`’s implementation, but retained the `SFSafariViewControllerDelegate` conformance as part of the interface
* Refactored `FIRDLDefaultRetrievalProcessV2`’s `retrievePasteboardContents` to return optional strings