### PR TITLE
Add `FIRAppCheckTokenProtocol` for use in `FIRAppCheckProtocol`

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.tvos.weak_framework = 'DeviceCheck'
 
   s.dependency 'AppCheckCore', '~> 10.19'
-  s.dependency 'FirebaseAppCheckInterop', '~> 10.17'
+  s.dependency 'FirebaseAppCheckInterop', '~> 10.28'
   s.dependency 'FirebaseCore', '~> 10.18'
   s.dependency 'PromisesObjC', '~> 2.1'
   s.dependency 'GoogleUtilities/Environment', '~> 7.13'

--- a/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckInterop.h
+++ b/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckInterop.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(AppCheckTokenHandlerInterop)
 typedef void (^FIRAppCheckTokenHandlerInterop)(id<FIRAppCheckTokenResultInterop> tokenResult);
 
-NS_SWIFT_NAME(AppCheckInterop) @protocol FIRAppCheckInterop
+NS_SWIFT_NAME(AppCheckInterop) @protocol FIRAppCheckInterop<NSObject>
 
 /// Retrieve a cached or generate a new FAA Token. If forcingRefresh == YES always generates a new
 /// token and updates the cache.

--- a/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckProtocol.h
+++ b/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckProtocol.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class FIRAppCheckToken;
+@protocol FIRAppCheckTokenProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,8 +38,8 @@ NS_SWIFT_NAME(AppCheckProtocol)
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:
-                     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
+                 completion:(void (^)(id<FIRAppCheckTokenProtocol> _Nullable token,
+                                      NSError *_Nullable error))handler
     NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Requests a limited-use Firebase App Check token. This method should be used only if you need to
@@ -50,7 +50,7 @@ NS_SWIFT_NAME(AppCheckProtocol)
 /// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
 /// This method does not affect the token generation behavior of the
 /// ``tokenForcingRefresh()`` method.
-- (void)limitedUseTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
+- (void)limitedUseTokenWithCompletion:(void (^)(id<FIRAppCheckTokenProtocol> _Nullable token,
                                                 NSError *_Nullable error))handler;
 
 @end

--- a/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckTokenProtocol.h
+++ b/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FIRAppCheckTokenProtocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#import <Foundation/Foundation.h>
-
-#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
-/// An object representing a Firebase App Check token.
-NS_SWIFT_NAME(AppCheckToken)
-@interface FIRAppCheckToken : NSObject <FIRAppCheckTokenProtocol>
+NS_SWIFT_NAME(AppCheckTokenProtocol)
+@protocol FIRAppCheckTokenProtocol <NSObject>
 
 /// A Firebase App Check token.
 @property(nonatomic, readonly) NSString *token;
@@ -30,13 +24,5 @@ NS_SWIFT_NAME(AppCheckToken)
 /// The App Check token's expiration date in the device's local time.
 @property(nonatomic, readonly) NSDate *expirationDate;
 
-- (instancetype)init NS_UNAVAILABLE;
-
-/// The default initializer.
-/// @param token A Firebase App Check token.
-/// @param expirationDate A Firebase App Check token expiration date in the device local time.
-- (instancetype)initWithToken:(NSString *)token expirationDate:(NSDate *)expirationDate;
-
 @end
-
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FirebaseAppCheckInterop.h
+++ b/FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/FirebaseAppCheckInterop.h
@@ -16,4 +16,5 @@
 
 #import "FIRAppCheckInterop.h"
 #import "FIRAppCheckProtocol.h"
+#import "FIRAppCheckTokenProtocol.h"
 #import "FIRAppCheckTokenResultInterop.h"

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -89,7 +89,8 @@ NS_SWIFT_NAME(AppCheck)
 /// @param handler The completion handler. Includes the app check token if the request succeeds,
 /// or an error if the request fails.
 - (void)tokenForcingRefresh:(BOOL)forcingRefresh
-                 completion:(void (^)(FIRAppCheckToken *token, NSError *_Nullable error))handler
+                 completion:
+                     (void (^)(FIRAppCheckToken *_Nullable token, NSError *_Nullable error))handler
     NS_SWIFT_NAME(token(forcingRefresh:completion:));
 
 /// Requests a limited-use Firebase App Check token. This method should be used only if you need to

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheck.h
@@ -74,6 +74,35 @@ NS_SWIFT_NAME(AppCheck)
 /// set explicitly, the value will be persisted and used as a default value on next app launches.
 @property(nonatomic, assign) BOOL isTokenAutoRefreshEnabled;
 
+/// Requests Firebase app check token. This method should *only* be used if you need to authorize
+/// requests to a non-Firebase backend. Requests to Firebase backend are authorized automatically if
+/// configured.
+///
+/// If your non-Firebase backend exposes sensitive or expensive endpoints that have low traffic
+/// volume, consider protecting it with [Replay
+/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
+/// In this case, use the ``limitedUseToken(completion:)`` instead to obtain a limited-use token.
+/// @param forcingRefresh If `YES`,  a new Firebase app check token is requested and the token
+/// cache is ignored. If `NO`, the cached token is used if it exists and has not expired yet. In
+/// most cases, `NO` should be used. `YES` should only be used if the server explicitly returns an
+/// error, indicating a revoked token.
+/// @param handler The completion handler. Includes the app check token if the request succeeds,
+/// or an error if the request fails.
+- (void)tokenForcingRefresh:(BOOL)forcingRefresh
+                 completion:(void (^)(FIRAppCheckToken *token, NSError *_Nullable error))handler
+    NS_SWIFT_NAME(token(forcingRefresh:completion:));
+
+/// Requests a limited-use Firebase App Check token. This method should be used only if you need to
+/// authorize requests to a non-Firebase backend.
+///
+/// Returns limited-use tokens that are intended for use with your non-Firebase backend endpoints
+/// that are protected with [Replay
+/// Protection](https://firebase.google.com/docs/app-check/custom-resource-backend#replay-protection).
+/// This method does not affect the token generation behavior of the
+/// ``tokenForcingRefresh()`` method.
+- (void)limitedUseTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
+                                                NSError *_Nullable error))handler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Interop/ObjC/FIRAppCheckInteropAPITests.m
+++ b/FirebaseAppCheck/Tests/Interop/ObjC/FIRAppCheckInteropAPITests.m
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckInteropAPITests : NSObject
+@end
+
+@implementation FIRAppCheckInteropAPITests
+
+- (void)usage {
+  id<FIRAppCheckInterop> appCheckInterop;
+
+  [appCheckInterop getTokenForcingRefresh:NO
+                               completion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
+                                 NSString *__unused token = tokenResult.token;
+                                 NSError *__unused _Nullable error = tokenResult.error;
+                               }];
+
+  NSString *__unused tokenDidChangeNotificationName =
+      [appCheckInterop tokenDidChangeNotificationName];
+
+  NSString *__unused notificationTokenKey = [appCheckInterop notificationTokenKey];
+
+  NSString *__unused notificationAppNameKey = [appCheckInterop notificationAppNameKey];
+
+  if ([appCheckInterop respondsToSelector:@selector(getLimitedUseTokenWithCompletion:)]) {
+    [appCheckInterop
+        getLimitedUseTokenWithCompletion:^(id<FIRAppCheckTokenResultInterop> tokenResult) {
+          NSString *__unused token = tokenResult.token;
+          NSError *__unused _Nullable error = tokenResult.error;
+        }];
+  }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Interop/ObjC/FIRAppCheckProtocolAPITests.m
+++ b/FirebaseAppCheck/Tests/Interop/ObjC/FIRAppCheckProtocolAPITests.m
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppCheckProtocolAPITests : NSObject
+@end
+
+@implementation FIRAppCheckProtocolAPITests
+
+- (void)usage {
+  id<FIRAppCheckProtocol> appCheck;
+
+  [appCheck tokenForcingRefresh:NO
+                     completion:^(id<FIRAppCheckTokenProtocol> _Nullable token,
+                                  NSError *_Nullable error) {
+                       if (token) {
+                         NSString *__unused tokenValue = token.token;
+                         NSDate *__unused expirationDate = token.expirationDate;
+                       }
+                     }];
+
+  if ([appCheck respondsToSelector:@selector(limitedUseTokenWithCompletion:)]) {
+    [appCheck limitedUseTokenWithCompletion:^(id<FIRAppCheckTokenProtocol> _Nullable token,
+                                              NSError *_Nullable error) {
+      if (token) {
+        NSString *__unused tokenValue = token.token;
+        NSDate *__unused expirationDate = token.expirationDate;
+      }
+    }];
+  }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Tests/Interop/Swift/AppCheckInteropAPITests.swift
+++ b/FirebaseAppCheck/Tests/Interop/Swift/AppCheckInteropAPITests.swift
@@ -1,0 +1,63 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MARK: This file is used to evaluate the AppCheckInterop API in Swift.
+
+import Foundation
+
+// MARK: Do not import `FirebaseAppCheck`, this file is for `FirebaseAppCheckInterop` only.
+
+import FirebaseAppCheckInterop
+
+final class AppCheckInteropAPITests {
+  let appCheckInterop: AppCheckInterop! = nil
+
+  func usage() {
+    let _: Void = appCheckInterop.getToken(forcingRefresh: false) { result in
+      let _: FIRAppCheckTokenResultInterop = result
+      let _: String = result.token
+      if let error = result.error {
+        let _: String = error.localizedDescription
+      }
+    }
+
+    let _: String = appCheckInterop.tokenDidChangeNotificationName()
+
+    let _: String = appCheckInterop.notificationTokenKey()
+
+    let _: String = appCheckInterop.notificationAppNameKey()
+
+    guard let getLimitedUseToken: (@escaping AppCheckTokenHandlerInterop) -> Void =
+      appCheckInterop.getLimitedUseToken else { return }
+    let _: Void = getLimitedUseToken { result in
+      let _: FIRAppCheckTokenResultInterop = result
+      let _: String = result.token
+      if let error = result.error {
+        let _: String = error.localizedDescription
+      }
+    }
+  }
+
+  func usage_async() async {
+    let result: FIRAppCheckTokenResultInterop =
+      await appCheckInterop.getToken(forcingRefresh: false)
+    let _: String = result.token
+    if let error = result.error {
+      let _: String = error.localizedDescription
+    }
+
+    // The following fails to compile with "Command SwiftCompile failed with a nonzero exit code".
+    // let _ = await appCheckInterop.getLimitedUseToken?()
+  }
+}

--- a/FirebaseAppCheck/Tests/Interop/Swift/AppCheckInteropAPITests.swift
+++ b/FirebaseAppCheck/Tests/Interop/Swift/AppCheckInteropAPITests.swift
@@ -49,6 +49,7 @@ final class AppCheckInteropAPITests {
     }
   }
 
+  @available(iOS 13, macOS 10.15, macCatalyst 13, tvOS 13, *)
   func usage_async() async {
     let result: FIRAppCheckTokenResultInterop =
       await appCheckInterop.getToken(forcingRefresh: false)

--- a/FirebaseAppCheck/Tests/Interop/Swift/AppCheckProtocolAPITests.swift
+++ b/FirebaseAppCheck/Tests/Interop/Swift/AppCheckProtocolAPITests.swift
@@ -45,6 +45,7 @@ final class AppCheckProtocolAPITests {
     }
   }
 
+  @available(iOS 13, macOS 10.15, macCatalyst 13, tvOS 13, *)
   func usage_async() async {
     do {
       let token: AppCheckTokenProtocol = try await appCheck.token(forcingRefresh: false)

--- a/FirebaseAppCheck/Tests/Interop/Swift/AppCheckProtocolAPITests.swift
+++ b/FirebaseAppCheck/Tests/Interop/Swift/AppCheckProtocolAPITests.swift
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MARK: This file is used to evaluate the AppCheckProtocol API in Swift.
+
+import Foundation
+
+// MARK: Do not import `FirebaseAppCheck`, this file is for `FirebaseAppCheckInterop` only.
+
+import FirebaseAppCheckInterop
+
+final class AppCheckProtocolAPITests {
+  let appCheck: AppCheckProtocol! = nil
+
+  func usage() {
+    let _: Void = appCheck.token(forcingRefresh: false, completion: { token, error in
+      if let token: AppCheckTokenProtocol {
+        let _: String = token.token
+        let _: Date = token.expirationDate
+      }
+      if let error: Error {
+        let _: String = error.localizedDescription
+      }
+    })
+
+    let _: Void = appCheck.limitedUseToken { token, error in
+      if let token: AppCheckTokenProtocol {
+        let _: String = token.token
+        let _: Date = token.expirationDate
+      }
+      if let error: Error {
+        let _: String = error.localizedDescription
+      }
+    }
+  }
+
+  func usage_async() async {
+    do {
+      let token: AppCheckTokenProtocol = try await appCheck.token(forcingRefresh: false)
+      let _: String = token.token
+      let _: Date = token.expirationDate
+    } catch {
+      let _: String = error.localizedDescription
+    }
+  }
+}

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -34,6 +34,17 @@ Pod::Spec.new do |s|
   s.source_files = 'FirebaseAppCheck/Interop/**/*.[hm]'
   s.public_header_files = 'FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/*.h'
 
+  s.test_spec 'objc-unit' do |unit_tests|
+    unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
+    unit_tests.source_files = [
+      'FirebaseAppCheck/Tests/Interop/ObjC/**/*.[hm]',
+    ]
+  end
+
   s.test_spec 'swift-unit' do |swift_unit_tests|
     swift_unit_tests.platforms = {
       :ios => ios_deployment_target,

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -20,11 +20,28 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '12.0'
-  s.watchos.deployment_target = '6.0'
+
+  ios_deployment_target = '10.0'
+  osx_deployment_target = '10.13'
+  tvos_deployment_target = '12.0'
+  watchos_deployment_target = '6.0'
+
+  s.ios.deployment_target = ios_deployment_target
+  s.osx.deployment_target = osx_deployment_target
+  s.tvos.deployment_target = tvos_deployment_target
+  s.watchos.deployment_target = watchos_deployment_target
 
   s.source_files = 'FirebaseAppCheck/Interop/**/*.[hm]'
   s.public_header_files = 'FirebaseAppCheck/Interop/Public/FirebaseAppCheckInterop/*.h'
+
+  s.test_spec 'swift-unit' do |swift_unit_tests|
+    swift_unit_tests.platforms = {
+      :ios => ios_deployment_target,
+      :osx => osx_deployment_target,
+      :tvos => tvos_deployment_target
+    }
+    swift_unit_tests.source_files = [
+      'FirebaseAppCheck/Tests/Interop/Swift/**/*.swift',
+    ]
+  end
 end


### PR DESCRIPTION
Previously a user of `FIRAppCheckProtocol` would need access to the `FIRAppCheckToken` class (in the main SDK, not in the Interop SDK) to get the token/error value.