### PR TITLE
[Firebase 11] Add bridged casts in FirebasePerformance

### DIFF
--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -427,18 +427,20 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 
 + (void)addNetworkTrace:(FPRNetworkTrace *)networkTrace toObject:(id)object {
   if (object != nil && networkTrace != nil) {
-    [GULObjectSwizzler setAssociatedObject:object
-                                       key:kFPRNetworkTracePropertyName
-                                     value:networkTrace
-                               association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
+    [GULObjectSwizzler
+        setAssociatedObject:object
+                        key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName
+                      value:networkTrace
+                association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
   }
 }
 
 + (FPRNetworkTrace *)networkTraceFromObject:(id)object {
   FPRNetworkTrace *networkTrace = nil;
   if (object != nil) {
-    id traceObject = [GULObjectSwizzler getAssociatedObject:object
-                                                        key:kFPRNetworkTracePropertyName];
+    id traceObject = [GULObjectSwizzler
+        getAssociatedObject:object
+                        key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName];
     if ([traceObject isKindOfClass:[FPRNetworkTrace class]]) {
       networkTrace = (FPRNetworkTrace *)traceObject;
     }
@@ -449,10 +451,11 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 
 + (void)removeNetworkTraceFromObject:(id)object {
   if (object != nil) {
-    [GULObjectSwizzler setAssociatedObject:object
-                                       key:kFPRNetworkTracePropertyName
-                                     value:nil
-                               association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
+    [GULObjectSwizzler
+        setAssociatedObject:object
+                        key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName
+                      value:nil
+                association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
   }
 }
 

--- a/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
@@ -98,13 +98,13 @@ void InstrumentInitWithRequestDelegate(FPRClassInstrumentor *instrumentor,
       [delegateInstrument registerClass:[delegate class]];
       [delegateInstrument registerObject:delegate];
       [GULObjectSwizzler setAssociatedObject:connection
-                                         key:kFPRDelegateKey
+                                         key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     } else {
       delegate = [[FPRNSURLConnectionDelegate alloc] init];
       [GULObjectSwizzler setAssociatedObject:connection
-                                         key:kFPRDelegateKey
+                                         key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     }
@@ -133,13 +133,13 @@ void InstrumentInitWithRequestDelegateStartImmediately(
       [delegateInstrument registerObject:delegate];
 
       [GULObjectSwizzler setAssociatedObject:connection
-                                         key:kFPRDelegateKey
+                                         key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     } else {
       delegate = [[FPRNSURLConnectionDelegate alloc] init];
       [GULObjectSwizzler setAssociatedObject:connection
-                                         key:kFPRDelegateKey
+                                         key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     }
@@ -161,7 +161,8 @@ void InstrumentConnectionStart(FPRClassInstrumentor *instrumentor) {
   [selectorInstrumentor setReplacingBlock:^(id object) {
     typedef void (*OriginalImp)(id, SEL);
     NSURLConnection *connection = (NSURLConnection *)object;
-    if ([GULObjectSwizzler getAssociatedObject:connection key:kFPRDelegateKey]) {
+    if ([GULObjectSwizzler getAssociatedObject:connection
+                                           key:(__bridge const void *_Nonnull)kFPRDelegateKey]) {
       FPRNetworkTrace *trace =
           [[FPRNetworkTrace alloc] initWithURLRequest:connection.originalRequest];
       [trace start];


### PR DESCRIPTION
After moving to `GoogleUtilities` 8.0 we need to use a bridged cast when passing an `NSString *const` as key in `GULObjectSwizzler`'s `- setAssociatedObject:key:value:networkTrace:association:` method. See https://github.com/google/GoogleUtilities/pull/141 for the details.

#no-changelog