### PR TITLE
Make sure rollouts logging queue is not nil

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# # Unreleased
+- [fixed] Created a new queue for rollouts persistence writes and made sure rollouts logging queue is not nil while dispatching (#12913).
+
 # 10.27.0
 - [added] Added support for catching the SIGTERM signal (#12881).
 - [fixed] Fixed a hang when persisting Remote Config Rollouts to disk (#12913).

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.h
@@ -25,7 +25,8 @@
 
 @interface FIRCLSRolloutsPersistenceManager : NSObject <FIRCLSPersistenceLog>
 
-- (instancetype _Nullable)initWithFileManager:(FIRCLSFileManager *_Nonnull)fileManager;
+- (instancetype _Nullable)initWithFileManager:(FIRCLSFileManager *_Nonnull)fileManager
+                                     andQueue:(dispatch_queue_t _Nonnull)queue;
 - (instancetype _Nonnull)init NS_UNAVAILABLE;
 + (instancetype _Nonnull)new NS_UNAVAILABLE;
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
-#include "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
 #include "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
 #import "Crashlytics/Crashlytics/Helpers/FIRCLSLogger.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSFileManager.h"
@@ -32,15 +31,23 @@
 
 @interface FIRCLSRolloutsPersistenceManager : NSObject <FIRCLSPersistenceLog>
 @property(nonatomic, readonly) FIRCLSFileManager *fileManager;
+@property(nonnull, nonatomic, readonly) dispatch_queue_t rolloutsLoggingQueue;
 @end
 
 @implementation FIRCLSRolloutsPersistenceManager
-- (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager {
+- (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
+                           andQueue:(dispatch_queue_t)queue {
   self = [super init];
   if (!self) {
     return nil;
   }
   _fileManager = fileManager;
+
+  if (!queue) {
+    FIRCLSDebugLog(@"Failed to intialize FIRCLSRolloutsPersistenceManager, logging queue is nil");
+    return nil;
+  }
+  _rolloutsLoggingQueue = queue;
   return self;
 }
 
@@ -57,18 +64,20 @@
 
   NSFileHandle *rolloutsFile = [NSFileHandle fileHandleForUpdatingAtPath:rolloutsPath];
 
-  dispatch_async(FIRCLSGetLoggingQueue(), ^{
-    @try {
-      [rolloutsFile seekToEndOfFile];
-      NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];
-      [rolloutsWithNewLineData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
-      [rolloutsFile writeData:rolloutsWithNewLineData];
-      [rolloutsFile closeFile];
-    } @catch (NSException *exception) {
-      FIRCLSDebugLog(@"Failed to write new rollouts. Exception name: %s - message: %s",
-                     exception.name, exception.reason);
-    }
-  });
+  if (_rolloutsLoggingQueue) {
+    dispatch_async(_rolloutsLoggingQueue, ^{
+      @try {
+        [rolloutsFile seekToEndOfFile];
+        NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];
+        [rolloutsWithNewLineData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
+        [rolloutsFile writeData:rolloutsWithNewLineData];
+        [rolloutsFile closeFile];
+      } @catch (NSException *exception) {
+        FIRCLSDebugLog(@"Failed to write new rollouts. Exception name: %s - message: %s",
+                       exception.name, exception.reason);
+      }
+    });
+  }
 }
 
 - (void)debugLogWithMessage:(NSString *_Nonnull)message {

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -64,20 +64,22 @@
 
   NSFileHandle *rolloutsFile = [NSFileHandle fileHandleForUpdatingAtPath:rolloutsPath];
 
-  if (_rolloutsLoggingQueue) {
-    dispatch_async(_rolloutsLoggingQueue, ^{
-      @try {
-        [rolloutsFile seekToEndOfFile];
-        NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];
-        [rolloutsWithNewLineData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
-        [rolloutsFile writeData:rolloutsWithNewLineData];
-        [rolloutsFile closeFile];
-      } @catch (NSException *exception) {
-        FIRCLSDebugLog(@"Failed to write new rollouts. Exception name: %s - message: %s",
-                       exception.name, exception.reason);
-      }
-    });
+  if (!_rolloutsLoggingQueue) {
+    FIRCLSDebugLog(@"Rollouts logging queue is dealloccated");
   }
+
+  dispatch_async(_rolloutsLoggingQueue, ^{
+    @try {
+      [rolloutsFile seekToEndOfFile];
+      NSMutableData *rolloutsWithNewLineData = [rollouts mutableCopy];
+      [rolloutsWithNewLineData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
+      [rolloutsFile writeData:rolloutsWithNewLineData];
+      [rolloutsFile closeFile];
+    } @catch (NSException *exception) {
+      FIRCLSDebugLog(@"Failed to write new rollouts. Exception name: %s - message: %s",
+                     exception.name, exception.reason);
+    }
+  });
 }
 
 - (void)debugLogWithMessage:(NSString *_Nonnull)message {

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -211,7 +211,11 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       FIRCLSDebugLog(@"Registering RemoteConfig SDK subscription for rollouts data");
 
       FIRCLSRolloutsPersistenceManager *persistenceManager =
-          [[FIRCLSRolloutsPersistenceManager alloc] initWithFileManager:_fileManager];
+          [[FIRCLSRolloutsPersistenceManager alloc]
+              initWithFileManager:_fileManager
+                         andQueue:dispatch_queue_create(
+                                      "com.google.firebase.FIRCLSRolloutsPersistence",
+                                      DISPATCH_QUEUE_SERIAL)];
       _remoteConfigManager =
           [[FIRCLSRemoteConfigManager alloc] initWithRemoteConfig:remoteConfig
                                               persistenceDelegate:persistenceManager];


### PR DESCRIPTION
Related to #12913 

I haven't be able to reproduce the problem naturally but with some hack I am able to get the exactly same stack trace as the user showed. It seems like when dispatch async the default logging queue is deallocated already. 
<img width="1366" alt="Screenshot 2024-06-03 at 2 18 23 PM" src="https://github.com/firebase/firebase-ios-sdk/assets/16548721/3a60d6e1-0d6e-4ac7-99c3-ff3e3eab6058">

The bit wired thing for this particular issue is that if we can log the crash, this means the logging queue and exception queue has been initialized previously under [here](https://github.com/firebase/firebase-ios-sdk/blob/main/Crashlytics/Crashlytics/Components/FIRCLSContext.m#L236). So for a more safe approach, creating a queue for rollouts logging and double check for the the existence. 
