### PR TITLE
[Vertex AI] Add support for compiling on tvOS

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,7 +18,7 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, macOS, catalyst]
+        target: [iOS, macOS, catalyst, tvOS]
         os: [macos-14]
         include:
           - os: macos-14

--- a/FirebaseVertexAI/Sources/Chat.swift
+++ b/FirebaseVertexAI/Sources/Chat.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// An object that represents a back-and-forth chat with a model, capturing the history and saving
 /// the context in memory between each message sent.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public class Chat {
   private let model: GenerativeModel
 

--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -19,7 +19,6 @@ import Foundation
 #endif
 
 /// Constants associated with the Vertex AI for Firebase SDK.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 enum Constants {
   /// The Vertex AI backend endpoint URL.
   static let baseURL = "https://firebaseml.googleapis.com"

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -14,14 +14,14 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 struct CountTokensRequest {
   let model: String
   let contents: [ModelContent]
   let options: RequestOptions
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
@@ -31,7 +31,7 @@ extension CountTokensRequest: GenerativeAIRequest {
 }
 
 /// The model's response to a count tokens request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct CountTokensResponse {
   /// The total number of tokens in the input given to the model as a prompt.
   public let totalTokens: Int
@@ -45,14 +45,14 @@ public struct CountTokensResponse {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CountTokensRequest: Encodable {
   enum CodingKeys: CodingKey {
     case contents
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CountTokensResponse: Decodable {
   enum CodingKeys: CodingKey {
     case totalTokens

--- a/FirebaseVertexAI/Sources/GenerateContentError.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentError.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Errors that occur when generating content from a model.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public enum GenerateContentError: Error {
   /// An error occurred when constructing the prompt. Examine the related error for details.
   case promptImageContentError(underlying: ImageConversionError)

--- a/FirebaseVertexAI/Sources/GenerateContentRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentRequest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 struct GenerateContentRequest {
   /// Model name.
   let model: String
@@ -28,7 +28,7 @@ struct GenerateContentRequest {
   let options: RequestOptions
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension GenerateContentRequest: Encodable {
   enum CodingKeys: String, CodingKey {
     case contents
@@ -40,7 +40,7 @@ extension GenerateContentRequest: Encodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// The model's response to a generate content request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct GenerateContentResponse {
   /// Token usage metadata for processing the generate content request.
   public struct UsageMetadata {
@@ -84,7 +84,7 @@ public struct GenerateContentResponse {
 
 /// A struct representing a possible reply to a content generation prompt. Each content generation
 /// prompt may produce multiple candidate responses.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct CandidateResponse {
   /// The response's content.
   public let content: ModelContent
@@ -110,14 +110,14 @@ public struct CandidateResponse {
 }
 
 /// A collection of source attributions for a piece of content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct CitationMetadata {
   /// A list of individual cited sources and the parts of the content to which they apply.
   public let citationSources: [Citation]
 }
 
 /// A struct describing a source attribution.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct Citation {
   /// The inclusive beginning of a sequence in a model response that derives from a cited source.
   public let startIndex: Int
@@ -133,7 +133,7 @@ public struct Citation {
 }
 
 /// A value enumerating possible reasons for a model to terminate a content generation request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public enum FinishReason: String {
   case unknown = "FINISH_REASON_UNKNOWN"
 
@@ -158,7 +158,7 @@ public enum FinishReason: String {
 }
 
 /// A metadata struct containing any feedback the model had on the prompt it was provided.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct PromptFeedback {
   /// A type describing possible reasons to block a prompt.
   public enum BlockReason: String {
@@ -190,7 +190,7 @@ public struct PromptFeedback {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension GenerateContentResponse: Decodable {
   enum CodingKeys: CodingKey {
     case candidates
@@ -224,7 +224,7 @@ extension GenerateContentResponse: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension GenerateContentResponse.UsageMetadata: Decodable {
   enum CodingKeys: CodingKey {
     case promptTokenCount
@@ -241,7 +241,7 @@ extension GenerateContentResponse.UsageMetadata: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CandidateResponse: Decodable {
   enum CodingKeys: CodingKey {
     case content
@@ -290,14 +290,14 @@ extension CandidateResponse: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CitationMetadata: Decodable {
   enum CodingKeys: String, CodingKey {
     case citationSources = "citations"
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension Citation: Decodable {
   enum CodingKeys: CodingKey {
     case startIndex
@@ -315,7 +315,7 @@ extension Citation: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension FinishReason: Decodable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -330,7 +330,7 @@ extension FinishReason: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension PromptFeedback.BlockReason: Decodable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -345,7 +345,7 @@ extension PromptFeedback.BlockReason: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension PromptFeedback: Decodable {
   enum CodingKeys: CodingKey {
     case blockReason

--- a/FirebaseVertexAI/Sources/GenerationConfig.swift
+++ b/FirebaseVertexAI/Sources/GenerationConfig.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// A struct defining model parameters to be used when sending generative AI
 /// requests to the backend model.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct GenerationConfig {
   /// A parameter controlling the degree of randomness in token selection. A
   /// temperature of zero is deterministic, always choosing the
@@ -95,5 +95,5 @@ public struct GenerationConfig {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension GenerationConfig: Encodable {}

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 protocol GenerativeAIRequest: Encodable {
   associatedtype Response: Decodable
 
@@ -24,7 +24,7 @@ protocol GenerativeAIRequest: Encodable {
 }
 
 /// Configuration parameters for sending requests to the backend.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct RequestOptions {
   /// The request’s timeout interval in seconds; if not specified uses the default value for a
   /// `URLRequest`.

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -17,7 +17,7 @@ import FirebaseAuthInterop
 import FirebaseCore
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 struct GenerativeAIService {
   /// The language of the SDK in the format `gl-<language>/<version>`.
   static let languageTag = "gl-swift/5"

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A type that represents a remote multimodal model (like Gemini), with the ability to generate
 /// content based on various input types.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public final class GenerativeModel {
   // The prefix for a model resource in the Gemini API.
   private static let modelResourcePrefix = "models/"
@@ -318,7 +318,7 @@ public final class GenerativeModel {
 }
 
 /// An error thrown in `GenerativeModel.countTokens(_:)`.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public enum CountTokensError: Error {
   case internalError(underlying: Error)
 }

--- a/FirebaseVertexAI/Sources/Logging.swift
+++ b/FirebaseVertexAI/Sources/Logging.swift
@@ -15,7 +15,7 @@
 import Foundation
 import OSLog
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 struct Logging {
   /// Subsystem that should be used for all Loggers.
   static let subsystem = "com.google.firebase.vertex-ai"

--- a/FirebaseVertexAI/Sources/ModelContent.swift
+++ b/FirebaseVertexAI/Sources/ModelContent.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type describing data in media formats interpretable by an AI model. Each generative AI
 /// request or response contains an `Array` of ``ModelContent``s, and each ``ModelContent`` value
 /// may comprise multiple heterogeneous ``ModelContent/Part``s.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct ModelContent: Equatable {
   /// A discrete piece of data in a media format interpretable by an AI model. Within a single value
   /// of ``Part``, different data types may not mix.
@@ -116,10 +116,10 @@ public struct ModelContent: Equatable {
 
 // MARK: Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension ModelContent: Codable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension ModelContent.Part: Codable {
   enum CodingKeys: String, CodingKey {
     case text

--- a/FirebaseVertexAI/Sources/PartsRepresentable+Image.swift
+++ b/FirebaseVertexAI/Sources/PartsRepresentable+Image.swift
@@ -38,7 +38,7 @@ public enum ImageConversionError: Error {
 
 #if canImport(UIKit)
   /// Enables images to be representable as ``ThrowingPartsRepresentable``.
-  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
   extension UIImage: ThrowingPartsRepresentable {
     public func tryPartsValue() throws -> [ModelContent.Part] {
       guard let data = jpegData(compressionQuality: imageCompressionQuality) else {
@@ -50,7 +50,7 @@ public enum ImageConversionError: Error {
 
 #elseif canImport(AppKit)
   /// Enables images to be representable as ``ThrowingPartsRepresentable``.
-  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
   extension NSImage: ThrowingPartsRepresentable {
     public func tryPartsValue() throws -> [ModelContent.Part] {
       guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else {
@@ -67,7 +67,7 @@ public enum ImageConversionError: Error {
 #endif
 
 /// Enables `CGImages` to be representable as model content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CGImage: ThrowingPartsRepresentable {
   public func tryPartsValue() throws -> [ModelContent.Part] {
     let output = NSMutableData()
@@ -88,7 +88,7 @@ extension CGImage: ThrowingPartsRepresentable {
 }
 
 /// Enables `CIImages` to be representable as model content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension CIImage: ThrowingPartsRepresentable {
   public func tryPartsValue() throws -> [ModelContent.Part] {
     let context = CIContext()

--- a/FirebaseVertexAI/Sources/PartsRepresentable.swift
+++ b/FirebaseVertexAI/Sources/PartsRepresentable.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// A protocol describing any data that could be serialized to model-interpretable input data,
 /// where the serialization process might fail with an error.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public protocol ThrowingPartsRepresentable {
   func tryPartsValue() throws -> [ModelContent.Part]
 }
@@ -24,12 +24,12 @@ public protocol ThrowingPartsRepresentable {
 /// A protocol describing any data that could be serialized to model-interpretable input data,
 /// where the serialization process cannot fail with an error. For a failable conversion, see
 /// ``ThrowingPartsRepresentable``
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public protocol PartsRepresentable: ThrowingPartsRepresentable {
   var partsValue: [ModelContent.Part] { get }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public extension PartsRepresentable {
   func tryPartsValue() throws -> [ModelContent.Part] {
     return partsValue
@@ -37,7 +37,7 @@ public extension PartsRepresentable {
 }
 
 /// Enables a ``ModelContent.Part`` to be passed in as ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension ModelContent.Part: ThrowingPartsRepresentable {
   public typealias ErrorType = Never
   public func tryPartsValue() throws -> [ModelContent.Part] {
@@ -47,7 +47,7 @@ extension ModelContent.Part: ThrowingPartsRepresentable {
 
 /// Enable an `Array` of ``ThrowingPartsRepresentable`` values to be passed in as a single
 /// ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension [ThrowingPartsRepresentable]: ThrowingPartsRepresentable {
   public func tryPartsValue() throws -> [ModelContent.Part] {
     return try compactMap { element in
@@ -58,7 +58,7 @@ extension [ThrowingPartsRepresentable]: ThrowingPartsRepresentable {
 }
 
 /// Enables a `String` to be passed in as ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension String: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     return [.text(self)]

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type defining potentially harmful media categories and their model-assigned ratings. A value
 /// of this type may be assigned to a category for every model-generated response, not just
 /// responses that exceed a certain threshold.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct SafetyRating: Equatable, Hashable {
   /// The category describing the potential harm a piece of content may pose. See
   /// ``SafetySetting/HarmCategory`` for a list of possible values.
@@ -60,7 +60,7 @@ public struct SafetyRating: Equatable, Hashable {
 }
 
 /// Safety feedback for an entire request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct SafetyFeedback {
   /// Safety rating evaluated from content.
   public let rating: SafetyRating
@@ -77,7 +77,7 @@ public struct SafetyFeedback {
 
 /// A type used to specify a threshold for harmful content, beyond which the model will return a
 /// fallback response instead of generated content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public struct SafetySetting {
   /// A type describing safety attributes, which include harmful categories and topics that can
   /// be considered sensitive.
@@ -142,7 +142,7 @@ public struct SafetySetting {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetyRating.HarmProbability: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -157,13 +157,13 @@ extension SafetyRating.HarmProbability: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetyRating: Decodable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetyFeedback: Decodable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetySetting.HarmCategory: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -178,7 +178,7 @@ extension SafetySetting.HarmCategory: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetySetting.BlockThreshold: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -193,5 +193,5 @@ extension SafetySetting.BlockThreshold: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetySetting: Codable {}

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -21,7 +21,7 @@ import Foundation
 @_implementationOnly import FirebaseCoreExtension
 
 /// The Vertex AI for Firebase SDK provides access to Gemini models directly from your app.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 public class VertexAI: NSObject {
   // MARK: - Public APIs
 

--- a/FirebaseVertexAI/Sources/VertexAIComponent.swift
+++ b/FirebaseVertexAI/Sources/VertexAIComponent.swift
@@ -20,13 +20,13 @@ import Foundation
 // Avoids exposing internal FirebaseCore APIs to Swift users.
 @_implementationOnly import FirebaseCoreExtension
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 @objc(FIRVertexAIProvider)
 protocol VertexAIProvider {
   @objc func vertexAI(_ location: String) -> VertexAI
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 @objc(FIRVertexAIComponent)
 class VertexAIComponent: NSObject, Library, VertexAIProvider {
   // MARK: - Private Variables

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -22,7 +22,7 @@ import XCTest
 // Since these requests are billed, we are running them more sparsely than the unit tests.
 #if os(macOS)
 
-  @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+  @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
   final class IntegrationTests: XCTestCase {
     // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.
     let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 final class ChatTests: XCTestCase {
   var urlSession: URLSession!
 

--- a/FirebaseVertexAI/Tests/Unit/Fakes/AuthInteropFake.swift
+++ b/FirebaseVertexAI/Tests/Unit/Fakes/AuthInteropFake.swift
@@ -15,7 +15,7 @@
 import FirebaseAuthInterop
 import Foundation
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 class AuthInteropFake: NSObject, AuthInterop {
   let token: String?
   let error: Error?

--- a/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
@@ -16,7 +16,7 @@ import FirebaseVertexAI
 import Foundation
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 final class GenerationConfigTests: XCTestCase {
   let encoder = JSONEncoder()
 

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 final class GenerativeModelTests: XCTestCase {
   let testPrompt = "What sorts of questions can I ask you?"
   let safetyRatingsNegligible: [SafetyRating] = [
@@ -1347,7 +1347,7 @@ private extension URLRequest {
   }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 class AppCheckInteropFake: NSObject, AppCheckInterop {
   /// The placeholder token value returned when an error occurs
   static let placeholderTokenValue = "placeholder-token"
@@ -1397,7 +1397,7 @@ class AppCheckInteropFake: NSObject, AppCheckInterop {
 
 struct AppCheckErrorFake: Error {}
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 extension SafetyRating: Comparable {
   public static func < (lhs: FirebaseVertexAI.SafetyRating,
                         rhs: FirebaseVertexAI.SafetyRating) -> Bool {

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -15,7 +15,7 @@
 import Foundation
 import XCTest
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 class MockURLProtocol: URLProtocol {
   static var requestHandler: ((URLRequest) throws -> (
     URLResponse,

--- a/FirebaseVertexAI/Tests/Unit/ModelContentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ModelContentTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 final class ModelContentTests: XCTestCase {
   let encoder = JSONEncoder()
 

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -22,7 +22,7 @@ import XCTest
   import AppKit
 #endif
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 final class PartsRepresentableTests: XCTestCase {
   func testModelContentFromCGImageIsNotEmpty() throws {
     // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -21,7 +21,7 @@ import XCTest
   import UIKit // For UIImage extensions.
 #endif
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 final class VertexAIAPITests: XCTestCase {
   func codeSamples() async throws {
     let app = FirebaseApp.app()

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -21,7 +21,7 @@ import SharedTestUtilities
 
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
 class VertexComponentTests: XCTestCase {
   static var app: FirebaseApp!
 


### PR DESCRIPTION
Added support for compiling the Vertex AI SDK on tvOS. Note that the following still applies: https://github.com/firebase/firebase-ios-sdk/blob/901844a9213e241d06315f92d6524d8c695e0dd7/FirebaseVertexAI/Sources/Constants.swift#L17-L19

#no-changelog