### PR TITLE
Replace SystemConfiguration with a more recent Apple provided network monitoring API.

### DIFF
--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -58,7 +58,6 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
 
   s.ios.framework = 'CoreTelephony'
   s.framework = 'QuartzCore'
-  s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseCore', '~> 10.5'
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'FirebaseRemoteConfig', '~> 10.0'

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Fix Crash from InstrumentUploadTaskWithStreamedRequest (#12983).
+- Replace SystemConfiguration with a more available network monitoring API by Apple (#13079).
 
 # 10.25.0
 - [changed] Removed usages of user defaults API to eliminate required reason impact.

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRTrace.h"
 #import "FirebasePerformance/Sources/Protogen/nanopb/perf_metric.nanopb.h"
+#import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRTrace.h"
 
 FOUNDATION_EXTERN NSString *__nonnull const kFPRAppStartTraceName;
 FOUNDATION_EXTERN NSString *__nonnull const kFPRAppStartStageNameTimeToUI;

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRTrace.h"
+#import "FirebasePerformance/Sources/Protogen/nanopb/perf_metric.nanopb.h"
 
 FOUNDATION_EXTERN NSString *__nonnull const kFPRAppStartTraceName;
 FOUNDATION_EXTERN NSString *__nonnull const kFPRAppStartStageNameTimeToUI;
@@ -49,6 +50,9 @@ NS_EXTENSION_UNAVAILABLE("Firebase Performance is not supported for extensions."
 
 /** Current running state of the application. */
 @property(nonatomic, readonly) FPRApplicationState applicationState;
+
+/** Current network connection type of the application. */
+@property(nonatomic, readonly) firebase_perf_v1_NetworkConnectionInfo_NetworkType networkType;
 
 /** Accesses the singleton instance.
  *  @return Reference to the shared object if successful; <code>nil</code> if not.

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -331,7 +331,11 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 }
 
 - (void)dealloc {
+#if TARGET_OS_IOS
   if (@available(iOS 12, *)) {
+#elif TARGET_OS_TVOS
+  if (@available(tvOS 12, *)) {
+#endif
     nw_path_monitor_cancel(self.monitor);
   }
 

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -328,7 +328,10 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 }
 
 - (void)dealloc {
-  nw_path_monitor_cancel(self.monitor);
+  
+  if (@available(iOS 12, *)) {
+    nw_path_monitor_cancel(self.monitor);
+  }
 
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:UIApplicationDidBecomeActiveNotification

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -163,10 +163,14 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 - (void)startTrackingNetwork {
   self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
+#if TARGET_OS_IOS
   if (@available(iOS 12, *)) {
+#elif TARGET_OS_TVOS
+  if (@available(tvOS 12, *)) {
+#endif
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT);
-    self.monitorQueue = dispatch_queue_create("com.example.network.monitor", attrs);
+    self.monitorQueue = dispatch_queue_create("com.google.perf.network.monitor", attrs);
 
     self.monitor = nw_path_monitor_create();
     nw_path_monitor_set_queue(self.monitor, self.monitorQueue);

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -164,11 +164,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
   self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
   __weak FPRAppActivityTracker *weakSelf = self;
-#if TARGET_OS_IOS
-  if (@available(iOS 12, *)) {
-#elif TARGET_OS_TV
-  if (@available(tvOS 12, *)) {
-#endif
+  if (@available(iOS 12, tvOS 12, *)) {
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT);
     weakSelf.monitorQueue =
@@ -333,11 +329,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 }
 
 - (void)dealloc {
-#if TARGET_OS_IOS
-  if (@available(iOS 12, *)) {
-#elif TARGET_OS_TV
-  if (@available(tvOS 12, *)) {
-#endif
+  if (@available(iOS 12, tvOS 12, *)) {
     nw_path_monitor_cancel(self.monitor);
   }
 

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -15,8 +15,8 @@
 #import "FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h"
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 #import <Network/Network.h>
+#import <UIKit/UIKit.h>
 
 #import "FirebasePerformance/Sources/AppActivity/FPRSessionManager.h"
 #import "FirebasePerformance/Sources/Configurations/FPRConfigurations.h"
@@ -60,10 +60,10 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 @property(nonatomic, readwrite) firebase_perf_v1_NetworkConnectionInfo_NetworkType networkType;
 
 /** Network monitor object to track network movements. */
-@property (nonatomic, readwrite) nw_path_monitor_t monitor;
+@property(nonatomic, readwrite) nw_path_monitor_t monitor;
 
 /** Queue used to track the network monitoring changes. */
-@property (nonatomic, readwrite) dispatch_queue_t monitorQueue;
+@property(nonatomic, readwrite) dispatch_queue_t monitorQueue;
 
 /** Trace to measure the app start performance. */
 @property(nonatomic) FIRTrace *appStartTrace;
@@ -164,10 +164,8 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
   self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
   if (@available(iOS 12, *)) {
-    dispatch_queue_attr_t attrs = 
-      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL,
-                                              QOS_CLASS_UTILITY,
-                                              DISPATCH_QUEUE_PRIORITY_DEFAULT);
+    dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT);
     self.monitorQueue = dispatch_queue_create("com.example.network.monitor", attrs);
 
     self.monitor = nw_path_monitor_create();
@@ -337,7 +335,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 
 - (void)dealloc {
   nw_path_monitor_cancel(self.monitor);
-  
+
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:UIApplicationDidBecomeActiveNotification
                                                 object:[UIApplication sharedApplication]];

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -163,6 +163,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 - (void)startTrackingNetwork {
   self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
+  __weak FPRAppActivityTracker *weakSelf = self;
 #if TARGET_OS_IOS
   if (@available(iOS 12, *)) {
 #elif TARGET_OS_TV
@@ -170,21 +171,22 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 #endif
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT);
-    self.monitorQueue = dispatch_queue_create("com.google.perf.network.monitor", attrs);
+    weakSelf.monitorQueue =
+        dispatch_queue_create("com.google.firebase.perf.network.monitor", attrs);
 
-    self.monitor = nw_path_monitor_create();
-    nw_path_monitor_set_queue(self.monitor, self.monitorQueue);
-    nw_path_monitor_set_update_handler(self.monitor, ^(nw_path_t _Nonnull path) {
+    weakSelf.monitor = nw_path_monitor_create();
+    nw_path_monitor_set_queue(weakSelf.monitor, weakSelf.monitorQueue);
+    nw_path_monitor_set_update_handler(weakSelf.monitor, ^(nw_path_t _Nonnull path) {
       BOOL isWiFi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
       BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
       BOOL isEthernet = nw_path_uses_interface_type(path, nw_interface_type_wired);
 
       if (isWiFi) {
-        self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_WIFI;
+        weakSelf.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_WIFI;
       } else if (isCellular) {
-        self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE;
+        weakSelf.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE;
       } else if (isEthernet) {
-        self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_ETHERNET;
+        weakSelf.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_ETHERNET;
       }
     });
 

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -165,7 +165,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 
 #if TARGET_OS_IOS
   if (@available(iOS 12, *)) {
-#elif TARGET_OS_TVOS
+#elif TARGET_OS_TV
   if (@available(tvOS 12, *)) {
 #endif
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
@@ -333,7 +333,7 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 - (void)dealloc {
 #if TARGET_OS_IOS
   if (@available(iOS 12, *)) {
-#elif TARGET_OS_TVOS
+#elif TARGET_OS_TV
   if (@available(tvOS 12, *)) {
 #endif
     nw_path_monitor_cancel(self.monitor);

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -175,10 +175,6 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
       BOOL isWiFi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
       BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
       BOOL isEthernet = nw_path_uses_interface_type(path, nw_interface_type_wired);
-      BOOL isExpensive = nw_path_is_expensive(path);
-      BOOL hasIPv4 = nw_path_has_ipv4(path);
-      BOOL hasIPv6 = nw_path_has_ipv6(path);
-      BOOL hasNewDNS = nw_path_has_dns(path);
 
       if (isWiFi) {
         self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_WIFI;
@@ -186,8 +182,6 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
         self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_MOBILE;
       } else if (isEthernet) {
         self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_ETHERNET;
-      } else if (hasIPv4) {
-        self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
       }
     });
 

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -171,7 +171,6 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
     self.monitor = nw_path_monitor_create();
     nw_path_monitor_set_queue(self.monitor, self.monitorQueue);
     nw_path_monitor_set_update_handler(self.monitor, ^(nw_path_t _Nonnull path) {
-      nw_path_status_t status = nw_path_get_status(path);
       BOOL isWiFi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
       BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
       BOOL isEthernet = nw_path_uses_interface_type(path, nw_interface_type_wired);

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -328,7 +328,6 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 }
 
 - (void)dealloc {
-  
   if (@available(iOS 12, *)) {
     nw_path_monitor_cancel(self.monitor);
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.m
@@ -163,16 +163,15 @@ NSString *const kFPRAppCounterNameActivePrewarm = @"_fsapc";
 - (void)startTrackingNetwork {
   self.networkType = firebase_perf_v1_NetworkConnectionInfo_NetworkType_NONE;
 
-  __weak FPRAppActivityTracker *weakSelf = self;
   if (@available(iOS 12, tvOS 12, *)) {
     dispatch_queue_attr_t attrs = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, DISPATCH_QUEUE_PRIORITY_DEFAULT);
-    weakSelf.monitorQueue =
-        dispatch_queue_create("com.google.firebase.perf.network.monitor", attrs);
+    self.monitorQueue = dispatch_queue_create("com.google.firebase.perf.network.monitor", attrs);
 
-    weakSelf.monitor = nw_path_monitor_create();
-    nw_path_monitor_set_queue(weakSelf.monitor, weakSelf.monitorQueue);
-    nw_path_monitor_set_update_handler(weakSelf.monitor, ^(nw_path_t _Nonnull path) {
+    self.monitor = nw_path_monitor_create();
+    nw_path_monitor_set_queue(self.monitor, self.monitorQueue);
+    __weak FPRAppActivityTracker *weakSelf = self;
+    nw_path_monitor_set_update_handler(self.monitor, ^(nw_path_t _Nonnull path) {
       BOOL isWiFi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
       BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
       BOOL isEthernet = nw_path_uses_interface_type(path, nw_interface_type_wired);

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -35,7 +35,6 @@
 
 static firebase_perf_v1_NetworkRequestMetric_HttpMethod FPRHTTPMethodForString(
     NSString *methodString);
-static firebase_perf_v1_NetworkConnectionInfo_NetworkType FPRNetworkConnectionInfoNetworkType(void);
 #ifdef TARGET_HAS_MOBILE_CONNECTIVITY
 static firebase_perf_v1_NetworkConnectionInfo_MobileSubtype FPRCellularNetworkType(void);
 #endif

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -18,7 +18,6 @@
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
-#import <SystemConfiguration/SystemConfiguration.h>
 
 #import "FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h"
 #import "FirebasePerformance/Sources/Common/FPRConstants.h"

--- a/FirebasePerformance/Sources/FPRNanoPbUtils.m
+++ b/FirebasePerformance/Sources/FPRNanoPbUtils.m
@@ -20,13 +20,13 @@
 #endif
 #import <SystemConfiguration/SystemConfiguration.h>
 
+#import "FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h"
 #import "FirebasePerformance/Sources/Common/FPRConstants.h"
 #import "FirebasePerformance/Sources/FIRPerformance+Internal.h"
 #import "FirebasePerformance/Sources/FPRDataUtils.h"
 #import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRPerformance.h"
 #import "FirebasePerformance/Sources/Timer/FIRTrace+Internal.h"
 #import "FirebasePerformance/Sources/Timer/FIRTrace+Private.h"
-#import "FirebasePerformance/Sources/AppActivity/FPRAppActivityTracker.h"
 
 #import "FirebasePerformance/Sources/Gauges/CPU/FPRCPUGaugeData.h"
 #import "FirebasePerformance/Sources/Gauges/Memory/FPRMemoryGaugeData.h"

--- a/Package.swift
+++ b/Package.swift
@@ -949,7 +949,6 @@ let package = Package(
         .define("FIRPerformance_LIB_VERSION", to: firebaseVersion),
       ],
       linkerSettings: [
-        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .tvOS])),
         .linkedFramework("MobileCoreServices", .when(platforms: [.iOS, .tvOS])),
         .linkedFramework("QuartzCore", .when(platforms: [.iOS, .tvOS])),
       ]


### PR DESCRIPTION
SystemConfiguration framework APIs are getting deprecated. This PR replaces the usage of SystemConfiguration with Network Monitoring provided by Apple - this API is available from 12.0 onwards.

This fixes https://github.com/firebase/firebase-ios-sdk/issues/13079.