### PR TITLE
[Vertex AI] Add CI for visionOS

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,11 +18,14 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, macOS, catalyst, visionOS]
+        target: [iOS, macOS, catalyst]
         os: [macos-14]
         include:
           - os: macos-14
             xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.3
+            target: visionOS
     runs-on: ${{ matrix.os }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -24,7 +24,7 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.2
           - os: macos-14
-            xcode: Xcode_15.3
+            xcode: Xcode_15.4
             target: visionOS
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,14 +18,11 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, macOS, catalyst]
+        target: [iOS, macOS, catalyst, visionOS]
         os: [macos-14]
         include:
           - os: macos-14
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_15.4
-            target: visionOS
     runs-on: ${{ matrix.os }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,7 +18,7 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, macOS, catalyst]
+        target: [iOS, macOS, catalyst, visionOS]
         os: [macos-14]
         include:
           - os: macos-14

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -51,27 +51,27 @@ final class PartsRepresentableTests: XCTestCase {
     XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
   }
 
-  func testModelContentFromInvalidCIImageThrows() throws {
-    let image = CIImage.empty()
-    do {
-      let _ = try image.tryPartsValue()
-    } catch {
-      guard let imageError = (error as? ImageConversionError) else {
-        XCTFail("Got unexpected error type: \(error)")
-        return
-      }
-      switch imageError {
-      case let .couldNotConvertToJPEG(source):
-        // String(describing:) works around a type error.
-        XCTAssertEqual(String(describing: source), String(describing: image))
-        return
-      case _:
-        XCTFail("Expected image conversion error, got \(imageError) instead")
-        return
-      }
-    }
-    XCTFail("Expected model content from invlaid image to error")
-  }
+//  func testModelContentFromInvalidCIImageThrows() throws {
+//    let image = CIImage.empty()
+//    do {
+//      let _ = try image.tryPartsValue()
+//    } catch {
+//      guard let imageError = (error as? ImageConversionError) else {
+//        XCTFail("Got unexpected error type: \(error)")
+//        return
+//      }
+//      switch imageError {
+//      case let .couldNotConvertToJPEG(source):
+//        // String(describing:) works around a type error.
+//        XCTAssertEqual(String(describing: source), String(describing: image))
+//        return
+//      case _:
+//        XCTFail("Expected image conversion error, got \(imageError) instead")
+//        return
+//      }
+//    }
+//    XCTFail("Expected model content from invlaid image to error")
+//  }
 
   #if canImport(UIKit)
     func testModelContentFromInvalidUIImageThrows() throws {

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -74,36 +74,37 @@ final class PartsRepresentableTests: XCTestCase {
   }
 
   #if canImport(UIKit)
-    func testModelContentFromInvalidUIImageThrows() throws {
-      let image = UIImage()
-      do {
-        _ = try image.tryPartsValue()
-      } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
+    #if !os(visionOS)
+      func testModelContentFromInvalidUIImageThrows() throws {
+        let image = UIImage()
+        do {
+          _ = try image.tryPartsValue()
+        } catch {
+          guard let imageError = (error as? ImageConversionError) else {
+            XCTFail("Got unexpected error type: \(error)")
+            return
+          }
+          switch imageError {
+          case let .couldNotConvertToJPEG(source):
+            // String(describing:) works around a type error.
+            XCTAssertEqual(String(describing: source), String(describing: image))
+            return
+          case _:
+            XCTFail("Expected image conversion error, got \(imageError) instead")
+            return
+          }
         }
-        switch imageError {
-        case let .couldNotConvertToJPEG(source):
-          // String(describing:) works around a type error.
-          XCTAssertEqual(String(describing: source), String(describing: image))
-          return
-        case _:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Expected model content from invlaid image to error")
       }
-      XCTFail("Expected model content from invlaid image to error")
-    }
 
-    func testModelContentFromUIImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let image = UIImage(ciImage: coreImage)
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-    }
-
+      func testModelContentFromUIImageIsNotEmpty() throws {
+        let coreImage = CIImage(color: CIColor.red)
+          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+        let image = UIImage(ciImage: coreImage)
+        let modelContent = try image.tryPartsValue()
+        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+      }
+    #endif // !os(visionOS)
   #elseif canImport(AppKit)
     func testModelContentFromNSImageIsNotEmpty() throws {
       let coreImage = CIImage(color: CIColor.red)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -74,37 +74,36 @@ final class PartsRepresentableTests: XCTestCase {
   }
 
   #if canImport(UIKit)
-    #if !os(visionOS)
-      func testModelContentFromInvalidUIImageThrows() throws {
-        let image = UIImage()
-        do {
-          _ = try image.tryPartsValue()
-        } catch {
-          guard let imageError = (error as? ImageConversionError) else {
-            XCTFail("Got unexpected error type: \(error)")
-            return
-          }
-          switch imageError {
-          case let .couldNotConvertToJPEG(source):
-            // String(describing:) works around a type error.
-            XCTAssertEqual(String(describing: source), String(describing: image))
-            return
-          case _:
-            XCTFail("Expected image conversion error, got \(imageError) instead")
-            return
-          }
+    func testModelContentFromInvalidUIImageThrows() throws {
+      let image = UIImage()
+      do {
+        _ = try image.tryPartsValue()
+      } catch {
+        guard let imageError = (error as? ImageConversionError) else {
+          XCTFail("Got unexpected error type: \(error)")
+          return
         }
-        XCTFail("Expected model content from invlaid image to error")
+        switch imageError {
+        case let .couldNotConvertToJPEG(source):
+          // String(describing:) works around a type error.
+          XCTAssertEqual(String(describing: source), String(describing: image))
+          return
+        case _:
+          XCTFail("Expected image conversion error, got \(imageError) instead")
+          return
+        }
       }
+      XCTFail("Expected model content from invlaid image to error")
+    }
 
-      func testModelContentFromUIImageIsNotEmpty() throws {
-        let coreImage = CIImage(color: CIColor.red)
-          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-        let image = UIImage(ciImage: coreImage)
-        let modelContent = try image.tryPartsValue()
-        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-      }
-    #endif // !os(visionOS)
+    func testModelContentFromUIImageIsNotEmpty() throws {
+      let coreImage = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let image = UIImage(ciImage: coreImage)
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+    }
+
   #elseif canImport(AppKit)
     func testModelContentFromNSImageIsNotEmpty() throws {
       let coreImage = CIImage(color: CIColor.red)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -22,62 +22,41 @@ import XCTest
   import AppKit
 #endif
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
-final class PartsRepresentableTests: XCTestCase {
-  func testModelContentFromCGImageIsNotEmpty() throws {
-    // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
-    var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
-    let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
-      let ctx = CGContext(
-        data: ptr.baseAddress,
-        width: 8,
-        height: 8,
-        bitsPerComponent: 8,
-        bytesPerRow: 4 * 8,
-        space: CGColorSpace(name: CGColorSpace.sRGB)!,
-        bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
-          CGImageAlphaInfo.premultipliedFirst.rawValue
-      )!
-      return ctx.makeImage()!
+#if !os(visionOS)
+
+  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+  final class PartsRepresentableTests: XCTestCase {
+    func testModelContentFromCGImageIsNotEmpty() throws {
+      // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
+      var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
+      let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
+        let ctx = CGContext(
+          data: ptr.baseAddress,
+          width: 8,
+          height: 8,
+          bitsPerComponent: 8,
+          bytesPerRow: 4 * 8,
+          space: CGColorSpace(name: CGColorSpace.sRGB)!,
+          bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
+            CGImageAlphaInfo.premultipliedFirst.rawValue
+        )!
+        return ctx.makeImage()!
+      }
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
     }
-    let modelContent = try image.tryPartsValue()
-    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
-  }
 
-  func testModelContentFromCIImageIsNotEmpty() throws {
-    let image = CIImage(color: CIColor.red)
-      .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-    let modelContent = try image.tryPartsValue()
-    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
-  }
+    func testModelContentFromCIImageIsNotEmpty() throws {
+      let image = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
+    }
 
-//  func testModelContentFromInvalidCIImageThrows() throws {
-//    let image = CIImage.empty()
-//    do {
-//      let _ = try image.tryPartsValue()
-//    } catch {
-//      guard let imageError = (error as? ImageConversionError) else {
-//        XCTFail("Got unexpected error type: \(error)")
-//        return
-//      }
-//      switch imageError {
-//      case let .couldNotConvertToJPEG(source):
-//        // String(describing:) works around a type error.
-//        XCTAssertEqual(String(describing: source), String(describing: image))
-//        return
-//      case _:
-//        XCTFail("Expected image conversion error, got \(imageError) instead")
-//        return
-//      }
-//    }
-//    XCTFail("Expected model content from invlaid image to error")
-//  }
-
-  #if canImport(UIKit)
-    func testModelContentFromInvalidUIImageThrows() throws {
-      let image = UIImage()
+    func testModelContentFromInvalidCIImageThrows() throws {
+      let image = CIImage.empty()
       do {
-        _ = try image.tryPartsValue()
+        let _ = try image.tryPartsValue()
       } catch {
         guard let imageError = (error as? ImageConversionError) else {
           XCTFail("Got unexpected error type: \(error)")
@@ -96,43 +75,68 @@ final class PartsRepresentableTests: XCTestCase {
       XCTFail("Expected model content from invlaid image to error")
     }
 
-    func testModelContentFromUIImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let image = UIImage(ciImage: coreImage)
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-    }
-  #else
-    func testModelContentFromNSImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let rep = NSCIImageRep(ciImage: coreImage)
-      let image = NSImage(size: rep.size)
-      image.addRepresentation(rep)
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for NSImage: \(image)")
-    }
-
-    func testModelContentFromInvalidNSImageThrows() throws {
-      let image = NSImage()
-      do {
-        _ = try image.tryPartsValue()
-      } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
+    #if canImport(UIKit)
+      func testModelContentFromInvalidUIImageThrows() throws {
+        let image = UIImage()
+        do {
+          _ = try image.tryPartsValue()
+        } catch {
+          guard let imageError = (error as? ImageConversionError) else {
+            XCTFail("Got unexpected error type: \(error)")
+            return
+          }
+          switch imageError {
+          case let .couldNotConvertToJPEG(source):
+            // String(describing:) works around a type error.
+            XCTAssertEqual(String(describing: source), String(describing: image))
+            return
+          case _:
+            XCTFail("Expected image conversion error, got \(imageError) instead")
+            return
+          }
         }
-        switch imageError {
-        case .invalidUnderlyingImage:
-          // Pass
-          return
-        case _:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Expected model content from invlaid image to error")
       }
-      XCTFail("Expected model content from invlaid image to error")
-    }
-  #endif
-}
+
+      func testModelContentFromUIImageIsNotEmpty() throws {
+        let coreImage = CIImage(color: CIColor.red)
+          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+        let image = UIImage(ciImage: coreImage)
+        let modelContent = try image.tryPartsValue()
+        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+      }
+    #else
+      func testModelContentFromNSImageIsNotEmpty() throws {
+        let coreImage = CIImage(color: CIColor.red)
+          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+        let rep = NSCIImageRep(ciImage: coreImage)
+        let image = NSImage(size: rep.size)
+        image.addRepresentation(rep)
+        let modelContent = try image.tryPartsValue()
+        XCTAssert(modelContent.count > 0, "Expected non-empty model content for NSImage: \(image)")
+      }
+
+      func testModelContentFromInvalidNSImageThrows() throws {
+        let image = NSImage()
+        do {
+          _ = try image.tryPartsValue()
+        } catch {
+          guard let imageError = (error as? ImageConversionError) else {
+            XCTFail("Got unexpected error type: \(error)")
+            return
+          }
+          switch imageError {
+          case .invalidUnderlyingImage:
+            // Pass
+            return
+          case _:
+            XCTFail("Expected image conversion error, got \(imageError) instead")
+            return
+          }
+        }
+        XCTFail("Expected model content from invlaid image to error")
+      }
+    #endif
+  }
+
+#endif // !os(visionOS)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -73,35 +73,45 @@ final class PartsRepresentableTests: XCTestCase {
     XCTFail("Expected model content from invlaid image to error")
   }
 
-  #if canImport(UIKit) && !os(visionOS) // These tests are stalling in CI on visionOS.
-    func testModelContentFromInvalidUIImageThrows() throws {
+  #if canImport(UIKit)
+    func testModelContentFromInvalidUIImageThrows() {
+      print("Instantiating UIImage.")
       let image = UIImage()
       do {
+        print("Getting image parts.")
         _ = try image.tryPartsValue()
+        XCTFail("Expected ImageConversionError.couldNotConvertToJPEG; no error.")
+      } catch let ImageConversionError.couldNotConvertToJPEG(source as UIImage) {
+        print("Checking image equality.")
+        XCTAssertEqual(source, image)
       } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
-        }
-        switch imageError {
-        case let .couldNotConvertToJPEG(source):
-          // String(describing:) works around a type error.
-          XCTAssertEqual(String(describing: source), String(describing: image))
-          return
-        case _:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Expected ImageConversionError.couldNotConvertToJPEG; error thrown: \(error)")
       }
-      XCTFail("Expected model content from invlaid image to error")
+      print("Done testModelContentFromInvalidUIImageThrows.")
     }
 
-    func testModelContentFromUIImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let image = UIImage(ciImage: coreImage)
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+    func testModelContentFromUIImageIsNotEmpty() {
+      print("Creating UIImage with systemName.")
+      guard let image = UIImage(systemName: "photo") else {
+        XCTFail("Failed to create UIImage with system name.")
+        return
+      }
+      print("Getting image parts.")
+      let modelContent: [ModelContent.Part]
+      do {
+        modelContent = try image.tryPartsValue()
+        print("Got image parts.")
+      } catch {
+        XCTFail("Getting image parts failed with error: \(error)")
+        return
+      }
+      print("Checking content part count.")
+      XCTAssertEqual(
+        modelContent.count,
+        1,
+        "Expected non-empty model content for UIImage: \(image)"
+      )
+      print("Done testModelContentFromUIImageIsNotEmpty.")
     }
 
   #elseif canImport(AppKit)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -18,7 +18,7 @@ import FirebaseVertexAI
 import XCTest
 #if canImport(UIKit)
   import UIKit
-#else
+#elseif canImport(AppKit)
   import AppKit
 #endif
 
@@ -96,16 +96,16 @@ final class PartsRepresentableTests: XCTestCase {
         }
         XCTFail("Expected model content from invlaid image to error")
       }
-    #endif // !os(visionOS)
 
-    func testModelContentFromUIImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let image = UIImage(ciImage: coreImage)
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-    }
-  #else
+      func testModelContentFromUIImageIsNotEmpty() throws {
+        let coreImage = CIImage(color: CIColor.red)
+          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+        let image = UIImage(ciImage: coreImage)
+        let modelContent = try image.tryPartsValue()
+        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+      }
+    #endif // !os(visionOS)
+  #elseif canImport(AppKit)
     func testModelContentFromNSImageIsNotEmpty() throws {
       let coreImage = CIImage(color: CIColor.red)
         .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -74,27 +74,29 @@ final class PartsRepresentableTests: XCTestCase {
   }
 
   #if canImport(UIKit)
-    func testModelContentFromInvalidUIImageThrows() throws {
-      let image = UIImage()
-      do {
-        _ = try image.tryPartsValue()
-      } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
+    #if !os(visionOS)
+      func testModelContentFromInvalidUIImageThrows() throws {
+        let image = UIImage()
+        do {
+          _ = try image.tryPartsValue()
+        } catch {
+          guard let imageError = (error as? ImageConversionError) else {
+            XCTFail("Got unexpected error type: \(error)")
+            return
+          }
+          switch imageError {
+          case let .couldNotConvertToJPEG(source):
+            // String(describing:) works around a type error.
+            XCTAssertEqual(String(describing: source), String(describing: image))
+            return
+          case _:
+            XCTFail("Expected image conversion error, got \(imageError) instead")
+            return
+          }
         }
-        switch imageError {
-        case let .couldNotConvertToJPEG(source):
-          // String(describing:) works around a type error.
-          XCTAssertEqual(String(describing: source), String(describing: image))
-          return
-        case _:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Expected model content from invlaid image to error")
       }
-      XCTFail("Expected model content from invlaid image to error")
-    }
+    #endif // !os(visionOS)
 
     func testModelContentFromUIImageIsNotEmpty() throws {
       let coreImage = CIImage(color: CIColor.red)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -73,38 +73,37 @@ final class PartsRepresentableTests: XCTestCase {
     XCTFail("Expected model content from invlaid image to error")
   }
 
-  #if canImport(UIKit)
-    #if !os(visionOS)
-      func testModelContentFromInvalidUIImageThrows() throws {
-        let image = UIImage()
-        do {
-          _ = try image.tryPartsValue()
-        } catch {
-          guard let imageError = (error as? ImageConversionError) else {
-            XCTFail("Got unexpected error type: \(error)")
-            return
-          }
-          switch imageError {
-          case let .couldNotConvertToJPEG(source):
-            // String(describing:) works around a type error.
-            XCTAssertEqual(String(describing: source), String(describing: image))
-            return
-          case _:
-            XCTFail("Expected image conversion error, got \(imageError) instead")
-            return
-          }
+  #if canImport(UIKit) && !os(visionOS) // These tests are stalling in CI on visionOS.
+    func testModelContentFromInvalidUIImageThrows() throws {
+      let image = UIImage()
+      do {
+        _ = try image.tryPartsValue()
+      } catch {
+        guard let imageError = (error as? ImageConversionError) else {
+          XCTFail("Got unexpected error type: \(error)")
+          return
         }
-        XCTFail("Expected model content from invlaid image to error")
+        switch imageError {
+        case let .couldNotConvertToJPEG(source):
+          // String(describing:) works around a type error.
+          XCTAssertEqual(String(describing: source), String(describing: image))
+          return
+        case _:
+          XCTFail("Expected image conversion error, got \(imageError) instead")
+          return
+        }
       }
+      XCTFail("Expected model content from invlaid image to error")
+    }
 
-      func testModelContentFromUIImageIsNotEmpty() throws {
-        let coreImage = CIImage(color: CIColor.red)
-          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-        let image = UIImage(ciImage: coreImage)
-        let modelContent = try image.tryPartsValue()
-        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-      }
-    #endif // !os(visionOS)
+    func testModelContentFromUIImageIsNotEmpty() throws {
+      let coreImage = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let image = UIImage(ciImage: coreImage)
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+    }
+
   #elseif canImport(AppKit)
     func testModelContentFromNSImageIsNotEmpty() throws {
       let coreImage = CIImage(color: CIColor.red)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -22,41 +22,62 @@ import XCTest
   import AppKit
 #endif
 
-#if !os(visionOS)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+final class PartsRepresentableTests: XCTestCase {
+  func testModelContentFromCGImageIsNotEmpty() throws {
+    // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
+    var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
+    let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
+      let ctx = CGContext(
+        data: ptr.baseAddress,
+        width: 8,
+        height: 8,
+        bitsPerComponent: 8,
+        bytesPerRow: 4 * 8,
+        space: CGColorSpace(name: CGColorSpace.sRGB)!,
+        bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
+          CGImageAlphaInfo.premultipliedFirst.rawValue
+      )!
+      return ctx.makeImage()!
+    }
+    let modelContent = try image.tryPartsValue()
+    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
+  }
 
-  @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
-  final class PartsRepresentableTests: XCTestCase {
-    func testModelContentFromCGImageIsNotEmpty() throws {
-      // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
-      var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
-      let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
-        let ctx = CGContext(
-          data: ptr.baseAddress,
-          width: 8,
-          height: 8,
-          bitsPerComponent: 8,
-          bytesPerRow: 4 * 8,
-          space: CGColorSpace(name: CGColorSpace.sRGB)!,
-          bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
-            CGImageAlphaInfo.premultipliedFirst.rawValue
-        )!
-        return ctx.makeImage()!
+  func testModelContentFromCIImageIsNotEmpty() throws {
+    let image = CIImage(color: CIColor.red)
+      .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+    let modelContent = try image.tryPartsValue()
+    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
+  }
+
+  func testModelContentFromInvalidCIImageThrows() throws {
+    let image = CIImage.empty()
+    do {
+      let _ = try image.tryPartsValue()
+    } catch {
+      guard let imageError = (error as? ImageConversionError) else {
+        XCTFail("Got unexpected error type: \(error)")
+        return
       }
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
+      switch imageError {
+      case let .couldNotConvertToJPEG(source):
+        // String(describing:) works around a type error.
+        XCTAssertEqual(String(describing: source), String(describing: image))
+        return
+      case _:
+        XCTFail("Expected image conversion error, got \(imageError) instead")
+        return
+      }
     }
+    XCTFail("Expected model content from invlaid image to error")
+  }
 
-    func testModelContentFromCIImageIsNotEmpty() throws {
-      let image = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let modelContent = try image.tryPartsValue()
-      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
-    }
-
-    func testModelContentFromInvalidCIImageThrows() throws {
-      let image = CIImage.empty()
+  #if canImport(UIKit)
+    func testModelContentFromInvalidUIImageThrows() throws {
+      let image = UIImage()
       do {
-        let _ = try image.tryPartsValue()
+        _ = try image.tryPartsValue()
       } catch {
         guard let imageError = (error as? ImageConversionError) else {
           XCTFail("Got unexpected error type: \(error)")
@@ -75,68 +96,43 @@ import XCTest
       XCTFail("Expected model content from invlaid image to error")
     }
 
-    #if canImport(UIKit)
-      func testModelContentFromInvalidUIImageThrows() throws {
-        let image = UIImage()
-        do {
-          _ = try image.tryPartsValue()
-        } catch {
-          guard let imageError = (error as? ImageConversionError) else {
-            XCTFail("Got unexpected error type: \(error)")
-            return
-          }
-          switch imageError {
-          case let .couldNotConvertToJPEG(source):
-            // String(describing:) works around a type error.
-            XCTAssertEqual(String(describing: source), String(describing: image))
-            return
-          case _:
-            XCTFail("Expected image conversion error, got \(imageError) instead")
-            return
-          }
+    func testModelContentFromUIImageIsNotEmpty() throws {
+      let coreImage = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let image = UIImage(ciImage: coreImage)
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
+    }
+  #else
+    func testModelContentFromNSImageIsNotEmpty() throws {
+      let coreImage = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let rep = NSCIImageRep(ciImage: coreImage)
+      let image = NSImage(size: rep.size)
+      image.addRepresentation(rep)
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for NSImage: \(image)")
+    }
+
+    func testModelContentFromInvalidNSImageThrows() throws {
+      let image = NSImage()
+      do {
+        _ = try image.tryPartsValue()
+      } catch {
+        guard let imageError = (error as? ImageConversionError) else {
+          XCTFail("Got unexpected error type: \(error)")
+          return
         }
-        XCTFail("Expected model content from invlaid image to error")
-      }
-
-      func testModelContentFromUIImageIsNotEmpty() throws {
-        let coreImage = CIImage(color: CIColor.red)
-          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-        let image = UIImage(ciImage: coreImage)
-        let modelContent = try image.tryPartsValue()
-        XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
-      }
-    #else
-      func testModelContentFromNSImageIsNotEmpty() throws {
-        let coreImage = CIImage(color: CIColor.red)
-          .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-        let rep = NSCIImageRep(ciImage: coreImage)
-        let image = NSImage(size: rep.size)
-        image.addRepresentation(rep)
-        let modelContent = try image.tryPartsValue()
-        XCTAssert(modelContent.count > 0, "Expected non-empty model content for NSImage: \(image)")
-      }
-
-      func testModelContentFromInvalidNSImageThrows() throws {
-        let image = NSImage()
-        do {
-          _ = try image.tryPartsValue()
-        } catch {
-          guard let imageError = (error as? ImageConversionError) else {
-            XCTFail("Got unexpected error type: \(error)")
-            return
-          }
-          switch imageError {
-          case .invalidUnderlyingImage:
-            // Pass
-            return
-          case _:
-            XCTFail("Expected image conversion error, got \(imageError) instead")
-            return
-          }
+        switch imageError {
+        case .invalidUnderlyingImage:
+          // Pass
+          return
+        case _:
+          XCTFail("Expected image conversion error, got \(imageError) instead")
+          return
         }
-        XCTFail("Expected model content from invlaid image to error")
       }
-    #endif
-  }
-
-#endif // !os(visionOS)
+      XCTFail("Expected model content from invlaid image to error")
+    }
+  #endif
+}


### PR DESCRIPTION
Added CI for testing the Vertex AI SDK on visionOS. Note that the following still applies: https://github.com/firebase/firebase-ios-sdk/blob/901844a9213e241d06315f92d6524d8c695e0dd7/FirebaseVertexAI/Sources/Constants.swift#L17-L19

#no-changelog