### PR TITLE
[v11] Dependency version updates

### DIFF
--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -18,6 +18,7 @@ target 'FirebasePodTest' do
   pod 'FirebaseDatabase', :path => '../../../'
   pod 'FirebaseDynamicLinks', :path => '../../../'
   pod 'FirebaseFirestore', :path => '../../../'
+  pod 'FirebaseFirestoreInternal', :path => '../../../'
   pod 'FirebaseFunctions', :path => '../../../'
   pod 'FirebaseInAppMessaging', :path => '../../../'
   pod 'FirebaseInstallations', :path => '../../../'

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.0'
     s.dependency 'GoogleUtilities/NSData+zlib', '~> 8.0'
     s.dependency 'GoogleUtilities/Network', '~> 8.0'
-    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+    s.dependency 'nanopb', '~> 3.30910.0'
 
     s.default_subspecs = 'AdIdSupport'
 

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency 'AppCheckCore', '~> 11.0'
   s.dependency 'FirebaseAppCheckInterop', '~> 11.0'
   s.dependency 'FirebaseCore', '~> 11.0'
-  s.dependency 'PromisesObjC', '~> 2.1'
+  s.dependency 'PromisesObjC', '~> 2.4'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
 

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -61,7 +61,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'FirebaseCoreExtension', '~> 11.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
-  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
+  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
   s.ios.dependency 'RecaptchaInterop', '~> 100.0'
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -63,10 +63,10 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 11.0'
   s.dependency 'FirebaseSessions', '~> 11.0'
   s.dependency 'FirebaseRemoteConfigInterop', '~> 11.0'
-  s.dependency 'PromisesObjC', '~> 2.1'
+  s.dependency 'PromisesObjC', '~> 2.4'
   s.dependency 'GoogleDataTransport', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
 
   s.libraries = 'c++', 'z'
   s.ios.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -107,7 +107,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'gRPC-Core', '~> 1.62.0'
   s.dependency 'gRPC-C++', '~> 1.62.0'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
 
   s.ios.frameworks = 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -41,7 +41,7 @@ Cloud Functions for Firebase.
   s.dependency 'FirebaseAuthInterop', '~> 11.0'
   s.dependency 'FirebaseMessagingInterop', '~> 11.0'
   s.dependency 'FirebaseSharedSwift', '~> 11.0'
-  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
+  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
 
   s.test_spec 'objc' do |objc_tests|
     objc_tests.platforms = {

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -85,7 +85,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'FirebaseABTesting', '~> 11.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
 
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 11.0'
-  s.dependency 'PromisesObjC', '~> 2.1'
+  s.dependency 'PromisesObjC', '~> 2.4'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -68,7 +68,7 @@ device, and it is completely free.
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
   s.dependency 'GoogleDataTransport', '~> 10.0'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -68,7 +68,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'GoogleUtilities/ISASwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => ios_deployment_target, :tvos => tvos_deployment_target}

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.dependency 'GoogleDataTransport', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+  s.dependency 'nanopb', '~> 3.30910.0'
   s.dependency 'PromisesSwift', '~> 2.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -41,7 +41,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.dependency 'FirebaseAuthInterop', '~> 11.0'
   s.dependency 'FirebaseCore', '~> 11.0'
   s.dependency 'FirebaseCoreExtension', '~> 11.0'
-  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
+  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
 
   s.test_spec 'ObjCIntegration' do |objc_tests|

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.0'
     s.dependency 'GoogleUtilities/NSData+zlib', '~> 8.0'
     s.dependency 'GoogleUtilities/Network', '~> 8.0'
-    s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
+    s.dependency 'nanopb', '~> 3.30910.0'
 
     s.default_subspecs = 'AdIdSupport'
 

--- a/IntegrationTesting/ClientApp/Podfile
+++ b/IntegrationTesting/ClientApp/Podfile
@@ -22,6 +22,7 @@ target 'ClientApp-CocoaPods' do
   pod 'FirebaseDatabase', :path => '../../'
   pod 'FirebaseDynamicLinks', :path => '../../'
   pod 'FirebaseFirestore', :path => '../../'
+  pod 'FirebaseFirestoreInternal', :path => '../../'
   pod 'FirebaseFunctions', :path => '../../'
   pod 'FirebaseInAppMessaging', :path => '../../'
   pod 'FirebaseMessaging', :path => '../../'

--- a/IntegrationTesting/ClientApp/Podfile
+++ b/IntegrationTesting/ClientApp/Podfile
@@ -25,6 +25,7 @@ target 'ClientApp-CocoaPods' do
   pod 'FirebaseFunctions', :path => '../../'
   pod 'FirebaseInAppMessaging', :path => '../../'
   pod 'FirebaseMessaging', :path => '../../'
+  pod 'FirebaseSessions', :path => '../../'
   pod 'FirebasePerformance', :path => '../../'
   pod 'FirebaseMLModelDownloader', :path => '../../'
   pod 'Firebase', :path => '../../'

--- a/Package.swift
+++ b/Package.swift
@@ -134,7 +134,9 @@ let package = Package(
     googleAppMeasurementDependency(),
     .package(
       url: "https://github.com/google/GoogleDataTransport.git",
-      "9.3.0" ..< "10.0.0"
+      branch: "release-10.0"
+      // TODO: Update to 10.0.0 when ready.
+      // "10.0.0" ..< "11.0.0"
     ),
     .package(
       url: "https://github.com/google/GoogleUtilities.git",

--- a/Package.swift
+++ b/Package.swift
@@ -175,7 +175,10 @@ let package = Package(
       url: "https://github.com/google/interop-ios-for-google-sdks.git",
       "100.0.0" ..< "101.0.0"
     ),
-    .package(url: "https://github.com/google/app-check.git", "10.19.0" ..< "11.0.0"),
+    .package(url: "https://github.com/google/app-check.git",
+             branch: "release-11.0"),
+    // TODO: Update to 11.0.0 when ready.
+    // "11.0.0" ..< "12.0.0",
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let firebaseVersion = "11.0.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v12), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",
@@ -125,7 +124,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/google/promises.git",
-      "2.1.0" ..< "3.0.0"
+      "2.4.0" ..< "3.0.0"
     ),
     .package(
       url: "https://github.com/apple/swift-protobuf.git",
@@ -144,7 +143,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "2.1.0" ..< "4.0.0"
+      "3.4.1" ..< "4.0.0"
     ),
     .package(
       url: "https://github.com/firebase/nanopb.git",

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let firebaseVersion = "11.0.0"
 
 let package = Package(
   name: "Firebase",
+  platforms: [.iOS(.v12), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",


### PR DESCRIPTION
- Update to breaking change podspec versions of nanopb and GDT
- Tighten version ranges for other deps
- Incorporate AppCheck fixes from https://github.com/google/app-check/pull/60

Part of https://github.com/firebase/firebase-ios-sdk/issues/10187