### PR TITLE
[Vertex AI] Add environment variable to control integration tests

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -50,7 +50,7 @@ jobs:
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     env:
-      VERTEXAI_RUN_INTEGRATION_TESTS: 1
+      TEST_RUNNER_VertexAIRunIntegrationTests: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -50,7 +50,6 @@ jobs:
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     env:
-      TEST_RUNNER_VertexAIRunIntegrationTests: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
@@ -68,7 +67,8 @@ jobs:
         max_attempts: 3
         retry_on: error
         retry_wait_seconds: 120
-        command: scripts/build.sh FirebaseVertexAIIntegration ${{ matrix.target }} spm
+        command: TEST_RUNNER_VertexAIRunIntegrationTests=1 scripts/build.sh \
+          FirebaseVertexAIIntegration ${{ matrix.target }} spm
 
   sample:
     strategy:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -43,13 +43,14 @@ jobs:
   spm-integration:
     strategy:
       matrix:
-        target: [macOS]
+        target: [iOS]
         os: [macos-14]
         include:
           - os: macos-14
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     env:
+      VERTEXAI_RUN_INTEGRATION_TESTS: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -50,6 +50,7 @@ jobs:
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     env:
+      TEST_RUNNER_VertexAIRunIntegrationTests: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
@@ -67,8 +68,7 @@ jobs:
         max_attempts: 3
         retry_on: error
         retry_wait_seconds: 120
-        command: TEST_RUNNER_VertexAIRunIntegrationTests=1 scripts/build.sh \
-          FirebaseVertexAIIntegration ${{ matrix.target }} spm
+        command: scripts/build.sh FirebaseVertexAIIntegration ${{ matrix.target }} spm
 
   sample:
     strategy:

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -16,62 +16,59 @@ import FirebaseCore
 import FirebaseVertexAI
 import XCTest
 
-// These tests are functional on other platforms but are compiled-out of non-macOS platforms to
-// avoid re-running them as part of `swift-build-run` job (iOS-only) in the `spm` workflow on CI:
-// https://github.com/firebase/firebase-ios-sdk/blob/0492e83cb22833ec548e61d854bb7b830e83b826/.github/workflows/spm.yml#L57
-// Since these requests are billed, we are running them more sparsely than the unit tests.
-#if os(macOS)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+final class IntegrationTests: XCTestCase {
+  // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.
+  let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)
 
-  @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
-  final class IntegrationTests: XCTestCase {
-    // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.
-    let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)
+  var vertex: VertexAI!
+  var model: GenerativeModel!
 
-    var vertex: VertexAI!
-    var model: GenerativeModel!
+  override func setUp() async throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["VERTEXAI_RUN_INTEGRATION_TESTS"] == nil, """
+    Vertex AI integration tests skipped; to enable them, set the VERTEXAI_RUN_INTEGRATION_TESTS \
+    environment variable in Xcode or CI jobs.
+    """)
 
-    override func setUp() async throws {
-      let plistPath = try XCTUnwrap(Bundle.module.path(
-        forResource: "GoogleService-Info",
-        ofType: "plist"
-      ))
-      let options = try XCTUnwrap(FirebaseOptions(contentsOfFile: plistPath))
-      FirebaseApp.configure(options: options)
+    let plistPath = try XCTUnwrap(Bundle.module.path(
+      forResource: "GoogleService-Info",
+      ofType: "plist"
+    ))
+    let options = try XCTUnwrap(FirebaseOptions(contentsOfFile: plistPath))
+    FirebaseApp.configure(options: options)
 
-      vertex = VertexAI.vertexAI()
-      model = vertex.generativeModel(
-        modelName: "gemini-1.5-flash",
-        generationConfig: generationConfig
-      )
-    }
+    vertex = VertexAI.vertexAI()
+    model = vertex.generativeModel(
+      modelName: "gemini-1.5-flash",
+      generationConfig: generationConfig
+    )
+  }
 
-    override func tearDown() async throws {
-      if let app = FirebaseApp.app() {
-        await app.delete()
-      }
-    }
-
-    // MARK: - Generate Content
-
-    func testGenerateContent() async throws {
-      let prompt = "Where is Google headquarters located? Answer with the city name only."
-
-      let response = try await model.generateContent(prompt)
-
-      let text = try XCTUnwrap(response.text).trimmingCharacters(in: .whitespacesAndNewlines)
-      XCTAssertEqual(text, "Mountain View")
-    }
-
-    // MARK: - Count Tokens
-
-    func testCountTokens() async throws {
-      let prompt = "Why is the sky blue?"
-
-      let response = try await model.countTokens(prompt)
-
-      XCTAssertEqual(response.totalTokens, 6)
-      XCTAssertEqual(response.totalBillableCharacters, 16)
+  override func tearDown() async throws {
+    if let app = FirebaseApp.app() {
+      await app.delete()
     }
   }
 
-#endif // os(macOS)
+  // MARK: - Generate Content
+
+  func testGenerateContent() async throws {
+    let prompt = "Where is Google headquarters located? Answer with the city name only."
+
+    let response = try await model.generateContent(prompt)
+
+    let text = try XCTUnwrap(response.text).trimmingCharacters(in: .whitespacesAndNewlines)
+    XCTAssertEqual(text, "Mountain View")
+  }
+
+  // MARK: - Count Tokens
+
+  func testCountTokens() async throws {
+    let prompt = "Why is the sky blue?"
+
+    let response = try await model.countTokens(prompt)
+
+    XCTAssertEqual(response.totalTokens, 6)
+    XCTAssertEqual(response.totalBillableCharacters, 16)
+  }
+}

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -25,11 +25,6 @@ final class IntegrationTests: XCTestCase {
   var model: GenerativeModel!
 
   override func setUp() async throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["VERTEXAI_RUN_INTEGRATION_TESTS"] == nil, """
-    Vertex AI integration tests skipped; to enable them, set the VERTEXAI_RUN_INTEGRATION_TESTS \
-    environment variable in Xcode or CI jobs.
-    """)
-
     let plistPath = try XCTUnwrap(Bundle.module.path(
       forResource: "GoogleService-Info",
       ofType: "plist"

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -29,7 +29,7 @@ final class IntegrationTests: XCTestCase {
     Vertex AI integration tests skipped; to enable them, set the VertexAIRunIntegrationTests \
     environment variable in Xcode or CI jobs.
     """)
-	
+
     let plistPath = try XCTUnwrap(Bundle.module.path(
       forResource: "GoogleService-Info",
       ofType: "plist"

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -25,6 +25,11 @@ final class IntegrationTests: XCTestCase {
   var model: GenerativeModel!
 
   override func setUp() async throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["VertexAIRunIntegrationTests"] == nil, """
+    Vertex AI integration tests skipped; to enable them, set the VertexAIRunIntegrationTests \
+    environment variable in Xcode or CI jobs.
+    """)
+	
     let plistPath = try XCTUnwrap(Bundle.module.path(
       forResource: "GoogleService-Info",
       ofType: "plist"

--- a/Package.swift
+++ b/Package.swift
@@ -1381,14 +1381,11 @@ let package = Package(
       resources: [
         .process("CountTokenResponses"),
         .process("GenerateContentResponses"),
-      ],
-      cSettings: [
-        .headerSearchPath("../../../"),
       ]
     ),
     .testTarget(
       name: "FirebaseVertexAIIntegration",
-      dependencies: ["FirebaseVertexAI", "SharedTestUtilities"],
+      dependencies: ["FirebaseVertexAI"],
       path: "FirebaseVertexAI/Tests/Integration",
       resources: [
         .process("Resources"),

--- a/Package.swift
+++ b/Package.swift
@@ -1381,6 +1381,9 @@ let package = Package(
       resources: [
         .process("CountTokenResponses"),
         .process("GenerateContentResponses"),
+      ],
+      cSettings: [
+        .headerSearchPath("../../../"),
       ]
     ),
     .testTarget(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -496,15 +496,6 @@ case "$product-$platform-$method" in
       build
     ;;
 
-  FirebaseVertexAIIntegration-*-*)
-    if [[ -n "${VERTEXAI_RUN_INTEGRATION_TESTS:-}" ]]; then
-      RunXcodebuild \
-        -scheme "$product" \
-        "${xcb_flags[@]}" \
-        test
-    fi
-    ;;
-
   VertexSample-*-*)
     RunXcodebuild \
       -project 'FirebaseVertexAI/Sample/VertexAISample.xcodeproj' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -496,6 +496,15 @@ case "$product-$platform-$method" in
       build
     ;;
 
+  FirebaseVertexAIIntegration-*-*)
+    if [[ -n "${VERTEXAI_RUN_INTEGRATION_TESTS:-}" ]]; then
+      RunXcodebuild \
+        -scheme "$product" \
+        "${xcb_flags[@]}" \
+        test
+    fi
+    ;;
+
   VertexSample-*-*)
     RunXcodebuild \
       -project 'FirebaseVertexAI/Sample/VertexAISample.xcodeproj' \


### PR DESCRIPTION
- Skip Vertex AI integration tests when the `VertexAIRunIntegrationTests` environment variable is not set.
- Switched `spm-integration` to run on iOS.
- Cleaned up dependencies in the `FirebaseVertexAIIntegration` test target.

#no-changelog