### PR TITLE
[v11] Rename AuthProviderString to AuthProviderID

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 11.0.0
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`
   even if the server returns the `web.app` domain listed first. (#7992)
+- [added] Introduced the Swift enum `AuthProviderID` for the Auth Provider IDs. (#9236)
 
 # 10.21.0
 - [fixed] Fixed multifactor resolver to use the correct Auth instance instead of

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`
   even if the server returns the `web.app` domain listed first. (#7992)
 - [added] Introduced the Swift enum `AuthProviderID` for the Auth Provider IDs. (#9236)
+- [deprecated] Swift APIs using `String`-typed `productID`s have been deprecated in favor
+  of newly added API that leverages the `AuthProviderID` enum.
 
 # 10.21.0
 - [fixed] Fixed multifactor resolver to use the correct Auth instance instead of

--- a/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderStrings.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderStrings.swift
@@ -14,8 +14,8 @@
 
 import Foundation
 
-/// Enumeration of the available Auth Providers.
-public enum AuthProviderString: String {
+/// Enumeration of the available Auth Provider IDs.
+public enum AuthProviderID: String {
   case apple = "apple.com"
   case email = "password"
   case facebook = "facebook.com"

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -91,11 +91,67 @@ import Foundation
   /// - Parameter accessToken: The access token associated with the Auth credential be created, if
   /// available.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
+  @available(swift, introduced: 100.0)
   @objc(credentialWithProviderID:IDToken:accessToken:)
+  public static func credential(withProviderID providerID: NSString,
+                                idToken: NSString,
+                                accessToken: NSString?) -> OAuthCredential {
+    return OAuthCredential(
+      withProviderID: providerID as String,
+      idToken: idToken as String,
+      accessToken: accessToken as String?
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use `credential(providerID: AuthProviderID, idToken: String, accessToken: String) -> OAuthCredential` instead."
+  )
   public static func credential(withProviderID providerID: String,
                                 idToken: String,
                                 accessToken: String?) -> OAuthCredential {
     return OAuthCredential(withProviderID: providerID, idToken: idToken, accessToken: accessToken)
+  }
+
+  /// Creates an `AuthCredential` for the OAuth 2 provider identified by provider ID, ID
+  /// token, and access token.
+  /// - Parameter providerID: The provider ID associated with the Auth credential being created.
+  /// - Parameter idToken: The IDToken associated with the Auth credential being created.
+  /// - Parameter accessToken: The access token associated with the Auth credential be created, if
+  /// available.
+  /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
+  public static func credential(providerID: AuthProviderID,
+                                idToken: String,
+                                accessToken: String?) -> OAuthCredential {
+    return OAuthCredential(
+      withProviderID: providerID.rawValue,
+      idToken: idToken,
+      accessToken: accessToken
+    )
+  }
+
+  /// Creates an `AuthCredential` for the OAuth 2 provider identified by provider ID, ID
+  /// token, and access token.
+  /// - Parameter providerID: The provider ID associated with the Auth credential being created.
+  /// - Parameter accessToken: The access token associated with the Auth credential be created, if
+  /// available.
+  /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
+  @available(swift, introduced: 100.0)
+  @objc(credentialWithProviderID:accessToken:)
+  public static func credential(withProviderID providerID: NSString,
+                                accessToken: NSString) -> OAuthCredential {
+    return OAuthCredential(withProviderID: providerID as String, accessToken: accessToken as String)
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use `credential(providerID: AuthProviderID, accessToken: String) -> OAuthCredential` instead."
+  )
+  public static func credential(withProviderID providerID: String,
+                                accessToken: String) -> OAuthCredential {
+    return OAuthCredential(withProviderID: providerID, accessToken: accessToken)
   }
 
   /// Creates an `AuthCredential` for the OAuth 2 provider identified by provider ID using
@@ -103,10 +159,9 @@ import Foundation
   /// - Parameter providerID: The provider ID associated with the Auth credential being created.
   /// - Parameter accessToken: The access token associated with the Auth credential be created
   /// - Returns: An AuthCredential.
-  @objc(credentialWithProviderID:accessToken:)
-  public static func credential(withProviderID providerID: String,
+  public static func credential(providerID: AuthProviderID,
                                 accessToken: String) -> OAuthCredential {
-    return OAuthCredential(withProviderID: providerID, accessToken: accessToken)
+    return OAuthCredential(withProviderID: providerID.rawValue, accessToken: accessToken)
   }
 
   /// Creates an `AuthCredential` for that OAuth 2 provider identified by provider ID, ID
@@ -114,10 +169,26 @@ import Foundation
   /// - Parameter providerID: The provider ID associated with the Auth credential being created.
   /// - Parameter idToken: The IDToken associated with the Auth credential being created.
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
-  /// - Parameter accessToken: The access token associated with the Auth credential be created, if
-  /// available.
+  /// - Parameter accessToken: The access token associated with the Auth credential be created.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
+  @available(swift, introduced: 100.0)
   @objc(credentialWithProviderID:IDToken:rawNonce:accessToken:)
+  public static func credential(withProviderID providerID: NSString, idToken: NSString,
+                                rawNonce: NSString,
+                                accessToken: NSString) -> OAuthCredential {
+    return OAuthCredential(
+      withProviderID: providerID as String,
+      idToken: idToken as String,
+      rawNonce: rawNonce as String,
+      accessToken: accessToken as String
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use `credential(providerID: AuthProviderID, rawNonce: String, accessToken: String) -> OAuthCredential` instead."
+  )
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String,
                                 accessToken: String) -> OAuthCredential {
@@ -135,10 +206,44 @@ import Foundation
   /// - Parameter idToken: The IDToken associated with the Auth credential being created.
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
   /// - Returns: An AuthCredential.
+  @available(swift, introduced: 100.0)
   @objc(credentialWithProviderID:IDToken:rawNonce:)
+  public static func credential(withProviderID providerID: NSString, idToken: NSString,
+                                rawNonce: NSString) -> OAuthCredential {
+    return OAuthCredential(
+      withProviderID: providerID as String,
+      idToken: idToken as String,
+      rawNonce: rawNonce as String
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String) -> OAuthCredential` instead."
+  )
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String) -> OAuthCredential {
     return OAuthCredential(withProviderID: providerID, idToken: idToken, rawNonce: rawNonce)
+  }
+
+  /// Creates an `AuthCredential` for that OAuth 2 provider identified by provider ID, ID
+  /// token, raw nonce, and access token.
+  /// - Parameter providerID: The provider ID associated with the Auth credential being created.
+  /// - Parameter idToken: The IDToken associated with the Auth credential being created.
+  /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
+  /// - Parameter accessToken: The access token associated with the Auth credential be created, if
+  /// available.
+  /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
+  public static func credential(providerID: AuthProviderID, idToken: String,
+                                rawNonce: String,
+                                accessToken: String? = nil) -> OAuthCredential {
+    return OAuthCredential(
+      withProviderID: providerID.rawValue,
+      idToken: idToken,
+      rawNonce: rawNonce,
+      accessToken: accessToken
+    )
   }
 
   #if os(iOS)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -55,7 +55,7 @@ import Foundation
         fatalError("Sign in with Facebook is not supported via generic IDP; the Facebook TOS " +
           "dictate that you must use the Facebook iOS SDK for Facebook login.")
       }
-      if providerID == AuthProviderString.apple.rawValue {
+      if providerID == AuthProviderID.apple.rawValue {
         fatalError("Sign in with Apple is not supported via generic IDP; You must use the Apple SDK" +
           " for Sign in with Apple.")
       }
@@ -247,7 +247,7 @@ import Foundation
   public static func appleCredential(withIDToken idToken: String,
                                      rawNonce: String?,
                                      fullName: PersonNameComponents?) -> OAuthCredential {
-    return OAuthCredential(withProviderID: AuthProviderString.apple.rawValue,
+    return OAuthCredential(withProviderID: AuthProviderID.apple.rawValue,
                            idToken: idToken,
                            rawNonce: rawNonce,
                            fullName: fullName)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -29,20 +29,53 @@ import Foundation
   /// The provider ID indicating the specific OAuth provider this OAuthProvider instance represents.
   @objc public let providerID: String
 
-  /// - Parameter providerID: The provider ID of the IDP for which this auth provider instance will
-  /// be configured.
+  /// An instance of OAuthProvider corresponding to the given provider ID.
+  /// - Parameters:
+  ///   - providerID: The provider ID of the IDP for which this auth provider instance will be
+  /// configured.
   /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
+  @available(
+    swift,
+    deprecated: 0.01,
+    message: "Use `provider(providerID: AuthProviderID) -> OAuthProvider` instead."
+  )
   @objc(providerWithProviderID:) open class func provider(providerID: String) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: Auth.auth())
   }
 
-  /// - Parameter providerID: The provider ID of the IDP for which this auth provider instance will
-  /// be configured.
-  /// - Parameter auth: The auth instance to be associated with the OAuthProvider instance.
+  /// An instance of OAuthProvider corresponding to the given provider ID.
+  /// - Parameters:
+  ///   - providerID: The provider ID of the IDP for which this auth provider instance will be
+  /// configured.
   /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
+  public class func provider(providerID: AuthProviderID) -> OAuthProvider {
+    return OAuthProvider(providerID: providerID.rawValue, auth: Auth.auth())
+  }
+
+  /// An instance of OAuthProvider corresponding to the given provider ID and auth instance.
+  /// - Parameters:
+  ///   - providerID: The provider ID of the IDP for which this auth provider instance will be
+  /// configured.
+  ///   - auth: The auth instance to be associated with the OAuthProvider instance.
+  /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
+  @available(
+    swift,
+    deprecated: 0.01,
+    message: "Use `provider(providerID: AuthProviderID, auth: Auth) -> OAuthProvider` instead."
+  )
   @objc(providerWithProviderID:auth:) open class func provider(providerID: String,
                                                                auth: Auth) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: auth)
+  }
+
+  /// An instance of OAuthProvider corresponding to the given provider ID and auth instance.
+  /// - Parameters:
+  ///   - providerID: The provider ID of the IDP for which this auth provider instance will be
+  /// configured.
+  ///   - auth: The auth instance to be associated with the OAuthProvider instance.
+  /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
+  public class func provider(providerID: AuthProviderID, auth: Auth) -> OAuthProvider {
+    return OAuthProvider(providerID: providerID.rawValue, auth: auth)
   }
 
   /// - Parameter providerID: The provider ID of the IDP for which this auth provider instance will
@@ -91,23 +124,12 @@ import Foundation
   /// - Parameter accessToken: The access token associated with the Auth credential be created, if
   /// available.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(swift, introduced: 100.0)
-  @objc(credentialWithProviderID:IDToken:accessToken:)
-  public static func credential(withProviderID providerID: NSString,
-                                idToken: NSString,
-                                accessToken: NSString?) -> OAuthCredential {
-    return OAuthCredential(
-      withProviderID: providerID as String,
-      idToken: idToken as String,
-      accessToken: accessToken as String?
-    )
-  }
-
   @available(
-    *,
-    deprecated,
-    message: "Use `credential(providerID: AuthProviderID, idToken: String, accessToken: String) -> OAuthCredential` instead."
+    swift,
+    deprecated: 0.01,
+    message: "Use `credential(providerID: AuthProviderID, idToken: String, accessToken: String? = nil) -> OAuthCredential` instead."
   )
+  @objc(credentialWithProviderID:IDToken:accessToken:)
   public static func credential(withProviderID providerID: String,
                                 idToken: String,
                                 accessToken: String?) -> OAuthCredential {
@@ -123,7 +145,7 @@ import Foundation
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
   public static func credential(providerID: AuthProviderID,
                                 idToken: String,
-                                accessToken: String?) -> OAuthCredential {
+                                accessToken: String? = nil) -> OAuthCredential {
     return OAuthCredential(
       withProviderID: providerID.rawValue,
       idToken: idToken,
@@ -137,18 +159,12 @@ import Foundation
   /// - Parameter accessToken: The access token associated with the Auth credential be created, if
   /// available.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(swift, introduced: 100.0)
-  @objc(credentialWithProviderID:accessToken:)
-  public static func credential(withProviderID providerID: NSString,
-                                accessToken: NSString) -> OAuthCredential {
-    return OAuthCredential(withProviderID: providerID as String, accessToken: accessToken as String)
-  }
-
   @available(
-    *,
-    deprecated,
+    swift,
+    deprecated: 0.01,
     message: "Use `credential(providerID: AuthProviderID, accessToken: String) -> OAuthCredential` instead."
   )
+  @objc(credentialWithProviderID:accessToken:)
   public static func credential(withProviderID providerID: String,
                                 accessToken: String) -> OAuthCredential {
     return OAuthCredential(withProviderID: providerID, accessToken: accessToken)
@@ -171,24 +187,12 @@ import Foundation
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
   /// - Parameter accessToken: The access token associated with the Auth credential be created.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(swift, introduced: 100.0)
-  @objc(credentialWithProviderID:IDToken:rawNonce:accessToken:)
-  public static func credential(withProviderID providerID: NSString, idToken: NSString,
-                                rawNonce: NSString,
-                                accessToken: NSString) -> OAuthCredential {
-    return OAuthCredential(
-      withProviderID: providerID as String,
-      idToken: idToken as String,
-      rawNonce: rawNonce as String,
-      accessToken: accessToken as String
-    )
-  }
-
   @available(
-    *,
-    deprecated,
-    message: "Use `credential(providerID: AuthProviderID, rawNonce: String, accessToken: String) -> OAuthCredential` instead."
+    swift,
+    deprecated: 0.01,
+    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
   )
+  @objc(credentialWithProviderID:IDToken:rawNonce:accessToken:)
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String,
                                 accessToken: String) -> OAuthCredential {
@@ -206,22 +210,12 @@ import Foundation
   /// - Parameter idToken: The IDToken associated with the Auth credential being created.
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
   /// - Returns: An AuthCredential.
-  @available(swift, introduced: 100.0)
-  @objc(credentialWithProviderID:IDToken:rawNonce:)
-  public static func credential(withProviderID providerID: NSString, idToken: NSString,
-                                rawNonce: NSString) -> OAuthCredential {
-    return OAuthCredential(
-      withProviderID: providerID as String,
-      idToken: idToken as String,
-      rawNonce: rawNonce as String
-    )
-  }
-
   @available(
-    *,
-    deprecated,
-    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String) -> OAuthCredential` instead."
+    swift,
+    deprecated: 0.01,
+    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
   )
+  @objc(credentialWithProviderID:IDToken:rawNonce:)
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String) -> OAuthCredential {
     return OAuthCredential(withProviderID: providerID, idToken: idToken, rawNonce: rawNonce)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -78,6 +78,7 @@ import Foundation
     return OAuthProvider(providerID: providerID.rawValue, auth: auth)
   }
 
+  /// Initializes an `OAuthProvider`.
   /// - Parameter providerID: The provider ID of the IDP for which this auth provider instance will
   /// be configured.
   /// - Parameter auth: The auth instance to be associated with the OAuthProvider instance.
@@ -115,6 +116,15 @@ import Foundation
     } else {
       fatalError("Missing googleAppID for constructing callbackScheme")
     }
+  }
+
+  /// Initializes an `OAuthProvider`.
+  /// - Parameter providerID: The provider ID of the IDP for which this auth provider instance will
+  /// be configured.
+  /// - Parameter auth: The auth instance to be associated with the OAuthProvider instance.
+  /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
+  public convenience init(providerID: AuthProviderID, auth: Auth = Auth.auth()) {
+    self.init(providerID: providerID.rawValue, auth: auth)
   }
 
   /// Creates an `AuthCredential` for the OAuth 2 provider identified by provider ID, ID

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -62,7 +62,7 @@ class RevokeTokenRequest: IdentityToolkitRequest, AuthRPCRequest {
        requestConfiguration: AuthRequestConfiguration) {
     // Apple and authorization code are the only provider and token type we support for now.
     // Generalize this initializer to accept other providers and token types once supported.
-    providerID = AuthProviderString.apple.rawValue
+    providerID = AuthProviderID.apple.rawValue
     tokenType = .authorizationCode
     self.token = token
     self.idToken = idToken

--- a/FirebaseAuth/Tests/Unit/AuthProviderIDTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthProviderIDTests.swift
@@ -21,14 +21,14 @@ final class AuthProviderIDTests: XCTestCase {
   // Verify that AuthProviderID enum values match the class values published for Objective C
   // compatibility.
   func testAuthProviderIDEnumRawValue() {
-    XCTAssertEqual(AuthProviderString.apple.rawValue, "apple.com")
-    XCTAssertEqual(AuthProviderString.email.rawValue, EmailAuthProvider.id)
-    XCTAssertEqual(AuthProviderString.facebook.rawValue, FacebookAuthProvider.id)
+    XCTAssertEqual(AuthProviderID.apple.rawValue, "apple.com")
+    XCTAssertEqual(AuthProviderID.email.rawValue, EmailAuthProvider.id)
+    XCTAssertEqual(AuthProviderID.facebook.rawValue, FacebookAuthProvider.id)
     #if !os(watchOS)
-      XCTAssertEqual(AuthProviderString.gameCenter.rawValue, GameCenterAuthProvider.id)
+      XCTAssertEqual(AuthProviderID.gameCenter.rawValue, GameCenterAuthProvider.id)
     #endif
-    XCTAssertEqual(AuthProviderString.gitHub.rawValue, GitHubAuthProvider.id)
-    XCTAssertEqual(AuthProviderString.google.rawValue, GoogleAuthProvider.id)
-    XCTAssertEqual(AuthProviderString.phone.rawValue, PhoneAuthProvider.id)
+    XCTAssertEqual(AuthProviderID.gitHub.rawValue, GitHubAuthProvider.id)
+    XCTAssertEqual(AuthProviderID.google.rawValue, GoogleAuthProvider.id)
+    XCTAssertEqual(AuthProviderID.phone.rawValue, PhoneAuthProvider.id)
   }
 }

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -1132,7 +1132,7 @@ class AuthTests: RPCBaseTests {
       // 2. Validate the created Request instance.
       let request = try XCTUnwrap(self.rpcIssuer.request as? VerifyAssertionRequest)
       XCTAssertEqual(request.apiKey, AuthTests.kFakeAPIKey)
-      XCTAssertEqual(request.providerID, AuthProviderString.apple.rawValue)
+      XCTAssertEqual(request.providerID, AuthProviderID.apple.rawValue)
       XCTAssertEqual(request.providerIDToken, kAppleIDToken)
       XCTAssertEqual(request.fullName, fullName)
       XCTAssertTrue(request.returnSecureToken)
@@ -1141,7 +1141,7 @@ class AuthTests: RPCBaseTests {
       try self.rpcIssuer.respond(withJSON: ["idToken": RPCBaseTests.kFakeAccessToken,
                                             "refreshToken": self.kRefreshToken,
                                             "federatedId": self.kGoogleID,
-                                            "providerId": AuthProviderString.apple.rawValue,
+                                            "providerId": AuthProviderID.apple.rawValue,
                                             "localId": self.kLocalID,
                                             "displayName": self.kGoogleDisplayName,
                                             "rawUserInfo": self.kGoogleProfile,
@@ -1164,7 +1164,7 @@ class AuthTests: RPCBaseTests {
         }
         XCTAssertEqual(profile, self.kGoogleProfile)
         XCTAssertEqual(additionalUserInfo.username, self.kGoogleDisplayName)
-        XCTAssertEqual(additionalUserInfo.providerID, AuthProviderString.apple.rawValue)
+        XCTAssertEqual(additionalUserInfo.providerID, AuthProviderID.apple.rawValue)
       } catch {
         XCTFail("\(error)")
       }
@@ -1910,7 +1910,7 @@ class AuthTests: RPCBaseTests {
     rpcIssuer.respondBlock = {
       let request = try XCTUnwrap(self.rpcIssuer.request as? RevokeTokenRequest)
       XCTAssertEqual(request.apiKey, AuthTests.kFakeAPIKey)
-      XCTAssertEqual(request.providerID, AuthProviderString.apple.rawValue)
+      XCTAssertEqual(request.providerID, AuthProviderID.apple.rawValue)
       XCTAssertEqual(request.token, code)
       XCTAssertEqual(request.tokenType, .authorizationCode)
 
@@ -1936,7 +1936,7 @@ class AuthTests: RPCBaseTests {
     issuer?.respondBlock = {
       let request = try XCTUnwrap(issuer?.request as? RevokeTokenRequest)
       XCTAssertEqual(request.apiKey, AuthTests.kFakeAPIKey)
-      XCTAssertEqual(request.providerID, AuthProviderString.apple.rawValue)
+      XCTAssertEqual(request.providerID, AuthProviderID.apple.rawValue)
       XCTAssertEqual(request.token, code)
       XCTAssertEqual(request.tokenType, .authorizationCode)
 

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -55,10 +55,10 @@ import FirebaseCore
      */
     func testObtainingOAuthCredentialNoIDToken() throws {
       initApp(#function)
-      let credential = OAuthProvider.credential(withProviderID: kFakeProviderID,
+      let credential = OAuthProvider.credential(providerID: .apple,
                                                 accessToken: kFakeAccessToken)
       XCTAssertEqual(credential.accessToken, kFakeAccessToken)
-      XCTAssertEqual(credential.provider, kFakeProviderID)
+      XCTAssertEqual(credential.provider, AuthProviderID.apple.rawValue)
       XCTAssertNil(credential.idToken)
     }
 
@@ -85,11 +85,11 @@ import FirebaseCore
      */
     func testObtainingOAuthCredentialWithIDToken() throws {
       initApp(#function)
-      let credential = OAuthProvider.credential(withProviderID: kFakeProviderID,
+      let credential = OAuthProvider.credential(providerID: .email,
                                                 idToken: kFakeIDToken,
                                                 accessToken: kFakeAccessToken)
       XCTAssertEqual(credential.accessToken, kFakeAccessToken)
-      XCTAssertEqual(credential.provider, kFakeProviderID)
+      XCTAssertEqual(credential.provider, AuthProviderID.email.rawValue)
       XCTAssertEqual(credential.idToken, kFakeIDToken)
     }
 

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -417,6 +417,9 @@
 
 #if TARGET_OS_IOS
 - (void)FIROAuthProvider_h:(FIROAuthProvider *)provider {
+  FIROAuthProvider *p = [FIROAuthProvider providerWithProviderID:@""];
+  p = [FIROAuthProvider providerWithProviderID:@"" auth:[FIRAuth auth]];
+
   FIROAuthCredential *c = [FIROAuthProvider credentialWithProviderID:@"id" accessToken:@"token"];
   c = [FIROAuthProvider credentialWithProviderID:@"id"
                                          IDToken:@"idToken"

--- a/FirebaseAuth/Tests/Unit/RevokeTokenTests.swift
+++ b/FirebaseAuth/Tests/Unit/RevokeTokenTests.swift
@@ -42,7 +42,7 @@ class RevokeTokenTests: RPCBaseTests {
       value: kFakeToken
     )
     let requestDictionary = try XCTUnwrap(rpcIssuer.decodedRequest as? [String: AnyHashable])
-    XCTAssertEqual(requestDictionary[kFakeProviderIDKey], AuthProviderString.apple.rawValue)
+    XCTAssertEqual(requestDictionary[kFakeProviderIDKey], AuthProviderID.apple.rawValue)
     XCTAssertEqual(requestDictionary[kFakeTokenTypeKey], "3")
   }
 

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -469,13 +469,22 @@ class AuthAPI_hOnlyTests: XCTestCase {
   }
 
   func FIROAuthProvider_h() {
-    let provider = OAuthProvider(providerID: "id", auth: FirebaseAuth.Auth.auth())
-    _ = provider.providerID
+    let _: (String, Auth) -> OAuthProvider = OAuthProvider.init(providerID:auth:)
+    let _: (String) -> OAuthProvider = OAuthProvider.provider(providerID:)
+    let _: (String, Auth) -> OAuthProvider = OAuthProvider.provider(providerID:auth:)
+    let _: (AuthProviderID) -> OAuthProvider = OAuthProvider.provider(providerID:)
+    let _: (AuthProviderID, Auth) -> OAuthProvider = OAuthProvider.provider(providerID:auth:)
+    // `auth` defaults to `nil`
+    let provider = OAuthProvider(providerID: "id")
+    let _: String = provider.providerID
     #if os(iOS)
       let _: (String, String, String?) -> OAuthCredential =
         OAuthProvider.credential(withProviderID:idToken:accessToken:)
       let _: (AuthProviderID, String, String?) -> OAuthCredential =
         OAuthProvider.credential(providerID:idToken:accessToken:)
+      // `accessToken` defaults to `nil`
+      let _: OAuthCredential =
+        OAuthProvider.credential(providerID: .apple, idToken: "")
       let _: (String, String) -> OAuthCredential =
         OAuthProvider.credential(withProviderID:accessToken:)
       let _: (AuthProviderID, String) -> OAuthCredential = OAuthProvider

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -472,14 +472,24 @@ class AuthAPI_hOnlyTests: XCTestCase {
     let provider = OAuthProvider(providerID: "id", auth: FirebaseAuth.Auth.auth())
     _ = provider.providerID
     #if os(iOS)
-      _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToden", accessToken: "token")
-      _ = OAuthProvider.credential(withProviderID: "id", accessToken: "token")
-      _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce",
-                                   accessToken: "token")
-      _ = OAuthProvider.credential(withProviderID: "id", idToken: "idToken", rawNonce: "nonce")
-      _ = OAuthProvider.appleCredential(withIDToken: "idToken",
-                                        rawNonce: "nonce",
-                                        fullName: nil)
+      let _: (String, String, String?) -> OAuthCredential =
+        OAuthProvider.credential(withProviderID:idToken:accessToken:)
+      let _: (AuthProviderID, String, String?) -> OAuthCredential =
+        OAuthProvider.credential(providerID:idToken:accessToken:)
+      let _: (String, String) -> OAuthCredential =
+        OAuthProvider.credential(withProviderID:accessToken:)
+      let _: (AuthProviderID, String) -> OAuthCredential = OAuthProvider
+        .credential(providerID:accessToken:)
+      let _: (String, String, String, String) -> OAuthCredential =
+        OAuthProvider.credential(withProviderID:idToken:rawNonce:accessToken:)
+      let _: (AuthProviderID, String, String, String?) -> OAuthCredential =
+        OAuthProvider.credential(providerID:idToken:rawNonce:accessToken:)
+      // `accessToken` defaults to `nil`
+      let _: OAuthCredential =
+        OAuthProvider.credential(providerID: .apple, idToken: "", rawNonce: "")
+      let _: (String, String, String) -> OAuthCredential =
+        OAuthProvider.credential(withProviderID:idToken:rawNonce:)
+
       provider.getCredentialWith(provider as? AuthUIDelegate) { credential, error in
       }
     #endif

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -470,6 +470,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
 
   func FIROAuthProvider_h() {
     let _: (String, Auth) -> OAuthProvider = OAuthProvider.init(providerID:auth:)
+    let _: (AuthProviderID, Auth) -> OAuthProvider = OAuthProvider.init(providerID:auth:)
     let _: (String) -> OAuthProvider = OAuthProvider.provider(providerID:)
     let _: (String, Auth) -> OAuthProvider = OAuthProvider.provider(providerID:auth:)
     let _: (AuthProviderID) -> OAuthProvider = OAuthProvider.provider(providerID:)


### PR DESCRIPTION
Better enum name thanks to @ncooke3 . Fix #9236