### PR TITLE
[Vertex AI] Add App Check to integration tests

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TEST_RUNNER_VertexAIRunIntegrationTests: 1
+      TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FirebaseAppCheck
 import FirebaseCore
 import FirebaseVertexAI
 import XCTest
@@ -29,6 +30,8 @@ final class IntegrationTests: XCTestCase {
     Vertex AI integration tests skipped; to enable them, set the VertexAIRunIntegrationTests \
     environment variable in Xcode or CI jobs.
     """)
+
+    AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())
 
     let plistPath = try XCTUnwrap(Bundle.module.path(
       forResource: "GoogleService-Info",

--- a/Package.swift
+++ b/Package.swift
@@ -1387,7 +1387,10 @@ let package = Package(
     ),
     .testTarget(
       name: "FirebaseVertexAIIntegration",
-      dependencies: ["FirebaseVertexAI"],
+      dependencies: [
+        "FirebaseAppCheck",
+        "FirebaseVertexAI",
+      ],
       path: "FirebaseVertexAI/Tests/Integration",
       resources: [
         .process("Resources"),


### PR DESCRIPTION
Added Firebase App Check (using the Debug Provider) in the Vertex AI integration tests.

#no-changelog
