### PR TITLE
[Vertex AI] Update samples/docs to use `gemini-1.5-flash`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 10.28.0
-- [changed] Removed uses of the `gemini-1.5-pro-preview-0514` model in docs and
-  samples. Developers should now use the auto-updated versions, `gemini-1.5-pro`
-  or `gemini-1.5-flash`, or a specific stable version; see
+- [changed] Removed uses of the `gemini-1.5-flash-preview-0514` model in docs
+  and samples. Developers should now use the auto-updated versions,
+  `gemini-1.5-pro` or `gemini-1.5-flash`, or a specific stable version; see
   [available model names](https://firebase.google.com/docs/vertex-ai/gemini-models#available-model-names)
   for more details. (#13099)
 

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 10.28.0
+- [changed] Removed uses of the `gemini-1.5-pro-preview-0514` model in docs and
+  samples. Developers should now use the auto-updated versions, `gemini-1.5-pro`
+  or `gemini-1.5-flash`, or a specific stable version; see
+  [available model names](https://firebase.google.com/docs/vertex-ai/gemini-models#available-model-names)
+  for more details.
+
 # 10.27.0
 - [changed] Removed uses of the `gemini-1.5-pro-preview-0409` model in docs and
   samples. Developers should now use `gemini-1.5-pro-preview-0514` or

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -3,7 +3,7 @@
   samples. Developers should now use the auto-updated versions, `gemini-1.5-pro`
   or `gemini-1.5-flash`, or a specific stable version; see
   [available model names](https://firebase.google.com/docs/vertex-ai/gemini-models#available-model-names)
-  for more details.
+  for more details. (#13099)
 
 # 10.27.0
 - [changed] Removed uses of the `gemini-1.5-pro-preview-0409` model in docs and

--- a/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash")
     chat = model.startChat()
   }
 

--- a/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -39,7 +39,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init() {
     model = VertexAI.vertexAI().generativeModel(
-      modelName: "gemini-1.5-flash-preview-0514",
+      modelName: "gemini-1.5-flash",
       tools: [Tool(functionDeclarations: [
         FunctionDeclaration(
           name: "get_exchange_rate",

--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash")
   }
 
   func reason() async {

--- a/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash-preview-0514")
+    model = VertexAI.vertexAI().generativeModel(modelName: "gemini-1.5-flash")
   }
 
   func summarize(inputText: String) async {

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -64,8 +64,8 @@ public class VertexAI: NSObject {
   /// guidance on choosing an appropriate model for your use case.
   ///
   /// - Parameters:
-  ///   - modelName: The name of the model to use, for example `"gemini-1.5-flash-preview-0514"`;
-  ///     see [available model names
+  ///   - modelName: The name of the model to use, for example `"gemini-1.5-flash"`; see
+  ///     [available model names
   ///     ](https://firebase.google.com/docs/vertex-ai/gemini-models#available-model-names) for a
   ///     list of supported model names.
   ///   - generationConfig: The content generation parameters your model should use.


### PR DESCRIPTION
Updated the Vertex AI samples and docs to use the auto-updating `gemini-1.5-flash` model.

Note: See [Gemini 1.5 Flash model names](https://firebase.google.com/docs/vertex-ai/gemini-models#model-names-gemini-1.5-flash) for the `gemini-1.5-flash-preview-0514` (previous model) discontinuation date.