### PR TITLE
[v11] Storage Error Handling Consistency

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 11.0.0
+- [fixed] Updated error handling to support both Swift error enum handling and NSError error
+  handling. Some of the Swift enums have additional parameters which may be a **breaking** change.
+  There are additional NSError's for completeness, but nothing related to NSError handling is
+  breaking. (#13071, #10889, #13114)
+
 # 10.24.0
 - [fixed] `putFile` and `putFileAsync` now work in app extensions. A background session
    configuration is not used when uploading from an app extension (#12579).

--- a/FirebaseStorage/Sources/AsyncAwait.swift
+++ b/FirebaseStorage/Sources/AsyncAwait.swift
@@ -66,7 +66,8 @@ public extension StorageReference {
       }
       uploadTask.observe(.failure) { snapshot in
         continuation.resume(with: .failure(
-          snapshot.error ?? StorageError.internalError("Internal Storage Error in putDataAsync")
+          snapshot.error ?? StorageError
+            .internalError(message: "Internal Storage Error in putDataAsync")
         ))
       }
     }
@@ -103,7 +104,8 @@ public extension StorageReference {
       }
       uploadTask.observe(.failure) { snapshot in
         continuation.resume(with: .failure(
-          snapshot.error ?? StorageError.internalError("Internal Storage Error in putFileAsync")
+          snapshot.error ?? StorageError
+            .internalError(message: "Internal Storage Error in putFileAsync")
         ))
       }
     }
@@ -137,7 +139,8 @@ public extension StorageReference {
       }
       downloadTask.observe(.failure) { snapshot in
         continuation.resume(with: .failure(
-          snapshot.error ?? StorageError.internalError("Internal Storage Error in writeAsync")
+          snapshot.error ?? StorageError
+            .internalError(message: "Internal Storage Error in writeAsync")
         ))
       }
     }

--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -75,8 +75,8 @@ class StorageGetDownloadURLTask: StorageTask, StorageTaskManagement {
             downloadURL = self.downloadURLFromMetadataDictionary(responseDictionary)
             if downloadURL == nil {
               self.error = StorageError.unknown(
-                "Failed to retrieve a download URL.",
-                [:]
+                message: "Failed to retrieve a download URL.",
+                serverError: [:]
               ) as NSError
             }
           } else {

--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -74,10 +74,10 @@ class StorageGetDownloadURLTask: StorageTask, StorageTaskManagement {
              .jsonObject(with: data) as? [String: Any] {
             downloadURL = self.downloadURLFromMetadataDictionary(responseDictionary)
             if downloadURL == nil {
-              self.error = NSError(domain: StorageErrorDomain,
-                                   code: StorageErrorCode.unknown.rawValue,
-                                   userInfo: [NSLocalizedDescriptionKey:
-                                     "Failed to retrieve a download URL."])
+              self.error = StorageError.unknown(
+                "Failed to retrieve a download URL.",
+                [:]
+              ) as NSError
             }
           } else {
             self.error = StorageErrorCode.error(withInvalidRequest: data)

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -45,7 +45,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
           var errorDictionary = error.userInfo
           errorDictionary["ResponseErrorDomain"] = error.domain
           errorDictionary["ResponseErrorCode"] = error.code
-          tokenError = StorageError.unauthenticated(errorDictionary) as NSError
+          tokenError = StorageError.unauthenticated(serverError: errorDictionary) as NSError
         } else if let token {
           let firebaseToken = "Firebase \(token)"
           request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -45,12 +45,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
           var errorDictionary = error.userInfo
           errorDictionary["ResponseErrorDomain"] = error.domain
           errorDictionary["ResponseErrorCode"] = error.code
-          errorDictionary[NSLocalizedDescriptionKey] =
-            "User is not authenticated, please authenticate" +
-            " using Firebase Authentication and try again."
-          tokenError = NSError(domain: "FIRStorageErrorDomain",
-                               code: StorageErrorCode.unauthenticated.rawValue,
-                               userInfo: errorDictionary)
+          tokenError = StorageError.unauthenticated(errorDictionary) as NSError
         } else if let token {
           let firebaseToken = "Firebase \(token)"
           request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")

--- a/FirebaseStorage/Sources/Result.swift
+++ b/FirebaseStorage/Sources/Result.swift
@@ -31,7 +31,9 @@ private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Vo
     } else if let error {
       completion(.failure(error))
     } else {
-      completion(.failure(StorageError.internalError("Internal failure in getResultCallback")))
+      completion(.failure(StorageError.internalError(
+        message: "Internal failure in getResultCallback"
+      )))
     }
   }
 }

--- a/FirebaseStorage/Sources/Result.swift
+++ b/FirebaseStorage/Sources/Result.swift
@@ -29,7 +29,7 @@ private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Vo
     if let value {
       completion(.success(value))
     } else if let error {
-      completion(.failure(StorageError.swiftConvert(objcError: error as NSError)))
+      completion(.failure(error))
     } else {
       completion(.failure(StorageError.internalError("Internal failure in getResultCallback")))
     }

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -193,9 +193,9 @@ import FirebaseCore
     do {
       path = try StoragePath.path(string: url.absoluteString)
     } catch let StoragePathError.storagePathError(message) {
-      throw StorageError.pathError(message)
+      throw StorageError.pathError(message: message)
     } catch {
-      throw StorageError.pathError("Internal error finding StoragePath: \(error)")
+      throw StorageError.pathError(message: "Internal error finding StoragePath: \(error)")
     }
 
     // If no default bucket exists (empty string), accept anything.
@@ -205,7 +205,7 @@ import FirebaseCore
     // If there exists a default bucket, throw if provided a different bucket.
     if path.bucket != storageBucket {
       throw StorageError
-        .bucketMismatch("Provided bucket: `\(path.bucket)` does not match the Storage " +
+        .bucketMismatch(message: "Provided bucket: `\(path.bucket)` does not match the Storage " +
           "bucket of the current instance: `\(storageBucket)`")
     }
     return StorageReference(storage: self, path: path)

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -67,8 +67,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Cancels a task.
    */
   @objc open func cancel() {
-    let error = StorageErrorCode.error(withCode: .cancelled)
-    cancel(withError: error)
+    cancel(withError: StorageError.cancelled as NSError)
   }
 
   /**

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -94,22 +94,23 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
   }
 }
 
+/// Firebase Storage errors
 public enum StorageError: Error, CustomNSError {
-  case unknown(String, [String: Any])
-  case objectNotFound(String, [String: Any])
-  case bucketNotFound(String)
-  case projectNotFound(String)
-  case quotaExceeded(String, [String: Any])
-  case unauthenticated([String: Any])
-  case unauthorized(String, String, [String: Any])
+  case unknown(_ message: String, _ serverError: [String: Any])
+  case objectNotFound(_ object: String, _ serverError: [String: Any])
+  case bucketNotFound(_ bucket: String)
+  case projectNotFound(_ project: String)
+  case quotaExceeded(_ bucket: String, _ serverError: [String: Any])
+  case unauthenticated(_ serverError: [String: Any])
+  case unauthorized(_ bucket: String, _ object: String, _ serverError: [String: Any])
   case retryLimitExceeded
   case nonMatchingChecksum
-  case downloadSizeExceeded(Int64, Int64)
+  case downloadSizeExceeded(_ total: Int64, _ maxSize: Int64)
   case cancelled
-  case invalidArgument(String)
-  case internalError(String)
-  case bucketMismatch(String)
-  case pathError(String)
+  case invalidArgument(_ message: String)
+  case internalError(_ message: String)
+  case bucketMismatch(_ message: String)
+  case pathError(_ message: String)
 
   // MARK: - CustomNSError
 

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -89,8 +89,8 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     } else {
       requestString = "<nil request returned from server>"
     }
-    let invalidDataString = "Invalid data returned from the server:\(requestString)"
-    return StorageError.internalError(invalidDataString) as NSError
+    let invalidDataString = "Invalid data returned from the server: \(requestString)"
+    return StorageError.unknown(invalidDataString, [:]) as NSError
   }
 }
 

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -59,26 +59,25 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     if let data = (errorDictionary["data"] as? Data) {
       errorDictionary["ResponseBody"] = String(data: data, encoding: .utf8)
     }
-    var storageError: StorageError
-    switch serverError.code {
-    case 400: storageError = StorageError.unknown(
+    let storageError = switch serverError.code {
+    case 400: StorageError.unknown(
         message: "Unknown 400 error from backend",
         serverError: errorDictionary
       )
-    case 401: storageError = StorageError.unauthenticated(serverError: errorDictionary)
-    case 402: storageError = StorageError.quotaExceeded(
+    case 401: StorageError.unauthenticated(serverError: errorDictionary)
+    case 402: StorageError.quotaExceeded(
         bucket: ref.path.bucket,
         serverError: errorDictionary
       )
-    case 403: storageError = StorageError.unauthorized(
+    case 403: StorageError.unauthorized(
         bucket: ref.path.bucket,
         object: ref.path.object ?? "<object-entity-internal-error>",
         serverError: errorDictionary
       )
-    case 404: storageError = StorageError.objectNotFound(
+    case 404: StorageError.objectNotFound(
         object: ref.path.object ?? "<object-entity-internal-error>", serverError: errorDictionary
       )
-    default: storageError = StorageError.unknown(
+    default: StorageError.unknown(
         message: "Unexpected \(serverError.code) code from backend", serverError: errorDictionary
       )
     }

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -61,17 +61,25 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     }
     var storageError: StorageError
     switch serverError.code {
-    case 400: storageError = StorageError.unknown("Unknown 400 error from backend", errorDictionary)
-    case 401: storageError = StorageError.unauthenticated(errorDictionary)
-    case 402: storageError = StorageError.quotaExceeded(ref.path.bucket, errorDictionary)
+    case 400: storageError = StorageError.unknown(
+        message: "Unknown 400 error from backend",
+        serverError: errorDictionary
+      )
+    case 401: storageError = StorageError.unauthenticated(serverError: errorDictionary)
+    case 402: storageError = StorageError.quotaExceeded(
+        bucket: ref.path.bucket,
+        serverError: errorDictionary
+      )
     case 403: storageError = StorageError.unauthorized(
-        ref.path.bucket, ref.path.object ?? "<object-entity-internal-error>", errorDictionary
+        bucket: ref.path.bucket,
+        object: ref.path.object ?? "<object-entity-internal-error>",
+        serverError: errorDictionary
       )
     case 404: storageError = StorageError.objectNotFound(
-        ref.path.object ?? "<object-entity-internal-error>", errorDictionary
+        object: ref.path.object ?? "<object-entity-internal-error>", serverError: errorDictionary
       )
     default: storageError = StorageError.unknown(
-        "Unexpected \(serverError.code) code from backend", errorDictionary
+        message: "Unexpected \(serverError.code) code from backend", serverError: errorDictionary
       )
     }
     return storageError as NSError
@@ -90,27 +98,27 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
       requestString = "<nil request returned from server>"
     }
     let invalidDataString = "Invalid data returned from the server: \(requestString)"
-    return StorageError.unknown(invalidDataString, [:]) as NSError
+    return StorageError.unknown(message: invalidDataString, serverError: [:]) as NSError
   }
 }
 
 /// Firebase Storage errors
 public enum StorageError: Error, CustomNSError {
-  case unknown(_ message: String, _ serverError: [String: Any])
-  case objectNotFound(_ object: String, _ serverError: [String: Any])
-  case bucketNotFound(_ bucket: String)
-  case projectNotFound(_ project: String)
-  case quotaExceeded(_ bucket: String, _ serverError: [String: Any])
-  case unauthenticated(_ serverError: [String: Any])
-  case unauthorized(_ bucket: String, _ object: String, _ serverError: [String: Any])
+  case unknown(message: String, serverError: [String: Any])
+  case objectNotFound(object: String, serverError: [String: Any])
+  case bucketNotFound(bucket: String)
+  case projectNotFound(project: String)
+  case quotaExceeded(bucket: String, serverError: [String: Any])
+  case unauthenticated(serverError: [String: Any])
+  case unauthorized(bucket: String, object: String, serverError: [String: Any])
   case retryLimitExceeded
   case nonMatchingChecksum
-  case downloadSizeExceeded(_ total: Int64, _ maxSize: Int64)
+  case downloadSizeExceeded(total: Int64, maxSize: Int64)
   case cancelled
-  case invalidArgument(_ message: String)
-  case internalError(_ message: String)
-  case bucketMismatch(_ message: String)
-  case pathError(_ message: String)
+  case invalidArgument(message: String)
+  case internalError(message: String)
+  case bucketMismatch(message: String)
+  case pathError(message: String)
 
   // MARK: - CustomNSError
 

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -400,7 +400,7 @@ import Foundation
                  completion: @escaping ((_: StorageListResult?, _: Error?) -> Void)) {
     if maxResults <= 0 || maxResults > 1000 {
       completion(nil, StorageError.invalidArgument(
-        "Argument 'maxResults' must be between 1 and 1000 inclusive."
+        message: "Argument 'maxResults' must be between 1 and 1000 inclusive."
       ))
     } else {
       let fetcherService = storage.fetcherServiceForApp
@@ -436,7 +436,7 @@ import Foundation
                  completion: @escaping ((_: StorageListResult?, _: Error?) -> Void)) {
     if maxResults <= 0 || maxResults > 1000 {
       completion(nil, StorageError.invalidArgument(
-        "Argument 'maxResults' must be between 1 and 1000 inclusive."
+        message: "Argument 'maxResults' must be between 1 and 1000 inclusive."
       ))
     } else {
       let fetcherService = storage.fetcherServiceForApp
@@ -580,7 +580,10 @@ import Foundation
   /// For maxSize API, return an error if the size is exceeded.
   private func checkSizeOverflow(task: StorageTask, maxSize: Int64) -> NSError? {
     if task.progress.totalUnitCount > maxSize || task.progress.completedUnitCount > maxSize {
-      return StorageError.downloadSizeExceeded(task.progress.totalUnitCount, maxSize) as NSError
+      return StorageError.downloadSizeExceeded(
+        total: task.progress.totalUnitCount,
+        maxSize: maxSize
+      ) as NSError
     }
     return nil
   }

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -399,11 +399,9 @@ import Foundation
   open func list(maxResults: Int64,
                  completion: @escaping ((_: StorageListResult?, _: Error?) -> Void)) {
     if maxResults <= 0 || maxResults > 1000 {
-      completion(nil,
-                 NSError(domain: StorageErrorDomain,
-                         code: StorageErrorCode.invalidArgument.rawValue,
-                         userInfo: [NSLocalizedDescriptionKey:
-                           "Argument 'maxResults' must be between 1 and 1000 inclusive."]))
+      completion(nil, StorageError.invalidArgument(
+        "Argument 'maxResults' must be between 1 and 1000 inclusive."
+      ))
     } else {
       let fetcherService = storage.fetcherServiceForApp
       let task = StorageListTask(reference: self,
@@ -437,11 +435,9 @@ import Foundation
                  pageToken: String,
                  completion: @escaping ((_: StorageListResult?, _: Error?) -> Void)) {
     if maxResults <= 0 || maxResults > 1000 {
-      completion(nil,
-                 NSError(domain: StorageErrorDomain,
-                         code: StorageErrorCode.invalidArgument.rawValue,
-                         userInfo: [NSLocalizedDescriptionKey:
-                           "Argument 'maxResults' must be between 1 and 1000 inclusive."]))
+      completion(nil, StorageError.invalidArgument(
+        "Argument 'maxResults' must be between 1 and 1000 inclusive."
+      ))
     } else {
       let fetcherService = storage.fetcherServiceForApp
       let task = StorageListTask(reference: self,
@@ -584,11 +580,7 @@ import Foundation
   /// For maxSize API, return an error if the size is exceeded.
   private func checkSizeOverflow(task: StorageTask, maxSize: Int64) -> NSError? {
     if task.progress.totalUnitCount > maxSize || task.progress.completedUnitCount > maxSize {
-      return StorageErrorCode.error(withCode: .downloadSizeExceeded,
-                                    infoDictionary: [
-                                      "totalSize": task.progress.totalUnitCount,
-                                      "maxAllowedSize": maxSize,
-                                    ])
+      return StorageError.downloadSizeExceeded(task.progress.totalUnitCount, maxSize) as NSError
     }
     return nil
   }

--- a/FirebaseStorage/Sources/StorageTaskSnapshot.swift
+++ b/FirebaseStorage/Sources/StorageTaskSnapshot.swift
@@ -68,7 +68,7 @@ import Foundation
        reference: StorageReference,
        progress: Progress,
        metadata: StorageMetadata? = nil,
-       error: NSError? = nil) {
+       error: Error? = nil) {
     self.task = task
     self.reference = reference
     self.progress = progress

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -237,9 +237,10 @@ import Foundation
        isFile == true {
       return nil
     }
-    return StorageError.unknown("File at URL: \(fileURL?.absoluteString ?? "") is " +
+    return StorageError.unknown(message: "File at URL: \(fileURL?.absoluteString ?? "") is " +
       "not reachable. Ensure file URL is not " +
-      "a directory, symbolic link, or invalid url.", [:]) as NSError
+      "a directory, symbolic link, or invalid url.",
+      serverError: [:]) as NSError
   }
 
   func finishTaskWithStatus(status: StorageTaskStatus, snapshot: StorageTaskSnapshot) {

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -237,14 +237,9 @@ import Foundation
        isFile == true {
       return nil
     }
-    let userInfo = [NSLocalizedDescriptionKey:
-      "File at URL: \(fileURL?.absoluteString ?? "") is not reachable."
-      + " Ensure file URL is not a directory, symbolic link, or invalid url."]
-    return NSError(
-      domain: StorageErrorDomain,
-      code: StorageErrorCode.unknown.rawValue,
-      userInfo: userInfo
-    )
+    return StorageError.unknown("File at URL: \(fileURL?.absoluteString ?? "") is " +
+      "not reachable. Ensure file URL is not " +
+      "a directory, symbolic link, or invalid url.", [:]) as NSError
   }
 
   func finishTaskWithStatus(status: StorageTaskStatus, snapshot: StorageTaskSnapshot) {

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -201,7 +201,7 @@ class StorageResultTests: StorageIntegrationCommon {
         XCTFail("Unexpected success from unauthorized putData")
       case let .failure(error as StorageError):
         switch error {
-        case let .unauthorized(bucket, object):
+        case let .unauthorized(bucket, object, serverError):
           XCTAssertEqual(bucket, "ios-opensource-samples.appspot.com")
           XCTAssertEqual(object, file)
           expectation.fulfill()

--- a/FirebaseStorage/Tests/Unit/StorageAPITests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAPITests.swift
@@ -158,6 +158,9 @@ final class StorageAPITests: XCTestCase {
     case .downloadSizeExceeded: return code
     case .cancelled: return code
     case .invalidArgument: return code
+    case .bucketMismatch: return code
+    case .internalError: return code
+    case .pathError: return code
     @unknown default:
       fatalError()
     }

--- a/FirebaseStorage/Tests/Unit/StorageGetMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageGetMetadataTests.swift
@@ -181,7 +181,9 @@ class StorageGetMetadataTests: StorageTestHelpers {
       fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { metadata, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.unknown.rawValue)
+      XCTAssertNil(metadata)
+      let nsError = try! XCTUnwrap(error as? NSError)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unknown.rawValue)
       expectation.fulfill()
     }
     task.enqueue()

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -219,7 +219,7 @@ class StorageReferenceTests: XCTestCase {
         XCTFail("Unexpected success.", file: #file, line: #line)
       case let .failure(error):
         switch error {
-        case let StorageError.unknown(message):
+        case let StorageError.unknown(message, serverError):
           let expectedDescription = "File at URL: \(dummyFileURL.absoluteString) " +
             "is not reachable. Ensure file URL is not a directory, symbolic link, or invalid url."
           XCTAssertEqual(expectedDescription, message)

--- a/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageReferenceTests.swift
@@ -72,7 +72,7 @@ class StorageReferenceTests: XCTestCase {
     XCTAssertThrowsError(try storage!.reference(for: url), "This was supposed to fail.") { error in
       XCTAssertEqual(
         "\(error)",
-        "bucketMismatch(\"Provided bucket: `bcket` does not match the Storage " +
+        "bucketMismatch(message: \"Provided bucket: `bcket` does not match the Storage " +
           "bucket of the current instance: `bucket`\")"
       )
     }
@@ -95,8 +95,9 @@ class StorageReferenceTests: XCTestCase {
   func testBadBucketScheme2() throws {
     let url = try XCTUnwrap(URL(string: "htttp://bucket/"))
     XCTAssertThrowsError(try storage!.reference(for: url), "This was supposed to fail.") { error in
-      XCTAssertEqual("\(error)", "pathError(\"Internal error: URL scheme must be one of gs://, " +
-        "http://, or https://\")")
+      XCTAssertEqual("\(error)",
+                     "pathError(message: \"Internal error: URL scheme must be one of gs://, " +
+                       "http://, or https://\")")
     }
   }
 

--- a/FirebaseStorage/Tests/Unit/StorageTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageTests.swift
@@ -45,7 +45,7 @@ class StorageTests: XCTestCase {
     XCTAssertThrowsError(try storage.reference(for: url), "This was supposed to fail.") { error in
       XCTAssertEqual(
         "\(error)",
-        "bucketMismatch(\"Provided bucket: `benwu-test2.storage.firebase.com` does not match the " +
+        "bucketMismatch(message: \"Provided bucket: `benwu-test2.storage.firebase.com` does not match the " +
           "Storage bucket of the current instance: `benwu-test1.storage.firebase.com`\")"
       )
     }
@@ -126,7 +126,7 @@ class StorageTests: XCTestCase {
     XCTAssertThrowsError(try storage.reference(for: url), "This was supposed to fail.") { error in
       XCTAssertEqual(
         "\(error)",
-        "bucketMismatch(\"Provided bucket: `bucket` does not match the " +
+        "bucketMismatch(message: \"Provided bucket: `bucket` does not match the " +
           "Storage bucket of the current instance: `notMyBucket`\")"
       )
     }


### PR DESCRIPTION
Fix #13071 Fix #10889

Storage Error handling was a mix of Swift error and NSError generation. With this PR, all errors are created as Swift errors and thanks to [CustomNSError](https://developer.apple.com/documentation/foundation/customnserror), NSError's are generated as needed from the Swift error enum.

- All Objective C/NSError handling should remain the same from a public API perspective
- Some of the Swift error enums have additional fields to have enough information to support the corresponding NSError and to provide useful information to Swift error enum users. This is most commonly information about underlying server errors.
- Additional error codes are added to provide NSError code mapping for errors that were introduced only in Swift after the Swift implementation transition.

Internal API review at go/storage-error-handling