### PR TITLE
Address some Swift 6 warnings in Auth sample

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthMenu.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthMenu.swift
@@ -348,7 +348,7 @@ class AuthMenuData: DataSourceProvidable {
     return Section(headerDescription: header, items: items)
   }
 
-  static var sections: [Section] =
+  static let sections: [Section] =
     [settingsSection, providerSection, emailPasswordSection, otherSection, recaptchaSection,
      customAuthDomainSection, appSection, oobSection, multifactorSection]
 

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/DataSourceProvider/DataSourceProvider.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/DataSourceProvider/DataSourceProvider.swift
@@ -18,7 +18,7 @@ import UIKit
 /// datasource and delegate
 class DataSourceProvider<DataSource: DataSourceProvidable>: NSObject, UITableViewDataSource,
   UITableViewDelegate {
-  weak var delegate: DataSourceProviderDelegate?
+  weak var delegate: (any DataSourceProviderDelegate)?
 
   private var emptyView: UIView?
 

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
@@ -195,7 +195,7 @@ extension UINavigationBar: UserDisplayable {
 
 // MARK: Extending UITabBarController to work with custom transition animator
 
-extension UITabBarController: @retroactive UITabBarControllerDelegate {
+extension UITabBarController: UITabBarControllerDelegate {
   public func tabBarController(_ tabBarController: UITabBarController,
                                animationControllerForTransitionFrom fromVC: UIViewController,
                                to toVC: UIViewController)

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
@@ -76,7 +76,7 @@ public extension UIViewController {
     }
   }
 
-  func displayError(_ error: Error?, from function: StaticString = #function) {
+  func displayError(_ error: (any Error)?, from function: StaticString = #function) {
     guard let error = error else { return }
     print("ⓧ Error in \(function): \(error.localizedDescription)")
     let message = "\(error.localizedDescription)\n\n Occurred in \(function)"
@@ -195,11 +195,11 @@ extension UINavigationBar: UserDisplayable {
 
 // MARK: Extending UITabBarController to work with custom transition animator
 
-extension UITabBarController: UITabBarControllerDelegate {
+extension UITabBarController: @retroactive UITabBarControllerDelegate {
   public func tabBarController(_ tabBarController: UITabBarController,
                                animationControllerForTransitionFrom fromVC: UIViewController,
                                to toVC: UIViewController)
-    -> UIViewControllerAnimatedTransitioning? {
+    -> (any UIViewControllerAnimatedTransitioning)? {
     let fromIndex = tabBarController.viewControllers!.firstIndex(of: fromVC)!
     let toIndex = tabBarController.viewControllers!.firstIndex(of: toVC)!
 

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/TransitionAnimator/Animator.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/TransitionAnimator/Animator.swift
@@ -27,12 +27,12 @@ class Animator: NSObject, UIViewControllerAnimatedTransitioning {
     transitionDirection = direction
   }
 
-  func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?)
+  func transitionDuration(using transitionContext: (any UIViewControllerContextTransitioning)?)
     -> TimeInterval {
     return transitionDuration as TimeInterval
   }
 
-  func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+  func animateTransition(using transitionContext: any UIViewControllerContextTransitioning) {
     let container = transitionContext.containerView
 
     guard let fromView = transitionContext.view(forKey: .from),

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
@@ -516,7 +516,7 @@ extension AccountLinkingViewController: ASAuthorizationControllerDelegate,
   }
 
   func authorizationController(controller: ASAuthorizationController,
-                               didCompleteWithError error: Error) {
+                               didCompleteWithError error: any Error) {
     // Ensure that you have:
     //  - enabled `Sign in with Apple` on the Firebase console
     //  - added the `Sign in with Apple` capability for this project

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -567,7 +567,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func requestVerifyEmail() {
     showSpinner()
-    let completionHandler: (Error?) -> Void = { [weak self] error in
+    let completionHandler: ((any Error)?) -> Void = { [weak self] error in
       guard let self = self else { return }
       self.hideSpinner()
 
@@ -599,7 +599,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
     showTextInputPrompt(with: "Email:", completion: { email in
       print("Sending password reset link to: \(email)")
       self.showSpinner()
-      let completionHandler: (Error?) -> Void = { [weak self] error in
+      let completionHandler: ((any Error)?) -> Void = { [weak self] error in
         guard let self = self else { return }
         self.hideSpinner()
         if let error = error {
@@ -628,7 +628,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func resetPassword() {
     showSpinner()
-    let completionHandler: (Error?) -> Void = { [weak self] error in
+    let completionHandler: ((any Error)?) -> Void = { [weak self] error in
       guard let self = self else { return }
       self.hideSpinner()
       if let error = error {
@@ -673,7 +673,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func checkActionCode() {
     showSpinner()
-    let completionHandler: (ActionCodeInfo?, Error?) -> Void = { [weak self] info, error in
+    let completionHandler: (ActionCodeInfo?, (any Error)?) -> Void = { [weak self] info, error in
       guard let self = self else { return }
       self.hideSpinner()
       if let error = error {
@@ -696,7 +696,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func applyActionCode() {
     showSpinner()
-    let completionHandler: (Error?) -> Void = { [weak self] error in
+    let completionHandler: ((any Error)?) -> Void = { [weak self] error in
       guard let self = self else { return }
       self.hideSpinner()
       if let error = error {
@@ -715,7 +715,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func verifyPasswordResetCode() {
     showSpinner()
-    let completionHandler: (String?, Error?) -> Void = { [weak self] email, error in
+    let completionHandler: (String?, (any Error)?) -> Void = { [weak self] email, error in
       guard let self = self else { return }
       self.hideSpinner()
       if let error = error {
@@ -1123,7 +1123,7 @@ extension AuthViewController: ASAuthorizationControllerDelegate,
   }
 
   func authorizationController(controller: ASAuthorizationController,
-                               didCompleteWithError error: Error) {
+                               didCompleteWithError error: any Error) {
     // Ensure that you have:
     //  - enabled `Sign in with Apple` on the Firebase console
     //  - added the `Sign in with Apple` capability for this project

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/LoginController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/LoginController.swift
@@ -16,7 +16,7 @@ import FirebaseAuth
 import UIKit
 
 class LoginController: UIViewController {
-  weak var delegate: LoginDelegate?
+  weak var delegate: (any LoginDelegate)?
 
   private var loginView: LoginView { view as! LoginView }
 
@@ -108,7 +108,7 @@ class LoginController: UIViewController {
   }
 
   override func viewWillTransition(to size: CGSize,
-                                   with coordinator: UIViewControllerTransitionCoordinator) {
+                                   with coordinator: any UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
     loginView.emailTopConstraint.constant = UIDevice.current.orientation.isLandscape ? 15 : 50
     loginView.passwordTopConstraint.constant = UIDevice.current.orientation.isLandscape ? 5 : 20

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/OtherAuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/OtherAuthViewController.swift
@@ -17,7 +17,7 @@ import UIKit
 /// Base UIViewController Class for presenting auth flows defined in
 /// [OtherAuthMethods](x-source-tag://OtherAuthMethods)
 class OtherAuthViewController: UIViewController {
-  weak var delegate: LoginDelegate?
+  weak var delegate: (any LoginDelegate)?
 
   lazy var textField: UITextField = {
     let textField = UITextField()
@@ -183,7 +183,7 @@ class OtherAuthViewController: UIViewController {
   }
 
   override func viewWillTransition(to size: CGSize,
-                                   with coordinator: UIViewControllerTransitionCoordinator) {
+                                   with coordinator: any UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
     textFieldTopConstraint.constant = UIDevice.current.orientation.isLandscape ? 10 : 60
     buttonTopConstraint.constant = UIDevice.current.orientation.isLandscape ? 15 : 110

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
@@ -366,7 +366,7 @@ extension UserViewController: ASAuthorizationControllerDelegate,
   // [END token_revocation]
 
   func authorizationController(controller: ASAuthorizationController,
-                               didCompleteWithError error: Error) {
+                               didCompleteWithError error: any Error) {
     // Ensure that you have:
     //  - enabled `Sign in with Apple` on the Firebase console
     //  - added the `Sign in with Apple` capability for this project


### PR DESCRIPTION
Address easy Swift 6 warnings building Auth sample.

Several `@Sendable` warnings remain and a few more are fixed by `@retroactive` but that fails to build in Swift 5.