### PR TITLE
Migrate ISASwizzler into FirebasePerformance

### DIFF
--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -65,7 +65,6 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'FirebaseSessions', '~> 11.0'
   s.dependency 'GoogleDataTransport', '~> 10.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
-  s.dependency 'GoogleUtilities/ISASwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.0'
   s.dependency 'nanopb', '~> 3.30910.0'

--- a/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler+Internal.h
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler+Internal.h
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
+
+FOUNDATION_EXPORT const NSString *const kGULSwizzlerAssociatedObjectKey;
+
+@interface FPRObjectSwizzler (Internal)
+
+- (void)swizzledObjectHasBeenDeallocatedWithGeneratedSubclass:(BOOL)isInstanceOfGeneratedSubclass;
+
+@end

--- a/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Enums that map to their OBJC-prefixed counterparts. */
+typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
+
+    // Is a weak association.
+    GUL_ASSOCIATION_ASSIGN,
+
+    // Is a nonatomic strong association.
+    GUL_ASSOCIATION_RETAIN_NONATOMIC,
+
+    // Is a nonatomic copy association.
+    GUL_ASSOCIATION_COPY_NONATOMIC,
+
+    // Is an atomic strong association.
+    GUL_ASSOCIATION_RETAIN,
+
+    // Is an atomic copy association.
+    GUL_ASSOCIATION_COPY};
+
+/** This class handles swizzling a specific instance of a class by generating a
+ *  dynamic subclass and installing selectors and properties onto the dynamic
+ *  subclass. Then, the instance's class is set to the dynamic subclass. There
+ *  should be a 1:1 ratio of object swizzlers to swizzled instances.
+ */
+@interface FPRObjectSwizzler : NSObject
+
+/** The subclass that is generated. */
+@property(nullable, nonatomic, readonly) Class generatedClass;
+
+/** Sets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param object The object that will be queried for the associated object.
+ *  @param key The key of the associated object.
+ *  @param value The value to associate to the swizzled object.
+ *  @param association The mechanism to use when associating the objects.
+ */
++ (void)setAssociatedObject:(id)object
+                        key:(const void *)key
+                      value:(nullable id)value
+                association:(GUL_ASSOCIATION)association;
+
+/** Gets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param object The object that will be queried for the associated object.
+ *  @param key The key of the associated object.
+ */
++ (nullable id)getAssociatedObject:(id)object key:(const void *)key;
+
+/** Please use the designated initializer. */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Instantiates an object swizzler using an object it will operate on.
+ *  Generates a new class pair.
+ *
+ *  @note There is no need to store this object. After calling -swizzle, this
+ *  object can be found by calling -gul_objectSwizzler
+ *
+ *  @param object The object to be swizzled.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithObject:(id)object NS_DESIGNATED_INITIALIZER;
+
+/** Sets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param key The key of the associated object.
+ *  @param value The value to associate to the swizzled object.
+ *  @param association The mechanism to use when associating the objects.
+ */
+- (void)setAssociatedObjectWithKey:(const void *)key
+                             value:(id)value
+                       association:(GUL_ASSOCIATION)association;
+
+/** Gets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param key The key of the associated object.
+ */
+- (nullable id)getAssociatedObjectForKey:(const void *)key;
+
+/** Copies a selector from an existing class onto the generated dynamic subclass
+ *  that this object will adopt. This mechanism can be used to add methods to
+ *  specific instances of a class.
+ *
+ *  @note Should not be called after calling -swizzle.
+ *  @param selector The selector to add to the instance.
+ *  @param aClass The class supplying an implementation of the method.
+ *  @param isClassSelector A BOOL specifying whether the selector is a class or
+ * instance selector.
+ */
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector;
+
+/** Swizzles the object, changing its class to the generated class. Registers
+ *  the class pair. */
+- (void)swizzle;
+
+/** @return The value of -[objectBeingSwizzled isProxy] */
+- (BOOL)isSwizzlingProxyObject;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
@@ -1,0 +1,212 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
+
+#import <objc/runtime.h>
+
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler+Internal.h"
+#import "FirebasePerformance/Sources/ISASwizzler/FPRSwizzledObject.h"
+
+@implementation FPRObjectSwizzler {
+  // The swizzled object.
+  __weak id _swizzledObject;
+
+  // The original class of the object.
+  Class _originalClass;
+
+  // The dynamically generated subclass of _originalClass.
+  Class _generatedClass;
+}
+
+#pragma mark - Class methods
+
++ (void)setAssociatedObject:(id)object
+                        key:(const void *)key
+                      value:(nullable id)value
+                association:(GUL_ASSOCIATION)association {
+  objc_AssociationPolicy resolvedAssociation;
+  switch (association) {
+    case GUL_ASSOCIATION_ASSIGN:
+      resolvedAssociation = OBJC_ASSOCIATION_ASSIGN;
+      break;
+
+    case GUL_ASSOCIATION_RETAIN_NONATOMIC:
+      resolvedAssociation = OBJC_ASSOCIATION_RETAIN_NONATOMIC;
+      break;
+
+    case GUL_ASSOCIATION_COPY_NONATOMIC:
+      resolvedAssociation = OBJC_ASSOCIATION_COPY_NONATOMIC;
+      break;
+
+    case GUL_ASSOCIATION_RETAIN:
+      resolvedAssociation = OBJC_ASSOCIATION_RETAIN;
+      break;
+
+    case GUL_ASSOCIATION_COPY:
+      resolvedAssociation = OBJC_ASSOCIATION_COPY;
+      break;
+
+    default:
+      break;
+  }
+  objc_setAssociatedObject(object, key, value, resolvedAssociation);
+}
+
++ (nullable id)getAssociatedObject:(id)object key:(const void *)key {
+  return objc_getAssociatedObject(object, key);
+}
+
+#pragma mark - Instance methods
+
+/** Instantiates an instance of this class.
+ *
+ *  @param object The object to swizzle.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithObject:(id)object {
+  if (object == nil) {
+    return nil;
+  }
+
+  FPRObjectSwizzler *existingSwizzler =
+      [[self class] getAssociatedObject:object key:&kGULSwizzlerAssociatedObjectKey];
+  if ([existingSwizzler isKindOfClass:[FPRObjectSwizzler class]]) {
+    // The object has been swizzled already, no need to swizzle again.
+    return existingSwizzler;
+  }
+
+  self = [super init];
+  if (self) {
+    _swizzledObject = object;
+    _originalClass = object_getClass(object);
+    NSString *newClassName = [NSString stringWithFormat:@"fir_%@_%@", [[NSUUID UUID] UUIDString],
+                                                        NSStringFromClass(_originalClass)];
+    _generatedClass = objc_allocateClassPair(_originalClass, newClassName.UTF8String, 0);
+    NSAssert(_generatedClass, @"Wasn't able to allocate the class pair.");
+  }
+  return self;
+}
+
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector {
+  NSAssert(_generatedClass, @"This object has already been unswizzled.");
+  Method method = isClassSelector ? class_getClassMethod(aClass, selector)
+                                  : class_getInstanceMethod(aClass, selector);
+  Class targetClass = isClassSelector ? object_getClass(_generatedClass) : _generatedClass;
+  IMP implementation = method_getImplementation(method);
+
+  const char *typeEncoding = method_getTypeEncoding(method);
+  class_replaceMethod(targetClass, selector, implementation, typeEncoding);
+}
+
+- (void)setAssociatedObjectWithKey:(const void *)key
+                             value:(id)value
+                       association:(GUL_ASSOCIATION)association {
+  __strong id swizzledObject = _swizzledObject;
+  if (swizzledObject) {
+    [[self class] setAssociatedObject:swizzledObject key:key value:value association:association];
+  }
+}
+
+- (nullable id)getAssociatedObjectForKey:(const void *)key {
+  __strong id swizzledObject = _swizzledObject;
+  if (swizzledObject) {
+    return [[self class] getAssociatedObject:swizzledObject key:key];
+  }
+  return nil;
+}
+
+- (void)swizzle {
+  __strong id swizzledObject = _swizzledObject;
+  FPRObjectSwizzler *existingSwizzler =
+      [[self class] getAssociatedObject:swizzledObject key:&kGULSwizzlerAssociatedObjectKey];
+  if (existingSwizzler != nil) {
+    NSAssert(existingSwizzler == self, @"The swizzled object has a different swizzler.");
+    // The object has been swizzled already.
+    return;
+  }
+
+  if (swizzledObject) {
+    [FPRObjectSwizzler setAssociatedObject:swizzledObject
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:self
+                               association:GUL_ASSOCIATION_RETAIN];
+
+    [FPRSwizzledObject copyDonorSelectorsUsingObjectSwizzler:self];
+
+    NSAssert(_originalClass == object_getClass(swizzledObject),
+             @"The original class is not the reported class now.");
+    NSAssert(class_getInstanceSize(_originalClass) == class_getInstanceSize(_generatedClass),
+             @"The instance size of the generated class must be equal to the original class.");
+    objc_registerClassPair(_generatedClass);
+    Class doubleCheckOriginalClass __unused = object_setClass(_swizzledObject, _generatedClass);
+    NSAssert(_originalClass == doubleCheckOriginalClass,
+             @"The original class must be the same as the class returned by object_setClass");
+  } else {
+    NSAssert(NO, @"You can't swizzle a nil object");
+  }
+}
+
+- (void)dealloc {
+  // When the Zombies instrument is enabled, a zombie is created for the swizzled object upon
+  // deallocation. Because this zombie subclasses the generated class, the swizzler should not
+  // dispose it during the swizzler's deallocation.
+  //
+  // There are other special cases where the generated class might be subclassed by a third-party
+  // generated classes, for example: https://github.com/firebase/firebase-ios-sdk/issues/9083
+  // To avoid errors in such cases, the environment variable `GULGeneratedClassDisposeDisabled` can
+  // be set with `YES`.
+  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+  if ([[environment objectForKey:@"NSZombieEnabled"] boolValue] ||
+      [[environment objectForKey:@"GULGeneratedClassDisposeDisabled"] boolValue]) {
+    return;
+  }
+
+  if (_generatedClass) {
+    if (_swizzledObject == nil) {
+      // The swizzled object has been deallocated already, so the generated class can be disposed
+      // now.
+      objc_disposeClassPair(_generatedClass);
+      return;
+    }
+
+    // FPRSwizzledObject is retained by the swizzled object which means that the swizzled object is
+    // being deallocated now. Let's see if we should schedule the generated class disposal.
+
+    // If the swizzled object has a different class, it most likely indicates that the object was
+    // ISA swizzled one more time. In this case it is not safe to dispose the generated class. We
+    // will have to keep it to prevent a crash.
+
+    // TODO: Consider adding a flag that can be set by the host application to dispose the class
+    // pair unconditionally. It may be used by apps that use ISA Swizzling themself and are
+    // confident in disposing their subclasses.
+    BOOL isSwizzledObjectInstanceOfGeneratedClass =
+        object_getClass(_swizzledObject) == _generatedClass;
+
+    if (isSwizzledObjectInstanceOfGeneratedClass) {
+      Class generatedClass = _generatedClass;
+
+      // Schedule the generated class disposal after the swizzled object has been deallocated.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        objc_disposeClassPair(generatedClass);
+      });
+    }
+  }
+}
+
+- (BOOL)isSwizzlingProxyObject {
+  return [_swizzledObject isProxy];
+}
+
+@end

--- a/FirebasePerformance/Sources/ISASwizzler/FPRSwizzledObject.h
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRSwizzledObject.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class FPRObjectSwizzler;
+
+/** This class exists as a method donor. These methods will be added to all objects that are
+ *  swizzled by the object swizzler. This class should not be instantiated.
+ */
+@interface FPRSwizzledObject : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Copies the methods below to the swizzled object.
+ *
+ *  @param objectSwizzler The swizzler to use when adding the methods below.
+ */
++ (void)copyDonorSelectorsUsingObjectSwizzler:(FPRObjectSwizzler *)objectSwizzler;
+
+#pragma mark - Donor methods.
+
+/** @return The generated subclass. Used in respondsToSelector: calls. */
+- (Class)gul_class;
+
+/** @return The object swizzler that manages this object. */
+- (FPRObjectSwizzler *)gul_objectSwizzler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -24,8 +24,7 @@
 #import "FirebasePerformance/Sources/FPRDataUtils.h"
 #import "FirebasePerformance/Sources/FPRURLFilter.h"
 #import "FirebasePerformance/Sources/Gauges/FPRGaugeManager.h"
-
-#import <GoogleUtilities/GULObjectSwizzler.h>
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
 
 NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 
@@ -427,7 +426,7 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 
 + (void)addNetworkTrace:(FPRNetworkTrace *)networkTrace toObject:(id)object {
   if (object != nil && networkTrace != nil) {
-    [GULObjectSwizzler
+    [FPRObjectSwizzler
         setAssociatedObject:object
                         key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName
                       value:networkTrace
@@ -438,7 +437,7 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 + (FPRNetworkTrace *)networkTraceFromObject:(id)object {
   FPRNetworkTrace *networkTrace = nil;
   if (object != nil) {
-    id traceObject = [GULObjectSwizzler
+    id traceObject = [FPRObjectSwizzler
         getAssociatedObject:object
                         key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName];
     if ([traceObject isKindOfClass:[FPRNetworkTrace class]]) {
@@ -451,7 +450,7 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 
 + (void)removeNetworkTraceFromObject:(id)object {
   if (object != nil) {
-    [GULObjectSwizzler
+    [FPRObjectSwizzler
         setAssociatedObject:object
                         key:(__bridge const void *_Nonnull)kFPRNetworkTracePropertyName
                       value:nil

--- a/FirebasePerformance/Sources/Instrumentation/FPRObjectInstrumentor.h
+++ b/FirebasePerformance/Sources/Instrumentation/FPRObjectInstrumentor.h
@@ -14,7 +14,7 @@
 
 #import "FirebasePerformance/Sources/Instrumentation/FPRInstrument.h"
 
-#import <GoogleUtilities/GULSwizzledObject.h>
+#import "FirebasePerformance/Sources/ISASwizzler/FPRSwizzledObject.h"
 
 @class FPRSelectorInstrumentor;
 

--- a/FirebasePerformance/Sources/Instrumentation/FPRObjectInstrumentor.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRObjectInstrumentor.m
@@ -15,14 +15,13 @@
 #import "FirebasePerformance/Sources/Instrumentation/FPRObjectInstrumentor.h"
 
 #import "FirebasePerformance/Sources/Common/FPRDiagnostics.h"
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRInstrument_Private.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRSelectorInstrumentor.h"
 
-#import <GoogleUtilities/GULObjectSwizzler.h>
-
 @interface FPRObjectInstrumentor () {
   // The object swizzler instance this instrumentor will use.
-  GULObjectSwizzler *_objectSwizzler;
+  FPRObjectSwizzler *_objectSwizzler;
 }
 
 @end
@@ -37,7 +36,7 @@
 - (instancetype)initWithObject:(id)object {
   self = [super init];
   if (self) {
-    _objectSwizzler = [[GULObjectSwizzler alloc] initWithObject:object];
+    _objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
     _instrumentedObject = object;
   }
   return self;

--- a/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument.m
@@ -16,6 +16,7 @@
 #import "FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLConnectionInstrument_Private.h"
 
 #import "FirebasePerformance/Sources/Common/FPRDiagnostics.h"
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRClassInstrumentor.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRInstrument_Private.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h"
@@ -23,8 +24,6 @@
 #import "FirebasePerformance/Sources/Instrumentation/FPRSelectorInstrumentor.h"
 #import "FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLConnectionDelegate.h"
 #import "FirebasePerformance/Sources/Instrumentation/Network/FPRNetworkInstrumentHelpers.h"
-
-#import <GoogleUtilities/GULObjectSwizzler.h>
 
 #import "FirebasePerformance/Sources/Configurations/FPRConfigurations.h"
 
@@ -97,13 +96,13 @@ void InstrumentInitWithRequestDelegate(FPRClassInstrumentor *instrumentor,
     if (delegate) {
       [delegateInstrument registerClass:[delegate class]];
       [delegateInstrument registerObject:delegate];
-      [GULObjectSwizzler setAssociatedObject:connection
+      [FPRObjectSwizzler setAssociatedObject:connection
                                          key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     } else {
       delegate = [[FPRNSURLConnectionDelegate alloc] init];
-      [GULObjectSwizzler setAssociatedObject:connection
+      [FPRObjectSwizzler setAssociatedObject:connection
                                          key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
@@ -132,13 +131,13 @@ void InstrumentInitWithRequestDelegateStartImmediately(
       [delegateInstrument registerClass:[delegate class]];
       [delegateInstrument registerObject:delegate];
 
-      [GULObjectSwizzler setAssociatedObject:connection
+      [FPRObjectSwizzler setAssociatedObject:connection
                                          key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
     } else {
       delegate = [[FPRNSURLConnectionDelegate alloc] init];
-      [GULObjectSwizzler setAssociatedObject:connection
+      [FPRObjectSwizzler setAssociatedObject:connection
                                          key:(__bridge const void *_Nonnull)kFPRDelegateKey
                                        value:delegate
                                  association:GUL_ASSOCIATION_ASSIGN];
@@ -161,7 +160,7 @@ void InstrumentConnectionStart(FPRClassInstrumentor *instrumentor) {
   [selectorInstrumentor setReplacingBlock:^(id object) {
     typedef void (*OriginalImp)(id, SEL);
     NSURLConnection *connection = (NSURLConnection *)object;
-    if ([GULObjectSwizzler getAssociatedObject:connection
+    if ([FPRObjectSwizzler getAssociatedObject:connection
                                            key:(__bridge const void *_Nonnull)kFPRDelegateKey]) {
       FPRNetworkTrace *trace =
           [[FPRNetworkTrace alloc] initWithURLRequest:connection.originalRequest];

--- a/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLSessionInstrument.m
+++ b/FirebasePerformance/Sources/Instrumentation/Network/FPRNSURLSessionInstrument.m
@@ -23,6 +23,7 @@
 
 #import "FirebasePerformance/Sources/Common/FPRDiagnostics.h"
 #import "FirebasePerformance/Sources/Configurations/FPRConfigurations.h"
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRClassInstrumentor.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRInstrument_Private.h"
 #import "FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.h"
@@ -30,8 +31,6 @@
 #import "FirebasePerformance/Sources/Instrumentation/FPRSelectorInstrumentor.h"
 #import "FirebasePerformance/Sources/Instrumentation/Network/Delegates/FPRNSURLSessionDelegate.h"
 #import "FirebasePerformance/Sources/Instrumentation/Network/FPRNetworkInstrumentHelpers.h"
-
-#import <GoogleUtilities/GULObjectSwizzler.h>
 
 // Declared for use in instrumentation functions below.
 @interface FPRNSURLSessionInstrument ()

--- a/FirebasePerformance/Tests/Unit/FPRObjectInstrumentorTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRObjectInstrumentorTest.m
@@ -48,9 +48,9 @@
   XCTAssertTrue([[object class] isSubclassOfClass:[NSObject class]]);
   instrumentor = nil;
   XCTAssertNil(weakInstrumentor);
-  XCTAssertNotNil([(GULSwizzledObject *)object gul_objectSwizzler]);
-  XCTAssertNoThrow([(GULSwizzledObject *)object gul_class]);
-  XCTAssertEqual([object class], [(GULSwizzledObject *)object gul_class]);
+  XCTAssertNotNil([(FPRSwizzledObject *)object gul_objectSwizzler]);
+  XCTAssertNoThrow([(FPRSwizzledObject *)object gul_class]);
+  XCTAssertEqual([object class], [(FPRSwizzledObject *)object gul_class]);
 }
 
 /** Tests copying a selector that already exists on the object doesn't work. */

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -1,0 +1,495 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+
+#import "FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler+Internal.h"
+#import "FirebasePerformance/Sources/ISASwizzler/FPRSwizzledObject.h"
+
+#import "FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.h"
+
+@interface FPRObjectSwizzlerTest : XCTestCase
+
+@end
+
+@implementation FPRObjectSwizzlerTest
+
+/** Used as a donor method to add a method that doesn't exist on the superclass. */
+- (NSString *)donorDescription {
+  return @"SwizzledDonorDescription";
+}
+
+/** Used as a donor method to add a method that exists on the superclass. */
+- (NSString *)description {
+  return @"SwizzledDescription";
+}
+
+/** Exists just as a donor method. */
+- (void)donorMethod {
+}
+
+- (void)testRetainedAssociatedObjects {
+  NSObject *object = [[NSObject alloc] init];
+  NSObject *associatedObject = [[NSObject alloc] init];
+  size_t addressOfAssociatedObject = (size_t)&associatedObject;
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"test"
+                                   value:associatedObject
+                             association:GUL_ASSOCIATION_RETAIN];
+  associatedObject = nil;
+  associatedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"test"];
+  XCTAssertEqual((size_t)&associatedObject, addressOfAssociatedObject);
+  XCTAssertNotNil(associatedObject);
+}
+
+/** Tests that creating an object swizzler works. */
+- (void)testObjectSwizzlerInit {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  XCTAssertNotNil(objectSwizzler);
+}
+
+/** Tests that you're able to swizzle an object. */
+- (void)testSwizzle {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  XCTAssertEqual([object class], [NSObject class]);
+  [objectSwizzler swizzle];
+  XCTAssertNotEqual([object class], [NSObject class]);
+  XCTAssertTrue([[object class] isSubclassOfClass:[NSObject class]]);
+  XCTAssertTrue([object respondsToSelector:@selector(gul_class)]);
+}
+
+/** Tests that swizzling a nil object fails. */
+- (void)testSwizzleNil {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  XCTAssertEqual([object class], [NSObject class]);
+  object = nil;
+  XCTAssertThrows([objectSwizzler swizzle]);
+}
+
+/** Tests the ability to copy a selector from one class to the swizzled object's generated class. */
+- (void)testCopySelectorFromClassIsClassSelectorAndSwizzle {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [objectSwizzler copySelector:@selector(donorMethod) fromClass:[self class] isClassSelector:NO];
+  XCTAssertFalse([object respondsToSelector:@selector(donorMethod)]);
+  XCTAssertFalse([[object class] instancesRespondToSelector:@selector(donorMethod)]);
+  [objectSwizzler swizzle];
+  XCTAssertTrue([object respondsToSelector:@selector(donorMethod)]);
+  // [object class] should return the original class, not the swizzled class.
+  XCTAssertTrue(
+      [[(FPRSwizzledObject *)object gul_class] instancesRespondToSelector:@selector(donorMethod)]);
+}
+
+/** Tests that some helper methods are always added to swizzled objects. */
+- (void)testCommonSelectorsAddedUponSwizzling {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  XCTAssertFalse([object respondsToSelector:@selector(gul_class)]);
+  [objectSwizzler swizzle];
+  XCTAssertTrue([object respondsToSelector:@selector(gul_class)]);
+}
+
+/** Tests that there's no retain cycle and that -dealloc causes unswizzling. */
+- (void)testRetainCycleDoesntExistAndDeallocCausesUnswizzling {
+  NSObject *object = [[NSObject alloc] init];
+  FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [objectSwizzler copySelector:@selector(donorMethod) fromClass:[self class] isClassSelector:NO];
+  [objectSwizzler swizzle];
+  // If objectSwizzler were used, the strong reference would make it live to the end of this test.
+  // We want to make sure it dies when the object dies, hence the weak reference.
+  __weak FPRObjectSwizzler *weakObjectSwizzler = objectSwizzler;
+  objectSwizzler = nil;
+  XCTAssertNotNil(weakObjectSwizzler);
+  object = nil;
+  XCTAssertNil(weakObjectSwizzler);
+}
+
+/** Tests the class get/set associated object methods. */
+- (void)testClassSetAssociatedObjectCopy {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *objectToBeAssociated = [[NSDictionary alloc] init];
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"fir_key"
+                                   value:objectToBeAssociated
+                             association:GUL_ASSOCIATION_COPY];
+  NSDictionary *returnedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"fir_key"];
+  XCTAssertEqualObjects(returnedObject, objectToBeAssociated);
+}
+
+/** Tests the class get/set associated object methods. */
+- (void)testClassSetAssociatedObjectAssign {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *objectToBeAssociated = [[NSDictionary alloc] init];
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"fir_key"
+                                   value:objectToBeAssociated
+                             association:GUL_ASSOCIATION_ASSIGN];
+  NSDictionary *returnedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"fir_key"];
+  XCTAssertEqualObjects(returnedObject, objectToBeAssociated);
+}
+
+/** Tests the class get/set associated object methods. */
+- (void)testClassSetAssociatedObjectRetain {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *objectToBeAssociated = [[NSDictionary alloc] init];
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"fir_key"
+                                   value:objectToBeAssociated
+                             association:GUL_ASSOCIATION_RETAIN];
+  NSDictionary *returnedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"fir_key"];
+  XCTAssertEqualObjects(returnedObject, objectToBeAssociated);
+}
+
+/** Tests the class get/set associated object methods. */
+- (void)testClassSetAssociatedObjectCopyNonatomic {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *objectToBeAssociated = [[NSDictionary alloc] init];
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"fir_key"
+                                   value:objectToBeAssociated
+                             association:GUL_ASSOCIATION_COPY_NONATOMIC];
+  NSDictionary *returnedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"fir_key"];
+  XCTAssertEqualObjects(returnedObject, objectToBeAssociated);
+}
+
+/** Tests the class get/set associated object methods. */
+- (void)testClassSetAssociatedObjectRetainNonatomic {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *objectToBeAssociated = [[NSDictionary alloc] init];
+  [FPRObjectSwizzler setAssociatedObject:object
+                                     key:@"fir_key"
+                                   value:objectToBeAssociated
+                             association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
+  NSDictionary *returnedObject = [FPRObjectSwizzler getAssociatedObject:object key:@"fir_key"];
+  XCTAssertEqualObjects(returnedObject, objectToBeAssociated);
+}
+
+/** Tests the swizzler get/set associated object methods. */
+- (void)testSetGetAssociatedObjectCopy {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key"
+                                 value:associatedObject
+                           association:GUL_ASSOCIATION_COPY];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests the swizzler get/set associated object methods. */
+- (void)testSetGetAssociatedObjectAssign {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key"
+                                 value:associatedObject
+                           association:GUL_ASSOCIATION_ASSIGN];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests the swizzler get/set associated object methods. */
+- (void)testSetGetAssociatedObjectRetain {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key"
+                                 value:associatedObject
+                           association:GUL_ASSOCIATION_RETAIN];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests the swizzler get/set associated object methods. */
+- (void)testSetGetAssociatedObjectCopyNonatomic {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key"
+                                 value:associatedObject
+                           association:GUL_ASSOCIATION_COPY_NONATOMIC];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests the swizzler get/set associated object methods. */
+- (void)testSetGetAssociatedObjectRetainNonatomic {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key"
+                                 value:associatedObject
+                           association:GUL_ASSOCIATION_RETAIN_NONATOMIC];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests getting and setting an associated object with an invalid association type. */
+- (void)testSetGetAssociatedObjectWithoutProperAssociation {
+  NSObject *object = [[NSObject alloc] init];
+  NSDictionary *associatedObject = [[NSDictionary alloc] init];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+  [swizzler setAssociatedObjectWithKey:@"key" value:associatedObject association:1337];
+  NSDictionary *returnedObject = [swizzler getAssociatedObjectForKey:@"key"];
+  XCTAssertEqualObjects(returnedObject, associatedObject);
+}
+
+/** Tests using the FPRObjectSwizzler to swizzle an object wrapped in an NSProxy. */
+- (void)testSwizzleProxiedObject {
+  NSObject *object = [[NSObject alloc] init];
+  FPRProxy *proxyObject = [FPRProxy proxyWithDelegate:object];
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:proxyObject];
+
+  XCTAssertNoThrow([swizzler swizzle]);
+
+  XCTAssertNotEqual(object_getClass(proxyObject), [FPRProxy class]);
+  XCTAssertTrue([object_getClass(proxyObject) isSubclassOfClass:[FPRProxy class]]);
+
+  XCTAssertTrue([proxyObject respondsToSelector:@selector(gul_objectSwizzler)]);
+  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_objectSwizzler)]);
+
+  XCTAssertTrue([proxyObject respondsToSelector:@selector(gul_class)]);
+  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_class)]);
+}
+
+/** Tests overriding a method that already exists on a proxied object works as expected. */
+- (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenOverridingMethod {
+  NSObject *object = [[NSObject alloc] init];
+  FPRProxy *proxyObject = [FPRProxy proxyWithDelegate:object];
+
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:proxyObject];
+  [swizzler copySelector:@selector(description)
+               fromClass:[FPRObjectSwizzlerTest class]
+         isClassSelector:NO];
+  [swizzler swizzle];
+
+  XCTAssertEqual([proxyObject performSelector:@selector(description)], @"SwizzledDescription");
+}
+
+/** Tests adding a method that doesn't exist on a proxied object works as expected. */
+- (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenAddingMethod {
+  NSObject *object = [[NSObject alloc] init];
+  FPRProxy *proxyObject = [FPRProxy proxyWithDelegate:object];
+
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:proxyObject];
+  [swizzler copySelector:@selector(donorDescription)
+               fromClass:[FPRObjectSwizzlerTest class]
+         isClassSelector:NO];
+  [swizzler swizzle];
+
+  XCTAssertEqual([proxyObject performSelector:@selector(donorDescription)],
+                 @"SwizzledDonorDescription");
+}
+
+/** Tests KVOing a proxy object that we've ISA Swizzled works as expected. */
+- (void)testRespondsToSelectorWorksEvenIfSwizzledProxyIsKVOd {
+  NSObject *object = [[NSObject alloc] init];
+  FPRProxy *proxyObject = [FPRProxy proxyWithDelegate:object];
+
+  FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:proxyObject];
+  [swizzler copySelector:@selector(donorDescription)
+               fromClass:[FPRObjectSwizzlerTest class]
+         isClassSelector:NO];
+  [swizzler swizzle];
+
+  [(NSObject *)proxyObject addObserver:self
+                            forKeyPath:NSStringFromSelector(@selector(description))
+                               options:0
+                               context:NULL];
+
+  XCTAssertTrue([proxyObject respondsToSelector:@selector(donorDescription)]);
+  XCTAssertEqual([proxyObject performSelector:@selector(donorDescription)],
+                 @"SwizzledDonorDescription");
+
+  [(NSObject *)proxyObject removeObserver:self
+                               forKeyPath:NSStringFromSelector(@selector(description))];
+}
+
+// TODO: Investigate why this test fails in Swift PM build.
+
+/** Tests that -[NSObjectProtocol respondsToSelector:] works as expected after someone else ISA
+ *  swizzles a proxy object that we've also ISA Swizzled.
+ */
+- (void)testRespondsToSelectorWorksEvenIfSwizzledProxyISASwizzledBySomeoneElse {
+  Class generatedClass = nil;
+  __weak FPRObjectSwizzler *weakSwizzler;
+
+  @autoreleasepool {
+    NSObject *object = [[NSObject alloc] init];
+    FPRProxy *proxyObject = [FPRProxy proxyWithDelegate:object];
+
+    FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:proxyObject];
+    weakSwizzler = swizzler;
+    [swizzler copySelector:@selector(donorDescription)
+                 fromClass:[FPRObjectSwizzlerTest class]
+           isClassSelector:NO];
+    [swizzler swizzle];
+
+    // Someone else ISA Swizzles the same object after FPRObjectSwizzler.
+    Class originalClass = object_getClass(proxyObject);
+    NSString *newClassName = [NSString
+        stringWithFormat:@"gul_test_%p_%@", proxyObject, NSStringFromClass(originalClass)];
+    generatedClass = objc_allocateClassPair(originalClass, newClassName.UTF8String, 0);
+    objc_registerClassPair(generatedClass);
+    object_setClass(proxyObject, generatedClass);
+
+    XCTAssertTrue([proxyObject respondsToSelector:@selector(donorDescription)]);
+    XCTAssertEqual([proxyObject performSelector:@selector(donorDescription)],
+                   @"SwizzledDonorDescription");
+
+    // Release FPRObjectSwizzler
+    [FPRObjectSwizzler setAssociatedObject:proxyObject
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:nil
+                               association:GUL_ASSOCIATION_RETAIN];
+  }
+  XCTAssertNil(weakSwizzler);
+
+  // Clean up.
+  objc_disposeClassPair(generatedClass);
+}
+
+#if !TARGET_OS_MACCATALYST
+// Test fails on Catalyst due to an interaction with GULSceneDelegateSwizzlerTests.
+
+- (void)testSwizzlerDoesntDisposeGeneratedClassWhenObjectIsISASwizzledBySomeoneElse {
+  Class generatedClass = nil;
+  __weak FPRObjectSwizzler *weakSwizzler;
+
+  XCTestExpectation *swizzlerDeallocatedExpectation =
+      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
+
+  @autoreleasepool {
+    NSObject *object = [[NSObject alloc] init];
+
+    @autoreleasepool {
+      FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+      weakSwizzler = swizzler;
+      [swizzler copySelector:@selector(donorDescription)
+                   fromClass:[FPRObjectSwizzlerTest class]
+             isClassSelector:NO];
+      [swizzler swizzle];
+    }
+
+    // Someone else ISA Swizzles the same object after FPRObjectSwizzler.
+    Class originalClass = object_getClass(object);
+    NSString *newClassName =
+        [NSString stringWithFormat:@"gul_test_%p_%@", object, NSStringFromClass(originalClass)];
+    generatedClass = objc_allocateClassPair(originalClass, newClassName.UTF8String, 0);
+    objc_registerClassPair(generatedClass);
+    object_setClass(object, generatedClass);
+
+    // Release FPRObjectSwizzler
+    [FPRObjectSwizzler setAssociatedObject:object
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:nil
+                               association:GUL_ASSOCIATION_RETAIN];
+
+    // Wait for a while
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+                     [swizzlerDeallocatedExpectation fulfill];
+                   });
+
+    [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
+
+    XCTAssertNil(weakSwizzler);
+    // A class generated by FPRObjectSwizzler must not be disposed if there is its subclass.
+    XCTAssertNoThrow([generatedClass description]);
+  }
+
+  // Clean up.
+  objc_disposeClassPair(generatedClass);
+}
+#endif
+
+// The test is disabled because in the case of success it should crash with SIGABRT, so it is not
+// suitable for CI.
+- (void)disabledForCI_testSwizzlerDisposesGeneratedClass {
+  __weak FPRObjectSwizzler *weakSwizzler;
+
+  XCTestExpectation *swizzlerDeallocatedExpectation =
+      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
+
+  @autoreleasepool {
+    NSObject *object = [[NSObject alloc] init];
+
+    @autoreleasepool {
+      FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+      weakSwizzler = swizzler;
+      [swizzler copySelector:@selector(donorDescription)
+                   fromClass:[FPRObjectSwizzlerTest class]
+             isClassSelector:NO];
+      [swizzler swizzle];
+    }
+
+    // Release FPRObjectSwizzler
+    [FPRObjectSwizzler setAssociatedObject:object
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:nil
+                               association:GUL_ASSOCIATION_RETAIN];
+
+    // Wait for a while until FPRObjectSwizzler has disposed the generated class.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+                     [swizzlerDeallocatedExpectation fulfill];
+                   });
+
+    [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
+
+    XCTAssertNil(weakSwizzler);
+
+    // Must crash here with SIGABRT.
+    XCTAssertThrows([object description]);
+    XCTFail(@"The test must have crashed on the previous line.");
+  }
+}
+
+- (void)testMultiSwizzling {
+  NSObject *object = [[NSObject alloc] init];
+
+  __weak FPRObjectSwizzler *existingSwizzler;
+
+  // Use @autoreleasepool to make the memory management in the test more deterministic.
+  @autoreleasepool {
+    NSInteger swizzleCount = 10;
+    for (NSInteger i = 0; i < swizzleCount; i++) {
+      FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+
+      if (i > 0) {
+        XCTAssertEqualObjects(swizzler, existingSwizzler,
+                              @"There must be a single swizzler per object.");
+      } else {
+        existingSwizzler = swizzler;
+      }
+
+      [swizzler copySelector:@selector(donorDescription)
+                   fromClass:[FPRObjectSwizzlerTest class]
+             isClassSelector:NO];
+      [swizzler swizzle];
+    }
+
+    XCTAssertNoThrow([object performSelector:@selector(donorDescription)]);
+    object = nil;
+  }
+
+  XCTAssertNil(existingSwizzler,
+               @"FPRObjectSwizzler must be deallocated after the object deallocation.");
+}
+
+@end

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.h
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/** An example NSProxy that could be used to wrap an object that we have to ISA Swizzle. */
+@interface FPRProxy : NSProxy
+
++ (instancetype)proxyWithDelegate:(id)delegate;
+
+@end

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.m
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FirebasePerformance/Tests/Unit/ISASwizzler/FPRProxy.h"
+
+@interface FPRProxy ()
+
+@property(nonatomic, strong) id delegateObject;
+
+@end
+
+@implementation FPRProxy
+
+- (instancetype)initWithDelegate:(id)delegate {
+  _delegateObject = delegate;
+  return self;
+}
+
++ (instancetype)proxyWithDelegate:(id)delegate {
+  return [[FPRProxy alloc] initWithDelegate:delegate];
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector {
+  return _delegateObject;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+  if (_delegateObject != nil) {
+    [invocation setTarget:_delegateObject];
+    [invocation invoke];
+  }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
+  return [_delegateObject instanceMethodSignatureForSelector:selector];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [_delegateObject respondsToSelector:aSelector];
+}
+
+- (BOOL)isEqual:(id)object {
+  return [_delegateObject isEqual:object];
+}
+
+- (NSUInteger)hash {
+  return [_delegateObject hash];
+}
+
+- (Class)superclass {
+  return [_delegateObject superclass];
+}
+
+- (Class)class {
+  return [_delegateObject class];
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+  return [_delegateObject isKindOfClass:aClass];
+}
+
+- (BOOL)isMemberOfClass:(Class)aClass {
+  return [_delegateObject isMemberOfClass:aClass];
+}
+
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+  return [_delegateObject conformsToProtocol:aProtocol];
+}
+
+- (BOOL)isProxy {
+  return YES;
+}
+
+- (NSString *)description {
+  return [_delegateObject description];
+}
+
+- (NSString *)debugDescription {
+  return [_delegateObject debugDescription];
+}
+
+@end

--- a/Package.swift
+++ b/Package.swift
@@ -886,7 +886,6 @@ let package = Package(
         "FirebaseSessions",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
-        .product(name: "GULISASwizzler", package: "GoogleUtilities"),
         .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
         .product(name: "GULUserDefaults", package: "GoogleUtilities"),
         .product(name: "nanopb", package: "nanopb"),


### PR DESCRIPTION
Migrate ISASwizzler into FirebasePerformance  since it is the only client and we don't want to do additional swizzling.

Corresponding GoogleUtilities PR is https://github.com/google/GoogleUtilities/pull/190