### PR TITLE
[Messaging] Rename initWithFileName internal method

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.29.0
+- [fixed] Renamed "initWithFileName" internal method that was causing submission issues for some
+  users. (#13134).
+
 # 10.27.0
 - [fixed] Fixed bug preventing Messaging from working with a custom sqlite3
   dependency (#12900).

--- a/FirebaseMessaging/Sources/Token/FIRMessagingBackupExcludedPlist.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingBackupExcludedPlist.h
@@ -39,7 +39,7 @@
  *
  *  @return Helper which allows to read write data to a backup excluded plist.
  */
-- (instancetype)initWithFileName:(NSString *)fileName subDirectory:(NSString *)subDirectory;
+- (instancetype)initWithPlistFile:(NSString *)fileName subDirectory:(NSString *)subDirectory;
 
 /**
  *  Write dictionary data to the backup excluded plist file. If the file does not exist

--- a/FirebaseMessaging/Sources/Token/FIRMessagingBackupExcludedPlist.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingBackupExcludedPlist.m
@@ -28,7 +28,7 @@
 
 @implementation FIRMessagingBackupExcludedPlist
 
-- (instancetype)initWithFileName:(NSString *)fileName subDirectory:(NSString *)subDirectory {
+- (instancetype)initWithPlistFile:(NSString *)fileName subDirectory:(NSString *)subDirectory {
   self = [super init];
   if (self) {
     _fileName = [fileName copy];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingCheckinStore.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingCheckinStore.m
@@ -48,8 +48,8 @@ NSString *const kFIRMessagingCheckinKeychainService = @"com.google.iid.checkin";
   self = [super init];
   if (self) {
     _plist = [[FIRMessagingBackupExcludedPlist alloc]
-        initWithFileName:kCheckinFileName
-            subDirectory:kFIRMessagingInstanceIDSubDirectoryName];
+        initWithPlistFile:kCheckinFileName
+             subDirectory:kFIRMessagingInstanceIDSubDirectoryName];
     _keychain =
         [[FIRMessagingAuthKeychain alloc] initWithIdentifier:kFIRMessagingCheckinKeychainGeneric];
   }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingBackupExcludedPlistTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingBackupExcludedPlistTest.m
@@ -44,8 +44,8 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
 - (void)setUp {
   [super setUp];
   [FIRMessaging createSubDirectory:kSubDirectoryName];
-  self.plist = [[FIRMessagingBackupExcludedPlist alloc] initWithFileName:kTestPlistFileName
-                                                            subDirectory:kSubDirectoryName];
+  self.plist = [[FIRMessagingBackupExcludedPlist alloc] initWithPlistFile:kTestPlistFileName
+                                                             subDirectory:kSubDirectoryName];
 }
 
 - (void)tearDown {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingCheckinStoreTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingCheckinStoreTest.m
@@ -67,8 +67,8 @@ static int64_t const kLastCheckinTimestamp = 123456;
   [super setUp];
   [FIRMessaging createSubDirectory:kSubDirectoryName];
   self.checkinStore = [[FIRMessagingCheckinStore alloc] init];
-  self.plist = [[FIRMessagingBackupExcludedPlist alloc] initWithFileName:kFakeCheckinPlistName
-                                                            subDirectory:kSubDirectoryName];
+  self.plist = [[FIRMessagingBackupExcludedPlist alloc] initWithPlistFile:kFakeCheckinPlistName
+                                                             subDirectory:kSubDirectoryName];
   self.checkinStore.plist = self.plist;
 }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenStoreTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenStoreTest.m
@@ -76,8 +76,8 @@ static NSString *const kFakeCheckinPlistName = @"com.google.test.TestTokenStore"
   [FIRMessaging createSubDirectory:kSubDirectoryName];
 
   self.checkinPlist =
-      [[FIRMessagingBackupExcludedPlist alloc] initWithFileName:kFakeCheckinPlistName
-                                                   subDirectory:kSubDirectoryName];
+      [[FIRMessagingBackupExcludedPlist alloc] initWithPlistFile:kFakeCheckinPlistName
+                                                    subDirectory:kSubDirectoryName];
 
   // checkin store
   FIRMessagingFakeKeychain *fakeKeychain = [[FIRMessagingFakeKeychain alloc] init];


### PR DESCRIPTION
Fix #13134 

Rename `initWithFileName` internal method. No references should remain in Firebase.

There is another unused definition in GoogleUtilities that will be removed in GoogleUtilities 8.0.0. 