### PR TITLE
[v11] Fix recaptcha bug - mixing vars and funcs

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -62,9 +62,7 @@ class IdentityToolkitRequest {
     tenantID = requestConfiguration.auth?.tenantID
   }
 
-  func containsPostBody() -> Bool {
-    true
-  }
+  var containsPostBody: Bool { return true }
 
   func queryParams() -> String {
     return ""

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
@@ -32,5 +32,5 @@ class GetProjectConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
     fatalError()
   }
 
-  var containsPostBody: Bool { false }
+  override var containsPostBody: Bool { return false }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
@@ -60,9 +60,7 @@ class GetRecaptchaConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
     return [:]
   }
 
-  override func containsPostBody() -> Bool {
-    false
-  }
+  override var containsPostBody: Bool { return false }
 
   override func queryParams() -> String {
     var queryParams = "&\(kClientTypeKey)=\(clientType)&\(kVersionKey)=\(kRecaptchaVersion)"

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -127,7 +127,7 @@ class SecureTokenRequest: AuthRPCRequest {
     return URL(string: urlString)!
   }
 
-  func containsPostBody() -> Bool { true }
+  var containsPostBody: Bool { return true }
 
   func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
     var postBody: [String: AnyHashable] = [

--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -673,9 +673,7 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       )
     }
 
-    func containsPostBody() -> Bool {
-      return true
-    }
+    var containsPostBody: Bool { return true }
 
     private let configuration: AuthRequestConfiguration
 

--- a/FirebaseAuth/Tests/Unit/GetRecaptchaConfigTests.swift
+++ b/FirebaseAuth/Tests/Unit/GetRecaptchaConfigTests.swift
@@ -25,7 +25,7 @@ class GetRecaptchaConfigTests: RPCBaseTests {
   func testGetRecaptchaConfigRequest() async throws {
     let request = GetRecaptchaConfigRequest(requestConfiguration: makeRequestConfiguration())
     //    let _ = try await AuthBackend.call(with: request)
-    XCTAssertFalse(request.containsPostBody())
+    XCTAssertFalse(request.containsPostBody)
 
     // Confirm that the request has no decoded body as it is get request.
     XCTAssertNil(rpcIssuer.decodedRequest)


### PR DESCRIPTION
Processing the GetRecaptchaConfigRequest RPC request was failing because it was getting a `true` from the `containsPostBody` var because it defined a `containsPostBody` func instead of overriding the var.