### PR TITLE
Fix symbol collision nightly

### DIFF
--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -30,6 +30,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
     - name: Prereqs
       run: scripts/install_prereqs.sh SymbolCollision iOS
     - name: Build


### PR DESCRIPTION
Fix #13150 - originally tested fix in #13151. 

Looks like one of the binary deps is built with a newish Xcode 15 version.