### PR TITLE
attempt fix for adding option for sigterm

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -174,8 +174,15 @@ bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager*
     dispatch_group_async(group, queue, ^{
       _firclsContext.readonly->signal.path =
           FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
+      bool firebaseCrashlyticsSIGTERMEnabled = false;
 
-      FIRCLSSignalInitialize(&_firclsContext.readonly->signal);
+      id isSIGTERMEnabled =
+          [NSBundle.mainBundle.infoDictionary objectForKey:@"FirebaseCrashlyticsEnabled"];
+      if ([isSIGTERMEnabled isKindOfClass:[NSString class]] ||
+          [isSIGTERMEnabled isKindOfClass:[NSNumber class]]) {
+        firebaseCrashlyticsSIGTERMEnabled = [isSIGTERMEnabled boolValue];
+      }
+      FIRCLSSignalInitialize(&_firclsContext.readonly->signal, firebaseCrashlyticsSIGTERMEnabled);
     });
 #endif
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -177,7 +177,7 @@ bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager*
       bool firebaseCrashlyticsSIGTERMEnabled = false;
 
       id isSIGTERMEnabled =
-          [NSBundle.mainBundle.infoDictionary objectForKey:@"FirebaseCrashlyticsEnabled"];
+          [NSBundle.mainBundle.infoDictionary objectForKey:@"FirebaseCrashlyticsSIGTERMEnabled"];
       if ([isSIGTERMEnabled isKindOfClass:[NSString class]] ||
           [isSIGTERMEnabled isKindOfClass:[NSNumber class]]) {
         firebaseCrashlyticsSIGTERMEnabled = [isSIGTERMEnabled boolValue];

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
@@ -42,7 +42,7 @@ typedef struct {
 #endif
 } FIRCLSSignalReadContext;
 
-void FIRCLSSignalInitialize(FIRCLSSignalReadContext* roContext);
+void FIRCLSSignalInitialize(FIRCLSSignalReadContext* roContext, bool isSIGTERMEnabled);
 void FIRCLSSignalCheckHandlers(void);
 
 void FIRCLSSignalSafeRemoveHandlers(bool includingAbort);


### PR DESCRIPTION
Test Steps:

Enable case:
- Adding `FirebaseCrashlyticsSIGTERMEnabled=YES` to Info.plist
- Build app, launch without debugger attached
- Run `kill -TERM <pid>`
- Seeing signal record

Disable case:
- Removing the flag or set the `FirebaseCrashlyticsSIGTERMEnabled=NO`
- Build app, launch without debugger attached
- Run `kill -TERM <pid>`
- Don't seeing signal record anymore

#no-changelog