### PR TITLE
[MLModelDownloader] Use `FirebaseLogger` instead of `GULLoggerWrapper`

### DIFF
--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -184,7 +184,8 @@ NS_SWIFT_NAME(FirebaseLogger)
 + (void)logWithLevel:(FIRLoggerLevel)level
              service:(FIRLoggerService)service
                 code:(NSString *)code
-             message:(NSString *)message NS_SWIFT_NAME(log(level:service:code:message:));
+             message:(NSString *)message
+    __attribute__((__swift_name__("log(level:service:code:message:)")));
 
 @end
 

--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -181,12 +181,10 @@ NS_SWIFT_NAME(FirebaseLogger)
 ///   three-character service identifier and a six digit integer message ID that is unique within
 ///   the service. An example of the message code is @"I-COR000001".
 ///   - message: Formatted string to be used as the log's message.
-///   - args: Arguments list obtained from calling `va_start`, used when message is a format string.
 + (void)logWithLevel:(FIRLoggerLevel)level
              service:(FIRLoggerService)service
                 code:(NSString *)code
-             message:(NSString *)message
-    __attribute__((__swift_name__("log(level:service:code:message:)")));
+             message:(NSString *)message NS_SWIFT_NAME(log(level:service:code:message:));
 
 @end
 

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -37,10 +37,9 @@ Pod::Spec.new do |s|
 
   s.framework = 'Foundation'
   s.dependency 'FirebaseCore', '~> 10.0'
+  s.dependency 'FirebaseCoreExtension', '~> 10.29'
   s.dependency 'FirebaseInstallations', '~> 10.0'
   s.dependency 'GoogleDataTransport', '~> 9.2'
-  # TODO: Revisit this dependency
-  s.dependency 'GoogleUtilities/Logger', '~> 7.13'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 7.13'
   s.dependency 'SwiftProtobuf', '~> 1.19'
 

--- a/FirebaseMLModelDownloader/Sources/DeviceLogger.swift
+++ b/FirebaseMLModelDownloader/Sources/DeviceLogger.swift
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 import Foundation
-#if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Logger
-#else
-  @_implementationOnly import GoogleUtilities
-#endif
+
+@_implementationOnly import FirebaseCoreExtension
 
 /// Enum of log messages.
 enum LoggerMessageCode: Int {
@@ -76,15 +73,9 @@ enum DeviceLogger {
   /// Log identifier.
   static let service = "[Firebase/MLModelDownloader]"
 
-  static func logEvent(level: GoogleLoggerLevel, message: String, messageCode: LoggerMessageCode) {
+  static func logEvent(level: FirebaseLoggerLevel, message: String,
+                       messageCode: LoggerMessageCode) {
     let code = String(format: "I-MLM%06d", messageCode.rawValue)
-    let args: [CVarArg] = []
-    GULLoggerWrapper.log(
-      with: level,
-      withService: DeviceLogger.service,
-      withCode: code,
-      withMessage: message,
-      withArgs: getVaList(args)
-    )
+    FirebaseLogger.log(level: level, service: DeviceLogger.service, code: code, message: message)
   }
 }

--- a/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
@@ -23,7 +23,6 @@
   @testable import FirebaseMLModelDownloader
   import XCTest
   #if SWIFT_PACKAGE
-    @_implementationOnly import GoogleUtilities_Logger
     @_implementationOnly import GoogleUtilities_UserDefaults
   #else
     @_implementationOnly import GoogleUtilities

--- a/Package.swift
+++ b/Package.swift
@@ -846,9 +846,9 @@ let package = Package(
       name: "FirebaseMLModelDownloader",
       dependencies: [
         "FirebaseCore",
+        "FirebaseCoreExtension",
         "FirebaseInstallations",
         .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
-        .product(name: "GULLogger", package: "GoogleUtilities"),
         .product(name: "GULUserDefaults", package: "GoogleUtilities"),
         .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       ],


### PR DESCRIPTION
Migrate from `GULLoggerWrapper` from `GoogleUtilities` to `FirebaseLogger` from `FirebaseCoreExtension`. After this change, `FirebaseCoreExtension` is the only target in the repo depending directly on `GULLogger`.

Note: `FirebaseLogger` still uses the ASL-based implementation of `GULLogger`. Migration to OSLog won't happen until Firebase 11.

#no-changelog