### PR TITLE
[Messaging] Fix APS Environment entitlement key on visionOS

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed the APS Environment key on visionOS. (#13173)
+
 # 10.29.0
 - [fixed] Renamed "initWithFileName" internal method that was causing submission issues for some
   users. (#13134).

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -28,12 +28,16 @@ static NSString *const kFIRMessagingAPNSProdPrefix = @"p_";
 
 static NSString *const kFIRMessagingWatchKitExtensionPoint = @"com.apple.watchkit";
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
-static NSString *const kEntitlementsAPSEnvironmentKey = @"Entitlements.aps-environment";
-#else
+#if TARGET_OS_OSX
+// macOS uses a different entitlement key than the rest of Apple's platforms:
+// https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_aps-environment
 static NSString *const kEntitlementsAPSEnvironmentKey =
     @"Entitlements.com.apple.developer.aps-environment";
-#endif
+#else
+// Entitlement key for all non-macOS platforms:
+// https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment
+static NSString *const kEntitlementsAPSEnvironmentKey = @"Entitlements.aps-environment";
+#endif  // TARGET_OS_OSX
 static NSString *const kAPSEnvironmentDevelopmentValue = @"development";
 
 #pragma mark - URL Helpers


### PR DESCRIPTION
On visionOS we should use the APS Entitlement Key [`aps-environment`](https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment), not [`com.apple.developer.aps-environment`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_aps-environment) (macOS only -- excluding Catalyst). This should fix #13173.

Note: Previously `TARGET_OS_IOS` was true on visionOS but not as of [Xcode 15.2](https://developer.apple.com/documentation/xcode-release-notes/xcode-15_2-release-notes#Resolved-Issues).