### PR TITLE
Fix deployment targets in FirebaseAppCheckInterop.podspec

### DIFF
--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -21,10 +21,10 @@ Pod::Spec.new do |s|
   }
   s.social_media_url = 'https://twitter.com/Firebase'
 
-  ios_deployment_target = '10.0'
-  osx_deployment_target = '10.13'
-  tvos_deployment_target = '12.0'
-  watchos_deployment_target = '6.0'
+  ios_deployment_target = '13.0'
+  osx_deployment_target = '10.15'
+  tvos_deployment_target = '13.0'
+  watchos_deployment_target = '7.0'
 
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target


### PR DESCRIPTION
These were accidentally reverted when resolving the merge conflicts in https://github.com/firebase/firebase-ios-sdk/pull/13169.

#no-changelog