### PR TITLE
[Messaging] Update CHANGELOG.md

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Unreleased
-- [fixed] Fixed the APS Environment key on visionOS. (#13173)
-
-# 10.29.0
 - [fixed] Renamed "initWithFileName" internal method that was causing submission issues for some
   users. (#13134).
+- [fixed] Fixed the APS Environment key on visionOS. (#13173)
 
 # 10.27.0
 - [fixed] Fixed bug preventing Messaging from working with a custom sqlite3


### PR DESCRIPTION
10.29.0 is not released yet so grouping release notes under "Unreleased" header

#no-changelog