### PR TITLE
[Messaging] Update `TARGET_OS_*` conditionals

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -221,7 +221,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   // This is not needed for app extension except for watch.
 #if TARGET_OS_WATCH
   [self didCompleteConfigure];
-#else  // TARGET_OS_WATCH
+#else   // TARGET_OS_WATCH
   if (![GULAppEnvironmentUtil isAppExtension]) {
     [self didCompleteConfigure];
   }

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -415,9 +415,9 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   SEL openURLWithOptionsSelector = @selector(application:openURL:options:);
   SEL openURLWithSourceApplicationSelector = @selector(application:
                                                            openURL:sourceApplication:annotation:);
-#if TARGET_OS_IOS && !TARGET_OS_VISION
+#if TARGET_OS_IOS
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
-#endif  // TARGET_OS_IOS && !TARGET_OS_VISION
+#endif  // TARGET_OS_IOS
   // Due to FIRAAppDelegateProxy swizzling, this selector will most likely get chosen, whether or
   // not the actual application has implemented
   // |application:continueUserActivity:restorationHandler:|. A warning will be displayed to the user
@@ -438,7 +438,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called,
     // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
-#if TARGET_OS_IOS && !TARGET_OS_VISION
+#if TARGET_OS_IOS
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application
@@ -451,7 +451,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
-#endif  // TARGET_OS_IOS && !TARGET_OS_VISION
+#endif  // TARGET_OS_IOS
   }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 }

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -221,11 +221,11 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   // This is not needed for app extension except for watch.
 #if TARGET_OS_WATCH
   [self didCompleteConfigure];
-#else
+#else  // TARGET_OS_WATCH
   if (![GULAppEnvironmentUtil isAppExtension]) {
     [self didCompleteConfigure];
   }
-#endif
+#endif  // TARGET_OS_WATCH
 }
 
 - (void)didCompleteConfigure {
@@ -393,7 +393,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 }
 
 - (void)handleIncomingLinkIfNeededFromMessage:(NSDictionary *)message {
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
   NSURL *url = [self linkURLFromMessage:message];
   if (url == nil) {
     return;
@@ -415,11 +415,9 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   SEL openURLWithOptionsSelector = @selector(application:openURL:options:);
   SEL openURLWithSourceApplicationSelector = @selector(application:
                                                            openURL:sourceApplication:annotation:);
-// TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
-// check if `TARGET_OS_VISION` is defined.
-#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#if TARGET_OS_IOS && !TARGET_OS_VISION
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#endif  // TARGET_OS_IOS && !TARGET_OS_VISION
   // Due to FIRAAppDelegateProxy swizzling, this selector will most likely get chosen, whether or
   // not the actual application has implemented
   // |application:continueUserActivity:restorationHandler:|. A warning will be displayed to the user
@@ -440,9 +438,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called,
     // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
-// TODO(Xcode 15): When Xcode 15 is the minimum supported Xcode version, it will be unnecessary to
-// check if `TARGET_OS_VISION` is defined.
-#if TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#if TARGET_OS_IOS && !TARGET_OS_VISION
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application
@@ -455,9 +451,9 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
-#endif  // TARGET_OS_IOS && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+#endif  // TARGET_OS_IOS && !TARGET_OS_VISION
   }
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 }
 
 - (NSURL *)linkURLFromMessage:(NSDictionary *)message {

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -173,7 +173,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
     content.badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
   }
-#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#if !TARGET_OS_TV
   // The following fields are not available on tvOS
   if ([apsDictionary[kFIRMessagingContextManagerBodyKey] length]) {
     content.body = apsDictionary[kFIRMessagingContextManagerBodyKey];
@@ -201,7 +201,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   if (userInfo.count) {
     content.userInfo = userInfo;
   }
-#endif  // TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#endif  // !TARGET_OS_TV
   return content;
 }
 

--- a/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
+++ b/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
@@ -131,7 +131,7 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
                             @"The Image URL provided is invalid %@.", currentImageURL);
     [self deliverNotification];
   }
-#else  // !TARGET_OS_TV
+#else   // !TARGET_OS_TV
   [self deliverNotification];
 #endif  // !TARGET_OS_TV
 }

--- a/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
+++ b/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
@@ -111,7 +111,7 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
   self.bestAttemptContent = content;
 
   // The `userInfo` property isn't available on newer versions of tvOS.
-#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#if !TARGET_OS_TV
   NSObject *currentImageURL = content.userInfo[kPayloadOptionsName][kPayloadOptionsImageURLName];
   if (!currentImageURL || currentImageURL == [NSNull null]) {
     [self deliverNotification];
@@ -131,12 +131,12 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
                             @"The Image URL provided is invalid %@.", currentImageURL);
     [self deliverNotification];
   }
-#else
+#else  // !TARGET_OS_TV
   [self deliverNotification];
-#endif
+#endif  // !TARGET_OS_TV
 }
 
-#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#if !TARGET_OS_TV
 - (NSString *)fileExtensionForResponse:(NSURLResponse *)response {
   NSString *suggestedPathExtension = [response.suggestedFilename pathExtension];
   if (suggestedPathExtension.length > 0) {
@@ -194,7 +194,7 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
           completionHandler(attachment);
         }] resume];
 }
-#endif
+#endif  // !TARGET_OS_TV
 
 - (void)deliverNotification {
   if (self.contentHandler) {

--- a/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
@@ -392,7 +392,7 @@ id FIRMessagingPropertyNameFromObject(id object, NSString *propertyName, Class k
 }
 #pragma clang diagnostic pop
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 - (void)application:(UIApplication *)application
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
@@ -408,7 +408,7 @@ id FIRMessagingPropertyNameFromObject(id object, NSString *propertyName, Class k
                           @"application:didFailToRegisterForRemoteNotificationsWithError: %@",
                           error.localizedDescription);
 }
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
 - (void)application:(GULApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -89,7 +89,7 @@ NSString *FIRMessagingAppIdentifier(void) {
   } else {
     return bundleID;
   }
-#else  // TARGET_OS_WATCH
+#else   // TARGET_OS_WATCH
   return bundleID;
 #endif  // TARGET_OS_WATCH
 }
@@ -112,7 +112,7 @@ BOOL FIRMessagingIsWatchKitExtension(void) {
   } else {
     return NO;
   }
-#else  // TARGET_OS_WATCH
+#else   // TARGET_OS_WATCH
   return NO;
 #endif  // TARGET_OS_WATCH
 }
@@ -120,7 +120,7 @@ BOOL FIRMessagingIsWatchKitExtension(void) {
 NSSearchPathDirectory FIRMessagingSupportedDirectory(void) {
 #if TARGET_OS_TV
   return NSCachesDirectory;
-#else  // TARGET_OS_TV
+#else   // TARGET_OS_TV
   return NSApplicationSupportDirectory;
 #endif  // TARGET_OS_TV
 }
@@ -315,7 +315,7 @@ BOOL FIRMessagingIsProductionApp(void) {
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
   NSString *path = [[[[NSBundle mainBundle] resourcePath] stringByDeletingLastPathComponent]
       stringByAppendingPathComponent:@"embedded.provisionprofile"];
-#else  // TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#else   // TARGET_OS_OSX || TARGET_OS_MACCATALYST
   NSString *path = [[[NSBundle mainBundle] bundlePath]
       stringByAppendingPathComponent:@"embedded.mobileprovision"];
 #endif  // TARGET_OS_OSX || TARGET_OS_MACCATALYST

--- a/FirebaseMessaging/Sources/FIRMessagingUtilities.m
+++ b/FirebaseMessaging/Sources/FIRMessagingUtilities.m
@@ -89,9 +89,9 @@ NSString *FIRMessagingAppIdentifier(void) {
   } else {
     return bundleID;
   }
-#else
+#else  // TARGET_OS_WATCH
   return bundleID;
-#endif
+#endif  // TARGET_OS_WATCH
 }
 
 NSString *FIRMessagingFirebaseAppID(void) {
@@ -112,17 +112,17 @@ BOOL FIRMessagingIsWatchKitExtension(void) {
   } else {
     return NO;
   }
-#else
+#else  // TARGET_OS_WATCH
   return NO;
-#endif
+#endif  // TARGET_OS_WATCH
 }
 
 NSSearchPathDirectory FIRMessagingSupportedDirectory(void) {
 #if TARGET_OS_TV
   return NSCachesDirectory;
-#else
+#else  // TARGET_OS_TV
   return NSApplicationSupportDirectory;
-#endif
+#endif  // TARGET_OS_TV
 }
 
 #pragma mark - Locales
@@ -315,10 +315,10 @@ BOOL FIRMessagingIsProductionApp(void) {
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
   NSString *path = [[[[NSBundle mainBundle] resourcePath] stringByDeletingLastPathComponent]
       stringByAppendingPathComponent:@"embedded.provisionprofile"];
-#elif TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH || TARGET_OS_VISION
+#else  // TARGET_OS_OSX || TARGET_OS_MACCATALYST
   NSString *path = [[[NSBundle mainBundle] bundlePath]
       stringByAppendingPathComponent:@"embedded.mobileprovision"];
-#endif
+#endif  // TARGET_OS_OSX || TARGET_OS_MACCATALYST
 
   if ([GULAppEnvironmentUtil isAppStoreReceiptSandbox] && !path.length) {
     // Distributed via TestFlight

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
@@ -95,13 +95,13 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
 #if TARGET_OS_OSX || TARGET_OS_WATCH
   keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
   NSData *passwordInfos =
-  CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
-#else  // TARGET_OS_OSX || TARGET_OS_WATCH
+      CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
+#else   // TARGET_OS_OSX || TARGET_OS_WATCH
   keychainQuery[(__bridge id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
   keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitAll;
   // FIRMessagingKeychain should only take a query and return a result, will handle the query here.
   NSArray *passwordInfos =
-  CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
+      CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
 #endif  // TARGET_OS_OSX || TARGET_OS_WATCH
 
   if (!passwordInfos) {
@@ -121,7 +121,7 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
   results = [[NSMutableArray alloc] init];
 #if TARGET_OS_OSX || TARGET_OS_WATCH
   [results addObject:passwordInfos];
-#else  // TARGET_OS_OSX || TARGET_OS_WATCH
+#else   // TARGET_OS_OSX || TARGET_OS_WATCH
   NSInteger numPasswords = passwordInfos.count;
   for (NSUInteger i = 0; i < numPasswords; i++) {
     NSDictionary *passwordInfo = [passwordInfos objectAtIndex:i];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingAuthKeychain.m
@@ -92,17 +92,17 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
   NSMutableDictionary *keychainQuery = [self keychainQueryForService:service account:account];
   NSMutableArray<NSData *> *results;
   keychainQuery[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
+#if TARGET_OS_OSX || TARGET_OS_WATCH
+  keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+  NSData *passwordInfos =
+  CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
+#else  // TARGET_OS_OSX || TARGET_OS_WATCH
   keychainQuery[(__bridge id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
   keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitAll;
   // FIRMessagingKeychain should only take a query and return a result, will handle the query here.
   NSArray *passwordInfos =
-      CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
-#elif TARGET_OS_OSX || TARGET_OS_WATCH
-  keychainQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
-  NSData *passwordInfos =
-      CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
-#endif
+  CFBridgingRelease([[FIRMessagingKeychain sharedInstance] itemWithQuery:keychainQuery]);
+#endif  // TARGET_OS_OSX || TARGET_OS_WATCH
 
   if (!passwordInfos) {
     // Nothing was found, simply return from this sync block.
@@ -119,7 +119,9 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
     return @[];
   }
   results = [[NSMutableArray alloc] init];
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_OSX || TARGET_OS_WATCH
+  [results addObject:passwordInfos];
+#else  // TARGET_OS_OSX || TARGET_OS_WATCH
   NSInteger numPasswords = passwordInfos.count;
   for (NSUInteger i = 0; i < numPasswords; i++) {
     NSDictionary *passwordInfo = [passwordInfos objectAtIndex:i];
@@ -127,9 +129,7 @@ NSString *const kFIRMessagingKeychainWildcardIdentifier = @"*";
       [results addObject:passwordInfo[(__bridge id)kSecValueData]];
     }
   }
-#elif TARGET_OS_OSX || TARGET_OS_WATCH
-  [results addObject:passwordInfos];
-#endif
+#endif  // TARGET_OS_OSX || TARGET_OS_WATCH
   // We query the keychain because it didn't exist in cache, now query is done, update the result in
   // the cache.
   if ([service isEqualToString:kFIRMessagingKeychainWildcardIdentifier] ||

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -693,7 +693,7 @@
   // If APNS token is available on iOS Simulator, we must use the sandbox profile
   // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
   BOOL isSandboxApp = YES;
-#else  // TARGET_OS_SIMULATOR
+#else   // TARGET_OS_SIMULATOR
   NSInteger type = [userInfo[kFIRMessagingAPNSTokenType] integerValue];
   BOOL isSandboxApp = (type == FIRMessagingAPNSTokenTypeSandbox);
   if (type == FIRMessagingAPNSTokenTypeUnknown) {

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -194,13 +194,13 @@
     return;
   }
 
-#if TARGET_OS_SIMULATOR && TARGET_OS_IOS
+#if TARGET_OS_SIMULATOR
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil) {
     // If APNS token is available on iOS Simulator, we must use the sandbox profile
     // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
     tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] = @(YES);
   }
-#endif
+#endif  // TARGET_OS_SIMULATOR
 
   if (tokenOptions[kFIRMessagingTokenOptionsAPNSKey] != nil &&
       tokenOptions[kFIRMessagingTokenOptionsAPNSIsSandboxKey] == nil) {
@@ -689,17 +689,17 @@
     return;
   }
   // Use this token type for when we have to automatically fetch tokens in the future
-#if TARGET_OS_SIMULATOR && TARGET_OS_IOS
+#if TARGET_OS_SIMULATOR
   // If APNS token is available on iOS Simulator, we must use the sandbox profile
   // https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
   BOOL isSandboxApp = YES;
-#else
+#else  // TARGET_OS_SIMULATOR
   NSInteger type = [userInfo[kFIRMessagingAPNSTokenType] integerValue];
   BOOL isSandboxApp = (type == FIRMessagingAPNSTokenTypeSandbox);
   if (type == FIRMessagingAPNSTokenTypeUnknown) {
     isSandboxApp = FIRMessagingIsSandboxApp();
   }
-#endif
+#endif  // TARGET_OS_SIMULATOR
 
   // Pro-actively invalidate the default token, if the APNs change makes it
   // invalid. Previously, we invalidated just before fetching the token.

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingPubSubTest.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingPubSubTest.swift
@@ -76,4 +76,4 @@
       wait(for: [expectation], timeout: 5)
     }
   }
-#endif // !TARGET_OS_OSX
+#endif // !os(OSX)

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
@@ -145,4 +145,4 @@
       return app.options.gcmSenderID
     }
   }
-#endif // !TARGET_OS_OSX
+#endif // !os(OSX)

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
@@ -488,4 +488,4 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
 }
 @end
 
-#endif
+#endif  // TARGET_OS_IOS

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAuthKeychainTest.m
@@ -39,7 +39,7 @@ static NSString *const kSecret = @"test-secret";
 static NSString *const kToken2 = @"c8oEXUYIl3s:APA91bHtJMs_dZ2lXYXIcwsC47abYIuWhEJ_CshY2PJRjVuI_"
                                  @"H659iYUwfmNNghnZVkCmeUdKDSrK8xqVb0PVHxyAW391Ynp2NchMB87kJWb3BS0z"
                                  @"ud6Ej_xDES_oc353eFRvt0E6NXefDmrUCpBY8y89_1eVFFfiA";
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 static NSString *const kFirebaseAppID = @"abcdefg:ios:QrjxYS1BdtxHdVVnQKuxlF3Z0QO";
 
 static NSString *const kBundleID1 = @"com.google.fcm.dev";
@@ -139,7 +139,7 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                      }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 }
 
 - (void)testKeyChainNoCorruptionWithUniqueService {
@@ -214,7 +214,7 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                   }];
          }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 }
 
 // Skip keychain tests on Catalyst and macOS. Tests are skipped because they
@@ -404,7 +404,7 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   XCTAssertNotNil(keychain.cachedKeychainData[service][account2]);
 }
 
-#endif
+#endif  // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
 
 #pragma mark - helper function
 - (NSData *)tokenDataWithAuthorizedEntity:(NSString *)authorizedEntity
@@ -425,4 +425,4 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
 }
 @end
 
-#endif  // TARGET_OS_MACCATALYST
+#endif  // !TARGET_OS_MACCATALYST && !SWIFT_PACKAGE

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingBackupExcludedPlistTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingBackupExcludedPlistTest.m
@@ -89,10 +89,10 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
 #if TARGET_OS_TV
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-#else
+#else   // TARGET_OS_TV
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-#endif
+#endif  // TARGET_OS_TV
   NSString *dirPath = directoryPaths.lastObject;
   NSArray *components =
       @[ dirPath, kSubDirectoryName, [NSString stringWithFormat:@"%@.plist", kTestPlistFileName] ];

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingCheckinStoreTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingCheckinStoreTest.m
@@ -203,4 +203,4 @@ static int64_t const kLastCheckinTimestamp = 123456;
 }
 
 @end
-#endif
+#endif  // !TARGET_OS_MACCATALYST

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -105,11 +105,11 @@ API_AVAILABLE(macos(10.14))
     XCTAssertEqual(self.requests.count, 1);
     UNNotificationRequest *request = self.requests.firstObject;
     XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
-#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_OSX
+#if !TARGET_OS_TV
     XCTAssertEqualObjects(request.content.body, kBody);
     XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey1], kUserInfoValue1);
     XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey2], kUserInfoValue2);
-#endif
+#endif  // TARGET_OS_TV
     return;
   }
 
@@ -124,7 +124,7 @@ API_AVAILABLE(macos(10.14))
   XCTAssertEqualObjects(notification.alertBody, kBody);
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
-#endif
+#endif  // TARGET_OS_IOS
 }
 
 /**
@@ -193,7 +193,7 @@ API_AVAILABLE(macos(10.14))
   XCTAssertEqual([notification.fireDate compare:endDate], NSOrderedAscending);
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
-#endif
+#endif  // TARGET_OS_IOS
 }
 
 /**
@@ -229,7 +229,7 @@ API_AVAILABLE(macos(10.14))
 #pragma clang diagnostic pop
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
   XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
-#endif
+#endif  // TARGET_OS_IOS
 }
 
 #pragma mark - Private Helpers
@@ -271,7 +271,7 @@ API_AVAILABLE(macos(10.14))
        return NO;
      }]];
 #pragma clang diagnostic pop
-#endif
+#endif  // TARGET_OS_IOS
 }
 
 - (void)testScheduleiOS10LocalNotification {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -26,7 +26,7 @@
 API_AVAILABLE(macos(10.14), ios(10.0), watchos(3.0))
 typedef void (^FIRMessagingContentHandler)(UNNotificationContent *content);
 
-#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#if !TARGET_OS_TV
 static NSString *const kFCMPayloadOptionsName = @"fcm_options";
 static NSString *const kFCMPayloadOptionsImageURLName = @"image";
 static NSString *const kValidImageURL =
@@ -221,4 +221,4 @@ static NSString *const kValidImageURL =
 
 @end
 
-#endif  // TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+#endif  // !TARGET_OS_TV

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -40,13 +40,13 @@
     API_AVAILABLE(ios(10.0), macos(10.14), tvos(10.0)) {
 }
 
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if !TARGET_OS_TV
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler
     API_AVAILABLE(macos(10.14), ios(10.0)) {
 }
-#endif
+#endif  // !TARGET_OS_TV
 
 @end
 
@@ -72,13 +72,13 @@
 }
 #pragma clang diagnostic pop
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 - (void)application:(UIApplication *)application
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   self.remoteNotificationWithFetchHandlerWasCalled = YES;
 }
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
 - (void)application:(GULApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -112,14 +112,14 @@
     API_AVAILABLE(ios(10.0), macos(10.14), tvos(10.0)) {
   self.willPresentWasCalled = YES;
 }
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if !TARGET_OS_TV
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler
     API_AVAILABLE(ios(10.0), macos(10.14)) {
   self.didReceiveResponseWasCalled = YES;
 }
-#endif
+#endif  // !TARGET_OS_TV
 @end
 
 @interface GULAppDelegateSwizzler (FIRMessagingRemoteNotificationsProxyTest)
@@ -187,7 +187,7 @@
   [invalidAppDelegate application:[GULAppDelegateSwizzler sharedApplication]
       didReceiveRemoteNotification:@{}];
 }
-#endif
+#endif  // !TARGET_OS_WATCH
 
 #if !SWIFT_PACKAGE
 // The next 3 tests depend on a sharedApplication which is not available in the Swift PM test env.
@@ -217,7 +217,7 @@
   SEL remoteNotificationWithFetchHandler = @selector(application:
                                     didReceiveRemoteNotification:fetchCompletionHandler:);
   XCTAssertFalse([incompleteAppDelegate respondsToSelector:remoteNotificationWithFetchHandler]);
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 
   SEL remoteNotification = @selector(application:didReceiveRemoteNotification:);
   XCTAssertTrue([incompleteAppDelegate respondsToSelector:remoteNotification]);
@@ -259,7 +259,7 @@
   XCTAssertTrue(appDelegate.remoteNotificationWithFetchHandlerWasCalled);
 
   [self.mockMessaging verify];
-#endif
+#endif  // TARGET_OS_IOS || TARGET_OS_TV
 
   // Verify application:didRegisterForRemoteNotificationsWithDeviceToken:
   NSData *deviceToken = [NSData data];
@@ -280,7 +280,7 @@
 
   XCTAssertEqual(appDelegate.registerForRemoteNotificationsError, error);
 }
-#endif
+#endif  // !SWIFT_PACKAGE
 
 - (void)testListeningForDelegateChangesOnInvalidUserNotificationCenter {
   if (@available(macOS 10.14, iOS 10.0, *)) {
@@ -337,7 +337,7 @@
 
 // Use an object that does actually implement the optional methods. Both should be called.
 - (void)testSwizzledUserNotificationsCenterDelegate {
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if !TARGET_OS_TV
   FakeUserNotificationCenterDelegate *delegate = [[FakeUserNotificationCenterDelegate alloc] init];
   OCMStub([self.mockUserNotificationCenter delegate]).andReturn(delegate);
   [self.proxy swizzleMethodsIfPossible];
@@ -377,11 +377,11 @@
     // Verify our swizzled method was called
     [self.mockMessaging verify];
   }
-#endif
+#endif  // !TARGET_OS_TV
 }
 
 - (id)userNotificationResponseWithMessage:(NSDictionary *)message {
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if !TARGET_OS_TV
   if (@available(macOS 10.14, iOS 10.0, *)) {
     // Stub out: response.[mock notification above]
     id mockNotificationResponse = OCMClassMock([UNNotificationResponse class]);
@@ -389,16 +389,16 @@
     OCMStub([mockNotificationResponse notification]).andReturn(mockNotification);
     return mockNotificationResponse;
   }
-#endif
+#endif  // !TARGET_OS_TV
   return nil;
 }
 
 - (UNNotification *)userNotificationWithMessage:(NSDictionary *)message
     API_AVAILABLE(macos(10.14), ios(10.0)) {
   UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if !TARGET_OS_TV
   content.userInfo = message;
-#endif
+#endif  // !TARGET_OS_TV
   id notificationRequest = OCMClassMock([UNNotificationRequest class]);
   OCMStub([notificationRequest content]).andReturn(content);
   id notification = OCMClassMock([UNNotification class]);

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingUtilitiesTest.m
@@ -74,10 +74,10 @@
   [[[_mainBundleMock stub] andReturn:fakeInfoDictionary] infoDictionary];
   NSString *bundleIdentifier = @"com.me.myapp.watchkit.watchkitextensions";
   NSString *expectedIdentifier = @"com.me.myapp.watchkit";
-#else
+#else   // TARGET_OS_WATCH
   NSString *bundleIdentifier = @"com.me.myapp";
   NSString *expectedIdentifier = @"com.me.myapp";
-#endif
+#endif  // TARGET_OS_WATCH
 
   [[[_mainBundleMock stub] andReturn:bundleIdentifier] bundleIdentifier];
   NSString *appIdentifier = FIRMessagingAppIdentifier();


### PR DESCRIPTION
Updated `TARGET_OS_*` in Messaging now that Xcode 15.2 is required and `TARGET_OS_IOS` is no longer `1` on visionOS.

#no-changelog