### PR TITLE
Storage: Fix a var that should be a let

### DIFF
--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -230,7 +230,7 @@ import Foundation
     return 0
   }
 
-  private static var dateFormatter: DateFormatter = {
+  private static let dateFormatter: DateFormatter = {
     let dateFormatter = DateFormatter()
     dateFormatter.locale = Locale(identifier: "en_US_POSIX") // set locale to reliable US_POSIX
     dateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZZZZZ"


### PR DESCRIPTION
The only change for building with Swift 6 that doesn't look to be part of a big lift to Sendable.

#no-changelog