### PR TITLE
VertexAI: add support for mock responses versioning system

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -15,6 +15,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-mock-responses-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Clone mock responses
+      run: scripts/update_vertexai_responses.sh
+    - name: Find cloned and latest versions
+      run: |
+        echo "current_tag=$(git describe --tags | awk -F'/' '{print $NF}')" >> $GITHUB_ENV
+        echo "latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/FirebaseExtended/vertexai-sdk-test-data.git | tail -n1 | awk -F'/' '{print $NF}')" >> $GITHUB_ENV
+      working-directory: FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data
+    - name: Find comment from previous run if exists
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{github.event.number}}
+        body-includes: Mock Responses Check
+    - name: Comment on PR if newer version is available
+      if: ${{env.current_tag != env.latest_tag && !steps.fc.outputs.comment-id}}
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{github.event.number}}
+        body: |
+          ### Vertex AI Mock Responses Check :warning:
+          A newer major version of the mock responses for Vertex AI unit tests is available.
+          [update_vertexai_responses.sh](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh) should be updated to clone the latest version of the responses.
+    - name: Fail job if newer version is available
+      if: ${{env.current_tag != env.latest_tag}}
+      run: exit 1
+    - name: Delete comment when version gets updated
+      if: ${{env.current_tag == env.latest_tag && steps.fc.outputs.comment-id}}
+      uses: detomarco/delete-comment@v1.0.4
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+
   spm-unit:
     strategy:
       matrix:

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -17,6 +17,10 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
+RESPONSES_VERSION='v1.*' # the major version of mock responses to use
+REPO="https://github.com/FirebaseExtended/vertexai-sdk-test-data.git"
+TAG=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' "$REPO" | grep "$RESPONSES_VERSION" | tail -n1 | awk -F'/' '{print $NF}')
+
 cd "$(dirname "$0")/../FirebaseVertexAI/Tests/Unit" || exit
 rm -rf vertexai-sdk-test-data || exit
-git clone --depth 1 https://github.com/FirebaseExtended/vertexai-sdk-test-data.git
+git clone --depth 1 --branch "$TAG" "$REPO"


### PR DESCRIPTION
This updates update_vertexai_responses.sh to clone the latest minor version within a hard-coded major version of the mock responses.

It also adds a CI job that fails and leaves a comment on the PR if update_vertexai_responses.sh is cloning an outdated major version.