### PR TITLE
[Vertex AI] Add support for compiling on watchOS

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,7 +18,7 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, macOS, catalyst, tvOS, visionOS]
+        target: [iOS, macOS, catalyst, tvOS, visionOS, watchOS]
         os: [macos-14]
         include:
           - os: macos-14

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 10.29.0
+- [feature] Added community support for watchOS. (#13215)
+
 # 10.28.0
 - [changed] Removed uses of the `gemini-1.5-flash-preview-0514` model in docs
   and samples. Developers should now use the auto-updated versions,

--- a/FirebaseVertexAI/Sources/Chat.swift
+++ b/FirebaseVertexAI/Sources/Chat.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// An object that represents a back-and-forth chat with a model, capturing the history and saving
 /// the context in memory between each message sent.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public class Chat {
   private let model: GenerativeModel
 

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -14,14 +14,14 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct CountTokensRequest {
   let model: String
   let contents: [ModelContent]
   let options: RequestOptions
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
@@ -31,7 +31,7 @@ extension CountTokensRequest: GenerativeAIRequest {
 }
 
 /// The model's response to a count tokens request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct CountTokensResponse {
   /// The total number of tokens in the input given to the model as a prompt.
   public let totalTokens: Int
@@ -45,14 +45,14 @@ public struct CountTokensResponse {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CountTokensRequest: Encodable {
   enum CodingKeys: CodingKey {
     case contents
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CountTokensResponse: Decodable {
   enum CodingKeys: CodingKey {
     case totalTokens

--- a/FirebaseVertexAI/Sources/GenerateContentError.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentError.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Errors that occur when generating content from a model.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum GenerateContentError: Error {
   /// An error occurred when constructing the prompt. Examine the related error for details.
   case promptImageContentError(underlying: ImageConversionError)

--- a/FirebaseVertexAI/Sources/GenerateContentRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentRequest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct GenerateContentRequest {
   /// Model name.
   let model: String
@@ -28,7 +28,7 @@ struct GenerateContentRequest {
   let options: RequestOptions
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension GenerateContentRequest: Encodable {
   enum CodingKeys: String, CodingKey {
     case contents
@@ -40,7 +40,7 @@ extension GenerateContentRequest: Encodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// The model's response to a generate content request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct GenerateContentResponse {
   /// Token usage metadata for processing the generate content request.
   public struct UsageMetadata {
@@ -84,7 +84,7 @@ public struct GenerateContentResponse {
 
 /// A struct representing a possible reply to a content generation prompt. Each content generation
 /// prompt may produce multiple candidate responses.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct CandidateResponse {
   /// The response's content.
   public let content: ModelContent
@@ -110,14 +110,14 @@ public struct CandidateResponse {
 }
 
 /// A collection of source attributions for a piece of content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct CitationMetadata {
   /// A list of individual cited sources and the parts of the content to which they apply.
   public let citationSources: [Citation]
 }
 
 /// A struct describing a source attribution.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct Citation {
   /// The inclusive beginning of a sequence in a model response that derives from a cited source.
   public let startIndex: Int
@@ -133,7 +133,7 @@ public struct Citation {
 }
 
 /// A value enumerating possible reasons for a model to terminate a content generation request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum FinishReason: String {
   case unknown = "FINISH_REASON_UNKNOWN"
 
@@ -158,7 +158,7 @@ public enum FinishReason: String {
 }
 
 /// A metadata struct containing any feedback the model had on the prompt it was provided.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct PromptFeedback {
   /// A type describing possible reasons to block a prompt.
   public enum BlockReason: String {
@@ -190,7 +190,7 @@ public struct PromptFeedback {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension GenerateContentResponse: Decodable {
   enum CodingKeys: CodingKey {
     case candidates
@@ -224,7 +224,7 @@ extension GenerateContentResponse: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension GenerateContentResponse.UsageMetadata: Decodable {
   enum CodingKeys: CodingKey {
     case promptTokenCount
@@ -241,7 +241,7 @@ extension GenerateContentResponse.UsageMetadata: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CandidateResponse: Decodable {
   enum CodingKeys: CodingKey {
     case content
@@ -290,14 +290,14 @@ extension CandidateResponse: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension CitationMetadata: Decodable {
   enum CodingKeys: String, CodingKey {
     case citationSources = "citations"
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Citation: Decodable {
   enum CodingKeys: CodingKey {
     case startIndex
@@ -315,7 +315,7 @@ extension Citation: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FinishReason: Decodable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -330,7 +330,7 @@ extension FinishReason: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension PromptFeedback.BlockReason: Decodable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -345,7 +345,7 @@ extension PromptFeedback.BlockReason: Decodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension PromptFeedback: Decodable {
   enum CodingKeys: CodingKey {
     case blockReason

--- a/FirebaseVertexAI/Sources/GenerationConfig.swift
+++ b/FirebaseVertexAI/Sources/GenerationConfig.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// A struct defining model parameters to be used when sending generative AI
 /// requests to the backend model.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct GenerationConfig {
   /// A parameter controlling the degree of randomness in token selection. A
   /// temperature of zero is deterministic, always choosing the
@@ -95,5 +95,5 @@ public struct GenerationConfig {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension GenerationConfig: Encodable {}

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 protocol GenerativeAIRequest: Encodable {
   associatedtype Response: Decodable
 
@@ -24,7 +24,7 @@ protocol GenerativeAIRequest: Encodable {
 }
 
 /// Configuration parameters for sending requests to the backend.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct RequestOptions {
   /// The request’s timeout interval in seconds; if not specified uses the default value for a
   /// `URLRequest`.

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -17,7 +17,7 @@ import FirebaseAuthInterop
 import FirebaseCore
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct GenerativeAIService {
   /// The language of the SDK in the format `gl-<language>/<version>`.
   static let languageTag = "gl-swift/5"

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A type that represents a remote multimodal model (like Gemini), with the ability to generate
 /// content based on various input types.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public final class GenerativeModel {
   // The prefix for a model resource in the Gemini API.
   private static let modelResourcePrefix = "models/"
@@ -318,7 +318,7 @@ public final class GenerativeModel {
 }
 
 /// An error thrown in `GenerativeModel.countTokens(_:)`.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum CountTokensError: Error {
   case internalError(underlying: Error)
 }

--- a/FirebaseVertexAI/Sources/Logging.swift
+++ b/FirebaseVertexAI/Sources/Logging.swift
@@ -15,7 +15,7 @@
 import Foundation
 import OSLog
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct Logging {
   /// Subsystem that should be used for all Loggers.
   static let subsystem = "com.google.firebase.vertex-ai"

--- a/FirebaseVertexAI/Sources/ModelContent.swift
+++ b/FirebaseVertexAI/Sources/ModelContent.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type describing data in media formats interpretable by an AI model. Each generative AI
 /// request or response contains an `Array` of ``ModelContent``s, and each ``ModelContent`` value
 /// may comprise multiple heterogeneous ``ModelContent/Part``s.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ModelContent: Equatable {
   /// A discrete piece of data in a media format interpretable by an AI model. Within a single value
   /// of ``Part``, different data types may not mix.
@@ -116,10 +116,10 @@ public struct ModelContent: Equatable {
 
 // MARK: Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ModelContent: Codable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ModelContent.Part: Codable {
   enum CodingKeys: String, CodingKey {
     case text

--- a/FirebaseVertexAI/Sources/PartsRepresentable.swift
+++ b/FirebaseVertexAI/Sources/PartsRepresentable.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// A protocol describing any data that could be serialized to model-interpretable input data,
 /// where the serialization process might fail with an error.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public protocol ThrowingPartsRepresentable {
   func tryPartsValue() throws -> [ModelContent.Part]
 }
@@ -24,12 +24,12 @@ public protocol ThrowingPartsRepresentable {
 /// A protocol describing any data that could be serialized to model-interpretable input data,
 /// where the serialization process cannot fail with an error. For a failable conversion, see
 /// ``ThrowingPartsRepresentable``
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public protocol PartsRepresentable: ThrowingPartsRepresentable {
   var partsValue: [ModelContent.Part] { get }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public extension PartsRepresentable {
   func tryPartsValue() throws -> [ModelContent.Part] {
     return partsValue
@@ -37,7 +37,7 @@ public extension PartsRepresentable {
 }
 
 /// Enables a ``ModelContent.Part`` to be passed in as ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ModelContent.Part: ThrowingPartsRepresentable {
   public typealias ErrorType = Never
   public func tryPartsValue() throws -> [ModelContent.Part] {
@@ -47,7 +47,7 @@ extension ModelContent.Part: ThrowingPartsRepresentable {
 
 /// Enable an `Array` of ``ThrowingPartsRepresentable`` values to be passed in as a single
 /// ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension [ThrowingPartsRepresentable]: ThrowingPartsRepresentable {
   public func tryPartsValue() throws -> [ModelContent.Part] {
     return try compactMap { element in
@@ -58,7 +58,7 @@ extension [ThrowingPartsRepresentable]: ThrowingPartsRepresentable {
 }
 
 /// Enables a `String` to be passed in as ``ThrowingPartsRepresentable``.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension String: PartsRepresentable {
   public var partsValue: [ModelContent.Part] {
     return [.text(self)]

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type defining potentially harmful media categories and their model-assigned ratings. A value
 /// of this type may be assigned to a category for every model-generated response, not just
 /// responses that exceed a certain threshold.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct SafetyRating: Equatable, Hashable {
   /// The category describing the potential harm a piece of content may pose. See
   /// ``SafetySetting/HarmCategory`` for a list of possible values.
@@ -60,7 +60,7 @@ public struct SafetyRating: Equatable, Hashable {
 }
 
 /// Safety feedback for an entire request.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct SafetyFeedback {
   /// Safety rating evaluated from content.
   public let rating: SafetyRating
@@ -77,7 +77,7 @@ public struct SafetyFeedback {
 
 /// A type used to specify a threshold for harmful content, beyond which the model will return a
 /// fallback response instead of generated content.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct SafetySetting {
   /// A type describing safety attributes, which include harmful categories and topics that can
   /// be considered sensitive.
@@ -142,7 +142,7 @@ public struct SafetySetting {
 
 // MARK: - Codable Conformances
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetyRating.HarmProbability: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -157,13 +157,13 @@ extension SafetyRating.HarmProbability: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetyRating: Decodable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetyFeedback: Decodable {}
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetySetting.HarmCategory: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -178,7 +178,7 @@ extension SafetySetting.HarmCategory: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetySetting.BlockThreshold: Codable {
   public init(from decoder: Decoder) throws {
     let value = try decoder.singleValueContainer().decode(String.self)
@@ -193,5 +193,5 @@ extension SafetySetting.BlockThreshold: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetySetting: Codable {}

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -21,7 +21,7 @@ import Foundation
 @_implementationOnly import FirebaseCoreExtension
 
 /// The Vertex AI for Firebase SDK provides access to Gemini models directly from your app.
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public class VertexAI: NSObject {
   // MARK: - Public APIs
 

--- a/FirebaseVertexAI/Sources/VertexAIComponent.swift
+++ b/FirebaseVertexAI/Sources/VertexAIComponent.swift
@@ -20,13 +20,13 @@ import Foundation
 // Avoids exposing internal FirebaseCore APIs to Swift users.
 @_implementationOnly import FirebaseCoreExtension
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 @objc(FIRVertexAIProvider)
 protocol VertexAIProvider {
   @objc func vertexAI(_ location: String) -> VertexAI
 }
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 @objc(FIRVertexAIComponent)
 class VertexAIComponent: NSObject, Library, VertexAIProvider {
   // MARK: - Private Variables

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -16,7 +16,7 @@ import FirebaseCore
 import FirebaseVertexAI
 import XCTest
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class IntegrationTests: XCTestCase {
   // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.
   let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class ChatTests: XCTestCase {
   var urlSession: URLSession!
 
@@ -37,6 +37,11 @@ final class ChatTests: XCTestCase {
       withExtension: "txt"
     ))
 
+    // Skip tests using MockURLProtocol on watchOS; unsupported in watchOS 2 and later, see
+    // https://developer.apple.com/documentation/foundation/urlprotocol for details.
+    guard #unavailable(watchOS 2) else {
+      throw XCTSkip("Custom URL protocols are unsupported in watchOS 2 and later.")
+    }
     MockURLProtocol.requestHandler = { request in
       let response = HTTPURLResponse(
         url: request.url!,

--- a/FirebaseVertexAI/Tests/Unit/Fakes/AuthInteropFake.swift
+++ b/FirebaseVertexAI/Tests/Unit/Fakes/AuthInteropFake.swift
@@ -15,7 +15,7 @@
 import FirebaseAuthInterop
 import Foundation
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class AuthInteropFake: NSObject, AuthInterop {
   let token: String?
   let error: Error?

--- a/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
@@ -16,7 +16,7 @@ import FirebaseVertexAI
 import Foundation
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class GenerationConfigTests: XCTestCase {
   let encoder = JSONEncoder()
 

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class GenerativeModelTests: XCTestCase {
   let testPrompt = "What sorts of questions can I ask you?"
   let safetyRatingsNegligible: [SafetyRating] = [
@@ -1281,6 +1281,11 @@ final class GenerativeModelTests: XCTestCase {
     URLResponse,
     AsyncLineSequence<URL.AsyncBytes>?
   )) {
+    // Skip tests using MockURLProtocol on watchOS; unsupported in watchOS 2 and later, see
+    // https://developer.apple.com/documentation/foundation/urlprotocol for details.
+    guard #unavailable(watchOS 2) else {
+      throw XCTSkip("Custom URL protocols are unsupported in watchOS 2 and later.")
+    }
     return { request in
       // This is *not* an HTTPURLResponse
       let response = URLResponse(
@@ -1302,6 +1307,11 @@ final class GenerativeModelTests: XCTestCase {
     URLResponse,
     AsyncLineSequence<URL.AsyncBytes>?
   )) {
+    // Skip tests using MockURLProtocol on watchOS; unsupported in watchOS 2 and later, see
+    // https://developer.apple.com/documentation/foundation/urlprotocol for details.
+    guard #unavailable(watchOS 2) else {
+      throw XCTSkip("Custom URL protocols are unsupported in watchOS 2 and later.")
+    }
     let fileURL = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: ext))
     return { request in
       let requestURL = try XCTUnwrap(request.url)
@@ -1343,7 +1353,7 @@ private extension URLRequest {
   }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class AppCheckInteropFake: NSObject, AppCheckInterop {
   /// The placeholder token value returned when an error occurs
   static let placeholderTokenValue = "placeholder-token"
@@ -1393,7 +1403,7 @@ class AppCheckInteropFake: NSObject, AppCheckInterop {
 
 struct AppCheckErrorFake: Error {}
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension SafetyRating: Comparable {
   public static func < (lhs: FirebaseVertexAI.SafetyRating,
                         rhs: FirebaseVertexAI.SafetyRating) -> Bool {

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -15,14 +15,20 @@
 import Foundation
 import XCTest
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class MockURLProtocol: URLProtocol {
   static var requestHandler: ((URLRequest) throws -> (
     URLResponse,
     AsyncLineSequence<URL.AsyncBytes>?
   ))?
 
-  override class func canInit(with request: URLRequest) -> Bool { return true }
+  override class func canInit(with request: URLRequest) -> Bool {
+    guard #unavailable(watchOS 2) else {
+      print("MockURLProtocol cannot be used on watchOS.")
+      return false
+    }
+    return true
+  }
 
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { return request }
 

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -23,11 +23,12 @@ class MockURLProtocol: URLProtocol {
   ))?
 
   override class func canInit(with request: URLRequest) -> Bool {
-    guard #unavailable(watchOS 2) else {
+    #if os(watchOS)
       print("MockURLProtocol cannot be used on watchOS.")
       return false
-    }
-    return true
+    #else
+      return true
+    #endif // os(watchOS)
   }
 
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { return request }

--- a/FirebaseVertexAI/Tests/Unit/ModelContentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ModelContentTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseVertexAI
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class ModelContentTests: XCTestCase {
   let encoder = JSONEncoder()
 

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import CoreGraphics
-import CoreImage
 import FirebaseVertexAI
 import XCTest
 #if canImport(UIKit)
@@ -21,57 +20,64 @@ import XCTest
 #elseif canImport(AppKit)
   import AppKit
 #endif
+#if canImport(CoreImage)
+  import CoreImage
+#endif // canImport(CoreImage)
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class PartsRepresentableTests: XCTestCase {
-  func testModelContentFromCGImageIsNotEmpty() throws {
-    // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
-    var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
-    let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
-      let ctx = CGContext(
-        data: ptr.baseAddress,
-        width: 8,
-        height: 8,
-        bitsPerComponent: 8,
-        bytesPerRow: 4 * 8,
-        space: CGColorSpace(name: CGColorSpace.sRGB)!,
-        bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
-          CGImageAlphaInfo.premultipliedFirst.rawValue
-      )!
-      return ctx.makeImage()!
-    }
-    let modelContent = try image.tryPartsValue()
-    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
-  }
-
-  func testModelContentFromCIImageIsNotEmpty() throws {
-    let image = CIImage(color: CIColor.red)
-      .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-    let modelContent = try image.tryPartsValue()
-    XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
-  }
-
-  func testModelContentFromInvalidCIImageThrows() throws {
-    let image = CIImage.empty()
-    do {
-      let _ = try image.tryPartsValue()
-    } catch {
-      guard let imageError = (error as? ImageConversionError) else {
-        XCTFail("Got unexpected error type: \(error)")
-        return
+  #if !os(watchOS)
+    func testModelContentFromCGImageIsNotEmpty() throws {
+      // adapted from https://forums.swift.org/t/creating-a-cgimage-from-color-array/18634/2
+      var srgbArray = [UInt32](repeating: 0xFFFF_FFFF, count: 8 * 8)
+      let image = srgbArray.withUnsafeMutableBytes { ptr -> CGImage in
+        let ctx = CGContext(
+          data: ptr.baseAddress,
+          width: 8,
+          height: 8,
+          bitsPerComponent: 8,
+          bytesPerRow: 4 * 8,
+          space: CGColorSpace(name: CGColorSpace.sRGB)!,
+          bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue +
+            CGImageAlphaInfo.premultipliedFirst.rawValue
+        )!
+        return ctx.makeImage()!
       }
-      switch imageError {
-      case let .couldNotConvertToJPEG(source):
-        // String(describing:) works around a type error.
-        XCTAssertEqual(String(describing: source), String(describing: image))
-        return
-      case _:
-        XCTFail("Expected image conversion error, got \(imageError) instead")
-        return
-      }
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
     }
-    XCTFail("Expected model content from invlaid image to error")
-  }
+  #endif // !os(watchOS)
+
+  #if canImport(CoreImage)
+    func testModelContentFromCIImageIsNotEmpty() throws {
+      let image = CIImage(color: CIColor.red)
+        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
+      let modelContent = try image.tryPartsValue()
+      XCTAssert(modelContent.count > 0, "Expected non-empty model content for CGImage: \(image)")
+    }
+
+    func testModelContentFromInvalidCIImageThrows() throws {
+      let image = CIImage.empty()
+      do {
+        _ = try image.tryPartsValue()
+      } catch {
+        guard let imageError = (error as? ImageConversionError) else {
+          XCTFail("Got unexpected error type: \(error)")
+          return
+        }
+        switch imageError {
+        case let .couldNotConvertToJPEG(source):
+          // String(describing:) works around a type error.
+          XCTAssertEqual(String(describing: source), String(describing: image))
+          return
+        case _:
+          XCTFail("Expected image conversion error, got \(imageError) instead")
+          return
+        }
+      }
+      XCTFail("Expected model content from invlaid image to error")
+    }
+  #endif // canImport(CoreImage)
 
   #if canImport(UIKit) && !os(visionOS) // These tests are stalling in CI on visionOS.
     func testModelContentFromInvalidUIImageThrows() throws {
@@ -97,9 +103,7 @@ final class PartsRepresentableTests: XCTestCase {
     }
 
     func testModelContentFromUIImageIsNotEmpty() throws {
-      let coreImage = CIImage(color: CIColor.red)
-        .cropped(to: CGRect(origin: CGPointZero, size: CGSize(width: 16, height: 16)))
-      let image = UIImage(ciImage: coreImage)
+      let image = try XCTUnwrap(UIImage(systemName: "star.fill"))
       let modelContent = try image.tryPartsValue()
       XCTAssert(modelContent.count > 0, "Expected non-empty model content for UIImage: \(image)")
     }

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -21,7 +21,7 @@ import XCTest
   import UIKit // For UIImage extensions.
 #endif
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class VertexAIAPITests: XCTestCase {
   func codeSamples() async throws {
     let app = FirebaseApp.app()

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -21,7 +21,7 @@ import SharedTestUtilities
 
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class VertexComponentTests: XCTestCase {
   static var app: FirebaseApp!
 


### PR DESCRIPTION
Added support for compiling the Vertex AI SDK on watchOS. Note that the following still applies: https://github.com/firebase/firebase-ios-sdk/blob/901844a9213e241d06315f92d6524d8c695e0dd7/FirebaseVertexAI/Sources/Constants.swift#L17-L19