### PR TITLE
[Messaging] Update CHANGELOG for 10.29 release

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.29.0
 - [fixed] Renamed "initWithFileName" internal method that was causing submission issues for some
   users. (#13134).
 - [fixed] Fixed the APS Environment key on visionOS. (#13173)


### PR DESCRIPTION
Note: This is the only changelog with `Unreleased` entries for the upcoming release.