### PR TITLE
[Vertex AI] Add README for unit test mock files

### DIFF
--- a/FirebaseVertexAI/README.md
+++ b/FirebaseVertexAI/README.md
@@ -6,3 +6,25 @@ ways.
 
 - For developer documentation, please visit https://firebase.google.com/docs/vertex-ai.
 - Try out the [sample app](Sample/README.md) to get started.
+
+## Development
+
+After following the Swift Package Manager
+[setup instructions](https://github.com/firebase/firebase-ios-sdk#swift-package-manager-1),
+choose the `FirebaseVertexAI-Preview` scheme to build the SDK.
+
+### Unit Tests
+
+> [!IMPORTANT]
+> These unit tests require mock response files, which can be downloaded by
+running `scripts/update_vertexai_responses.sh` from the root of this repository.
+
+Choose the `FirebaseVertexAIUnit` scheme to build and run the unit tests.
+
+#### Updating Mock Responses
+
+To update the mock responses, create a PR in the
+[`vertexai-sdk-test-data`](https://github.com/FirebaseExtended/vertexai-sdk-test-data)
+repo. After it is merged, re-run the
+[script](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
+above to download the updated files.

--- a/FirebaseVertexAI/Tests/Unit/README.md
+++ b/FirebaseVertexAI/Tests/Unit/README.md
@@ -1,6 +1,6 @@
 # Vertex AI for Firebase Unit Tests
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > These unit tests require mock response files, which can be downloaded by
 running `scripts/update_vertexai_responses.sh` from the root of this repository.
 

--- a/FirebaseVertexAI/Tests/Unit/README.md
+++ b/FirebaseVertexAI/Tests/Unit/README.md
@@ -1,0 +1,13 @@
+# Vertex AI for Firebase Unit Tests
+
+> [!IMPORTANT]  
+> These unit tests require mock response files, which can be downloaded by
+running `scripts/update_vertexai_responses.sh` from the root of this repository.
+
+## Updating Mock Responses
+
+To update the mock responses, create a PR in the
+[`vertexai-sdk-test-data`](https://github.com/FirebaseExtended/vertexai-sdk-test-data)
+repo. After it is merged, re-run the
+[script](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
+above to download the updated files.

--- a/FirebaseVertexAI/Tests/Unit/README.md
+++ b/FirebaseVertexAI/Tests/Unit/README.md
@@ -1,13 +1,3 @@
-# Vertex AI for Firebase Unit Tests
-
-> [!IMPORTANT]
-> These unit tests require mock response files, which can be downloaded by
-running `scripts/update_vertexai_responses.sh` from the root of this repository.
-
-## Updating Mock Responses
-
-To update the mock responses, create a PR in the
-[`vertexai-sdk-test-data`](https://github.com/FirebaseExtended/vertexai-sdk-test-data)
-repo. After it is merged, re-run the
-[script](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
-above to download the updated files.
+See the Vertex AI for Firebase
+[README](https://github.com/firebase/firebase-ios-sdk/tree/main/FirebaseVertexAI#unit-tests)
+for required setup instructions.

--- a/Package.swift
+++ b/Package.swift
@@ -1379,6 +1379,9 @@ let package = Package(
       path: "FirebaseVertexAI/Tests/Unit",
       resources: [
         .process("vertexai-sdk-test-data/mock-responses"),
+        // Including this README ensures that SPM will always generate a `Bundle.module`, even if
+        // the mock-responses have not been downloaded with the update_vertexai_responses.sh script.
+        .process("README.md"),
       ],
       cSettings: [
         .headerSearchPath("../../../"),

--- a/README.md
+++ b/README.md
@@ -235,8 +235,10 @@ at **Project Settings > Cloud Messaging > [Your Firebase App]**.
 The iOS Simulator cannot register for remote notifications and will not receive push notifications.
 To receive push notifications, follow the steps above and run the app on a physical device.
 
-### Firebase Vertex AI
-The Firebase Vertex AI unit tests require mock response files, which can be downloaded by running `./scripts/update_vertexai_responses.sh`.
+### Vertex AI for Firebase
+
+See the [Vertex AI for Firebase README](FirebaseVertexAI#development) for
+instructions about building and testing the SDK.
 
 ## Building with Firebase on Apple platforms
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -183,6 +183,10 @@ Test QuickStart with the zip distribution.
 
 Script to add a file to an Xcode target.
 
+### [update_vertexai_responses.sh](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
+
+Downloads mock response files for Vertex AI unit tests.
+
 ### [xcresult_logs.py](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/xcresult_logs.py)
 
 Tooling used by `build.sh` to get the log output for an `xcodebuild` invocation.


### PR DESCRIPTION
Added a `README.md` with instructions for running the `update_vertexai_responses.sh` script. This file was also added as a resource in the `FirebaseVertexAIUnit` `testTarget` ensuring that a `Bundle.module` will always be generated by Swift Package Manager. This prevents the following build error if the script has not yet been run:
![Bundle.module Error Screenshot](https://github.com/firebase/firebase-ios-sdk/assets/3010484/2988a89f-df37-4a1f-854b-d17ab9f22d36)

#no-changelog
