### PR TITLE
[Release] Carthage updates for 10.29.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseABTesting-7c24443801777936.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseABTesting-8b2f53436c64a872.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseABTesting-130e2b6d9a63718c.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseABTesting-a8a467b0d6b916f0.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseABTesting-e87c686cee02758a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseABTesting-6a65ab8b888172af.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseABTesting-197f0cb4125363b6.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAdMobBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/Google-Mobile-Ads-SDK-4088408e21a81c67.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/Google-Mobile-Ads-SDK-3a13e621232a5f94.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/Google-Mobile-Ads-SDK-74659cf2b864d68a.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/Google-Mobile-Ads-SDK-48b3c0588ad13719.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/Google-Mobile-Ads-SDK-8b0d1ce3d1162b67.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/Google-Mobile-Ads-SDK-046511c3fd0189eb.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/Google-Mobile-Ads-SDK-50008c143ad8f268.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAnalytics-8af4daf086589ec7.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseAnalytics-974d555fcd032bea.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseAnalytics-b7d18db02bafdf76.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseAnalytics-d5af9229359eb423.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalytics-95669fcf109f74a2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalytics-c0db6cb0e858e397.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalytics-e8ebe991b5743f71.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsOnDeviceConversionBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAnalyticsOnDeviceConversion-3ab4488b5238043b.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseAnalyticsOnDeviceConversion-ed2151b105873898.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseAnalyticsOnDeviceConversion-a668cbfbe931742e.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseAnalyticsOnDeviceConversion-3e91796347772a3e.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAnalyticsOnDeviceConversion-091f5252d693a9f9.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAnalyticsOnDeviceConversion-7bbb73d46383a042.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAnalyticsOnDeviceConversion-eca2f83d40e0278d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAppCheck-81762cfe63fc1817.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseAppCheck-4bade8711d550a40.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseAppCheck-557e75fbadbf73b4.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseAppCheck-d272835be7283780.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppCheck-d19e46a728b1ac4f.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppCheck-8339fde989fe8f24.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppCheck-3ce0f074bfcd2596.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAppDistribution-cd27707b993aae9d.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseAppDistribution-8d5ae519bf3807da.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseAppDistribution-07507e5460ace602.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseAppDistribution-b607905b9635b6ca.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAppDistribution-cefc3327ddfceda6.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAppDistribution-7931e42d39575534.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAppDistribution-79dc2b1348d9aee9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseAuth-a223b8ebda8fd2c2.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseAuth-216efd548d80077e.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseAuth-69251e74656bdaff.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseAuth-97753dfde6cc7096.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseAuth-e43e66353617f093.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseAuth-8a9591e6daa7e207.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseAuth-7e18a510d0a5b02e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseCrashlytics-4035e9332410161e.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseCrashlytics-a17b8ea7cb348df9.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseCrashlytics-fc7d57774a86e67a.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseCrashlytics-f3ab6ae4e85cf2f0.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseCrashlytics-d29d3285a7d9fa1d.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseCrashlytics-165beb64483b4278.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseCrashlytics-53604573442e756b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseDatabase-0ac7f999ddc3f338.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseDatabase-b3a0f37d3bbf9b85.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseDatabase-b6d4193728727fb4.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseDatabase-b2f4220f8302b6d0.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDatabase-5b22f689cb66d83a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDatabase-e1a9d1f0c4222cf7.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDatabase-aea9249d81841ee1.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDynamicLinksBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseDynamicLinks-1c3a48e8f12fc824.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseDynamicLinks-4d0eab3bc03dbfa7.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseDynamicLinks-9f6a1855f6e51747.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseDynamicLinks-cfa82daed8fc241d.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseDynamicLinks-7cf4ae5e96882ca8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseDynamicLinks-c3bdeb37651a5d5d.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseDynamicLinks-bcb5df6ec32f6684.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseFirestore-c5fda3ae8ab62345.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseFirestore-bc3c67a3c464cc42.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseFirestore-37c5641f3cc3dabc.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseFirestore-65b8c0f822b6e7f4.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFirestore-73ba0700b1aa6d6a.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFirestore-02eb8da05f81fca5.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFirestore-46fa68ddf287f76e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseFunctions-c143cedcb64ae0d6.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseFunctions-89f2ce118be4d7c0.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseFunctions-119db44dbfc036ec.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseFunctions-141adee070c3a8b8.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseFunctions-47189f2c99cdf806.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseFunctions-17c4b760141e38ad.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseFunctions-688a38b567392fcf.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/GoogleSignIn-fb2542a2c86f843a.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/GoogleSignIn-3e022a3cbea42c13.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/GoogleSignIn-35b57118942c81f6.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/GoogleSignIn-59ea2c936c9a28d3.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/GoogleSignIn-a5b49807be66100b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/GoogleSignIn-0d2e746eb3ff9f92.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/GoogleSignIn-5cb2a2f1f74efd5e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseInAppMessaging-b90e8ce0168460cd.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseInAppMessaging-ded8d27be0804e67.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseInAppMessaging-1481f107672b9d18.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseInAppMessaging-0c8beb938f99e551.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseInAppMessaging-91e5426eade46bca.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseInAppMessaging-10801bd111df59de.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseInAppMessaging-91d4dd9878a06b7e.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseMLModelDownloader-0373c9fd0cc9bd65.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseMLModelDownloader-d6b2523fc880d0e3.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseMLModelDownloader-fdf89520652f4015.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseMLModelDownloader-404c6b032df7d0a9.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMLModelDownloader-559cb113c0cfd8f2.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMLModelDownloader-9c909894999c92e4.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMLModelDownloader-9abf9b0e24bfb921.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseMessaging-e6c8a212895199fa.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseMessaging-d86ddfbb5cf01c0c.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseMessaging-e9a0de34fb03ce6c.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseMessaging-a7f41b8d94c919e7.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseMessaging-59ef1cc63c660712.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseMessaging-76c02a69e3fe1008.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseMessaging-439a17dcc8b8172b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebasePerformance-bc7b306425147b0a.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebasePerformance-624ad2fbf9ae8d09.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebasePerformance-41280788b8a0b61b.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebasePerformance-edf551fd217188b6.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebasePerformance-36ac6dfb99caa11b.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebasePerformance-f9f5be8ffad5cbb0.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebasePerformance-0ffe559f7554d8a5.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseRemoteConfig-93bad5de6b479bb5.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseRemoteConfig-70f13aecff6c35d7.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseRemoteConfig-bb8658d3f69938cb.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseRemoteConfig-c3eb675725bafdb6.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseRemoteConfig-edd1b427b8bbe782.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseRemoteConfig-10b62ee5663aaab3.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseRemoteConfig-2237eb5fcd4a4525.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -20,6 +20,7 @@
   "10.25.0": "https://dl.google.com/dl/firebase/ios/carthage/10.25.0/FirebaseStorage-472cc5950e16fed9.zip",
   "10.27.0": "https://dl.google.com/dl/firebase/ios/carthage/10.27.0/FirebaseStorage-bc934ea10a13d857.zip",
   "10.28.0": "https://dl.google.com/dl/firebase/ios/carthage/10.28.0/FirebaseStorage-be690a9652c98190.zip",
+  "10.29.0": "https://dl.google.com/dl/firebase/ios/carthage/10.29.0/FirebaseStorage-9ddf5ba251e7dced.zip",
   "10.3.0": "https://dl.google.com/dl/firebase/ios/carthage/10.3.0/FirebaseStorage-ac463d14593d10a8.zip",
   "10.4.0": "https://dl.google.com/dl/firebase/ios/carthage/10.4.0/FirebaseStorage-fdf8479115660ce6.zip",
   "10.5.0": "https://dl.google.com/dl/firebase/ios/carthage/10.5.0/FirebaseStorage-04f255ea8c3a7420.zip",


### PR DESCRIPTION
Updated the Carthage artifacts for the https://github.com/firebase/firebase-ios-sdk/releases/tag/10.29.0. Verified with `carthage update`.

<details>
<summary>Cartfile.resolved</summary>

```
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppDistributionBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDynamicLinksBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseGoogleSignInBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLModelDownloaderBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json" "10.29.0"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json" "10.29.0"
```

</details>

#no-changelog