### PR TITLE
[Messaging] Remove extraneous const on FIRMessagingIsAPNSSyncMessage

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -60,7 +60,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 NSString *const FIRMessagingErrorDomain = @"com.google.fcm";
 
-const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
+BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   if ([message[kFIRMessagingMessageViaAPNSRootKey] isKindOfClass:[NSDictionary class]]) {
     NSDictionary *aps = message[kFIRMessagingMessageViaAPNSRootKey];
     if (aps && [aps isKindOfClass:[NSDictionary class]]) {


### PR DESCRIPTION
Removed an extraneous `const` on the `BOOL` return type of `FIRMessagingIsAPNSSyncMessage(...)` to resolve a warning surfaced with internal tooling:

> return type 'const BOOL' (aka 'const bool') is 'const'-qualified at the top level, which may reduce code readability without improving const correctness
>
> https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html

#no-changelog