### PR TITLE
[Auth] Update unnecessary nullable API

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [added] Introduced the Swift enum `AuthProviderID` for the Auth Provider IDs. (#9236)
 - [deprecated] Swift APIs using `String`-typed `productID`s have been deprecated in favor
   of newly added API that leverages the `AuthProviderID` enum.
+- [fixed] Breaking API: The `email` property in `ActionCodeInfo` is now non-optional.
 
 # 10.21.0
 - [fixed] Fixed multifactor resolver to use the correct Auth instance instead of

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
@@ -21,7 +21,7 @@ import Foundation
 
   /// The email address to which the code was sent. The new email address in the case of
   /// `ActionCodeOperation.recoverEmail`.
-  @objc public let email: String?
+  @objc public let email: String
 
   /// The email that is being recovered in the case of `ActionCodeOperation.recoverEmail`.
   @objc public let previousEmail: String?

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -62,8 +62,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
     let auth = FirebaseAuth.Auth.auth()
     let info = try await auth.checkActionCode("code")
     let _: ActionCodeOperation = info.operation
-    if let _: String = info.email,
-       let _: String = info.previousEmail {}
+    let _: String = info.email
+    if let _: String = info.previousEmail {}
   }
 
   func ActionCodeURL() {


### PR DESCRIPTION
The property definition was inconsistent with the non-nullable initializer parameter.