### PR TITLE
[Auth] Investigate and fix v11 integration test CI failures

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -57,6 +57,9 @@ jobs:
   integration-tests:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        scheme: [ObjCApiTests, SwiftApiTests, AuthenticationExampleUITests]
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -84,14 +87,14 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
           FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
     - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
     - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 120
         max_attempts: 3
         retry_on: error
         retry_wait_seconds: 120
-        command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS)
+        command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
 
   spm:
     # Don't run on private repo unless it is a PR.

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj/project.pbxproj
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj/project.pbxproj
@@ -478,7 +478,6 @@
 				DE8B63702BEC2FB900607B82 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				DE8B63752BEC302200607B82 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
 				DE8B63782BEC342000607B82 /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */,
-				DEE261C32C21E9F500EECAC5 /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */,
 			);
 			productRefGroup = EAE4CBC224855E3A00245E92 /* Products */;
 			projectDirPath = "";
@@ -988,7 +987,7 @@
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 14.1.0;
+				minimumVersion = 17.0.2;
 			};
 		};
 		DE8B63782BEC342000607B82 /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */ = {
@@ -997,14 +996,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 3.4.1;
-			};
-		};
-		DEE261C32C21E9F500EECAC5 /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 18.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1038,11 +1029,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DE8B63782BEC342000607B82 /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */;
 			productName = GTMSessionFetcher;
-		};
-		DEE261C42C21E9F500EECAC5 /* RecaptchaEnterprise */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DEE261C32C21E9F500EECAC5 /* XCRemoteSwiftPackageReference "recaptcha-enterprise-mobile-sdk" */;
-			productName = RecaptchaEnterprise;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExampleUITests/AuthenticationExampleUITests.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExampleUITests/AuthenticationExampleUITests.swift
@@ -229,12 +229,16 @@ class AuthenticationExampleUITests: XCTestCase {
   // MARK: - Private Helpers
 
   private func signOut() {
-    app.tabBars.firstMatch.buttons.element(boundBy: 1).tap()
+    if app.tabBars.firstMatch.buttons.element(boundBy: 1).exists {
+      app.tabBars.firstMatch.buttons.element(boundBy: 1).tap()
+    }
     wait(forElement: app.navigationBars["User"], timeout: 5.0)
     if app.staticTexts["Sign Out"].exists {
       app.staticTexts["Sign Out"].tap()
     }
-    app.tabBars.firstMatch.buttons.element(boundBy: 0).tap()
+    if app.tabBars.firstMatch.buttons.element(boundBy: 0).exists {
+      app.tabBars.firstMatch.buttons.element(boundBy: 0).tap()
+    }
   }
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -300,25 +300,12 @@ case "$product-$platform-$method" in
         build
     ;;
 
-  Auth-*-xcodebuild)
+  Auth-*-*)
     if check_secrets; then
       RunXcodebuild \
         -project 'FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj' \
-        -scheme "ObjCApiTests" \
+        -scheme "$scheme" \
         "${xcb_flags[@]}" \
-        test
-
-      RunXcodebuild \
-        -project 'FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj' \
-        -scheme "SwiftApiTests" \
-        "${xcb_flags[@]}" \
-        test
-
-      RunXcodebuild \
-        -project 'FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj' \
-        -scheme "AuthenticationExampleUITests" \
-        "${xcb_flags[@]}" \
-        build \
         test
     fi
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -304,7 +304,7 @@ case "$product-$platform-$method" in
     if check_secrets; then
       RunXcodebuild \
         -project 'FirebaseAuth/Tests/SampleSwift/AuthenticationExample.xcodeproj' \
-        -scheme "$scheme" \
+        -scheme "$method" \
         "${xcb_flags[@]}" \
         test
     fi


### PR DESCRIPTION
The Auth integration tests were failing to run because of dependencies on old Swift Package binaries. They don't cause a failure to build when using the Xcode UI, but fail with xcodebuild. To resolve, I updated the Facebook SDK version and removed the recaptchaEnterprise dependency. Until Recaptcha resolves, its package should be added for manual testing.

I also separated the three integration tests with a matrix for easier analysis and fixed a regression that happened in the UITests.


#no-changelog