### PR TITLE
[Auth] Compile out deprecated API on CI

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -12,6 +12,9 @@ on:
     # Run every day at 1am (PST) - cron uses UTC times
     - cron:  '0 9 * * *'
 
+env:
+  FIREBASE_CI: true
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
@@ -52,7 +55,7 @@ jobs:
         max_attempts: 3
         retry_on: error
         retry_wait_seconds: 120
-        command: scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.tests }} --allow-warnings
+        command: scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.tests }}
 
   integration-tests:
     # Don't run on private repo unless it is a PR.

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -52,6 +52,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     # The second path is to find FirebaseAuth-Swift.h from a pod gen project
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}" "${OBJECT_FILE_DIR_normal}/${NATIVE_ARCH_ACTUAL}"',
+    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI' : ''}"
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -52,7 +52,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     # The second path is to find FirebaseAuth-Swift.h from a pod gen project
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}" "${OBJECT_FILE_DIR_normal}/${NATIVE_ARCH_ACTUAL}"',
-    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI' : ''}"
+    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI -warnings-as-errors' : ''}"
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -279,11 +279,13 @@ extension Auth: AuthInterop {
   /// - Parameter completion: Optionally; a block which is invoked when the list of sign in methods
   /// for the specified email address is ready or an error was encountered. Invoked asynchronously
   /// on the main thread in the future.
-  @available(
-    *,
-    deprecated,
-    message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
-  )
+  #if !FIREBASE_CI
+    @available(
+      *,
+      deprecated,
+      message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
+    )
+  #endif // !FIREBASE_CI
   @objc open func fetchSignInMethods(forEmail email: String,
                                      completion: (([String]?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -279,13 +279,11 @@ extension Auth: AuthInterop {
   /// - Parameter completion: Optionally; a block which is invoked when the list of sign in methods
   /// for the specified email address is ready or an error was encountered. Invoked asynchronously
   /// on the main thread in the future.
-  #if !FIREBASE_CI
-    @available(
-      *,
-      deprecated,
-      message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
-    )
-  #endif // !FIREBASE_CI
+  @available(
+    *,
+    deprecated,
+    message: "`fetchSignInMethods` is deprecated and will be removed in a future release. This method returns an empty list when Email Enumeration Protection is enabled."
+  )
   @objc open func fetchSignInMethods(forEmail email: String,
                                      completion: (([String]?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -34,11 +34,13 @@ import Foundation
   ///   - providerID: The provider ID of the IDP for which this auth provider instance will be
   /// configured.
   /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `provider(providerID: AuthProviderID) -> OAuthProvider` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `provider(providerID: AuthProviderID) -> OAuthProvider` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(providerWithProviderID:) open class func provider(providerID: String) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: Auth.auth())
   }
@@ -58,11 +60,13 @@ import Foundation
   /// configured.
   ///   - auth: The auth instance to be associated with the OAuthProvider instance.
   /// - Returns: An instance of OAuthProvider corresponding to the specified provider ID.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `provider(providerID: AuthProviderID, auth: Auth) -> OAuthProvider` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `provider(providerID: AuthProviderID, auth: Auth) -> OAuthProvider` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(providerWithProviderID:auth:) open class func provider(providerID: String,
                                                                auth: Auth) -> OAuthProvider {
     return OAuthProvider(providerID: providerID, auth: auth)
@@ -134,11 +138,13 @@ import Foundation
   /// - Parameter accessToken: The access token associated with the Auth credential be created, if
   /// available.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `credential(providerID: AuthProviderID, idToken: String, accessToken: String? = nil) -> OAuthCredential` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `credential(providerID: AuthProviderID, idToken: String, accessToken: String? = nil) -> OAuthCredential` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(credentialWithProviderID:IDToken:accessToken:)
   public static func credential(withProviderID providerID: String,
                                 idToken: String,
@@ -169,11 +175,13 @@ import Foundation
   /// - Parameter accessToken: The access token associated with the Auth credential be created, if
   /// available.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `credential(providerID: AuthProviderID, accessToken: String) -> OAuthCredential` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `credential(providerID: AuthProviderID, accessToken: String) -> OAuthCredential` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(credentialWithProviderID:accessToken:)
   public static func credential(withProviderID providerID: String,
                                 accessToken: String) -> OAuthCredential {
@@ -197,11 +205,13 @@ import Foundation
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
   /// - Parameter accessToken: The access token associated with the Auth credential be created.
   /// - Returns: An AuthCredential for the specified provider ID, ID token and access token.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(credentialWithProviderID:IDToken:rawNonce:accessToken:)
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String,
@@ -220,11 +230,13 @@ import Foundation
   /// - Parameter idToken: The IDToken associated with the Auth credential being created.
   /// - Parameter rawNonce: The raw nonce associated with the Auth credential being created.
   /// - Returns: An AuthCredential.
-  @available(
-    swift,
-    deprecated: 0.01,
-    message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      swift,
+      deprecated: 0.01,
+      message: "Use `credential(providerID: AuthProviderID, idToken: String, rawNonce: String, accessToken: String? = nil) -> OAuthCredential` instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(credentialWithProviderID:IDToken:rawNonce:)
   public static func credential(withProviderID providerID: String, idToken: String,
                                 rawNonce: String) -> OAuthCredential {

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -90,11 +90,13 @@ extension User: NSSecureCoding {}
   /// - Parameter email: The email address for the user.
   /// - Parameter completion: Optionally; the block invoked when the user profile change has
   /// finished.
-  @available(
-    *,
-    deprecated,
-    message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      *,
+      deprecated,
+      message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
+    )
+  #endif // !FIREBASE_CI
   @objc(updateEmail:completion:)
   open func updateEmail(to email: String, completion: ((Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
@@ -130,11 +132,13 @@ extension User: NSSecureCoding {}
   ///  the user has not signed in recently enough. To resolve, reauthenticate the user by
   ///  calling `reauthenticate(with:)`.
   /// - Parameter email: The email address for the user.
-  @available(
-    *,
-    deprecated,
-    message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
-  )
+  #if !FIREBASE_CI
+    @available(
+      *,
+      deprecated,
+      message: "`updateEmail` is deprecated and will be removed in a future release. Use sendEmailVerification(beforeUpdatingEmail:) instead."
+    )
+  #endif // !FIREBASE_CI
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   open func updateEmail(to email: String) async throws {
     return try await withCheckedThrowingContinuation { continuation in

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -684,8 +684,7 @@ case "$product-$platform-$method" in
       "${xcb_flags[@]}" \
       IPHONEOS_DEPLOYMENT_TARGET=13.0 \
       TVOS_DEPLOYMENT_TARGET=13.0 \
-      ${FIREBASE_CI:+OTHER_SWIFT_FLAGS="\$(inherited) -D FIREBASE_CI"} \
-      SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       test
     ;;
 
@@ -693,8 +692,7 @@ case "$product-$platform-$method" in
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
-      ${FIREBASE_CI:+OTHER_SWIFT_FLAGS="\$(inherited) -D FIREBASE_CI"} \
-      SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       build
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -684,7 +684,6 @@ case "$product-$platform-$method" in
       "${xcb_flags[@]}" \
       IPHONEOS_DEPLOYMENT_TARGET=13.0 \
       TVOS_DEPLOYMENT_TARGET=13.0 \
-      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       test
     ;;
 
@@ -692,7 +691,6 @@ case "$product-$platform-$method" in
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
-      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       build
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -684,6 +684,7 @@ case "$product-$platform-$method" in
       "${xcb_flags[@]}" \
       IPHONEOS_DEPLOYMENT_TARGET=13.0 \
       TVOS_DEPLOYMENT_TARGET=13.0 \
+      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       test
     ;;
 
@@ -691,6 +692,7 @@ case "$product-$platform-$method" in
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
+      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
       build
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -684,7 +684,8 @@ case "$product-$platform-$method" in
       "${xcb_flags[@]}" \
       IPHONEOS_DEPLOYMENT_TARGET=13.0 \
       TVOS_DEPLOYMENT_TARGET=13.0 \
-      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
+      ${FIREBASE_CI:+OTHER_SWIFT_FLAGS="\$(inherited) -D FIREBASE_CI"} \
+      SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
       test
     ;;
 
@@ -692,7 +693,8 @@ case "$product-$platform-$method" in
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
-      "${FIREBASE_CI:+SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) FIREBASE_CI" SWIFT_TREAT_WARNINGS_AS_ERRORS=YES}" \
+      ${FIREBASE_CI:+OTHER_SWIFT_FLAGS="\$(inherited) -D FIREBASE_CI"} \
+      SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
       build
     ;;
 


### PR DESCRIPTION
Demonstrates how to disable deprecation warnings when linting pods on CI.

#no-changelog

(reverted for now) commit needed to apply to spm: https://github.com/firebase/firebase-ios-sdk/pull/13264/commits/01febc66e5b4c488d160f61b42fa6ff02edf671f