### PR TITLE
Clean up PThread attributes when it fails to be created

### DIFF
--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -108,11 +108,13 @@ static bool FIRCLSMachExceptionThreadStart(FIRCLSMachExceptionReadContext* conte
 
   if (pthread_attr_init(&attr) != 0) {
     FIRCLSSDKLog("pthread_attr_init %s\n", strerror(errno));
+    pthread_attr_destroy(&attr);
     return false;
   }
 
   if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0) {
     FIRCLSSDKLog("pthread_attr_setdetachstate %s\n", strerror(errno));
+    pthread_attr_destroy(&attr);
     return false;
   }
 
@@ -121,11 +123,13 @@ static bool FIRCLSMachExceptionThreadStart(FIRCLSMachExceptionReadContext* conte
   if (pthread_attr_setstack(&attr, _firclsContext.readonly->machStack,
                             CLS_MACH_EXCEPTION_HANDLER_STACK_SIZE) != 0) {
     FIRCLSSDKLog("pthread_attr_setstack %s\n", strerror(errno));
+    pthread_attr_destroy(&attr);
     return false;
   }
 
   if (pthread_create(&context->thread, &attr, FIRCLSMachExceptionServer, context) != 0) {
     FIRCLSSDKLog("pthread_create %s\n", strerror(errno));
+    pthread_attr_destroy(&attr);
     return false;
   }
 


### PR DESCRIPTION
PThread attributes should be destroyed in failure and success cases.

#no-changelog
