### PR TITLE
[Config] Wait for installations token before starting realtime connection

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -310,7 +310,8 @@ static NSInteger const gMaxRetries = 7;
 
     if (![strongSelf->_settings.configInstallationsIdentifier length]) {
       FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013",
-                  @"Realtime connection will not include valid installations token.");
+                  @"Installation token retrieval failed. Realtime connection will not include "
+                  @"valid installations token.");
     }
 
     [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -309,7 +309,8 @@ static NSInteger const gMaxRetries = 7;
     if (!strongSelf) return;
 
     if (![strongSelf->_settings.configInstallationsIdentifier length]) {
-      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013", @"Realtime connection will not include valid installations token.");
+      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013",
+                  @"Realtime connection will not include valid installations token.");
     }
 
     [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -331,32 +331,6 @@ static NSInteger const gMaxRetries = 7;
   }];
 }
 
-- (NSData *)createRequestBody {
-  [self refreshInstallationsTokenWithCompletionHandler:^(FIRRemoteConfigFetchStatus status,
-                                                         NSError *_Nullable error) {
-    if (status != FIRRemoteConfigFetchStatusSuccess) {
-      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013", @"Installation token retrival failed.");
-    }
-  }];
-
-  [_request setValue:_settings.configInstallationsToken
-      forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
-  if (_settings.lastETag) {
-    [_request setValue:_settings.lastETag forHTTPHeaderField:kIfNoneMatchETagHeaderName];
-  }
-
-  NSString *namespace = [_namespace substringToIndex:[_namespace rangeOfString:@":"].location];
-  NSString *postBody = [NSString
-      stringWithFormat:@"{project:'%@', namespace:'%@', lastKnownVersionNumber:'%@', appId:'%@', "
-                       @"sdkVersion:'%@', appInstanceId:'%@'}",
-                       [self->_options GCMSenderID], namespace, _configFetch.templateVersionNumber,
-                       _options.googleAppID, FIRRemoteConfigPodVersion(),
-                       _settings.configInstallationsIdentifier];
-  NSData *postData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
-  NSError *compressionError;
-  return [NSData gul_dataByGzippingData:postData error:&compressionError];
-}
-
 /// Creates request.
 - (void)setUpHttpRequest {
   NSString *address = [self constructServerURL];

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -314,6 +314,8 @@ static NSInteger const gMaxRetries = 7;
                   @"valid installations token.");
     }
 
+    // strongSelf->_settings.configInstallationsToken = nil;
+    // strongSelf->_settings.configInstallationsIdentifier = nil;
     [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken
               forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
     if (strongSelf->_settings.lastETag) {
@@ -669,12 +671,12 @@ static NSInteger const gMaxRetries = 7;
   dispatch_async(_realtimeLockQueue, ^{
     __strong __typeof(self) strongSelf = weakSelf;
 
-    if (self->_settings.getRealtimeBackoffInterval > 0) {
-      [self retryHTTPConnection];
+    if (strongSelf->_settings.getRealtimeBackoffInterval > 0) {
+      [strongSelf retryHTTPConnection];
       return;
     }
 
-    if ([self canMakeConnection]) {
+    if ([strongSelf canMakeConnection]) {
       __weak __typeof(self) weakSelf = strongSelf;
       [strongSelf createRequestBodyWithCompletion:^(NSData *_Nonnull requestBody) {
         __strong __typeof(self) strongSelf = weakSelf;

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -290,6 +290,9 @@ static NSInteger const gMaxRetries = 7;
 
         FIRLogInfo(kFIRLoggerRemoteConfig, @"I-RCN000022", @"Success to get iid : %@.",
                    strongSelfQueue->_settings.configInstallationsIdentifier);
+        return [strongSelfQueue reportCompletionOnHandler:completionHandler
+                                               withStatus:FIRRemoteConfigFetchStatusNoFetchYet
+                                                withError:nil];
       });
     }];
   };
@@ -302,13 +305,13 @@ static NSInteger const gMaxRetries = 7;
   __weak __typeof(self) weakSelf = self;
   [self refreshInstallationsTokenWithCompletionHandler:^(FIRRemoteConfigFetchStatus status,
                                                          NSError *_Nullable error) {
-    if (status != FIRRemoteConfigFetchStatusSuccess) {
-      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013", @"Installation token retrieval failed.");
-    }
-
     __strong __typeof(self) strongSelf = weakSelf;
     if (!strongSelf) return;
-    // Note that token may still be nil if installations refresh failed.
+
+    if (![strongSelf->_settings.configInstallationsIdentifier length]) {
+      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013", @"Realtime connection will not include valid installations token.");
+    }
+
     [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken
               forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
     if (strongSelf->_settings.lastETag) {

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -314,8 +314,6 @@ static NSInteger const gMaxRetries = 7;
                   @"valid installations token.");
     }
 
-    // strongSelf->_settings.configInstallationsToken = nil;
-    // strongSelf->_settings.configInstallationsIdentifier = nil;
     [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken
               forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
     if (strongSelf->_settings.lastETag) {

--- a/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m
@@ -298,6 +298,39 @@ static NSInteger const gMaxRetries = 7;
   [installations authTokenWithCompletion:installationsTokenHandler];
 }
 
+- (void)createRequestBodyWithCompletion:(void (^)(NSData *_Nonnull requestBody))completion {
+  __weak __typeof(self) weakSelf = self;
+  [self refreshInstallationsTokenWithCompletionHandler:^(FIRRemoteConfigFetchStatus status,
+                                                         NSError *_Nullable error) {
+    if (status != FIRRemoteConfigFetchStatusSuccess) {
+      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000013", @"Installation token retrieval failed.");
+    }
+
+    __strong __typeof(self) strongSelf = weakSelf;
+    if (!strongSelf) return;
+    // Note that token may still be nil if installations refresh failed.
+    [strongSelf.request setValue:strongSelf->_settings.configInstallationsToken
+              forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
+    if (strongSelf->_settings.lastETag) {
+      [strongSelf.request setValue:strongSelf->_settings.lastETag
+                forHTTPHeaderField:kIfNoneMatchETagHeaderName];
+    }
+
+    NSString *namespace = [strongSelf->_namespace
+        substringToIndex:[strongSelf->_namespace rangeOfString:@":"].location];
+    NSString *postBody = [NSString
+        stringWithFormat:@"{project:'%@', namespace:'%@', lastKnownVersionNumber:'%@', appId:'%@', "
+                         @"sdkVersion:'%@', appInstanceId:'%@'}",
+                         [strongSelf->_options GCMSenderID], namespace,
+                         strongSelf->_configFetch.templateVersionNumber,
+                         strongSelf->_options.googleAppID, FIRRemoteConfigPodVersion(),
+                         strongSelf->_settings.configInstallationsIdentifier];
+    NSData *postData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *compressionError;
+    completion([NSData gul_dataByGzippingData:postData error:&compressionError]);
+  }];
+}
+
 - (NSData *)createRequestBody {
   [self refreshInstallationsTokenWithCompletionHandler:^(FIRRemoteConfigFetchStatus status,
                                                          NSError *_Nullable error) {
@@ -353,20 +386,24 @@ static NSInteger const gMaxRetries = 7;
 
 #pragma mark - Retry Helpers
 
+- (BOOL)canMakeConnection {
+  BOOL noRunningConnection =
+      self->_dataTask == nil || self->_dataTask.state != NSURLSessionTaskStateRunning;
+  BOOL canMakeConnection = noRunningConnection && [self->_listeners count] > 0 &&
+                           !self->_isInBackground && !self->_isRealtimeDisabled;
+  return canMakeConnection;
+}
+
 // Retry mechanism for HTTP connections
 - (void)retryHTTPConnection {
   __weak RCNConfigRealtime *weakSelf = self;
   dispatch_async(_realtimeLockQueue, ^{
     __strong RCNConfigRealtime *strongSelf = weakSelf;
-    if (strongSelf->_isInBackground) {
+    if (!strongSelf || strongSelf->_isInBackground) {
       return;
     }
 
-    bool noRunningConnection =
-        strongSelf->_dataTask == nil || strongSelf->_dataTask.state != NSURLSessionTaskStateRunning;
-    bool canMakeConnection = noRunningConnection && [strongSelf->_listeners count] > 0 &&
-                             !strongSelf->_isRealtimeDisabled;
-    if (canMakeConnection && strongSelf->_remainingRetryCount > 0) {
+    if ([strongSelf canMakeConnection] && strongSelf->_remainingRetryCount > 0) {
       NSTimeInterval backOffInterval = self->_settings.getRealtimeBackoffInterval;
 
       strongSelf->_remainingRetryCount--;
@@ -649,25 +686,25 @@ static NSInteger const gMaxRetries = 7;
 #pragma mark - Top level methods
 
 - (void)beginRealtimeStream {
-  __weak RCNConfigRealtime *weakSelf = self;
+  __weak __typeof(self) weakSelf = self;
   dispatch_async(_realtimeLockQueue, ^{
-    __strong RCNConfigRealtime *strongSelf = weakSelf;
-    bool noRunningConnection =
-        strongSelf->_dataTask == nil || strongSelf->_dataTask.state != NSURLSessionTaskStateRunning;
-    bool canMakeConnection = noRunningConnection && [strongSelf->_listeners count] > 0 &&
-                             !strongSelf->_isInBackground && !strongSelf->_isRealtimeDisabled;
+    __strong __typeof(self) strongSelf = weakSelf;
 
     if (self->_settings.getRealtimeBackoffInterval > 0) {
       [self retryHTTPConnection];
       return;
     }
 
-    if (canMakeConnection) {
-      strongSelf->_isRequestInProgress = true;
-      NSData *compressedContent = [strongSelf createRequestBody];
-      [strongSelf->_request setHTTPBody:compressedContent];
-      strongSelf->_dataTask = [strongSelf->_session dataTaskWithRequest:strongSelf->_request];
-      [strongSelf->_dataTask resume];
+    if ([self canMakeConnection]) {
+      __weak __typeof(self) weakSelf = strongSelf;
+      [strongSelf createRequestBodyWithCompletion:^(NSData *_Nonnull requestBody) {
+        __strong __typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        strongSelf->_isRequestInProgress = true;
+        [strongSelf->_request setHTTPBody:requestBody];
+        strongSelf->_dataTask = [strongSelf->_session dataTaskWithRequest:strongSelf->_request];
+        [strongSelf->_dataTask resume];
+      }];
     }
   });
 }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -76,7 +76,7 @@
 - (void)autoFetch:(NSInteger)remainingAttempts targetVersion:(NSInteger)targetVersion;
 - (void)beginRealtimeStream;
 - (void)pauseRealtimeStream;
-- (NSData *)createRequestBody;
+- (void)createRequestBodyWithCompletion:(void (^)(NSData *_Nonnull requestBody))completion;
 
 - (FIRConfigUpdateListenerRegistration *_Nonnull)addConfigUpdateListener:
     (RCNConfigUpdateCompletion _Nonnull)listener;
@@ -1786,8 +1786,14 @@ static NSString *UTCToLocal(NSString *utcTime) {
 }
 
 - (void)testRealtimeStreamRequestBody {
+  XCTestExpectation *requestBodyExpectation = [self expectationWithDescription:@"requestBody"];
+  __block NSData *requestBody;
+  [_configRealtime[0] createRequestBodyWithCompletion:^(NSData *_Nonnull data) {
+    requestBody = data;
+    [requestBodyExpectation fulfill];
+  }];
+  [self waitForExpectations:@[ requestBodyExpectation ] timeout:5.0];
   NSError *error;
-  NSData *requestBody = [_configRealtime[0] createRequestBody];
   NSData *uncompressedRequest = [NSData gul_dataByInflatingGzippedData:requestBody error:&error];
   NSString *strData = [[NSString alloc] initWithData:uncompressedRequest
                                             encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
When constructing the request payload for the realtime connection, a FIS token is requested for including in the payload. Previously, the payload construction did not wait for the FIS token request as it was async. I'm unsure if it was intentional or not, but it opened it up to a race condition where the async FIS token request may write to ivars that collide with reads to ivars during request payload construction. 

There's an existing comment indicating that the realtime request _needs_ a FIS token. In experiments thought where I hardcoded the FIS token to nil, I was still able to successfully fetch so that's a bit confusing. The wait for the installations token should be short in practice and it may set the realtime request up for success to have it.

This may address #13193 (I was not able to reproduce it).