### PR TITLE
[GoogleUtilitiesComponents] Major version update

### DIFF
--- a/.github/workflows/google-utilities-components.yml
+++ b/.github/workflows/google-utilities-components.yml
@@ -23,7 +23,10 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        flags: [
+          '',
+          '--use-static-frameworks'
+        ]
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
@@ -31,43 +34,4 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Build and test
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleUtilitiesComponents.podspec \
-          --platforms=${{ matrix.target }}
-
-  catalyst:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-    runs-on: macos-14
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Setup project and Build for Catalyst
-      run: scripts/test_catalyst.sh GoogleUtilitiesComponents test GoogleUtilitiesComponents-Unit-unit
-
-  utilities-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-
-    runs-on: macos-14
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod-lib-lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint GoogleUtilitiesComponents Cron
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
-          GoogleUtilitiesComponents.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleUtilitiesComponents.podspec ${{ matrix.flags }}

--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilitiesComponents'
-  s.version          = '1.1.0'
+  s.version          = '2.0.0'
   s.summary          = 'Google Utilities Component Container for Apple platforms.'
 
   s.description      = <<-DESC
@@ -18,9 +18,7 @@ Not intended for direct public usage.
     :tag => 'UtilitiesComponents-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '12.0'
+  s.ios.deployment_target = '12.0'
 
   s.cocoapods_version = '>= 1.12.0'
   s.prefix_header_file = false
@@ -29,7 +27,7 @@ Not intended for direct public usage.
   s.source_files = 'GoogleUtilitiesComponents/Sources/**/*.[mh]'
   s.public_header_files = 'GoogleUtilitiesComponents/Sources/Public/*.h', 'GoogleUtilitiesComponents/Sources/Private/*.h'
   s.private_header_files = 'GoogleUtilitiesComponents/Sources/Private/*.h'
-  s.dependency 'GoogleUtilities/Logger'
+  s.dependency 'GoogleUtilities/Logger', "~> 8.0"
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/GoogleUtilitiesComponents/Sources/GULCCComponentContainer.m
+++ b/GoogleUtilitiesComponents/Sources/GULCCComponentContainer.m
@@ -21,7 +21,8 @@
 
 #import <GoogleUtilities/GULLogger.h>
 
-static GULLoggerService kGULComponentContainer = @"[GoogleUtilitiesComponents]";
+static NSString *kGULComponentSubsystem = @"com.google.googleutilitiescomponents";
+static NSString *kGULComponentContainer = @"[GoogleUtilitiesComponents]";
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -93,9 +94,9 @@ static NSMutableSet<Class> *sGULComponentRegistrants;
       // Check if the component has been registered before, and error out if so.
       NSString *protocolName = NSStringFromProtocol(component.protocol);
       if (self.components[protocolName]) {
-        GULLogError(kGULComponentContainer, NO, @"I-COM000001",
-                    @"Attempted to register protocol %@, but it already has an implementation.",
-                    protocolName);
+        GULOSLogError(kGULComponentSubsystem, kGULComponentContainer, NO, @"I-COM000001",
+                      @"Attempted to register protocol %@, but it already has an implementation.",
+                      protocolName);
         continue;
       }
 
@@ -152,10 +153,10 @@ static NSMutableSet<Class> *sGULComponentRegistrants;
   // An instance was created, validate that it conforms to the protocol it claims to.
   NSString *protocolName = NSStringFromProtocol(protocol);
   if (![instance conformsToProtocol:protocol]) {
-    GULLogError(kGULComponentContainer, NO, @"I-COM000002",
-                @"An instance conforming to %@ was requested, but the instance provided does not "
-                @"conform to the protocol",
-                protocolName);
+    GULOSLogError(kGULComponentSubsystem, kGULComponentContainer, NO, @"I-COM000002",
+                  @"An instance conforming to %@ was requested, but the instance provided does not "
+                  @"conform to the protocol",
+                  protocolName);
   }
 
   // The instance is ready to be returned, but check if it should be cached first before returning.


### PR DESCRIPTION
- Update GoogleUtilitiesComponent for a breaking change to its internal dependency - GoogleUtilities.
- Drop osx and tvos support since its only client, MLKit, is iOS only
- Bump minimum iOS version to 12 
- Specify version for GoogleUtilities dependencies

**NOTE:** Clients still using the GoogleUtilitiesComponents 1.x may need to add `pod GoogleUtilities/Logger', "~> 7.13"` to their Podfiles.