### PR TITLE
[auth] Fix getIDToken API and an error handling case

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/UserActions.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/UserActions.swift
@@ -18,6 +18,7 @@ enum UserAction: String {
   case link = "Link/Unlink Auth Providers"
   case requestVerifyEmail = "Request Verify Email"
   case tokenRefresh = "Token Refresh"
+  case tokenRefreshAsync = "Token Refresh Async"
   case delete = "Delete"
   case updateEmail = "Email"
   case updatePhotoURL = "Photo URL"

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
@@ -54,6 +54,7 @@ extension User: DataSourceProvidable {
       Item(title: UserAction.requestVerifyEmail.rawValue, textColor: .systemBlue),
       Item(title: UserAction.updatePassword.rawValue, textColor: .systemBlue),
       Item(title: UserAction.tokenRefresh.rawValue, textColor: .systemBlue),
+      Item(title: UserAction.tokenRefreshAsync.rawValue, textColor: .systemBlue),
       Item(title: UserAction.delete.rawValue, textColor: .systemRed),
     ]
     return Section(headerDescription: "Actions", items: actionsRows)

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/UserViewController.swift
@@ -86,6 +86,9 @@ class UserViewController: UIViewController, DataSourceProviderDelegate {
     case .tokenRefresh:
       refreshCurrentUserIDToken()
 
+    case .tokenRefreshAsync:
+      refreshCurrentUserIDTokenAsync()
+
     case .delete:
       deleteCurrentUser()
 
@@ -139,6 +142,17 @@ class UserViewController: UIViewController, DataSourceProviderDelegate {
       guard error == nil else { return self.displayError(error) }
       if let token = token {
         print("New token: \(token)")
+      }
+    }
+  }
+
+  public func refreshCurrentUserIDTokenAsync() {
+    Task {
+      do {
+        let token = try await user!.idTokenForcingRefresh(true)
+        print("New token: \(token)")
+      } catch {
+        self.displayError(error)
       }
     }
   }


### PR DESCRIPTION
- Add a missing API - Firebase 10 was missing an `NS_SWIFT_NAME` on one of the getIDToken APIs, leading to an inconsistent API set.
- Fix an error handling case that could crash in Firebase 10 and wasn't ported correctly in Firebase 11
- Update the sample app to make it easier to test the async getIDToken APIs

Details below:

Firebase 10 APIs
![Screenshot 2024-07-14 at 9 51 06 AM](https://github.com/user-attachments/assets/4bf26571-1c4d-4eb2-864b-242df61366f3)

Firebase 11 APIs after this PR
![Screenshot 2024-07-14 at 10 41 15 AM](https://github.com/user-attachments/assets/7c26b198-826e-4a3f-84c2-d87720e29659)

In Firebase 10 it was possible for the completion handler to return both a nil tokenResult and error, when `tokenResultWithToken:token` errored.  In Firebase 11, the JWT error detection wasn't yet implemented. That is now fixed.
<img width="892" alt="Screenshot 2024-07-14 at 10 58 45 AM" src="https://github.com/user-attachments/assets/1a7641fa-7bb1-4341-b2eb-719d33bbbb80">
