### PR TITLE
Fix typo in some method documentations, md files and local variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ To learn more about running tests with Swift Package Manager, visit the
 [Testing](#testing) section.
 
 <!-- SwiftPM troubleshooting -->
-<!-- TODO: Common issues and fixes like resolve depencies & reset cache. -->
+<!-- TODO: Common issues and fixes like resolve dependencies & reset cache. -->
 
 #### **[CocoaPods]**
 
@@ -425,7 +425,7 @@ following criteria:
 2. The committed code has been styled in accordance with this repo's style
    guidelines.
 3. A CHANGELOG has been updated to reflect the PR's associated changes.
-4. Unit and/or integration tests have been added or updatd to test and
+4. Unit and/or integration tests have been added or updatde to test and
    validate the contribution's changes.
 5. Refer to the
    [Contributor License Agreement](#contributor-license-agreement) section below

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -177,7 +177,7 @@ Refer to the [README.md](https://github.com/firebase/firebase-ios-sdk/blob/main/
 
 # 1.3.1
 - [added] Adds FIRLogger support (not public-facing)
-- [fixed] Fixes IPv6 compatibilty issues
+- [fixed] Fixes IPv6 compatibility issues
 
 # 1.3.0
 - [changed] Removes the SFSafariViewController per Apple's Review Guidelines

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -184,7 +184,7 @@ Refer to the [README.md](https://github.com/firebase/firebase-ios-sdk/blob/main/
 - [changed] Removes dependency on the Core Location framework
 
 # 1.2.0
-- [added] iOS 10 Supoort
+- [added] iOS 10 Support
 
 # 1.1.1
 - [fixed] Fixes an issue where if resolveLink() API returned a non-JSON object, it

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -1774,8 +1774,8 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 - (void)removeAllFIRApps {
   NSDictionary *apps = [FIRApp allApps];
   for (FIRApp *app in apps.allValues) {
-    [app deleteApp:^(BOOL succes) {
-      if (!succes) {
+    [app deleteApp:^(BOOL success) {
+      if (!success) {
         NSLog(@"Error deleting FIRApp before tests - config tests may fail.");
       }
     }];

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -106,7 +106,7 @@ app update.
                               'FirebaseRemoteConfig/Tests/Swift/ObjC/*.[hm]',
                              ]
     # Excludes tests that cannot be include in API tests because it requires fetch remote values from
-    # a real console but only one test can be run without poluting other tests' remote values.
+    # a real console but only one test can be run without polluting other tests' remote values.
     swift_api.exclude_files = ['FirebaseRemoteConfig/Tests/Swift/SwiftAPI/PropertyWrapperTests.swift']
     swift_api.resources = 'FirebaseRemoteConfig/Tests/Swift/Defaults-testInfo.plist'
     swift_api.requires_app_host = true

--- a/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
@@ -132,7 +132,7 @@ NS_SWIFT_NAME(MemoryCacheSettings)
 
 /**
  * Creates an instance of `MemoryCacheSettings` with given `MemoryGarbageCollectorSettings` to
- * custom the gabarge collector.
+ * custom the garbage collector.
  */
 - (instancetype)initWithGarbageCollectorSettings:
     (id<FIRMemoryGarbageCollectorSettings, NSObject>)settings;

--- a/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
@@ -44,7 +44,7 @@ NS_SWIFT_NAME(PersistentCacheSettings)
 /**
  * Creates `PersistentCacheSettings` with default cache size: 100MB.
  *
- * The cache size is not a hard limit, but a target for the SDK's gabarge collector to work towards.
+ * The cache size is not a hard limit, but a target for the SDK's garbage collector to work towards.
  */
 - (instancetype)init;
 

--- a/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRLocalCacheSettings.h
@@ -51,7 +51,7 @@ NS_SWIFT_NAME(PersistentCacheSettings)
 /**
  * Creates `PersistentCacheSettings` with a custom cache size in bytes.
  *
- * The cache size is not a hard limit, but a target for the SDK's gabarge collector to work towards.
+ * The cache size is not a hard limit, but a target for the SDK's garbage collector to work towards.
  */
 - (instancetype)initWithSizeBytes:(NSNumber *)size;
 

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -9,7 +9,7 @@
 ## Limitations
 
 - Product availability varies by platform. See [the chart on this page](https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform)
-  for information on product availabilty for each platform.
+  for information on product availability for each platform.
 
 ## Installation
 


### PR DESCRIPTION
 - Corrected typos primarily found in comments and non-compiling sections of the project.
 - Ensured all changes were fully backward-compatible, with no breaking changes introduced.
 - Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).

Please review the changes and let me know if this process is acceptable so that I can continue cleaning up the files incrementally, making this awesome SDK even more perfect.

Thank you