### PR TITLE
[Infra] Use full paths when importing public Core header

### DIFF
--- a/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
@@ -20,7 +20,7 @@
 #import <FirebaseFirestore/FIRGeoPoint.h>
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 #import "Firestore/Source/API/converters.h"

--- a/Firestore/Example/Tests/Integration/API/FIRCompositeIndexQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCompositeIndexQueryTests.mm
@@ -16,7 +16,7 @@
 
 #import <FirebaseFirestore/FirebaseFirestore.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 

--- a/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
@@ -18,7 +18,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -21,7 +21,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 #import "Firestore/Example/Tests/Util/FSTEventAccumulator.h"

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -18,7 +18,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 

--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
@@ -18,7 +18,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTEventAccumulator.h"
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"

--- a/Firestore/Example/Tests/Integration/API/FIRTypeTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRTypeTests.mm
@@ -18,7 +18,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 

--- a/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
@@ -21,7 +21,7 @@
 #include <memory>
 #include <vector>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FSTUserDataReader.h"

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #include "Firestore/core/src/util/warnings.h"
 

--- a/Firestore/Source/API/FSTUserDataReader.mm
+++ b/Firestore/Source/API/FSTUserDataReader.mm
@@ -23,7 +23,7 @@
 #include <vector>
 
 #import "FIRGeoPoint.h"
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FIRFieldPath+Internal.h"

--- a/Firestore/Source/API/converters.mm
+++ b/Firestore/Source/API/converters.mm
@@ -19,7 +19,7 @@
 #include <utility>
 
 #import "FIRGeoPoint.h"
-#import "FirebaseCore/FIRTimestamp.h"
+#import "FirebaseCore/Sources/Public/FirebaseCore/FIRTimestamp.h"
 
 #include "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #include "Firestore/core/include/firebase/firestore/geo_point.h"


### PR DESCRIPTION
At HEAD, I'm getting:
```
% pod repo push --skip-tests --use-json  staging FirebaseFirestoreInternal.podspec --sources=git@github.com:firebase/SpecsStaging.git,https://cdn.cocoapods.org

Validating spec
 -> FirebaseFirestoreInternal (11.0.0)
    - WARN  | compiler_flags: Warnings must not be disabled(`-Wno compiler` flags).
    - ERROR | xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Building targets in dependency order
    - NOTE  | xcodebuild:  note: Target dependency graph (24 targets)
    - NOTE  | xcodebuild:  ld: warning: ignoring duplicate libraries: '-lc++'
    - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'FirebaseCoreInternal' from project 'Pods')
    - WARN  | xcodebuild:  FirebaseFirestoreInternal/Firestore/core/src/local/local_store.cc:589:24: warning: implicit conversion loses integer precision: 'typename std::enable_if<!std::is_same<void, decltype(block())>::value, decltype(block())>::type' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
    - NOTE  | xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: fatal error: 'FirebaseCore/FIRTimestamp.h' file not found
    - NOTE  | [iOS] xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: note: did not find header 'FIRTimestamp.h' in framework 'FirebaseCore' (loaded from '/Users/nickcooke/Library/Developer/Xcode/DerivedData/App-bwwbjhqkfyrjpicwznzbmqpkvyts/Build/Products/Release-iphonesimulator/FirebaseCore')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'leveldb-library' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'gRPC-Core-grpc' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'leveldb-library-leveldb_Privacy' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'gRPC-Core' from project 'Pods')
    - NOTE  | xcodebuild:  warning: Run script build phase 'Create Symlinks to Header Folders' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'gRPC-Core' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'gRPC-C++-grpcpp' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'gRPC-C++-gRPCCertificates-Cpp' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'gRPC-C++' from project 'Pods')
    - NOTE  | xcodebuild:  warning: Run script build phase 'Create Symlinks to Header Folders' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'gRPC-C++' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'abseil-xcprivacy' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'abseil' from project 'Pods')
    - NOTE  | xcodebuild:  warning: Run script build phase 'Create Symlinks to Header Folders' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'abseil' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'BoringSSL-GRPC-openssl_grpc' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'BoringSSL-GRPC' from project 'Pods')
    - NOTE  | xcodebuild:  warning: Run script build phase 'Create Symlinks to Header Folders' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'BoringSSL-GRPC' from project 'Pods')
    - NOTE  | xcodebuild:  note: Using codesigning identity override: 
    - NOTE  | [OSX] xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: note: did not find header 'FIRTimestamp.h' in framework 'FirebaseCore' (loaded from '/Users/nickcooke/Library/Developer/Xcode/DerivedData/App-bwwbjhqkfyrjpicwznzbmqpkvyts/Build/Products/Release/FirebaseCore')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'gRPC-Core-grpc' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'gRPC-Core' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'gRPC-C++-grpcpp' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'gRPC-C++-gRPCCertificates-Cpp' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'gRPC-C++' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.11, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'abseil-xcprivacy' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.11, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'abseil' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'BoringSSL-GRPC-openssl_grpc' from project 'Pods')
    - NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.12, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'BoringSSL-GRPC' from project 'Pods')
    - NOTE  | [tvOS] xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: note: did not find header 'FIRTimestamp.h' in framework 'FirebaseCore' (loaded from '/Users/nickcooke/Library/Developer/Xcode/DerivedData/App-bwwbjhqkfyrjpicwznzbmqpkvyts/Build/Products/Release-appletvsimulator/FirebaseCore')
    - NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'abseil-xcprivacy' from project 'Pods')
    - NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'leveldb-library-leveldb_Privacy' from project 'Pods')
    - NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'leveldb-library' from project 'Pods')
    - NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.2.99. (in target 'abseil' from project 'Pods')

[!] The `FirebaseFirestoreInternal.podspec` specification does not validate.
```

The issue seems to be:
```
    - NOTE  | xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: fatal error: 'FirebaseCore/FIRTimestamp.h' file not found
    - NOTE  | [iOS] xcodebuild:  FirebaseFirestoreInternal/Firestore/Source/API/converters.mm:22:9: note: did not find header 'FIRTimestamp.h' in framework 'FirebaseCore' (loaded from '/Users/nickcooke/Library/Developer/Xcode/DerivedData/App-bwwbjhqkfyrjpicwznzbmqpkvyts/Build/Products/Release-iphonesimulator/FirebaseCore')
```

I'm not sure why this didn't surface earlier...

edit: likely a subtle difference with spec lint. 