### PR TITLE
Update imports for internal build system

### DIFF
--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -16,14 +16,11 @@
   import Foundation
   import UIKit
 
-  // TODO: This may be needed for extension detecting support
-  // @_implementationOnly import FirebaseCoreExtension
-
-  #if SWIFT_PACKAGE
-    @_implementationOnly import GoogleUtilities_Environment
-  #else
+  #if COCOAPODS
     @_implementationOnly import GoogleUtilities
-  #endif // SWIFT_PACKAGE
+  #else
+    @_implementationOnly import GoogleUtilities_Environment
+  #endif // COCOAPODS
 
   // Protocol to help with unit tests.
   protocol AuthAPNSTokenApplication {

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -14,11 +14,11 @@
 
 import Foundation
 
-#if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
-#else
+#if COCOAPODS
   @_implementationOnly import GoogleUtilities
-#endif // SWIFT_PACKAGE
+#else
+  @_implementationOnly import GoogleUtilities_Environment
+#endif // COCOAPODS
 
 #if COCOAPODS
   import GTMSessionFetcher


### PR DESCRIPTION
Our internal build system needs separate imports for each GoogleUtilities module like SWIFT_PM and unlike CocoaPods, so switch the define flag accordingly.