### PR TITLE
Add missing implementation_onlys

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -17,7 +17,7 @@ import Foundation
 import FirebaseAppCheckInterop
 import FirebaseAuthInterop
 import FirebaseCore
-import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 #if COCOAPODS
   @_implementationOnly import GoogleUtilities
 #else

--- a/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthComponent.swift
@@ -17,7 +17,7 @@ import Foundation
 import FirebaseAppCheckInterop
 import FirebaseAuthInterop
 import FirebaseCore
-import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 @objc(FIRAuthComponent)

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import FirebaseCore
-import FirebaseCoreExtension
-import FirebaseCoreInternal
+@_implementationOnly import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreInternal
 import Foundation
 #if COCOAPODS
   import GTMSessionFetcher

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 import FirebaseAppCheckInterop
-import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 
 /// Defines configurations to be added to a request to Firebase Auth's backend.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 import Foundation
 
 /// The prefix string for keychain item account attribute before the key.

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -17,7 +17,7 @@
   import UIKit
 
   // TODO: This may be needed for extension detecting support
-  // @_implementationOnly import FirebaseCoreExtension
+  // @_implementationOnly @_implementationOnly import FirebaseCoreExtension
 
   #if SWIFT_PACKAGE
     @_implementationOnly import GoogleUtilities_Environment

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthLog.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthLog.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreExtension
 import Foundation
 
 enum AuthLog {

--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -16,8 +16,8 @@ import Foundation
 import XCTest
 
 @testable import FirebaseAuth
-import FirebaseCoreExtension
-import FirebaseCoreInternal
+@_implementationOnly import FirebaseCoreExtension
+@_implementationOnly import FirebaseCoreInternal
 
 private let kFakeAPIKey = "kTestAPIKey"
 private let kFakeAppID = "kTestFirebaseAppID"


### PR DESCRIPTION
APIs from FirebaseCoreExtension and FirebaseCoreInternal should not be exposed.

This makes Auth consistent with other Firebase Swift implementations.