### PR TITLE
Export FirebaseCore.Timestamp in Firestore files to reduce the breakage of moving Timestamp

### DIFF
--- a/Example/FirestoreSample/FirestoreSample/App/FirestoreSampleApp.swift
+++ b/Example/FirestoreSample/FirestoreSample/App/FirestoreSampleApp.swift
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseAuth
-import FirebaseCore
 import FirebaseFirestore
 import SwiftUI
 

--- a/Firestore/Swift/Source/Codable/CodablePassThroughTypes.swift
+++ b/Firestore/Swift/Source/Codable/CodablePassThroughTypes.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseSharedSwift
 import Foundation
 

--- a/Firestore/Swift/Source/Codable/ServerTimestamp.swift
+++ b/Firestore/Swift/Source/Codable/ServerTimestamp.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
 
 /// A type that can initialize itself from a Firestore Timestamp, which makes
 /// it suitable for use with the `@ServerTimestamp` property wrapper.

--- a/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
+++ b/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
 
 /**
  * A protocol describing the encodable properties of a Timestamp.

--- a/Firestore/Swift/Source/Codable/TimestampDecodingStrategy.swift
+++ b/Firestore/Swift/Source/Codable/TimestampDecodingStrategy.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseSharedSwift
 
 public extension FirebaseDataDecoder.DateDecodingStrategy {

--- a/Firestore/Swift/Source/Codable/TimestampEncodingStrategy.swift
+++ b/Firestore/Swift/Source/Codable/TimestampEncodingStrategy.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseSharedSwift
 import Foundation
 

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -17,10 +17,11 @@
 // These aren't tests in the usual sense--they just verify that the Objective-C to Swift translation
 // results in the right names.
 
+@_exported import class FirebaseCore.Timestamp
+
 import Foundation
 import XCTest
 
-import FirebaseCore
 import FirebaseFirestore
 
 class BasicCompileTests: XCTestCase {

--- a/Firestore/Swift/Tests/Codable/CodableTimestampTests.swift
+++ b/Firestore/Swift/Tests/Codable/CodableTimestampTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseFirestore
 import Foundation
 import XCTest

--- a/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
+++ b/Firestore/Swift/Tests/Codable/ConditionalConformanceTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseFirestore
 import Foundation
 import XCTest

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 import FirebaseFirestore
 import Foundation
 import XCTest

--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import FirebaseCore
+@_exported import class FirebaseCore.Timestamp
+
 @testable import FirebaseFirestore
 import Foundation
 

--- a/Firestore/Swift/Tests/Integration/DatabaseTests.swift
+++ b/Firestore/Swift/Tests/Integration/DatabaseTests.swift
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+@_exported import FirebaseCore
+
 import Foundation
 import XCTest
 
-import FirebaseCore
 import FirebaseFirestore
 
 #if swift(>=5.5.2)


### PR DESCRIPTION
same as title

#no-changelog