### PR TITLE
[Infra] Remove missing resource for Vertex AI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1312,7 +1312,6 @@ let package = Package(
       dependencies: ["FirebaseVertexAI", "SharedTestUtilities"],
       path: "FirebaseVertexAI/Tests/Unit",
       resources: [
-        .process("vertexai-sdk-test-data/mock-responses"),
         // Including this README ensures that SPM will always generate a `Bundle.module`, even if
         // the mock-responses have not been downloaded with the update_vertexai_responses.sh script.
         .process("README.md"),


### PR DESCRIPTION
Fixes SPM warning: `Invalid Resource 'vertexai-sdk-test-data/mock-responses': File not found.`
