### PR TITLE
Fix VertexAI Unit Test resource handing in SPM

### DIFF
--- a/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
+++ b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
@@ -1,0 +1,4 @@
+Placeholder file for Package.swift - required to prevent a warning.
+
+It should be replace before running the FirebaseVertexAI by running
+`scripts/update_vertexai_responses.sh`.

--- a/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
+++ b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
@@ -1,4 +1,4 @@
 Placeholder file for Package.swift - required to prevent a warning.
 
-It should be replace before running the FirebaseVertexAI by running
-`scripts/update_vertexai_responses.sh`.
+It should be replaced before running the FirebaseVertexAI unit tests by
+running `scripts/update_vertexai_responses.sh`.

--- a/Package.swift
+++ b/Package.swift
@@ -1312,6 +1312,7 @@ let package = Package(
       dependencies: ["FirebaseVertexAI", "SharedTestUtilities"],
       path: "FirebaseVertexAI/Tests/Unit",
       resources: [
+        .process("vertexai-sdk-test-data/mock-responses"),
         // Including this README ensures that SPM will always generate a `Bundle.module`, even if
         // the mock-responses have not been downloaded with the update_vertexai_responses.sh script.
         .process("README.md"),

--- a/Package.swift
+++ b/Package.swift
@@ -1313,9 +1313,6 @@ let package = Package(
       path: "FirebaseVertexAI/Tests/Unit",
       resources: [
         .process("vertexai-sdk-test-data/mock-responses"),
-        // Including this README ensures that SPM will always generate a `Bundle.module`, even if
-        // the mock-responses have not been downloaded with the update_vertexai_responses.sh script.
-        .process("README.md"),
       ],
       cSettings: [
         .headerSearchPath("../../../"),


### PR DESCRIPTION
- Revert #13300 
- Add a placeholder file instead to avoid the Swift Package Manager missing resource warning

Fixes failure in https://github.com/firebase/firebase-ios-sdk/actions/runs/9987020216