### PR TITLE
Fix typo of all scripts

### DIFF
--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -24,7 +24,7 @@ EOF
   exit 1
 fi
 
-# The release build won't generage Carthage distro if the curreent
+# The release build won't generate Carthage distro if the current
 # PackageManifest version has already been released.
 carthage_version_check="--enable-carthage-version-check"
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -24,7 +24,7 @@ USAGE: scripts/check.sh [--allow-dirty] [--commit] [<revision>]
 Runs auto-formatting scripts, source-tree checks, and linters on any files that
 have changed since origin/main.
 
-By default, any changes are left as uncommited changes in the working tree. You
+By default, any changes are left as uncommitted changes in the working tree. You
 can review them with git diff. Pass --commit to automatically commit any changes.
 
 Pass an alternate revision to use as the basis for checking changes.
@@ -174,7 +174,7 @@ if ! git diff-index --quiet HEAD --; then
   fi
 fi
 
-# Show Travis-related environment variables, to help with debuging failures.
+# Show Travis-related environment variables, to help with debugging failures.
 if [[ "${VERBOSE}" == true ]]; then
   env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL|REPO)' | sort || true
 fi

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -857,7 +857,7 @@ _repository = None
 # Files to exclude from linting. This is set by the --exclude flag.
 _excludes = None
 
-# Whether to supress all PrintInfo messages, UNRELATED to --quiet flag
+# Whether to suppress all PrintInfo messages, UNRELATED to --quiet flag
 _quiet = False
 
 # The allowed line length of files.

--- a/scripts/health_metrics/README.md
+++ b/scripts/health_metrics/README.md
@@ -69,7 +69,7 @@ python3 measure_cocoapod_size.py --cocoapods FirebaseABTesting
 
 The `binary_size_metrics` on GitHub Actions [workflow](https://github.com/firebase/firebase-ios-sdk/blob/main/.github/workflows/health-metrics-presubmit.yml)
 is running binary size measurement presubmits and postsubmits. The environment for this job
-could be found in `runs-on`. More details about the envionment could be found [here](https://github.com/actions/virtual-environments#available-environments).
+could be found in `runs-on`. More details about the environment could be found [here](https://github.com/actions/virtual-environments#available-environments).
 
 Factors below might also affect the binary size:
 - Each testapp is measured by a default version Xcode from the GitHub Actions environment above.

--- a/scripts/health_metrics/generate_code_coverage_report/README.md
+++ b/scripts/health_metrics/generate_code_coverage_report/README.md
@@ -24,7 +24,7 @@ Common parameters for both pull_request and merge:
 
 In a workflow, this will run for each pull request update. The command below will generate a report
 in a PR. After a workflow of test coverage is done, a new coverage report will be posted on a
-comment of a pull request. If such comment has existed, this comment will be overriden by the latest
+comment of a pull request. If such comment has existed, this comment will be overridden by the latest
 report.
 
 Since the flag is `presubmit` here, the following options are required for a PR request:

--- a/scripts/health_metrics/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
+++ b/scripts/health_metrics/generate_code_coverage_report/Sources/IncrementalCoverageReportGenerator/main.swift
@@ -45,7 +45,7 @@ struct FileIncrementalChanges: Codable {
   }
 }
 
-/// `xccov` outcomes of a file from a xcresult bundle will be transfered
+/// `xccov` outcomes of a file from a xcresult bundle will be transferred
 /// to the following instance.
 struct LineCoverage: Codable {
   var fileName: String

--- a/scripts/health_metrics/generate_code_coverage_report/Sources/UpdatedFilesCollector/main.swift
+++ b/scripts/health_metrics/generate_code_coverage_report/Sources/UpdatedFilesCollector/main.swift
@@ -115,7 +115,7 @@ struct UpdatedFilesCollector: ParsableCommand {
           encoding: String.Encoding.utf8
         )
       } catch {
-        fatalError("Error while writting in \(outputPath.path).\n\(error)")
+        fatalError("Error while writing in \(outputPath.path).\n\(error)")
       }
     }
   }

--- a/scripts/rotate_secrets.sh
+++ b/scripts/rotate_secrets.sh
@@ -78,6 +78,6 @@ for encrypted_file in $files; do
     exit 1
   fi
 
-  # Cleanup the decrpted file now that it's been re-encrypted.
+  # Cleanup the decrypted file now that it's been re-encrypted.
   rm "$decrypted_file"
 done

--- a/scripts/run_database_emulator.sh
+++ b/scripts/run_database_emulator.sh
@@ -16,7 +16,7 @@
 
 # USAGE: run_database_emulator.sh { run | start | stop }
 #
-# Downloads and runs the Firebase Realtime Databas emulator
+# Downloads and runs the Firebase Realtime Database emulator
 
 set -euo pipefail
 


### PR DESCRIPTION
- All script files, README documents, and Swift codes under the scripts directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).

Please review the changes and let me know if this process is acceptable so that I can continue cleaning up the files incrementally, making this awesome SDK even more perfect.

Thank you