### PR TITLE
[Firebase 11] Default back to building static frameworks for RCs

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -47,7 +47,7 @@ jobs:
          sh -x scripts/build_zip.sh release_zip_dir \
            "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}" \
            build-release \
-           dynamic
+           static
     - uses: actions/upload-artifact@v4
       with:
         name: Firebase-release-zip-zip
@@ -95,7 +95,7 @@ jobs:
            ${{ matrix.linking_type }}
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.linking_type == 'dynamic' && 'Firebase-actions-dir' || 'Firebase-actions-dir-static' }}
+        name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
         # Zip the entire output directory since the builder adds subdirectories we don't know the
         # name of.
         path: zip_output_dir
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -173,7 +173,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -227,7 +227,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -279,7 +279,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -355,7 +355,7 @@ jobs:
       matrix:
         os: [macos-13]
         xcode: [Xcode_15.2]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -466,7 +466,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -551,7 +551,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -608,7 +608,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
@@ -664,7 +664,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-static]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -13,8 +13,6 @@
   been removed. See
   https://firebase.google.com/docs/ios/swift-migration for migration
   instructions.
-- [changed] **Breaking change**: Binary release artifacts now contain dynamic
-  XCFrameworks.
 - Update underlying FIRLogger implementation from `asl` to `os_log`.
 - Remove `FIRLoggerForceSTDERR` configuration option.
 - [changed] Move `Timestamp` class into `FirebaseCore`. `FirebaseFirestore.Timestamp`

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -61,8 +61,9 @@ struct ZipBuilderTool: ParsableCommand {
         help: ArgumentHelp("A flag for enabling or disabling versions checks for Carthage builds."))
   var carthageVersionCheck: Bool
 
-  /// A flag that indicates to build dynamic library frameworks. Defaults to true.
-  @Flag(default: true,
+  /// A flag that indicates to build dynamic library frameworks. The default is false and static
+  /// linkage.
+  @Flag(default: false,
         inversion: .prefixedNo,
         help: ArgumentHelp("A flag specifying to build dynamic library frameworks."))
   var dynamic: Bool

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -51,8 +51,8 @@ if [[ "$LINKING_TYPE" == "dynamic" ]]; then
 elif [[ "$LINKING_TYPE" == "static" ]]; then
   linking_mode="--no-dynamic"
 else
-  echo "Defaulting to `dynamic`."
-  linking_mode="--dynamic"
+  echo "Defaulting to `static`."
+  linking_mode="--no-dynamic"
 fi
 
 source_repo=()


### PR DESCRIPTION
#no-changelog

Selective revert.

Probably should look into building/running the dylib tests on a less frequent basis.