### PR TITLE
[Infra] Improve release tooling logging when updating tags

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/main.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/main.swift
@@ -86,7 +86,19 @@ struct FirebaseReleaser: ParsableCommand {
       Tags.createTags(gitRoot: gitRoot)
       Push.pushPodsToStaging(gitRoot: gitRoot)
     } else if updateTagsOnly {
+      let tag = "CocoaPods-\(FirebaseManifest.shared.version)"
+      let podsNeedingStaging = Shell.executeCommandFromScript(
+        "git diff --name-only \(tag) -- *.podspec",
+        outputToConsole: false,
+        workingDir: gitRoot
+      )
       Tags.updateTags(gitRoot: gitRoot)
+      if case let .success(pods) = podsNeedingStaging, !pods.isEmpty {
+        Shell.executeCommand(
+          "echo -e \"\\033[33m⚠ Warning – the following pods need re-staging:\n \(pods)\\033[33m\"",
+          outputToConsole: false
+        )
+      }
     } else if pushOnly {
       Push.pushPodsToStaging(gitRoot: gitRoot)
     } else if publish {


### PR DESCRIPTION
When `--update--tags-only` is used, I think it could be helpful to advise to re-push pods as needed. I'd like to make it do so by default, but this PR is small improvement on the way there.

Example of what the output looks like (I amended the code to add a trailing newline for the first line after screenshotting this):
<img width="453" alt="Screenshot 2024-07-19 at 7 29 34 PM" src="https://github.com/user-attachments/assets/78647db7-828a-4c72-9177-b5813fd80ad5">



#no-changelog