### PR TITLE
Fix typo of the Crashlytics Objective-C and MD files

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -78,7 +78,7 @@
 # 8.2.0
 - [changed] Incorporated code quality changes around integer overflow, potential race conditions, and reinstalling signal handlers.
 - [fixed] Fixed an issue where iOS-only apps running on iPads would report iOS as their OS Name.
-- [fixed] Fixed depcrecation warning for projects with minimum deployment version iOS 13 and up.
+- [fixed] Fixed deprecation warning for projects with minimum deployment version iOS 13 and up.
 
 # 8.0.0
 - [changed] Added a warning to upload-symbols when it detects a dSYM with hidden symbols.

--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
@@ -510,7 +510,7 @@ static void FIRCLSBinaryImageRecordLibraryFrameworkInfo(FIRCLSFile* file, const 
 
   // Because this function is so expensive, we've decided to omit this info for all Apple-supplied
   // frameworks. This really isn't that bad, because we can know their info ahead of time (within a
-  // small margin of error). With this implemenation, we will still record this info for any
+  // small margin of error). With this implementation, we will still record this info for any
   // user-built framework, which in the end is the most important thing.
   if (strncmp(path, "/System", 7) == 0) {
     return;

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -35,7 +35,7 @@
 
 // The writable size is our handler stack plus whatever scratch we need.  We have to use this space
 // extremely carefully, however, because thread stacks always needs to be page-aligned.  Only the
-// first allocation is gauranteed to be page-aligned.
+// first allocation is guaranteed to be page-aligned.
 //
 // CLS_SIGNAL_HANDLER_STACK_SIZE and CLS_MACH_EXCEPTION_HANDLER_STACK_SIZE are platform dependant,
 // defined as 0 for tv/watch.

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -458,7 +458,7 @@ typedef NSNumber FIRCLSWrappedReportAction;
   // When the ApplicationIdentifierModel fails to initialize, it is usually due to
   // failing computeExecutableInfo. This can happen if the user sets the
   // Exported Symbols File in Build Settings, and leaves off the one symbol
-  // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as
+  // that Crashlytics needs, "__mh_execute_header" (which is defined in mach-o/ldsyms.h as
   // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(@"Crashlytics could not find the symbol for the app's main function and cannot "

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSRolloutsPersistenceManager.m
@@ -44,7 +44,7 @@
   _fileManager = fileManager;
 
   if (!queue) {
-    FIRCLSDebugLog(@"Failed to intialize FIRCLSRolloutsPersistenceManager, logging queue is nil");
+    FIRCLSDebugLog(@"Failed to initialize FIRCLSRolloutsPersistenceManager, logging queue is nil");
     return nil;
   }
   _rolloutsLoggingQueue = queue;

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFile.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFile.m
@@ -301,7 +301,7 @@ static void FIRCLSFileWriteUnbufferedStringWithSuffix(FIRCLSFile* file,
                                                       char suffix) {
   char suffixBuffer[2];
 
-  // collaspe the quote + suffix into one single write call, for a small performance win
+  // collapse the quote + suffix into one single write call, for a small performance win
   suffixBuffer[0] = '"';
   suffixBuffer[1] = suffix;
 
@@ -403,14 +403,14 @@ void FIRCLSFileWriteHexEncodedString(FIRCLSFile* file, const char* string) {
 void FIRCLSFileWriteUInt64(FIRCLSFile* file, uint64_t number, bool hex) {
   char buffer[FIRCLSUInt64StringBufferLength];
   short i = FIRCLSFilePrepareUInt64(buffer, number, hex);
-  char* beginning = &buffer[i];  // Write from a pointer to the begining of the string.
+  char* beginning = &buffer[i];  // Write from a pointer to the beginning of the string.
   FIRCLSFileWriteToFileDescriptorOrBuffer(file, beginning, strlen(beginning));
 }
 
 void FIRCLSFileFDWriteUInt64(int fd, uint64_t number, bool hex) {
   char buffer[FIRCLSUInt64StringBufferLength];
   short i = FIRCLSFilePrepareUInt64(buffer, number, hex);
-  char* beginning = &buffer[i];  // Write from a pointer to the begining of the string.
+  char* beginning = &buffer[i];  // Write from a pointer to the beginning of the string.
   FIRCLSFileWriteWithRetries(fd, beginning, strlen(beginning));
 }
 
@@ -485,7 +485,7 @@ void FIRCLSFileWriteCollectionStart(FIRCLSFile* file, const char openingChar) {
   string[1] = openingChar;
 
   if (file->needComma) {
-    FIRCLSFileWriteToFileDescriptorOrBuffer(file, string, 2);  // write the seperator + opening char
+    FIRCLSFileWriteToFileDescriptorOrBuffer(file, string, 2);  // write the separator + opening char
   } else {
     FIRCLSFileWriteToFileDescriptorOrBuffer(file, &string[1], 1);  // write only the opening char
   }
@@ -643,7 +643,7 @@ NSArray* FIRCLSFileReadSections(const char* path,
 
   NSMutableArray* array = [NSMutableArray array];
 
-  // loop through all the entires, and
+  // loop through all the entries, and
   for (NSString* component in components) {
     NSData* data = [component dataUsingEncoding:NSUTF8StringEncoding];
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
@@ -86,7 +86,7 @@ static unsigned long long FIRCLSInstallationsWaitTime = 10 * NSEC_PER_SEC;
 
 /**
  * Generates a new UUID and saves it in persistent storage.
- * Does not sychronize the user defaults (to allow optimized
+ * Does not synchronize the user defaults (to allow optimized
  * batching of user default synchronizing)
  */
 - (NSString *)generateInstallationUUID {

--- a/Crashlytics/Crashlytics/Models/FIRCLSLaunchMarkerModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSLaunchMarkerModel.m
@@ -54,7 +54,7 @@
 - (BOOL)createLaunchFailureMarker {
   // It's tempting to use - [NSFileManger createFileAtPath:contents:attributes:] here. But that
   // operation, even with empty/nil contents does a ton of work to write out nothing via a
-  // temporarly file. This is a much faster implemenation.
+  // temporarly file. This is a much faster implementation.
   const char *path = [[self launchFailureMarkerPath] fileSystemRepresentation];
 
 #if TARGET_OS_IPHONE

--- a/Crashlytics/Crashlytics/Models/FIRCLSOnDemandModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSOnDemandModel.m
@@ -91,7 +91,7 @@ static const double SEC_PER_MINUTE = 60;
              withDataCollectionEnabled:(BOOL)dataCollectionEnabled
             usingExistingReportManager:(FIRCLSExistingReportManager *)existingReportManager {
   // Record the exception model into a new report if there is unused on-demand quota. Otherwise,
-  // log the occurence but drop the event.
+  // log the occurrence but drop the event.
   @synchronized(self) {
     if ([self isQueueFull]) {
       FIRCLSDebugLog(@"No available on-demand quota, dropping report");

--- a/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
@@ -60,7 +60,7 @@
       continue;
     }
 
-    // This does happen occationally and causes a crash. I'm really not sure there
+    // This does happen occasionally and causes a crash. I'm really not sure there
     // is anything sane we can do in this case.
     if (![details objectForKey:@"base"] || ![details objectForKey:@"size"]) {
       continue;

--- a/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
@@ -129,7 +129,7 @@
   }
 
   // TODO: the instance identifier calculation needs to match Beta's expectation. So, we have to
-  // continue generating a less-correct value for now. One day, we should encorporate a hash of the
+  // continue generating a less-correct value for now. One day, we should incorporate a hash of the
   // Info.plist and icon data.
 
   _buildInstanceID = FIRCLSHashNSData([string dataUsingEncoding:NSUTF8StringEncoding]);

--- a/Crashlytics/Shared/FIRCLSNetworking/FIRCLSNetworkResponseHandler.m
+++ b/Crashlytics/Shared/FIRCLSNetworking/FIRCLSNetworkResponseHandler.m
@@ -138,7 +138,7 @@ NSInteger const FIRCLSNetworkErrorUnknownURLCancelReason = -1;
 
   // NSURLErrorCancelled is a potential special-case. I believe there are
   // situations where a cancelled request cannot be successfully restarted. But,
-  // until I can prove it, we'll retry. There are defnitely many cases where
+  // until I can prove it, we'll retry. There are definitely many cases where
   // a cancelled request definitely can be restarted and will work.
 
   return YES;

--- a/Crashlytics/UnitTests/FIRCLSDwarfTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfTests.m
@@ -73,7 +73,7 @@
   FIRCLSMachOSliceInitSectionByName(&slice, SEG_TEXT, "__eh_frame", &section);
 
   // This computation is a little funny. Because we've just opened this dylib as a file,
-  // the "slide" is really whereever the file ended up being mapped in memory.
+  // the "slide" is really wherever the file ended up being mapped in memory.
   ehFrame = (void*)(section.addr + (uintptr_t)slice.startAddress);
 
   XCTAssertTrue(ehFrame != NULL, @"");
@@ -154,7 +154,7 @@
   state.registers[CLS_DWARF_REG_RETURN].location = FIRCLSDwarfRegisterInRegister;
 
   // Setup our arch-specific values. Be careful not to use the 0 register enum value
-  // because that can artifically pass.
+  // because that can artificially pass.
 #if CLS_CPU_X86_64
   state.registers[CLS_DWARF_REG_RETURN].value = CLS_DWARF_X86_64_RDX;
   FIRCLSDwarfUnwindSetRegisterValue(&inputRegisters, CLS_DWARF_X86_64_RDX, 777);


### PR DESCRIPTION
- All md files, Objective-C, and Swift codes under the Crashlytics directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).