### PR TITLE
Fix typo of the FirebaseAuth source and test files

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1802,7 +1802,7 @@ extension Auth: AuthInterop {
   ///
   /// This map is needed for looking up the keychain service name after the FirebaseApp instance
   /// is deleted, to remove the associated keychain item. Accessing should occur within a
-  /// @syncronized([FIRAuth class]) context.
+  /// @synchronized([FIRAuth class]) context.
   fileprivate static var gKeychainServiceNameForAppName: [String: String] = [:]
 
   /// Sets the keychain service name global data for the particular app.
@@ -1847,7 +1847,7 @@ extension Auth: AuthInterop {
     }
     lastNotifiedUserToken = token
     if autoRefreshTokens {
-      // Shedule new refresh task after successful attempt.
+      // Schedule new refresh task after successful attempt.
       scheduleAutoTokenRefresh()
     }
     var internalNotificationParameters: [String: Any] = [:]
@@ -2386,6 +2386,6 @@ extension Auth: AuthInterop {
   /// Handles returned from `NSNotificationCenter` for blocks which are "auth state did
   /// change" notification listeners.
   ///
-  /// Mutations should occur within a @syncronized(self) context.
+  /// Mutations should occur within a @synchronized(self) context.
   private var listenerHandles: NSMutableArray = []
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
@@ -51,10 +51,10 @@ class SignUpNewUserRequest: IdentityToolkitRequest, AuthRPCRequest {
   /// The email of the user.
   private(set) var email: String?
 
-  /// The password inputed by the user.
+  /// The password inputted by the user.
   private(set) var password: String?
 
-  /// The password inputed by the user.
+  /// The password inputted by the user.
   private(set) var displayName: String?
 
   /// The idToken of the user.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
@@ -53,7 +53,7 @@ class VerifyPasswordRequest: IdentityToolkitRequest, AuthRPCRequest {
   /// The email of the user.
   private(set) var email: String
 
-  /// The password inputed by the user.
+  /// The password inputted by the user.
   private(set) var password: String
 
   /// The GITKit token for the non-trusted IDP, which is to be confirmed by the user.

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactorInfo.swift
@@ -35,7 +35,7 @@ import Foundation
 
     init(proto: AuthProtoMFAEnrollment, factorID: String) {
       guard let uid = proto.mfaEnrollmentID else {
-        fatalError("Auth Internal Error: Failed to inialize MFA: missing enrollment ID")
+        fatalError("Auth Internal Error: Failed to initialize MFA: missing enrollment ID")
       }
       self.uid = uid
       self.factorID = factorID

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -82,7 +82,7 @@ import Foundation
   /// Indicates account linking is required.
   case accountExistsWithDifferentCredential = 17012
 
-  /// Indicates the user has attemped to change email or password more than 5 minutes after
+  /// Indicates the user has attempted to change email or password more than 5 minutes after
   /// signing in.
   case requiresRecentLogin = 17014
 
@@ -236,7 +236,7 @@ import Foundation
   /// Indicates that the local player was not authenticated prior to attempting Game Center signin.
   case localPlayerNotAuthenticated = 17066
 
-  /// Indicates that a non-null user was expected as an argmument to the operation but a null
+  /// Indicates that a non-null user was expected as an argument to the operation but a null
   /// user was provided.
   case nullUser = 17067
 
@@ -258,7 +258,7 @@ import Foundation
   /// unauthorized for the current project.
   case invalidDynamicLinkDomain = 17074
 
-  /// Indicates that the credential is rejected because it's misformed or mismatching.
+  /// Indicates that the credential is rejected because it's malformed or mismatching.
   case rejectedCredential = 17075
 
   /// Indicates that the GameKit framework is not linked prior to attempting Game Center signin.
@@ -294,7 +294,7 @@ import Foundation
   /// Indicates that the first factor is not supported.
   case unsupportedFirstFactor = 17089
 
-  /// Indicates that the a verifed email is required to changed to.
+  /// Indicates that the a verified email is required to changed to.
   case emailChangeNeedsVerification = 17090
 
   /// Indicates that the request does not contain a client identifier.

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -346,7 +346,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
     @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
     func FIRFedederatedAuthProvider_hAsync() async throws {
       class FederatedAuthImplementation: NSObject, FederatedAuthProvider {
-        // TODO: Document this API breakage - needing to add this functon for classes implementing
+        // TODO: Document this API breakage - needing to add this function for classes implementing
         // FederatedAuthProvider.
         func credential(with UIDelegate: AuthUIDelegate?) async throws -> AuthCredential {
           return FacebookAuthProvider.credential(withAccessToken: "token")


### PR DESCRIPTION
- All source codes under the FirebaseAuth directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).

Important Note:
- I have ignored spelling variations when the word was acceptable in another English variation, such as British English, but there are inconsistencies in using these variations originally.
- I have ignored strings that are returned by the code [like this one where `unparseable` is not the standard spelling and The correct spelling is `unparsable`.](https://github.com/firebase/firebase-ios-sdk/blob/3c760cb1803e3cde368d8f3a28ef1ad8274fec08/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift#L402) to avoid causing any breaking changes.