### PR TITLE
[#13326] App Check Tests

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h
@@ -22,6 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAppCheckValidator : NSObject
 
+// `FIRAppCheckValidator` doesn’t provide any instance methods.
+- (instancetype)init NS_UNAVAILABLE;
+
 /** The method validates if all parameters required to send App Check token exchange requests are
  * present in the `FIROptions` instance.
  *  @param options The `FIROptions` to validate.

--- a/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/AppAttestProvider/FIRAppAttestProviderTests.m
@@ -114,4 +114,42 @@ FIR_APP_ATTEST_PROVIDER_AVAILABILITY
   OCMVerifyAll(self.appAttestProviderMock);
 }
 
+#pragma mark - Limited-Use Token
+
+- (void)testGetLimitedUseTokenSuccess {
+  GACAppCheckToken *validInternalToken = [[GACAppCheckToken alloc] initWithToken:@"TEST_ValidToken"
+                                                                  expirationDate:[NSDate date]
+                                                                  receivedAtDate:[NSDate date]];
+  OCMExpect([self.appAttestProviderMock
+      getLimitedUseTokenWithCompletion:([OCMArg invokeBlockWithArgs:validInternalToken,
+                                                                    [NSNull null], nil])]);
+
+  [self.provider getLimitedUseTokenWithCompletion:^(FIRAppCheckToken *_Nullable token,
+                                                    NSError *_Nullable error) {
+    XCTAssertEqualObjects(token.token, validInternalToken.token);
+    XCTAssertEqualObjects(token.expirationDate, validInternalToken.expirationDate);
+    XCTAssertEqualObjects(token.receivedAtDate, validInternalToken.receivedAtDate);
+    XCTAssertNil(error);
+  }];
+
+  OCMVerifyAll(self.appAttestProviderMock);
+}
+
+- (void)testGetLimitedUseTokenProviderError {
+  NSError *expectedError = [NSError errorWithDomain:@"TEST_LimitedUseToken_Error"
+                                               code:-1
+                                           userInfo:nil];
+  OCMExpect([self.appAttestProviderMock
+      getLimitedUseTokenWithCompletion:([OCMArg invokeBlockWithArgs:[NSNull null], expectedError,
+                                                                    nil])]);
+
+  [self.provider getLimitedUseTokenWithCompletion:^(FIRAppCheckToken *_Nullable token,
+                                                    NSError *_Nullable error) {
+    XCTAssertNil(token);
+    XCTAssertIdentical(error, expectedError);
+  }];
+
+  OCMVerifyAll(self.appAttestProviderMock);
+}
+
 @end

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckValidatorTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckValidatorTests.m
@@ -17,7 +17,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h"
-#import "FirebaseCore/FIROptions.h"
+#import "FirebaseCore/Extension/FIROptionsInternal.h"
 
 @interface FIRAppCheckValidatorTests : XCTestCase
 @end
@@ -25,10 +25,11 @@
 @implementation FIRAppCheckValidatorTests
 
 - (void)test_tokenExchangeMissingFieldsInOptions_noMissingFields {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"TEST_GoogleAppID"
-                                                    GCMSenderID:@"TEST_GCMSenderID"];
-  options.APIKey = @"TEST_APIKey";
-  options.projectID = @"TEST_ProjectID";
+  FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:@{
+    kFIRGoogleAppID : @"TEST_GoogleAppID",
+    kFIRAPIKey : @"TEST_APIKey",
+    kFIRProjectID : @"TEST_ProjectID"
+  }];
 
   NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
 
@@ -37,10 +38,11 @@
 
 - (void)test_tokenExchangeMissingFieldsInOptions_singleMissingField {
   // Google App ID is empty:
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@""
-                                                    GCMSenderID:@"TEST_GCMSenderID"];
-  options.APIKey = @"TEST_APIKey";
-  options.projectID = @"TEST_ProjectID";
+  FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:@{
+    kFIRGoogleAppID : @"",
+    kFIRAPIKey : @"TEST_APIKey",
+    kFIRProjectID : @"TEST_ProjectID"
+  }];
 
   NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
 
@@ -48,10 +50,9 @@
 }
 
 - (void)test_tokenExchangeMissingFieldsInOptions_multipleMissingFields {
-  // Google App ID is empty:
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@""
-                                                    GCMSenderID:@"TEST_GCMSenderID"];
-  // API Key and Project ID are not set (`nil`).
+  // Google App ID is empty, and API Key and Project ID are not set:
+  FIROptions *options =
+      [[FIROptions alloc] initInternalWithOptionsDictionary:@{kFIRGoogleAppID : @""}];
 
   NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
 

--- a/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckValidatorTests.m
+++ b/FirebaseAppCheck/Tests/Unit/Core/FIRAppCheckValidatorTests.m
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FirebaseAppCheck/Sources/Core/FIRAppCheckValidator.h"
+#import "FirebaseCore/FIROptions.h"
+
+@interface FIRAppCheckValidatorTests : XCTestCase
+@end
+
+@implementation FIRAppCheckValidatorTests
+
+- (void)test_tokenExchangeMissingFieldsInOptions_noMissingFields {
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"TEST_GoogleAppID"
+                                                    GCMSenderID:@"TEST_GCMSenderID"];
+  options.APIKey = @"TEST_APIKey";
+  options.projectID = @"TEST_ProjectID";
+
+  NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
+
+  XCTAssertEqual(missingFields.count, 0);
+}
+
+- (void)test_tokenExchangeMissingFieldsInOptions_singleMissingField {
+  // Google App ID is empty:
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@""
+                                                    GCMSenderID:@"TEST_GCMSenderID"];
+  options.APIKey = @"TEST_APIKey";
+  options.projectID = @"TEST_ProjectID";
+
+  NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
+
+  XCTAssertTrue([missingFields isEqualToArray:@[ @"googleAppID" ]]);
+}
+
+- (void)test_tokenExchangeMissingFieldsInOptions_multipleMissingFields {
+  // Google App ID is empty:
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@""
+                                                    GCMSenderID:@"TEST_GCMSenderID"];
+  // API Key and Project ID are not set (`nil`).
+
+  NSArray *missingFields = [FIRAppCheckValidator tokenExchangeMissingFieldsInOptions:options];
+
+  NSArray *expectedMissingFields = @[ @"APIKey", @"projectID", @"googleAppID" ];
+  XCTAssertTrue([missingFields isEqualToArray:expectedMissingFields]);
+}
+
+@end

--- a/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DeviceCheckProvider/FIRDeviceCheckProviderTests.m
@@ -131,4 +131,42 @@ FIR_DEVICE_CHECK_PROVIDER_AVAILABILITY
   OCMVerifyAll(self.deviceCheckProviderMock);
 }
 
+#pragma mark - Limited-Use Token
+
+- (void)testGetLimitedUseTokenSuccess {
+  GACAppCheckToken *validInternalToken = [[GACAppCheckToken alloc] initWithToken:@"TEST_ValidToken"
+                                                                  expirationDate:[NSDate date]
+                                                                  receivedAtDate:[NSDate date]];
+  OCMExpect([self.deviceCheckProviderMock
+      getLimitedUseTokenWithCompletion:([OCMArg invokeBlockWithArgs:validInternalToken,
+                                                                    [NSNull null], nil])]);
+
+  [self.provider getLimitedUseTokenWithCompletion:^(FIRAppCheckToken *_Nullable token,
+                                                    NSError *_Nullable error) {
+    XCTAssertEqualObjects(token.token, validInternalToken.token);
+    XCTAssertEqualObjects(token.expirationDate, validInternalToken.expirationDate);
+    XCTAssertEqualObjects(token.receivedAtDate, validInternalToken.receivedAtDate);
+    XCTAssertNil(error);
+  }];
+
+  OCMVerifyAll(self.deviceCheckProviderMock);
+}
+
+- (void)testGetLimitedUseTokenProviderError {
+  NSError *expectedError = [NSError errorWithDomain:@"TEST_LimitedUseToken_Error"
+                                               code:-1
+                                           userInfo:nil];
+  OCMExpect([self.deviceCheckProviderMock
+      getLimitedUseTokenWithCompletion:([OCMArg invokeBlockWithArgs:[NSNull null], expectedError,
+                                                                    nil])]);
+
+  [self.provider getLimitedUseTokenWithCompletion:^(FIRAppCheckToken *_Nullable token,
+                                                    NSError *_Nullable error) {
+    XCTAssertNil(token);
+    XCTAssertIdentical(error, expectedError);
+  }];
+
+  OCMVerifyAll(self.deviceCheckProviderMock);
+}
+
 @end


### PR DESCRIPTION
[Closes #13326]

* Added tests for `getLimitedUseTokenWithCompletion:` in `FIRAppAttestProvider`, `FIRDeviceCheckProvider`, and `FIRAppCheckDebugProvider`
* Added a test for `FIRAppCheckDebugProvider`’s `localDebugToken`
* Introduced the `FIRAppCheckValidatorTests` suite
* Marked `FIRAppCheckValidator`’s `init` as unavailable