### PR TITLE
Fix typo of the CoreOnly directory files

### DIFF
--- a/CoreOnly/Tests/FirebasePodTest/FirebasePodTest/SceneDelegate.swift
+++ b/CoreOnly/Tests/FirebasePodTest/FirebasePodTest/SceneDelegate.swift
@@ -32,7 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Called as the scene is being released by the system.
     // This occurs shortly after the scene enters the background, or when its session is discarded.
     // Release any resources associated with this scene that can be re-created the next time the
-    // scene connects. The scene may re-connect later, as its session was not neccessarily
+    // scene connects. The scene may re-connect later, as its session was not necessarily
     // discarded (see `application:didDiscardSceneSessions` instead).
   }
 


### PR DESCRIPTION
- **All files** (including source codes, md files, and etc.) under the CoreOnly directory have been reviewed.
- The corrected typo was found in a comment and non-compiling sections of the project so it is fully backward-compatible, with no breaking changes introduced.

Important Note:
- I ignored the typos in the NOTICES file ([like this on](https://github.com/firebase/firebase-ios-sdk/blob/6b74ae7ec159ad73c9c96782381b9a90e5e2dae4/CoreOnly/NOTICES#L352C55-L352C62)) because it seemed like they were from another source and could cause conflicts in the future. Please let me know if I am wrong, and I will fix them as well.