### PR TITLE
Fix typo of the Crashlytics c files

### DIFF
--- a/CoreOnly/Tests/FirebasePodTest/FirebasePodTest/SceneDelegate.swift
+++ b/CoreOnly/Tests/FirebasePodTest/FirebasePodTest/SceneDelegate.swift
@@ -32,7 +32,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // Called as the scene is being released by the system.
     // This occurs shortly after the scene enters the background, or when its session is discarded.
     // Release any resources associated with this scene that can be re-created the next time the
-    // scene connects. The scene may re-connect later, as its session was not neccessarily
+    // scene connects. The scene may re-connect later, as its session was not necessarily
     // discarded (see `application:didDiscardSceneSessions` instead).
   }
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
@@ -558,7 +558,7 @@ void FIRCLSProcessRecordDispatchQueueNames(FIRCLSProcess *process, FIRCLSFile *f
   FIRCLSFileWriteSectionEnd(file);
 }
 
-#pragma mark - Othe Process Info
+#pragma mark - Other Process Info
 bool FIRCLSProcessGetMemoryUsage(uint64_t *active,
                                  uint64_t *inactive,
                                  uint64_t *wired,
@@ -782,7 +782,7 @@ static void FIRCLSProcessRecordCrashInfo(FIRCLSFile *file) {
     FIRCLSSDKLogDebug("Found crash info with version %d\n", info.version);
 
     // Currently support versions 0 through 5.
-    // 4 was in use for a long time, but it appears that with iOS 9 / swift 2.0, the verison has
+    // 4 was in use for a long time, but it appears that with iOS 9 / swift 2.0, the version has
     // been bumped.
     if (info.version > 5) {
       continue;

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -389,7 +389,7 @@ static void FIRCLSCatchAndRecordActiveException(std::type_info *typeInfo) {
 
   // This is a funny technique to get the exception object. The inner @try
   // has the ability to capture NSException-derived objects. It seems that
-  // c++ trys can do that in some cases, but I was warned by the WWDC labs
+  // c++ tries can do that in some cases, but I was warned by the WWDC labs
   // that there are cases where that will not work (like for NSException subclasses).
   try {
     @try {
@@ -416,7 +416,7 @@ static void FIRCLSCatchAndRecordActiveException(std::type_info *typeInfo) {
     FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, FIRCLSExceptionDemangle(name), exc->what(), nil,
                           nil);
   } catch (const std::bad_alloc &exc) {
-    // it is especially important to avoid demangling in this case, because the expetation at this
+    // it is especially important to avoid demangling in this case, because the expectation at this
     // point is that all allocations could fail
     FIRCLSExceptionRecord(FIRCLSExceptionTypeCpp, "std::bad_alloc", exc.what(), nil, nil);
   } catch (...) {

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -110,7 +110,7 @@ static void FIRCLSSignalInstallHandlers(FIRCLSSignalReadContext *roContext) {
 void FIRCLSSignalCheckHandlers(void) {
   if (_firclsContext.readonly->debuggerAttached) {
     // Adding this log to remind user deattachs from the debugger. Besides FIRCLSSignal, this logic is on FIRCLSMachException and FIRCLSException as well. Only log once since the check is same.
-    FIRCLSSDKLog("[Crashlytics] App is attached to a debugger, to see the crash reports please deattach from the debugger, https://firebase.google.com/docs/crashlytics/get-started?platform=ios#force-test-crash");
+    FIRCLSSDKLog("[Crashlytics] App is attached to a debugger, to see the crash reports please detach from the debugger, https://firebase.google.com/docs/crashlytics/get-started?platform=ios#force-test-crash");
     return;
   }
 

--- a/Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h
+++ b/Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  * non-ObjC, non-C++, and non-Swift exceptions. All information included here will be displayed in
  *the Crashlytics UI, and can influence crash grouping. Be particularly careful with the use of the
  *address properties. If set, Crashlytics will attempt symbolication and could overwrite other
- *properities in the process.
+ *properties in the process.
  **/
 @interface FIRStackFrame (Private)
 

--- a/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.c
+++ b/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.c
@@ -243,7 +243,7 @@ bool FIRCLSCompactUnwindLookupSecondLevelCompressed(FIRCLSCompactUnwindContext* 
 
   uint32_t entry = entryArray[index];
 
-  // Computing the fuction start address is easy
+  // Computing the function start address is easy
   result->functionStart = UNWIND_INFO_COMPRESSED_ENTRY_FUNC_OFFSET(entry) +
                           FIRCLSCompactUnwindGetIndexFunctionOffset(context);
 

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.c
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.c
@@ -178,7 +178,7 @@ bool FIRCLSDwarfParseFDERecord(DWARFFDERecord* fdeRecord,
   if (parseCIE) {
     // The CIE offset is really weird. It appears to be an offset from the
     // beginning of its field. This isn't what the documentation says, but it is
-    // a little ambigious. This is what DwarfParser.hpp does.
+    // a little ambiguous. This is what DwarfParser.hpp does.
     // Note that we have to back up one sizeof(uint32_t), because we've advanced
     // by parsing the offset
     const void* ciePointer = ptr - fdeRecord->cieOffset - sizeof(uint32_t);

--- a/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind.c
+++ b/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind.c
@@ -287,7 +287,7 @@ bool FIRCLSUnwindFirstExecutableAddress(vm_address_t start,
                                         vm_address_t end,
                                         vm_address_t* foundAddress) {
   // This function walks up the data on the stack, looking for the first value that is an address on
-  // an exectuable page.  This is a heurestic, and can hit false positives.
+  // an executable page.  This is a heurestic, and can hit false positives.
 
   *foundAddress = 0;  // write in a 0
 
@@ -304,7 +304,7 @@ bool FIRCLSUnwindFirstExecutableAddress(vm_address_t start,
       }
 
       FIRCLSSDKLogDebug("Checking for executable %p\n", (void*)address);
-      // when we find an exectuable address, we're finished
+      // when we find an executable address, we're finished
       if (FIRCLSUnwindIsAddressExecutable(address)) {
         *foundAddress = address;
         return true;

--- a/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind_arm.c
+++ b/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind_arm.c
@@ -291,7 +291,7 @@ bool FIRCLSDwarfUnwindSetRegisterValue(FIRCLSThreadContext* registers,
       // Here's what's going on. For x86, the "return register" is virtual. The architecture
       // doesn't actually have one, but DWARF does have the concept. So, when the system
       // tries to set the return register, we set the PC. You can see this behavior
-      // in the FIRCLSDwarfUnwindSetRegisterValue implemenation for that architecture. In the
+      // in the FIRCLSDwarfUnwindSetRegisterValue implementation for that architecture. In the
       // case of ARM64, the register is real. So, we have to be extra careful to make sure
       // we update the PC here. Otherwise, when a DWARF unwind completes, it won't have
       // changed the PC to the right value.

--- a/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind_x86.c
+++ b/Crashlytics/Crashlytics/Unwind/FIRCLSUnwind_x86.c
@@ -412,7 +412,7 @@ bool FIRCLSCompactUnwindRemapRegisters(const compact_unwind_encoding_t encoding,
   // Re-number the registers
 
   // You are probably wondering, what the hell is this algorithm even doing? It is
-  // taken from libunwind's implemenation that does the same thing.
+  // taken from libunwind's implementation that does the same thing.
   bool used[7] = {false, false, false, false, false, false, false};
   for (uint32_t i = 0; i < regCount; ++i) {
     int renum = 0;


### PR DESCRIPTION
- All source codes under the Crashlytics directory have been reviewed. (Swift, md, and other files were reviewed previously)
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).

Important Note:
- One of the fixes is a `pragma mark` which seems to be safe to change.
- One of the fixes is **a log message** which seems to be safe to change.