### PR TITLE
Fix file copyrights

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.m
@@ -1,4 +1,4 @@
-// Copyright 2023 Google
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSRolloutsPersistenceManagerTests.m
@@ -1,4 +1,4 @@
-// Copyright 2024 Google
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Firestore/Swift/FirebaseFirestore.h
+++ b/Firestore/Swift/FirebaseFirestore.h
@@ -1,1 +1,15 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 @import FirestoreInternal;

--- a/Firestore/core/src/api/listen_source.h
+++ b/Firestore/core/src/api/listen_source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/util/thread_safe_memoizer.h
+++ b/Firestore/core/src/util/thread_safe_memoizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/unit/util/thread_safe_memoizer_test.cc
+++ b/Firestore/core/test/unit/util/thread_safe_memoizer_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -28,7 +28,7 @@ list=$(git grep "${options[@]}" -- \
 
 # Allow copyrights before 2020 without LLC.
 if [[ $list ]]; then
-  result=$(grep -L 'Copyright 20[0-1][0-9].*Google' "$list")
+  result=$(grep -L 'Copyright 20[0-1][0-9].*Google' $list)
 fi
 
 if [[ $result ]]; then


### PR DESCRIPTION
`scripts/check_copyright.sh` was broken in #11647 

Fix the script and the files that were added with incorrectly formatted copyrights since.