### PR TITLE
Fix typo of the FirebaseCore source files

### DIFF
--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -133,7 +133,7 @@ NS_SWIFT_NAME(FirebaseLogger)
 /// - Parameters:
 ///   - level: The log level to use (defined by `FirebaseLoggerLevel` enum values).
 ///   - service: The service name of type `FirebaseLoggerService`.
-///   - code: The mesage code. Starting with "I-" which means iOS, followed by a capitalized
+///   - code: The message code. Starting with "I-" which means iOS, followed by a capitalized
 ///   three-character service identifier and a six digit integer message ID that is unique within
 ///   the service. An example of the message code is @"I-COR000001".
 ///   - message: Formatted string to be used as the log's message.

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -707,7 +707,7 @@ static FIRApp *sDefaultApp;
  *
  * @param appID Contents of GOOGLE_APP_ID from the plist file.
  * @param version Indicates what version of the app id format this string should be.
- * @return YES if provided string fulfills the expected hashed bundle ID and the version is known, 
+ * @return YES if provided string fulfills the expected hashed bundle ID and the version is known,
  *         NO otherwise.
  */
 + (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -707,8 +707,8 @@ static FIRApp *sDefaultApp;
  *
  * @param appID Contents of GOOGLE_APP_ID from the plist file.
  * @param version Indicates what version of the app id format this string should be.
- * @return YES if provided string fulfills the expected hashed bundle ID and the version is known, NO
- *         otherwise.
+ * @return YES if provided string fulfills the expected hashed bundle ID and the version is known, 
+ *         NO otherwise.
  */
 + (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {
   // Extract the hashed bundle ID from the given app ID.

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -625,7 +625,7 @@ static FIRApp *sDefaultApp;
  *
  * @param appID Contents of GOOGLE_APP_ID from the plist file.
  * @param version Indicates what version of the app id format this string should be.
- * @return YES if provided string fufills the expected format, NO otherwise.
+ * @return YES if provided string fulfills the expected format, NO otherwise.
  */
 + (BOOL)validateAppIDFormat:(NSString *)appID withVersion:(NSString *)version {
   if (!appID.length || !version.length) {
@@ -707,7 +707,7 @@ static FIRApp *sDefaultApp;
  *
  * @param appID Contents of GOOGLE_APP_ID from the plist file.
  * @param version Indicates what version of the app id format this string should be.
- * @return YES if provided string fufills the expected hashed bundle ID and the version is known, NO
+ * @return YES if provided string fulfills the expected hashed bundle ID and the version is known, NO
  *         otherwise.
  */
 + (BOOL)validateBundleIDHashWithinAppID:(NSString *)appID forVersion:(NSString *)version {

--- a/FirebaseCore/Sources/FIRComponentContainer.m
+++ b/FirebaseCore/Sources/FIRComponentContainer.m
@@ -148,7 +148,7 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
 ///   - Validate that the instance returned conforms to the protocol it claims to,
 ///   - Cache the instance if the block requests it
 ///
-/// Note that this method assumes the caller already has @sychronized on self.
+/// Note that this method assumes the caller already has @synchronized on self.
 - (nullable id)instantiateInstanceForProtocol:(Protocol *)protocol
                                     withBlock:(FIRComponentCreationBlock)creationBlock {
   if (!creationBlock) {

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -441,7 +441,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 - (BOOL)isAnalyticsCollectionExplicitlySet {
-  // If it's de-activated, it classifies as explicitly set. If not, it's not a good enough 
+  // If it's de-activated, it classifies as explicitly set. If not, it's not a good enough
   // indication that the developer wants FirebaseAnalytics enabled so continue checking.
   if (self.isAnalyticsCollectionDeactivated) {
     return YES;

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -441,7 +441,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 - (BOOL)isAnalyticsCollectionExplicitlySet {
-  // If it's de-activated, it classifies as explicity set. If not, it's not a good enough indication
+  // If it's de-activated, it classifies as explicitly set. If not, it's not a good enough indication
   // that the developer wants FirebaseAnalytics enabled so continue checking.
   if (self.isAnalyticsCollectionDeactivated) {
     return YES;

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -441,8 +441,8 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 - (BOOL)isAnalyticsCollectionExplicitlySet {
-  // If it's de-activated, it classifies as explicitly set. If not, it's not a good enough indication
-  // that the developer wants FirebaseAnalytics enabled so continue checking.
+  // If it's de-activated, it classifies as explicitly set. If not, it's not a good enough 
+  // indication that the developer wants FirebaseAnalytics enabled so continue checking.
   if (self.isAnalyticsCollectionDeactivated) {
     return YES;
   }


### PR DESCRIPTION
- **All source codes** (including Swift, Objective-C, etc.) under the FirebaseCore source directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).