### PR TITLE
Fix typo of the FirebaseABTesting files

### DIFF
--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -191,7 +191,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
   ABTConditionalUserPropertyController *controller =
       [ABTConditionalUserPropertyController sharedInstanceWithAnalytics:_analytics];
 
-  // Get the list of expriments from Firebase Analytics.
+  // Get the list of experiments from Firebase Analytics.
   NSArray *experiments = [controller experimentsWithOrigin:origin];
   if (!experiments) {
     NSString *errorDescription =


### PR DESCRIPTION
- All files (including Swift, Objective-C, etc.) under the FirebaseABTesting directory have been reviewed.

Fortunately, there was only a single typo in a single comment among all the files of this package.