### PR TITLE
Update Xcode for RC Sample

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -191,6 +191,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
     - name: Prereqs
       run: scripts/install_prereqs.sh RemoteConfigSample iOS
     - name: Build


### PR DESCRIPTION
Fix CI failure resulting from Analytics now requiring at least Xcode 15.2.

https://github.com/firebase/firebase-ios-sdk/actions/runs/10037044999/job/27764665204