### PR TITLE
Fix typo of the FirebaseAppDistribution files

### DIFF
--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -244,7 +244,7 @@
   [self mockFetchReleasesCompletion:_mockReleases error:nil];
   XCTestExpectation *expectation =
       [self expectationWithDescription:
-                @"Persist sign in state fails when the delegate recieves a failure."];
+                @"Persist sign in state fails when the delegate receives a failure."];
 
   [[self appDistribution] signInTesterWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNotNil(error);


### PR DESCRIPTION
- All files (including all sources and non-sources.) under the FirebaseAppDistribution directory have been reviewed.

Fortunately, there was only a single typo in a single expectation description among all the files of this package.