### PR TITLE
Fix typo of the FirebaseCombineSwift files

### DIFF
--- a/FirebaseCombineSwift/DECISIONS.md
+++ b/FirebaseCombineSwift/DECISIONS.md
@@ -18,7 +18,7 @@ Instead of implementing [custom  publishers](https://thoughtbot.com/blog/lets-bu
 
 ## Using capture lists
 
-After discussing internally, we came to the conclusion that the outer closure in the following piece of code is non-escaping, hence there is no benefit to weakly capture `self`. As the inner closure does't refer to `self`, the reference does not outlive the current call stack.
+After discussing internally, we came to the conclusion that the outer closure in the following piece of code is non-escaping, hence there is no benefit to weakly capture `self`. As the inner closure doesn't refer to `self`, the reference does not outlive the current call stack.
 
 It is thus safe to not use `[weak self]` in this instance.
 


### PR DESCRIPTION
- All files (including both Swift and MD files) under the FirebaseCombineSwift directory have been reviewed.

Fortunately, there was only a single typo in a single md file among all the files of this directory.