### PR TITLE
Fix all typos found under the FirebaseDatabase/Sources directory

### DIFF
--- a/FirebaseDatabase/Sources/Core/FQueryParams.m
+++ b/FirebaseDatabase/Sources/Core/FQueryParams.m
@@ -295,7 +295,7 @@
         if (![viewFrom isEqualToString:kFQPViewFromLeft] &&
             ![viewFrom isEqualToString:kFQPViewFromRight]) {
             [NSException raise:NSInvalidArgumentException
-                        format:@"Unknown view from paramter: %@", viewFrom];
+                        format:@"Unknown view from parameter: %@", viewFrom];
         }
         params->_viewFrom = viewFrom;
     }

--- a/FirebaseDatabase/Sources/Core/FRangeMerge.m
+++ b/FirebaseDatabase/Sources/Core/FRangeMerge.m
@@ -63,7 +63,7 @@
                      [currentPath contains:self.optInclusiveEnd];
     if (startComparison == NSOrderedDescending &&
         endComparison == NSOrderedAscending && !endInNode) {
-        // child is completly contained
+        // child is completely contained
         return updates;
     } else if (startComparison == NSOrderedDescending && endInNode &&
                [updates isLeafNode]) {

--- a/FirebaseDatabase/Sources/Core/FRepo.m
+++ b/FirebaseDatabase/Sources/Core/FRepo.m
@@ -813,7 +813,7 @@
     if (!self.config.persistenceEnabled)
         return;
 
-// Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
+// Targeted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
     // The idea is to wait until any outstanding sets get written to disk. Since

--- a/FirebaseDatabase/Sources/Core/FWriteTree.m
+++ b/FirebaseDatabase/Sources/Core/FWriteTree.m
@@ -36,7 +36,7 @@
 @property(nonatomic, strong) FCompoundWrite *visibleWrites;
 /**
  * A list of pending writes, regardless of visibility and shadowed-ness. Used to
- * calcuate arbitrary sets of the changed data, such as hidden writes (from
+ * calculate arbitrary sets of the changed data, such as hidden writes (from
  * transactions) or changes with certain writes excluded (also used by
  * transactions). Contains FWriteRecords.
  */
@@ -46,7 +46,7 @@
 
 /**
  * FWriteTree tracks all pending user-initiated writes and has methods to
- * calcuate the result of merging them with underlying server data (to create
+ * calculate the result of merging them with underlying server data (to create
  * "event cache" data). Pending writes are added with addOverwriteAtPath: and
  * addMergeAtPath: and removed with removeWriteId:.
  */

--- a/FirebaseDatabase/Sources/Core/FWriteTreeRef.m
+++ b/FirebaseDatabase/Sources/Core/FWriteTreeRef.m
@@ -90,7 +90,7 @@
  * 1. No writes are shadowing. Events should be raised, the snap to be applied
  * comes from the server data.
  *
- * 2. Some writes are completly shadowing. No events to be raised.
+ * 2. Some writes are completely shadowing. No events to be raised.
  *
  * 3. Is partially shadowed. Events should be raised.
  *

--- a/FirebaseDatabase/Sources/Core/View/FKeepSyncedEventRegistration.m
+++ b/FirebaseDatabase/Sources/Core/View/FKeepSyncedEventRegistration.m
@@ -55,7 +55,7 @@
 }
 
 - (FIRDatabaseHandle)handle {
-    // TODO[offline]: returning arbitray, can't return NSNotFound since that is
+    // TODO[offline]: returning arbitrary, can't return NSNotFound since that is
     // used to match other event registrations We should really redo this to
     // match on different kind of events (single observer, all observers,
     // cancelled) rather than on a NSNotFound handle...

--- a/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
+++ b/FirebaseDatabase/Sources/Persistence/FLevelDBStorageEngine.m
@@ -131,7 +131,7 @@ static NSString *trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
                    error);
         }
     } else if ([oldVersion isEqualToString:kFPersistenceVersion]) {
-        // Everythings fine no need for migration
+        // Everything's fine, no need for migration
     } else if ([oldVersion length] == 0) {
         FFWarn(@"I-RDB076036",
                @"Version file empty. Assuming database version 1.");

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
+// Targeted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
 
 #import <Foundation/Foundation.h>
@@ -141,7 +141,7 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     NSString *deviceName;
     BOOL hasUiDeviceClass = NO;
 
-// Targetted compilation is ONLY for testing. UIKit is weak-linked in actual
+// Targeted compilation is ONLY for testing. UIKit is weak-linked in actual
 // release build.
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
     Class uiDeviceClass = NSClassFromString(@"UIDevice");

--- a/FirebaseDatabase/Sources/Snapshot/FCompoundWrite.m
+++ b/FirebaseDatabase/Sources/Snapshot/FCompoundWrite.m
@@ -176,7 +176,7 @@
     return children;
 }
 
-// TODO: change into enumarate method
+// TODO: change into enumerate method
 - (NSDictionary *)childCompoundWrites {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     [self.writeTree.children

--- a/FirebaseDatabase/Sources/Utilities/FNextPushId.m
+++ b/FirebaseDatabase/Sources/Utilities/FNextPushId.m
@@ -205,7 +205,7 @@ static unichar const HIGH_SURROGATE_PAIR_END = 0xDBFF;
                             withString:@""];
         return next;
     }
-    // Replace the last character with its immedate predecessor, and fill the
+    // Replace the last character with its immediate predecessor, and fill the
     // suffix of the key with MAX_PUSH_CHAR. This is the lexicographically
     // largest possible key smaller than `key`.
     NSUInteger i = next.length - 1;

--- a/FirebaseDatabase/Sources/third_party/FImmutableSortedDictionary/FImmutableSortedDictionary/FLLRBValueNode.m
+++ b/FirebaseDatabase/Sources/third_party/FImmutableSortedDictionary/FImmutableSortedDictionary/FLLRBValueNode.m
@@ -40,7 +40,7 @@
 }
 
 /**
-* Early terminates if aciton returns YES.
+* Early terminates if action returns YES.
 * @return The first truthy value returned by action, or the last falsey value returned by action.
 */
 - (BOOL) inorderTraversal:(BOOL (^)(id key, id value))action {


### PR DESCRIPTION
- All source codes under the FirebaseDatabase/Sources directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).

Important note
Based on my experience with the previous PRs, I have decided to make the commit chunks bigger and group them by their parent directory for ease of use.