### PR TITLE
Fix all typos found under the FirebaseDatabase/Tests and the main directory

### DIFF
--- a/FirebaseDatabase/Tests/Resources/syncPointSpec.json
+++ b/FirebaseDatabase/Tests/Resources/syncPointSpec.json
@@ -6725,7 +6725,7 @@
         ]
       },
       {
-        ".comment": "Server now incorperates user update",
+        ".comment": "Server now incorporates user update",
         "type": "serverUpdate",
         "tag": 1,
         "path": "key-2",

--- a/FirebaseDatabase/Tests/Unit/FArraySortedDictionaryTest.m
+++ b/FirebaseDatabase/Tests/Unit/FArraySortedDictionaryTest.m
@@ -289,7 +289,7 @@
   XCTAssertEqualObjects([map getPredecessorKey:@7], @4, @"@4");
   XCTAssertEqualObjects([map getPredecessorKey:@9], @7, @"@7");
   XCTAssertEqualObjects([map getPredecessorKey:@50], @9, @"@9");
-  XCTAssertThrows([map getPredecessorKey:@777], @"Expect exception about nonexistant key");
+  XCTAssertThrows([map getPredecessorKey:@777], @"Expect exception about nonexistent key");
 }
 
 - (void)testEnumerator {

--- a/FirebaseDatabase/Tests/Unit/FCompoundWriteTest.m
+++ b/FirebaseDatabase/Tests/Unit/FCompoundWriteTest.m
@@ -224,7 +224,7 @@
       [self.baseNode updateImmediateChild:@"child-1"
                              withNewChild:[FSnapshotUtilities nodeFrom:expectedChild1]];
   id<FNode> updatedNode = [compoundWrite applyToNode:self.baseNode];
-  XCTAssertEqualObjects(updatedNode, expectedNode, @"Shallow update should remove deep udpates.");
+  XCTAssertEqualObjects(updatedNode, expectedNode, @"Shallow update should remove deep updates.");
 }
 
 - (void)testChildPriorityDoesntUpdateEmptyNodePriorityOnChildMerge {

--- a/FirebaseDatabase/Tests/Unit/FTreeSortedDictionaryTests.m
+++ b/FirebaseDatabase/Tests/Unit/FTreeSortedDictionaryTests.m
@@ -458,7 +458,7 @@
   XCTAssertEqualObjects([map getPredecessorKey:@7], @4, @"@4");
   XCTAssertEqualObjects([map getPredecessorKey:@9], @7, @"@7");
   XCTAssertEqualObjects([map getPredecessorKey:@50], @9, @"@9");
-  XCTAssertThrows([map getPredecessorKey:@777], @"Expect exception about nonexistant key");
+  XCTAssertThrows([map getPredecessorKey:@777], @"Expect exception about nonexistent key");
 }
 
 - (void)testEnumerator {

--- a/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
+++ b/FirebaseDatabase/Tests/Unit/Swift/DatabaseAPITests.swift
@@ -193,7 +193,7 @@ final class DatabaseAPITests {
     let values = [AnyHashable: Any]()
     var transactionResult = TransactionResult()
 
-    // Retreive Child DatabaseReference
+    // Retrieve Child DatabaseReference
     databaseReference = databaseReference.child(child)
     databaseReference = databaseReference.childByAutoId()
 


### PR DESCRIPTION
- All source codes under the FirebaseDatabase/Test and the main directory were reviewed.
- Corrected typos primarily found in comments, exception logs, and non-compiling sections of the project.
