### PR TITLE
Fix all typos found in the FirebaseDynamicLinks/Sources directory

### DIFF
--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FDLURLComponents.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FDLURLComponents.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, FIRShortDynamicLinkPathLength) {
  * @abstract The definition of the completion block used by URL shortener.
  * @param shortURL Shortened URL.
  * @param warnings Warnings that describe usability or function limitations of the generated
- *     short link. Usually presence of warnings means parameteres format error, parametres value
+ *     short link. Usually presence of warnings means parameters format error, parameters value
  *     error or missing parameter.
  * @param error Error if URL can't be shortened.
  */

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.h
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.h
@@ -94,7 +94,7 @@ NSURL *FIRDLDeepLinkURLWithInviteID(NSString *_Nullable inviteID,
  * @abstract Determines if the system version is greater than or equal to the minSupportedVersion.
  * @param systemVersion The iOS version to use as the current version in the comparison.
  * @param minSupportedVersion The minimum iOS system version that is supported.
- * @return YES if the system version is greater than or equal to the minimum, othewise, NO.
+ * @return YES if the system version is greater than or equal to the minimum, otherwise, NO.
  */
 BOOL FIRDLOSVersionSupported(NSString *_Nullable systemVersion, NSString *minSupportedVersion);
 

--- a/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
+++ b/FirebaseDynamicLinks/Sources/Utilities/FDLUtilities.m
@@ -107,7 +107,7 @@ NSURL *FIRDLDeepLinkURLWithInviteID(NSString *_Nullable inviteID,
                                     NSString *_Nullable minAppVersion,
                                     NSString *URLScheme,
                                     NSString *_Nullable matchMessage) {
-  // We are unable to use NSURLComponents as NSURLQueryItem is avilable beginning in iOS 8 and
+  // We are unable to use NSURLComponents as NSURLQueryItem is available beginning in iOS 8 and
   // appending our query string with NSURLComponents improperly formats the query by adding
   // a second '?' in the query.
   NSMutableDictionary *queryDictionary = [NSMutableDictionary dictionary];


### PR DESCRIPTION
- All source codes under the FirebaseDynamicLinks/Sources directory have been reviewed.
- All corrected typos found in the comments of the files.