### PR TITLE
Fix all typos found under the FirebaseDynamicLinks/Tests and the main directory 

### DIFF
--- a/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
+++ b/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
@@ -41,7 +41,7 @@
   // Called as the scene is being released by the system.
   // This occurs shortly after the scene enters the background, or when its session is discarded.
   // Release any resources associated with this scene that can be re-created the next time the scene
-  // connects. The scene may re-connect later, as its session was not neccessarily discarded (see
+  // connects. The scene may re-connect later, as its session was not necessarily discarded (see
   // `application:didDiscardSceneSessions` instead).
 }
 


### PR DESCRIPTION
- All files (including source/non-source files) under the FirebaseAppDistributionInternal directory have been reviewed.

Fortunately, there was only a single comment in the test sample project remaining among all the files of the package.