### PR TITLE
Fix typos in the FunctionalTestApp project of the FirebaseInAppMessaging package

### DIFF
--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AppDelegate.m
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AppDelegate.m
@@ -73,7 +73,7 @@
       handleUniversalLink:userActivity.webpageURL
                completion:^(FIRDynamicLink *_Nullable dynamicLink, NSError *_Nullable error) {
                  if (dynamicLink) {
-                   NSLog(@"dynamic link recogized with url as %@", dynamicLink.url.absoluteString);
+                   NSLog(@"dynamic link recognized with url as %@", dynamicLink.url.absoluteString);
                    [self showDeepLink:dynamicLink.url.absoluteString forUrlType:@"universal link"];
                  } else {
                    NSLog(@"error happened %@", error);

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayFlowViewController.m
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayFlowViewController.m
@@ -17,7 +17,7 @@
 #import "AppDelegate.h"
 
 #import "AutoDisplayFlowViewController.h"
-#import "AutoDisplayMesagesTableVC.h"
+#import "AutoDisplayMessagesTableVC.h"
 
 #import <FirebaseInAppMessaging/FIRIAMDisplayCheckOnAppForegroundFlow.h>
 #import <FirebaseInAppMessaging/FIRIAMMessageClientCache.h>
@@ -38,7 +38,7 @@
 @interface AutoDisplayFlowViewController ()
 @property(weak, nonatomic) IBOutlet UISwitch *autoDisplayFlowSwitch;
 
-@property(nonatomic, weak) AutoDisplayMesagesTableVC *messageTableVC;
+@property(nonatomic, weak) AutoDisplayMessagesTableVC *messageTableVC;
 @property(weak, nonatomic) IBOutlet UITextField *autoDisplayIntervalText;
 @property(weak, nonatomic) IBOutlet UITextField *autoFetchIntervalText;
 @property(weak, nonatomic) IBOutlet UITextField *eventNameText;
@@ -171,7 +171,7 @@
   // Pass the selected object to the new view controller.
 
   if ([segue.identifier isEqualToString:@"message-table-segue"]) {
-    self.messageTableVC = (AutoDisplayMesagesTableVC *)[segue destinationViewController];
+    self.messageTableVC = (AutoDisplayMessagesTableVC *)[segue destinationViewController];
   }
 }
 @end

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.h
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.h
@@ -18,6 +18,6 @@
 
 #import <FirebaseInAppMessaging/FIRIAMMessageClientCache.h>
 
-@interface AutoDisplayMesagesTableVC : UITableViewController <FIRIAMCacheDataObserver>
+@interface AutoDisplayMessagesTableVC : UITableViewController <FIRIAMCacheDataObserver>
 @property(nonatomic) FIRIAMMessageClientCache *messageCache;
 @end

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.m
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.m
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#import "AutoDisplayMesagesTableVC.h"
+#import "AutoDisplayMessagesTableVC.h"
 #import <FirebaseInAppMessaging/FIRIAMDisplayTriggerDefinition.h>
 #import <FirebaseInAppMessaging/FIRIAMMessageContentData.h>
 
-@interface AutoDisplayMesagesTableVC ()
+@interface AutoDisplayMessagesTableVC ()
 @end
 
-@implementation AutoDisplayMesagesTableVC
+@implementation AutoDisplayMessagesTableVC
 
 - (void)messageDataChanged {
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/Base.lproj/Main.storyboard
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/App/InAppMessaging-Example-iOS/Base.lproj/Main.storyboard
@@ -342,10 +342,10 @@
             </objects>
             <point key="canvasLocation" x="-562.31884057971024" y="635.86956521739137"/>
         </scene>
-        <!--Auto Display Mesages TableVC-->
+        <!--Auto Display Messages TableVC-->
         <scene sceneID="q5h-FN-tiy">
             <objects>
-                <tableViewController id="PsL-F0-NPD" customClass="AutoDisplayMesagesTableVC" sceneMemberID="viewController">
+                <tableViewController id="PsL-F0-NPD" customClass="AutoDisplayMessagesTableVC" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="qfr-gm-4ZH">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="237.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/InAppMessaging-Example-iOS.xcodeproj/project.pbxproj
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/InAppMessaging-Example-iOS.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		AD6A6CB11F56093700A6DFA1 /* FIRIAMBookKeeperViaUserDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6A6CAE1F5606CD00A6DFA1 /* FIRIAMBookKeeperViaUserDefaultsTests.m */; };
 		AD764A341FE4856400378AE0 /* AutoDisplayFlowViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AD764A2E1FE4856300378AE0 /* AutoDisplayFlowViewController.m */; };
 		AD764A361FE4856400378AE0 /* LogDumpViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AD764A301FE4856300378AE0 /* LogDumpViewController.m */; };
-		AD764A371FE4856400378AE0 /* AutoDisplayMesagesTableVC.m in Sources */ = {isa = PBXBuildFile; fileRef = AD764A331FE4856300378AE0 /* AutoDisplayMesagesTableVC.m */; };
+		AD764A371FE4856400378AE0 /* AutoDisplayMessagesTableVC.m in Sources */ = {isa = PBXBuildFile; fileRef = AD764A331FE4856300378AE0 /* AutoDisplayMessagesTableVC.m */; };
 		AD811A321F13F88800BF632A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AD811A311F13F88800BF632A /* main.m */; };
 		AD811A351F13F88800BF632A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AD811A341F13F88800BF632A /* AppDelegate.m */; };
 		AD81223D1F14100700BF632A /* FIRIAMMessageContentDataWithImageURLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AD8122391F140FFC00BF632A /* FIRIAMMessageContentDataWithImageURLTests.m */; };
@@ -67,12 +67,12 @@
 		AD40FB071F38CCB700AB8C14 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = ../App/InAppMessaging_Example_iOS_Swift/SnapshotHelper.swift; sourceTree = "<group>"; };
 		AD5D25CA1FA91C9900F1B0EB /* FIRIAMActivityLoggerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FIRIAMActivityLoggerTests.m; path = Tests/FIRIAMActivityLoggerTests.m; sourceTree = "<group>"; };
 		AD6A6CAE1F5606CD00A6DFA1 /* FIRIAMBookKeeperViaUserDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRIAMBookKeeperViaUserDefaultsTests.m; path = Tests/FIRIAMBookKeeperViaUserDefaultsTests.m; sourceTree = "<group>"; };
-		AD764A2C1FE4856300378AE0 /* AutoDisplayMesagesTableVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AutoDisplayMesagesTableVC.h; path = "App/InAppMessaging-Example-iOS/AutoDisplayMesagesTableVC.h"; sourceTree = "<group>"; };
+		AD764A2C1FE4856300378AE0 /* AutoDisplayMessagesTableVC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AutoDisplayMessagesTableVC.h; path = "App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.h"; sourceTree = "<group>"; };
 		AD764A2D1FE4856300378AE0 /* AutoDisplayFlowViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AutoDisplayFlowViewController.h; path = "App/InAppMessaging-Example-iOS/AutoDisplayFlowViewController.h"; sourceTree = "<group>"; };
 		AD764A2E1FE4856300378AE0 /* AutoDisplayFlowViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AutoDisplayFlowViewController.m; path = "App/InAppMessaging-Example-iOS/AutoDisplayFlowViewController.m"; sourceTree = "<group>"; };
 		AD764A301FE4856300378AE0 /* LogDumpViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LogDumpViewController.m; path = "App/InAppMessaging-Example-iOS/LogDumpViewController.m"; sourceTree = "<group>"; };
 		AD764A311FE4856300378AE0 /* LogDumpViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LogDumpViewController.h; path = "App/InAppMessaging-Example-iOS/LogDumpViewController.h"; sourceTree = "<group>"; };
-		AD764A331FE4856300378AE0 /* AutoDisplayMesagesTableVC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AutoDisplayMesagesTableVC.m; path = "App/InAppMessaging-Example-iOS/AutoDisplayMesagesTableVC.m"; sourceTree = "<group>"; };
+		AD764A331FE4856300378AE0 /* AutoDisplayMessagesTableVC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AutoDisplayMessagesTableVC.m; path = "App/InAppMessaging-Example-iOS/AutoDisplayMessagesTableVC.m"; sourceTree = "<group>"; };
 		AD811A2D1F13F88800BF632A /* InAppMessaging_Example_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InAppMessaging_Example_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD811A311F13F88800BF632A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "App/InAppMessaging-Example-iOS/main.m"; sourceTree = "<group>"; };
 		AD811A331F13F88800BF632A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = "App/InAppMessaging-Example-iOS/AppDelegate.h"; sourceTree = "<group>"; };
@@ -210,8 +210,8 @@
 				257270CC238C813900238991 /* GoogleService-Info.plist */,
 				AD764A2D1FE4856300378AE0 /* AutoDisplayFlowViewController.h */,
 				AD764A2E1FE4856300378AE0 /* AutoDisplayFlowViewController.m */,
-				AD764A2C1FE4856300378AE0 /* AutoDisplayMesagesTableVC.h */,
-				AD764A331FE4856300378AE0 /* AutoDisplayMesagesTableVC.m */,
+				AD764A2C1FE4856300378AE0 /* AutoDisplayMessagesTableVC.h */,
+				AD764A331FE4856300378AE0 /* AutoDisplayMessagesTableVC.m */,
 				AD764A311FE4856300378AE0 /* LogDumpViewController.h */,
 				AD764A301FE4856300378AE0 /* LogDumpViewController.m */,
 				AD81221B1F14064800BF632A /* LaunchScreen.storyboard */,
@@ -477,7 +477,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD764A341FE4856400378AE0 /* AutoDisplayFlowViewController.m in Sources */,
-				AD764A371FE4856400378AE0 /* AutoDisplayMesagesTableVC.m in Sources */,
+				AD764A371FE4856400378AE0 /* AutoDisplayMessagesTableVC.m in Sources */,
 				AD811A351F13F88800BF632A /* AppDelegate.m in Sources */,
 				AD764A361FE4856400378AE0 /* LogDumpViewController.m in Sources */,
 				AD811A321F13F88800BF632A /* main.m in Sources */,


### PR DESCRIPTION
- The primary change is due to a typo in a class name and its corresponding file name.
- All references to the updated resources have been revised, including storyboards, headers, implementations, and project files, using Xcode’s native refactor feature.

Please manually verify the changes in addition to my manual tests, as there are no existing UI tests to ensure coverage and this PR contains changes in XML files.