### PR TITLE
Fix all typos found under the FirebaseInAppMessaging/Sources directory

### DIFF
--- a/FirebaseInAppMessaging/Sources/DefaultUI/ImageOnly/FIRIAMImageOnlyViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/ImageOnly/FIRIAMImageOnlyViewController.m
@@ -145,7 +145,7 @@
       adjustedImageViewWidth =
           adjustedImageViewHeight * self.imageOriginalSize.width / self.imageOriginalSize.height;
       FIRLogDebug(kFIRLoggerInAppMessagingDisplay, @"I-FID110003",
-                  @"Use max avilable image display height as %lf", adjustedImageViewHeight);
+                  @"Use max available image display height as %lf", adjustedImageViewHeight);
     }
   } else {
     // image can be rendered fully at its original size

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Modal/FIRIAMModalViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Modal/FIRIAMModalViewController.m
@@ -185,7 +185,7 @@ static CGFloat LandScapePaddingBetweenImageAndTextColumn = 24;
 // In both landscape or portrait mode, the title, body & button are aligned vertically and they form
 // together have an impact on the height for that column. Many times, we need to calculate a
 // suitable heights for them to help decide the layout. The height calculation is influced by quite
-// a few factors: the text lenght of title and body, the presence/absense of body & button and
+// a few factors: the text length of title and body, the presence/absence of body & button and
 // available card/window sizes. So these are wrapped within
 // estimateTextButtomColumnHeightWithDisplayWidth which produce a TitleBodyButtonHeightInfo struct
 // to give the estimates of the heights of different elements.
@@ -389,7 +389,7 @@ struct TitleBodyButtonHeightInfo {
 
     // now we can estimate the new card width given the desired image size
 
-    // this assumes we use half of the window width for diplaying the text/button column
+    // this assumes we use half of the window width for displaying the text/button column
     CGFloat cardFitWidth = imageDisplaySize.width + self.view.window.frame.size.width / 2 +
                            LandScapePaddingBetweenImageAndTextColumn;
 

--- a/FirebaseInAppMessaging/Sources/Private/Runtime/FIRIAMSDKSettings.h
+++ b/FirebaseInAppMessaging/Sources/Private/Runtime/FIRIAMSDKSettings.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) NSString *apiServerHost;
 @property(nonatomic, copy) NSString *apiHttpProtocol;  // http or https. It should be always
                                                        // https on production. Allow http to
-                                                       // faciliate testing in non-prod environment
+                                                       // facilitate testing in non-prod environment
 @property(nonatomic) NSTimeInterval fetchMinIntervalInMinutes;
 
 // settings related to activity logger
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) FIRIAMClearcutStrategy *clearcutStrategy;
 
 // The global flag at whole Firebase level for automatic data collection. On FIAM SDK startup,
-// it would be retreived from FIRApp's corresponding setting.
+// it would be retrieved from FIRApp's corresponding setting.
 @property(nonatomic, getter=isFirebaseAutoDataCollectionEnabled)
     BOOL firebaseAutoDataCollectionEnabled;
 

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -66,13 +66,13 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
                 @"Detected %d custom URL schemes from environment", (int)customSchemeURLs.count);
 
     if ([NSThread isMainThread]) {
-      // We can not dispatch sychronously to main queue if we are already in main queue. That
+      // We can not dispatch synchronously to main queue if we are already in main queue. That
       // can cause deadlock.
       URLFollower = [[FIRIAMActionURLFollower alloc]
           initWithCustomURLSchemeArray:customSchemeURLs
                        withApplication:UIApplication.sharedApplication];
     } else {
-      // If we are not on main thread, dispatch it to main queue since it invovles calling UIKit
+      // If we are not on main thread, dispatch it to main queue since it involves calling UIKit
       // methods, which are required to be carried out on main queue.
       dispatch_sync(dispatch_get_main_queue(), ^{
         URLFollower = [[FIRIAMActionURLFollower alloc]
@@ -162,7 +162,7 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
   }
 
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240010",
-              @"No approriate openURL method defined for App Delegate");
+              @"No appropriate openURL method defined for App Delegate");
   return NO;
 }
 

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
@@ -43,7 +43,7 @@
 #import "FirebaseInAppMessaging/Sources/Private/Runtime/FIRIAMSDKModeManager.h"
 #import "FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FIRInAppMessaging.h"
 
-// A enum indicating 3 different possiblities of a setting about auto data collection.
+// A enum indicating 3 different possibilities of a setting about auto data collection.
 typedef NS_ENUM(NSInteger, FIRIAMAutoDataCollectionSetting) {
   // This indicates that the config is not explicitly set.
   FIRIAMAutoDataCollectionSettingNone = 0,


### PR DESCRIPTION
- All source codes under the FirebaseInAppMessaging/Sources directory have been reviewed.
- Corrected typos primarily found in comments and non-compiling sections of the project.
- Ensured all changes were fully backward-compatible, with no breaking changes introduced.
- Commits are organized into distinct chunks to facilitate easy review (or cherry-picking if needed).