### PR TITLE
Fix all typos found under the FirebaseInAppMessaging/Tests directory

### DIFF
--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClearcutUploaderTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClearcutUploaderTests.m
@@ -377,7 +377,7 @@
   NSNumber *waitTime =
       [NSNumber numberWithLongLong:self.defaultStrategy.maximumWaitTimeInMills + 200];
 
-  // Notice that it's invoking completion with falure flag and a flag to re-push those logs
+  // Notice that it's invoking completion with failure flag and a flag to re-push those logs
   OCMStub(
       [self.mockRequestSender
           sendClearcutHttpRequestForLogs:[OCMArg any]

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMMsgFetcherUsingRestfulTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMMsgFetcherUsingRestfulTests.m
@@ -203,7 +203,7 @@ static NSString *apiKey = @"Api-key";
 
   XCTAssertEqualObjects(osVersion, requestBodyDict[@"client_signals"][@"platform_version"]);
   XCTAssertEqualObjects(appVersion, requestBodyDict[@"client_signals"][@"app_version"]);
-  // not expexting language siganl since it's not mocked on mockclientInfoFetcher
+  // not expecting language signal since it's not mocked on mockclientInfoFetcher
   XCTAssertNil(requestBodyDict[@"client_signals"][@"language_code"]);
 }
 

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMSDKModeManagerTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMSDKModeManagerTests.m
@@ -94,7 +94,7 @@
       [[FIRIAMSDKModeManager alloc] initWithUserDefaults:self.mockUserDefaults
                                      testingModeListener:self.mockTestingModeListener];
 
-  // now we do new fetch registeration
+  // now we do new fetch registration
   [sdkManager registerOneMoreFetch];
 
   // verify that we are writing currentFetchCount+1 into user defaults
@@ -116,7 +116,7 @@
       [[FIRIAMSDKModeManager alloc] initWithUserDefaults:self.mockUserDefaults
                                      testingModeListener:self.mockTestingModeListener];
 
-  // now we do new fetch registeration, but no more fetch count or mode updates in user defaults
+  // now we do new fetch registration, but no more fetch count or mode updates in user defaults
   [sdkManager registerOneMoreFetch];
   XCTAssertEqual(FIRIAMSDKModeRegular, [sdkManager currentMode]);
   OCMReject([self.mockUserDefaults setInteger:currentFetchCount + 1 forKey:[OCMArg any]]);


### PR DESCRIPTION
- All files in the FirebaseInAppMessaging/Tests directory have been reviewed.
- All corrected typos were just comments so no breaking changes were introduced.