### PR TITLE
Fix all typos found in the FirebaseInstallations package

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
@@ -19,7 +19,7 @@
 static const NSTimeInterval k24Hours = 24 * 60 * 60;
 static const NSTimeInterval k30Minutes = 30 * 60;
 
-/** The class represents `FIRInstallationsBackoffController` sate required to calculate next allowed
+/** The class represents `FIRInstallationsBackoffController` state required to calculate next allowed
  request time. The properties of the class are intentionally immutable because changing them
  separately leads to an inconsistent state. */
 @interface FIRInstallationsBackoffEventData : NSObject

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
@@ -19,8 +19,8 @@
 static const NSTimeInterval k24Hours = 24 * 60 * 60;
 static const NSTimeInterval k30Minutes = 30 * 60;
 
-/** The class represents `FIRInstallationsBackoffController` state required to calculate next allowed
- request time. The properties of the class are intentionally immutable because changing them
+/** The class represents `FIRInstallationsBackoffController` state required to calculate next
+ allowed request time. The properties of the class are intentionally immutable because changing them
  separately leads to an inconsistent state. */
 @interface FIRInstallationsBackoffEventData : NSObject
 


### PR DESCRIPTION
All files (including Swift, Objective-C, etc.) in the package directory have been reviewed.
Fortunately, there was only a single typo in a single comment among all the files.