### PR TITLE
Fix typos in FirebaseMLModelDownloader package

### DIFF
--- a/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
@@ -432,7 +432,7 @@
         case let .success(fakemodelInfoResult):
           switch fakemodelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
-          case .notModified: XCTFail("Expected failure since model name is not availabl.")
+          case .notModified: XCTFail("Expected failure since model name is not available.")
           }
         case let .failure(error):
           XCTAssertEqual(error, .notFound)

--- a/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Unit/ModelDownloaderUnitTests.swift
@@ -39,7 +39,7 @@
   // TODO: Create separate files for each class tested.
   final class ModelDownloaderUnitTests: XCTestCase {
     let fakeModelName = "fakeModelName"
-    let fakemodelPath = "fakemodelPath"
+    let fakeModelPath = "fakeModelPath"
     let fakeModelHash = "fakeModelHash"
     let fakeDownloadURL = URL(string: "www.fake-download-url.com")!
     let fakeFileURL = URL(string: "www.fake-model-file.com")!
@@ -269,7 +269,7 @@
       let fakeModel = CustomModel(
         name: fakeModelName,
         size: 10,
-        path: fakemodelPath,
+        path: fakeModelPath,
         hash: fakeModelHash
       )
       var modelOptions = ModelOptions()
@@ -298,8 +298,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case let .modelInfo(remoteModelInfo):
             XCTAssertEqual(remoteModelInfo.name, self.fakeModelName)
             XCTAssertEqual(remoteModelInfo.downloadURL, self.fakeDownloadURL)
@@ -326,8 +326,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: break
           }
@@ -346,8 +346,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: XCTFail("Expected failure since local model info was not set.")
           }
@@ -375,8 +375,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: XCTFail("Expected failure since model hash does not match.")
           }
@@ -404,8 +404,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: XCTFail("Expected failure since model name is invalid.")
           }
@@ -429,8 +429,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: XCTFail("Expected failure since model name is not available.")
           }
@@ -454,8 +454,8 @@
       modelInfoRetriever.downloadModelInfo { result in
         completionExpectation.fulfill()
         switch result {
-        case let .success(fakemodelInfoResult):
-          switch fakemodelInfoResult {
+        case let .success(fakeModelInfoResult):
+          switch fakeModelInfoResult {
           case .modelInfo: XCTFail("Unexpected new model info from server.")
           case .notModified: XCTFail("Expected failure since resource exhausted.")
           }


### PR DESCRIPTION
All files in the package directory have been reviewed.
Fortunately, there was only a single typo in a single comment and a single one in an XCTFail message among all the files.