### PR TITLE
Fix all typos found under the FirebaseMessaging/Sources/Token directory

### DIFF
--- a/FirebaseMessaging/Sources/Token/FIRMessagingCheckinService.h
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingCheckinService.h
@@ -44,7 +44,7 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingDeviceDataVersionKey;
  *  gService data.
  *
  *  @param existingCheckin An existing checkin preference object, if available.
- *  @param completion Completion hander called on success or failure of device checkin.
+ *  @param completion Completion handler called on success or failure of device checkin.
  */
 - (void)checkinWithExistingCheckin:(nullable FIRMessagingCheckinPreferences *)existingCheckin
                         completion:

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -26,7 +26,7 @@
  *              created from a dictionary. The same keys are used
  *              when decoding/encoding an archive.
  */
-/// Specifies a dictonary key whose value represents the authorized entity, or
+/// Specifies a dictionary key whose value represents the authorized entity, or
 /// Sender ID for the token.
 static NSString *const kFIRInstanceIDAuthorizedEntityKey = @"authorized_entity";
 /// Specifies a dictionary key whose value represents the scope of the token,

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -333,7 +333,7 @@
               handler:^(NSError *error) {
                 if (!error) {
                   // Do not send the token back in case the save was unsuccessful. Since with
-                  // the new asychronous fetch mechanism this can lead to infinite loops, for
+                  // the new asynchronous fetch mechanism this can lead to infinite loops, for
                   // example, we will return a valid token even though we weren't able to store
                   // it in our cache. The first token will lead to a onTokenRefresh callback
                   // wherein the user again calls `getToken` but since we weren't able to save


### PR DESCRIPTION
All files in the directory have been reviewed and all the typos were just comments.