### PR TITLE
Fix all typos found under the FirebaseMessaging/Sources directory

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -502,7 +502,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 }
 
 - (NSString *)FCMToken {
-  // Gets the current default token, and requets a new one if it doesn't exist.
+  // Gets the current default token, and requests a new one if it doesn't exist.
   NSString *token = [self.tokenManager tokenAndRequestIfNotExist];
   return token;
 }

--- a/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
@@ -353,7 +353,7 @@ static NSString *kUserNotificationDidReceiveResponseSelectorString =
 
 // This is useful to generate from a stable, "known missing" selector, as the IMP can be compared
 // in case we are setting an implementation for a class that was previously "unswizzled" into a
-// non-existant implementation.
+// non-existent implementation.
 - (IMP)nonExistantMethodImplementationForClass:(Class)klass {
   SEL nonExistantSelector = NSSelectorFromString(@"aNonExistantMethod");
   IMP nonExistantMethodImplementation = class_getMethodImplementation(klass, nonExistantSelector);

--- a/FirebaseMessaging/Sources/FIRMessagingRmqManager.h
+++ b/FirebaseMessaging/Sources/FIRMessagingRmqManager.h
@@ -56,7 +56,7 @@
 - (FIRMessagingPersistentSyncMessage *)querySyncMessageWithRmqID:(NSString *)rmqID;
 
 /**
- *  Delete the expired sync messages from persisten store. Also deletes messages that have been
+ *  Delete the expired sync messages from persistent store. Also deletes messages that have been
  *  delivered both via APNS and MCS.
  */
 - (void)deleteExpiredOrFinishedSyncMessages;

--- a/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
@@ -489,7 +489,7 @@ NSString *_Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
     BOOL didOpenDatabase = YES;
     if (![fileManager fileExistsAtPath:path]) {
-      // We've to separate between different versions here because of backwards compatbility issues.
+      // We've to separate between different versions here because of backwards compatibility issues.
       int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 #ifdef SQLITE_OPEN_FILEPROTECTION_NONE
       flags |= SQLITE_OPEN_FILEPROTECTION_NONE;

--- a/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
@@ -489,7 +489,7 @@ NSString *_Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
     BOOL didOpenDatabase = YES;
     if (![fileManager fileExistsAtPath:path]) {
-      // We've to separate between different versions here because of backwards compatibility issues.
+      // We've to separate between different versions here because of backward compatibility issues.
       int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
 #ifdef SQLITE_OPEN_FILEPROTECTION_NONE
       flags |= SQLITE_OPEN_FILEPROTECTION_NONE;

--- a/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.h
+++ b/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.h
@@ -39,7 +39,7 @@
 - (void)removeExpiredSyncMessages;
 
 /**
- *  App did recive a sync message via APNS.
+ *  App did receive a sync message via APNS.
  *
  *  @param message The sync message received.
  *


### PR DESCRIPTION
All files in the directory have been reviewed and all the typos were just comments.
I had to use a slightly less common version of a word to satisfy the linter line length check.