### PR TITLE
Fix all typos found under the FirebasePerformance test app

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -96,7 +96,7 @@
 
 # 7.0.0
 - Fix issue related to crashes on specific kind of network requests #6713.
-- Fixed issue related to race condition on Firebase Remote Config initializaton #6287.
+- Fixed issue related to race condition on Firebase Remote Config initialization #6287.
 - Update Firebase dependencies to be latest and greatest.
 
 # 3.3.1

--- a/FirebasePerformance/Tests/TestApp/Source/Models/PerfLogger.m
+++ b/FirebasePerformance/Tests/TestApp/Source/Models/PerfLogger.m
@@ -19,7 +19,7 @@ static NSString *const kPerfLogPrefix = @"PerfTestAppLog_";
 
 @implementation PerfLogger
 
-#pragma mark - Initializtion
+#pragma mark - Initialization
 
 + (instancetype)sharedInstance {
   static PerfLogger *logger = nil;

--- a/FirebasePerformance/Tests/TestApp/Source/Networking/PerfNetworkConnection.m
+++ b/FirebasePerformance/Tests/TestApp/Source/Networking/PerfNetworkConnection.m
@@ -50,7 +50,7 @@
 
 - (void)makeNetworkRequestWithSuccessCallback:(SuccessNetworkCallback)success
                               failureCallback:(FailureNetworkCallback)fail {
-  NSAssert(NO, @"Abstract class. The method must be overriden.");
+  NSAssert(NO, @"Abstract class. The method must be overridden.");
 }
 
 @end

--- a/FirebasePerformance/Tests/TestApp/Source/ViewControllers/ScreenTracesViewController.h
+++ b/FirebasePerformance/Tests/TestApp/Source/ViewControllers/ScreenTracesViewController.h
@@ -15,7 +15,7 @@
 #import <UIKit/UIKit.h>
 
 /** This is a split view controller subclass that sets up everything needed to display the catalog
- *  of all the screen trace test screens availble.
+ *  of all the screen trace test screens available.
  */
 @interface ScreenTracesViewController : UISplitViewController
 

--- a/FirebasePerformance/Tests/TestApp/Source/Views/PerfTraceView.m
+++ b/FirebasePerformance/Tests/TestApp/Source/Views/PerfTraceView.m
@@ -35,7 +35,7 @@
 /** A button to increment a second metric on the currently running trace. */
 @property(nonatomic) UIButton *metricTwoButton;
 
-/** A button to add a custom attribute to the currrently running trace. */
+/** A button to add a custom attribute to the currently running trace. */
 @property(nonatomic) UIButton *customAttributeButton;
 
 /** A label for the current stage state. */


### PR DESCRIPTION
All files have been reviewed.
Most of the changes are just comments but there are pragma marks and NSAssert messages as well.