### PR TITLE
Review FirebaseStorage test files

### DIFF
--- a/FirebaseStorage/Tests/Unit/StorageAPITests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAPITests.swift
@@ -191,7 +191,7 @@ final class StorageAPITests: XCTestCase {
 
   func StorageObservableTaskApis(ref: StorageReference) throws {
     let task = ref.write(toFile: URL(string: "url")!)
-    _ = task.observe(.pause) { snaphot in
+    _ = task.observe(.pause) { snapshot in
     }
     task.removeObserver(withHandle: "handle")
     task.removeAllObservers()


### PR DESCRIPTION
The only change is the name of a local variable within a closure that has a very limited scope and is unused. It might be best to remove it entirely.