### PR TITLE
Review FirebaseVertexAI Tests

### DIFF
--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -75,7 +75,7 @@ final class PartsRepresentableTests: XCTestCase {
           return
         }
       }
-      XCTFail("Expected model content from invlaid image to error")
+      XCTFail("Expected model content from invalid image to error")
     }
   #endif // canImport(CoreImage)
 
@@ -99,7 +99,7 @@ final class PartsRepresentableTests: XCTestCase {
           return
         }
       }
-      XCTFail("Expected model content from invlaid image to error")
+      XCTFail("Expected model content from invalid image to error")
     }
 
     func testModelContentFromUIImageIsNotEmpty() throws {
@@ -137,7 +137,7 @@ final class PartsRepresentableTests: XCTestCase {
           return
         }
       }
-      XCTFail("Expected model content from invlaid image to error")
+      XCTFail("Expected model content from invalid image to error")
     }
   #endif
 }


### PR DESCRIPTION
It was a single typo repeated in multiple XCTFail messages, likely due to a copy-paste error.