### PR TITLE
Revisit scripts

### DIFF
--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -238,7 +238,7 @@ struct SpecRepoBuilder: ParsableCommand {
         if depPrefix.hasSuffix(Constants.specDependencyLabel) {
           // e.g. In Firebase.podspec, Firebase/Core will not be considered a
           // dependency.
-          // "ss.dependency 'Firebase/Core'" will be splitted in
+          // "ss.dependency 'Firebase/Core'" will be split in
           // ["ss.dependency", "'Firebase", "Core'"]
           let podNameRaw = String(tokens[1]).replacingOccurrences(of: "'", with: "")
           // In the example above, deps here will not include Firebase since


### PR DESCRIPTION
This typo was some sort of ok but the past form of `split` is `split`, right? I fixed it to stop Xcode from screaming on users :)