### PR TITLE
Add Firestore async counterparts

### DIFF
--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -51,6 +51,7 @@ public extension CollectionReference {
   /// - Parameters:
   ///   - value: An instance of `Encodable` to be encoded to a document.
   ///   - encoder: An encoder instance to use to run the encoding.
+  ///   - Throws: `Error` if the backend rejected the write.
   /// - Returns: A `DocumentReference` pointing to the newly created document.
   @discardableResult
   func addDocument<T: Encodable>(from value: T,

--- a/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
+++ b/Firestore/Swift/Source/AsyncAwait/CollectionReference+AsyncAwait.swift
@@ -42,4 +42,30 @@ public extension CollectionReference {
       }
     }
   }
+
+  /// Encodes an instance of `Encodable` and adds a new document to this collection
+  /// with the encoded data, assigning it a document ID automatically.
+  ///
+  /// See `Firestore.Encoder` for more details about the encoding process.
+  ///
+  /// - Parameters:
+  ///   - value: An instance of `Encodable` to be encoded to a document.
+  ///   - encoder: An encoder instance to use to run the encoding.
+  /// - Returns: A `DocumentReference` pointing to the newly created document.
+  @discardableResult
+  func addDocument<T: Encodable>(from value: T,
+                                 encoder: Firestore.Encoder = Firestore.Encoder()) async throws
+  -> DocumentReference {
+    return try await withCheckedThrowingContinuation { continuation in
+      var document: DocumentReference?
+      document = self.addDocument(from: value, encoder: encoder) { error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else {
+          // Our callbacks guarantee that we either return an error or a document.
+          continuation.resume(returning: document!)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
- The function signature is from the original; I just converted the completion parameter.
- The documentation is from the original; I only added the Throws line from another existing function.
- The implementation is from another existing function, but it uses the original `addDocument` which takes an encodable.