### PR TITLE
Renamed `FUNSerializer` to `FunctionsSerializer`

### DIFF
--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -47,7 +47,7 @@ enum FunctionsConstants {
   /// The projectID to use for all function references.
   private let projectID: String
   /// A serializer to encode/decode data and return values.
-  private let serializer = FUNSerializer()
+  private let serializer = FunctionsSerializer()
   /// A factory for getting the metadata to include with function calls.
   private let contextProvider: FunctionsContextProvider
 

--- a/FirebaseFunctions/Sources/FunctionsError.swift
+++ b/FirebaseFunctions/Sources/FunctionsError.swift
@@ -211,7 +211,7 @@ extension FunctionsErrorCode {
 
 func FunctionsErrorForResponse(status: NSInteger,
                                body: Data?,
-                               serializer: FUNSerializer) -> NSError? {
+                               serializer: FunctionsSerializer) -> NSError? {
   // Start with reasonable defaults from the status code.
   var code = FunctionsCodeForHTTPStatus(status)
   var description = code.descriptionForErrorCode

--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -20,7 +20,7 @@ private enum Constants {
   static let dateType = "type.googleapis.com/google.protobuf.Timestamp"
 }
 
-extension FUNSerializer {
+extension FunctionsSerializer {
   enum Error: Swift.Error {
     case unsupportedType(typeName: String)
     case unknownNumberType(charValue: String, number: NSNumber)
@@ -28,7 +28,7 @@ extension FUNSerializer {
   }
 }
 
-class FUNSerializer: NSObject {
+class FunctionsSerializer: NSObject {
   private let dateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"

--- a/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
@@ -24,12 +24,12 @@ import FirebaseCore
 
 import XCTest
 
-class SerializerTests: XCTestCase {
-  private var serializer: FUNSerializer!
+class FunctionsSerializerTests: XCTestCase {
+  private var serializer: FunctionsSerializer!
 
   override func setUp() {
     super.setUp()
-    serializer = FUNSerializer()
+    serializer = FunctionsSerializer()
   }
 
   func testEncodeNull() throws {
@@ -98,7 +98,7 @@ class SerializerTests: XCTestCase {
     let dictLowLong = ["@type": typeString, "value": badVal]
     do {
       _ = try serializer.decode(dictLowLong) as? NSNumber
-    } catch let FUNSerializer.Error.invalidValueForType(value, type) {
+    } catch let FunctionsSerializer.Error.invalidValueForType(value, type) {
       XCTAssertEqual(value, badVal)
       XCTAssertEqual(type, typeString)
       return
@@ -136,7 +136,7 @@ class SerializerTests: XCTestCase {
     let coded = ["@type": typeString, "value": tooHighVal]
     do {
       _ = try serializer.decode(coded) as? NSNumber
-    } catch let FUNSerializer.Error.invalidValueForType(value, type) {
+    } catch let FunctionsSerializer.Error.invalidValueForType(value, type) {
       XCTAssertEqual(value, tooHighVal)
       XCTAssertEqual(type, typeString)
       return
@@ -241,7 +241,7 @@ class SerializerTests: XCTestCase {
       let _ = try serializer.encode(input)
       XCTFail("Expected an error")
     } catch {
-      guard case let .unsupportedType(typeName: typeName) = error as? FUNSerializer.Error
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
       else {
         return XCTFail("Unexpected error: \(error)")
       }
@@ -257,7 +257,7 @@ class SerializerTests: XCTestCase {
       let _ = try serializer.decode(input)
       XCTFail("Expected an error")
     } catch {
-      guard case let .unsupportedType(typeName: typeName) = error as? FUNSerializer.Error
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
       else {
         return XCTFail("Unexpected error: \(error)")
       }


### PR DESCRIPTION
* Renamed `FUNSerializer` to `FunctionsSerializer` to follow the naming convention for Swift
* Renamed `SerializerTests` to `FunctionsSerializerTests` for consistency
* `FunctionsSerializer` is internal, so this change does not affect the public API