### PR TITLE
[Infra] Fetch tags first when running firebase-releaser

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/main.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/main.swift
@@ -74,6 +74,7 @@ struct FirebaseReleaser: ParsableCommand {
 
     Shell.executeCommand("git checkout \(baseBranch)", workingDir: gitRoot)
     Shell.executeCommand("git pull origin \(baseBranch)", workingDir: gitRoot)
+    Shell.executeCommand("git fetch origin --tags --force", workingDir: gitRoot)
 
     if initBranch {
       let branch = InitializeRelease.setupRepo(gitRoot: gitRoot)


### PR DESCRIPTION
I ran into this when moving tags. My local tags were outdated so it recommending re-staging pods that had already been staged.