### PR TITLE
[Infra] Upload build-from-HEAD zips on failures

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -94,6 +94,7 @@ jobs:
            build-head \
            ${{ matrix.linking_type }}
     - uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
         # Zip the entire output directory since the builder adds subdirectories we don't know the


### PR DESCRIPTION
In the event there is a failure, it may be helpful to have the directory so we can access the build logs. This should hopefully save the need to locally build the zip to figure out what went wrong.