### PR TITLE
Consistent Collections Coding in `FunctionsSerializer`

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -47,22 +47,16 @@ class FunctionsSerializer: NSObject {
       return object as AnyObject
     } else if object is NSDictionary {
       let dict = object as! NSDictionary
-      let encoded: NSMutableDictionary = .init()
-      dict.enumerateKeysAndObjects { key, obj, _ in
-        // TODO(wilsonryan): Not exact translation
-        let anyObj = obj as AnyObject
-        let stringKey = key as! String
-        let value = try! encode(anyObj)
-        encoded[stringKey] = value
+      let encoded = NSMutableDictionary()
+      try dict.forEach { key, value in
+        encoded[key] = try encode(value)
       }
       return encoded
     } else if object is NSArray {
       let array = object as! NSArray
       let encoded = NSMutableArray()
-      for item in array {
-        let anyItem = item as AnyObject
-        let encodedItem = try encode(anyItem)
-        encoded.add(encodedItem)
+      try array.forEach { element in
+        try encoded.add(encode(element))
       }
       return encoded
 
@@ -91,14 +85,11 @@ class FunctionsSerializer: NSObject {
       }
       return decoded
     } else if let array = object as? NSArray {
-      let result = NSMutableArray(capacity: array.count)
-      for obj in array {
-        // TODO: Is this data loss? The API is a bit weird.
-        if let decoded = try decode(obj) {
-          result.add(decoded)
-        }
+      let decoded = NSMutableArray(capacity: array.count)
+      try array.forEach { element in
+        try decoded.add(decode(element) as Any)
       }
-      return result
+      return decoded
     } else if object is NSNumber || object is NSString || object is NSNull {
       return object as AnyObject
     }

--- a/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
@@ -190,14 +190,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeArrayWithInvalidElements() {
     let input = ["TEST", CustomObject()] as NSArray
 
-    XCTAssertThrowsError(try serializer.encode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.encode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testDecodeArray() throws {
@@ -214,14 +207,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testDecodeArrayWithInvalidElements() {
     let input = ["TEST", CustomObject()] as NSArray
 
-    XCTAssertThrowsError(try serializer.decode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.decode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testEncodeDictionary() throws {
@@ -242,28 +228,14 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeDictionaryWithInvalidElements() {
     let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
 
-    XCTAssertThrowsError(try serializer.encode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.encode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testEncodeDictionaryWithInvalidNestedDictionary() {
     let input =
       ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
 
-    XCTAssertThrowsError(try serializer.encode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.encode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testDecodeDictionary() throws {
@@ -275,28 +247,14 @@ class FunctionsSerializerTests: XCTestCase {
   func testDecodeDictionaryWithInvalidElements() {
     let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
 
-    XCTAssertThrowsError(try serializer.decode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.decode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testDecodeDictionaryWithInvalidNestedDictionary() {
     let input =
       ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
 
-    XCTAssertThrowsError(try serializer.decode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
-        .Error else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.decode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testEncodeUnknownType() {
@@ -317,26 +275,29 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeUnsupportedType() {
     let input = CustomObject()
 
-    XCTAssertThrowsError(try serializer.encode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
-      else {
-        return XCTFail("Unexpected error: \(error)")
-      }
-
-      XCTAssertEqual(typeName, "CustomObject")
-    }
+    try assert(serializer.encode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
   }
 
   func testDecodeUnsupportedType() {
     let input = CustomObject()
 
-    XCTAssertThrowsError(try serializer.decode(input)) { error in
-      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
-      else {
-        return XCTFail("Unexpected error: \(error)")
+    try assert(serializer.decode(input), throwsUnsupportedTypeErrorWithName: "CustomObject")
+  }
+}
+
+// MARK: - Utilities
+
+extension FunctionsSerializerTests {
+  private func assert<T>(_ expression: @autoclosure () throws -> T,
+                         throwsUnsupportedTypeErrorWithName expectedTypeName: String,
+                         line: UInt = #line) {
+    XCTAssertThrowsError(try expression(), line: line) { error in
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)", line: line)
       }
 
-      XCTAssertEqual(typeName, "CustomObject")
+      XCTAssertEqual(typeName, expectedTypeName, line: line)
     }
   }
 }

--- a/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
@@ -187,6 +187,22 @@ class FunctionsSerializerTests: XCTestCase {
     XCTAssertEqual(input, try serializer.encode(input) as? NSArray)
   }
 
+  func testEncodeArrayWithInvalidElements() {
+    let input = ["TEST", CustomObject()] as NSArray
+
+    do {
+      let _ = try serializer.encode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
+  }
+
   func testDecodeArray() throws {
     let input = [
       1 as Int64,
@@ -198,7 +214,23 @@ class FunctionsSerializerTests: XCTestCase {
     XCTAssertEqual(expected, try serializer.decode(input) as? NSArray)
   }
 
-  func testEncodeMap() {
+  func testDecodeArrayWithInvalidElements() {
+    let input = ["TEST", CustomObject()] as NSArray
+
+    do {
+      let _ = try serializer.decode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
+  }
+
+  func testEncodeDictionary() throws {
     let input = [
       "foo": 1 as Int32,
       "bar": "hello",
@@ -213,10 +245,76 @@ class FunctionsSerializerTests: XCTestCase {
     XCTAssertEqual(expected, try serializer.encode(input) as? NSDictionary)
   }
 
-  func testDecodeMap() {
+  func testEncodeDictionaryWithInvalidElements() {
+    let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
+
+    do {
+      let _ = try serializer.encode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
+  }
+
+  func testEncodeDictionaryWithInvalidNestedDictionary() {
+    let input =
+      ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
+
+    do {
+      let _ = try serializer.encode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
+  }
+
+  func testDecodeDictionary() throws {
     let input = ["foo": 1, "bar": "hello", "baz": [3, 9_876_543_210]] as NSDictionary
     let expected = ["foo": 1, "bar": "hello", "baz": [3, 9_876_543_210]] as NSDictionary
     XCTAssertEqual(expected, try serializer.decode(input) as? NSDictionary)
+  }
+
+  func testDecodeDictionaryWithInvalidElements() {
+    let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
+
+    do {
+      let _ = try serializer.decode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
+  }
+
+  func testDecodeDictionaryWithInvalidNestedDictionary() {
+    let input =
+      ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
+
+    do {
+      let _ = try serializer.decode(input)
+      XCTFail("Expected an error")
+    } catch {
+      guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
+        .Error else {
+        return XCTFail("Unexpected error: \(error)")
+      }
+
+      XCTAssertEqual(typeName, "CustomObject")
+    }
   }
 
   func testEncodeUnknownType() {
@@ -268,6 +366,6 @@ class FunctionsSerializerTests: XCTestCase {
 }
 
 /// Used to represent a type that cannot be encoded or decoded.
-private struct CustomObject {
+private class CustomObject {
   let id = 123
 }

--- a/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
@@ -190,10 +190,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeArrayWithInvalidElements() {
     let input = ["TEST", CustomObject()] as NSArray
 
-    do {
-      let _ = try serializer.encode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.encode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -217,10 +214,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testDecodeArrayWithInvalidElements() {
     let input = ["TEST", CustomObject()] as NSArray
 
-    do {
-      let _ = try serializer.decode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.decode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -248,10 +242,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeDictionaryWithInvalidElements() {
     let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
 
-    do {
-      let _ = try serializer.encode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.encode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -265,10 +256,7 @@ class FunctionsSerializerTests: XCTestCase {
     let input =
       ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
 
-    do {
-      let _ = try serializer.encode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.encode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -287,10 +275,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testDecodeDictionaryWithInvalidElements() {
     let input = ["TEST_CustomObj": CustomObject()] as NSDictionary
 
-    do {
-      let _ = try serializer.decode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.decode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -304,10 +289,7 @@ class FunctionsSerializerTests: XCTestCase {
     let input =
       ["TEST_NestedDict": ["TEST_CustomObj": CustomObject()] as NSDictionary] as NSDictionary
 
-    do {
-      let _ = try serializer.decode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.decode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer
         .Error else {
         return XCTFail("Unexpected error: \(error)")
@@ -335,10 +317,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testEncodeUnsupportedType() {
     let input = CustomObject()
 
-    do {
-      let _ = try serializer.encode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.encode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
       else {
         return XCTFail("Unexpected error: \(error)")
@@ -351,10 +330,7 @@ class FunctionsSerializerTests: XCTestCase {
   func testDecodeUnsupportedType() {
     let input = CustomObject()
 
-    do {
-      let _ = try serializer.decode(input)
-      XCTFail("Expected an error")
-    } catch {
+    XCTAssertThrowsError(try serializer.decode(input)) { error in
       guard case let .unsupportedType(typeName: typeName) = error as? FunctionsSerializer.Error
       else {
         return XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
* If `FunctionsSerializer` is given an object of unsupported type to encode, it throws an error
* However, if that object is contained in a dictionary, `FunctionsSerializer` crashes the app because of a force-unwrap
* The change fixes this inconsistency
* Additionally, array decoding no longer uses an `if-let` and instead inserts the optional value `as Any`
* Overall, this change achieves consistency in encoding and decoding of collections: Any non-codable element fails the operation, without crashing the app or resulting in missing elements
* New tests were added to check these scenarios