### PR TITLE
Move swiftformat options to a config file

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,9 +5,6 @@
 
 # Disabled Rules
 
-# sortedImports is broken, sorting into the middle of the copyright notice.
---disable sortedImports
-
 # Too many of our swift files have simplistic examples. While technically
 # it's correct to remove the unused argument labels, it makes our examples
 # look wrong.

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,17 @@
+# Formatting Options - Mimic Google style
+--indent 2
+--maxwidth 100
+--wrapparameters afterfirst
+
+# Disabled Rules
+
+# sortedImports is broken, sorting into the middle of the copyright notice.
+--disable sortedImports
+
+# Too many of our swift files have simplistic examples. While technically
+# it's correct to remove the unused argument labels, it makes our examples
+# look wrong.
+--disable unusedArguments
+
+# We prefer trailing braces.
+--disable wrapMultilineStatementBraces

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -253,10 +253,9 @@ style_cmd=("${top_dir}/scripts/style.sh")
 if [[ "${TEST_ONLY}" == true ]]; then
   style_cmd+=(test-only)
 fi
-# Temporarily force style checking on entire repo; revert before merging.
-# if [[ "$CHECK_DIFF" == true ]]; then
-#   style_cmd+=("${START_SHA}")
-# fi
+if [[ "$CHECK_DIFF" == true ]]; then
+  style_cmd+=("${START_SHA}")
+fi
 
 # Restyle and commit any changes
 "${style_cmd[@]}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -253,9 +253,10 @@ style_cmd=("${top_dir}/scripts/style.sh")
 if [[ "${TEST_ONLY}" == true ]]; then
   style_cmd+=(test-only)
 fi
-if [[ "$CHECK_DIFF" == true ]]; then
-  style_cmd+=("${START_SHA}")
-fi
+# Temporarily force style checking on entire repo; revert before merging.
+# if [[ "$CHECK_DIFF" == true ]]; then
+#   style_cmd+=("${START_SHA}")
+# fi
 
 # Restyle and commit any changes
 "${style_cmd[@]}"

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -92,6 +92,10 @@ function join() {
 }
 
 clang_options=(-style=file)
+
+# Swift formatting options for the repo should be configured in
+# https://github.com/firebase/firebase-ios-sdk/blob/main/.swiftformat.
+# These may be overriden with additional `.swiftformat` files in subdirectories.
 swift_options=()
 
 if [[ $# -gt 0 && "$1" == "test-only" ]]; then

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -92,29 +92,7 @@ function join() {
 }
 
 clang_options=(-style=file)
-
-# Rules to disable in swiftformat:
-swift_disable=(
-  # sortedImports is broken, sorting into the middle of the copyright notice.
-  sortedImports
-
-  # Too many of our swift files have simplistic examples. While technically
-  # it's correct to remove the unused argument labels, it makes our examples
-  # look wrong.
-  unusedArguments
-
-  # We prefer trailing braces.
-  wrapMultilineStatementBraces
-)
-
-swift_options=(
-  # Mimic Objective-C style.
-  --indent 2
-  --maxwidth 100
-  --wrapparameters afterfirst
-
-  --disable $(join , "${swift_disable[@]}")
-)
+swift_options=()
 
 if [[ $# -gt 0 && "$1" == "test-only" ]]; then
   test_only=true


### PR DESCRIPTION
Added a `.swiftformat` file for SwiftFormat configuration options, similar to `.clang-format`. This makes it easy to override options in specific subdirectories.

Enabled `sortedImports`, which was previously [disabled](https://github.com/firebase/firebase-ios-sdk/blob/6c5b8b796d9c772ea1072c3d12ce0081515666b4/scripts/style.sh#L98-L99). This feature appears to be working correctly now.

#no-changelog