### PR TITLE
[Infra] Fix auto-tagging in `release_testing_setup.sh` for prerelease.yml

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -158,7 +158,6 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
-      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
       podspec_repo_branch: main
     steps:
     - uses: actions/checkout@v4
@@ -171,7 +170,6 @@ jobs:
          # Update/create a nightly tag to the head of the main branch.
          test_version="${nightly_version}" \
            sdk_version_config="${GITHUB_WORKSPACE}/scripts/create_spec_repo/RC_firebase_sdk.textproto" \
-           local_sdk_repo_dir="${local_sdk_repo_dir}" \
            podspec_repo_branch="${podspec_repo_branch}" \
            scripts/release_testing_setup.sh prerelease_testing
       env:
@@ -179,7 +177,6 @@ jobs:
     - name: Push updated podspecs
       run: |
         botaccess=`cat bot-access.txt`
-        cd "${local_sdk_repo_dir}"
         # Changes in post submit tests will be fetched by getting diff between
         # the HEAD and HEAD^ of the main branch.
         common_commit=$(git rev-parse HEAD^)
@@ -200,7 +197,7 @@ jobs:
         cd scripts/create_spec_repo/
         swift build
         pod repo add --silent "${local_repo}" https://"$botaccess"@github.com/Firebase/SpecsTesting.git
-        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo "${local_sdk_repo_dir}" --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://cdn.cocoapods.org/" "FirebaseFirestoreTestingSupport" "FirebaseAuthTestingSupport" "FirebaseCombineSwift" --keep-repo --include-pods "${updated_podspecs[@]}"
+        BOT_TOKEN="${botaccess}" .build/debug/spec-repo-builder --sdk-repo $(pwd) --local-spec-repo-name "${local_repo}" --sdk-repo-name SpecsTesting --github-account Firebase --pod-sources 'https://${BOT_TOKEN}@github.com/Firebase/SpecsTesting' "https://github.com/firebase/SpecsDev.git" "https://github.com/firebase/SpecsStaging.git" "https://cdn.cocoapods.org/" "FirebaseFirestoreTestingSupport" "FirebaseAuthTestingSupport" "FirebaseCombineSwift" --keep-repo --include-pods "${updated_podspecs[@]}"
 
   abtesting_quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,10 +20,6 @@ jobs:
     runs-on: macos-14
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      # The SDK repo will be cloned to this dir and podspecs from
-      # 'podspec_repo_branch' of this repo will be validated and pushed to the
-      # testing repo.
-      local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
       local_repo: specstesting
       podspec_repo_branch: main
     outputs:
@@ -41,7 +37,6 @@ jobs:
       run: |
          test_version="${nightly_version}" \
            sdk_version_config="${GITHUB_WORKSPACE}/scripts/create_spec_repo/RC_firebase_sdk.textproto" \
-           local_sdk_repo_dir="${local_sdk_repo_dir}" \
            podspec_repo_branch="${podspec_repo_branch}" \
            scripts/release_testing_setup.sh prerelease_testing
       env:
@@ -69,8 +64,8 @@ jobs:
       with:
         name: firebase-ios-sdk
         path: |
-          ${{ env.local_sdk_repo_dir }}/*.podspec
-          ${{ env.local_sdk_repo_dir }}/*.podspec.json
+          *.podspec
+          *.podspec.json
   buildup_SpecsTesting_repo_FirebaseCore:
     needs: specs_checking
     # Don't run on private repo unless it is a PR.

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -32,7 +32,7 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   cd  "${local_sdk_repo_dir}"
 fi
 
-git fetch origin main
+git fetch --tags origin main
 git checkout main
 
 # The chunk below is to determine the latest version by searching

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -22,9 +22,9 @@ if [ -f "${HOME}/.cocoapods/repos" ]; then
   find "${HOME}/.cocoapods/repos" -type d -maxdepth 1 -exec sh -c 'pod repo remove $(basename {})' \;
 fi
 
-pwd 
-
 ls
+git status
+exit 1
 
 
 if [ "$TESTINGMODE" = "release_testing" ]; then

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -30,10 +30,10 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
   set -x
   cd  "${local_sdk_repo_dir}"
+elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
+  git fetch --tags origin main
+  git checkout main
 fi
-
-git fetch --tags origin main
-git checkout main
 
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -29,9 +29,9 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   # Using token here to update tags later.
   git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
   set -x
+  cd  "${local_sdk_repo_dir}"
 fi
 
-cd  "${local_sdk_repo_dir}"
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.
 test_version=$(git tag -l --sort=-version:refname --merged main CocoaPods-*[0-9] | head -n 1)

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -38,6 +38,10 @@ git checkout main
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.
 test_version=$(git tag -l --sort=-version:refname --merged main CocoaPods-*[0-9] | head -n 1)
+if [ -z "$test_version" ]; then
+  echo "Latest tag could not be found. Exiting." >&2
+  exit 1
+fi
 
 git config --global user.email "google-oss-bot@example.com"
 git config --global user.name "google-oss-bot"

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -32,8 +32,8 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   cd  "${local_sdk_repo_dir}"
 fi
 
-git --no-pager log -n 5 --oneline main
-exit 1
+git fetch origin main
+git checkout main
 
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -22,11 +22,6 @@ if [ -f "${HOME}/.cocoapods/repos" ]; then
   find "${HOME}/.cocoapods/repos" -type d -maxdepth 1 -exec sh -c 'pod repo remove $(basename {})' \;
 fi
 
-ls
-git status
-exit 1
-
-
 if [ "$TESTINGMODE" = "release_testing" ]; then
   mkdir -p "${local_sdk_repo_dir}"
   echo "git clone from github.com/firebase/firebase-ios-sdk.git to ${local_sdk_repo_dir}"
@@ -36,6 +31,9 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   set -x
   cd  "${local_sdk_repo_dir}"
 fi
+
+git --no-pager log -n 5 --oneline main
+exit 1
 
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -22,12 +22,14 @@ if [ -f "${HOME}/.cocoapods/repos" ]; then
   find "${HOME}/.cocoapods/repos" -type d -maxdepth 1 -exec sh -c 'pod repo remove $(basename {})' \;
 fi
 
-mkdir -p "${local_sdk_repo_dir}"
-echo "git clone from github.com/firebase/firebase-ios-sdk.git to ${local_sdk_repo_dir}"
-set +x
-# Using token here to update tags later.
-git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
-set -x
+if [ "$TESTINGMODE" = "release_testing" ]; then
+  mkdir -p "${local_sdk_repo_dir}"
+  echo "git clone from github.com/firebase/firebase-ios-sdk.git to ${local_sdk_repo_dir}"
+  set +x
+  # Using token here to update tags later.
+  git clone -q https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
+  set -x
+fi
 
 cd  "${local_sdk_repo_dir}"
 # The chunk below is to determine the latest version by searching

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -22,6 +22,11 @@ if [ -f "${HOME}/.cocoapods/repos" ]; then
   find "${HOME}/.cocoapods/repos" -type d -maxdepth 1 -exec sh -c 'pod repo remove $(basename {})' \;
 fi
 
+pwd 
+
+ls
+
+
 if [ "$TESTINGMODE" = "release_testing" ]; then
   mkdir -p "${local_sdk_repo_dir}"
   echo "git clone from github.com/firebase/firebase-ios-sdk.git to ${local_sdk_repo_dir}"


### PR DESCRIPTION
https://github.com/firebase/firebase-ios-sdk/pull/13217 did not work as expected and the prerelease nightly has been broken. I think the takeaway is that the GITHUB_TOKEN cannot be used in new clones, only in the workflow's original checkout context.

#no-changelog