### PR TITLE
[storage] Migrate to actor to fix a potential data race in initialization

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix a potential data race in Storage initialization. (#13369)
+
 # 11.0.0
 - [fixed] Updated error handling to support both Swift error enum handling and NSError error
   handling. Some of the Swift enums have additional parameters which may be a **breaking** change.

--- a/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageDeleteTask.swift
@@ -24,11 +24,9 @@ import Foundation
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 enum StorageDeleteTask {
   static func deleteTask(reference: StorageReference,
-                         fetcherService: GTMSessionFetcherService,
                          queue: DispatchQueue,
                          completion: ((_: Data?, _: Error?) -> Void)?) {
     StorageInternalTask(reference: reference,
-                        fetcherService: fetcherService,
                         queue: queue,
                         httpMethod: "DELETE",
                         fetcherComment: "DeleteTask",

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -66,7 +66,7 @@ actor StorageFetcherService {
     testBlock = block
   }
 
-  private var testBlock: GTMSessionFetcherTestBlock? = nil
+  private var testBlock: GTMSessionFetcherTestBlock?
 
   /// Map of apps to a dictionary of buckets to GTMSessionFetcherService.
   private static var fetcherServiceMap: [String: [String: GTMSessionFetcherService]] = [:]

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -1,0 +1,86 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+#if COCOAPODS
+  import GTMSessionFetcher
+#else
+  import GTMSessionFetcherCore
+#endif
+
+/// Manage Storage's fetcherService
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+actor StorageFetcherService {
+  private var _fetcherService: GTMSessionFetcherService?
+
+  func fetcherService(_ storage: Storage) -> GTMSessionFetcherService {
+    if let _fetcherService {
+      return _fetcherService
+    }
+    let app = storage.app
+    var bucketMap = StorageFetcherService.fetcherServiceMap[app.name]
+    if bucketMap == nil {
+      bucketMap = [:]
+      StorageFetcherService.fetcherServiceMap[app.name] = bucketMap
+    }
+    var fetcherService = bucketMap?[storage.storageBucket]
+    if fetcherService == nil {
+      fetcherService = GTMSessionFetcherService()
+      fetcherService?.isRetryEnabled = true
+      fetcherService?.retryBlock = retryWhenOffline
+      fetcherService?.allowLocalhostRequest = true
+      fetcherService?.maxRetryInterval = storage.maxOperationRetryInterval
+      fetcherService?.testBlock = testBlock
+      let authorizer = StorageTokenAuthorizer(
+        googleAppID: app.options.googleAppID,
+        callbackQueue: storage.callbackQueue,
+        authProvider: storage.auth,
+        appCheck: storage.appCheck
+      )
+      fetcherService?.authorizer = authorizer
+      bucketMap?[storage.storageBucket] = fetcherService
+    }
+    if storage.usesEmulator {
+      fetcherService?.allowLocalhostRequest = true
+      fetcherService?.allowedInsecureSchemes = ["http"]
+    }
+    _fetcherService = fetcherService
+    return fetcherService!
+  }
+
+  /// Update the testBlock for unit testing. Save it as a property since this may be called before
+  /// fetcherService is initialized.
+  func updateTestBlock(_ block: @escaping GTMSessionFetcherTestBlock) {
+    testBlock = block
+  }
+
+  private var testBlock: GTMSessionFetcherTestBlock? = nil
+
+  /// Map of apps to a dictionary of buckets to GTMSessionFetcherService.
+  private static var fetcherServiceMap: [String: [String: GTMSessionFetcherService]] = [:]
+
+  private var retryWhenOffline: GTMSessionFetcherRetryBlock = {
+    (suggestedWillRetry: Bool,
+     error: Error?,
+     response: @escaping GTMSessionFetcherRetryResponse) in
+    var shouldRetry = suggestedWillRetry
+    // GTMSessionFetcher does not consider being offline a retryable error, but we do, so we
+    // special-case it here.
+    if !shouldRetry, error != nil {
+      shouldRetry = (error as? NSError)?.code == URLError.notConnectedToInternet.rawValue
+    }
+    response(shouldRetry)
+  }
+}

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -30,12 +30,10 @@ actor StorageFetcherService {
       return _fetcherService
     }
     let app = storage.app
-    var bucketMap = StorageFetcherService.fetcherServiceMap[app.name]
-    if bucketMap == nil {
-      bucketMap = [:]
-      StorageFetcherService.fetcherServiceMap[app.name] = bucketMap
+    if StorageFetcherService.fetcherServiceMap[app.name] == nil {
+      StorageFetcherService.fetcherServiceMap[app.name] = [:]
     }
-    var fetcherService = bucketMap?[storage.storageBucket]
+    var fetcherService = StorageFetcherService.fetcherServiceMap[app.name]?[storage.storageBucket]
     if fetcherService == nil {
       fetcherService = GTMSessionFetcherService()
       fetcherService?.isRetryEnabled = true
@@ -50,7 +48,7 @@ actor StorageFetcherService {
         appCheck: storage.appCheck
       )
       fetcherService?.authorizer = authorizer
-      bucketMap?[storage.storageBucket] = fetcherService
+      StorageFetcherService.fetcherServiceMap[app.name]?[storage.storageBucket] = fetcherService
     }
     if storage.usesEmulator {
       fetcherService?.allowLocalhostRequest = true
@@ -64,6 +62,9 @@ actor StorageFetcherService {
   /// fetcherService is initialized.
   func updateTestBlock(_ block: @escaping GTMSessionFetcherTestBlock) {
     testBlock = block
+    if let _fetcherService {
+      _fetcherService.testBlock = testBlock
+    }
   }
 
   private var testBlock: GTMSessionFetcherTestBlock?

--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -14,21 +14,13 @@
 
 import Foundation
 
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
-
 /// Task which provides the ability to get a download URL for an object in Firebase Storage.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 enum StorageGetDownloadURLTask {
   static func getDownloadURLTask(reference: StorageReference,
-                                 fetcherService: GTMSessionFetcherService,
                                  queue: DispatchQueue,
                                  completion: ((_: URL?, _: Error?) -> Void)?) {
     StorageInternalTask(reference: reference,
-                        fetcherService: fetcherService,
                         queue: queue,
                         httpMethod: "GET",
                         fetcherComment: "GetDownloadURLTask") { (data: Data?, error: Error?) in

--- a/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetMetadataTask.swift
@@ -14,21 +14,13 @@
 
 import Foundation
 
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
-
 /// Task which provides the ability to delete an object in Firebase Storage.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 enum StorageGetMetadataTask {
   static func getMetadataTask(reference: StorageReference,
-                              fetcherService: GTMSessionFetcherService,
                               queue: DispatchQueue,
                               completion: ((_: StorageMetadata?, _: Error?) -> Void)?) {
     StorageInternalTask(reference: reference,
-                        fetcherService: fetcherService,
                         queue: queue,
                         httpMethod: "GET",
                         fetcherComment: "GetMetadataTask") { (data: Data?, error: Error?) in

--- a/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
@@ -27,35 +27,35 @@ class StorageInternalTask: StorageTask {
 
   @discardableResult
   init(reference: StorageReference,
-       fetcherService: GTMSessionFetcherService,
        queue: DispatchQueue,
        request: URLRequest? = nil,
        httpMethod: String,
        fetcherComment: String,
        completion: ((_: Data?, _: Error?) -> Void)?) {
-    super.init(reference: reference, service: fetcherService, queue: queue)
+    super.init(reference: reference, queue: queue)
 
     // Prepare a task and begins execution.
     dispatchQueue.async { [self] in
       self.state = .queueing
-      var request = request ?? self.baseRequest
-      request.httpMethod = httpMethod
-      request.timeoutInterval = self.reference.storage.maxOperationRetryTime
-
-      let fetcher = self.fetcherService.fetcher(with: request)
-      fetcher.comment = fetcherComment
-      self.fetcher = fetcher
-
       Task {
-        let callbackQueue = reference.storage.fetcherService != nil ?
-          reference.storage.fetcherServiceForApp.callbackQueue : DispatchQueue.main
+        let fetcherService = await reference.storage.fetcherService
+          .fetcherService(reference.storage)
+
+        var request = request ?? self.baseRequest
+        request.httpMethod = httpMethod
+        request.timeoutInterval = self.reference.storage.maxOperationRetryTime
+
+        let fetcher = fetcherService.fetcher(with: request)
+        fetcher.comment = fetcherComment
+        self.fetcher = fetcher
+        let callbackQueue = reference.storage.callbackQueue
         do {
           let data = try await self.fetcher?.beginFetch()
-          callbackQueue?.async {
+          callbackQueue.async {
             completion?(data, nil)
           }
         } catch {
-          callbackQueue?.async {
+          callbackQueue.async {
             completion?(nil, StorageErrorCode.error(withServerError: error as NSError,
                                                     ref: self.reference))
           }

--- a/FirebaseStorage/Sources/Internal/StorageListTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageListTask.swift
@@ -14,17 +14,10 @@
 
 import Foundation
 
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
-
 /// A Task that lists the entries under a StorageReference
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 enum StorageListTask {
   static func listTask(reference: StorageReference,
-                       fetcherService: GTMSessionFetcherService,
                        queue: DispatchQueue,
                        pageSize: Int64?,
                        previousPageToken: String?,
@@ -60,7 +53,6 @@ enum StorageListTask {
     )
 
     StorageInternalTask(reference: reference,
-                        fetcherService: fetcherService,
                         queue: queue,
                         request: request,
                         httpMethod: "GET",

--- a/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageUpdateMetadataTask.swift
@@ -14,17 +14,10 @@
 
 import Foundation
 
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
-
 /// A Task that lists the entries under a StorageReference
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 enum StorageUpdateMetadataTask {
   static func updateMetadataTask(reference: StorageReference,
-                                 fetcherService: GTMSessionFetcherService,
                                  queue: DispatchQueue,
                                  metadata: StorageMetadata,
                                  completion: ((_: StorageMetadata?, _: Error?) -> Void)?) {
@@ -37,7 +30,6 @@ enum StorageUpdateMetadataTask {
     }
 
     StorageInternalTask(reference: reference,
-                        fetcherService: fetcherService,
                         queue: queue,
                         request: request,
                         httpMethod: "PATCH",

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -17,11 +17,6 @@ import Foundation
 import FirebaseAppCheckInterop
 import FirebaseAuthInterop
 import FirebaseCore
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
 @_implementationOnly import FirebaseCoreExtension
@@ -129,7 +124,7 @@ import FirebaseCore
   /// - Returns: An instance of `StorageReference` referencing the root of the storage bucket.
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc open func reference() -> StorageReference {
-    ensureConfigured()
+    configured = true
     let path = StoragePath(with: storageBucket)
     return StorageReference(storage: self, path: path)
   }
@@ -146,7 +141,7 @@ import FirebaseCore
   /// initialize this Storage instance.
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc open func reference(forURL url: String) -> StorageReference {
-    ensureConfigured()
+    configured = true
     do {
       let path = try StoragePath.path(string: url)
 
@@ -178,7 +173,7 @@ import FirebaseCore
   /// - Throws: Throws an Error if `url` is not associated with the `FirebaseApp` used to initialize
   ///     this Storage instance.
   open func reference(for url: URL) throws -> StorageReference {
-    ensureConfigured()
+    configured = true
     var path: StoragePath
     do {
       path = try StoragePath.path(string: url.absoluteString)
@@ -222,7 +217,7 @@ import FirebaseCore
     guard port >= 0 else {
       fatalError("Invalid port argument: Port must be greater or equal to zero.")
     }
-    guard fetcherService == nil else {
+    guard configured == false else {
       fatalError("Cannot connect to emulator after Storage SDK initialization. " +
         "Call useEmulator(host:port:) before creating a Storage " +
         "reference or trying to load data.")
@@ -254,14 +249,7 @@ import FirebaseCore
 
   // MARK: - Internal and Private APIs
 
-  var fetcherService: GTMSessionFetcherService?
-
-  var fetcherServiceForApp: GTMSessionFetcherService {
-    guard let value = fetcherService else {
-      fatalError("Internal error: fetcherServiceForApp not yet configured.")
-    }
-    return value
-  }
+  let fetcherService = StorageFetcherService()
 
   let dispatchQueue: DispatchQueue
 
@@ -275,7 +263,6 @@ import FirebaseCore
     host = "firebasestorage.googleapis.com"
     scheme = "https"
     port = 443
-    fetcherService = nil // Configured in `ensureConfigured()`
     // Must be a serial queue.
     dispatchQueue = DispatchQueue(label: "com.google.firebase.storage")
     maxDownloadRetryTime = 600.0
@@ -286,57 +273,13 @@ import FirebaseCore
     maxUploadRetryInterval = Storage.computeRetryInterval(fromRetryTime: maxUploadRetryTime)
   }
 
-  /// Map of apps to a dictionary of buckets to GTMSessionFetcherService.
-  private static let fetcherServiceLock = NSObject()
-  private static var fetcherServiceMap: [String: [String: GTMSessionFetcherService]] = [:]
-  private static var retryWhenOffline: GTMSessionFetcherRetryBlock = {
-    (suggestedWillRetry: Bool,
-     error: Error?,
-     response: @escaping GTMSessionFetcherRetryResponse) in
-    var shouldRetry = suggestedWillRetry
-    // GTMSessionFetcher does not consider being offline a retryable error, but we do, so we
-    // special-case it here.
-    if !shouldRetry, error != nil {
-      shouldRetry = (error as? NSError)?.code == URLError.notConnectedToInternet.rawValue
-    }
-    response(shouldRetry)
-  }
+  let auth: AuthInterop?
+  let appCheck: AppCheckInterop?
+  let storageBucket: String
+  var usesEmulator = false
 
-  private static func initFetcherServiceForApp(_ app: FirebaseApp,
-                                               _ bucket: String,
-                                               _ auth: AuthInterop?,
-                                               _ appCheck: AppCheckInterop?,
-                                               _ callbackQueue: DispatchQueue)
-    -> GTMSessionFetcherService {
-    objc_sync_enter(fetcherServiceLock)
-    defer { objc_sync_exit(fetcherServiceLock) }
-    var bucketMap = fetcherServiceMap[app.name]
-    if bucketMap == nil {
-      bucketMap = [:]
-      fetcherServiceMap[app.name] = bucketMap
-    }
-    var fetcherService = bucketMap?[bucket]
-    if fetcherService == nil {
-      fetcherService = GTMSessionFetcherService()
-      fetcherService?.isRetryEnabled = true
-      fetcherService?.retryBlock = retryWhenOffline
-      fetcherService?.allowLocalhostRequest = true
-      let authorizer = StorageTokenAuthorizer(
-        googleAppID: app.options.googleAppID,
-        callbackQueue: callbackQueue,
-        authProvider: auth,
-        appCheck: appCheck
-      )
-      fetcherService?.authorizer = authorizer
-      bucketMap?[bucket] = fetcherService
-    }
-    return fetcherService!
-  }
-
-  private let auth: AuthInterop?
-  private let appCheck: AppCheckInterop?
-  private let storageBucket: String
-  private var usesEmulator: Bool = false
+  /// Once `configured` is true, the emulator can no longer be enabled.
+  var configured = false
 
   /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
   /// instances of Storage associated with the given app.
@@ -354,9 +297,9 @@ import FirebaseCore
 
   /// Performs a crude translation of the user provided timeouts to the retry intervals that
   /// GTMSessionFetcher accepts. GTMSessionFetcher times out operations if the time between
-  /// individual
-  /// retry attempts exceed a certain threshold, while our API contract looks at the total observed
-  /// time of the operation (i.e. the sum of all retries).
+  /// individual retry attempts exceed a certain threshold, while our API contract looks at the
+  /// total
+  /// observed time of the operation (i.e. the sum of all retries).
   /// @param retryTime A timeout that caps the sum of all retry attempts
   /// @return A timeout that caps the timeout of the last retry attempt
   static func computeRetryInterval(fromRetryTime retryTime: TimeInterval) -> TimeInterval {
@@ -372,19 +315,6 @@ import FirebaseCore
       sumOfAllIntervals += lastInterval
     }
     return lastInterval
-  }
-
-  /// Configures the storage instance. Freezes the host setting.
-  private func ensureConfigured() {
-    guard fetcherService == nil else {
-      return
-    }
-    fetcherService = Storage.initFetcherServiceForApp(app, storageBucket, auth, appCheck,
-                                                      callbackQueue)
-    if usesEmulator {
-      fetcherService?.allowLocalhostRequest = true
-      fetcherService?.allowedInsecureSchemes = ["http"]
-    }
   }
 
   private static func bucket(for app: FirebaseApp) -> String {

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -185,7 +185,6 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
       guard let self = self else { return }
       self.state = .cancelled
       self.fetcher?.stopFetching()
-      print("stopped fetching")
       self.error = error
       self.fire(for: .failure, snapshot: self.snapshot)
       self.removeAllObservers()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -39,7 +39,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Prepares a task and begins execution.
    */
   @objc open func enqueue() {
-    enqueueImplementation()
+    Task {
+      await enqueueImplementation()
+    }
   }
 
   /**
@@ -80,7 +82,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
       self.state = .resuming
       self.fire(for: .resume, snapshot: self.snapshot)
       self.state = .running
-      self.enqueueImplementation(resumeWith: self.downloadData)
+      Task {
+        await self.enqueueImplementation(resumeWith: self.downloadData)
+      }
     }
   }
 
@@ -93,90 +97,87 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
   // MARK: - Internal Implementations
 
   override init(reference: StorageReference,
-                service: GTMSessionFetcherService,
                 queue: DispatchQueue,
                 file: URL?) {
-    super.init(reference: reference, service: service, queue: queue, file: file)
+    super.init(reference: reference, queue: queue, file: file)
   }
 
   deinit {
     self.fetcher?.stopFetching()
   }
 
-  private func enqueueImplementation(resumeWith resumeData: Data? = nil) {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .queueing
-      var request = self.baseRequest
-      request.httpMethod = "GET"
-      request.timeoutInterval = self.reference.storage.maxDownloadRetryTime
-      var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
-      components?.query = "alt=media"
-      request.url = components?.url
+  private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
+    state = .queueing
 
-      var fetcher: GTMSessionFetcher
-      if let resumeData {
-        fetcher = GTMSessionFetcher(downloadResumeData: resumeData)
-        fetcher.comment = "Resuming DownloadTask"
-      } else {
-        fetcher = self.fetcherService.fetcher(with: request)
-        fetcher.comment = "Starting DownloadTask"
-      }
-      fetcher.maxRetryInterval = self.reference.storage.maxDownloadRetryInterval
+    var request = baseRequest
+    request.httpMethod = "GET"
+    request.timeoutInterval = reference.storage.maxDownloadRetryTime
+    var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+    components?.query = "alt=media"
+    request.url = components?.url
 
-      if let fileURL {
-        // Handle file downloads
-        fetcher.destinationFileURL = fileURL
-        fetcher.downloadProgressBlock = { [weak self] (bytesWritten: Int64,
-                                                       totalBytesWritten: Int64,
-                                                       totalBytesExpectedToWrite: Int64) in
-            guard let self = self else { return }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesWritten
-            self.progress.totalUnitCount = totalBytesExpectedToWrite
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .running
-        }
-      } else {
-        // Handle data downloads
-        fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
-                                                       totalBytesWritten: Int64) in
-            guard let self = self else { return }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesWritten
-            if let totalLength = self.fetcher?.response?.expectedContentLength {
-              self.progress.totalUnitCount = totalLength
-            }
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .running
-        }
-      }
-      self.fetcher = fetcher
-      self.state = .running
-      Task {
-        do {
-          let data = try await self.fetcher?.beginFetch()
-          // Fire last progress updates
+    var fetcher: GTMSessionFetcher
+    if let resumeData {
+      fetcher = GTMSessionFetcher(downloadResumeData: resumeData)
+      fetcher.comment = "Resuming DownloadTask"
+    } else {
+      let fetcherService = await reference.storage.fetcherService.fetcherService(reference.storage)
+
+      fetcher = fetcherService.fetcher(with: request)
+      fetcher.comment = "Starting DownloadTask"
+    }
+    fetcher.maxRetryInterval = reference.storage.maxDownloadRetryInterval
+
+    if let fileURL {
+      // Handle file downloads
+      fetcher.destinationFileURL = fileURL
+      fetcher.downloadProgressBlock = { [weak self] (bytesWritten: Int64,
+                                                     totalBytesWritten: Int64,
+                                                     totalBytesExpectedToWrite: Int64) in
+          guard let self = self else { return }
+          self.state = .progress
+          self.progress.completedUnitCount = totalBytesWritten
+          self.progress.totalUnitCount = totalBytesExpectedToWrite
           self.fire(for: .progress, snapshot: self.snapshot)
-
-          // Download completed successfully, fire completion callbacks
-          self.state = .success
-          if let data {
-            self.downloadData = data
+          self.state = .running
+      }
+    } else {
+      // Handle data downloads
+      fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
+                                                     totalBytesWritten: Int64) in
+          guard let self = self else { return }
+          self.state = .progress
+          self.progress.completedUnitCount = totalBytesWritten
+          if let totalLength = self.fetcher?.response?.expectedContentLength {
+            self.progress.totalUnitCount = totalLength
           }
-          self.fire(for: .success, snapshot: self.snapshot)
-        } catch {
           self.fire(for: .progress, snapshot: self.snapshot)
-          self.state = .failed
-          self.error = StorageErrorCode.error(
-            withServerError: error as NSError,
-            ref: self.reference
-          )
-          self.fire(for: .failure, snapshot: self.snapshot)
-        }
-        self.removeAllObservers()
+          self.state = .running
       }
     }
+    self.fetcher = fetcher
+    state = .running
+    do {
+      let data = try await self.fetcher?.beginFetch()
+      // Fire last progress updates
+      fire(for: .progress, snapshot: snapshot)
+
+      // Download completed successfully, fire completion callbacks
+      state = .success
+      if let data {
+        downloadData = data
+      }
+      fire(for: .success, snapshot: snapshot)
+    } catch {
+      fire(for: .progress, snapshot: snapshot)
+      state = .failed
+      self.error = StorageErrorCode.error(
+        withServerError: error as NSError,
+        ref: reference
+      )
+      fire(for: .failure, snapshot: snapshot)
+    }
+    removeAllObservers()
   }
 
   func cancel(withError error: NSError) {
@@ -184,8 +185,10 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
       guard let self = self else { return }
       self.state = .cancelled
       self.fetcher?.stopFetching()
+      print("stopped fetching")
       self.error = error
       self.fire(for: .failure, snapshot: self.snapshot)
+      self.removeAllObservers()
     }
   }
 }

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -14,12 +14,6 @@
 
 import Foundation
 
-#if COCOAPODS
-  import GTMSessionFetcher
-#else
-  import GTMSessionFetcherCore
-#endif
-
 /**
  * An extended `StorageTask` providing observable semantics that can be used for responding to changes
  * in task state.
@@ -134,7 +128,6 @@ import Foundation
   // MARK: - Internal Implementations
 
   init(reference: StorageReference,
-       service: GTMSessionFetcherService,
        queue: DispatchQueue,
        file: URL?) {
     handlerDictionaries = [
@@ -146,7 +139,7 @@ import Foundation
     ]
     handleToStatusMap = [:]
     fileURL = file
-    super.init(reference: reference, service: service, queue: queue)
+    super.init(reference: reference, queue: queue)
   }
 
   func updateHandlerDictionary(for status: StorageTaskStatus,

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -246,7 +246,6 @@ import Foundation
   /// in the Firebase Console.
   /// - Throws: An error if the download URL could not be retrieved.
   /// - Returns: The URL on success.
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
   open func downloadURL() async throws -> URL {
     return try await withCheckedThrowingContinuation { continuation in
       self.downloadURL { result in
@@ -361,7 +360,6 @@ import Foundation
   /// `listAll()` is only available for projects using Firebase Rules Version 2.
   /// - Throws: An error if the list operation failed.
   /// - Returns: All items and prefixes under the current `StorageReference`.
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
   open func listAll() async throws -> StorageListResult {
     return try await withCheckedThrowingContinuation { continuation in
       self.listAll { result in
@@ -446,7 +444,6 @@ import Foundation
   /// Retrieves metadata associated with an object at the current path.
   /// - Throws: An error if the object metadata could not be retrieved.
   /// - Returns: The object metadata on success.
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
   open func getMetadata() async throws -> StorageMetadata {
     return try await withCheckedThrowingContinuation { continuation in
       self.getMetadata { result in
@@ -473,7 +470,6 @@ import Foundation
   /// - Parameter metadata: A `StorageMetadata` object with the metadata to update.
   /// - Throws: An error if the metadata update operation failed.
   /// - Returns: The object metadata on success.
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
   open func updateMetadata(_ metadata: StorageMetadata) async throws -> StorageMetadata {
     return try await withCheckedThrowingContinuation { continuation in
       self.updateMetadata(metadata) { result in
@@ -500,7 +496,6 @@ import Foundation
 
   /// Deletes the object at the current path.
   /// - Throws: An error if the delete operation failed.
-  @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
   open func delete() async throws {
     return try await withCheckedThrowingContinuation { continuation in
       self.delete { error in

--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -128,7 +128,6 @@ import Foundation
       putMetadata.name = (path as NSString).lastPathComponent as String
     }
     let task = StorageUploadTask(reference: self,
-                                 service: storage.fetcherServiceForApp,
                                  queue: storage.dispatchQueue,
                                  data: uploadData,
                                  metadata: putMetadata)
@@ -175,7 +174,6 @@ import Foundation
       putMetadata.name = (path as NSString).lastPathComponent as String
     }
     let task = StorageUploadTask(reference: self,
-                                 service: storage.fetcherServiceForApp,
                                  queue: storage.dispatchQueue,
                                  file: fileURL,
                                  metadata: putMetadata)
@@ -199,9 +197,7 @@ import Foundation
   @objc(dataWithMaxSize:completion:) @discardableResult
   open func getData(maxSize: Int64,
                     completion: @escaping ((_: Data?, _: Error?) -> Void)) -> StorageDownloadTask {
-    let fetcherService = storage.fetcherServiceForApp
     let task = StorageDownloadTask(reference: self,
-                                   service: fetcherService,
                                    queue: storage.dispatchQueue,
                                    file: nil)
 
@@ -240,9 +236,7 @@ import Foundation
   ///     or an error on failure.
   @objc(downloadURLWithCompletion:)
   open func downloadURL(completion: @escaping ((_: URL?, _: Error?) -> Void)) {
-    let fetcherService = storage.fetcherServiceForApp
     StorageGetDownloadURLTask.getDownloadURLTask(reference: self,
-                                                 fetcherService: fetcherService,
                                                  queue: storage.dispatchQueue,
                                                  completion: completion)
   }
@@ -280,9 +274,7 @@ import Foundation
   @objc(writeToFile:completion:) @discardableResult
   open func write(toFile fileURL: URL,
                   completion: ((_: URL?, _: Error?) -> Void)?) -> StorageDownloadTask {
-    let fetcherService = storage.fetcherServiceForApp
     let task = StorageDownloadTask(reference: self,
-                                   service: fetcherService,
                                    queue: storage.dispatchQueue,
                                    file: fileURL)
 
@@ -322,7 +314,6 @@ import Foundation
   ///       the current `StorageReference`.
   @objc(listAllWithCompletion:)
   open func listAll(completion: @escaping ((_: StorageListResult?, _: Error?) -> Void)) {
-    let fetcherService = storage.fetcherServiceForApp
     var prefixes = [StorageReference]()
     var items = [StorageReference]()
 
@@ -343,7 +334,6 @@ import Foundation
 
       if let pageToken = listResult.pageToken {
         StorageListTask.listTask(reference: strongSelf,
-                                 fetcherService: fetcherService,
                                  queue: strongSelf.storage.dispatchQueue,
                                  pageSize: nil,
                                  previousPageToken: pageToken,
@@ -358,7 +348,6 @@ import Foundation
     }
 
     StorageListTask.listTask(reference: self,
-                             fetcherService: fetcherService,
                              queue: storage.dispatchQueue,
                              pageSize: nil,
                              previousPageToken: nil,
@@ -401,9 +390,7 @@ import Foundation
         message: "Argument 'maxResults' must be between 1 and 1000 inclusive."
       ))
     } else {
-      let fetcherService = storage.fetcherServiceForApp
       StorageListTask.listTask(reference: self,
-                               fetcherService: fetcherService,
                                queue: storage.dispatchQueue,
                                pageSize: maxResults,
                                previousPageToken: nil,
@@ -436,9 +423,7 @@ import Foundation
         message: "Argument 'maxResults' must be between 1 and 1000 inclusive."
       ))
     } else {
-      let fetcherService = storage.fetcherServiceForApp
       StorageListTask.listTask(reference: self,
-                               fetcherService: fetcherService,
                                queue: storage.dispatchQueue,
                                pageSize: maxResults,
                                previousPageToken: pageToken,
@@ -453,9 +438,7 @@ import Foundation
   ///   or an error on failure.
   @objc(metadataWithCompletion:)
   open func getMetadata(completion: @escaping ((_: StorageMetadata?, _: Error?) -> Void)) {
-    let fetcherService = storage.fetcherServiceForApp
     StorageGetMetadataTask.getMetadataTask(reference: self,
-                                           fetcherService: fetcherService,
                                            queue: storage.dispatchQueue,
                                            completion: completion)
   }
@@ -480,9 +463,7 @@ import Foundation
   @objc(updateMetadata:completion:)
   open func updateMetadata(_ metadata: StorageMetadata,
                            completion: ((_: StorageMetadata?, _: Error?) -> Void)?) {
-    let fetcherService = storage.fetcherServiceForApp
     StorageUpdateMetadataTask.updateMetadataTask(reference: self,
-                                                 fetcherService: fetcherService,
                                                  queue: storage.dispatchQueue,
                                                  metadata: metadata,
                                                  completion: completion)
@@ -507,14 +488,12 @@ import Foundation
   /// - Parameter completion: A completion block which returns a nonnull error on failure.
   @objc(deleteWithCompletion:)
   open func delete(completion: ((_: Error?) -> Void)?) {
-    let fetcherService = storage.fetcherServiceForApp
     let completionWrap = { (_: Data?, error: Error?) in
       if let completion {
         completion(error)
       }
     }
     StorageDeleteTask.deleteTask(reference: self,
-                                 fetcherService: fetcherService,
                                  queue: storage.dispatchQueue,
                                  completion: completionWrap)
   }
@@ -590,7 +569,7 @@ import Foundation
                                          completion: ((_: StorageMetadata?, _: Error?) -> Void)?) {
     if let completion {
       task.completionMetadata = completion
-      let callbackQueue = storage.fetcherServiceForApp.callbackQueue ?? DispatchQueue.main
+      let callbackQueue = storage.callbackQueue
 
       task.observe(.success) { snapshot in
         callbackQueue.async {

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -81,16 +81,11 @@ import Foundation
    */
   let dispatchQueue: DispatchQueue
 
-  let fetcherService: GTMSessionFetcherService
-
   let baseRequest: URLRequest
 
   init(reference: StorageReference,
-       service: GTMSessionFetcherService,
        queue: DispatchQueue) {
     self.reference = reference
-    fetcherService = service
-    fetcherService.maxRetryInterval = reference.storage.maxOperationRetryInterval
     dispatchQueue = queue
     state = .unknown
     progress = Progress(totalUnitCount: 0)

--- a/FirebaseStorage/Tests/Unit/StorageComponentTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageComponentTests.swift
@@ -32,14 +32,14 @@ class StorageComponentTests: StorageTestHelpers {
 
   /// Tests that a Storage instance can be created properly.
   func testStorageInstanceCreation() throws {
-    let app = try XCTUnwrap(StorageComponentTests.app)
+    let app = try XCTUnwrap(app)
     let storage1 = Storage.storage(app: app, url: "gs://foo-bar.appspot.com")
     XCTAssertNotNil(storage1)
   }
 
   /// Tests that a Storage instances are reused properly.
   func testMultipleComponentInstancesCreated() throws {
-    let app = try XCTUnwrap(StorageComponentTests.app)
+    let app = try XCTUnwrap(app)
     let storage1 = Storage.storage(app: app, url: "gs://foo-bar.appspot.com")
     let storage2 = Storage.storage(app: app, url: "gs://foo-bar.appspot.com")
 

--- a/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
@@ -56,7 +56,6 @@ class StorageDeleteTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage(), path: path)
     StorageDeleteTask.deleteTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { _, error in
       expectation.fulfill()
@@ -82,7 +81,6 @@ class StorageDeleteTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage(), path: path)
     StorageDeleteTask.deleteTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { _, error in
       expectation.fulfill()
@@ -105,7 +103,6 @@ class StorageDeleteTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage, path: path)
     StorageDeleteTask.deleteTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { _, error in
       expectation.fulfill()
@@ -113,54 +110,39 @@ class StorageDeleteTests: StorageTestHelpers {
     waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchUnauthenticated() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = unauthenticatedBlock()
+  func testUnsuccessfulFetchUnauthenticated() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(unauthenticatedBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageDeleteTask.deleteTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { _, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.unauthenticated.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      try await ref.delete()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.unauthenticated.rawValue)
     }
-    waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchUnauthorized() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = unauthorizedBlock()
+  func testUnsuccessfulFetchUnauthorized() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(unauthorizedBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageDeleteTask.deleteTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { _, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.unauthorized.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      try await ref.delete()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.unauthorized.rawValue)
     }
-    waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchObjectDoesntExist() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = notFoundBlock()
+  func testUnsuccessfulFetchObjectDoesntExist() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(notFoundBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageDeleteTask.deleteTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { _, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.objectNotFound.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      try await ref.delete()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.objectNotFound.rawValue)
     }
-    waitForExpectation(test: self)
   }
 }

--- a/FirebaseStorage/Tests/Unit/StorageGetMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageGetMetadataTests.swift
@@ -56,7 +56,6 @@ class StorageGetMetadataTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage(), path: path)
     StorageGetMetadataTask.getMetadataTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { metadata, error in
       expectation.fulfill()
@@ -82,7 +81,6 @@ class StorageGetMetadataTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage(), path: path)
     StorageGetMetadataTask.getMetadataTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { metadata, error in
       expectation.fulfill()
@@ -105,7 +103,6 @@ class StorageGetMetadataTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage, path: path)
     StorageGetMetadataTask.getMetadataTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { metadata, error in
       expectation.fulfill()
@@ -113,55 +110,40 @@ class StorageGetMetadataTests: StorageTestHelpers {
     waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchUnauthenticated() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = unauthenticatedBlock()
+  func testUnsuccessfulFetchUnauthenticated() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(unauthenticatedBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageGetMetadataTask.getMetadataTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { metadata, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.unauthenticated.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      let _ = try await ref.getMetadata()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.unauthenticated.rawValue)
     }
-    waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchUnauthorized() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = unauthorizedBlock()
+  func testUnsuccessfulFetchUnauthorized() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(unauthorizedBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageGetMetadataTask.getMetadataTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { metadata, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.unauthorized.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      let _ = try await ref.getMetadata()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.unauthorized.rawValue)
     }
-    waitForExpectation(test: self)
   }
 
-  func testUnsuccessfulFetchObjectDoesntExist() {
-    let expectation = self.expectation(description: #function)
-
-    fetcherService!.testBlock = notFoundBlock()
+  func testUnsuccessfulFetchObjectDoesntExist() async {
+    let storage = storage()
+    await storage.fetcherService.updateTestBlock(notFoundBlock())
     let path = objectPath()
-    let ref = StorageReference(storage: storage(), path: path)
-    StorageGetMetadataTask.getMetadataTask(
-      reference: ref,
-      fetcherService: fetcherService!.self,
-      queue: dispatchQueue!.self
-    ) { metadata, error in
-      XCTAssertEqual((error as? NSError)!.code, StorageErrorCode.objectNotFound.rawValue)
-      expectation.fulfill()
+    let ref = StorageReference(storage: storage, path: path)
+    do {
+      let _ = try await ref.getMetadata()
+    } catch {
+      XCTAssertEqual((error as NSError).code, StorageErrorCode.objectNotFound.rawValue)
     }
-    waitForExpectation(test: self)
   }
 
   func testUnsuccessfulFetchBadJSON() {
@@ -172,7 +154,6 @@ class StorageGetMetadataTests: StorageTestHelpers {
     let ref = StorageReference(storage: storage(), path: path)
     StorageGetMetadataTask.getMetadataTask(
       reference: ref,
-      fetcherService: fetcherService!.self,
       queue: dispatchQueue!.self
     ) { metadata, error in
       XCTAssertNil(metadata)

--- a/FirebaseStorage/Tests/Unit/StorageTestHelpers.swift
+++ b/FirebaseStorage/Tests/Unit/StorageTestHelpers.swift
@@ -22,20 +22,23 @@ import XCTest
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class StorageTestHelpers: XCTestCase {
-  static var app: FirebaseApp!
+  var app: FirebaseApp!
 
+  static var uniqueApp = 0
   func storage() -> Storage {
-    return Storage(app: FirebaseApp.app()!, bucket: "bucket")
+    return Storage(app: app, bucket: "bucket")
   }
 
-  override class func setUp() {
+  override func setUp() {
     super.setUp()
     if app == nil {
       let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
                                     gcmSenderID: "00000000000000000-00000000000-000000000")
       options.projectID = "myProjectID"
-      FirebaseApp.configure(options: options)
-      app = FirebaseApp(instanceWithName: "test", options: options)
+      StorageTestHelpers.uniqueApp += 1
+      let appName = "test\(StorageTestHelpers.uniqueApp)"
+      FirebaseApp.configure(name: appName, options: options)
+      app = FirebaseApp.app(name: appName)
     }
   }
 


### PR DESCRIPTION
Fix #13369

Moves fetcherService to an actor

Not only should it fix the issue, the code and tests are more compact and readable.

Removed unnecessary `availability` checks that were incorrectly setting watchOS to 8