### PR TITLE
[Auth] Add custom provider support for AuthProviderID

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 11.1.0
+- [added] Added custom provider support to `AuthProviderID`. Note that this change will be breaking
+  to any code that implemented an exhaustive `switch` on `AuthProviderID` in 11.0.0 - the `switch`
+  will need expansion. (#13429)
+
 # 11.0.0
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`
   even if the server returns the `web.app` domain listed first. (#7992)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderID.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderID.swift
@@ -15,9 +15,9 @@
 import Foundation
 
 /// Enumeration of the available Auth Provider IDs.
-public struct AuthProviderID: RawRepresentable, Equatable {
-  public var rawValue: String
-  public init(rawValue: String) {
+public struct AuthProviderID: Equatable {
+  public let rawValue: String
+  private init(rawValue: String) {
     self.rawValue = rawValue
   }
 }

--- a/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderStrings.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/AuthProviderStrings.swift
@@ -15,12 +15,43 @@
 import Foundation
 
 /// Enumeration of the available Auth Provider IDs.
-public enum AuthProviderID: String {
-  case apple = "apple.com"
-  case email = "password"
-  case facebook = "facebook.com"
-  case gameCenter = "gc.apple.com"
-  case gitHub = "github.com"
-  case google = "google.com"
-  case phone
+public struct AuthProviderID: RawRepresentable, Equatable {
+  public var rawValue: String
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+}
+
+public extension AuthProviderID {
+  static var apple: Self {
+    Self(rawValue: "apple.com")
+  }
+
+  static var email: Self {
+    Self(rawValue: "password")
+  }
+
+  static var facebook: Self {
+    Self(rawValue: "facebook.com")
+  }
+
+  static var gameCenter: Self {
+    Self(rawValue: "gc.apple.com")
+  }
+
+  static var gitHub: Self {
+    Self(rawValue: "github.com")
+  }
+
+  static var google: Self {
+    Self(rawValue: "google.com")
+  }
+
+  static var phone: Self {
+    Self(rawValue: "phone")
+  }
+
+  static func custom(_ value: String) -> Self {
+    Self(rawValue: value)
+  }
 }

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -702,4 +702,27 @@ class AuthAPI_hOnlyTests: XCTestCase {
     if let _: Date = metadata.lastSignInDate,
        let _: Date = metadata.creationDate {}
   }
+
+  func regression13429(id: AuthProviderID) -> Int {
+    switch id {
+    case .apple:
+      return 1
+    case .email:
+      return 2
+    case .facebook:
+      return 3
+    case .gameCenter:
+      return 4
+    case .gitHub:
+      return 5
+    case .google:
+      return 6
+    case .phone:
+      return 7
+    case .custom("myCustom"):
+      return 8
+    default:
+      return 9
+    }
+  }
 }


### PR DESCRIPTION
Fix #13429

The change from an `enum` to a `struct` also enables us to add future providers without breaking existing code.