### PR TITLE
[AuthErrorCode] should conform to Swift.Error

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 11.1.0
+- [fixed] Fixed `Swift.error` conformance for `AuthErrorCode`. (#13430)
 - [added] Added custom provider support to `AuthProviderID`. Note that this change will be breaking
   to any code that implemented an exhaustive `switch` on `AuthProviderID` in 11.0.0 - the `switch`
   will need expansion. (#13429)

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -48,7 +48,7 @@ import Foundation
 }
 
 /// Error codes used by Firebase Auth.
-@objc(FIRAuthErrorCode) public enum AuthErrorCode: Int {
+@objc(FIRAuthErrorCode) public enum AuthErrorCode: Int, Error {
   /// Indicates a validation error with the custom token.
   case invalidCustomToken = 17000
 
@@ -535,6 +535,11 @@ import Foundation
     case .recaptchaActionCreationFailed:
       return kErrorRecaptchaActionCreationFailed
     }
+  }
+
+  /// The error code. It's redundant but implemented for compatibility with the Objective-C implementation.
+  public var code: Self {
+    return self
   }
 
   var errorCodeString: String {

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -537,7 +537,8 @@ import Foundation
     }
   }
 
-  /// The error code. It's redundant but implemented for compatibility with the Objective-C implementation.
+  /// The error code. It's redundant but implemented for compatibility with the Objective-C
+  /// implementation.
   public var code: Self {
     return self
   }

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -725,4 +725,22 @@ class AuthAPI_hOnlyTests: XCTestCase {
       return 9
     }
   }
+
+  func regression13430(error : NSError) -> Int {
+    if let firebaseError = error as? AuthErrorCode, firebaseError == .networkError {
+      return 1
+    }
+
+    if let firebaseError = error as? AuthErrorCode, firebaseError.code == .invalidPhoneNumber {
+      switch firebaseError.localizedDescription {
+      case "TOO_SHORT":
+        return 1
+      case "TOO_LONG":
+        return 1
+      default:
+        return 1
+      }
+    }
+    return 2
+  }
 }

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -726,7 +726,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
     }
   }
 
-  func regression13430(error : NSError) -> Int {
+  func regression13430(error: NSError) -> Int {
     if let firebaseError = error as? AuthErrorCode, firebaseError == .networkError {
       return 1
     }


### PR DESCRIPTION
Fix #13430 

AuthErrorCode now implements Swift.Error

A `code` var is added to provide backwards compatibility.