### PR TITLE
[AppCheck] Force link categories

### DIFF
--- a/FirebaseAppCheck/Sources/Core/FIRApp+AppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRApp+AppCheck.m
@@ -24,3 +24,7 @@
 }
 
 @end
+
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_FIRApp_AppCheck_Category(void) {
+}

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -267,6 +267,20 @@ static id<FIRAppCheckProviderFactory> _providerFactory;
       stringWithFormat:@"projects/%@/apps/%@", app.options.projectID, app.options.googleAppID];
 }
 
+#pragma mark - Force Category Linking
+
+extern void FIRInclude_FIRApp_AppCheck_Category(void);
+extern void FIRInclude_FIRHeartbeatLogger_AppCheck_Category(void);
+
+/// Does nothing when called, and not meant to be called.
+///
+/// This method forces the linker to include categories even if
+/// users do not include the '-ObjC' linker flag in their project.
++ (void)noop {
+  FIRInclude_FIRApp_AppCheck_Category();
+  FIRInclude_FIRHeartbeatLogger_AppCheck_Category();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Core/FIRHeartbeatLogger+AppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRHeartbeatLogger+AppCheck.m
@@ -31,3 +31,7 @@ static NSString *const kFIRHeartbeatLoggerPayloadHeaderKey = @"X-firebase-client
 }
 
 @end
+
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_FIRHeartbeatLogger_AppCheck_Category(void) {
+}


### PR DESCRIPTION
This PR is a bit defensive since I don't know if this will be a problem. It's possible
these symbols, if not linked, could lead to undefined behavior in a SwiftUI preview
context where we don't have clear control over the linking parameters.

