### PR TITLE
[Infra] Attempt to fix post-merge tagging in prerelease.yml

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -161,6 +161,8 @@ jobs:
       podspec_repo_branch: main
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Get token
       run: |
          scripts/decrypt_gha_secret.sh scripts/gha-encrypted/prerelease-testing-token.txt.gpg \

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -31,16 +31,12 @@ if [ "$TESTINGMODE" = "release_testing" ]; then
   set -x
   cd  "${local_sdk_repo_dir}"
 elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
-  set -x
   git fetch --tags --quiet origin main
   git checkout main
 fi
 
 # The chunk below is to determine the latest version by searching
 # Get the latest released tag Cocoapods-X.Y.Z for release and prerelease testing, beta version will be excluded.
-test_version=$(git tag -l --sort=-version:refname CocoaPods-*[0-9] | head -n 1)
-test_version=$(git tag -l --sort=-version:refname 'CocoaPods-*[0-9]' | head -n 1)
-test_version=$(git tag -l --sort=-version:refname --merged main CocoaPods-*[0-9] | head -n 1)
 test_version=$(git tag -l --sort=-version:refname --merged main 'CocoaPods-*[0-9]' | head -n 1)
 git for-each-ref --sort=-creatordate --format '%(creatordate:short) %(refname:short)' refs/tags | head -n 3
 if [ -z "$test_version" ]; then


### PR DESCRIPTION
The issue stems from #13061. I think it's a good, future-looking fix (because of long running)
pre-release branches for major version changes, but didn't take into account that the
checkout action will only do a shallow checkout. The script can't find the latest tag merged to
main when the checkout is shallow, so doing a full clone should resolve this.
