### PR TITLE
[Storage] Addressing Swift 6 issues with `Storage`'s instance management

### DIFF
--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -22,7 +22,7 @@ import FirebaseCore
 @_implementationOnly import FirebaseCoreExtension
 
 private final class StorageInstanceCache: @unchecked Sendable {
-  public static let shared = StorageInstanceCache()
+  static let shared = StorageInstanceCache()
 
   /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
   /// instances of Storage associated with the given app.

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -283,10 +283,10 @@ import FirebaseCore
 
   /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
   /// instances of Storage associated with the given app.
-  private static var instances: [String: Storage] = [:]
+  private nonisolated(unsafe) static var instances: [String: Storage] = [:]
 
   /// Lock to manage access to the instances array to avoid race conditions.
-  private static var instancesLock: os_unfair_lock = .init()
+  private nonisolated(unsafe) static var instancesLock: os_unfair_lock = .init()
 
   var host: String
   var scheme: String

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -240,7 +240,7 @@ import FirebaseCore
   }
 
   // MARK: - Internal and Private APIs
-  
+
   private final class InstanceCache: @unchecked Sendable {
     static let shared = InstanceCache()
 

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -21,6 +21,31 @@ import FirebaseCore
 // Avoids exposing internal FirebaseCore APIs to Swift users.
 @_implementationOnly import FirebaseCoreExtension
 
+private final class StorageInstanceCache: @unchecked Sendable {
+  public static let shared = StorageInstanceCache()
+
+  /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
+  /// instances of Storage associated with the given app.
+  private var instances: [String: Storage] = [:]
+
+  /// Lock to manage access to the instances array to avoid race conditions.
+  private var instancesLock: os_unfair_lock = .init()
+
+  private init() {}
+
+  func storage(app: FirebaseApp, bucket: String) -> Storage {
+    os_unfair_lock_lock(&instancesLock)
+    defer { os_unfair_lock_unlock(&instancesLock) }
+
+    if let instance = instances[bucket] {
+      return instance
+    }
+    let newInstance = FirebaseStorage.Storage(app: app, bucket: bucket)
+    instances[bucket] = newInstance
+    return newInstance
+  }
+}
+
 /// Firebase Storage is a service that supports uploading and downloading binary objects,
 /// such as images, videos, and other files to Google Cloud Storage. Instances of `Storage`
 /// are not thread-safe, but can be accessed from any thread.
@@ -73,15 +98,7 @@ import FirebaseCore
   }
 
   private class func storage(app: FirebaseApp, bucket: String) -> Storage {
-    os_unfair_lock_lock(&instancesLock)
-    defer { os_unfair_lock_unlock(&instancesLock) }
-
-    if let instance = instances[bucket] {
-      return instance
-    }
-    let newInstance = FirebaseStorage.Storage(app: app, bucket: bucket)
-    instances[bucket] = newInstance
-    return newInstance
+    return StorageInstanceCache.shared.storage(app: app, bucket: bucket)
   }
 
   /// The `FirebaseApp` associated with this Storage instance.
@@ -280,13 +297,6 @@ import FirebaseCore
 
   /// Once `configured` is true, the emulator can no longer be enabled.
   var configured = false
-
-  /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
-  /// instances of Storage associated with the given app.
-  private nonisolated(unsafe) static var instances: [String: Storage] = [:]
-
-  /// Lock to manage access to the instances array to avoid race conditions.
-  private nonisolated(unsafe) static var instancesLock: os_unfair_lock = .init()
 
   var host: String
   var scheme: String


### PR DESCRIPTION
For context, the original error was: <img width="587" alt="Screenshot 2024-08-01 at 1 31 49 PM" src="https://github.com/user-attachments/assets/496e1a93-54df-4643-8a0d-5096782c0e78">

The important takeaway is that if you synchronize something with an actor (e.g. instance management) in a method that isn't async like:
```swift
private class func storage(app: FirebaseApp, bucket: String) -> Storage
```
you'd have to change the signature of the public function which would be breaking.

So I avoided the formal route by decorating the property with `nonisolated(unsafe)` which tells the compiler that we know what we are doing (which we do with the locking mechanism in place). But using `nonisolated(unsafe)` ([3f1ba97](https://github.com/firebase/firebase-ios-sdk/pull/13445/commits/3f1ba97f27051d633d783d2e3672f9ac7360d3ba)) on static properties does not work in Swift 5.5 ([pitch revision](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md#:~:text=Limit%20nonisolated(unsafe)%20to%20stored%20instance%20properties.%20The%20prior%20definition%20was%20far%20too%20broad.)). I'm not sure why it works on Swift 6.0, but the only way around this was to do it both ways for each property and differentiate with a `#if swift(>=6.0)` which seemed hacky.

So the next stop was to remove the properties from global state by making them instance properties. We can't do so on `Storage` though because there can be multiple instances of Storage (e.g. for multiple Firebase apps), so I made a new class that offers a singleton (so all Storage instances must access the same instance cache). 

I couldn't make it an actor because of the first learning at the top (the actor would bubble up the added asynchronous-ness). I then ran into:
<img width="1099" alt="Screenshot 2024-08-01 at 5 31 15 PM" src="https://github.com/user-attachments/assets/86a51df4-0cc5-4a9c-a8b3-f39a6270c063">
which makes sense. I added `Sendable` conformance, but the class doesn't meet [all requirements](https://developer.apple.com/documentation/swift/sendable#Sendable-Classes). Particularly:
> Contain only stored properties that are immutable and sendable

I tried working around this by changing the `var`s to `let`s. I tried using `NSLock` because it has reference semantics and we can therefore use the `let`:
```diff
-  private var instancesLock: os_unfair_lock = .init()
+  private let instancesLock: NSLock = .init()
```
But, this strategy has no corresponding solution for the `var instances: [String: Storage]`. I tried making it of type `NSDictionary`, but `NSDictionary`, does not conform to `Sendable`. We could box it the dictionary on a reference type, but you're just moving the problem down one abstraction.

So, the last option is to mark it with `@unchecked Sendable` which I believe means "I know what I'm doing in this type's implementation so don't worry": https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/commonproblems/#Retroactive-Sendable-Conformance

Unfortunately, using `@unchecked Sendable` doesn't offer any improvements in terms of compile time safety. Since the instance cache management is used in a few places (here, GTMSessionFetcher mapping, heartbeat storage), it may make sense to carefully refactor the functionality in a generic type that lives in `FirebaseSharedSwift`.

```swift
private final class StorageInstanceCache: @unchecked Sendable {
  static let shared = StorageInstanceCache()

  /// A map of active instances, grouped by app. Keys are FirebaseApp names and values are
  /// instances of Storage associated with the given app.
  private var instances: [String: Storage] = [:]

  /// Lock to manage access to the instances array to avoid race conditions.
  private var instancesLock: os_unfair_lock = .init()

  /// ...
```