### PR TITLE
Functions Cleanup

### DIFF
--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -440,16 +440,12 @@ enum FunctionsConstants {
                              cachePolicy: .useProtocolCachePolicy,
                              timeoutInterval: timeout)
     let fetcher = fetcherService.fetcher(with: request)
-    let body = NSMutableDictionary()
 
     // Encode the data in the body.
-    var localData = data
-    if data == nil {
-      localData = NSNull()
-    }
+    let data = data ?? NSNull()
     // Force unwrap to match the old invalid argument thrown.
-    let encoded = try! serializer.encode(localData!)
-    body["data"] = encoded
+    let encoded = try! serializer.encode(data)
+    let body = ["data": encoded]
 
     do {
       let payload = try JSONSerialization.data(withJSONObject: body)

--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -28,14 +28,7 @@ extension FunctionsSerializer {
   }
 }
 
-class FunctionsSerializer: NSObject {
-  private let dateFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-    formatter.timeZone = TimeZone(identifier: "UTC")
-    return formatter
-  }()
-
+final class FunctionsSerializer {
   // MARK: - Internal APIs
 
   func encode(_ object: Any) throws -> AnyObject {


### PR DESCRIPTION
* Removed `dateFormatter` from `FunctionsSerializer` as it wasn’t used anywhere
* Redeclared `FunctionsSerializer` as a native Swift class
* Updated `Functions`’s `callFunction(url:withObject:options:timeout:context:completion:)` to reduce mutability