### PR TITLE
Add prototype for FirebaseLogger implementation

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -41,6 +41,11 @@ jobs:
         retry_on: error
         retry_wait_seconds: 120
         command: scripts/build.sh FirebaseVertexAIUnit ${{ matrix.target }} spm
+    - uses: actions/upload-artifact@v4
+      if: ${{ always() }}
+      with:
+        name: xcodebuild-raw-logs
+        path: xcodebuild.log
 
   spm-integration:
     strategy:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: xcodebuild-raw-logs
+        name: xcodebuild-raw-logs-${{ matrix.target }}
         path: xcodebuild.log
 
   spm-integration:

--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <os/log.h>
 
 #import <FirebaseCore/FIRLoggerLevel.h>
 
@@ -70,6 +71,12 @@ void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
  * (required) whether or not this function is called from the Analytics component.
  */
 BOOL FIRIsLoggableLevel(FIRLoggerLevel loggerLevel, BOOL analyticsComponent);
+
+extern NSString *FIRLogMessageCode(NSString *categoryID, NSInteger messageID);
+
+extern NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSString *messageID);
+
+extern os_log_t FIRLogOSLogObject(NSString *category);
 
 /**
  * Logs a message to the Xcode console and the device log. If running from AppStore, will

--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -72,9 +72,11 @@ void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
  */
 BOOL FIRIsLoggableLevel(FIRLoggerLevel loggerLevel, BOOL analyticsComponent);
 
+extern os_log_type_t FIRLoggerLevelToOSLogType(FIRLoggerLevel level);
+
 extern NSString *FIRLogMessageCode(NSString *categoryID, NSInteger messageID);
 
-extern NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSString *messageID);
+extern NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSInteger messageID);
 
 extern os_log_t FIRLogOSLogObject(NSString *category);
 

--- a/FirebaseCore/Sources/FIRLogger.m
+++ b/FirebaseCore/Sources/FIRLogger.m
@@ -124,6 +124,23 @@ __attribute__((no_sanitize("thread"))) BOOL FIRIsLoggableLevel(FIRLoggerLevel lo
   return GULIsLoggableLevel((GULLoggerLevel)loggerLevel);
 }
 
+NSString *FIRLogMessageCode(NSString *categoryID, NSInteger messageID) {
+  return [NSString stringWithFormat:@"I-%@%06ld", categoryID, (long)messageID];
+}
+
+NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSString *messageID) {
+  // TODO: Replace with call to GoogleUtilities, e.g., GULOSLogPrefix(category, messageID)
+  // This implementation is for prototyping purposes only.
+  return [NSString stringWithFormat:@"%@ - %@[%@]", FIRFirebaseVersion(), category,
+                                    FIRLogMessageCode(categoryID, messageID)];
+}
+
+os_log_t FIRLogOSLogObject(NSString *category) {
+  // TODO: Replace with call to GoogleUtilities, e.g., GULOSLogObject(kFIRLoggerSubsystem, category)
+  // This implementation is for prototyping purposes only.
+  return os_log_create(kFIRLoggerSubsystem.UTF8String, category.UTF8String);
+}
+
 void FIRLogBasic(FIRLoggerLevel level,
                  NSString *category,
                  NSString *messageCode,

--- a/FirebaseCore/Sources/FIRLogger.m
+++ b/FirebaseCore/Sources/FIRLogger.m
@@ -124,11 +124,27 @@ __attribute__((no_sanitize("thread"))) BOOL FIRIsLoggableLevel(FIRLoggerLevel lo
   return GULIsLoggableLevel((GULLoggerLevel)loggerLevel);
 }
 
+extern os_log_type_t FIRLoggerLevelToOSLogType(FIRLoggerLevel level) {
+  // TODO: Replace with call to GoogleUtilities, e.g., GULLoggerLevelToOSLogType(level)
+  // This implementation is for prototyping purposes only.
+  switch (level) {
+    case FIRLoggerLevelError:
+      return OS_LOG_TYPE_ERROR;
+    case FIRLoggerLevelWarning:
+    case FIRLoggerLevelNotice:
+      return OS_LOG_TYPE_DEFAULT;
+    case FIRLoggerLevelInfo:
+      return OS_LOG_TYPE_INFO;
+    case FIRLoggerLevelDebug:
+      return OS_LOG_TYPE_DEBUG;
+  }
+}
+
 NSString *FIRLogMessageCode(NSString *categoryID, NSInteger messageID) {
   return [NSString stringWithFormat:@"I-%@%06ld", categoryID, (long)messageID];
 }
 
-NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSString *messageID) {
+NSString *FIRLogPrefix(NSString *category, NSString *categoryID, NSInteger messageID) {
   // TODO: Replace with call to GoogleUtilities, e.g., GULOSLogPrefix(category, messageID)
   // This implementation is for prototyping purposes only.
   return [NSString stringWithFormat:@"%@ - %@[%@]", FIRFirebaseVersion(), category,

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -37,6 +37,9 @@ Firebase products. FirebaseSharedSwift is not supported for non-Firebase usage.
     'FirebaseSharedSwift/Sources/**/*.swift',
   ]
 
+  s.dependency 'FirebaseCore', '~> 11.1'
+  s.dependency 'FirebaseCoreExtension', '~> 11.1'
+
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {
       :ios => ios_deployment_target,

--- a/FirebaseSharedSwift/Sources/FirebaseLogger.swift
+++ b/FirebaseSharedSwift/Sources/FirebaseLogger.swift
@@ -42,7 +42,7 @@ public class FirebaseLogger {
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   ///   - message: The message to log; may be a format string.
   ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
-  /// format string.
+  ///     format string.
   public func notice(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
     log(level: .notice, messageID: messageID, message, arguments)
   }
@@ -53,7 +53,7 @@ public class FirebaseLogger {
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   ///   - message: The message to log; may be a format string.
   ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
-  /// format string.
+  ///     format string.
   public func info(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
     log(level: .info, messageID: messageID, message, arguments)
   }
@@ -64,7 +64,7 @@ public class FirebaseLogger {
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   ///   - message: The message to log; may be a format string.
   ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
-  /// format string.
+  ///   format string.
   public func debug(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
     log(level: .debug, messageID: messageID, message, arguments)
   }
@@ -75,7 +75,7 @@ public class FirebaseLogger {
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   ///   - message: The message to log; may be a format string.
   ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
-  /// format string.
+  ///     format string.
   public func warning(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
     log(level: .warning, messageID: messageID, message, arguments)
   }
@@ -86,7 +86,7 @@ public class FirebaseLogger {
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   ///   - message: The message to log; may be a format string.
   ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
-  /// format string.
+  ///     format string.
   public func error(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
     log(level: .error, messageID: messageID, message, arguments)
   }
@@ -120,7 +120,47 @@ public class FirebaseLogger {
     return FIRLogPrefix(category, categoryIdentifier, messageID)
   }
 
-  /// Returns the log object that should be used when using OSLog directly.
+  /// Returns the log object that may be used when using OSLog directly.
+  ///
+  /// ## Example Usage
+  /// ```swift
+  /// // Create a FirebaseLogger for the product.
+  /// let logger = FirebaseLogger(category: "FirebaseProduct", categoryIdentifier: "FBP")
+  ///
+  /// // Check if messages with the chosen log level (severity) should be logged.
+  /// if FirebaseLogger.isLoggableLevel(FirebaseLoggerLevel.debug) {
+  ///   os_log(
+  ///     // Get the equivalent OSLogType for the chosen log level.
+  ///     FirebaseLogger.osLogType(FirebaseLoggerLevel.debug),
+  ///     // Write to the OSLog log object for your FirebaseLogger.
+  ///     log: logger.logObject(),
+  ///     // Add the standard Firebase log message prefix with `%{public}@` since the contents of
+  ///     // dynamic strings are redacted by default.
+  ///     "%{public}@ Logged in - User name: %@, ID: %{private}ld, admin: %{BOOL}d",
+  ///     // The standard Firebase log message prefix does not contain sensitive user data but
+  ///     // dynamic string values are redacted by default; use the `%{public}@` format specifier to
+  ///     // prevent redacting.
+  ///     logger.messagePrefix(messageID: 1),
+  ///     // The user name is sensitive user data but is redacted by default; the `%@` format
+  ///     // specifier is sufficient.
+  ///     getUserName(),
+  ///     // The user ID is sensitive user data but integer values are not redacted by default;
+  ///     // redact using the `%{private}ld` format specifier.
+  ///     getUserID(),
+  ///     // The user's administrator status is not sensitive user data and is not redacted by
+  ///     // default; the `%{BOOL}d` format specifier is sufficient.
+  ///     getUserAdmin()
+  ///   )
+  /// }
+  /// ```
+  ///
+  /// - Important: When writing log messages that **do not** contain sensitive data, it is
+  ///   preferable to use the convenience logging methods ``notice(messageID:_:_:)``,
+  ///   ``info(messageID:_:_:)``, ``debug(messageID:_:_:)``, ``warning(messageID:_:_:)`` or
+  ///   ``error(messageID:_:_:)``; these methods default to `OSLogPrivacy.public`.
+  ///
+  /// - Tip: The `Logger` struct returned by ``osLogger()`` provides a nicer API for SDKs
+  ///   targeting iOS 14+ and equivalent.
   public func logObject() -> OSLog {
     return FIRLogOSLogObject(category)
   }

--- a/FirebaseSharedSwift/Sources/FirebaseLogger.swift
+++ b/FirebaseSharedSwift/Sources/FirebaseLogger.swift
@@ -1,0 +1,130 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseCore
+import Foundation
+import os
+
+@_implementationOnly import FirebaseCoreExtension
+
+public class FirebaseLogger {
+  let category: String
+  let categoryIdentifier: String
+
+  /// Initializes a `FirebaseLogger`.
+  ///
+  /// - Parameters:
+  ///   - category: The product or component name to use as an OSLog category to differentiate logs
+  ///     within the Firebase subsystem.
+  ///   - categoryIdentifier: A three-character identifier for the `category` that is unique within
+  ///     Firebase, e.g., "COR" for the "FirebaseCore" category.
+  public init(category: String, categoryIdentifier: String) {
+    self.category = category
+    self.categoryIdentifier = categoryIdentifier
+  }
+
+  // MARK: - Logging Methods
+
+  /// Writes a log message with the log level `notice`.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  ///   - message: The message to log; may be a format string.
+  ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
+  /// format string.
+  public func notice(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
+    log(level: .notice, messageID: messageID, message, arguments)
+  }
+
+  /// Writes a log message with the log level `info`.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  ///   - message: The message to log; may be a format string.
+  ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
+  /// format string.
+  public func info(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
+    log(level: .info, messageID: messageID, message, arguments)
+  }
+
+  /// Writes a log message with the log level `debug`.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  ///   - message: The message to log; may be a format string.
+  ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
+  /// format string.
+  public func debug(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
+    log(level: .debug, messageID: messageID, message, arguments)
+  }
+
+  /// Writes a log message with the log level `warning`.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  ///   - message: The message to log; may be a format string.
+  ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
+  /// format string.
+  public func warning(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
+    log(level: .warning, messageID: messageID, message, arguments)
+  }
+
+  /// Writes a log message with the log level `error`.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  ///   - message: The message to log; may be a format string.
+  ///   - arguments: A comma-separated list of arguments to substitute into `message`, if it is a
+  /// format string.
+  public func error(messageID: Int, _ message: String, _ arguments: any CVarArg...) {
+    log(level: .error, messageID: messageID, message, arguments)
+  }
+
+  // MARK: - Manual Logging Helpers
+
+  /// Returns true if the specified logging level should be logged.
+  ///
+  /// - Parameters:
+  ///   - level: The logging level to check.
+  public func isLoggableLevel(_ level: FirebaseLoggerLevel) -> Bool {
+    FIRIsLoggableLevel(level, false)
+  }
+
+  /// Returns the prefix that should be prepended to log messages when using OSLog directly.
+  ///
+  /// - Important: This prefix is added automatically when using the logging methods `notice`,
+  ///   `info`, etc., in this class and should not be added manually to avoid duplication.
+  ///
+  /// - Parameters:
+  ///   - messageID: A six digit integer message identifier that is unique within the category.
+  public func messagePrefix(messageID: Int) -> String {
+    let code = FIRLogMessageCode(categoryIdentifier, messageID)
+    return FIRLogPrefix(category, categoryIdentifier, code)
+  }
+
+  /// Returns the log object that should be used when using OSLog directly.
+  public func logObject() -> OSLog {
+    return FIRLogOSLogObject(category)
+  }
+
+  // MARK: - Private Helpers
+
+  private func log(level: FirebaseLoggerLevel, messageID: Int, _ message: String,
+                   _ arguments: any CVarArg...) {
+    withVaList(arguments) { va_list in
+      let code = FIRLogMessageCode(self.categoryIdentifier, messageID)
+      FIRLogBasic(level, category, code, message, va_list)
+    }
+  }
+}

--- a/FirebaseSharedSwift/Sources/FirebaseLogger.swift
+++ b/FirebaseSharedSwift/Sources/FirebaseLogger.swift
@@ -97,8 +97,16 @@ public class FirebaseLogger {
   ///
   /// - Parameters:
   ///   - level: The logging level to check.
-  public func isLoggableLevel(_ level: FirebaseLoggerLevel) -> Bool {
+  public static func isLoggableLevel(_ level: FirebaseLoggerLevel) -> Bool {
     FIRIsLoggableLevel(level, false)
+  }
+
+  /// Returns the `OSLogType` equivalent of the specified `FirebaseLoggerLevel`.
+  ///
+  /// - Parameters:
+  ///   - level: The desired Firebase logging level.
+  public static func osLogType(_ level: FirebaseLoggerLevel) -> OSLogType {
+    return FIRLoggerLevelToOSLogType(level)
   }
 
   /// Returns the prefix that should be prepended to log messages when using OSLog directly.
@@ -109,8 +117,7 @@ public class FirebaseLogger {
   /// - Parameters:
   ///   - messageID: A six digit integer message identifier that is unique within the category.
   public func messagePrefix(messageID: Int) -> String {
-    let code = FIRLogMessageCode(categoryIdentifier, messageID)
-    return FIRLogPrefix(category, categoryIdentifier, code)
+    return FIRLogPrefix(category, categoryIdentifier, messageID)
   }
 
   /// Returns the log object that should be used when using OSLog directly.

--- a/FirebaseSharedSwift/Sources/FirebaseLogger.swift
+++ b/FirebaseSharedSwift/Sources/FirebaseLogger.swift
@@ -125,6 +125,12 @@ public class FirebaseLogger {
     return FIRLogOSLogObject(category)
   }
 
+  /// Returns a Swift Logger struct that may be used when using OSLog directly.
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+  public func osLogger() -> Logger {
+    return Logger(logObject())
+  }
+
   // MARK: - Private Helpers
 
   private func log(level: FirebaseLoggerLevel, messageID: Int, _ message: String,

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -322,13 +322,17 @@ struct GenerativeAIService {
 
     private func printCURLCommand(from request: URLRequest) {
       let command = cURLCommand(from: request)
-      if FirebaseLogger.vertexAI.isLoggableLevel(.debug) {
-        os_log(.debug, log: FirebaseLogger.vertexAI.logObject(), """
-        [FirebaseVertexAI] Creating request with the equivalent cURL command:
+      let logLevel = FirebaseLoggerLevel.debug
+      let messagePrefix = FirebaseLogger.vertexAI
+        .messagePrefix(messageID: LogMessageID.curlCommandForRequest.rawValue)
+
+      if FirebaseLogger.isLoggableLevel(logLevel) {
+        FirebaseLogger.vertexAI.osLogger().log(level: FirebaseLogger.osLogType(logLevel), """
+        \(messagePrefix, privacy: .public) Creating request with the equivalent cURL command:
         ----- cURL command -----
-        %{private}@
+        \(command, privacy: .private)
         ------------------------
-        """, command)
+        """)
       }
     }
   #endif // DEBUG

--- a/FirebaseVertexAI/Sources/Logging.swift
+++ b/FirebaseVertexAI/Sources/Logging.swift
@@ -12,8 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FirebaseSharedSwift
 import Foundation
 import OSLog
+
+extension FirebaseLogger {
+  static let vertexAI = FirebaseLogger(category: "[FirebaseVertexAI]", categoryIdentifier: "VTX")
+}
+
+/// Enum of log messages.
+enum LogMessageID: Int {
+  case loadRequestError = 1
+  case loadRequestErrorResponse
+  case loadRequestStreamError
+  case loadRequestStreamErrorResponse
+  case loadRequestStreamLine
+  case appCheckTokenFetchError
+  case nonHTTPResponseError
+  case mlServiceDisabledError
+  case jsonResponseError
+  case jsonDecodingError
+}
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct Logging {

--- a/FirebaseVertexAI/Sources/Logging.swift
+++ b/FirebaseVertexAI/Sources/Logging.swift
@@ -32,6 +32,7 @@ enum LogMessageID: Int {
   case mlServiceDisabledError
   case jsonResponseError
   case jsonDecodingError
+  case curlCommandForRequest
 }
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseCoreExtension
 import FirebaseSharedSwift
 import XCTest
+
+@_implementationOnly import FirebaseCoreExtension
 
 @testable import FirebaseVertexAI
 

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -33,6 +33,7 @@ final class LoggingTests: XCTestCase {
     FirebaseLogger.vertexAI.notice(messageID: messageID, "This is a NOTICE message.")
     FirebaseLogger.vertexAI.warning(messageID: messageID, "This is a WARNING message.")
     FirebaseLogger.vertexAI.error(messageID: messageID, "This is an ERROR message.")
+    XCTFail("Fail to show up in logs.")
   }
 
   @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
@@ -48,5 +49,6 @@ final class LoggingTests: XCTestCase {
       .error("Private Privacy: bundleID[\(bundleID, privacy: .private)]")
     FirebaseLogger.vertexAI.osLogger()
       .error("Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
+    XCTFail("Fail to show up in logs.")
   }
 }

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseCoreExtension
+import FirebaseSharedSwift
+import XCTest
+
+@testable import FirebaseVertexAI
+
+// TODO: Remove this file; manually testing by inspecting logs on CI.
+final class LoggingTests: XCTestCase {
+  let messageID = 42
+
+  override func setUp() {
+    FIRSetLoggerLevel(.max)
+  }
+
+  func testLoggingFunctions() {
+    FirebaseLogger.vertexAI.debug(messageID: messageID, "This is a DEBUG message.")
+    FirebaseLogger.vertexAI.info(messageID: messageID, "This is an INFO message.")
+    FirebaseLogger.vertexAI.notice(messageID: messageID, "This is a NOTICE message.")
+    FirebaseLogger.vertexAI.warning(messageID: messageID, "This is a WARNING message.")
+    FirebaseLogger.vertexAI.error(messageID: messageID, "This is an ERROR message.")
+  }
+
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+  func testLoggingFunctionPrivacy() {
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      XCTFail("Bundle ID was nil.")
+      return
+    }
+    FirebaseLogger.vertexAI.osLogger().error("Default Privacy: bundleID[\(bundleID)]")
+    FirebaseLogger.vertexAI.osLogger()
+      .error("Public Privacy: bundleID[\(bundleID, privacy: .public)]")
+    FirebaseLogger.vertexAI.osLogger()
+      .error("Private Privacy: bundleID[\(bundleID, privacy: .private)]")
+    FirebaseLogger.vertexAI.osLogger()
+      .error("Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -33,7 +33,6 @@ final class LoggingTests: XCTestCase {
     FirebaseLogger.vertexAI.notice(messageID: messageID, "This is a NOTICE message.")
     FirebaseLogger.vertexAI.warning(messageID: messageID, "This is a WARNING message.")
     FirebaseLogger.vertexAI.error(messageID: messageID, "This is an ERROR message.")
-    XCTFail("Fail to show up in logs.")
   }
 
   @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
@@ -49,6 +48,5 @@ final class LoggingTests: XCTestCase {
       .error("Private Privacy: bundleID[\(bundleID, privacy: .private)]")
     FirebaseLogger.vertexAI.osLogger()
       .error("Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
-    XCTFail("Fail to show up in logs.")
   }
 }

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -87,4 +87,15 @@ final class LoggingTests: XCTestCase {
     os_log(.error, log: logObj, "Private Privacy: bundleID[%{private}@]", bundleID)
     os_log(.error, log: logObj, "Sensitive Privacy: bundleID[%{sensitive}@]", bundleID)
   }
+
+  func testOSLogLegacyPrivacy_defaultLog() {
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      XCTFail("Bundle ID was nil.")
+      return
+    }
+    os_log(.error, "Default Privacy: bundleID[%@]", bundleID)
+    os_log(.error, "Public Privacy: bundleID[%{public}@]", bundleID)
+    os_log(.error, "Private Privacy: bundleID[%{private}@]", bundleID)
+    os_log(.error, "Sensitive Privacy: bundleID[%{sensitive}@]", bundleID)
+  }
 }

--- a/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/LoggingTests.swift
@@ -49,4 +49,42 @@ final class LoggingTests: XCTestCase {
     FirebaseLogger.vertexAI.osLogger()
       .error("Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
   }
+
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+  func testSwiftLoggerPrivacy() {
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      XCTFail("Bundle ID was nil.")
+      return
+    }
+    let logger = Logger(subsystem: "com.google.firebase", category: "[FirebaseVertexAI]")
+    logger.error("Default Privacy: bundleID[\(bundleID)]")
+    logger.error("Public Privacy: bundleID[\(bundleID, privacy: .public)]")
+    logger.error("Private Privacy: bundleID[\(bundleID, privacy: .private)]")
+    logger.error("Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
+  }
+
+  @available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
+  func testOSLogPrivacy() {
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      XCTFail("Bundle ID was nil.")
+      return
+    }
+    let logObj = OSLog(subsystem: "com.google.firebase", category: "[FirebaseVertexAI]")
+    os_log(.error, log: logObj, "Default Privacy: bundleID[\(bundleID)]")
+    os_log(.error, log: logObj, "Public Privacy: bundleID[\(bundleID, privacy: .public)]")
+    os_log(.error, log: logObj, "Private Privacy: bundleID[\(bundleID, privacy: .private)]")
+    os_log(.error, log: logObj, "Sensitive Privacy: bundleID[\(bundleID, privacy: .sensitive)]")
+  }
+
+  func testOSLogLegacyPrivacy() {
+    guard let bundleID = Bundle.main.bundleIdentifier else {
+      XCTFail("Bundle ID was nil.")
+      return
+    }
+    let logObj = OSLog(subsystem: "com.google.firebase", category: "[FirebaseVertexAI]")
+    os_log(.error, log: logObj, "Default Privacy: bundleID[%@]", bundleID)
+    os_log(.error, log: logObj, "Public Privacy: bundleID[%{public}@]", bundleID)
+    os_log(.error, log: logObj, "Private Privacy: bundleID[%{private}@]", bundleID)
+    os_log(.error, log: logObj, "Sensitive Privacy: bundleID[%{sensitive}@]", bundleID)
+  }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -630,6 +630,10 @@ let package = Package(
     ),
     .target(
       name: "FirebaseSharedSwift",
+      dependencies: [
+        "FirebaseCore",
+        "FirebaseCoreExtension",
+      ],
       path: "FirebaseSharedSwift/Sources",
       exclude: [
         "third_party/FirebaseDataEncoder/LICENSE",

--- a/Package.swift
+++ b/Package.swift
@@ -1307,6 +1307,7 @@ let package = Package(
         "FirebaseAuthInterop",
         "FirebaseCore",
         "FirebaseCoreExtension",
+        "FirebaseSharedSwift",
       ],
       path: "FirebaseVertexAI/Sources"
     ),


### PR DESCRIPTION
- Added a prototype implementation of `FirebaseLogger` that wraps `FIRLogBasic`.
- `GenerativeAIService` in Vertex AI to use it
  - Example of manually calling `os_log` in `printCURLCommand`

#no-changelog