### PR TITLE
[CoreInternal] Address Swift 6 warnings (1)

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
@@ -23,7 +23,7 @@ public final class HeartbeatController {
   /// Current date provider. It is used for testability.
   private let dateProvider: () -> Date
   /// Used for standardizing dates for calendar-day comparison.
-  static let dateStandardizer: (Date) -> (Date) = {
+  static let dateStandardizer: @Sendable (Date) -> (Date) = {
     var calendar = Calendar(identifier: .iso8601)
     calendar.locale = Locale(identifier: "en_US_POSIX")
     calendar.timeZone = TimeZone(secondsFromGMT: 0)!

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift
@@ -16,6 +16,20 @@ import Foundation
 
 /// An object that provides API to log and flush heartbeats from a synchronized storage container.
 public final class HeartbeatController {
+  /// Used for standardizing dates for calendar-day comparison.
+  private enum DateStandardizer {
+    private static let calendar: Calendar = {
+      var calendar = Calendar(identifier: .iso8601)
+      calendar.locale = Locale(identifier: "en_US_POSIX")
+      calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+      return calendar
+    }()
+
+    static func standardize(_ date: Date) -> (Date) {
+      return calendar.startOfDay(for: date)
+    }
+  }
+
   /// The thread-safe storage object to log and flush heartbeats from.
   private let storage: HeartbeatStorageProtocol
   /// The max capacity of heartbeats to store in storage.
@@ -23,12 +37,7 @@ public final class HeartbeatController {
   /// Current date provider. It is used for testability.
   private let dateProvider: () -> Date
   /// Used for standardizing dates for calendar-day comparison.
-  static let dateStandardizer: @Sendable (Date) -> (Date) = {
-    var calendar = Calendar(identifier: .iso8601)
-    calendar.locale = Locale(identifier: "en_US_POSIX")
-    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-    return calendar.startOfDay(for:)
-  }()
+  private static let dateStandardizer = DateStandardizer.self
 
   /// Public initializer.
   /// - Parameter id: The `id` to associate this controller's heartbeat storage with.
@@ -54,7 +63,7 @@ public final class HeartbeatController {
   init(storage: HeartbeatStorageProtocol,
        dateProvider: @escaping () -> Date = Date.init) {
     self.storage = storage
-    self.dateProvider = { Self.dateStandardizer(dateProvider()) }
+    self.dateProvider = { Self.dateStandardizer.standardize(dateProvider()) }
   }
 
   /// Asynchronously logs a new heartbeat, if needed.

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -115,8 +115,8 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
 // MARK: - Static Defaults
 
 extension HeartbeatsPayload {
-  /// Convenience instance that represents an empty payload.
-  static let emptyPayload = HeartbeatsPayload()
+  /// Conveniently creates an  instance that represents an empty payload.
+  static var emptyPayload: Self { HeartbeatsPayload() }
 
   /// A default date formatter that uses `yyyy-MM-dd` format.
   public static let dateFormatter: DateFormatter = {

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift
@@ -44,7 +44,7 @@ public protocol HTTPHeaderRepresentable {
 ///       ]
 ///     }
 ///
-public struct HeartbeatsPayload: Codable {
+public struct HeartbeatsPayload: Codable, Sendable {
   /// The version of the payload. See go/firebase-apple-heartbeats for details regarding current
   /// version.
   static let version: Int = 2
@@ -115,8 +115,8 @@ extension HeartbeatsPayload: HTTPHeaderRepresentable {
 // MARK: - Static Defaults
 
 extension HeartbeatsPayload {
-  /// Conveniently creates an  instance that represents an empty payload.
-  static var emptyPayload: Self { HeartbeatsPayload() }
+  /// Convenience instance that represents an empty payload.
+  static let emptyPayload = HeartbeatsPayload()
 
   /// A default date formatter that uses `yyyy-MM-dd` format.
   public static let dateFormatter: DateFormatter = {


### PR DESCRIPTION
#### File: `FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatController.swift`

```swift
public final class HeartbeatController {
  /// ...
  static let dateStandardizer: (Date) -> (Date) = {
    var calendar = Calendar(identifier: .iso8601)
    calendar.locale = Locale(identifier: "en_US_POSIX")
    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
    return calendar.startOfDay(for:)
  }()
 /// ...
}
```

Gave the following error:
> error: static property 'dateStandardizer' is not concurrency-safe because non-'Sendable' type '(Date) -> (Date)' may have shared mutable state
  static let dateStandardizer: (Date) -> (Date) = {
             ^

I marked the closure `@Sendable` (because there should be no mutable state due to this static property), which silenced the Swift 6 build but the Swift 5 build issues a warning for this:

> warning: converting non-sendable function value to '`@Sendable` (Date) -> (Date)' may introduce data races
    return calendar.startOfDay(for:)
                    ^

I can't find the link now but I found at least one Swift forums post about Swift 5 warning about things that are non-warnings in Swift 6. I think this explained the difference here as to why adding `@Sendable` worked in Swift 6 vs. not in Swift 5.

So, I moved the static property out into an enum, and more importantly, removed the closure in favor of a dedicated method:
```swift
  /// Used for standardizing dates for calendar-day comparison.
  private enum DateStandardizer {
    private static let calendar: Calendar = {
      var calendar = Calendar(identifier: .iso8601)
      calendar.locale = Locale(identifier: "en_US_POSIX")
      calendar.timeZone = TimeZone(secondsFromGMT: 0)!
      return calendar
    }()

    static func standardize(_ date: Date) -> (Date) {
      return calendar.startOfDay(for: date)
    }
  }
```

--- 

#### File: `FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatsPayload.swift`

See https://github.com/firebase/firebase-ios-sdk/pull/13454#discussion_r1712040511 for discussion on final approach.

```swift
/// Convenience instance that represents an empty payload.
  static let emptyPayload = HeartbeatsPayload()
```
Gave the following error:
> error: static property 'emptyPayload' is not concurrency-safe because non-'Sendable' type 'HeartbeatsPayload' may have shared mutable state
  static let emptyPayload = HeartbeatsPayload()
             ^

Public structs are not implicitly Sendable, so Sendable conformance needed to be explicitly added.



#no-changelog