### PR TITLE
[Auth] Fix async/await crash from implicitly unwrapped nil error

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [added] Added custom provider support to `AuthProviderID`. Note that this change will be breaking
   to any code that implemented an exhaustive `switch` on `AuthProviderID` in 11.0.0 - the `switch`
   will need expansion. (#13429)
+- [fixed] Fix crash in phone authentication flow from implicitly unwrapping
+  `nil` error. (#13470)
 
 # 11.0.0
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -3,8 +3,8 @@
 - [added] Added custom provider support to `AuthProviderID`. Note that this change will be breaking
   to any code that implemented an exhaustive `switch` on `AuthProviderID` in 11.0.0 - the `switch`
   will need expansion. (#13429)
-- [fixed] Fix crash in phone authentication flow from implicitly unwrapping
-  `nil` error. (#13470)
+- [fixed] Fix crash introduced in 11.0.0 in phone authentication flow from implicitly unwrapping
+  `nil` error after a token timeout. (#13470)
 
 # 11.0.0
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -3,8 +3,8 @@
 - [added] Added custom provider support to `AuthProviderID`. Note that this change will be breaking
   to any code that implemented an exhaustive `switch` on `AuthProviderID` in 11.0.0 - the `switch`
   will need expansion. (#13429)
-- [fixed] Fix crash introduced in 11.0.0 in phone authentication flow from implicitly unwrapping
-  `nil` error after a token timeout. (#13470)
+- [fixed] Fix crash introduced in 11.0.0 in phone authentication flow from
+  implicitly unwrapping `nil` error after a token timeout. (#13470)
 
 # 11.0.0
 - [fixed] Fixed auth domain matching code to prioritize matching `firebaseapp.com` over `web.app`

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -68,7 +68,10 @@
       kAuthGlobalWorkQueue.asyncAfter(deadline: deadline) {
         // Only cancel if the pending callbacks remain the same, i.e., not triggered yet.
         if applicableCallbacks.count == self.pendingCallbacks.count {
-          self.callback(withToken: nil, error: nil)
+          self.callback(
+            withToken: nil,
+            error: AuthErrorUtils.missingAppTokenError(underlyingError: nil)
+          )
         }
       }
     }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -49,9 +49,9 @@
     /// token becomes available, or when timeout occurs, whichever happens earlier.
     ///
     /// This function is internal to make visible for tests.
-    func getTokenInternal(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
+    func getTokenInternal(callback: @escaping (Result<AuthAPNSToken, Error>) -> Void) {
       if let token = tokenStore {
-        callback(token, nil)
+        callback(.success(token))
         return
       }
       if pendingCallbacks.count > 0 {
@@ -68,21 +68,19 @@
       kAuthGlobalWorkQueue.asyncAfter(deadline: deadline) {
         // Only cancel if the pending callbacks remain the same, i.e., not triggered yet.
         if applicableCallbacks.count == self.pendingCallbacks.count {
-          self.callback(
-            withToken: nil,
-            error: AuthErrorUtils.missingAppTokenError(underlyingError: nil)
-          )
+          self.callback(.failure(AuthErrorUtils.missingAppTokenError(underlyingError: nil)))
         }
       }
     }
 
     func getToken() async throws -> AuthAPNSToken {
       return try await withCheckedThrowingContinuation { continuation in
-        self.getTokenInternal { token, error in
-          if let token {
+        self.getTokenInternal { result in
+          switch result {
+          case let .success(token):
             continuation.resume(returning: token)
-          } else {
-            continuation.resume(throwing: error!)
+          case let .failure(error):
+            continuation.resume(throwing: error)
           }
         }
       }
@@ -108,7 +106,7 @@
           newToken = AuthAPNSToken(withData: setToken.data, type: detectedTokenType)
         }
         tokenStore = newToken
-        callback(withToken: newToken, error: nil)
+        callback(.success(newToken))
       }
     }
 
@@ -118,18 +116,18 @@
     /// Cancels any pending `getTokenWithCallback:` request.
     /// - Parameter error: The error to return .
     func cancel(withError error: Error) {
-      callback(withToken: nil, error: error)
+      callback(.failure(error))
     }
 
     /// Enable unit test faking.
     var application: AuthAPNSTokenApplication
-    private var pendingCallbacks: [(AuthAPNSToken?, Error?) -> Void] = []
+    private var pendingCallbacks: [(Result<AuthAPNSToken, Error>) -> Void] = []
 
-    private func callback(withToken token: AuthAPNSToken?, error: Error?) {
+    private func callback(_ result: Result<AuthAPNSToken, Error>) {
       let pendingCallbacks = self.pendingCallbacks
       self.pendingCallbacks = []
       for callback in pendingCallbacks {
-        callback(token, error)
+        callback(result)
       }
     }
 

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -468,14 +468,14 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
   }
 
   private func verifyClient() {
-    AppManager.shared.auth().tokenManager.getTokenInternal { token, error in
-      if token == nil {
+    AppManager.shared.auth().tokenManager.getTokenInternal { result in
+      guard case .success(let token) = result else {
         print("Verify iOS Client failed.")
         return
       }
       let request = VerifyClientRequest(
-        withAppToken: token?.string,
-        isSandbox: token?.type == .sandbox,
+        withAppToken: token.string,
+        isSandbox: token.type == .sandbox,
         requestConfiguration: AppManager.shared.auth().requestConfiguration
       )
 

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -469,7 +469,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
   private func verifyClient() {
     AppManager.shared.auth().tokenManager.getTokenInternal { result in
-      guard case .success(let token) = result else {
+      guard case let .success(token) = result else {
         print("Verify iOS Client failed.")
         return
       }

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -690,9 +690,9 @@
     }
 
     class FakeTokenManager: AuthAPNSTokenManager {
-      override func getTokenInternal(callback: @escaping (AuthAPNSToken?, Error?) -> Void) {
+      override func getTokenInternal(callback: @escaping (Result<AuthAPNSToken, Error>) -> Void) {
         let error = NSError(domain: "dummy domain", code: AuthErrorCode.missingAppToken.rawValue)
-        callback(nil, error)
+        callback(.failure(error))
       }
     }
 


### PR DESCRIPTION
Issue reproducible by changing unit test like so:

<img width="472" alt="Screenshot 2024-08-08 at 12 50 21 PM" src="https://github.com/user-attachments/assets/b105244b-d153-4701-a752-f1e52bd33aee">

--- 

In the Objective-C implementation, `(nil, nil)` was being passed back by
getToken during timeouts.

https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.m#L89-L95

This didn't cause issue though because the API calling getToken only checked for
the presence of a non-nil token:

https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m#L613-L618

In Swift though, the catch block will implicitly unwrap error, leading to the
crash when error is nil due to the timeout:

https://github.com/firebase/firebase-ios-sdk/blob/a5c253d1b4409eb8aef4346015ba000f9935cb2d/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift#L320-L326

Since the error doesn't bubble up, how we handle this is an implementation
detail and I think we could either (1) remove the catch block and use `try?`,
and trigger the catch block's code if the `try? await` results in nil. Or, (2)
pass an error in the timeout case so a non-nil error is unwrapped. I think (2)
is more future proof so I went with that in this PR. 

Fix #13470