### PR TITLE
[Firestore] Resolve protocol conformance warnings

### DIFF
--- a/Firestore/Swift/Source/Codable/DocumentReference+Codable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+Codable.swift
@@ -50,4 +50,4 @@ extension CodableDocumentReference {
   }
 }
 
-extension DocumentReference: CodableDocumentReference {}
+extension FirebaseFirestore.DocumentReference: FirebaseFirestore.CodableDocumentReference {}

--- a/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
+++ b/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
@@ -21,7 +21,7 @@
 #endif // SWIFT_PACKAGE
 
 /** Extends FieldValue to conform to Encodable. */
-extension FieldValue: Encodable {
+extension FirebaseFirestore.FieldValue: Swift.Encodable {
   /// Encoding a FieldValue will throw by default unless the encoder implementation
   /// explicitly handles it, which is what Firestore.Encoder does.
   public func encode(to encoder: Encoder) throws {

--- a/Firestore/Swift/Source/Codable/GeoPoint+Codable.swift
+++ b/Firestore/Swift/Source/Codable/GeoPoint+Codable.swift
@@ -63,4 +63,4 @@ extension CodableGeoPoint {
 }
 
 /** Extends GeoPoint to conform to Codable. */
-extension GeoPoint: CodableGeoPoint {}
+extension FirebaseFirestore.GeoPoint: FirebaseFirestore.CodableGeoPoint {}

--- a/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
+++ b/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
@@ -59,4 +59,4 @@ extension CodableTimestamp {
 }
 
 /** Extends Timestamp to conform to Codable. */
-extension Timestamp: CodableTimestamp {}
+extension FirebaseFirestore.Timestamp: FirebaseFirestore.CodableTimestamp {}

--- a/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
+++ b/Firestore/Swift/Source/Codable/Timestamp+Codable.swift
@@ -59,4 +59,4 @@ extension CodableTimestamp {
 }
 
 /** Extends Timestamp to conform to Codable. */
-extension FirebaseFirestore.Timestamp: FirebaseFirestore.CodableTimestamp {}
+extension FirebaseCore.Timestamp: FirebaseFirestore.CodableTimestamp {}

--- a/Firestore/Swift/Source/Codable/VectorValue+Codable.swift
+++ b/Firestore/Swift/Source/Codable/VectorValue+Codable.swift
@@ -58,4 +58,4 @@ extension CodableVectorValue {
 }
 
 /** Extends VectorValue to conform to Codable. */
-extension VectorValue: CodableVectorValue {}
+extension FirebaseFirestore.VectorValue: FirebaseFirestore.CodableVectorValue {}


### PR DESCRIPTION
Addresses Swift 6.0 warning introduced in https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md

Using backwards compatible solution described in https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility

<img width="1360" alt="Screenshot 2024-08-12 at 12 06 10 PM" src="https://github.com/user-attachments/assets/aca940fc-5b88-4a3f-940d-f245e96c2e6d">
