### PR TITLE
[Infra] Force link remaining categories after #13435

### DIFF
--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -138,6 +138,24 @@ static BOOL _autoBootstrapOnFIRAppInit = YES;
       checkAndDisplayNextContextualMessageForAnalyticsEvent:eventName];
 }
 
+#pragma mark - Force Category Linking
+
+extern void FIRInclude_FIRInAppMessaging_Bootstrap_Category(void);
+extern void FIRInclude_UIApplication_FIRForegroundWindowScene_Category(void);
+extern void FIRInclude_NSString_InterlaceStrings_Category(void);
+extern void FIRInclude_UIColor_HexString_Category(void);
+
+/// Does nothing when called, and not meant to be called.
+///
+/// This method forces the linker to include categories even if
+/// users do not include the '-ObjC' linker flag in their project.
++ (void)noop {
+  FIRInclude_FIRInAppMessaging_Bootstrap_Category();
+  FIRInclude_UIApplication_FIRForegroundWindowScene_Category();
+  FIRInclude_NSString_InterlaceStrings_Category();
+  FIRInclude_UIColor_HexString_Category();
+}
+
 @end
 
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRInAppMessaging+Bootstrap.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRInAppMessaging+Bootstrap.m
@@ -137,4 +137,8 @@ static NSString *_fiamServerHostName = @"firebaseinappmessaging.googleapis.com";
 
 @end
 
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_FIRInAppMessaging_Bootstrap_Category(void) {
+}
+
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION

--- a/FirebaseInAppMessaging/Sources/Util/NSString+FIRInterlaceStrings.m
+++ b/FirebaseInAppMessaging/Sources/Util/NSString+FIRInterlaceStrings.m
@@ -44,4 +44,8 @@
 
 @end
 
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_NSString_InterlaceStrings_Category(void) {
+}
+
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION

--- a/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
+++ b/FirebaseInAppMessaging/Sources/Util/UIApplication+FIRForegroundWindowScene.m
@@ -37,4 +37,8 @@
 
 @end
 
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_UIApplication_FIRForegroundWindowScene_Category(void) {
+}
+
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION

--- a/FirebaseInAppMessaging/Sources/Util/UIColor+FIRIAMHexString.m
+++ b/FirebaseInAppMessaging/Sources/Util/UIColor+FIRIAMHexString.m
@@ -41,4 +41,8 @@
 }
 @end
 
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_UIColor_HexString_Category(void) {
+}
+
 #endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -267,6 +267,18 @@ static const NSUInteger kExpectedAPIKeyLength = 39;
   return isCompatibleVersion;
 }
 
+#pragma mark - Force Category Linking
+
+extern void FIRInclude_FIRInstallationsItem_RegisterInstallationAPI_Category(void);
+
+/// Does nothing when called, and not meant to be called.
+///
+/// This method forces the linker to include categories even if
+/// users do not include the '-ObjC' linker flag in their project.
++ (void)noop {
+  FIRInclude_FIRInstallationsItem_RegisterInstallationAPI_Category();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsItem+RegisterInstallationAPI.m
+++ b/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsItem+RegisterInstallationAPI.m
@@ -140,3 +140,7 @@
 }
 
 @end
+
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_FIRInstallationsItem_RegisterInstallationAPI_Category(void) {
+}

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -1028,4 +1028,18 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   return [self currentLocale];
 }
 
+#pragma mark - Force Category Linking
+
+extern void FIRInclude_NSDictionary_FIRMessaging_Category(void);
+extern void FIRInclude_NSError_FIRMessaging_Category(void);
+
+/// Does nothing when called, and not meant to be called.
+///
+/// This method forces the linker to include categories even if
+/// users do not include the '-ObjC' linker flag in their project.
++ (void)noop {
+  FIRInclude_NSDictionary_FIRMessaging_Category();
+  FIRInclude_NSError_FIRMessaging_Category();
+}
+
 @end

--- a/FirebaseMessaging/Sources/NSDictionary+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSDictionary+FIRMessaging.m
@@ -56,3 +56,7 @@
 }
 
 @end
+
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_NSDictionary_FIRMessaging_Category(void) {
+}

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -27,3 +27,7 @@
 }
 
 @end
+
+/// Stub used to force the linker to include the categories in this file.
+void FIRInclude_NSError_FIRMessaging_Category(void) {
+}


### PR DESCRIPTION
Final follow-up to #13435.


Used following command to find category implementations:
```
grep -E -l -r '@implementation\s+\w+\s+\(\w+\)\s*$' . --include='*.m' --exclude-dir='Tests' --exclude-dir='gen'
```

I skipped files where the category implementation was in a .m that also had a
non-category implementation.

Hard to say if any of these would affect SwiftUI preview/live preview behavior, but this PR shouldn't hurt.

#no-changelog

