### PR TITLE
update the sample app to use link domains for ActionCodeSettings

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthMenu.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Models/AuthMenu.swift
@@ -43,6 +43,7 @@ enum AuthMenu: String {
   case deleteApp
   case actionType
   case continueURL
+  case linkDomain
   case requestVerifyEmail
   case requestPasswordReset
   case resetPassword
@@ -117,6 +118,8 @@ enum AuthMenu: String {
       return "Action Type"
     case .continueURL:
       return "Continue URL"
+    case .linkDomain:
+      return "Link Domain"
     case .requestVerifyEmail:
       return "Request Verify Email"
     case .requestPasswordReset:
@@ -197,6 +200,8 @@ enum AuthMenu: String {
       self = .actionType
     case "Continue URL":
       self = .continueURL
+    case "Link Domain":
+      self = .linkDomain
     case "Request Verify Email":
       self = .requestVerifyEmail
     case "Request Password Reset":
@@ -328,6 +333,7 @@ class AuthMenuData: DataSourceProvidable {
     let items: [Item] = [
       Item(title: AuthMenu.actionType.name, detailTitle: ActionCodeRequestType.inApp.name),
       Item(title: AuthMenu.continueURL.name, detailTitle: "--", isEditable: true),
+      Item(title: AuthMenu.linkDomain.name, detailTitle: "--", isEditable: true),
       Item(title: AuthMenu.requestVerifyEmail.name),
       Item(title: AuthMenu.requestPasswordReset.name),
       Item(title: AuthMenu.resetPassword.name),

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AccountLinkingViewController.swift
@@ -317,6 +317,9 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
   /// Similar to in `PasswordlessViewController`, enter the authorized domain.
   /// Please refer to this Quickstart's README for more information.
   private let authorizedDomain: String = "ENTER AUTHORIZED DOMAIN"
+
+  /// This is the replacement for customized dynamic link domain.
+  private let customDomain: String = "ENTER AUTHORIZED HOSTING DOMAIN"
   /// Maintain a reference to the email entered for linking user to Passwordless.
   private var email: String?
 
@@ -343,6 +346,7 @@ class AccountLinkingViewController: UIViewController, DataSourceProviderDelegate
     // The sign-in operation must be completed in the app.
     actionCodeSettings.handleCodeInApp = true
     actionCodeSettings.setIOSBundleID(Bundle.main.bundleIdentifier!)
+    actionCodeSettings.linkDomain = customDomain
 
     AppManager.shared.auth()
       .sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -160,7 +160,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
 
     case .linkDomain:
       changeActionCodeLinkDomain(at: indexPath)
-      
+
     case .requestVerifyEmail:
       requestVerifyEmail()
 
@@ -569,7 +569,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
       self.tableView.reloadData()
     })
   }
-  
+
   private func changeActionCodeLinkDomain(at indexPath: IndexPath) {
     showTextInputPrompt(with: "Link Domain:", completion: { newLinkDomain in
       self.actionCodeLinkDomain = newLinkDomain

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/AuthViewController.swift
@@ -39,6 +39,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
   var authStateDidChangeListeners: [AuthStateDidChangeListenerHandle] = []
   var IDTokenDidChangeListeners: [IDTokenDidChangeListenerHandle] = []
   var actionCodeContinueURL: URL?
+  var actionCodeLinkDomain: String?
   var actionCodeRequestType: ActionCodeRequestType = .inApp
 
   let spinner = UIActivityIndicatorView(style: .medium)
@@ -69,6 +70,7 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
     let settings = ActionCodeSettings()
     settings.url = actionCodeContinueURL
     settings.handleCodeInApp = (actionCodeRequestType == .inApp)
+    settings.linkDomain = actionCodeLinkDomain
     return settings
   }
 
@@ -156,6 +158,9 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
     case .continueURL:
       changeActionCodeContinueURL(at: indexPath)
 
+    case .linkDomain:
+      changeActionCodeLinkDomain(at: indexPath)
+      
     case .requestVerifyEmail:
       requestVerifyEmail()
 
@@ -552,12 +557,28 @@ class AuthViewController: UIViewController, DataSourceProviderDelegate {
   private func changeActionCodeContinueURL(at indexPath: IndexPath) {
     showTextInputPrompt(with: "Continue URL:", completion: { newContinueURL in
       self.actionCodeContinueURL = URL(string: newContinueURL)
-      print("Successfully set Continue URL  to: \(newContinueURL)")
+      print("Successfully set Continue URL to: \(newContinueURL)")
       self.dataSourceProvider.updateItem(
         at: indexPath,
         item: Item(
           title: AuthMenu.continueURL.name,
           detailTitle: self.actionCodeContinueURL?.absoluteString,
+          isEditable: true
+        )
+      )
+      self.tableView.reloadData()
+    })
+  }
+  
+  private func changeActionCodeLinkDomain(at indexPath: IndexPath) {
+    showTextInputPrompt(with: "Link Domain:", completion: { newLinkDomain in
+      self.actionCodeLinkDomain = newLinkDomain
+      print("Successfully set Link Domain to: \(newLinkDomain)")
+      self.dataSourceProvider.updateItem(
+        at: indexPath,
+        item: Item(
+          title: AuthMenu.linkDomain.name,
+          detailTitle: self.actionCodeLinkDomain,
           isEditable: true
         )
       )

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/PasswordlessViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/OtherAuthMethodControllers/PasswordlessViewController.swift
@@ -32,6 +32,7 @@ class PasswordlessViewController: OtherAuthViewController {
   // MARK: - Firebase 🔥
 
   private let authorizedDomain: String = "ENTER AUTHORIZED DOMAIN"
+  private let customDomain: String = "ENTER AUTHORIZED HOSTING DOMAIN"
 
   private func sendSignInLink(to email: String) {
     let actionCodeSettings = ActionCodeSettings()
@@ -42,6 +43,7 @@ class PasswordlessViewController: OtherAuthViewController {
     // The sign-in operation must be completed in the app.
     actionCodeSettings.handleCodeInApp = true
     actionCodeSettings.setIOSBundleID(Bundle.main.bundleIdentifier!)
+    actionCodeSettings.linkDomain = customDomain
 
     AppManager.shared.auth()
       .sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in


### PR DESCRIPTION
Add abilities for swift sample app to add hosting domain for FDL deprecation.

Sample HTTP request observed from testing
postBody -
["requestType": AnyHashable("PASSWORD_RESET"), "continueUrl": AnyHashable("fake"), "clientType": AnyHashable("CLIENT_TYPE_IOS"), "canHandleCodeInApp": AnyHashable(true), "iOSBundleId": AnyHashable("fake"), "email": AnyHashable("fake"), "linkDomain": AnyHashable("<input link>")]