### PR TITLE
adding invalid-hosting-link-domain error code and API tests

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -485,6 +485,8 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
       .missingAppCredential(message: serverDetailErrorMessage)
     case "INVALID_CODE": return AuthErrorUtils
       .invalidVerificationCodeError(message: serverDetailErrorMessage)
+    case "INVALID_HOSTING_LINK_DOMAIN": return AuthErrorUtils
+      .invalidHostingLinkDomainError(message: serverDetailErrorMessage)
     case "INVALID_SESSION_INFO": return AuthErrorUtils
       .invalidVerificationIDError(message: serverDetailErrorMessage)
     case "SESSION_EXPIRED": return AuthErrorUtils

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
@@ -366,6 +366,10 @@ class AuthErrorUtils: NSObject {
     error(code: .invalidDynamicLinkDomain, message: message)
   }
 
+  static func invalidHostingLinkDomainError(message: String?) -> Error {
+    error(code: .invalidHostingLinkDomain, message: message)
+  }
+
   static func missingOrInvalidNonceError(message: String?) -> Error {
     error(code: .missingOrInvalidNonce, message: message)
   }

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrors.swift
@@ -258,6 +258,9 @@ import Foundation
   /// unauthorized for the current project.
   case invalidDynamicLinkDomain = 17074
 
+  /// Indicates that the provided Firebase Hosting Link domain is not owned by the current project.
+  case invalidHostingLinkDomain = 17214
+
   /// Indicates that the credential is rejected because it's malformed or mismatching.
   case rejectedCredential = 17075
 
@@ -468,6 +471,8 @@ import Foundation
       return kErrorInvalidProviderID
     case .invalidDynamicLinkDomain:
       return kErrorInvalidDynamicLinkDomain
+    case .invalidHostingLinkDomain:
+      return kErrorInvalidHostingLinkDomain
     case .webInternalError:
       return kErrorWebInternalError
     case .webSignInUserInteractionFailure:
@@ -661,6 +666,8 @@ import Foundation
       return "ERROR_INVALID_PROVIDER_ID"
     case .invalidDynamicLinkDomain:
       return "ERROR_INVALID_DYNAMIC_LINK_DOMAIN"
+    case .invalidHostingLinkDomain:
+      return "ERROR_INVALID_HOSTING_LINK_DOMAIN"
     case .webInternalError:
       return "ERROR_WEB_INTERNAL_ERROR"
     case .webSignInUserInteractionFailure:
@@ -904,6 +911,9 @@ private let kErrorInvalidProviderID =
 
 private let kErrorInvalidDynamicLinkDomain =
   "The Firebase Dynamic Link domain used is either not configured or is unauthorized for the current project."
+
+private let kErrorInvalidHostingLinkDomain =
+  "The provided hosting link domain is not configured in Firebase Hosting or is not owned by the current project."
 
 private let kErrorInternalError =
   "An internal error has occurred, print and inspect the error details for more information."

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -65,6 +65,7 @@
   s = [codeSettings androidPackageName];
   s = [codeSettings androidMinimumVersion];
   s = [codeSettings dynamicLinkDomain];
+  s = [codeSettings linkDomain];
 }
 
 - (void)FIRAuthAdditionalUserInfo_h:(FIRAdditionalUserInfo *)additionalUserInfo {
@@ -280,6 +281,7 @@
   c = FIRAuthErrorCodeTenantIDMismatch;
   c = FIRAuthErrorCodeUnsupportedTenantOperation;
   c = FIRAuthErrorCodeInvalidDynamicLinkDomain;
+  c = FIRAuthErrorCodeInvalidHostingLinkDomain;
   c = FIRAuthErrorCodeRejectedCredential;
   c = FIRAuthErrorCodeGameKitNotLinked;
   c = FIRAuthErrorCodeSecondFactorRequired;

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -41,7 +41,8 @@ class AuthAPI_hOnlyTests: XCTestCase {
        let _: String = codeSettings.iOSBundleID,
        let _: String = codeSettings.androidPackageName,
        let _: String = codeSettings.androidMinimumVersion,
-       let _: String = codeSettings.dynamicLinkDomain {}
+       let _: String = codeSettings.dynamicLinkDomain {},
+        let _: String = codeSettings.linkDomain
   }
 
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
@@ -276,6 +277,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
     _ = AuthErrorCode.tenantIDMismatch
     _ = AuthErrorCode.unsupportedTenantOperation
     _ = AuthErrorCode.invalidDynamicLinkDomain
+    _ = AuthErrorCode.invalidHostingLinkDomain
     _ = AuthErrorCode.rejectedCredential
     _ = AuthErrorCode.gameKitNotLinked
     _ = AuthErrorCode.secondFactorRequired


### PR DESCRIPTION
API proposal for error code - [go/firebaseauth-fdl-deprecation-api-proposal](http://goto.google.com/firebaseauth-fdl-deprecation-api-proposal)
