### PR TITLE
[Auth] Phone Auth – Fallback to reCATCHA flow when "invalid app credential" error is thrown

### DIFF
--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -346,15 +346,12 @@ import Foundation
       } catch {
         let nserror = error as NSError
         // reCAPTCHA Flow if it's an invalid app credential or a missing app token.
-        if (nserror.code == AuthErrorCode.internalError.rawValue &&
-          (nserror.userInfo[NSUnderlyingErrorKey] as? NSError)?.code ==
-          AuthErrorCode.invalidAppCredential.rawValue) ||
-          nserror.code == AuthErrorCode.missingAppToken.rawValue {
-          return try await CodeIdentity
-            .recaptcha(reCAPTCHAFlowWithUIDelegate(withUIDelegate: uiDelegate))
-        } else {
+        guard nserror.code == AuthErrorCode.invalidAppCredential.rawValue || nserror
+          .code == AuthErrorCode.missingAppToken.rawValue else {
           throw error
         }
+        return try await CodeIdentity
+          .recaptcha(reCAPTCHAFlowWithUIDelegate(withUIDelegate: uiDelegate))
       }
     }
 


### PR DESCRIPTION
This is one step towards fixing #13479.

There are two parts to fix for that issue:
1. why invalid app credential is being returned
2. how SDK responds to it

After testing 10.29.0, I can only reproduce the issue on 11.0.0. This PR addresses the second point– how the SDK responds to the error.

Based on the 11.0.0 code comment (see diff) and 10.29.0 code (see below snippet), reCAPTCHA should launch for a missing app token or invalid app credential. 

https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m#L628-L630

The issue is that the v11 parsing logic was expecting the invalid app credential to be an internal error, but it is not wrapped as such, so the control flow never enters the conditional and calls into reCAPTCHA.

https://github.com/firebase/firebase-ios-sdk/blob/9118aca998dbe2ceac45d64b21a91c6376928df7/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift#L95

Looking back at the 10.29.0 code, I think it's possible this was a bug there too where invalid app credential is also a public error. But, at least from my testing, I'm not seeing the server return "invalid app credential" on 10.29.0. 
https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m#L1032

https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h#L306-L309

This PR should add a fallback to reCAPTCHA to address [behavior](https://github.com/firebase/firebase-ios-sdk/issues/13479#issuecomment-2287373733).

#no-changelog