### PR TITLE
Update OCMock dependency to v3.9.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -150,15 +150,10 @@ let package = Package(
     ),
     abseilDependency(),
     grpcDependency(),
-    // TODO: restore OCMock when https://github.com/erikdoe/ocmock/pull/537
-    // gets merged to fix Xcode 15.3 builds.
     .package(
-      url: "https://github.com/paulb777/ocmock.git",
-      revision: "173955e93e6ee6999a10729ab67e4b4efdd1db6d"
+      url: "https://github.com/erikdoe/ocmock.git",
+      revision: "2c0bfd373289f4a7716db5d6db471640f91a6507"
     ),
-//      url: "https://github.com/erikdoe/ocmock.git",
-//      revision: "c5eeaa6dde7c308a5ce48ae4d4530462dd3a1110"
-//    ),
     .package(
       url: "https://github.com/firebase/leveldb.git",
       "1.22.2" ..< "1.23.0"


### PR DESCRIPTION
OCMock 3.9.4 now includes https://github.com/erikdoe/ocmock/pull/537 that fixes Xcode 15.3 builds on Intel.