### PR TITLE
[Vertex AI] Update MarkdownUI dep to 2.4.0 in sample app

### DIFF
--- a/FirebaseVertexAI/Sample/VertexAISample.xcodeproj/project.pbxproj
+++ b/FirebaseVertexAI/Sample/VertexAISample.xcodeproj/project.pbxproj
@@ -599,7 +599,7 @@
 			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
 			requirement = {
 				kind = revision;
-				revision = 5df8a4adedd6ae4eb2455ef60ff75183984daeb8;
+				revision = 55441810c0f678c78ed7e2ebd46dde89228e02fc;
 			};
 		};
 		DEA09AC32B1FCE22001962D9 /* XCRemoteSwiftPackageReference "NetworkImage" */ = {


### PR DESCRIPTION
Updated the Vertex AI sample apps to use [MarkdownUI 2.4.0](https://github.com/gonzalezreal/swift-markdown-ui/releases/tag/2.4.0) ([55441810c0f678c78ed7e2ebd46dde89228e02fc](https://github.com/gonzalezreal/swift-markdown-ui/commit/55441810c0f678c78ed7e2ebd46dde89228e02fc)). This fixes the Circular Reference error (https://github.com/gonzalezreal/swift-markdown-ui/issues/323) when compiling on Xcode 16 Beta (first included in [MarkdownUI 2.3.1](https://github.com/gonzalezreal/swift-markdown-ui/releases/tag/2.3.1) but updating to latest).

#no-changelog