### PR TITLE
[Auth] When swizzling is disabled, open URLs via SceneDelegate

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SceneDelegate.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SceneDelegate.swift
@@ -48,6 +48,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window?.makeKeyAndVisible()
   }
 
+  // Implementing this delegate method is needed when swizzling is disabled.
+  // Without it, reCAPTCHA's login view controller will not dismiss.
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    for urlContext in URLContexts {
+      let url = urlContext.url
+      _ = Auth.auth().canHandle(url)
+    }
+
+    // URL not auth related; it should be handled separately.
+  }
+
   func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
     if let incomingURL = userActivity.webpageURL {
       handleIncomingDynamicLink(incomingURL)


### PR DESCRIPTION
Without this in the auth sample app, recaptcha's login safari controller won't dismiss when swizzling is disabled. cc: @rizafran 

This is already covered in the last code snippet of the docs which is good: https://firebase.google.com/docs/auth/ios/phone-auth#appendix:-using-phone-sign-in-without-swizzling

In iOS 13+, the scene delegate may take priority when opening URLs: https://stackoverflow.com/a/75064585/9331576

#no-changelog