### PR TITLE
[Vertex AI] Add `Sendable` conformance to types

### DIFF
--- a/FirebaseVertexAI/Sources/FunctionCalling.swift
+++ b/FirebaseVertexAI/Sources/FunctionCalling.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// A predicted function call returned from the model.
-public struct FunctionCall: Equatable {
+public struct FunctionCall: Equatable, Sendable {
   /// The name of the function to call.
   public let name: String
 
@@ -131,7 +131,7 @@ public struct ToolConfig {
 /// Contains a string representing the `FunctionDeclaration.name` and a structured JSON object
 /// containing any output from the function is used as context to the model. This should contain the
 /// result of a ``FunctionCall`` made based on model prediction.
-public struct FunctionResponse: Equatable {
+public struct FunctionResponse: Equatable, Sendable {
   /// The name of the function that was called.
   let name: String
 

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -16,9 +16,9 @@ import Foundation
 
 /// The model's response to a generate content request.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct GenerateContentResponse {
+public struct GenerateContentResponse: Sendable {
   /// Token usage metadata for processing the generate content request.
-  public struct UsageMetadata {
+  public struct UsageMetadata: Sendable {
     /// The number of tokens in the request prompt.
     public let promptTokenCount: Int
 
@@ -85,7 +85,7 @@ public struct GenerateContentResponse {
 /// A struct representing a possible reply to a content generation prompt. Each content generation
 /// prompt may produce multiple candidate responses.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct CandidateResponse {
+public struct CandidateResponse: Sendable {
   /// The response's content.
   public let content: ModelContent
 
@@ -111,14 +111,14 @@ public struct CandidateResponse {
 
 /// A collection of source attributions for a piece of content.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct CitationMetadata {
+public struct CitationMetadata: Sendable {
   /// A list of individual cited sources and the parts of the content to which they apply.
   public let citationSources: [Citation]
 }
 
 /// A struct describing a source attribution.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct Citation {
+public struct Citation: Sendable {
   /// The inclusive beginning of a sequence in a model response that derives from a cited source.
   public let startIndex: Int
 
@@ -137,7 +137,7 @@ public struct Citation {
 
 /// A value enumerating possible reasons for a model to terminate a content generation request.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public enum FinishReason: String {
+public enum FinishReason: String, Sendable {
   case unknown = "FINISH_REASON_UNKNOWN"
 
   case unspecified = "FINISH_REASON_UNSPECIFIED"
@@ -162,9 +162,9 @@ public enum FinishReason: String {
 
 /// A metadata struct containing any feedback the model had on the prompt it was provided.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct PromptFeedback {
+public struct PromptFeedback: Sendable {
   /// A type describing possible reasons to block a prompt.
-  public enum BlockReason: String {
+  public enum BlockReason: String, Sendable {
     /// The block reason is unknown.
     case unknown = "UNKNOWN"
 

--- a/FirebaseVertexAI/Sources/JSONValue.swift
+++ b/FirebaseVertexAI/Sources/JSONValue.swift
@@ -24,7 +24,7 @@ public typealias JSONObject = [String: JSONValue]
 ///
 /// This may be decoded from, or encoded to, a
 /// [`google.protobuf.Value`](https://protobuf.dev/reference/protobuf/google.protobuf/#value).
-public enum JSONValue {
+public enum JSONValue: Sendable {
   /// A `null` value.
   case null
 

--- a/FirebaseVertexAI/Sources/ModelContent.swift
+++ b/FirebaseVertexAI/Sources/ModelContent.swift
@@ -18,10 +18,10 @@ import Foundation
 /// request or response contains an `Array` of ``ModelContent``s, and each ``ModelContent`` value
 /// may comprise multiple heterogeneous ``ModelContent/Part``s.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct ModelContent: Equatable {
+public struct ModelContent: Equatable, Sendable {
   /// A discrete piece of data in a media format interpretable by an AI model. Within a single value
   /// of ``Part``, different data types may not mix.
-  public enum Part: Equatable {
+  public enum Part: Equatable, Sendable {
     /// Text value.
     case text(String)
 

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -18,7 +18,7 @@ import Foundation
 /// of this type may be assigned to a category for every model-generated response, not just
 /// responses that exceed a certain threshold.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct SafetyRating: Equatable, Hashable {
+public struct SafetyRating: Equatable, Hashable, Sendable {
   /// The category describing the potential harm a piece of content may pose. See
   /// ``SafetySetting/HarmCategory`` for a list of possible values.
   public let category: SafetySetting.HarmCategory
@@ -37,7 +37,7 @@ public struct SafetyRating: Equatable, Hashable {
 
   /// The probability that a given model output falls under a harmful content category. This does
   /// not indicate the severity of harm for a piece of content.
-  public enum HarmProbability: String {
+  public enum HarmProbability: String, Sendable {
     /// Unknown. A new server value that isn't recognized by the SDK.
     case unknown = "UNKNOWN"
 
@@ -81,7 +81,7 @@ public struct SafetyFeedback {
 public struct SafetySetting {
   /// A type describing safety attributes, which include harmful categories and topics that can
   /// be considered sensitive.
-  public enum HarmCategory: String {
+  public enum HarmCategory: String, Sendable {
     /// Unknown. A new server value that isn't recognized by the SDK.
     case unknown = "HARM_CATEGORY_UNKNOWN"
 
@@ -102,7 +102,7 @@ public struct SafetySetting {
   }
 
   /// Block at and beyond a specified ``SafetyRating/HarmProbability``.
-  public enum BlockThreshold: String {
+  public enum BlockThreshold: String, Sendable {
     /// Unknown. A new server value that isn't recognized by the SDK.
     case unknown = "UNKNOWN"
 


### PR DESCRIPTION
Added `Sendable` conformance to Vertex AI types in preparation for strict concurrency checking in Swift 6.

#no-changelog