### PR TITLE
[Auth] Fix unexpected nil in fetchSignInMethods success case

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,7 +2,11 @@
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16
   betas. (#13480)
 - [Fixed] Fixed Phone Auth via Sandbox APNS tokens that broke in 11.0.0. (#13479)
-- [Fixed] Fix crash when fetching sign in methods due to unexpected nil. (#13550)
+- [Fixed] Fix crash when fetching sign in methods due to unexpected nil.
+  Previously, fetching sign in methods could return both a `nil` array of sign
+  in methods and a `nil` error. In such cases, an empty array is instead
+  returned with the `nil` error. (#13550)
+
 
 # 11.1.0
 - [fixed] Fixed `Swift.error` conformance for `AuthErrorCode`. (#13430)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 11.2.0
+# Unreleased
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16
   betas. (#13480)
 - [Fixed] Fixed Phone Auth via Sandbox APNS tokens that broke in 11.0.0. (#13479)
+- [Fixed] Fix crash when fetching sign in methods due to unexpected nil. (#13550)
 
 # 11.1.0
 - [fixed] Fixed `Swift.error` conformance for `AuthErrorCode`. (#13430)

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -290,7 +290,7 @@ extension Auth: AuthInterop {
                                      completion: (([String]?, Error?) -> Void)? = nil) {
     kAuthGlobalWorkQueue.async {
       let request = CreateAuthURIRequest(identifier: email,
-                                         continueURI: "http:www.google.com",
+                                         continueURI: "http://www.google.com/",
                                          requestConfiguration: self.requestConfiguration)
       Task {
         do {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
@@ -33,7 +33,7 @@ class CreateAuthURIResponse: AuthRPCResponse {
   /// A list of provider IDs the passed identifier could use to sign in with.
   var allProviders: [String]?
 
-  /// A list of sign-in methods available for the passed  identifier.
+  /// A list of sign-in methods available for the passed identifier.
   var signinMethods: [String] = []
 
   /// Bare initializer.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIResponse.swift
@@ -34,7 +34,7 @@ class CreateAuthURIResponse: AuthRPCResponse {
   var allProviders: [String]?
 
   /// A list of sign-in methods available for the passed  identifier.
-  var signinMethods: [String]?
+  var signinMethods: [String] = []
 
   /// Bare initializer.
   required init() {}
@@ -45,6 +45,6 @@ class CreateAuthURIResponse: AuthRPCResponse {
     registered = dictionary["registered"] as? Bool ?? false
     forExistingProvider = dictionary["forExistingProvider"] as? Bool ?? false
     allProviders = dictionary["allProviders"] as? [String]
-    signinMethods = dictionary["signinMethods"] as? [String]
+    signinMethods = dictionary["signinMethods"] as? [String] ?? []
   }
 }

--- a/FirebaseAuth/Tests/SampleSwift/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/SampleSwift/SwiftApiTests/EmailPasswordTests.swift
@@ -69,12 +69,15 @@ class EmailPasswordTests: TestsBase {
     waitForExpectations(timeout: TestsBase.kExpectationsTimeout)
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testSignInExistingUserWithEmailAndPasswordAsync() async throws {
     let auth = Auth.auth()
     try await auth.signIn(withEmail: kExistingEmailToSignIn, password: "password")
     XCTAssertEqual(auth.currentUser?.email,
                    kExistingEmailToSignIn,
                    "Signed user does not match request.")
+    // Regression test for #13550. Auth enumeration protection is enabled for
+    // the test project so the no sign in methods should be returned.
+    let signInMethods = try await auth.fetchSignInMethods(forEmail: kExistingEmailToSignIn)
+    XCTAssertEqual(signInMethods, [])
   }
 }

--- a/FirebaseAuth/Tests/SampleSwift/SwiftApiTests/EmailPasswordTests.swift
+++ b/FirebaseAuth/Tests/SampleSwift/SwiftApiTests/EmailPasswordTests.swift
@@ -76,7 +76,7 @@ class EmailPasswordTests: TestsBase {
                    kExistingEmailToSignIn,
                    "Signed user does not match request.")
     // Regression test for #13550. Auth enumeration protection is enabled for
-    // the test project so the no sign in methods should be returned.
+    // the test project, so no sign in methods should be returned.
     let signInMethods = try await auth.fetchSignInMethods(forEmail: kExistingEmailToSignIn)
     XCTAssertEqual(signInMethods, [])
   }


### PR DESCRIPTION
- Revert the URL to match Firebase 10 (https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/Auth/FIRAuth.m#L676). This actually didn't make a difference and I was able to get valid sign in methods when using both forms. LMK if there is a reason to not change it back.
- The below line lead to crash as `response.signinMethods` is `nil` so the continuation throws an implicitly unwrapped error which crashes.
https://github.com/firebase/firebase-ios-sdk/blob/486a0a03c197a267a4a54d5f0077e1703b197588/FirebaseAuth/Sources/Swift/Auth/Auth.swift#L298
  - This can be reproduced in a scenario where email enumeration protection is turned on. The unit test added will fail without the corresponding changes in [CreateAuthURIResponse.swift](https://github.com/firebase/firebase-ios-sdk/compare/nc/fix13550?expand=1#diff-4cbd76f6666aa4a7ceffedf79284cc8109a529b49146c0841bb37462211b7b63)

Fix #13550