### PR TITLE
Revert zip builds to macos-13

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -30,7 +30,7 @@ jobs:
   package-release:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -58,7 +58,7 @@ jobs:
   build:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Xcode 15.2
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         linking_type: [static, dynamic]
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126


### PR DESCRIPTION
There seems to be a general issue with macos-14 GHA configurations. See https://github.com/actions/runner-images/issues/10386#issuecomment-2322779560

Reverting to macos-13 fixes the problem at the cost of slower builds.

Let's merge this Tuesday if nightlies are still broken

Investigating zip failure in #13558 
![Screenshot 2024-08-31 at 9 03 09 AM](https://github.com/user-attachments/assets/2486e8cf-399d-4678-ba62-7667c8dc8d06)
