### PR TITLE
Fix temporary disconnect when app goes inactive

### DIFF
--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fix temporary disconnects when the app goes inactive. The issue was
+  introduced in 10.27.0. (#13529)
+
 # 11.0.0
 - [removed] **Breaking change**: The deprecated `FirebaseDatabaseSwift`
   module has been removed. See

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -110,27 +110,6 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
             NSURLSessionWebSocketTask *task =
                 [session webSocketTaskWithRequest:req];
             self.webSocketTask = task;
-
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION || TARGET_OS_MACCATALYST
-            NSString *resignName = UIApplicationWillResignActiveNotification;
-#elif TARGET_OS_OSX
-            NSString *resignName = NSApplicationWillResignActiveNotification;
-#elif TARGET_OS_WATCH
-            NSString *resignName = WKApplicationWillResignActiveNotification;
-#elif
-#error("missing platform")
-#endif
-            [[NSNotificationCenter defaultCenter]
-                addObserverForName:resignName
-                            object:nil
-                             queue:opQueue
-                        usingBlock:^(NSNotification *_Nonnull note) {
-                          FFLog(@"I-RDB083015",
-                                @"Received notification that application "
-                                @"will resign, "
-                                @"closing web socket.");
-                          [self onClosed];
-                        }];
         }
     }
     return self;


### PR DESCRIPTION
Remove background/foreground notification handling. They were only unnecessary for watchOS since it doesn't support persistent connections. When it was mistakenly applied to other platforms with the Socket Rocket to Web Socket update, it caused extra disconnects.

Fix #13529