### PR TITLE
Fix user session persistence in multi tenant projects

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,11 +2,11 @@
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16
   betas. (#13480)
 - [Fixed] Fixed Phone Auth via Sandbox APNS tokens that broke in 11.0.0. (#13479)
-- [Fixed] Fix crash when fetching sign in methods due to unexpected nil.
+- [Fixed] Fixed crash when fetching sign in methods due to unexpected nil.
   Previously, fetching sign in methods could return both a `nil` array of sign
   in methods and a `nil` error. In such cases, an empty array is instead
   returned with the `nil` error. (#13550)
-
+- [Fixed] Fixed user session persistence in multi tenant projects. Introduced in 11.0.0. (#13565)
 
 # 11.1.0
 - [fixed] Fixed `Swift.error` conformance for `AuthErrorCode`. (#13430)

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1667,9 +1667,11 @@ extension Auth: AuthInterop {
           try self.internalUseUserAccessGroup(storedUserAccessGroup)
         } else {
           let user = try self.getUser()
-          try self.updateCurrentUser(user, byForce: false, savingToDisk: false)
           if let user {
             self.tenantID = user.tenantID
+          }
+          try self.updateCurrentUser(user, byForce: false, savingToDisk: false)
+          if let user {
             self.lastNotifiedUserToken = user.rawAccessToken()
           }
         }
@@ -1941,8 +1943,7 @@ extension Auth: AuthInterop {
     }
     if let user {
       if user.tenantID != nil || tenantID != nil, tenantID != user.tenantID {
-        let error = AuthErrorUtils.tenantIDMismatchError()
-        throw error
+        throw AuthErrorUtils.tenantIDMismatchError()
       }
     }
     var throwError: Error?

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -484,8 +484,7 @@ private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation 
         code: AuthErrorCode.maximumSecondFactorCountExceeded,
         message: serverDetailErrorMessage
       )
-    case "TENANT_ID_MISMATCH": return AuthErrorUtils
-      .tenantIDMismatchError()
+    case "TENANT_ID_MISMATCH": return AuthErrorUtils.tenantIDMismatchError()
     case "TOKEN_EXPIRED": return AuthErrorUtils
       .userTokenExpiredError(message: serverDetailErrorMessage)
     case "UNSUPPORTED_FIRST_FACTOR": return AuthErrorUtils


### PR DESCRIPTION
Fix #13565 

The tenantID on the Auth instance must be set before calling `updateCurrentUser`