### PR TITLE
[Vertex AI] Make `Logger` properties constants

### DIFF
--- a/FirebaseVertexAI/Sources/Logging.swift
+++ b/FirebaseVertexAI/Sources/Logging.swift
@@ -38,10 +38,10 @@ struct Logging {
 
   /// The default logger that is visible for all users. Note: we shouldn't be using anything lower
   /// than `.notice`.
-  static var `default` = Logger(subsystem: subsystem, category: defaultCategory)
+  static let `default` = Logger(subsystem: subsystem, category: defaultCategory)
 
   /// A non default
-  static var network: Logger = {
+  static let network: Logger = {
     if additionalLoggingEnabled() {
       return Logger(subsystem: subsystem, category: "NetworkResponse")
     } else {
@@ -51,7 +51,7 @@ struct Logging {
   }()
 
   ///
-  static var verbose: Logger = {
+  static let verbose: Logger = {
     if additionalLoggingEnabled() {
       return Logger(subsystem: subsystem, category: defaultCategory)
     } else {


### PR DESCRIPTION
Made the `Logger` properties in the Vertex AI `Logging` struct constants since they can be immutable. This fixes a warning with Swift 6 strict concurrency checking:
> Static property 'default' is not concurrency-safe because it is nonisolated global shared mutable state; this is an error in the Swift 6 language mode

#no-changelog