### PR TITLE
Add `-Wno-error=redundant-move` to cmake builds

### DIFF
--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(CheckCXXCompilerFlag)
+
 # C++ Compiler setup
 
 # We use C++14
@@ -75,6 +77,14 @@ if(CXX_CLANG OR CXX_GNU)
     if(CXX_CLANG OR CXX_GNU)
       list(APPEND common_flags -fdiagnostics-color)
     endif()
+  endif()
+
+  # Disable treating "redundant-move" as an error since it's not really a problem,
+  # and is even a valid coding style to over-use std::move() in case the type is
+  # ever changed to become non-trivially moveable.
+  CHECK_CXX_COMPILER_FLAG("-Wno-error=redundant-move" FIREBASE_CXX_COMPILER_FLAG_REDUNDANT_MOVE_SUPPORTED)
+  if(FIREBASE_CXX_COMPILER_FLAG_REDUNDANT_MOVE_SUPPORTED)
+    list(APPEND common_flags -Wno-error=redundant-move)
   endif()
 endif()
 


### PR DESCRIPTION
Add `-Wno-error=redundant-move` to avoid failing the build due to unnecessary `std::move()` calls. It is common practice to use `std::move()` liberally, even if it's not strictly beneficial, to ensure that a type is moved if its definition is ever changed to not be trivially movable. Therefore, it doesn't make sense to fail the build due to unnecessary `std::move()` calls.

This fixes the following compiler error:

```
[2094/2338] Building CXX object Firestore/core/CMakeFiles/firestore_util.dir/src/util/logic_utils.cc.o
FAILED: Firestore/core/CMakeFiles/firestore_util.dir/src/util/logic_utils.cc.o 
/usr/bin/ccache /usr/bin/c++ -DCARES_STATICLIB -DFIRESTORE_HAVE_CONFIG_DETECTED_H -DPB_ENABLE_MALLOC -DPB_FIELD_32BIT -DPB_NO_PACKED_STRUCTS=1 -Ifirebase-ios-sdk/cmake-build-debug -Ifirebase-ios-sdk -Ifirebase-ios-sdk/cmake-build-debug/external/src/abseil-cpp -Ifirebase-ios-sdk/cmake-build-debug/external/src/nanopb -Ifirebase-ios-sdk/Firestore/Protos/nanopb -Ifirebase-ios-sdk/cmake-build-debug/external/src/grpc/include -Ifirebase-ios-sdk/cmake-build-debug/external/src/re2 -Ifirebase-ios-sdk/cmake-build-debug/external/src/grpc-build/third_party/cares/cares -Ifirebase-ios-sdk/cmake-build-debug/external/src/cares -Ifirebase-ios-sdk/cmake-build-debug/external/src/boringssl/src/include -Ifirebase-ios-sdk/cmake-build-debug/external/src/protobuf/src -g -std=c++14 -fdiagnostics-color=always -Wall -Wextra -Werror -Wformat -Wuninitialized -fno-common -Wunused-function -Wunused-value -Wunused-variable -fdiagnostics-color -Wreorder -Werror=reorder -MD -MT Firestore/core/CMakeFiles/firestore_util.dir/src/util/logic_utils.cc.o -MF Firestore/core/CMakeFiles/firestore_util.dir/src/util/logic_utils.cc.o.d -o Firestore/core/CMakeFiles/firestore_util.dir/src/util/logic_utils.cc.o -c firebase-ios-sdk/Firestore/core/src/util/logic_utils.cc
firebase-ios-sdk/Firestore/core/src/util/logic_utils.cc: In static member function ‘static firebase::firestore::core::Filter firebase::firestore::util::LogicUtils::ApplyAssociation(const firebase::firestore::core::Filter&)’:
firebase-ios-sdk/Firestore/core/src/util/logic_utils.cc:95:21: error: redundant move in return statement [-Werror=redundant-move]
   95 |     return std::move(composite_filter);
      |            ~~~~~~~~~^~~~~~~~~~~~~~~~~~
firebase-ios-sdk/Firestore/core/src/util/logic_utils.cc:95:21: note: remove ‘std::move’ call
cc1plus: all warnings being treated as errors
[2098/2338] Linking CXX static library external/src/grpc-build/libgrpc.a
ninja: build stopped: subcommand failed.
```

The compiler in use in this case was reported by cmake as `-- The CXX compiler identification is GNU 13.2.0`

#no-changelog