### PR TITLE
Fix cmake builds with Python 3.12, which deleted the long-deprecated 'distutils' module

### DIFF
--- a/cmake/external/nanopb.patch
+++ b/cmake/external/nanopb.patch
@@ -1,7 +1,7 @@
 diff -Naur nanopb/CMakeLists.txt nanopb-fix/CMakeLists.txt
 --- nanopb/CMakeLists.txt	2021-03-22 08:50:07.000000000 -0400
 +++ nanopb-fix/CMakeLists.txt	2022-06-24 16:17:09.130783413 -0400
-@@ -41,7 +41,7 @@
+@@ -41,10 +41,10 @@
  if(nanopb_BUILD_GENERATOR)
      set(generator_protos nanopb plugin)
  
@@ -9,7 +9,11 @@ diff -Naur nanopb/CMakeLists.txt nanopb-fix/CMakeLists.txt
 +    find_package(PythonInterp 3.7 REQUIRED)
      execute_process(
          COMMAND ${PYTHON_EXECUTABLE} -c
-             "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
+-            "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))"
++            "import os.path, sys, sysconfig; print(os.path.relpath(sysconfig.get_path('purelib'), start=sys.prefix))"
+         OUTPUT_VARIABLE PYTHON_INSTDIR
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+     )
 diff -Naur nanopb/generator/nanopb_generator.py nanopb-fix/generator/nanopb_generator.py
 --- nanopb/generator/nanopb_generator.py	2021-03-22 08:50:07.000000000 -0400
 +++ nanopb-fix/generator/nanopb_generator.py	2022-11-01 15:37:38.112297044 -0400


### PR DESCRIPTION
If performing a cmake build with Python 3.11 or earlier, everything works fine; however, if using Python 3.12 the cmake build fails with `ModuleNotFoundError: No module named 'distutils'`. This is because the `distutils` module was deleted in Python 3.12 (see https://peps.python.org/pep-0632/ and https://docs.python.org/3/whatsnew/3.12.html#distutils).

The problem was coming from nanopb which referenced the `distutils` module in its `CMakeLists.txt`. The fix was to copy the replacement command that works in Python 3.12, and should work all the way back to Python 3.7 (see https://github.com/nanopb/nanopb/pull/727 and https://github.com/nanopb/nanopb/pull/730). This PR merely tweaks the patching that is already done on nanopb.

Here is what the error looks like, which this PR fixes:

```
$ PATH="$HOME/.pyenv/versions/3.12.3/bin/python:$PATH" cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -GNinja
...
-- Found PythonInterp: /home/linuxbrew/.linuxbrew/bin/python3 (found suitable version "3.12.3", minimum required is "3.7") 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'distutils'
CMake Error at build/external/src/nanopb/CMakeLists.txt:61 (install):
  install FILES given no DESTINATION!


CMake Error at build/external/src/nanopb/CMakeLists.txt:61 (install):
  install FILES given no DESTINATION!


-- Found Python3: /home/linuxbrew/.linuxbrew/bin/python3.12 (found version "3.12.3") found components: Interpreter 
-- FirebaseSetupPythonInterpreter(FirestoreProtos): Creating Python virtualenv in firebase-ios-sdk/build/Firestore/Protos/pyvenv/FirestoreProtos using /home/linuxbrew/.linuxbrew/bin/python3.12
-- firebase_execute_process(): running command: /home/linuxbrew/.linuxbrew/bin/python3.12 -m venv firebase-ios-sdk/build/Firestore/Protos/pyvenv/FirestoreProtos
-- FirebaseSetupPythonInterpreter(FirestoreProtos): Found Python executable in virtualenv: firebase-ios-sdk/build/Firestore/Protos/pyvenv/FirestoreProtos/bin/python3
-- FirebaseSetupPythonInterpreter(FirestoreProtos): Installing Python dependencies into firebase-ios-sdk/build/Firestore/Protos/pyvenv/FirestoreProtos: six
-- firebase_execute_process(): running command: firebase-ios-sdk/build/Firestore/Protos/pyvenv/FirestoreProtos/bin/python3 -m pip install six
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six
Successfully installed six-1.16.0

[notice] A new release of pip is available: 24.0 -> 24.2
[notice] To update, run: python3 -m pip install --upgrade pip
-- FirebaseSetupPythonInterpreter(FirestoreCore): Creating Python virtualenv in firebase-ios-sdk/build/Firestore/core/pyvenv/FirestoreCore using /home/linuxbrew/.linuxbrew/bin/python3.12
-- firebase_execute_process(): running command: /home/linuxbrew/.linuxbrew/bin/python3.12 -m venv firebase-ios-sdk/build/Firestore/core/pyvenv/FirestoreCore
-- FirebaseSetupPythonInterpreter(FirestoreCore): Found Python executable in virtualenv: firebase-ios-sdk/build/Firestore/core/pyvenv/FirestoreCore/bin/python3
-- Looking for dispatch_async_f
-- Looking for dispatch_async_f - not found
-- Looking for arc4random
-- Looking for arc4random - found
-- Looking for include file openssl/rand.h
-- Looking for include file openssl/rand.h - found
-- Configuring incomplete, errors occurred!
```

#no-changelog