### PR TITLE
[Auth] Forward secure coding calls for TOTPMultiFactorInfo

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -7,6 +7,9 @@
   in methods and a `nil` error. In such cases, an empty array is instead
   returned with the `nil` error. (#13550)
 - [Fixed] Fixed user session persistence in multi tenant projects. Introduced in 11.0.0. (#13565)
+- [Fixed] Fixed encoding crash that occurs when using TOTP multi-factor
+  authentication. Note that this fix will not be in the 11.2.0 zip and Carthage
+  distributions, but will be included from 11.3.0 onwards. (#13591)
 
 # 11.1.0
 - [fixed] Fixed `Swift.error` conformance for `AuthErrorCode`. (#13430)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift
@@ -16,6 +16,8 @@ import Foundation
 
 class AuthProtoMFAEnrollment: NSObject, AuthProto {
   let phoneInfo: String?
+  // In practice, this will be an empty dictionary. The presence of which
+  // indicates TOTP MFA enrollment rather than phone MFA enrollment.
   let totpInfo: NSObject?
   let mfaEnrollmentID: String?
   let displayName: String?

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
@@ -32,13 +32,11 @@ import Foundation
       super.init(proto: proto, factorID: PhoneMultiFactorInfo.TOTPMultiFactorID)
     }
 
-    @available(*, unavailable)
     required init?(coder: NSCoder) {
       totpInfo = nil
       super.init(coder: coder)
     }
 
-    @available(*, unavailable)
     override class var supportsSecureCoding: Bool {
       super.supportsSecureCoding
     }

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
@@ -34,7 +34,13 @@ import Foundation
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
+      totpInfo = nil
+      super.init(coder: coder)
+    }
+
+    @available(*, unavailable)
+    override class var supportsSecureCoding: Bool {
+      super.supportsSecureCoding
     }
   }
 #endif

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
@@ -22,19 +22,18 @@ import Foundation
   ///
   /// This class is available on iOS only.
   class TOTPMultiFactorInfo: MultiFactorInfo {
-    /// This is the totp info for the second factor.
-    let totpInfo: NSObject?
-
     /// Initialize the AuthProtoMFAEnrollment instance with proto.
     /// - Parameter proto: AuthProtoMFAEnrollment proto object.
     init(proto: AuthProtoMFAEnrollment) {
-      totpInfo = proto.totpInfo
       super.init(proto: proto, factorID: PhoneMultiFactorInfo.TOTPMultiFactorID)
     }
 
     required init?(coder: NSCoder) {
-      totpInfo = nil
       super.init(coder: coder)
+    }
+
+    override func encode(with coder: NSCoder) {
+      super.encode(with: coder)
     }
 
     override class var supportsSecureCoding: Bool {

--- a/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/TOTP/TOTPMultiFactorInfo.swift
@@ -32,10 +32,6 @@ import Foundation
       super.init(coder: coder)
     }
 
-    override func encode(with coder: NSCoder) {
-      super.encode(with: coder)
-    }
-
     override class var supportsSecureCoding: Bool {
       super.supportsSecureCoding
     }

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -71,7 +71,7 @@ class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
   var respondBlock: (() throws -> Void)?
   var nextRespondBlock: (() throws -> Void)?
 
-  var fakeGetAccountProviderJSON: [[String: Any]]?
+  var fakeGetAccountProviderJSON: [[String: AnyHashable]]?
   var fakeSecureTokenServiceJSON: [String: AnyHashable]?
   var secureTokenNetworkError: NSError?
   var secureTokenErrorString: String?

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -71,7 +71,7 @@ class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
   var respondBlock: (() throws -> Void)?
   var nextRespondBlock: (() throws -> Void)?
 
-  var fakeGetAccountProviderJSON: [[String: AnyHashable]]?
+  var fakeGetAccountProviderJSON: [[String: Any]]?
   var fakeSecureTokenServiceJSON: [String: AnyHashable]?
   var secureTokenNetworkError: NSError?
   var secureTokenErrorString: String?

--- a/FirebaseAuth/Tests/Unit/UserTests.swift
+++ b/FirebaseAuth/Tests/Unit/UserTests.swift
@@ -150,11 +150,11 @@ class UserTests: RPCBaseTests {
         ],
         [
           // In practice, this will be an empty dictionary.
-          "totpInfo": [AnyHashable: Any](),
+          "totpInfo": [AnyHashable: AnyHashable](),
           "mfaEnrollmentId": kEnrollmentID,
           "displayName": kDisplayName,
           "enrolledAt": kEnrolledAt,
-        ],
+        ] as [AnyHashable: AnyHashable],
       ],
     ]]
 

--- a/FirebaseAuth/Tests/Unit/UserTests.swift
+++ b/FirebaseAuth/Tests/Unit/UserTests.swift
@@ -149,7 +149,8 @@ class UserTests: RPCBaseTests {
           "enrolledAt": kEnrolledAt,
         ],
         [
-          "totpInfo": "123456",
+          // In practice, this will be an empty dictionary.
+          "totpInfo": [AnyHashable: Any](),
           "mfaEnrollmentId": kEnrollmentID,
           "displayName": kDisplayName,
           "enrolledAt": kEnrolledAt,

--- a/FirebaseAuth/Tests/Unit/UserTests.swift
+++ b/FirebaseAuth/Tests/Unit/UserTests.swift
@@ -141,12 +141,20 @@ class UserTests: RPCBaseTests {
       "phoneNumber": kPhoneNumber,
       "createdAt": String(Int(kCreationDateTimeIntervalInSeconds) * 1000), // to nanoseconds
       "lastLoginAt": String(Int(kLastSignInDateTimeIntervalInSeconds) * 1000),
-      "mfaInfo": [[
-        "phoneInfo": kPhoneInfo,
-        "mfaEnrollmentId": kEnrollmentID,
-        "displayName": kDisplayName,
-        "enrolledAt": kEnrolledAt,
-      ]],
+      "mfaInfo": [
+        [
+          "phoneInfo": kPhoneInfo,
+          "mfaEnrollmentId": kEnrollmentID,
+          "displayName": kDisplayName,
+          "enrolledAt": kEnrolledAt,
+        ],
+        [
+          "totpInfo": "123456",
+          "mfaEnrollmentId": kEnrollmentID,
+          "displayName": kDisplayName,
+          "enrolledAt": kEnrolledAt,
+        ],
+      ],
     ]]
 
     let expectation = self.expectation(description: #function)
@@ -346,11 +354,15 @@ class UserTests: RPCBaseTests {
 
           // Verify MultiFactorInfo properties.
           let enrolledFactors = try XCTUnwrap(user.multiFactor.enrolledFactors)
+          XCTAssertEqual(enrolledFactors.count, 2)
           XCTAssertEqual(enrolledFactors[0].factorID, PhoneMultiFactorInfo.PhoneMultiFactorID)
-          XCTAssertEqual(enrolledFactors[0].uid, kEnrollmentID)
-          XCTAssertEqual(enrolledFactors[0].displayName, self.kDisplayName)
-          let date = try XCTUnwrap(enrolledFactors[0].enrollmentDate)
-          XCTAssertEqual("\(date)", kEnrolledAtMatch)
+          XCTAssertEqual(enrolledFactors[1].factorID, PhoneMultiFactorInfo.TOTPMultiFactorID)
+          for enrolledFactor in enrolledFactors {
+            XCTAssertEqual(enrolledFactor.uid, kEnrollmentID)
+            XCTAssertEqual(enrolledFactor.displayName, self.kDisplayName)
+            let date = try XCTUnwrap(enrolledFactor.enrollmentDate)
+            XCTAssertEqual("\(date)", kEnrolledAtMatch)
+          }
         #endif
       } catch {
         XCTFail("Caught an error in \(#function): \(error)")


### PR DESCRIPTION
Fix #13591

- Remove unneeded `totpInfo` property because it's not used. The property on `AuthProtoMFAEnrollment` is enough (e.g. `git grep "\.totpInfo" -- FirebaseAuth/Sources/Swift`. https://github.com/firebase/firebase-ios-sdk/blob/ed4269b40ceb932f82132032722fa2f6fd91c0d1/FirebaseAuth/Sources/Swift/Backend/RPC/Proto/AuthProtoMFAEnrollment.swift#L19

---

```console
nickcooke@nickcooke-mac firebase-3 % git grep "\.totpInfo" -- FirebaseAuth/Sources/Swift
FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift:          } else if let _ = enrollment.totpInfo {
FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift:        } else if enrollment.totpInfo != nil {
```