### PR TITLE
[Release] Update Firestore SPM binary for 11.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1507,8 +1507,8 @@ func firestoreTargets() -> [Target] {
     } else {
       return .binaryTarget(
         name: "FirebaseFirestoreInternal",
-        url: "https://dl.google.com/firebase/ios/bin/firestore/11.1.0/rc1/FirebaseFirestoreInternal.zip",
-        checksum: "fc5453c2dc5f77426a62992bda3bcea21051b27c0f697f3a8ec461ecfafcdc44"
+        url: "https://dl.google.com/firebase/ios/bin/firestore/11.2.0/rc0/FirebaseFirestoreInternal.zip",
+        checksum: "821acae8d3b79c6d35539d87926da8aeae4a63878bec2987b01cb885b5120df2"
       )
     }
   }()


### PR DESCRIPTION
Updated the `FirebaseFirestoreInternal` binary target in preparation for the 11.2.0 release.

Note: This will need to be cherry-picked into https://github.com/firebase/firebase-ios-sdk/tree/release-11.2 since `main` has commits after code freeze.