### PR TITLE
[Auth] Better keychain error descriptions

### DIFF
--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
@@ -371,7 +371,8 @@ class AuthErrorUtils: NSObject {
   }
 
   static func keychainError(function: String, status: OSStatus) -> Error {
-    let reason = "\(function) (\(status))"
+    let message = SecCopyErrorMessageString(status, nil)
+    let reason = "\(function) (\(status)) \(message)"
     return error(code: .keychainError, userInfo: [NSLocalizedFailureReasonErrorKey: reason])
   }
 

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
@@ -371,7 +371,7 @@ class AuthErrorUtils: NSObject {
   }
 
   static func keychainError(function: String, status: OSStatus) -> Error {
-    let message = SecCopyErrorMessageString(status, nil)
+    let message = SecCopyErrorMessageString(status, nil) as String? ?? ""
     let reason = "\(function) (\(status)) \(message)"
     return error(code: .keychainError, userInfo: [NSLocalizedFailureReasonErrorKey: reason])
   }

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
@@ -120,7 +120,7 @@ class SettingsViewController: UIViewController, DataSourceProviderDelegate {
           fatalError("Configure AppIdentifierPrefix in the plist")
         }
         try AppManager.shared.auth().useUserAccessGroup(group +
-                                                        ".com.google.firebase.auth.keychainGroup1")
+          "com.google.firebase.auth.keychainGroup1")
       } else {
         try AppManager.shared.auth().useUserAccessGroup(nil)
       }

--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
@@ -113,14 +113,19 @@ class SettingsViewController: UIViewController, DataSourceProviderDelegate {
   }
 
   private func toggleAccessGroup() {
-    if AppManager.shared.auth().userAccessGroup == nil {
-      guard let bundleDictionary = Bundle.main.infoDictionary,
-            let group = bundleDictionary["AppIdentifierPrefix"] as? String else {
-        fatalError("Configure AppIdentifierPrefix in the plist")
+    do {
+      if AppManager.shared.auth().userAccessGroup == nil {
+        guard let bundleDictionary = Bundle.main.infoDictionary,
+              let group = bundleDictionary["AppIdentifierPrefix"] as? String else {
+          fatalError("Configure AppIdentifierPrefix in the plist")
+        }
+        try AppManager.shared.auth().useUserAccessGroup(group +
+                                                        ".com.google.firebase.auth.keychainGroup1")
+      } else {
+        try AppManager.shared.auth().useUserAccessGroup(nil)
       }
-      AppManager.shared.auth().userAccessGroup = group + "com.google.firebase.auth.keychainGroup1"
-    } else {
-      AppManager.shared.auth().userAccessGroup = nil
+    } catch {
+      fatalError("Failed to set userAccessGroup with error \(error)")
     }
   }
 


### PR DESCRIPTION
- Add description string to generated keychain errors
- Use public API to set shared keychain instead of internal one in sample