### PR TITLE
[Infra] Reduce test flakes due to async variable assignment

### DIFF
--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -590,12 +590,11 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
         try self.rpcIssuer.respond(withJSON: [:])
       }
       _ = try? await rpcImplementation.call(with: request)
-      // Make sure completeRequest updates.
-      usleep(10000)
 
       // Then
       let expectedHeader = HeartbeatLoggingTestUtils.nonEmptyHeartbeatsPayload.headerValue()
-      let completeRequest = try XCTUnwrap(rpcIssuer.completeRequest)
+      let completeRequest = await rpcIssuer.completeRequest.value
+
       let headerValue = completeRequest.value(forHTTPHeaderField: "X-Firebase-Client")
       XCTAssertEqual(headerValue, expectedHeader)
     }
@@ -619,10 +618,8 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
         try self.rpcIssuer.respond(withJSON: [:])
       }
       _ = try? await rpcImplementation.call(with: request)
-      // Make sure completeRequest updates.
-      usleep(10000)
 
-      let completeRequest = try XCTUnwrap(rpcIssuer.completeRequest)
+      let completeRequest = await rpcIssuer.completeRequest.value
       let headerValue = completeRequest.value(forHTTPHeaderField: "X-Firebase-AppCheck")
       XCTAssertEqual(headerValue, fakeAppCheck.fakeAppCheckToken)
     }
@@ -651,11 +648,9 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
         try self.rpcIssuer.respond(withJSON: [:])
       }
       _ = try? await rpcImplementation.call(with: request)
-      // Make sure completRequest updates.
-      usleep(10000)
 
       // Then
-      let completeRequest = try XCTUnwrap(rpcIssuer.completeRequest)
+      let completeRequest = await rpcIssuer.completeRequest.value
       XCTAssertNil(completeRequest.value(forHTTPHeaderField: "X-Firebase-Client"))
     }
   #endif // COCOAPODS || SWIFT_PACKAGE

--- a/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthBackendRPCImplentationTests.swift
@@ -594,7 +594,6 @@ class AuthBackendRPCImplementationTests: RPCBaseTests {
       // Then
       let expectedHeader = HeartbeatLoggingTestUtils.nonEmptyHeartbeatsPayload.headerValue()
       let completeRequest = await rpcIssuer.completeRequest.value
-
       let headerValue = completeRequest.value(forHTTPHeaderField: "X-Firebase-Client")
       XCTAssertEqual(headerValue, expectedHeader)
     }

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -52,7 +52,7 @@ class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
   /** @property completeRequest
       @brief The last request to be processed by the backend.
    */
-  var completeRequest: URLRequest?
+  var completeRequest: Task<URLRequest, Never>!
 
   /** @var _handler
       @brief A block we must invoke when @c respondWithError or @c respondWithJSON are called.
@@ -148,12 +148,12 @@ class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
       requestData = body
       // Use the real implementation so that the complete request can
       // be verified during testing.
-      Task {
-        self.completeRequest = await AuthBackend.request(withURL: requestURL!,
-                                                         contentType: contentType,
-                                                         requestConfiguration: request
-                                                           .requestConfiguration())
+      completeRequest = Task {
+        await AuthBackend.request(withURL: requestURL!,
+                                  contentType: contentType,
+                                  requestConfiguration: request.requestConfiguration())
       }
+
       decodedRequest = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
     }
     if let respondBlock {

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -153,7 +153,6 @@ class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
                                   contentType: contentType,
                                   requestConfiguration: request.requestConfiguration())
       }
-
       decodedRequest = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
     }
     if let respondBlock {


### PR DESCRIPTION
This pattern should hopefully reduce testing flakes such as this: https://github.com/firebase/firebase-ios-sdk/actions/runs/10770066986/job/29862664996

Comments throughout to document approach.

#no-changelog