### PR TITLE
[Auth] Revoke SiwA token when unlinking Apple provider

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/Utility/Extensions.swift
@@ -77,7 +77,7 @@ public extension UIViewController {
     }
   }
 
-  func displayError(_ error: (any Error)?, from function: StaticString = #function) {
+  @MainActor func displayError(_ error: (any Error)?, from function: StaticString = #function) {
     guard let error = error else { return }
     print("ⓧ Error in \(function): \(error.localizedDescription)")
     let message = "\(error.localizedDescription)\n\n Occurred in \(function)"


### PR DESCRIPTION
Manually tested and confirmed the following:
- link account with SiwA successful
- unlink account with SiwA will also revoke SiwA token and remove the app from your Apple ID dashboard (new for this PR)

#no-changelog