### PR TITLE
[Infra] Address Sendable warnings in RC's URLSessionPartialMock.swift

### DIFF
--- a/FirebaseRemoteConfig/Tests/Swift/FakeUtils/URLSessionPartialMock.swift
+++ b/FirebaseRemoteConfig/Tests/Swift/FakeUtils/URLSessionPartialMock.swift
@@ -19,7 +19,7 @@ import Foundation
 #endif
 
 // Create a partial mock by subclassing the URLSessionDataTask.
-class URLSessionDataTaskMock: URLSessionDataTask {
+class URLSessionDataTaskMock: URLSessionDataTask, @unchecked Sendable {
   private let closure: () -> Void
 
   init(closure: @escaping () -> Void) {
@@ -31,7 +31,7 @@ class URLSessionDataTaskMock: URLSessionDataTask {
   }
 }
 
-class URLSessionMock: URLSession {
+class URLSessionMock: URLSession, @unchecked Sendable {
   typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
 
   private let fakeConsole: FakeConsole


### PR DESCRIPTION
<img width="856" alt="Screenshot 2024-09-12 at 5 39 15 PM" src="https://github.com/user-attachments/assets/86494d37-3812-4bc9-8630-f23e1f7a2e62">

#no-changelog