### PR TITLE
[Infra] Fix warning in Auth's 'SwiftAPI.swift' tests

### DIFF
--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -353,7 +353,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
         }
       }
       let obj = FederatedAuthImplementation()
-      try await _ = obj.credential(with: nil)
+      _ = try await obj.credential(with: nil)
     }
 
     func FIRFederatedAuthProvider_h() {


### PR DESCRIPTION
<img width="714" alt="Screenshot 2024-09-13 at 11 40 20 AM" src="https://github.com/user-attachments/assets/1f217452-d5d4-43f3-bf9c-a8f4d353f7c5">


#no-changelog