### PR TITLE
[Infra] Fix warning in Auth's AuthWebViewController.swift

### DIFF
--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
@@ -96,17 +96,14 @@
 
     // MARK: - WKNavigationDelegate
 
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction) async
+      -> WKNavigationActionPolicy {
       let canHandleURL = delegate?.webViewController(
         self,
         canHandle: navigationAction.request.url ?? url
       ) ?? false
-      if canHandleURL {
-        decisionHandler(.allow)
-      } else {
-        decisionHandler(.cancel)
-      }
+      return canHandleURL ? .allow : .cancel
     }
 
     func webView(_ webView: WKWebView,


### PR DESCRIPTION
Manually tested via macCatalyst (see below comment as to why) and confirmed that delegate gets triggered in both a macCatalyst app built with Xcode 15 and an app built with Xcode 16.

Fix #13507

This appears to avoif the `#if`s needed in this [workaround](https://github.com/swiftlang/swift/issues/74904#issuecomment-2289909804). 

#no-changelog
