### PR TITLE
[Vertex AI] Silence `SafetyRating: Comparable` warning in tests

### DIFF
--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -1375,7 +1375,7 @@ class AppCheckInteropFake: NSObject, AppCheckInterop {
 struct AppCheckErrorFake: Error {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension SafetyRating: Comparable {
+extension SafetyRating: Swift.Comparable {
   public static func < (lhs: FirebaseVertexAI.SafetyRating,
                         rhs: FirebaseVertexAI.SafetyRating) -> Bool {
     return lhs.category.rawValue < rhs.category.rawValue


### PR DESCRIPTION
Silenced the followed warning on on `extension SafetyRating: Comparable`:
> Extension declares a conformance of imported type 'SafetyRating' to imported protocol 'Comparable'; this will not behave correctly if the owners of 'FirebaseVertexAI' introduce this conformance in the future

`SafetyRating` does not have a natural ordering because its property `let category: SafetySetting.HarmCategory` does not (e.g., `dangerousContent` can't be compared as being greater than or equal to `harassment`): https://github.com/firebase/firebase-ios-sdk/blob/9e537325bf36a7c053154b685134a8bf99542c11/FirebaseVertexAI/Sources/Safety.swift#L84-L102

For this reason, it is reasonable to assume that we will not add `Comparable` conformance to `SafetyRating` in the SDK and the warning can be ignored with `Swift.Comparable` in the unit-test.

Note: `Swift.Comparable` is equivalent to `@retroactive Comparable` but is supported prior to Swift 6 (see [SE-0364](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility) for more details).

#no-changelog