### PR TITLE
[Core] Add ability to load version from product SDK

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -821,7 +821,7 @@ static FIRApp *sDefaultApp;
     @"FIRFunctions" : @"fire-fun",
     @"FIRStorage" : @"fire-str",
     @"FIRVertexAIComponent" : @"fire-vertex",
-    @"FIRFooComponent" : @"fire-foo",
+    @"FIRDataConnectComponent" : @"fire-dc",
   };
   for (NSString *className in swiftLibraries.allKeys) {
     Class klass = NSClassFromString(className);

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -821,11 +821,24 @@ static FIRApp *sDefaultApp;
     @"FIRFunctions" : @"fire-fun",
     @"FIRStorage" : @"fire-str",
     @"FIRVertexAIComponent" : @"fire-vertex",
+    @"FIRFooComponent" : @"fire-foo",
   };
   for (NSString *className in swiftLibraries.allKeys) {
     Class klass = NSClassFromString(className);
     if (klass) {
-      [FIRApp registerLibrary:swiftLibraries[className] withVersion:FIRFirebaseVersion()];
+      NSString *version = FIRFirebaseVersion();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+      SEL sdkVersionSelector = @selector(sdkVersion);
+#pragma clang diagnostic pop
+      if ([klass respondsToSelector:sdkVersionSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        NSString *sdkVersion = (NSString *)[klass performSelector:sdkVersionSelector];
+        if (sdkVersion) version = sdkVersion;
+#pragma clang diagnostic pop
+      }
+      [FIRApp registerLibrary:swiftLibraries[className] withVersion:version];
     }
   }
 }


### PR DESCRIPTION
This PR adds support for SDKs outside of the firebase-ios-sdk repo to register with core. Like how the Swift SDKs inside of the firebase-ios-sdk repo are registered, it relies on hardcoding information about the SDK in core.

To support SDKs that may have a version different from core, they have the option of implementing the `func sdkVersion() -> String` method.

For example, the below code belongs to the `Foo` package that lives outside of the firebease-ios-sdk repo. If the below code is included in the Foo SDK, and the client depends on both Foo and the firebase-ios-sdk packages, Foo will register itself with core.

```swift
// Foo.swift
// Inside of the `Foo` package

@objc(FIRFooComponent) class FirebaseFooComponent: NSObject {
  @objc static func sdkVersion() -> String {
    return "12.0.0" 
  }
}
```
