### PR TITLE
[Auth] Query with `kSecAttrSynchronizable` when auth sharing enabled

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [Fixed] Restore Firebase 10 behavior by querying with the
+  `kSecAttrSynchronizable` key when auth state is set to be shared across
+  devices. (#13584)
+
 # 11.2.0
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16
   betas. (#13480)

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -161,6 +161,10 @@ class AuthStoredUserManager {
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 
+    if (shareAuthStateAcrossDevices) {
+      query[kSecAttrSynchronizable as String] = true
+    }
+
     return query
   }
 }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -161,7 +161,7 @@ class AuthStoredUserManager {
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 
-    if (shareAuthStateAcrossDevices) {
+    if shareAuthStateAcrossDevices {
       query[kSecAttrSynchronizable as String] = true
     }
 


### PR DESCRIPTION
Address https://github.com/firebase/firebase-ios-sdk/pull/11109/files#r1759803212

I wasn't able to mirror exact behavior when repro'ing #13584, but I think this should address it.