### PR TITLE
[Auth] Handle corrupt keychain value resulting from incomplete v11 port

### DIFF
--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -162,7 +162,7 @@ class AuthStoredUserManager {
     // iCloud entry was written), then all future non-iCloud writes would fail
     // due to the mismatching `kSecAttrAccessible` flag and throw an
     // unrecoverable error. To address this the below error handling is used to
-    // detect such cases,remove the "corrupt" iCloud entry stored by the buggy
+    // detect such cases, remove the "corrupt" iCloud entry stored by the buggy
     // version in the non-iCloud bucket, and retry writing the current
     // non-iCloud entry again.
     do {

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -170,7 +170,8 @@ class AuthStoredUserManager {
     } catch let error as NSError {
       guard shareAuthStateAcrossDevices == false,
             error.localizedFailureReason == "SecItemAdd (-25299)" else {
-        // The error is not related to the 11.0 - 11.2, and should be rethrown.
+        // The error is not related to the 11.0 - 11.2 issue described above,
+        // and should be rethrown.
         throw error
       }
       // We are trying to write a non-iCloud entry but a corrupt iCloud entry

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -119,14 +119,81 @@ class AuthStoredUserManager {
     archiver.encode(user, forKey: Self.storedUserCoderKey)
     archiver.finishEncoding()
 
+    // In Firebase 10, the below query contained the `kSecAttrSynchronizable`
+    // key set to `true` when `shareAuthStateAcrossDevices == true`. This
+    // allows a user entry to be shared across devices via the iCloud keychain.
+    // For the purpose of this discussion, such a user entry will be referred
+    // to as a "iCloud entry". Conversely, a "non-iCloud entry" will refer to a
+    // user entry stored when `shareAuthStateAcrossDevices == false`. Keep in
+    // mind that this class exclusively manages user entries stored in
+    // device-specific keychain access groups, so both iCloud and non-iCloud
+    // entries are implicitly available at the device level to apps that
+    // have access rights to the specific keychain access group used.
+    //
+    // The iCloud/non-iCloud distinction is important because entries stored
+    // with `kSecAttrSynchronizable == true` can only be retrieved when the
+    // search query includes `kSecAttrSynchronizable == true`. Likewise,
+    // entries stored without the `kSecAttrSynchronizable` key (or
+    // `kSecAttrSynchronizable == false`) can only be retrieved when
+    // the search query omits `kSecAttrSynchronizable` or sets it to `false`.
+    //
+    // So for each access group, the SDK manages up to two buckets in the
+    // keychain, one for iCloud entries and one for non-iCloud entries.
+    //
+    // From Firebase 11.0.0 up to but not including 11.3.0, the
+    // `kSecAttrSynchronizable` key was *not* included in the query when
+    // `shareAuthStateAcrossDevices == true`. This had the effect of the iCloud
+    // bucket being inaccessible, and iCloud and non-iCloud entries attempting
+    // to be written to the same bucket. This was problematic because the
+    // two types of entries use another flag, the `kSecAttrAccessible` flag,
+    // with different values. If two queries are identical apart from different
+    // values for their `kSecAttrAccessible` key, whichever query written to
+    // the keychain first won't be accessible for reading or updating via the
+    // other query (resulting in a OSStatus of -25300 indicating the queried
+    // item cannot be found). And worse, attempting to write the other query to
+    // the keychain won't work because the write will conflict with the
+    // previously written query (resulting in a OSStatus of -25299 indicating a
+    // duplicate item already exists in the keychain). This formed the basis
+    // for the issues this bug caused.
+    //
+    // The missing key was added back in 11.3, but adding back the key
+    // introduced a new issue. If the buggy version succeeded at writing an
+    // iCloud entry to the non-iCloud bucket (e.g. keychain was empty before
+    // iCloud entry was written), then all future non-iCloud writes would fail
+    // due to the mismatching `kSecAttrAccessible` flag and throw an
+    // unrecoverable error. To address this the below error handling is used to
+    // detect such cases,remove the "corrupt" iCloud entry stored by the buggy
+    // version in the non-iCloud bucket, and retry writing the current
+    // non-iCloud entry again.
     do {
       try keychainServices.setItem(archiver.encodedData, withQuery: query)
     } catch let error as NSError {
-      // 11.0.0 ≤ version < 11.3.0
-      guard !shareAuthStateAcrossDevices,
+      guard shareAuthStateAcrossDevices == false,
             error.localizedFailureReason == "SecItemAdd (-25299)" else {
+        // The error is not related to the 11.0 - 11.2, and should be rethrown.
         throw error
       }
+      // We are trying to write a non-iCloud entry but a corrupt iCloud entry
+      // is likely preventing it from happening.
+      //
+      // The corrupt query was supposed to contain the following keys:
+      //   {
+      //     kSecAttrSynchronizable: true,
+      //     kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+      //   }
+      // Instead, it contained:
+      //   {
+      //     kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+      //   }
+      //
+      // Excluding `kSecAttrSynchronizable` treats the query as if it's false
+      // and the entry won't be shared in iCloud across devices. It is instead
+      // written to the non-iCloud bucket. This query is corrupting the
+      // non-iCloud bucket because its `kSecAttrAccessible` value is not
+      // compatible with the value used for non-iCloud entries. To delete it,
+      // a compatible query is formed by swapping the accessibility flag
+      // out for `kSecAttrAccessibleAfterFirstUnlock`. This frees up the bucket
+      // so the non-iCloud entry can attempt to be written again.
       let corruptQuery = query
         .merging([kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock]) { $1 }
       try keychainServices.removeItem(query: corruptQuery)


### PR DESCRIPTION
This should be covered in the changelog for entry for the previous PR that added back the missing key.

Addressing the second case described in https://github.com/firebase/firebase-ios-sdk/issues/13584#issuecomment-2352608025:
> There is another case I'm still investigating where a user (again with auth configured with a keychain access group and shareAuthStateAcrossDevices == true) is stored on 11.0, 11.1, or 11.2 and missing that key. In this case, such entries will not be read properly when 11.3 adds back the missing key (basically, the same problem you reported but from the upgrade path 11.0/ 11.1/11.2 -> 11.3 (fixed) rather than from 10.x -> 11.0/ 11.1/11.2). I'll leave this issue open until I have a fix for this case also staged in 11.3.


This was tricky enough where I thought it better for the explanation to be embedded next to the code for future us. See diff.

### Alternatives considered
- Rather than wrap error handling around the setter, change the code inside the setter. I chose against this as we would have to inspect the query within the setter whereas we have the context we need in the outer scope where we call it. I wanted to keep the setter's implementation unaware of the custom logic needed to solve this bug.

### Risks
- The added error handling will delete the iCloud entry from the buggy versions that is corrupting the non-iCloud bucket. Since the corrupt iCloud entry isn't really be synced across devices, it needs to be removed because it's blocking non-iCloud entries from being written. To avoid having to delete this, it would result in trickier keychain migration code that may things more complicated and prone to error.

### Test observations

Current behavior on buggy versions:
- In the buggy version, when can an iCloud entry be written?
     - Can it be written when there is already a non-iCloud entry there? 
          - No, it cannot because of the conflicting accessibility flag.
     - Can it be written when there is iCloud entry there?
          - Yes, if from buggy version.
          -  Maybe, if not from buggy version, because it will depend on if a non-iCloud entry is there (then no) or if the bucket is empty (then yes).
     - Can it be written when there is no entry there?
          - Yes.

Fix https://github.com/firebase/firebase-ios-sdk/issues/13584