### PR TITLE
Skip copyright check for data-connect ProtoGen files

### DIFF
--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -24,6 +24,7 @@ options=(
 list=$(git grep "${options[@]}" -- \
     '*.'{c,cc,cmake,h,js,m,mm,py,rb,sh,swift} \
     CMakeLists.txt '**/CMakeLists.txt' \
+    ':(exclude)**/Sources/ProtoGen' \
     ':(exclude)third_party/**' \
     ':(exclude)**/third_party/**')
 


### PR DESCRIPTION
Since they have a gRPC Authors copyright