### PR TITLE
[Infra] Upgrade to `clang-format@19`

### DIFF
--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
@@ -111,8 +111,8 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
     _userDefaults = userDefaults ? userDefaults : [GULUserDefaults standardUserDefaults];
     // it would be 0 if it does not exist, which is equvilent to saying that
     // you can send now
-    _nextValidSendTimeInMills = (int64_t)
-        [_userDefaults doubleForKey:FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills];
+    _nextValidSendTimeInMills = (int64_t)[_userDefaults
+        doubleForKey:FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills];
 
     NSArray<FIRIAMClearcutLogRecord *> *availableLogs =
         [logStorage popStillValidRecordsForUpTo:strategy.batchSendSize];

--- a/Firestore/core/src/immutable/keys_view.h
+++ b/Firestore/core/src/immutable/keys_view.h
@@ -47,8 +47,8 @@ auto KeysView(const Range& range) -> KeysRange<decltype(std::begin(range))> {
 }
 
 template <typename Range, typename K>
-auto KeysViewFrom(const Range& range,
-                  const K& key) -> KeysRange<decltype(range.lower_bound(key))> {
+auto KeysViewFrom(const Range& range, const K& key)
+    -> KeysRange<decltype(range.lower_bound(key))> {
   auto keys_begin = util::make_iterator_first(range.lower_bound(key));
   auto keys_end = util::make_iterator_first(std::end(range));
   return util::make_range(keys_begin, keys_end);

--- a/Firestore/core/src/util/filesystem_posix.cc
+++ b/Firestore/core/src/util/filesystem_posix.cc
@@ -132,7 +132,7 @@ Path Filesystem::TempDir() {
 
 #if !__APPLE__
 Status Filesystem::IsDirectory(const Path& path) {
-  struct stat buffer {};
+  struct stat buffer{};
   if (::stat(path.c_str(), &buffer)) {
     if (errno == ENOENT) {
       // Expected common error case.
@@ -168,7 +168,7 @@ Status Filesystem::IsDirectory(const Path& path) {
 }
 
 StatusOr<int64_t> Filesystem::FileSize(const Path& path) {
-  struct stat st {};
+  struct stat st{};
   if (::stat(path.c_str(), &st) == 0) {
     return st.st_size;
   } else {

--- a/Firestore/core/src/util/hashing.h
+++ b/Firestore/core/src/util/hashing.h
@@ -190,8 +190,8 @@ auto RankedInvokeHash(const Range& range, HashChoice<3>)
  * value can itself be hashed.
  */
 template <typename K>
-auto RankedInvokeHash(const absl::optional<K>& option,
-                      HashChoice<4>) -> decltype(InvokeHash(*option)) {
+auto RankedInvokeHash(const absl::optional<K>& option, HashChoice<4>)
+    -> decltype(InvokeHash(*option)) {
   return option ? InvokeHash(*option) : -1171;
 }
 
@@ -202,8 +202,8 @@ size_t RankedInvokeHash(K value, HashChoice<5>) {
 }
 
 template <typename K>
-auto RankedInvokeHash(const std::unique_ptr<K>& ptr,
-                      HashChoice<6>) -> decltype(InvokeHash(*ptr)) {
+auto RankedInvokeHash(const std::unique_ptr<K>& ptr, HashChoice<6>)
+    -> decltype(InvokeHash(*ptr)) {
   return ptr ? InvokeHash(*ptr) : 23631;
 }
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@18
+brew install clang-format@19
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -56,7 +56,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  18)
+  19)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"


### PR DESCRIPTION
Upgrade `clang-format` to v19 since v18 is no longer available on Homebrew.

#no-changelog