### PR TITLE
[Auth] Use native Swift types in Auth backend types

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [Fixed] Restore Firebase 10 behavior by querying with the
   `kSecAttrSynchronizable` key when auth state is set to be shared across
   devices. (#13584)
+- [Fixed] Prevent a bad memory access crash by using non-ObjC, native Swift
+  types in the SDK's networking layer, and moving synchronous work off of
+  the shared Swift concurrency queue. (#13650)
 
 # 11.2.0
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -22,7 +22,7 @@ import Foundation
 #endif
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-protocol AuthBackendRPCIssuer: NSObjectProtocol {
+protocol AuthBackendRPCIssuer {
   /// Asynchronously send a HTTP request.
   /// - Parameter request: The request to be made.
   /// - Parameter body: Request body.
@@ -35,10 +35,10 @@ protocol AuthBackendRPCIssuer: NSObjectProtocol {
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthBackendRPCIssuerImplementation: NSObject, AuthBackendRPCIssuer {
+class AuthBackendRPCIssuerImplementation: AuthBackendRPCIssuer {
   let fetcherService: GTMSessionFetcherService
 
-  override init() {
+  init() {
     fetcherService = GTMSessionFetcherService()
     fetcherService.userAgent = AuthBackend.authUserAgent()
     fetcherService.callbackQueue = kAuthGlobalWorkQueue
@@ -71,7 +71,7 @@ class AuthBackendRPCIssuerImplementation: NSObject, AuthBackendRPCIssuer {
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthBackend: NSObject {
+class AuthBackend {
   static func authUserAgent() -> String {
     return "FirebaseAuth.iOS/\(FirebaseVersion()) \(GTMFetcherStandardUserAgentString(nil))"
   }
@@ -143,11 +143,8 @@ protocol AuthBackendImplementation {
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-private class AuthBackendRPCImplementation: NSObject, AuthBackendImplementation {
-  var rpcIssuer: AuthBackendRPCIssuer
-  override init() {
-    rpcIssuer = AuthBackendRPCIssuerImplementation()
-  }
+private class AuthBackendRPCImplementation: AuthBackendImplementation {
+  var rpcIssuer: AuthBackendRPCIssuer = AuthBackendRPCIssuerImplementation()
 
   /// Calls the RPC using HTTP request.
   /// Possible error responses:

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -23,7 +23,7 @@ import XCTest
         response, and glue logic.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class FakeBackendRPCIssuer: NSObject, AuthBackendRPCIssuer {
+class FakeBackendRPCIssuer: AuthBackendRPCIssuer {
   /** @property requestURL
       @brief The URL which was requested.
    */


### PR DESCRIPTION
Follow-up to #13647 to further attempt to fix #13650.

The crash reports from #13650 show [`swift_unknownObjectRetain`](https://github.com/swiftlang/swift/blob/4e32b60e9e29eaf75f7facbc514a280d5e637a05/stdlib/public/runtime/SwiftObject.mm#L596-L602) as the last frame in the terminating thread.

Using a symbolic breakpoint, I verified that `swift_unknownObjectRetain` gets called to get the `rpcIssuer` used below:
https://github.com/firebase/firebase-ios-sdk/blob/b5e2c182c83db543829f2a712f5cff7e6ad1ce1e/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift#L274-L275

Stepping through the assembly from `swift_unknownObjectRetain`, the `objc_retain` is returned from its [source](https://github.com/swiftlang/swift/blob/4e32b60e9e29eaf75f7facbc514a280d5e637a05/stdlib/public/runtime/SwiftObject.mm#L596-L602).

When I removed the `NSObject` conformances and debugged again, `swift_unknownObjectRetain` is no longer called. I thought this was pretty interesting and will guarantee that should #13650 reappear, the report will at least look different as the object in question will have its memory managed differently as a native Swift type.