### PR TITLE
Expose FirebaseCore via SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -70,6 +70,10 @@ let package = Package(
       targets: ["FirebaseStorageCombineSwift"]
     ),
     .library(
+      name: "FirebaseCore",
+      targets: ["FirebaseCore"]
+    ),
+    .library(
       name: "FirebaseCrashlytics",
       targets: ["FirebaseCrashlytics"]
     ),


### PR DESCRIPTION
Expose FirebaseCore via SPM primarily for internal dependents like Data Connect, but also available for external clients - for direct `import` access for FirebaseApp APIs.