### PR TITLE
[Vertex AI] Remove pod from `FirebaseManifest`

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -53,6 +53,8 @@ public let shared = Manifest(
     Pod("FirebasePerformance", platforms: ["ios", "tvos"], zip: true),
     Pod("FirebaseStorage", zip: true),
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
+    // TODO(andrewheard): Re-add FirebaseVertexAI when ready for release as zip.
+    // Pod("FirebaseVertexAI", isBeta: true, allowWarnings: true, zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
   ]
 )

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -53,7 +53,6 @@ public let shared = Manifest(
     Pod("FirebasePerformance", platforms: ["ios", "tvos"], zip: true),
     Pod("FirebaseStorage", zip: true),
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
-    Pod("FirebaseVertexAI", isBeta: true, allowWarnings: true, zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
   ]
 )


### PR DESCRIPTION
Removed the `FirebaseVertexAI` pod from `FirebaseManifest`.

Context: Won't be included in the next zip release. Will re-add in the future.

#no-changelog