### PR TITLE
[Auth] Move applicable non-public types away from subclassing NSObject

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
@@ -19,7 +19,7 @@ import FirebaseCoreExtension
 
 /// Defines configurations to be added to a request to Firebase Auth's backend.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthRequestConfiguration: NSObject {
+class AuthRequestConfiguration {
   /// The Firebase Auth API key used in the request.
   let apiKey: String
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountResponse.swift
@@ -17,8 +17,8 @@ import Foundation
 /// Represents the response from the deleteAccount endpoint.
 ///
 /// See https://developers.google.com/identity/toolkit/web/reference/relyingparty/deleteAccount
-class DeleteAccountResponse: NSObject, AuthRPCResponse {
-  override required init() {}
+class DeleteAccountResponse: AuthRPCResponse {
+  required init() {}
 
   func setFields(dictionary: [String: AnyHashable]) throws {}
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInResponse.swift
@@ -15,8 +15,8 @@
 import Foundation
 
 /// Represents the response from the emailLinkSignin endpoint.
-class EmailLinkSignInResponse: NSObject, AuthRPCResponse, AuthMFAResponse {
-  override required init() {}
+class EmailLinkSignInResponse: AuthRPCResponse, AuthMFAResponse {
+  required init() {}
 
   /// The ID token in the email link sign-in response.
   private(set) var idToken: String?

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoResponse.swift
@@ -19,7 +19,7 @@ private let kErrorKey = "error"
 
 /// Represents the provider user info part of the response from the getAccountInfo endpoint.
 /// See https://developers.google.com/identity/toolkit/web/reference/relyingparty/getAccountInfo
-class GetAccountInfoResponseProviderUserInfo: NSObject {
+class GetAccountInfoResponseProviderUserInfo {
   /// The ID of the identity provider.
   let providerID: String?
 
@@ -57,7 +57,7 @@ class GetAccountInfoResponseProviderUserInfo: NSObject {
 
 /// Represents the firebase user info part of the response from the getAccountInfo endpoint.
 /// See https://developers.google.com/identity/toolkit/web/reference/relyingparty/getAccountInfo
-class GetAccountInfoResponseUser: NSObject {
+class GetAccountInfoResponseUser {
   /// The ID of the user.
   let localID: String?
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoResponse.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// Represents the provider user info part of the response from the setAccountInfo endpoint.
 /// See https: // developers.google.com/identity/toolkit/web/reference/relyingparty/setAccountInfo
-class SetAccountInfoResponseProviderUserInfo: NSObject {
+class SetAccountInfoResponseProviderUserInfo {
   /// The ID of the identity provider.
   var providerID: String?
 

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSToken.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSToken.swift
@@ -16,7 +16,7 @@
   import Foundation
 
   /// A data structure for an APNs token.
-  class AuthAPNSToken: NSObject {
+  class AuthAPNSToken {
     let data: Data
     let type: AuthAPNSTokenType
 

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAPNSTokenManager.swift
@@ -31,7 +31,7 @@
 
   /// A class to manage APNs token in memory.
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AuthAPNSTokenManager: NSObject {
+  class AuthAPNSTokenManager {
     /// The timeout for registering for remote notification.
     ///
     /// Only tests should access this property.

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
@@ -15,7 +15,8 @@
 import Foundation
 
 /// A class represents a credential that proves the identity of the app.
-@objc(FIRAuthAppCredential) class AuthAppCredential: NSObject, NSSecureCoding {
+@objc(FIRAuthAppCredential) // objc Needed for decoding old versions
+class AuthAppCredential: NSObject, NSSecureCoding {
   /// The server acknowledgement of receiving client's claim of identity.
   var receipt: String
 

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredentialManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredentialManager.swift
@@ -17,7 +17,7 @@
 
   /// A class to manage app credentials backed by iOS Keychain.
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AuthAppCredentialManager: NSObject {
+  class AuthAppCredentialManager {
     let kKeychainDataKey = "app_credentials"
     let kFullCredentialKey = "full_credential"
     let kPendingReceiptsKey = "pending_receipts"

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -18,7 +18,7 @@
 
   /// A class represents a credential that proves the identity of the app.
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AuthNotificationManager: NSObject {
+  class AuthNotificationManager {
     /// The key to locate payload data in the remote notification.
     private let kNotificationDataKey = "com.google.firebase.auth"
 

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthErrorUtils.swift
@@ -31,7 +31,7 @@ private let kFIRAuthErrorMessageMalformedJWT =
   "Failed to parse JWT. Check the userInfo dictionary for the full token."
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthErrorUtils: NSObject {
+class AuthErrorUtils {
   static let internalErrorDomain = "FIRAuthInternalErrorDomain"
   static let userInfoDeserializedResponseKey = "FIRAuthErrorUserInfoDeserializedResponseKey"
   static let userInfoDataKey = "FIRAuthErrorUserInfoDataKey"
@@ -563,5 +563,3 @@ class AuthErrorUtils: NSObject {
     return error(code: .recaptchaActionCreationFailed, message: message)
   }
 }
-
-protocol MultiFactorResolverWrapper: NSObjectProtocol {}

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebUtils.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthWebUtils: NSObject {
+class AuthWebUtils {
   static func randomString(withLength length: Int) -> String {
     var randomString = ""
     for _ in 0 ..< length {


### PR DESCRIPTION
Reviewing checklist:

Changed type should not have...
- open access
- public access
- NSSecureCoding availability

#no-changelog