### PR TITLE
[Infra] Require firestore status check only if firestore code changes

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -436,7 +436,6 @@ jobs:
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request')
     strategy:
-      max-parallel: 1
       matrix:
         target: [iOS, tvOS, macOS]
         os: [macos-13, macos-14]

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -559,6 +559,13 @@ jobs:
         if: needs.cmake.result == 'failure' || needs.cmake-prod-db.result == 'failure' || needs.xcodebuild.result == 'failure' || needs.spm.result == 'failure'
         run: exit 1
 
+  check-required-tests-2:
+    runs-on: ubuntu-latest
+    name: Check 222
+    steps:
+      - name: Check test matrix
+        run: echo needs.changes.outputs.changed
+
 
   # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept
   # Firebase UI 12

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -321,7 +321,7 @@ jobs:
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
-      (github.event_name == 'pull_request' && )
+      (github.event_name == 'pull_request')
     runs-on: macos-14
     needs: check
 

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -321,7 +321,7 @@ jobs:
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
-      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
+      (github.event_name == 'pull_request' && )
     runs-on: macos-14
     needs: check
 
@@ -342,17 +342,18 @@ jobs:
 
     - name: Build and test
       run: |
+        echo {{ needs.changes.outputs.changed }}
         export EXPERIMENTAL_MODE=true
         scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ matrix.target }} xcodebuild
 
 
   pod-lib-lint:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
-      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
+      (github.event_name == 'pull_request')
     runs-on: macos-13
-    needs: check
     strategy:
       matrix:
         podspec: [
@@ -430,10 +431,11 @@ jobs:
             --no-analyze
 
   spm-source:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
-      (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
+      (github.event_name == 'pull_request')
     strategy:
       max-parallel: 1
       matrix:
@@ -448,7 +450,6 @@ jobs:
             xcode: Xcode_15.3
             target: visionOS
     runs-on: ${{ matrix.os }}
-    needs: check
     env:
       FIREBASE_SOURCE_FIRESTORE: 1
     steps:
@@ -464,12 +465,12 @@ jobs:
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore ${{ matrix.target }} spmbuildonly
 
   spm-binary:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-14
-    needs: check
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -552,22 +553,12 @@ jobs:
   # to be used as a required check for merging.
   check-required-tests:
     runs-on: ubuntu-latest
-    if: needs.changes.outputs.changed == 'true'
     name: Check all required Firestore tests results
     needs: [cmake, cmake-prod-db, xcodebuild, spm-source, spm-binary]
     steps:
       - name: Check test matrix
-        if: needs.cmake.result == 'failure' || needs.cmake-prod-db.result == 'failure' || needs.xcodebuild.result == 'failure' || needs.spm.result == 'failure'
+        if: needs.*.result == 'failure'
         run: exit 1
-
-  check-required-tests-2:
-    runs-on: ubuntu-latest
-    needs: changes
-    name: Check 222
-    steps:
-      - name: Check test matrix
-        run: echo ${{ needs.changes.outputs.changed }}; echo ${{ needs.changes.outputs.changed }} == 'true'
-
 
   # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept
   # Firebase UI 12

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -551,7 +551,7 @@ jobs:
   # to be used as a required check for merging.
   check-required-tests:
     runs-on: ubuntu-latest
-    if: always()
+    if: needs.changes.outputs.changed == 'true'
     name: Check all required Firestore tests results
     needs: [cmake, cmake-prod-db, xcodebuild, spm-source, spm-binary]
     steps:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -435,6 +435,7 @@ jobs:
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     strategy:
+      max-parallel: 1
       matrix:
         target: [iOS, tvOS, macOS]
         os: [macos-13, macos-14]

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -342,7 +342,7 @@ jobs:
 
     - name: Build and test
       run: |
-        echo {{ needs.changes.outputs.changed }}
+        echo ${{ needs.changes.outputs.changed }}
         export EXPERIMENTAL_MODE=true
         scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ matrix.target }} xcodebuild
 

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -342,7 +342,6 @@ jobs:
 
     - name: Build and test
       run: |
-        echo ${{ needs.changes.outputs.changed }}
         export EXPERIMENTAL_MODE=true
         scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ matrix.target }} xcodebuild
 

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -143,11 +143,11 @@ jobs:
 
 
   cmake-prod-db:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
-    needs: check
 
     strategy:
       matrix:
@@ -230,11 +230,11 @@ jobs:
 
 
   sanitizers-mac:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
-    needs: check
 
     strategy:
       matrix:
@@ -272,11 +272,11 @@ jobs:
 
 
   sanitizers-ubuntu:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
-    needs: check
 
     strategy:
       matrix:
@@ -318,12 +318,12 @@ jobs:
 
 
   xcodebuild:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request')
     runs-on: macos-14
-    needs: check
 
     strategy:
       matrix:
@@ -379,8 +379,8 @@ jobs:
 
   # `pod lib lint` takes a long time so only run the other platforms and static frameworks build in the cron.
   pod-lib-lint-cron:
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: check
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     strategy:
       matrix:
         podspec: [
@@ -481,12 +481,12 @@ jobs:
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore iOS spmbuildonly
 
   check-firestore-internal-public-headers:
+    needs: check
     # Either a scheduled run from public repo, or a pull request with firestore changes.
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
     runs-on: macos-14
-    needs: check
     steps:
     - uses: actions/checkout@v4
     - name: Assert that Firestore and FirestoreInternal have identically named headers.

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -565,7 +565,7 @@ jobs:
     name: Check 222
     steps:
       - name: Check test matrix
-        run: echo needs.changes.outputs.changed
+        run: echo ${{ needs.changes.outputs.changed }}
 
 
   # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -562,10 +562,11 @@ jobs:
 
   check-required-tests-2:
     runs-on: ubuntu-latest
+    needs: changes
     name: Check 222
     steps:
       - name: Check test matrix
-        run: echo ${{ needs.changes.outputs.changed }}
+        run: echo ${{ needs.changes.outputs.changed }}; echo ${{ needs.changes.outputs.changed }} == 'true'
 
 
   # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept


### PR DESCRIPTION
The Firestore status check should only be required on Firestore PRs.

Relevant docs: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks


AC (to be tested post-merge): 
- [ ] status check is skipped if changes != true
- [ ] jobs are skipped if changes != true

#no-changelog