### PR TITLE
[Vertex AI] Use `actions/cache` in workflow

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -33,7 +33,7 @@ jobs:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
       - name: Print cache key
-        run: echo "Cache Key:" "${{ steps.cache.outputs.cache-primary-key }}"
+        run: echo "Cache Key:" "${{ toJSON(steps.cache.outputs) }}"
 
   spm-unit:
     strategy:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -54,14 +54,15 @@ jobs:
     needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      CACHE_KEY: ${{needs.spm-package-resolved.outputs.cache_key}}
     steps:
     - uses: actions/checkout@v4
     - name: Print cache key
-      run: echo "Cache Key:" "${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}"
+      run: echo "Cache Key:" "${CACHE_KEY}"
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
+        key: $CACHE_KEY
     - name: Clone mock responses
       run: scripts/update_vertexai_responses.sh
     - name: Xcode
@@ -95,7 +96,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/vertexai-integration.plist.gpg \
         FirebaseVertexAI/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
@@ -153,7 +154,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Initialize xcodebuild

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -50,7 +50,6 @@ jobs:
     needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-      CACHE_KEY: ${{needs.spm-package-resolved.outputs.cache_key}}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache/restore@v4

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -43,12 +43,11 @@ jobs:
     needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
     steps:
     - uses: actions/cache@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
         restore-keys: |
           ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
@@ -80,13 +79,12 @@ jobs:
     env:
       TEST_RUNNER_VertexAIRunIntegrationTests: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
     - uses: actions/cache@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
         restore-keys: |
           ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
@@ -142,12 +140,11 @@ jobs:
     needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
     steps:
     - uses: actions/cache@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
         restore-keys: |
           ${{ runner.os }}-spm-
     - uses: actions/checkout@v4

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+      - name: Print cache key
+        run: echo "Cache Key:" "${{ steps.cache.outputs.cache-primary-key }}"
 
   spm-unit:
     strategy:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           path: .build
           key: ${{ steps.generate_cache_key.outputs.cache_key }}
-      - name: Print outputs
-        run: |
-          echo "generate_cache_key: " "${{ toJSON(steps.generate_cache_key.outputs) }}"
-          echo "cache: " "${{ toJSON(steps.cache.outputs) }}"
 
   spm-unit:
     strategy:
@@ -57,12 +53,10 @@ jobs:
       CACHE_KEY: ${{needs.spm-package-resolved.outputs.cache_key}}
     steps:
     - uses: actions/checkout@v4
-    - name: Print cache key
-      run: echo "Cache Key:" "${CACHE_KEY}"
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: $CACHE_KEY
+        key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Clone mock responses
       run: scripts/update_vertexai_responses.sh
     - name: Xcode
@@ -96,7 +90,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache_key}}
+        key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/vertexai-integration.plist.gpg \
         FirebaseVertexAI/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
@@ -154,7 +148,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache_key}}
+        key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Initialize xcodebuild

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -35,7 +35,6 @@ jobs:
 
   spm-unit:
     strategy:
-      max-parallel: 1
       matrix:
         target: [iOS, macOS, catalyst, tvOS, visionOS, watchOS]
         os: [macos-14]
@@ -47,11 +46,11 @@ jobs:
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/cache/restore@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
-    - uses: actions/checkout@v4
     - name: Clone mock responses
       run: scripts/update_vertexai_responses.sh
     - name: Xcode
@@ -68,7 +67,6 @@ jobs:
 
   spm-integration:
     strategy:
-      max-parallel: 1
       matrix:
         target: [iOS]
         os: [macos-14]
@@ -82,13 +80,11 @@ jobs:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
-    - uses: actions/cache@v4
+    - uses: actions/checkout@v4
+    - uses: actions/cache/restore@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-    - uses: actions/checkout@v4
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/vertexai-integration.plist.gpg \
         FirebaseVertexAI/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
@@ -142,13 +138,11 @@ jobs:
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
-    - uses: actions/cache@v4
+    - uses: actions/checkout@v4
+    - uses: actions/cache/restore@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
-        restore-keys: |
-          ${{ runner.os }}-spm-
-    - uses: actions/checkout@v4
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Initialize xcodebuild

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -150,8 +150,6 @@ jobs:
         key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Initialize xcodebuild
-      run: xcodebuild -list
     - name: Placeholder GoogleService-Info.plist for build testing
       run: cp FirebaseCore/Tests/Unit/Resources/GoogleService-Info.plist FirebaseVertexAI/Sample/
     - uses: nick-fields/retry@v3

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -27,7 +27,7 @@ jobs:
         id: swift_package_resolve
         run: |
           swift package resolve
-          package_resolved_sha256=($(sha256sum Package.resolved))
+          package_resolved_sha256=($(shasum -a 256 Package.resolved))
           echo "package_resolved_hash=$package_resolved_sha256" >> "$GITHUB_OUTPUT"
 
   spm-unit:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,7 +18,7 @@ jobs:
   spm-package-resolved:
     runs-on: macos-14
     outputs:
-      package_resolved_hash: ${{ steps.swift_package_resolve.outputs.package_resolved }}
+      package_resolved_hash: ${{ steps.cache.outputs.cache-primary-key }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
@@ -27,8 +27,11 @@ jobs:
         id: swift_package_resolve
         run: |
           swift package resolve
-          package_resolved_sha256=($(shasum -a 256 Package.resolved))
-          echo "package_resolved_hash=$package_resolved_sha256" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache/save@v4
+        id: cache
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
   spm-unit:
     strategy:
@@ -44,12 +47,10 @@ jobs:
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
-        restore-keys: |
-          ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
     - name: Clone mock responses
       run: scripts/update_vertexai_responses.sh

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -47,6 +47,8 @@ jobs:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Print cache key
+      run: echo "Cache Key:" "${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}"
     - uses: actions/cache/restore@v4
       with:
         path: .build

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -18,7 +18,7 @@ jobs:
   spm-package-resolved:
     runs-on: macos-14
     outputs:
-      package_resolved_hash: ${{ steps.cache.outputs.cache-primary-key }}
+      cache_key: ${{ steps.generate_cache_key.outputs.cache_key }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
@@ -27,13 +27,20 @@ jobs:
         id: swift_package_resolve
         run: |
           swift package resolve
+      - name: Generate cache key
+        id: generate_cache_key
+        run: |
+          cache_key="${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+          echo "cache_key=${cache_key}" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/save@v4
         id: cache
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-      - name: Print cache key
-        run: echo "Cache Key:" "${{ toJSON(steps.cache.outputs) }}"
+          key: ${{ steps.generate_cache_key.outputs.cache_key }}
+      - name: Print outputs
+        run: |
+          echo "generate_cache_key: " "${{ toJSON(steps.generate_cache_key.outputs) }}"
+          echo "cache: " "${{ toJSON(steps.cache.outputs) }}"
 
   spm-unit:
     strategy:

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     steps:
+      - uses: actions/checkout@v4
       - name: Generate Swift Package.resolved
         id: swift_package_resolve
         run: |

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -15,6 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  spm-package-resolved:
+    runs-on: macos-14
+    outputs:
+      package_resolved_hash: ${{ steps.swift_package_resolve.outputs.package_resolved }}
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    steps:
+      - name: Generate Swift Package.resolved
+        id: swift_package_resolve
+        run: |
+          swift package resolve
+          package_resolved_sha256=($(sha256sum Package.resolved))
+          echo "package_resolved_hash=$package_resolved_sha256" >> "$GITHUB_OUTPUT"
+
   spm-unit:
     strategy:
       max-parallel: 1
@@ -25,9 +39,17 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
+    needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
     steps:
+    - uses: actions/cache@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        restore-keys: |
+          ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
     - name: Clone mock responses
       run: scripts/update_vertexai_responses.sh
@@ -53,11 +75,19 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
+    needs: spm-package-resolved
     env:
       TEST_RUNNER_VertexAIRunIntegrationTests: 1
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
+    - uses: actions/cache@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        restore-keys: |
+          ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/vertexai-integration.plist.gpg \
@@ -108,9 +138,17 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
+    needs: spm-package-resolved
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      PACKAGE_RESOLVED_HASH: ${{needs.spm-package-resolved.outputs.package_resolved_hash}}
     steps:
+    - uses: actions/cache@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${PACKAGE_RESOLVED_HASH}
+        restore-keys: |
+          ${{ runner.os }}-spm-
     - uses: actions/checkout@v4
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer


### PR DESCRIPTION
This resolves a failure that occurs when multiple jobs resolve Package.swift in parallel or in quick successful (the binary downloads fail). This PR uses `actions/cache/save` and `actions/cache/restore` to cache the `swift package resolve` steps where binary artifacts are downloaded. This also re-enables running the matrix platforms for `spm-unit` in parallel.

#no-changelog