### PR TITLE
[Vertex AI] Remove `unspecified` enum cases from response types

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -4,6 +4,9 @@
   removed. (#13686)
 - [changed] **Breaking Change**: The `BlockThreshold` enum in `SafetySetting`
   has been renamed to `HarmBlockThreshold`. (#13696)
+- [changed] **Breaking Change**: The `unspecified` case has been removed from
+  the `FinishReason`, `PromptFeedback` and `HarmProbability` enums; this
+  scenario is now handled by the existing `unknown` case. (#13699)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -36,7 +36,6 @@ extension SafetyRating.HarmProbability: CustomStringConvertible {
     case .medium: "Medium"
     case .negligible: "Negligible"
     case .unknown: "Unknown"
-    case .unspecified: "Unspecified"
     }
   }
 }

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -138,9 +138,8 @@ public struct Citation: Sendable {
 /// A value enumerating possible reasons for a model to terminate a content generation request.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum FinishReason: String, Sendable {
+  /// The finish reason is unknown.
   case unknown = "FINISH_REASON_UNKNOWN"
-
-  case unspecified = "FINISH_REASON_UNSPECIFIED"
 
   /// Natural stop point of the model or provided stop sequence.
   case stop = "STOP"
@@ -167,9 +166,6 @@ public struct PromptFeedback: Sendable {
   public enum BlockReason: String, Sendable {
     /// The block reason is unknown.
     case unknown = "UNKNOWN"
-
-    /// The block reason was not specified in the server response.
-    case unspecified = "BLOCK_REASON_UNSPECIFIED"
 
     /// The prompt was blocked because it was deemed unsafe.
     case safety = "SAFETY"

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -44,9 +44,6 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
     /// Unknown. A new server value that isn't recognized by the SDK.
     case unknown = "UNKNOWN"
 
-    /// The probability was not specified in the server response.
-    case unspecified = "HARM_PROBABILITY_UNSPECIFIED"
-
     /// The probability is zero or close to zero. For benign content, the probability across all
     /// categories will be this value.
     case negligible = "NEGLIGIBLE"


### PR DESCRIPTION
Removed the `unspecified` enum cases from `FinishReason`, `PromptFeedback` and `HarmProbability`. These should never be returned from the backend but, if ever, would be handled by the `unknown` case.