### PR TITLE
[Vertex AI] Rename `Part` enum case `data` to `inlineData`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -5,8 +5,8 @@
 - [changed] **Breaking Change**: The `BlockThreshold` enum in `SafetySetting`
   has been renamed to `HarmBlockThreshold`. (#13696)
 - [changed] **Breaking Change**: The `unspecified` case has been removed from
-  the `FinishReason`, `PromptFeedback` and `HarmProbability` enums; this
-  scenario is now handled by the existing `unknown` case. (#13699)
+  the `FinishReason`, `BlockReason` and `HarmProbability` enums; this scenario
+  is now handled by the existing `unknown` case. (#13699)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -7,6 +7,8 @@
 - [changed] **Breaking Change**: The `unspecified` case has been removed from
   the `FinishReason`, `BlockReason` and `HarmProbability` enums; this scenario
   is now handled by the existing `unknown` case. (#13699)
+- [changed] **Breaking Change**: The `data` case in the `Part` enum has been
+  renamed to `inlineData`; no functionality changes. (#13700)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -165,7 +165,7 @@ class FunctionCallingViewModel: ObservableObject {
       case let .functionCall(functionCall):
         messages.insert(functionCall.chatMessage(), at: messages.count - 1)
         functionCalls.append(functionCall)
-      case .data, .fileData, .functionResponse:
+      case .inlineData, .fileData, .functionResponse:
         fatalError("Unsupported response content.")
       }
     }

--- a/FirebaseVertexAI/Sources/Chat.swift
+++ b/FirebaseVertexAI/Sources/Chat.swift
@@ -155,7 +155,7 @@ public actor Chat {
         case let .text(str):
           combinedText += str
 
-        case .data, .fileData, .functionCall, .functionResponse:
+        case .inlineData, .fileData, .functionCall, .functionResponse:
           // Don't combine it, just add to the content. If there's any text pending, add that as
           // a part.
           if !combinedText.isEmpty {

--- a/FirebaseVertexAI/Sources/ModelContent.swift
+++ b/FirebaseVertexAI/Sources/ModelContent.swift
@@ -26,7 +26,7 @@ public struct ModelContent: Equatable, Sendable {
     case text(String)
 
     /// Data with a specified media type. Not all media types may be supported by the AI model.
-    case data(mimetype: String, Data)
+    case inlineData(mimetype: String, Data)
 
     /// File data stored in Cloud Storage for Firebase, referenced by URI.
     ///
@@ -53,12 +53,12 @@ public struct ModelContent: Equatable, Sendable {
 
     /// Convenience function for populating a Part with JPEG data.
     public static func jpeg(_ data: Data) -> Self {
-      return .data(mimetype: "image/jpeg", data)
+      return .inlineData(mimetype: "image/jpeg", data)
     }
 
     /// Convenience function for populating a Part with PNG data.
     public static func png(_ data: Data) -> Self {
-      return .data(mimetype: "image/png", data)
+      return .inlineData(mimetype: "image/png", data)
     }
 
     /// Returns the text contents of this ``Part``, if it contains text.
@@ -144,7 +144,7 @@ extension ModelContent.Part: Codable {
     switch self {
     case let .text(a0):
       try container.encode(a0, forKey: .text)
-    case let .data(mimetype, bytes):
+    case let .inlineData(mimetype, bytes):
       var inlineDataContainer = container.nestedContainer(
         keyedBy: InlineDataKeys.self,
         forKey: .inlineData
@@ -176,7 +176,7 @@ extension ModelContent.Part: Codable {
       )
       let mimetype = try dataContainer.decode(String.self, forKey: .mimeType)
       let bytes = try dataContainer.decode(Data.self, forKey: .bytes)
-      self = .data(mimetype: mimetype, bytes)
+      self = .inlineData(mimetype: mimetype, bytes)
     } else if values.contains(.functionCall) {
       self = try .functionCall(values.decode(FunctionCall.self, forKey: .functionCall))
     } else if values.contains(.functionResponse) {

--- a/FirebaseVertexAI/Sources/PartsRepresentable+Image.swift
+++ b/FirebaseVertexAI/Sources/PartsRepresentable+Image.swift
@@ -57,7 +57,7 @@ public enum ImageConversionError: Error {
       guard let data = jpegData(compressionQuality: imageCompressionQuality) else {
         throw ImageConversionError.couldNotConvertToJPEG(.uiImage(self))
       }
-      return [ModelContent.Part.data(mimetype: "image/jpeg", data)]
+      return [ModelContent.Part.inlineData(mimetype: "image/jpeg", data)]
     }
   }
 
@@ -74,7 +74,7 @@ public enum ImageConversionError: Error {
       else {
         throw ImageConversionError.couldNotConvertToJPEG(.nsImage(self))
       }
-      return [ModelContent.Part.data(mimetype: "image/jpeg", data)]
+      return [ModelContent.Part.inlineData(mimetype: "image/jpeg", data)]
     }
   }
 #endif
@@ -95,7 +95,7 @@ public enum ImageConversionError: Error {
         kCGImageDestinationLossyCompressionQuality: imageCompressionQuality,
       ] as CFDictionary)
       if CGImageDestinationFinalize(imageDestination) {
-        return [.data(mimetype: "image/jpeg", output as Data)]
+        return [.inlineData(mimetype: "image/jpeg", output as Data)]
       }
       throw ImageConversionError.couldNotConvertToJPEG(.cgImage(self))
     }
@@ -116,7 +116,7 @@ public enum ImageConversionError: Error {
           context.jpegRepresentation(of: self, colorSpace: $0, options: [:])
         }
       if let jpegData = jpegData {
-        return [.data(mimetype: "image/jpeg", jpegData)]
+        return [.inlineData(mimetype: "image/jpeg", jpegData)]
       }
       throw ImageConversionError.couldNotConvertToJPEG(.ciImage(self))
     }

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -1188,7 +1188,7 @@ final class GenerativeModelTests: XCTestCase {
       withExtension: "json"
     )
 
-    let response = try await model.countTokens(ModelContent.Part.data(
+    let response = try await model.countTokens(ModelContent.Part.inlineData(
       mimetype: "image/jpeg",
       Data()
     ))

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -123,7 +123,7 @@ final class VertexAIAPITests: XCTestCase {
     // convert value of type 'String' to expected element type
     // 'Array<ModelContent.Part>.ArrayLiteralElement'. Not sure if there's a way we can get it to
     // work.
-    let _ = try ModelContent(parts: [str, ModelContent.Part.data(
+    let _ = try ModelContent(parts: [str, ModelContent.Part.inlineData(
       mimetype: "foo",
       Data()
     )] as [any ThrowingPartsRepresentable])


### PR DESCRIPTION
Renamed the `Part` enum case from `data` to `inlineData` to align with the other SDKs.