### PR TITLE
[Vertex AI] Rename `citationSources` to `citations`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -7,6 +7,8 @@
 - [changed] **Breaking Change**: The `unspecified` case has been removed from
   the `FinishReason`, `PromptFeedback` and `HarmProbability` enums; this
   scenario is now handled by the existing `unknown` case. (#13699)
+- [changed] **Breaking Change**: The property `citationSources` of
+  `CitationMetadata` has been renamed to `citations`. (#13702)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -113,7 +113,7 @@ public struct CandidateResponse: Sendable {
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct CitationMetadata: Sendable {
   /// A list of individual cited sources and the parts of the content to which they apply.
-  public let citationSources: [Citation]
+  public let citations: [Citation]
 }
 
 /// A struct describing a source attribution.

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -290,11 +290,7 @@ extension CandidateResponse: Decodable {
 }
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension CitationMetadata: Decodable {
-  enum CodingKeys: String, CodingKey {
-    case citationSources = "citations"
-  }
-}
+extension CitationMetadata: Decodable {}
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension Citation: Decodable {

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -113,20 +113,20 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(candidate.content.parts.count, 1)
     XCTAssertEqual(response.text, "Some information cited from an external source")
     let citationMetadata = try XCTUnwrap(candidate.citationMetadata)
-    XCTAssertEqual(citationMetadata.citationSources.count, 3)
-    let citationSource1 = try XCTUnwrap(citationMetadata.citationSources[0])
+    XCTAssertEqual(citationMetadata.citations.count, 3)
+    let citationSource1 = try XCTUnwrap(citationMetadata.citations[0])
     XCTAssertEqual(citationSource1.uri, "https://www.example.com/some-citation-1")
     XCTAssertEqual(citationSource1.startIndex, 0)
     XCTAssertEqual(citationSource1.endIndex, 128)
     XCTAssertNil(citationSource1.title)
     XCTAssertNil(citationSource1.license)
-    let citationSource2 = try XCTUnwrap(citationMetadata.citationSources[1])
+    let citationSource2 = try XCTUnwrap(citationMetadata.citations[1])
     XCTAssertEqual(citationSource2.title, "some-citation-2")
     XCTAssertEqual(citationSource2.startIndex, 130)
     XCTAssertEqual(citationSource2.endIndex, 265)
     XCTAssertNil(citationSource2.uri)
     XCTAssertNil(citationSource2.license)
-    let citationSource3 = try XCTUnwrap(citationMetadata.citationSources[2])
+    let citationSource3 = try XCTUnwrap(citationMetadata.citations[2])
     XCTAssertEqual(citationSource3.uri, "https://www.example.com/some-citation-3")
     XCTAssertEqual(citationSource3.startIndex, 272)
     XCTAssertEqual(citationSource3.endIndex, 431)
@@ -947,7 +947,7 @@ final class GenerativeModelTests: XCTestCase {
       responses.append(content)
       XCTAssertNotNil(content.text)
       let candidate = try XCTUnwrap(content.candidates.first)
-      if let sources = candidate.citationMetadata?.citationSources {
+      if let sources = candidate.citationMetadata?.citations {
         citations.append(contentsOf: sources)
       }
     }


### PR DESCRIPTION
Renamed `CitationMetadata.citationSources` to `CitationMetadata.citations` to match other platforms.