### PR TITLE
Revert "Make GenerativeModel and Chat into Swift actors (#13545)"

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,5 +1,9 @@
-# Unreleased
+# 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)
+- [changed] **Breaking Change**: Reverted refactor of `GenerativeModel` and
+  `Chat` as Swift actors (#13545) introduced in 11.2; The methods
+  `generateContentStream`, `startChat` and `sendMessageStream`) no longer need
+  to be called with `await`.
 
 # 11.2.0
 - [fixed] Resolved a decoding error for citations without a `uri` and added

--- a/FirebaseVertexAI/Sample/ChatSample/Screens/ConversationScreen.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Screens/ConversationScreen.swift
@@ -104,9 +104,7 @@ struct ConversationScreen: View {
   }
 
   private func newChat() {
-    Task {
-      await viewModel.startNewChat()
-    }
+    viewModel.startNewChat()
   }
 }
 

--- a/FirebaseVertexAI/Sample/FunctionCallingSample/Screens/FunctionCallingScreen.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/Screens/FunctionCallingScreen.swift
@@ -106,9 +106,7 @@ struct FunctionCallingScreen: View {
   }
 
   private func newChat() {
-    Task {
-      await viewModel.startNewChat()
-    }
+    viewModel.startNewChat()
   }
 }
 

--- a/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -84,7 +84,7 @@ class PhotoReasoningViewModel: ObservableObject {
         }
       }
 
-      let outputContentStream = try await model.generateContentStream(prompt, images)
+      let outputContentStream = try model.generateContentStream(prompt, images)
 
       // stream response
       for try await outputContent in outputContentStream {

--- a/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/FirebaseVertexAI/Sample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -50,7 +50,7 @@ class SummarizeViewModel: ObservableObject {
 
       let prompt = "Summarize the following text for me: \(inputText)"
 
-      let outputContentStream = try await model.generateContentStream(prompt)
+      let outputContentStream = try model.generateContentStream(prompt)
 
       // stream response
       for try await outputContent in outputContentStream {

--- a/FirebaseVertexAI/Sources/Chat.swift
+++ b/FirebaseVertexAI/Sources/Chat.swift
@@ -17,7 +17,7 @@ import Foundation
 /// An object that represents a back-and-forth chat with a model, capturing the history and saving
 /// the context in memory between each message sent.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public actor Chat {
+public class Chat {
   private let model: GenerativeModel
 
   /// Initializes a new chat representing a 1:1 conversation between model and user.
@@ -116,7 +116,7 @@ public actor Chat {
 
         // Send the history alongside the new message as context.
         let request = history + newContent
-        let stream = try await model.generateContentStream(request)
+        let stream = try model.generateContentStream(request)
         do {
           for try await chunk in stream {
             // Capture any content that's streaming. This should be populated if there's no error.

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -69,20 +69,19 @@ final class ChatTests: XCTestCase {
     )
     let chat = Chat(model: model, history: [])
     let input = "Test input"
-    let stream = try await chat.sendMessageStream(input)
+    let stream = try chat.sendMessageStream(input)
 
     // Ensure the values are parsed correctly
     for try await value in stream {
       XCTAssertNotNil(value.text)
     }
 
-    let history = await chat.history
-    XCTAssertEqual(history.count, 2)
-    XCTAssertEqual(history[0].parts[0].text, input)
+    XCTAssertEqual(chat.history.count, 2)
+    XCTAssertEqual(chat.history[0].parts[0].text, input)
 
     let finalText = "1 2 3 4 5 6 7 8"
     let assembledExpectation = ModelContent(role: "model", parts: finalText)
-    XCTAssertEqual(history[0].parts[0].text, input)
-    XCTAssertEqual(history[1], assembledExpectation)
+    XCTAssertEqual(chat.history[0].parts[0].text, input)
+    XCTAssertEqual(chat.history[1], assembledExpectation)
   }
 }

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -760,7 +760,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     do {
-      let stream = try await model.generateContentStream("Hi")
+      let stream = try model.generateContentStream("Hi")
       for try await _ in stream {
         XCTFail("No content is there, this shouldn't happen.")
       }
@@ -784,7 +784,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     do {
-      let stream = try await model.generateContentStream(testPrompt)
+      let stream = try model.generateContentStream(testPrompt)
       for try await _ in stream {
         XCTFail("No content is there, this shouldn't happen.")
       }
@@ -807,7 +807,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     do {
-      let stream = try await model.generateContentStream("Hi")
+      let stream = try model.generateContentStream("Hi")
       for try await _ in stream {
         XCTFail("No content is there, this shouldn't happen.")
       }
@@ -827,7 +827,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     do {
-      let stream = try await model.generateContentStream("Hi")
+      let stream = try model.generateContentStream("Hi")
       for try await _ in stream {
         XCTFail("Content shouldn't be shown, this shouldn't happen.")
       }
@@ -847,7 +847,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     do {
-      let stream = try await model.generateContentStream("Hi")
+      let stream = try model.generateContentStream("Hi")
       for try await _ in stream {
         XCTFail("Content shouldn't be shown, this shouldn't happen.")
       }
@@ -866,7 +866,7 @@ final class GenerativeModelTests: XCTestCase {
         withExtension: "txt"
       )
 
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     do {
       for try await content in stream {
         XCTAssertNotNil(content.text)
@@ -887,7 +887,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     var responses = 0
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     for try await content in stream {
       XCTAssertNotNil(content.text)
       responses += 1
@@ -904,7 +904,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     var responses = 0
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     for try await content in stream {
       XCTAssertNotNil(content.text)
       responses += 1
@@ -921,7 +921,7 @@ final class GenerativeModelTests: XCTestCase {
       )
 
     var hadUnknown = false
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     for try await content in stream {
       XCTAssertNotNil(content.text)
       if let ratings = content.candidates.first?.safetyRatings,
@@ -940,7 +940,7 @@ final class GenerativeModelTests: XCTestCase {
         withExtension: "txt"
       )
 
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     var citations = [Citation]()
     var responses = [GenerateContentResponse]()
     for try await content in stream {
@@ -996,7 +996,7 @@ final class GenerativeModelTests: XCTestCase {
         appCheckToken: appCheckToken
       )
 
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     for try await _ in stream {}
   }
 
@@ -1018,7 +1018,7 @@ final class GenerativeModelTests: XCTestCase {
         appCheckToken: AppCheckInteropFake.placeholderTokenValue
       )
 
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     for try await _ in stream {}
   }
 
@@ -1030,7 +1030,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     var responses = [GenerateContentResponse]()
 
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     for try await response in stream {
       responses.append(response)
     }
@@ -1056,7 +1056,7 @@ final class GenerativeModelTests: XCTestCase {
 
     var responseCount = 0
     do {
-      let stream = try await model.generateContentStream("Hi")
+      let stream = try model.generateContentStream("Hi")
       for try await content in stream {
         XCTAssertNotNil(content.text)
         responseCount += 1
@@ -1076,7 +1076,7 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContentStream_nonHTTPResponse() async throws {
     MockURLProtocol.requestHandler = try nonHTTPRequestHandler()
 
-    let stream = try await model.generateContentStream("Hi")
+    let stream = try model.generateContentStream("Hi")
     do {
       for try await content in stream {
         XCTFail("Unexpected content in stream: \(content)")
@@ -1096,7 +1096,7 @@ final class GenerativeModelTests: XCTestCase {
         withExtension: "txt"
       )
 
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     do {
       for try await content in stream {
         XCTFail("Unexpected content in stream: \(content)")
@@ -1120,7 +1120,7 @@ final class GenerativeModelTests: XCTestCase {
         withExtension: "txt"
       )
 
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     do {
       for try await content in stream {
         XCTFail("Unexpected content in stream: \(content)")
@@ -1159,7 +1159,7 @@ final class GenerativeModelTests: XCTestCase {
     )
 
     var responses = 0
-    let stream = try await model.generateContentStream(testPrompt)
+    let stream = try model.generateContentStream(testPrompt)
     for try await content in stream {
       XCTAssertNotNil(content.text)
       responses += 1

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -170,8 +170,8 @@ final class VertexAIAPITests: XCTestCase {
     #endif
 
     // Chat
-    _ = await genAI.startChat()
-    _ = await genAI.startChat(history: [ModelContent(parts: "abc")])
+    _ = genAI.startChat()
+    _ = genAI.startChat(history: [ModelContent(parts: "abc")])
   }
 
   // Public API tests for GenerateContentResponse.

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -107,20 +107,15 @@ class VertexComponentTests: XCTestCase {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let vertex = VertexAI.vertexAI(app: app, location: location)
     let modelName = "test-model-name"
-    let expectedModelResourceName = vertex.modelResourceName(modelName: modelName)
-    let expectedSystemInstruction = ModelContent(
-      role: "system",
-      parts: "test-system-instruction-prompt"
-    )
+    let modelResourceName = vertex.modelResourceName(modelName: modelName)
+    let systemInstruction = ModelContent(role: "system", parts: "test-system-instruction-prompt")
 
     let generativeModel = vertex.generativeModel(
       modelName: modelName,
-      systemInstruction: expectedSystemInstruction
+      systemInstruction: systemInstruction
     )
 
-    let modelResourceName = await generativeModel.modelResourceName
-    let systemInstruction = await generativeModel.systemInstruction
-    XCTAssertEqual(modelResourceName, expectedModelResourceName)
-    XCTAssertEqual(systemInstruction, expectedSystemInstruction)
+    XCTAssertEqual(generativeModel.modelResourceName, modelResourceName)
+    XCTAssertEqual(generativeModel.systemInstruction, systemInstruction)
   }
 }


### PR DESCRIPTION
Reverted the Vertex AI refactor of `GenerativeModel` and `Chat` as Swift actors. The methods `generateContentStream` and `startChat` in `GenerativeModel` and `sendMessageStream` in `Chat` no longer need to be called with `await`. These methods do, however, continue to throw (new behaviour introduced in 11.2).