### PR TITLE
RC: fix internal API nullability issue caught by analyzer

### DIFF
--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
@@ -53,7 +53,8 @@ typedef void (^RCNConfigFetchCompletion)(FIRRemoteConfigFetchStatus status,
 /// @param expirationDuration  Expiration duration, in seconds.
 /// @param completionHandler   Callback handler.
 - (void)fetchConfigWithExpirationDuration:(NSTimeInterval)expirationDuration
-                        completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler;
+                        completionHandler:
+                            (_Nullable FIRRemoteConfigFetchCompletion)completionHandler;
 
 /// Fetches config data immediately, keyed by namespace. Completion block will be called on the main
 /// queue.

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -131,7 +131,8 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
 #pragma mark - Fetch Config API
 
 - (void)fetchConfigWithExpirationDuration:(NSTimeInterval)expirationDuration
-                        completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
+                        completionHandler:
+                            (_Nullable FIRRemoteConfigFetchCompletion)completionHandler {
   // Note: We expect the googleAppID to always be available.
   BOOL hasDeviceContextChanged =
       FIRRemoteConfigHasDeviceContextChanged(_settings.deviceContext, _options.googleAppID);


### PR DESCRIPTION
#no-changelog

![Screenshot 2024-09-24 at 10 45 02 AM](https://github.com/user-attachments/assets/b2142211-4871-46d5-b437-a3f80897e151)

    - WARN  | [iOS] xcodebuild:  /Users/runner/work/firebase-ios-sdk/firebase-ios-sdk/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m:255:3: warning: Null passed to a callee that requires a non-null 2nd parameter [nullability.NullPassedToNonnull]