### PR TITLE
[Infra] Switch back to building Auth with `-warnings-as-errors`

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -48,13 +48,11 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'FirebaseAuth/README.md',
     'FirebaseAuth/CHANGELOG.md'
   ]
-  # TODO(#13704) Restore warnings-as-errors checking.
-  #    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI -warnings-as-errors' : ''}"
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     # The second path is to find FirebaseAuth-Swift.h from a pod gen project
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}" "${OBJECT_FILE_DIR_normal}/${NATIVE_ARCH_ACTUAL}"',
-    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI' : ''}"
+    'OTHER_SWIFT_FLAGS' => "$(inherited) #{ENV.key?('FIREBASE_CI') ? '-D FIREBASE_CI -warnings-as-errors' : ''}"
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -365,7 +365,7 @@ class AuthAPI_hOnlyTests: XCTestCase {
       @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
       func FIRFedederatedAuthProvider_hAsync() async throws {
         let obj = FederatedAuthImplementation()
-        try await _ = obj.credential(with: nil)
+        _ = try await obj.credential(with: nil)
       }
     }
   #endif


### PR DESCRIPTION
#13634 addressed the warning so we should be able to go back to building with `-warnings-as-errors`.

Fix #13704 

#no-changelog