### PR TITLE
[Auth] Match Firebase 10 implementation in WKNavigationDelegate conformance

### DIFF
--- a/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthWebViewController.swift
@@ -99,11 +99,11 @@
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction) async
       -> WKNavigationActionPolicy {
-      let canHandleURL = delegate?.webViewController(
+      _ = delegate?.webViewController(
         self,
         canHandle: navigationAction.request.url ?? url
-      ) ?? false
-      return canHandleURL ? .allow : .cancel
+      )
+      return .allow
     }
 
     func webView(_ webView: WKWebView,


### PR DESCRIPTION
While testing #13634, found one behavior regression that led to reCATPCHA not working on macCatalyst.

Steps to repro:
1. Build Auth sample for macCatalyst (requires some disabling of code to get build green, and enabling Catalyst support)
2. Phone number flow, add phone #, verify
3. A blank screen will be presented

With this PR, the reCAPTCHA flow will be presented instead of a blank screen.

In v10, `allow` was always returned:
https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/Utilities/FIRAuthWebViewController.m#L87