### PR TITLE
[Auth] nil out SafariViewController when presentation finishes

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [Fixed] Prevent a bad memory access crash by using non-ObjC, native Swift
   types in the SDK's networking layer, and moving synchronous work off of
   the shared Swift concurrency queue. (#13650)
+- [Fixed] Restore Firebase 10 behavior by forwarding errors from interrupted
+  reCAPTCHA or OIDC login flows. (#13645)
 
 # 11.2.0
 - [Fixed] Fixed crashes that could occur in Swift continuation blocks running in the Xcode 16

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthURLPresenter.swift
@@ -89,6 +89,7 @@
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
       kAuthGlobalWorkQueue.async {
         if controller == self.safariViewController {
+          self.safariViewController = nil
           // TODO: Ensure that the SFSafariViewController is actually removed from the screen
           // before invoking finishPresentation
           self.finishPresentation(withURL: nil,


### PR DESCRIPTION
I figured how to easily reproduce #13645:
1. Launch app on iOS simulator
2. Navigate to the phone number view controller and enter a phone #, tap **Send Verification Code**
3. The reCaptcha flow should start. Dismiss the presented controller by tapping **Done** in top left or swiping down
4. An error should be propagated to indicate the user cancelled action. On Firebase 10.29.0, the error will be caught and displayed. On 11.2.0, nothing happens. 

This PR fixes the issue and the error propagates.

Compared to v10 implementation, the v11 implementation was missing **line 130**.

https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m#L127-L137

Fix #13645 