### PR TITLE
[Vertex AI] Optional `CountTokensResponse.totalBillableCharacters`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -18,6 +18,9 @@
   accepts an array of *optional* parameters instead of a list of *required*
   parameters; if a parameter is not listed as optional it is assumed to be
   required. (#13616)
+- [changed] **Breaking Change**: `CountTokensResponse.totalBillableCharacters`
+  is now optional (`Int?`); it may be `null` in cases such as when a
+  `GenerateContentRequest` contains only images or other non-text content.
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [changed] **Breaking Change**: `CountTokensResponse.totalBillableCharacters`
   is now optional (`Int?`); it may be `null` in cases such as when a
   `GenerateContentRequest` contains only images or other non-text content.
+  (#13721)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -40,7 +40,7 @@ public struct CountTokensResponse {
   ///
   /// > Important: This does not include billable image, video or other non-text input. See
   /// [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
-  public let totalBillableCharacters: Int
+  public let totalBillableCharacters: Int?
 }
 
 // MARK: - Codable Conformances
@@ -53,18 +53,4 @@ extension CountTokensRequest: Encodable {
 }
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension CountTokensResponse: Decodable {
-  enum CodingKeys: CodingKey {
-    case totalTokens
-    case totalBillableCharacters
-  }
-
-  public init(from decoder: any Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    totalTokens = try container.decode(Int.self, forKey: .totalTokens)
-    totalBillableCharacters = try container.decodeIfPresent(
-      Int.self,
-      forKey: .totalBillableCharacters
-    ) ?? 0
-  }
-}
+extension CountTokensResponse: Decodable {}

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -1194,7 +1194,7 @@ final class GenerativeModelTests: XCTestCase {
     ))
 
     XCTAssertEqual(response.totalTokens, 258)
-    XCTAssertEqual(response.totalBillableCharacters, 0)
+    XCTAssertNil(response.totalBillableCharacters)
   }
 
   func testCountTokens_modelNotFound() async throws {


### PR DESCRIPTION
Made the `totalBillableCharacters` property of `CountTokensResponse` an optional value (`Int?`) since it's not always populated.