### PR TITLE
[Vertex AI] Set default request timeout to 180 seconds

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -23,8 +23,8 @@
   `GenerateContentRequest` contains only images or other non-text content.
   (#13721)
 - [changed] The default request timeout is now 180 seconds instead of the
-  platform-default value for a `URLRequest` (typically 60 seconds); this timeout
-  may still be customized in `RequestOptions`. (#13722)
+  platform-default value of 60 seconds for a `URLRequest`; this timeout may
+  still be customized in `RequestOptions`. (#13722)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -22,6 +22,9 @@
   is now optional (`Int?`); it may be `null` in cases such as when a
   `GenerateContentRequest` contains only images or other non-text content.
   (#13721)
+- [changed] The default request timeout is now 180 seconds instead of the
+  platform-default value for a `URLRequest`; this timeout may still be
+  customized in `RequestOptions`.
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -24,7 +24,7 @@
   (#13721)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value for a `URLRequest`; this timeout may still be
-  customized in `RequestOptions`.
+  customized in `RequestOptions`. (#13722)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -23,8 +23,8 @@
   `GenerateContentRequest` contains only images or other non-text content.
   (#13721)
 - [changed] The default request timeout is now 180 seconds instead of the
-  platform-default value for a `URLRequest`; this timeout may still be
-  customized in `RequestOptions`. (#13722)
+  platform-default value for a `URLRequest` (typically 60 seconds); this timeout
+  may still be customized in `RequestOptions`. (#13722)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -28,7 +28,7 @@ protocol GenerativeAIRequest: Encodable {
 public struct RequestOptions {
   /// The request’s timeout interval in seconds; if not specified uses the default value for a
   /// `URLRequest`.
-  let timeout: TimeInterval?
+  let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
   let apiVersion = "v2beta"
@@ -36,9 +36,8 @@ public struct RequestOptions {
   /// Initializes a request options object.
   ///
   /// - Parameters:
-  ///   - timeout The request’s timeout interval in seconds; if not specified uses the default value
-  ///   for a `URLRequest`.
-  public init(timeout: TimeInterval? = nil) {
+  ///   - timeout The request’s timeout interval in seconds; defaults to 180 seconds.
+  public init(timeout: TimeInterval = 180.0) {
     self.timeout = timeout
   }
 }

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -191,10 +191,7 @@ struct GenerativeAIService {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     urlRequest.httpBody = try encoder.encode(request)
-
-    if let timeoutInterval = request.options.timeout {
-      urlRequest.timeoutInterval = timeoutInterval
-    }
+    urlRequest.timeoutInterval = request.options.timeout
 
     return urlRequest
   }

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -1267,7 +1267,7 @@ final class GenerativeModelTests: XCTestCase {
   private func httpRequestHandler(forResource name: String,
                                   withExtension ext: String,
                                   statusCode: Int = 200,
-                                  timeout: TimeInterval = URLRequest.defaultTimeoutInterval(),
+                                  timeout: TimeInterval = RequestOptions().timeout,
                                   appCheckToken: String? = nil,
                                   authToken: String? = nil) throws -> ((URLRequest) throws -> (
     URLResponse,
@@ -1313,14 +1313,6 @@ private extension String {
   /// Returns the number of occurrences of `substring` in the `String`.
   func occurrenceCount(of substring: String) -> Int {
     return components(separatedBy: substring).count - 1
-  }
-}
-
-private extension URLRequest {
-  /// Returns the default `timeoutInterval` for a `URLRequest`.
-  static func defaultTimeoutInterval() -> TimeInterval {
-    let placeholderURL = URL(string: "https://example.com")!
-    return URLRequest(url: placeholderURL).timeoutInterval
   }
 }
 


### PR DESCRIPTION
Updated the default request timeout to 180 seconds in `RequestOptions`. Previously the platform-defined default for `URLRequest` (60 seconds at the time of writing) was used.