### PR TITLE
[Vertex AI] Switch to `firebasevertexai.googleapis.com` API

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 11.4.0
+- [changed] **Breaking Change**: The SDK is now Generally Available (GA); both
+  new and existing users must perform the
+  [Build with Gemini](https://console.firebase.google.com/project/_/genai/)
+  onboarding flow in the Firebase Console to use the updated API. (#13725)
 - [changed] **Breaking Change**: The `HarmCategory` enum is no longer nested
   inside the `SafetySetting` struct and the `unspecified` case has been
   removed. (#13686)

--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -17,8 +17,5 @@ import Foundation
 /// Constants associated with the Vertex AI for Firebase SDK.
 enum Constants {
   /// The Vertex AI backend endpoint URL.
-  ///
-  /// TODO(andrewheard): Update to "https://firebasevertexai.googleapis.com" after the Vertex AI in
-  /// Firebase API launch.
-  static let baseURL = "https://firebaseml.googleapis.com"
+  static let baseURL = "https://firebasevertexai.googleapis.com"
 }

--- a/FirebaseVertexAI/Sources/Errors.swift
+++ b/FirebaseVertexAI/Sources/Errors.swift
@@ -31,11 +31,6 @@ struct RPCError: Error {
     self.details = details
   }
 
-  // TODO(andrewheard): Remove this method after the Vertex AI in Firebase API launch.
-  func isFirebaseMLServiceDisabledError() -> Bool {
-    return details.contains { $0.isFirebaseMLServiceDisabledErrorDetails() }
-  }
-
   func isVertexAIInFirebaseServiceDisabledError() -> Bool {
     return details.contains { $0.isVertexAIInFirebaseServiceDisabledErrorDetails() }
   }
@@ -93,17 +88,6 @@ struct ErrorDetails {
 
   func isServiceDisabledError() -> Bool {
     return isErrorInfo() && reason == "SERVICE_DISABLED" && domain == "googleapis.com"
-  }
-
-  // TODO(andrewheard): Remove this method after the Vertex AI in Firebase API launch.
-  func isFirebaseMLServiceDisabledErrorDetails() -> Bool {
-    guard isServiceDisabledError() else {
-      return false
-    }
-    guard let metadata, metadata["service"] == "firebaseml.googleapis.com" else {
-      return false
-    }
-    return true
   }
 
   func isVertexAIInFirebaseServiceDisabledErrorDetails() -> Bool {

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -31,9 +31,7 @@ public struct RequestOptions {
   let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
-  ///
-  /// TODO(andrewheard): Update to "v1beta" after the Vertex AI in Firebase API launch.
-  let apiVersion = "v2beta"
+  let apiVersion = "v1beta"
 
   /// Initializes a request options object.
   ///

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -263,17 +263,6 @@ struct GenerativeAIService {
   // Log specific RPC errors that cannot be mitigated or handled by user code.
   // These errors do not produce specific GenerateContentError or CountTokensError cases.
   private func logRPCError(_ error: RPCError) {
-    // TODO(andrewheard): Remove this check after the Vertex AI in Firebase API launch.
-    if error.isFirebaseMLServiceDisabledError() {
-      VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
-      The Vertex AI in Firebase SDK requires the Firebase ML API (`firebaseml.googleapis.com`) to \
-      be enabled in your Firebase project. Enable this API by visiting the Firebase Console at
-      https://console.firebase.google.com/project/\(projectID)/genai/ and clicking "Get started". \
-      If you enabled this API recently, wait a few minutes for the action to propagate to our \
-      systems and then retry.
-      """)
-    }
-
     if error.isVertexAIInFirebaseServiceDisabledError() {
       VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
       The Vertex AI in Firebase SDK requires the Vertex AI in Firebase API \

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -457,30 +457,6 @@ final class GenerativeModelTests: XCTestCase {
     }
   }
 
-  // TODO(andrewheard): Remove this test case after the Vertex AI in Firebase API launch.
-  func testGenerateContent_failure_firebaseMLAPINotEnabled() async throws {
-    let expectedStatusCode = 403
-    MockURLProtocol
-      .requestHandler = try httpRequestHandler(
-        forResource: "unary-failure-firebaseml-api-not-enabled",
-        withExtension: "json",
-        statusCode: expectedStatusCode
-      )
-
-    do {
-      _ = try await model.generateContent(testPrompt)
-      XCTFail("Should throw GenerateContentError.internalError; no error thrown.")
-    } catch let GenerateContentError.internalError(error as RPCError) {
-      XCTAssertEqual(error.httpResponseCode, expectedStatusCode)
-      XCTAssertEqual(error.status, .permissionDenied)
-      XCTAssertTrue(error.message.starts(with: "Firebase ML API has not been used in project"))
-      XCTAssertTrue(error.isFirebaseMLServiceDisabledError())
-      return
-    } catch {
-      XCTFail("Should throw GenerateContentError.internalError(RPCError); error thrown: \(error)")
-    }
-  }
-
   func testGenerateContent_failure_firebaseVertexAIAPINotEnabled() async throws {
     let expectedStatusCode = 403
     MockURLProtocol
@@ -799,32 +775,6 @@ final class GenerativeModelTests: XCTestCase {
       XCTAssertEqual(error.httpResponseCode, 400)
       XCTAssertEqual(error.status, .invalidArgument)
       XCTAssertEqual(error.message, "API key not valid. Please pass a valid API key.")
-      return
-    }
-
-    XCTFail("Should have caught an error.")
-  }
-
-  // TODO(andrewheard): Remove this test case after the Vertex AI in Firebase API launch.
-  func testGenerateContentStream_failure_firebaseMLAPINotEnabled() async throws {
-    let expectedStatusCode = 403
-    MockURLProtocol
-      .requestHandler = try httpRequestHandler(
-        forResource: "unary-failure-firebaseml-api-not-enabled",
-        withExtension: "json",
-        statusCode: expectedStatusCode
-      )
-
-    do {
-      let stream = try model.generateContentStream(testPrompt)
-      for try await _ in stream {
-        XCTFail("No content is there, this shouldn't happen.")
-      }
-    } catch let GenerateContentError.internalError(error as RPCError) {
-      XCTAssertEqual(error.httpResponseCode, expectedStatusCode)
-      XCTAssertEqual(error.status, .permissionDenied)
-      XCTAssertTrue(error.message.starts(with: "Firebase ML API has not been used in project"))
-      XCTAssertTrue(error.isFirebaseMLServiceDisabledError())
       return
     }
 


### PR DESCRIPTION
Switch to the new `firebasevertexai.googleapis.com` API. Both new and existing users must perform the [Build with Gemini](https://console.firebase.google.com/project/_/genai/) onboarding flow in the Firebase Console to use the updated API.

Note: If https://console.developers.google.com/apis/api/firebasevertexai.googleapis.com/overview shows Not Found or Permission Denied then the new API is not yet live. Please check back after the Firebase 11.4.0 launch.