### PR TITLE
[Vertex AI] Use `struct` instead of `enum` for `HarmCategory`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -37,8 +37,8 @@
 - [changed] **Breaking Change**: All initializers for `ModelContent` now require
   the label `parts: `. (#13832)
 - [changed] **Breaking Change**: `HarmCategory` is now a struct instead of an
-  enum type and the `unknown` case has been removed; use the `isUnknown()`
-  to check if a `HarmCategory` value is unknown. (#13728)
+  enum type and the `unknown` case has been removed; in a `switch` statement,
+  use the `default:` case to cover unknown or unhandled categories. (#13728)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value of 60 seconds for a `URLRequest`; this timeout may
   still be customized in `RequestOptions`. (#13722)

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -36,6 +36,9 @@
   as input. (#13767)
 - [changed] **Breaking Change**: All initializers for `ModelContent` now require
   the label `parts: `. (#13832)
+- [changed] **Breaking Change**: `HarmCategory` is now a struct instead of an
+  enum type and the `unknown` case has been removed; use the `isUnknown()`
+  to check if a `HarmCategory` value is unknown. (#13728)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value of 60 seconds for a `URLRequest`; this timeout may
   still be customized in `RequestOptions`. (#13722)

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -25,11 +25,7 @@ extension HarmCategory: CustomStringConvertible {
     case .sexuallyExplicit: "Sexually explicit"
     case .civicIntegrity: "Civic integrity"
     default:
-      if isUnknown() {
-        "Unknown HarmCategory: \(rawValue)"
-      } else {
-        "Unhandled HarmCategory: \(rawValue)"
-      }
+      "Unknown HarmCategory: \(rawValue)"
     }
   }
 }

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -23,7 +23,13 @@ extension HarmCategory: CustomStringConvertible {
     case .harassment: "Harassment"
     case .hateSpeech: "Hate speech"
     case .sexuallyExplicit: "Sexually explicit"
-    case .unknown: "Unknown"
+    case .civicIntegrity: "Civic integrity"
+    default:
+      if isUnknown() {
+        "Unknown HarmCategory: \(rawValue)"
+      } else {
+        "Unhandled HarmCategory: \(rawValue)"
+      }
     }
   }
 }

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -126,7 +126,7 @@ public struct HarmCategory: Sendable, Equatable, Hashable {
     return self.init(rawValue: Kind.dangerousContent.rawValue)
   }
 
-  /// Content related to civic integrity.
+  /// Content that may be used to harm civic integrity.
   public static var civicIntegrity: HarmCategory {
     return self.init(rawValue: Kind.civicIntegrity.rawValue)
   }

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -108,39 +108,27 @@ public struct HarmCategory: Sendable, Equatable, Hashable {
 
   /// Harassment content.
   public static var harassment: HarmCategory {
-    return self.init(rawValue: Kind.harassment.rawValue)
+    return self.init(kind: .harassment)
   }
 
   /// Negative or harmful comments targeting identity and/or protected attributes.
   public static var hateSpeech: HarmCategory {
-    return self.init(rawValue: Kind.hateSpeech.rawValue)
+    return self.init(kind: .hateSpeech)
   }
 
   /// Contains references to sexual acts or other lewd content.
   public static var sexuallyExplicit: HarmCategory {
-    return self.init(rawValue: Kind.sexuallyExplicit.rawValue)
+    return self.init(kind: .sexuallyExplicit)
   }
 
   /// Promotes or enables access to harmful goods, services, or activities.
   public static var dangerousContent: HarmCategory {
-    return self.init(rawValue: Kind.dangerousContent.rawValue)
+    return self.init(kind: .dangerousContent)
   }
 
   /// Content that may be used to harm civic integrity.
   public static var civicIntegrity: HarmCategory {
-    return self.init(rawValue: Kind.civicIntegrity.rawValue)
-  }
-
-  /// Returns true if the HarmCategory's `rawValue` is unknown to the SDK.
-  ///
-  /// > Important: If an unknown value is encountered, check for updates to the SDK as support for
-  /// > the new value may have been added; see
-  /// > [Release Notes](https://firebase.google.com/support/release-notes/ios). Alternatively,
-  /// > search for the `rawValue` in the Firebase Apple SDK
-  /// > [Issue Tracker](https://github.com/firebase/firebase-ios-sdk/issues) and file a
-  /// > [Bug Report](https://github.com/firebase/firebase-ios-sdk/issues/new/choose) if none found.
-  public func isUnknown() -> Bool {
-    return Kind(rawValue: rawValue) == nil
+    return self.init(kind: .civicIntegrity)
   }
 
   /// Returns the raw string representation of the `HarmCategory` value.
@@ -149,7 +137,23 @@ public struct HarmCategory: Sendable, Equatable, Hashable {
   /// > [REST API](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/HarmCategory).
   public let rawValue: String
 
+  init(kind: Kind) {
+    rawValue = kind.rawValue
+  }
+
   init(rawValue: String) {
+    if Kind(rawValue: rawValue) == nil {
+      VertexLog.error(
+        code: .generateContentResponseUnrecognizedHarmCategory,
+        """
+        Unrecognized HarmCategory with value "\(rawValue)":
+        - Check for updates to the SDK as support for "\(rawValue)" may have been added; see \
+        release notes at https://firebase.google.com/support/release-notes/ios
+        - Search for "\(rawValue)" in the Firebase Apple SDK Issue Tracker at \
+        https://github.com/firebase/firebase-ios-sdk/issues and file a Bug Report if none found
+        """
+      )
+    }
     self.rawValue = rawValue
   }
 }
@@ -179,15 +183,8 @@ extension SafetyRating: Decodable {}
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension HarmCategory: Codable {
   public init(from decoder: Decoder) throws {
-    let value = try decoder.singleValueContainer().decode(String.self)
-    let decodedCategory = HarmCategory(rawValue: value)
-    if decodedCategory.isUnknown() {
-      VertexLog.error(
-        code: .generateContentResponseUnrecognizedHarmCategory,
-        "Unrecognized HarmCategory with value \"\(value)\"."
-      )
-    }
-    self = decodedCategory
+    let rawValue = try decoder.singleValueContainer().decode(String.self)
+    self = HarmCategory(rawValue: rawValue)
   }
 }
 

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -972,18 +972,22 @@ final class GenerativeModelTests: XCTestCase {
         forResource: "streaming-success-unknown-safety-enum",
         withExtension: "txt"
       )
+    let unknownSafetyRating = SafetyRating(
+      category: HarmCategory(rawValue: "HARM_CATEGORY_DANGEROUS_CONTENT_NEW_ENUM"),
+      probability: .unknown
+    )
 
-    var hadUnknown = false
+    var foundUnknownSafetyRating = false
     let stream = try model.generateContentStream("Hi")
     for try await content in stream {
       XCTAssertNotNil(content.text)
       if let ratings = content.candidates.first?.safetyRatings,
-         ratings.contains(where: { $0.category.isUnknown() }) {
-        hadUnknown = true
+         ratings.contains(where: { $0 == unknownSafetyRating }) {
+        foundUnknownSafetyRating = true
       }
     }
 
-    XCTAssertTrue(hadUnknown)
+    XCTAssertTrue(foundUnknownSafetyRating)
   }
 
   func testGenerateContentStream_successWithCitations() async throws {

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -163,7 +163,7 @@ final class GenerativeModelTests: XCTestCase {
     let expectedSafetyRatings = [
       SafetyRating(category: .harassment, probability: .medium),
       SafetyRating(category: .dangerousContent, probability: .unknown),
-      SafetyRating(category: .unknown, probability: .high),
+      SafetyRating(category: HarmCategory(rawValue: "FAKE_NEW_HARM_CATEGORY"), probability: .high),
     ]
     MockURLProtocol
       .requestHandler = try httpRequestHandler(
@@ -978,7 +978,7 @@ final class GenerativeModelTests: XCTestCase {
     for try await content in stream {
       XCTAssertNotNil(content.text)
       if let ratings = content.candidates.first?.safetyRatings,
-         ratings.contains(where: { $0.category == .unknown }) {
+         ratings.contains(where: { $0.category.isUnknown() }) {
         hadUnknown = true
       }
     }


### PR DESCRIPTION
Replaced the `HarmCategory` enum with a struct to prevent breaking changes when new values are added (since switch statements must be exhaustively checked in Swift). Added support for `HARM_CATEGORY_CIVIC_INTEGRITY`.

#no-changelog