### PR TITLE
[Vertex AI] Update log message when API is not enabled

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -266,21 +266,22 @@ struct GenerativeAIService {
     // TODO(andrewheard): Remove this check after the Vertex AI in Firebase API launch.
     if error.isFirebaseMLServiceDisabledError() {
       VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
-      The Vertex AI for Firebase SDK requires the Firebase ML API `firebaseml.googleapis.com` to \
-      be enabled for your project. Enable it by visiting the the Firebase Console at
-      https://console.firebase.google.com/project/\(projectID)/genai/vertex then retry. If you
-      enabled this API recently, wait a few minutes for the action to propagate to our systems and
-      retry.
+      The Vertex AI in Firebase SDK requires the Firebase ML API (`firebaseml.googleapis.com`) to \
+      be enabled in your Firebase project. Enable this API by visiting the Firebase Console at
+      https://console.firebase.google.com/project/\(projectID)/genai/ and clicking "Get started". \
+      If you enabled this API recently, wait a few minutes for the action to propagate to our \
+      systems and then retry.
       """)
     }
 
     if error.isVertexAIInFirebaseServiceDisabledError() {
       VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
-      The Vertex AI for Firebase SDK requires the Firebase Vertex AI API \
-      `firebasevertexai.googleapis.com` to be enabled for your project. Enable it by visiting the \
-      the Firebase Console at https://console.firebase.google.com/project/\(projectID)/genai/vertex
-      then retry. If you enabled this API recently, wait a few minutes for the action to propagate
-      to our systems and retry.
+      The Vertex AI in Firebase SDK requires the Vertex AI in Firebase API \
+      (`firebasevertexai.googleapis.com`) to be enabled in your Firebase project. Enable this API \
+      by visiting the Firebase Console at
+      https://console.firebase.google.com/project/\(projectID)/genai/ and clicking "Get started". \
+      If you enabled this API recently, wait a few minutes for the action to propagate to our \
+      systems and then retry.
       """)
     }
   }

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -265,23 +265,33 @@ struct GenerativeAIService {
   private func logRPCError(_ error: RPCError) {
     // TODO(andrewheard): Remove this check after the Vertex AI in Firebase API launch.
     if error.isFirebaseMLServiceDisabledError() {
-      VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
+      let message = """
       The Vertex AI for Firebase SDK requires the Firebase ML API `firebaseml.googleapis.com` to \
-      be enabled for your project. Get started in the Firebase Console \
-      (https://console.firebase.google.com/project/\(projectID)/genai/vertex) or verify that the \
-      API is enabled in the Google Cloud Console \
-      (https://console.developers.google.com/apis/api/firebaseml.googleapis.com/overview?project=\
-      \(projectID)).
-      """)
+      be enabled for your project. Enable it by visiting the the Firebase Console at
+      https://console.firebase.google.com/project/\(projectID)/genai/vertex then retry. If you
+      enabled this API recently, wait a few minutes for the action to propagate to our systems and
+      retry.
+      """
+      #if DEBUG
+        fatalError(message)
+      #else
+        VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, message)
+      #endif // DEBUG
     }
 
     if error.isVertexAIInFirebaseServiceDisabledError() {
-      VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
+      let message = """
       The Vertex AI for Firebase SDK requires the Firebase Vertex AI API \
-      `firebasevertexai.googleapis.com` to be enabled for your project. Get started by visiting \
-      the Firebase Console at: \
-      https://console.firebase.google.com/project/\(projectID)/genai/vertex
-      """)
+      `firebasevertexai.googleapis.com` to be enabled for your project. Enable it by visiting the \
+      the Firebase Console at https://console.firebase.google.com/project/\(projectID)/genai/vertex
+      then retry. If you enabled this API recently, wait a few minutes for the action to propagate
+      to our systems and retry.
+      """
+      #if DEBUG
+        fatalError(message)
+      #else
+        VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, message)
+      #endif // DEBUG
     }
   }
 

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -265,33 +265,23 @@ struct GenerativeAIService {
   private func logRPCError(_ error: RPCError) {
     // TODO(andrewheard): Remove this check after the Vertex AI in Firebase API launch.
     if error.isFirebaseMLServiceDisabledError() {
-      let message = """
+      VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
       The Vertex AI for Firebase SDK requires the Firebase ML API `firebaseml.googleapis.com` to \
       be enabled for your project. Enable it by visiting the the Firebase Console at
       https://console.firebase.google.com/project/\(projectID)/genai/vertex then retry. If you
       enabled this API recently, wait a few minutes for the action to propagate to our systems and
       retry.
-      """
-      #if DEBUG
-        fatalError(message)
-      #else
-        VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, message)
-      #endif // DEBUG
+      """)
     }
 
     if error.isVertexAIInFirebaseServiceDisabledError() {
-      let message = """
+      VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, """
       The Vertex AI for Firebase SDK requires the Firebase Vertex AI API \
       `firebasevertexai.googleapis.com` to be enabled for your project. Enable it by visiting the \
       the Firebase Console at https://console.firebase.google.com/project/\(projectID)/genai/vertex
       then retry. If you enabled this API recently, wait a few minutes for the action to propagate
       to our systems and retry.
-      """
-      #if DEBUG
-        fatalError(message)
-      #else
-        VertexLog.error(code: .vertexAIInFirebaseAPIDisabled, message)
-      #endif // DEBUG
+      """)
     }
   }
 


### PR DESCRIPTION
- Updated the the log message when `firebasevertexai.googleapis.com` is not enabled to direct developers _solely_ to the Firebase Console.
- ~~In `DEBUG` builds, this situation is now a `fatalError` instead of an error log. This will quickly alert developers to the problem during development.~~
  - ~~To avoid crashing released apps, the message remains an error log in release builds.~~
  - `fatalError` approach breaks unit tests, always log at the error level.

#no-changelog