### PR TITLE
Add compatibility for GTMSessionFetcher 4

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -62,7 +62,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'FirebaseCoreExtension', '~> 11.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
+  s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 5.0'
   s.ios.dependency 'RecaptchaInterop', '~> 100.0'
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -41,7 +41,7 @@ Cloud Functions for Firebase.
   s.dependency 'FirebaseAuthInterop', '~> 11.0'
   s.dependency 'FirebaseMessagingInterop', '~> 11.0'
   s.dependency 'FirebaseSharedSwift', '~> 11.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
+  s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 5.0'
 
   s.test_spec 'objc' do |objc_tests|
     objc_tests.platforms = {

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -41,7 +41,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.dependency 'FirebaseAuthInterop', '~> 11.0'
   s.dependency 'FirebaseCore', '~> 11.0'
   s.dependency 'FirebaseCoreExtension', '~> 11.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 3.4'
+  s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 5.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.0'
 
   s.test_spec 'ObjCIntegration' do |objc_tests|

--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/google/gtm-session-fetcher.git",
-      "3.4.1" ..< "4.0.0"
+      "3.4.1" ..< "5.0.0"
     ),
     .package(
       url: "https://github.com/firebase/nanopb.git",


### PR DESCRIPTION
Fix #13729 

This should be a functional no-op for Firebase since GTMSessionFetcher 4 only restricts iOS version support to a subset of Firebase's.