### PR TITLE
[Vertex AI] Remove `ImageConversionError` from public API

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -22,6 +22,9 @@
   is now optional (`Int?`); it may be `null` in cases such as when a
   `GenerateContentRequest` contains only images or other non-text content.
   (#13721)
+- [changed] **Breaking Change**: The `ImageConversionError` enum is no longer
+  public; image conversion errors are still reported as
+  `GenerateContentError.promptImageContentError`. (#13735)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value of 60 seconds for a `URLRequest`; this timeout may
   still be customized in `RequestOptions`. (#13722)

--- a/FirebaseVertexAI/Sources/GenerateContentError.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentError.swift
@@ -17,11 +17,11 @@ import Foundation
 /// Errors that occur when generating content from a model.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public enum GenerateContentError: Error {
-  /// An error occurred when constructing the prompt. Examine the related error for details.
-  case promptImageContentError(underlying: ImageConversionError)
-
   /// An internal error occurred. See the underlying error for more context.
   case internalError(underlying: Error)
+
+  /// An error occurred when constructing the prompt. Examine the related error for details.
+  case promptImageContentError(underlying: Error)
 
   /// A prompt was blocked. See the response's `promptFeedback.blockReason` for more information.
   case promptBlocked(response: GenerateContentResponse)

--- a/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartsRepresentableTests.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import CoreGraphics
-import FirebaseVertexAI
 import XCTest
 #if canImport(UIKit)
   import UIKit
@@ -23,6 +22,8 @@ import XCTest
 #if canImport(CoreImage)
   import CoreImage
 #endif // canImport(CoreImage)
+
+@testable import FirebaseVertexAI
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class PartsRepresentableTests: XCTestCase {
@@ -61,22 +62,13 @@ final class PartsRepresentableTests: XCTestCase {
       do {
         _ = try image.tryPartsValue()
         XCTFail("Expected model content from invalid image to error")
+      } catch let imageError as ImageConversionError {
+        guard case .couldNotConvertToJPEG = imageError else {
+          XCTFail("Expected JPEG conversion error, got \(imageError) instead.")
+          return
+        }
       } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
-        }
-        switch imageError {
-        case let .couldNotConvertToJPEG(source):
-          guard case let .ciImage(ciImage) = source else {
-            XCTFail("Unexpected image source: \(source)")
-            return
-          }
-          XCTAssertEqual(ciImage, image)
-        default:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Got unexpected error type: \(error)")
       }
     }
   #endif // canImport(CoreImage)
@@ -87,22 +79,13 @@ final class PartsRepresentableTests: XCTestCase {
       do {
         _ = try image.tryPartsValue()
         XCTFail("Expected model content from invalid image to error")
+      } catch let imageError as ImageConversionError {
+        guard case .couldNotConvertToJPEG = imageError else {
+          XCTFail("Expected JPEG conversion error, got \(imageError) instead.")
+          return
+        }
       } catch {
-        guard let imageError = (error as? ImageConversionError) else {
-          XCTFail("Got unexpected error type: \(error)")
-          return
-        }
-        switch imageError {
-        case let .couldNotConvertToJPEG(source):
-          guard case let .uiImage(uiImage) = source else {
-            XCTFail("Unexpected image source: \(source)")
-            return
-          }
-          XCTAssertEqual(uiImage, image)
-        default:
-          XCTFail("Expected image conversion error, got \(imageError) instead")
-          return
-        }
+        XCTFail("Got unexpected error type: \(error)")
       }
     }
 


### PR DESCRIPTION
Removed the `ImageConversionError` enum from the public API. Devs can continue to handle image conversion errors by looking for the `GenerateContentError.promptImageContentError` case.