### PR TITLE
[Vertex AI] Remove supported platforms `#warning`

### DIFF
--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -14,10 +14,6 @@
 
 import Foundation
 
-#if !os(macOS) && !os(iOS)
-  #warning("Only iOS, macOS, and Catalyst targets are currently fully supported.")
-#endif
-
 /// Constants associated with the Vertex AI for Firebase SDK.
 enum Constants {
   /// The Vertex AI backend endpoint URL.


### PR DESCRIPTION
Removed the warning that `"Only iOS, macOS, and Catalyst targets are currently fully supported."` This pattern diverges from the rest of the SDKs, which do not have a warning for community-supported platforms. Additionally, most devs will not see these warnings in Xcode due to `-suppress-warnings` being enabled by default in SPM dependencies ([context](https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810)).

Note: The supported platforms remain unchanged. See [Firebase library support by platform](https://firebase.google.com/docs/ios/learn-more#firebase_library_support_by_platform) for more details.

#no-changelog 