### PR TITLE
[Infra] Extend expectation wait time in FIRCLSSettingsTests.m (2)

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -134,7 +134,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
   [self.settings cacheSettingsWithGoogleAppID:googleAppID currentTimestamp:currentTimestamp];
 
-  [self waitForExpectations:@[ self.fileManager.removeExpectation ] timeout:1];
+  [self waitForExpectations:@[ self.fileManager.removeExpectation ] timeout:5.0];
 }
 
 - (void)reloadFromCacheWithGoogleAppID:(NSString *)googleAppID


### PR DESCRIPTION
Extend timeout wait time to address CI runner flakes.
Successor to #13442.
Fix #13737
