### PR TITLE
Update some auth tests to Xcode 16

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -163,7 +163,7 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
           FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
     - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
     - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 120
@@ -205,6 +205,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup quickstart
       run: scripts/setup_quickstart.sh authentication
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
           quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -205,8 +205,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup quickstart
       run: scripts/setup_quickstart.sh authentication
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
           quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"


### PR DESCRIPTION
#no-changelog

The latest Facebook SDK release requires Xcode 16 - see https://github.com/facebook/facebook-ios-sdk/issues/2480