### PR TITLE
Fix enum case name in the Authentication example

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/ViewControllers/SettingsViewController.swift
@@ -24,7 +24,7 @@ enum SettingsAction: String {
   case toggleAccessGroup = "Current Access Group"
   case toggleAPNSToken = "APNs Token"
   case toggleAppCredential = "App Credential"
-  case setAuthLanugage = "Auth Language"
+  case setAuthLanguage = "Auth Language"
   case useAppLanguage = "Use App Language"
   case togglePhoneAppVerification = "Disable App Verification (Phone)"
 }
@@ -77,7 +77,7 @@ class SettingsViewController: UIViewController, DataSourceProviderDelegate {
       AppManager.shared.toggle()
     case .toggleAccessGroup:
       toggleAccessGroup()
-    case .setAuthLanugage:
+    case .setAuthLanguage:
       setAuthLanguage()
     case .useAppLanguage:
       auth.useAppLanguage()


### PR DESCRIPTION
The enum appears to be unused externally, so it seems reasonable to proceed with the fix. Please let me know if you think otherwise. Thank you!