### PR TITLE
Fix zip auth test

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -173,11 +173,9 @@ jobs:
       SDK:  "Authentication"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
-          - os: macos-13
-            xcode: Xcode_15.2
           - os: macos-14
             xcode: Xcode_16
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fix zip failure #13737 building Auth quickstart related to Facebook dependency. See #13745.