### PR TITLE
[Infra] Switch to the iPhone 16 sim on Xcode 16

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -146,7 +146,7 @@ if [[ "$xcode_major" -lt 15 ]]; then
 else
   ios_flags=(
     -sdk 'iphonesimulator'
-    -destination 'platform=iOS Simulator,name=iPhone 15'
+    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'
   )
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -143,6 +143,11 @@ if [[ "$xcode_major" -lt 15 ]]; then
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 14'
   )
+elif [[ "$xcode_major" -lt 16 ]]; then
+  ios_flags=(
+    -sdk 'iphonesimulator'
+    -destination 'platform=iOS Simulator,name=iPhone 15'
+  )
 else
   ios_flags=(
     -sdk 'iphonesimulator'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -146,7 +146,7 @@ if [[ "$xcode_major" -lt 15 ]]; then
 else
   ios_flags=(
     -sdk 'iphonesimulator'
-    -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'
+    -destination 'platform=iOS Simulator,name=iPhone 16'
   )
 fi
 


### PR DESCRIPTION
The iPhone 16 simulator running iOS 18.0 is currently available on both the [macOS 14](https://github.com/actions/runner-images/blob/22a8b4c4acd38579dd6bd5c2fcb5b7c492161ea7/images/macos/macos-14-arm64-Readme.md?plain=1#L238) and [macOS 15](https://github.com/actions/runner-images/blob/22a8b4c4acd38579dd6bd5c2fcb5b7c492161ea7/images/macos/macos-15-arm64-Readme.md?plain=1#L167) GitHub runner images (when using Xcode 16). 

#no-changelog