### PR TITLE
[Auth] Address possible race condition

### DIFF
--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -336,10 +336,13 @@ import Foundation
       }
     }
 
-    // Run the actual getCredential off the main thread. but the public API must return on the
-    // main thread.
-    private func getCredentialInternal(with uiDelegate: AuthUIDelegate?) async throws
-      -> AuthCredential {
+    /// Used to obtain an auth credential via a mobile web flow.
+    /// This method is available on iOS only.
+    /// - Parameter uiDelegate: An optional UI delegate used to present the mobile web flow.
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+    @objc(getCredentialWithUIDelegate:completion:)
+    @MainActor
+    open func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
       return try await withCheckedThrowingContinuation { continuation in
         getCredentialWith(uiDelegate) { credential, error in
           if let credential = credential {
@@ -349,16 +352,6 @@ import Foundation
           }
         }
       }
-    }
-
-    /// Used to obtain an auth credential via a mobile web flow.
-    /// This method is available on iOS only.
-    /// - Parameter uiDelegate: An optional UI delegate used to present the mobile web flow.
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    @objc(getCredentialWithUIDelegate:completion:)
-    @MainActor
-    open func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
-      return try await getCredentialInternal(with: uiDelegate)
     }
   #endif
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -336,13 +336,10 @@ import Foundation
       }
     }
 
-    /// Used to obtain an auth credential via a mobile web flow.
-    /// This method is available on iOS only.
-    /// - Parameter uiDelegate: An optional UI delegate used to present the mobile web flow.
-    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
-    @objc(getCredentialWithUIDelegate:completion:)
-    @MainActor
-    open func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
+    // Run the actual getCredential off the main thread. but the public API must return on the
+    // main thread.
+    private func getCredentialInternal(with uiDelegate: AuthUIDelegate?) async throws
+      -> AuthCredential {
       return try await withCheckedThrowingContinuation { continuation in
         getCredentialWith(uiDelegate) { credential, error in
           if let credential = credential {
@@ -352,6 +349,16 @@ import Foundation
           }
         }
       }
+    }
+
+    /// Used to obtain an auth credential via a mobile web flow.
+    /// This method is available on iOS only.
+    /// - Parameter uiDelegate: An optional UI delegate used to present the mobile web flow.
+    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 8, *)
+    @objc(getCredentialWithUIDelegate:completion:)
+    @MainActor
+    open func credential(with uiDelegate: AuthUIDelegate?) async throws -> AuthCredential {
+      return try await getCredentialInternal(with: uiDelegate)
     }
   #endif
 

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -76,12 +76,15 @@ class AuthBackend {
     return "FirebaseAuth.iOS/\(FirebaseVersion()) \(GTMFetcherStandardUserAgentString(nil))"
   }
 
-  private static var gBackendImplementation = AuthBackendRPCImplementation()
+  private static var realRPCBackend = AuthBackendRPCImplementation()
+  private static var gBackendImplementation = realRPCBackend
 
-  class func setDefaultBackendImplementationWithRPCIssuer(issuer: AuthBackendRPCIssuer?) {
-    if let issuer = issuer {
-      gBackendImplementation.rpcIssuer = issuer
-    }
+  class func setTestRPCIssuer(issuer: AuthBackendRPCIssuer) {
+    gBackendImplementation.rpcIssuer = issuer
+  }
+
+  class func resetRPCIssuer() {
+    gBackendImplementation.rpcIssuer = realRPCBackend.rpcIssuer
   }
 
   class func implementation() -> AuthBackendImplementation {

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -76,21 +76,16 @@ class AuthBackend {
     return "FirebaseAuth.iOS/\(FirebaseVersion()) \(GTMFetcherStandardUserAgentString(nil))"
   }
 
-  private static var gBackendImplementation: AuthBackendImplementation?
+  private static var gBackendImplementation = AuthBackendRPCImplementation()
 
   class func setDefaultBackendImplementationWithRPCIssuer(issuer: AuthBackendRPCIssuer?) {
-    let defaultImplementation = AuthBackendRPCImplementation()
     if let issuer = issuer {
-      defaultImplementation.rpcIssuer = issuer
+      gBackendImplementation.rpcIssuer = issuer
     }
-    gBackendImplementation = defaultImplementation
   }
 
   class func implementation() -> AuthBackendImplementation {
-    if gBackendImplementation == nil {
-      gBackendImplementation = AuthBackendRPCImplementation()
-    }
-    return gBackendImplementation!
+    return gBackendImplementation
   }
 
   class func call<T: AuthRPCRequest>(with request: T) async throws -> T.Response {

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -22,11 +22,6 @@
 @import FirebaseAuth;
 @import FirebaseCore;
 
-/** @var kExpectationTimeout
-    @brief The maximum time waiting for expectations to fulfill.
- */
-static const NSTimeInterval kExpectationTimeout = 1;
-
 /** @var kFakeAuthorizedDomain
     @brief A fake authorized domain for the app.
  */

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -162,32 +162,6 @@ static NSString *const kFakeOAuthResponseURL = @"fakeOAuthResponseURL";
   XCTAssertEqualObjects(OAuthCredential.IDToken, kFakeIDToken);
 }
 
-/** @fn testGetCredentialWithUIDelegateWithClientIDOnMainThread
-    @brief Verifies @c getCredentialWithUIDelegate:completion: calls its completion handler on the
-   main thread. Regression test for  firebase/FirebaseUI-iOS#1199.
- */
-- (void)testGetCredentialWithUIDelegateWithClientIDOnMainThread {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-
-  FIROptions *options =
-      [[FIROptions alloc] initWithGoogleAppID:@"0:0000000000000:ios:0000000000000000"
-                                  GCMSenderID:@"00000000000000000-00000000000-000000000"];
-  options.APIKey = kFakeAPIKey;
-  options.projectID = @"myProjectID";
-  options.clientID = kFakeClientID;
-  [FIRApp configureWithName:@"objAppName" options:options];
-  FIRAuth *auth = [FIRAuth authWithApp:[FIRApp appNamed:@"objAppName"]];
-  [auth setMainBundleUrlTypes:@[ @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]} ]];
-
-  FIROAuthProvider *provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:auth];
-  [provider getCredentialWithUIDelegate:nil
-                             completion:^(FIRAuthCredential *_Nullable credential,
-                                          NSError *_Nullable error) {
-                               XCTAssertTrue([NSThread isMainThread]);
-                               [expectation fulfill];
-                             }];
-  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
-}
 @end
 
 #endif  // TARGET_OS_IOS

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -72,13 +72,13 @@ class RPCBaseTests: XCTestCase {
 
   override func setUp() {
     rpcIssuer = FakeBackendRPCIssuer()
-    AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: rpcIssuer)
+    AuthBackend.setTestRPCIssuer(issuer: rpcIssuer)
     rpcImplementation = AuthBackend.implementation()
   }
 
   override func tearDown() {
     rpcIssuer = nil
-    AuthBackend.setDefaultBackendImplementationWithRPCIssuer(issuer: nil)
+    AuthBackend.resetRPCIssuer()
   }
 
   /** @fn checkRequest


### PR DESCRIPTION
This PR eliminates the possibility of multiple AuthBackendRPCImplementation instances other than in test code.

It's a possible fix for https://github.com/firebase/firebase-ios-sdk/issues/13761

(Also eliminates an Objective-C unit test that was relying upon the broken old code to succeed on GHA.



