### PR TITLE
Fix FirebaseCore swift unit tests function names

### DIFF
--- a/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
@@ -183,7 +183,7 @@ class FirebaseAppTests: XCTestCase {
     waitForExpectations(timeout: 1)
   }
 
-  func testGetUnitializedDefaultApp() {
+  func testGetUninitializedDefaultApp() {
     let app = FirebaseApp.app()
     XCTAssertNil(app)
   }


### PR DESCRIPTION
I couldn't find any reference to this function anywhere in the code, so it seems safe to change and merge. Please double check.
Thanks.