### PR TITLE
Fix a little typo in a comment of a json resource

### DIFF
--- a/FirebaseDatabase/Tests/Resources/syncPointSpec.json
+++ b/FirebaseDatabase/Tests/Resources/syncPointSpec.json
@@ -6957,7 +6957,7 @@
         ]
       },
       {
-        ".comment": "this caused vomitting in the past...",
+        ".comment": "this caused vomiting in the past...",
         "type": "set",
         "path": "a/foo/bar",
         "data": null,


### PR DESCRIPTION
This was very tiny but the quality matters and Xcode was underling it in red.