### PR TITLE
Refactor stream to notify first and next

### DIFF
--- a/Firestore/core/src/remote/stream.h
+++ b/Firestore/core/src/remote/stream.h
@@ -226,7 +226,9 @@ class Stream : public GrpcStreamObserver,
       const std::string& app_check_token) = 0;
   virtual void TearDown(GrpcStream* stream) = 0;
   virtual void NotifyStreamOpen() = 0;
-  virtual util::Status NotifyStreamResponse(
+  virtual util::Status NotifyFirstStreamResponse(
+      const grpc::ByteBuffer& message) = 0;
+  virtual util::Status NotifyNextStreamResponse(
       const grpc::ByteBuffer& message) = 0;
   virtual void NotifyStreamClose(const util::Status& status) = 0;
   // PORTING NOTE: C++ cannot rely on RTTI, unlike other platforms.
@@ -260,6 +262,7 @@ class Stream : public GrpcStreamObserver,
   // Used to prevent auth if the stream happens to be restarted before token is
   // received.
   int close_count_ = 0;
+  int response_count_ = 0;
 };
 
 }  // namespace remote

--- a/Firestore/core/src/remote/watch_stream.cc
+++ b/Firestore/core/src/remote/watch_stream.cc
@@ -92,7 +92,11 @@ void WatchStream::NotifyStreamOpen() {
   callback_->OnWatchStreamOpen();
 }
 
-Status WatchStream::NotifyStreamResponse(const grpc::ByteBuffer& message) {
+Status WatchStream::NotifyFirstStreamResponse(const grpc::ByteBuffer& message) {
+  return NotifyNextStreamResponse(message);
+}
+
+Status WatchStream::NotifyNextStreamResponse(const grpc::ByteBuffer& message) {
   ByteBufferReader reader{message};
   auto response = watch_serializer_.ParseResponse(&reader);
   if (!reader.ok()) {

--- a/Firestore/core/src/remote/watch_stream.h
+++ b/Firestore/core/src/remote/watch_stream.h
@@ -116,7 +116,10 @@ class WatchStream : public Stream {
   void TearDown(GrpcStream* grpc_stream) override;
 
   void NotifyStreamOpen() override;
-  util::Status NotifyStreamResponse(const grpc::ByteBuffer& message) override;
+  util::Status NotifyFirstStreamResponse(
+      const grpc::ByteBuffer& message) override;
+  util::Status NotifyNextStreamResponse(
+      const grpc::ByteBuffer& message) override;
   void NotifyStreamClose(const util::Status& status) override;
 
   std::string GetDebugName() const override {

--- a/Firestore/core/src/remote/write_stream.h
+++ b/Firestore/core/src/remote/write_stream.h
@@ -120,6 +120,8 @@ class WriteStream : public Stream {
     return handshake_complete_;
   }
 
+  void Start() override;
+
   /**
    * Sends an initial stream token to the server, performing the handshake
    * required to make the StreamingWrite RPC work.
@@ -143,7 +145,10 @@ class WriteStream : public Stream {
   void TearDown(GrpcStream* grpc_stream) override;
 
   void NotifyStreamOpen() override;
-  util::Status NotifyStreamResponse(const grpc::ByteBuffer& message) override;
+  util::Status NotifyFirstStreamResponse(
+      const grpc::ByteBuffer& message) override;
+  util::Status NotifyNextStreamResponse(
+      const grpc::ByteBuffer& message) override;
   void NotifyStreamClose(const util::Status& status) override;
 
   std::string GetDebugName() const override {

--- a/Firestore/core/test/unit/remote/stream_test.cc
+++ b/Firestore/core/test/unit/remote/stream_test.cc
@@ -108,14 +108,27 @@ class TestStream : public Stream {
     observed_states_.push_back("NotifyStreamOpen");
   }
 
-  util::Status NotifyStreamResponse(const grpc::ByteBuffer& message) override {
+  util::Status NotifyFirstStreamResponse(const grpc::ByteBuffer& message) override {
     std::string str = ByteBufferToString(message);
     if (str.empty()) {
-      observed_states_.push_back("NotifyStreamResponse");
+      observed_states_.push_back("NotifyFirstStreamResponse");
     } else {
-      observed_states_.push_back(StringFormat("NotifyStreamResponse(%s)", str));
+      observed_states_.push_back(StringFormat("NotifyFirstStreamResponse(%s)", str));
     }
+    return ResolveStreamResponse();
+  }
 
+  util::Status NotifyNextStreamResponse(const grpc::ByteBuffer& message) override {
+    std::string str = ByteBufferToString(message);
+    if (str.empty()) {
+      observed_states_.push_back("NotifyNextStreamResponse");
+    } else {
+      observed_states_.push_back(StringFormat("NotifyNextStreamResponse(%s)", str));
+    }
+    return ResolveStreamResponse();
+  }
+
+  util::Status ResolveStreamResponse() {
     if (fail_next_stream_read_) {
       fail_next_stream_read_ = false;
       // The parent stream will issue a finish operation and block until it's
@@ -294,8 +307,8 @@ TEST_F(StreamTest, ObserverReceivesStreamRead) {
     EXPECT_TRUE(firestore_stream->IsStarted());
     EXPECT_TRUE(firestore_stream->IsOpen());
     EXPECT_EQ(observed_states(),
-              States({"NotifyStreamOpen", "NotifyStreamResponse(foo)",
-                      "NotifyStreamResponse(bar)"}));
+              States({"NotifyStreamOpen", "NotifyFirstStreamResponse(foo)",
+                      "NotifyNextStreamResponse(bar)"}));
   });
 }
 


### PR DESCRIPTION
In preparation for handshake on streams, the abstract stream is expanded to have separate callback for first and next messages.
