### PR TITLE
Fix a crash related to thread sanitization on variables in FPRNetworkTrace class.

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Pending
+# Unreleased
 - [fixed] Fix a crash related to thread sanitization on FPRNetworkTrace class (#13581).
 
 # 10.28.0

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Pending
+- [fixed] Fix a crash related to thread sanitization on FPRNetworkTrace class (#13581).
+
 # 10.28.0
 - Fix Crash from InstrumentUploadTaskWithStreamedRequest (#12983).
 - Replace SystemConfiguration with a more recent network monitoring API by Apple (#13079).

--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -233,7 +233,9 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 #pragma mark - Overrides
 
 - (void)setResponseCode:(int32_t)responseCode {
-  _responseCode = responseCode;
+  dispatch_sync(self.syncQueue, ^{
+    _responseCode = responseCode;
+  });
   if (responseCode != 0) {
     _hasValidResponseCode = YES;
   }
@@ -279,7 +281,9 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
 }
 
 - (void)didReceiveData:(NSData *)data {
-  self.responseSize = data.length;
+  dispatch_sync(self.syncQueue, ^{
+    self.responseSize = data.length;
+  });
 }
 
 - (void)didReceiveFileURL:(NSURL *)URL {
@@ -290,7 +294,9 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
     if (error) {
       FPRLogNotice(kFPRNetworkTraceFileError, @"Unable to determine the size of file.");
     } else {
-      self.responseSize = value.unsignedIntegerValue;
+      dispatch_sync(self.syncQueue, ^{
+        self.responseSize = value.unsignedIntegerValue;
+      });
     }
   }
 }


### PR DESCRIPTION
Paired with @PolinaGo on this issue to resolve it.

Fix #13581