### PR TITLE
[Vertex AI] Add image / function call count tokens integration tests

### DIFF
--- a/FirebaseVertexAI/Sources/FunctionCalling.swift
+++ b/FirebaseVertexAI/Sources/FunctionCalling.swift
@@ -21,6 +21,18 @@ public struct FunctionCall: Equatable, Sendable {
 
   /// The function parameters and values.
   public let args: JSONObject
+
+  /// Constructs a new function call.
+  ///
+  /// > Note: A `FunctionCall` is typically received from the model, rather than created manually.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the function to call.
+  ///   - args: The function parameters and values.
+  public init(name: String, args: JSONObject) {
+    self.name = name
+    self.args = args
+  }
 }
 
 /// Structured representation of a function declaration.

--- a/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/Integration/IntegrationTests.swift
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 import FirebaseCore
+import FirebaseVertexAI
 import XCTest
-
-@testable import FirebaseVertexAI
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class IntegrationTests: XCTestCase {


### PR DESCRIPTION
Added integration tests for `countTokens` with images (inline base64 and Firebase Storage) and function calling. As a side-effect these tests verify our `Encodable` implementations for these types.

#no-changelog