### PR TITLE
Docs: fix app activity comments

### DIFF
--- a/FirebasePerformance/Sources/AppActivity/FPRSessionManager+Private.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRSessionManager+Private.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, nullable, readwrite) FPRSessionDetails *sessionDetails;
 
 /**
- * Creates an instance of FPRSesssionManager with the notification center provided. All the
+ * Creates an instance of FPRSessionManager with the notification center provided. All the
  * notifications from the session manager will sent using this notification center.
  *
  * @param gaugeManager Gauge manager used by the session manager to work with gauges.


### PR DESCRIPTION
A simple typo in the comments referencing a type. The original type spell was correct. 