### PR TITLE
docs: fix common sources comments

### DIFF
--- a/FirebasePerformance/Sources/Common/FPRDiagnostics_Private.h
+++ b/FirebasePerformance/Sources/Common/FPRDiagnostics_Private.h
@@ -21,7 +21,7 @@
  */
 @interface FPRDiagnostics ()
 
-/** FPRCongiguration to check if diagnostic is enabled. */
+/** FPRConfiguration to check if diagnostic is enabled. */
 @property(class, nonatomic, readwrite) FPRConfigurations *configuration;
 
 @end


### PR DESCRIPTION
A simple typo in a property documentation. The original referenced type spell was ok.