### PR TITLE
[Vertex AI] Sample app CI for Xcode 16

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -138,8 +138,6 @@ jobs:
   sample:
     strategy:
       matrix:
-        # Test build with debug and release configs (whether or not DEBUG is set and optimization level)
-        build: [build]
         include:
           - os: macos-13
             xcode: Xcode_15.2

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -16,7 +16,16 @@ concurrency:
 
 jobs:
   spm-package-resolved:
-    runs-on: macos-14
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
+    runs-on: ${{ matrix.os }}
     outputs:
       cache_key: ${{ steps.generate_cache_key.outputs.cache_key }}
     env:
@@ -30,7 +39,7 @@ jobs:
       - name: Generate cache key
         id: generate_cache_key
         run: |
-          cache_key="${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+          cache_key="${{ matrix.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
           echo "cache_key=${cache_key}" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/save@v4
         id: cache
@@ -133,9 +142,11 @@ jobs:
         build: [build]
         include:
           - os: macos-13
-            xcode: Xcode_15.0.1
-          - os: macos-14
             xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     needs: spm-package-resolved
     env:


### PR DESCRIPTION
Updated the `vertexai` workflow job `sample` to build the app on:
- macOS 13 / Xcode 15.2
- macOS 14 / Xcode 15.4
- macOS 15 / Xcode 16

#no-changelog