### PR TITLE
Xcode_16 will soon require macos-15 in GHA

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -24,8 +24,13 @@ jobs:
       matrix:
         # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
         target: [ios, tvos, macos --skip-tests, watchos]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -108,6 +108,9 @@ jobs:
           - os: macos-15
             xcode: Xcode_16
             target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -86,7 +86,6 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-      matrix:
         include:
           - os: macos-13
             xcode: Xcode_15.2

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -22,15 +22,25 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: macos tests are blocked by https://github.com/erikdoe/ocmock/pull/532
-        target: [ios, tvos, macos --skip-tests, watchos]
         include:
           - os: macos-13
             xcode: Xcode_15.2
+            target: ios
           - os: macos-14
             xcode: Xcode_15.4
+            target: ios
           - os: macos-15
             xcode: Xcode_16
+            target: ios
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvos
+          - os: macos-15
+            xcode: Xcode_16
+            target: macos
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchos
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -76,9 +86,29 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+      matrix:
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -69,6 +69,7 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
+        include:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-14

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -21,9 +21,12 @@ jobs:
 
     strategy:
       matrix:
-        target: [ios]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +38,7 @@ jobs:
     - name: Build and test
       run: |
        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAppDistribution.podspec \
-         --platforms=${{ matrix.target }}
+         --platforms=ios
 
   spm-package-resolved:
     env:
@@ -66,8 +69,12 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -21,6 +21,7 @@ jobs:
 
     strategy:
       matrix:
+        include:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-14

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -107,9 +107,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS spm, tvOS spm, macOS spmbuildonly, catalyst spm, watchOS spm]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS spm
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS spm
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         podspec: [FirebaseAuthInterop.podspec, FirebaseAuth.podspec]
         target: [ios, tvos, macos --skip-tests --allow-warnings, watchos]
-        os: [macos-14]
+        os: [macos-15]
         xcode: [Xcode_16]
     runs-on: ${{ matrix.os }}
     steps:
@@ -161,7 +161,7 @@ jobs:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache/restore@v4

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -64,9 +64,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/core_internal.yml
+++ b/.github/workflows/core_internal.yml
@@ -60,9 +60,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -77,9 +77,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -86,9 +86,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -64,8 +64,13 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -120,9 +120,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -461,9 +461,31 @@ jobs:
       (github.event_name == 'pull_request')
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     env:
       FIREBASE_SOURCE_FIRESTORE: 1

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -405,7 +405,7 @@ jobs:
           - os: macos-13
             platforms: 'ios'
         include:
-          - os: macos-14
+          - os: macos-15
             xcode: Xcode_16
           - os: macos-13
             xcode: Xcode_15.2
@@ -477,9 +477,6 @@ jobs:
           - os: macos-15
             xcode: Xcode_16
             target: macOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: watchOS
           - os: macos-15
             xcode: Xcode_16
             target: catalyst

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -108,9 +108,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -91,8 +91,13 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+          - os: macos-14
+            xcode: Xcode_15.4
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -85,9 +85,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -107,9 +107,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS spm, tvOS spmbuildonly, macOS spmbuildonly, catalyst spmbuildonly, watchOS spmbuildonly]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS spm
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS spm
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst spmbuildonly
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS spmbuildonly
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -21,31 +21,9 @@ jobs:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     strategy:
       matrix:
-        include:
-          - os: macos-13
-            xcode: Xcode_15.2
-            target: iOS
-          - os: macos-14
-            xcode: Xcode_15.4
-            target: iOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: iOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: tvOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: macOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: watchOS
-          - os: macos-15
-            xcode: Xcode_16
-            target: catalyst
-          - os: macos-15
-            xcode: Xcode_16
-            target: visionOS
+        target: [ios, tvos, macos, watchos]
+        os: [macos-14]
+        xcode: [Xcode_15.2, Xcode_16]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -116,9 +94,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -21,9 +21,31 @@ jobs:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     strategy:
       matrix:
-        target: [ios, tvos, macos, watchos]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -147,9 +147,19 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -114,9 +114,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -78,9 +78,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -51,9 +51,8 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        os: [macos-14]
         include:
-          - os: macos-14
+          - os: macos-15
             xcode: Xcode_16
             test: spm
           - os: macos-14
@@ -89,11 +88,10 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        os: [macos-14]
         include:
           - os: macos-14
             xcode: Xcode_15.3
-          - os: macos-14
+          - os: macos-15
             xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     steps:
@@ -121,9 +119,8 @@ jobs:
         # visionOS isn't buildable from here (even with Firestore source) because the test
         # targets need Analytics.
         target: [tvOS, macOS, catalyst]
-        os: [macos-14]
         include:
-          - os: macos-14
+          - os: macos-15
             xcode: Xcode_16
           - os: macos-14
             xcode: Xcode_15.3

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -88,9 +88,31 @@ jobs:
     needs: [spm-package-resolved]
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -41,9 +41,31 @@ jobs:
   spm-unit:
     strategy:
       matrix:
-        target: [iOS, tvOS, macOS, catalyst, watchOS]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-13
+            xcode: Xcode_15.2
+            target: iOS
+          - os: macos-14
+            xcode: Xcode_15.4
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: iOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: tvOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: macOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: watchOS
+          - os: macos-15
+            xcode: Xcode_16
+            target: catalyst
+          - os: macos-15
+            xcode: Xcode_16
+            target: visionOS
     runs-on: ${{ matrix.os }}
     needs: spm-package-resolved
     env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -143,15 +143,27 @@ if [[ "$xcode_major" -lt 15 ]]; then
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 14'
   )
+  watchos_flags=(
+    -sdk 'watchsimulator'
+    -destination 'platform=watchOS Simulator,name=Apple Watch Series 7 (45mm)'
+  )
 elif [[ "$xcode_major" -lt 16 ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 15'
   )
+  watchos_flags=(
+    -sdk 'watchsimulator'
+    -destination 'platform=watchOS Simulator,name=Apple Watch Series 7 (45mm)'
+  )
 else
   ios_flags=(
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 16'
+  )
+    watchos_flags=(
+    -sdk 'watchsimulator'
+    -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm) '
   )
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -185,10 +185,6 @@ tvos_flags=(
   -sdk "appletvsimulator"
   -destination 'platform=tvOS Simulator,name=Apple TV'
 )
-watchos_flags=(
-  -sdk 'watchsimulator'
-  -destination 'platform=watchOS Simulator,name=Apple Watch Series 7 (45mm)'
-)
 visionos_flags=(
   -sdk 'xrsimulator'
   -destination 'platform=visionOS Simulator,name=Apple Vision Pro'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -163,7 +163,7 @@ else
   )
     watchos_flags=(
     -sdk 'watchsimulator'
-    -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm) '
+    -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)'
   )
 fi
 


### PR DESCRIPTION
- Update all spm Xcode 16 jobs to run on macos-15
- Restore visionOS testing
- Xcode 16 pod lib lint test will follow in a later PR

See https://github.com/actions/runner-images/issues/10703

#no-changelog