### PR TITLE
[Vertex AI] Replace sample `CustomStringConvertible` extensions

### DIFF
--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -16,8 +16,9 @@ import FirebaseVertexAI
 import MarkdownUI
 import SwiftUI
 
-extension HarmCategory: CustomStringConvertible {
-  public var description: String {
+private extension HarmCategory {
+  /// Returns a description of the `HarmCategory` suitable for displaying in the UI.
+  var displayValue: String {
     switch self {
     case .dangerousContent: "Dangerous content"
     case .harassment: "Harassment"
@@ -28,8 +29,9 @@ extension HarmCategory: CustomStringConvertible {
   }
 }
 
-extension SafetyRating.HarmProbability: CustomStringConvertible {
-  public var description: String {
+private extension SafetyRating.HarmProbability {
+  /// Returns a description of the `HarmProbability` suitable for displaying in the UI.
+  var displayValue: String {
     switch self {
     case .high: "High"
     case .low: "Low"
@@ -73,10 +75,9 @@ private struct SafetyRatingsSection: View {
     Section("Safety ratings") {
       List(ratings, id: \.self) { rating in
         HStack {
-          Text("\(String(describing: rating.category))")
-            .font(.subheadline)
+          Text(rating.category.displayValue).font(.subheadline)
           Spacer()
-          Text("\(String(describing: rating.probability))")
+          Text(rating.probability.displayValue)
         }
       }
     }


### PR DESCRIPTION
Replaced the `CustomStringConvertible` extensions on `HarmCategory` and `HarmProbability` in the sample app with custom `displayValue` properties. This fixes the warning `Extension declares a conformance of imported type 'HarmCategory' to imported protocol 'CustomStringConvertible'; this will not behave correctly if the owners of 'FirebaseVertexAI' introduce this conformance in the future`.

As the warning describes, this also allows us to customize the `description` in the SDK by conforming to `CustomStringConvertible` for those types.

#no-changelog