### PR TITLE
[Vertex AI] Use `struct` instead of `enum` for `HarmProbability`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -36,9 +36,10 @@
   as input. (#13767)
 - [changed] **Breaking Change**: All initializers for `ModelContent` now require
   the label `parts: `. (#13832)
-- [changed] **Breaking Change**: `HarmCategory` is now a struct instead of an
-  enum type and the `unknown` case has been removed; in a `switch` statement,
-  use the `default:` case to cover unknown or unhandled categories. (#13728)
+- [changed] **Breaking Change**: `HarmCategory` and `HarmProbability` are now
+  structs instead of enums types and the `unknown` cases have been removed; in a
+  `switch` statement, use the `default:` case to cover unknown or unhandled
+  categories or probabilities. (#13728, #13854)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value of 60 seconds for a `URLRequest`; this timeout may
   still be customized in `RequestOptions`. (#13722)

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -25,8 +25,7 @@ private extension HarmCategory {
     case .hateSpeech: "Hate speech"
     case .sexuallyExplicit: "Sexually explicit"
     case .civicIntegrity: "Civic integrity"
-    default:
-      "Unknown HarmCategory: \(rawValue)"
+    default: "Unknown HarmCategory: \(rawValue)"
     }
   }
 }
@@ -39,7 +38,7 @@ private extension SafetyRating.HarmProbability {
     case .low: "Low"
     case .medium: "Medium"
     case .negligible: "Negligible"
-    case .unknown: "Unknown"
+    default: "Unknown HarmProbability: \(rawValue)"
     }
   }
 }

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -162,7 +162,10 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContent_success_unknownEnum_safetyRatings() async throws {
     let expectedSafetyRatings = [
       SafetyRating(category: .harassment, probability: .medium),
-      SafetyRating(category: .dangerousContent, probability: .unknown),
+      SafetyRating(
+        category: .dangerousContent,
+        probability: SafetyRating.HarmProbability(rawValue: "FAKE_NEW_HARM_PROBABILITY")
+      ),
       SafetyRating(category: HarmCategory(rawValue: "FAKE_NEW_HARM_CATEGORY"), probability: .high),
     ]
     MockURLProtocol
@@ -974,7 +977,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let unknownSafetyRating = SafetyRating(
       category: HarmCategory(rawValue: "HARM_CATEGORY_DANGEROUS_CONTENT_NEW_ENUM"),
-      probability: .unknown
+      probability: SafetyRating.HarmProbability(rawValue: "FAKE_NEW_HARM_PROBABILITY")
     )
 
     var foundUnknownSafetyRating = false

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -977,7 +977,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let unknownSafetyRating = SafetyRating(
       category: HarmCategory(rawValue: "HARM_CATEGORY_DANGEROUS_CONTENT_NEW_ENUM"),
-      probability: SafetyRating.HarmProbability(rawValue: "FAKE_NEW_HARM_PROBABILITY")
+      probability: SafetyRating.HarmProbability(rawValue: "NEGLIGIBLE_UNKNOWN_ENUM")
     )
 
     var foundUnknownSafetyRating = false


### PR DESCRIPTION
Replaced the `SafetyRating.HarmProbability` enum with a struct to prevent breaking changes when new values are added (since switch statements must be exhaustively checked in Swift). This follows the same design pattern as https://github.com/firebase/firebase-ios-sdk/pull/13728 (`HarmCategory`).

#no-changelog