### PR TITLE
Run fewer tests to reduce flakiness

### DIFF
--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -27,7 +27,7 @@ jobs:
         target: [ios, tvos, macos, watchos --skip-tests]
         os: [macos-14]
         flags: [
-          '--use-modular-headers',
+          '--use-modular-headers --skip-tests',
           ''
         ]
         xcode: [Xcode_15.2, Xcode_16]


### PR DESCRIPTION
The modular-header tests are run primarily for build tests. No need to run their unit tests and increase chance of overall workflow flaking.