### PR TITLE
[Vertex AI] Refactor `BlockReason` as a `struct` and add new values

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -52,6 +52,8 @@
   filter. (#13863)
 - [added] Added new `FinishReason` values `.blocklist`, `.prohibitedContent`,
   `.spii` and `.malformedFunctionCall` that may be reported. (#13860)
+- [added] Added new `BlockReason` values `.blocklist` and `.prohibitedContent`
+  that may be reported when a prompt is blocked. (#13861)
 
 # 11.3.0
 - [added] Added `Decodable` conformance for `FunctionResponse`. (#13606)

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -627,13 +627,14 @@ final class GenerativeModelTests: XCTestCase {
         forResource: "unary-failure-unknown-enum-prompt-blocked",
         withExtension: "json"
       )
+    let unknownBlockReason = PromptFeedback.BlockReason(rawValue: "FAKE_NEW_BLOCK_REASON")
 
     do {
       _ = try await model.generateContent(testPrompt)
       XCTFail("Should throw")
     } catch let GenerateContentError.promptBlocked(response) {
       let promptFeedback = try XCTUnwrap(response.promptFeedback)
-      XCTAssertEqual(promptFeedback.blockReason, .unknown)
+      XCTAssertEqual(promptFeedback.blockReason, unknownBlockReason)
     } catch {
       XCTFail("Should throw a promptBlocked")
     }


### PR DESCRIPTION
Replaced the `BlockReason` enum with a struct to prevent breaking changes when new values are added (since switch statements must be exhaustively checked in Swift). Added the new values `blocklist` and `prohibitedContent`.