### PR TITLE
[Vertex AI] Remove from zip build

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -53,8 +53,8 @@ public let shared = Manifest(
     Pod("FirebasePerformance", platforms: ["ios", "tvos"], zip: true),
     Pod("FirebaseStorage", zip: true),
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
-    Pod("FirebaseVertexAI", zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
+    Pod("FirebaseVertexAI", releasing: false, zip: false),
   ]
 )
 


### PR DESCRIPTION
- Removed the Vertex AI SDK from the zip build (`zip: false`).
- Re-ordered the `FirebaseVertexAI` pod to come after the `Firebase` pod to ensure it is not a dependency.
- Set `releasing: false` so it is not printed in the list when calling `swift run --package-path ReleaseTooling firebase-releaser --publish true --log-only true --git-root <release_dir>`
  - The pod could be manually pushed by running `pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/spec-staging/FirebaseVertexAI/11.4.0/FirebaseVertexAI.podspec.json` if the timing works out.

#no-changelog