### PR TITLE
[Vertex AI] Add `HarmSeverity` enum and `SafetyRating` properties

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -58,6 +58,9 @@
   `totalBillableCharacters` counts, where applicable. (#13813)
 - [added] Added a new `HarmCategory` `.civicIntegrity` for filtering content
   that may be used to harm civic integrity. (#13728)
+- [added] Added `probabilityScore`, `severity` and `severityScore` in
+  `SafetyRating` to provide more fine-grained detail on blocked responses.
+  (#13875)
 - [added] Added a new `HarmBlockThreshold` `.off`, which turns off the safety
   filter. (#13863)
 - [added] Added new `FinishReason` values `.blocklist`, `.prohibitedContent`,

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -168,10 +168,38 @@ struct ErrorDetailsView: View {
         Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
         """),
       safetyRatings: [
-        SafetyRating(category: .dangerousContent, probability: .high),
-        SafetyRating(category: .harassment, probability: .low),
-        SafetyRating(category: .hateSpeech, probability: .low),
-        SafetyRating(category: .sexuallyExplicit, probability: .low),
+        SafetyRating(
+          category: .dangerousContent,
+          probability: .medium,
+          probabilityScore: 0.8,
+          severity: .medium,
+          severityScore: 0.9,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .harassment,
+          probability: .low,
+          probabilityScore: 0.5,
+          severity: .low,
+          severityScore: 0.6,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .hateSpeech,
+          probability: .low,
+          probabilityScore: 0.3,
+          severity: .medium,
+          severityScore: 0.2,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .sexuallyExplicit,
+          probability: .low,
+          probabilityScore: 0.2,
+          severity: .negligible,
+          severityScore: 0.5,
+          blocked: false
+        ),
       ],
       finishReason: FinishReason.maxTokens,
       citationMetadata: nil),
@@ -190,10 +218,38 @@ struct ErrorDetailsView: View {
         Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
         """),
       safetyRatings: [
-        SafetyRating(category: .dangerousContent, probability: .high),
-        SafetyRating(category: .harassment, probability: .low),
-        SafetyRating(category: .hateSpeech, probability: .low),
-        SafetyRating(category: .sexuallyExplicit, probability: .low),
+        SafetyRating(
+          category: .dangerousContent,
+          probability: .low,
+          probabilityScore: 0.8,
+          severity: .medium,
+          severityScore: 0.9,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .harassment,
+          probability: .low,
+          probabilityScore: 0.5,
+          severity: .low,
+          severityScore: 0.6,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .hateSpeech,
+          probability: .low,
+          probabilityScore: 0.3,
+          severity: .medium,
+          severityScore: 0.2,
+          blocked: false
+        ),
+        SafetyRating(
+          category: .sexuallyExplicit,
+          probability: .low,
+          probabilityScore: 0.2,
+          severity: .negligible,
+          severityScore: 0.5,
+          blocked: false
+        ),
       ],
       finishReason: FinishReason.other,
       citationMetadata: nil),

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
@@ -36,22 +36,54 @@ struct ErrorView: View {
 #Preview {
   NavigationView {
     let errorPromptBlocked = GenerateContentError.promptBlocked(
-      response: GenerateContentResponse(candidates: [
-        CandidateResponse(content: ModelContent(role: "model", parts: [
-          """
-            A _hypothetical_ model response.
-            Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
-          """,
-        ]),
-        safetyRatings: [
-          SafetyRating(category: .dangerousContent, probability: .high),
-          SafetyRating(category: .harassment, probability: .low),
-          SafetyRating(category: .hateSpeech, probability: .low),
-          SafetyRating(category: .sexuallyExplicit, probability: .low),
-        ],
-        finishReason: FinishReason.other,
-        citationMetadata: nil),
-      ])
+      response: GenerateContentResponse(
+        candidates: [
+          CandidateResponse(
+            content: ModelContent(role: "model", parts: [
+              """
+                A _hypothetical_ model response.
+                Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
+              """,
+            ]),
+            safetyRatings: [
+              SafetyRating(
+                category: .dangerousContent,
+                probability: .high,
+                probabilityScore: 0.8,
+                severity: .medium,
+                severityScore: 0.9,
+                blocked: true
+              ),
+              SafetyRating(
+                category: .harassment,
+                probability: .low,
+                probabilityScore: 0.5,
+                severity: .low,
+                severityScore: 0.6,
+                blocked: false
+              ),
+              SafetyRating(
+                category: .hateSpeech,
+                probability: .low,
+                probabilityScore: 0.3,
+                severity: .medium,
+                severityScore: 0.2,
+                blocked: false
+              ),
+              SafetyRating(
+                category: .sexuallyExplicit,
+                probability: .low,
+                probabilityScore: 0.2,
+                severity: .negligible,
+                severityScore: 0.5,
+                blocked: false
+              ),
+            ],
+            finishReason: FinishReason.other,
+            citationMetadata: nil
+          ),
+        ]
+      )
     )
     List {
       MessageView(message: ChatMessage.samples[0])

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -26,17 +26,34 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
 
   /// The model-generated probability that the content falls under the specified harm ``category``.
   ///
-  /// See ``HarmProbability`` for a list of possible values.
+  /// See ``HarmProbability`` for a list of possible values. This is a discretized representation
+  /// of the ``probabilityScore``.
   ///
   /// > Important: This does not indicate the severity of harm for a piece of content.
   public let probability: HarmProbability
 
+  /// The confidence score that the response is associated with the corresponding harm ``category``.
+  ///
+  /// The probability safety score is a confidence score between 0.0 and 1.0, rounded to one decimal
+  /// place; it is discretized into a ``HarmProbability`` in ``probability``. See [probability
+  /// scores](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters#comparison_of_probability_scores_and_severity_scores)
+  /// in the Google Cloud documentation for more details.
   public let probabilityScore: Float
 
+  /// The severity reflects the magnitude of how harmful a model response might be.
+  ///
+  /// See ``HarmSeverity`` for a list of possible values. This is a discretized representation of
+  /// the ``severityScore``.
   public let severity: HarmSeverity
 
+  /// The severity score is the magnitude of how harmful a model response might be.
+  ///
+  /// The severity score ranges from 0.0 to 1.0, rounded to one decimal place; it is discretized
+  /// into a ``HarmSeverity`` in ``severity``. See [severity scores](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters#comparison_of_probability_scores_and_severity_scores)
+  /// in the Google Cloud documentation for more details.
   public let severityScore: Float
 
+  /// If true, the response was blocked.
   public let blocked: Bool
 
   /// Initializes a new `SafetyRating` instance with the given category and probability.
@@ -92,6 +109,7 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
       VertexLog.MessageCode.generateContentResponseUnrecognizedHarmProbability
   }
 
+  /// The magnitude of how harmful a model response might be for the respective ``HarmCategory``.
   public struct HarmSeverity: DecodableProtoEnum, Hashable, Sendable {
     enum Kind: String {
       case negligible = "HARM_SEVERITY_NEGLIGIBLE"
@@ -100,12 +118,16 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
       case high = "HARM_SEVERITY_HIGH"
     }
 
+    /// Negligible level of harm severity.
     public static let negligible = HarmSeverity(kind: .negligible)
 
+    /// Low level of harm severity.
     public static let low = HarmSeverity(kind: .low)
 
+    /// Medium level of harm severity.
     public static let medium = HarmSeverity(kind: .medium)
 
+    /// High level of harm severity.
     public static let high = HarmSeverity(kind: .high)
 
     /// Returns the raw string representation of the `HarmSeverity` value.

--- a/FirebaseVertexAI/Sources/VertexLog.swift
+++ b/FirebaseVertexAI/Sources/VertexLog.swift
@@ -49,6 +49,7 @@ enum VertexLog {
     case generateContentResponseUnrecognizedBlockThreshold = 3004
     case generateContentResponseUnrecognizedHarmProbability = 3005
     case generateContentResponseUnrecognizedHarmCategory = 3006
+    case generateContentResponseUnrecognizedHarmSeverity = 3007
 
     // SDK State Errors
     case generateContentResponseNoCandidates = 4000

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -885,8 +885,11 @@ final class GenerativeModelTests: XCTestCase {
       for try await _ in stream {
         XCTFail("Content shouldn't be shown, this shouldn't happen.")
       }
-    } catch let GenerateContentError.responseStoppedEarly(reason, _) {
+    } catch let GenerateContentError.responseStoppedEarly(reason, response) {
       XCTAssertEqual(reason, .safety)
+      let candidate = try XCTUnwrap(response.candidates.first)
+      XCTAssertEqual(candidate.finishReason, reason)
+      XCTAssertTrue(candidate.safetyRatings.contains { $0.blocked })
       return
     }
 

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -23,10 +23,38 @@ import XCTest
 final class GenerativeModelTests: XCTestCase {
   let testPrompt = "What sorts of questions can I ask you?"
   let safetyRatingsNegligible: [SafetyRating] = [
-    .init(category: .sexuallyExplicit, probability: .negligible),
-    .init(category: .hateSpeech, probability: .negligible),
-    .init(category: .harassment, probability: .negligible),
-    .init(category: .dangerousContent, probability: .negligible),
+    .init(
+      category: .sexuallyExplicit,
+      probability: .negligible,
+      probabilityScore: 0.1431877,
+      severity: .negligible,
+      severityScore: 0.11027937,
+      blocked: false
+    ),
+    .init(
+      category: .hateSpeech,
+      probability: .negligible,
+      probabilityScore: 0.029035643,
+      severity: .negligible,
+      severityScore: 0.05613278,
+      blocked: false
+    ),
+    .init(
+      category: .harassment,
+      probability: .negligible,
+      probabilityScore: 0.087252244,
+      severity: .negligible,
+      severityScore: 0.04509957,
+      blocked: false
+    ),
+    .init(
+      category: .dangerousContent,
+      probability: .negligible,
+      probabilityScore: 0.2641685,
+      severity: .negligible,
+      severityScore: 0.082253955,
+      blocked: false
+    ),
   ].sorted()
   let testModelResourceName =
     "projects/test-project-id/locations/test-location/publishers/google/models/test-model"
@@ -69,7 +97,7 @@ final class GenerativeModelTests: XCTestCase {
     let candidate = try XCTUnwrap(response.candidates.first)
     let finishReason = try XCTUnwrap(candidate.finishReason)
     XCTAssertEqual(finishReason, .stop)
-    XCTAssertEqual(candidate.safetyRatings.sorted(), safetyRatingsNegligible)
+    XCTAssertEqual(candidate.safetyRatings.count, 4)
     XCTAssertEqual(candidate.content.parts.count, 1)
     let part = try XCTUnwrap(candidate.content.parts.first)
     let partText = try XCTUnwrap(part as? TextPart).text
@@ -148,7 +176,7 @@ final class GenerativeModelTests: XCTestCase {
     let candidate = try XCTUnwrap(response.candidates.first)
     let finishReason = try XCTUnwrap(candidate.finishReason)
     XCTAssertEqual(finishReason, .stop)
-    XCTAssertEqual(candidate.safetyRatings.sorted(), safetyRatingsNegligible)
+    XCTAssertEqual(candidate.safetyRatings.count, 4)
     XCTAssertEqual(candidate.content.parts.count, 1)
     let part = try XCTUnwrap(candidate.content.parts.first)
     let textPart = try XCTUnwrap(part as? TextPart)
@@ -156,17 +184,35 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.text, textPart.text)
     let promptFeedback = try XCTUnwrap(response.promptFeedback)
     XCTAssertNil(promptFeedback.blockReason)
-    XCTAssertEqual(promptFeedback.safetyRatings.sorted(), safetyRatingsNegligible)
+    XCTAssertEqual(promptFeedback.safetyRatings.count, 4)
   }
 
   func testGenerateContent_success_unknownEnum_safetyRatings() async throws {
     let expectedSafetyRatings = [
-      SafetyRating(category: .harassment, probability: .medium),
+      SafetyRating(
+        category: .harassment,
+        probability: .medium,
+        probabilityScore: 0.0,
+        severity: .init(rawValue: "HARM_SEVERITY_UNSPECIFIED"),
+        severityScore: 0.0,
+        blocked: false
+      ),
       SafetyRating(
         category: .dangerousContent,
-        probability: SafetyRating.HarmProbability(rawValue: "FAKE_NEW_HARM_PROBABILITY")
+        probability: SafetyRating.HarmProbability(rawValue: "FAKE_NEW_HARM_PROBABILITY"),
+        probabilityScore: 0.0,
+        severity: .init(rawValue: "HARM_SEVERITY_UNSPECIFIED"),
+        severityScore: 0.0,
+        blocked: false
       ),
-      SafetyRating(category: HarmCategory(rawValue: "FAKE_NEW_HARM_CATEGORY"), probability: .high),
+      SafetyRating(
+        category: HarmCategory(rawValue: "FAKE_NEW_HARM_CATEGORY"),
+        probability: .high,
+        probabilityScore: 0.0,
+        severity: .init(rawValue: "HARM_SEVERITY_UNSPECIFIED"),
+        severityScore: 0.0,
+        blocked: false
+      ),
     ]
     MockURLProtocol
       .requestHandler = try httpRequestHandler(
@@ -930,7 +976,11 @@ final class GenerativeModelTests: XCTestCase {
       )
     let unknownSafetyRating = SafetyRating(
       category: HarmCategory(rawValue: "HARM_CATEGORY_DANGEROUS_CONTENT_NEW_ENUM"),
-      probability: SafetyRating.HarmProbability(rawValue: "NEGLIGIBLE_UNKNOWN_ENUM")
+      probability: SafetyRating.HarmProbability(rawValue: "NEGLIGIBLE_UNKNOWN_ENUM"),
+      probabilityScore: 0.0,
+      severity: SafetyRating.HarmSeverity(rawValue: "HARM_SEVERITY_UNSPECIFIED"),
+      severityScore: 0.0,
+      blocked: false
     )
 
     var foundUnknownSafetyRating = false


### PR DESCRIPTION
Added the [`HarmSeverity`](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/GenerateContentResponse#HarmSeverity) enum and added the properties `probabilityScore`, `severity`, `severityScore` and `blocked` to [`SafetyRating`](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/GenerateContentResponse#SafetyRating).