### PR TITLE
[Auth] Fix crash when using TOTP MFA auth

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 11.4.0
 - [Fixed] Restore Firebase 10 behavior by ignoring `nil` display names used
   during multi factor enrollment. (#13856)
+- [Fixed] Fix crash when enrolling account with TOTP MFA. (#13880)
 
 # 11.3.0
 - [Fixed] Restore Firebase 10 behavior by querying with the

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
@@ -114,6 +114,7 @@ import Foundation
             }
           }
         }
+        return
       } else if assertion.factorID != PhoneMultiFactorInfo.PhoneMultiFactorID {
         return
       }


### PR DESCRIPTION
Using the Auth sample app, enrolling account with TOTP MFA crashes. With this fix, it does not crash (and enrollment succeeds).