### PR TITLE
Removed Unused Availability Attributes in Functions

### DIFF
--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -128,7 +128,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
   /// - Throws: An error if the callable fails to complete
   ///
   /// - Returns: The decoded `Response` value
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   public func call(_ data: Request) async throws -> Response {
     let encoded = try encoder.encode(data)
     let result = try await callable.call(encoded)
@@ -155,7 +155,7 @@ public struct Callable<Request: Encodable, Response: Decodable> {
   /// - Parameters:
   ///   - data: Parameters to pass to the trigger.
   /// - Returns: The decoded `Response` value
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   public func callAsFunction(_ data: Request) async throws -> Response {
     return try await call(data)
   }

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -128,7 +128,7 @@ open class HTTPSCallable: NSObject {
   /// - Parameter data: Parameters to pass to the trigger.
   /// - Throws: An error if the Cloud Functions invocation failed.
   /// - Returns: The result of the call.
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   open func call(_ data: Any? = nil) async throws -> HTTPSCallableResult {
     return try await withCheckedThrowingContinuation { continuation in
       // TODO(bonus): Use task to handle and cancellation.

--- a/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
+++ b/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
@@ -69,7 +69,7 @@ public class HTTPSCallableResultFake: HTTPSCallableResult {
   }
 }
 
-@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13, *)
 class HTTPSCallableTests: XCTestCase {
   func testCallWithoutParametersSuccess() {
     // given

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -118,7 +118,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testDataAsync() async throws {
     let data = DataTestRequest(
       bool: true,
@@ -173,7 +173,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testScalarAsync() async throws {
     let byName = functions.httpsCallable(
       "scalarTest",
@@ -192,7 +192,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testScalarAsyncAlternateSignature() async throws {
     let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
     let byURL: Callable<Int16, Int> = functions.httpsCallable(emulatorURL("scalarTest"))
@@ -240,7 +240,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testTokenAsync() async throws {
     // Recreate functions with a token.
     let functions = Functions(
@@ -296,7 +296,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testFCMTokenAsync() async throws {
     let byName = functions.httpsCallable(
       "FCMTokenTest",
@@ -341,7 +341,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testNullAsync() async throws {
     let byName = functions.httpsCallable(
       "nullTest",
@@ -390,7 +390,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testMissingResultAsync() async {
     let byName = functions.httpsCallable(
       "missingResultTest",
@@ -444,7 +444,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testUnhandledErrorAsync() async {
     let byName = functions.httpsCallable(
       "unhandledErrorTest",
@@ -497,7 +497,7 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testUnknownErrorAsync() async {
     let byName = functions.httpsCallable(
       "unknownErrorTest",
@@ -552,7 +552,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testExplicitErrorAsync() async {
     let byName = functions.httpsCallable(
       "explicitErrorTest",
@@ -607,7 +607,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testHttpErrorAsync() async {
     let byName = functions.httpsCallable(
       "httpErrorTest",
@@ -660,7 +660,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testThrowErrorAsync() async {
     let byName = functions.httpsCallable(
       "throwTest",
@@ -715,7 +715,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testTimeoutAsync() async {
     var byName = functions.httpsCallable(
       "timeoutTest",
@@ -777,7 +777,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testCallAsFunctionAsync() async throws {
     let data = DataTestRequest(
       bool: true,
@@ -840,7 +840,7 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+  @available(iOS 13, *)
   func testInferredTyesAsync() async throws {
     let data = DataTestRequest(
       bool: true,

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -85,7 +85,7 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {
@@ -105,7 +105,7 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+    if #available(iOS 13, *) {
       // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
       Task {
         do {


### PR DESCRIPTION
* Since `Package.swift` already limits Functions support to Catalyst 13, macOS 10.15, tvOS 13, and watchOS 7, explicit checks for these versions aren’t needed
* `@available` attributes and `#available` checks for iOS 13 remain in place