### PR TITLE
Fixed `DispatchGroup`’s Excessive Wait in `FunctionsContext`

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
@@ -66,11 +66,17 @@ struct FunctionsContextProvider {
       dispatchGroup.enter()
 
       if options?.requireLimitedUseAppCheckTokens == true {
-        appCheck.getLimitedUseToken? { tokenResult in
-          // Send only valid token to functions.
-          if tokenResult.error == nil {
-            limitedUseAppCheckToken = tokenResult.token
+        // `getLimitedUseToken(completion:)` is an optional protocol method.
+        // If it’s not implemented, we still need to leave the dispatch group.
+        if let limitedUseTokenClosure = appCheck.getLimitedUseToken {
+          limitedUseTokenClosure { tokenResult in
+            // Send only valid token to functions.
+            if tokenResult.error == nil {
+              limitedUseAppCheckToken = tokenResult.token
+            }
+            dispatchGroup.leave()
           }
+        } else {
           dispatchGroup.leave()
         }
       } else {

--- a/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
+++ b/SharedTestUtilities/AppCheckFake/FIRAppCheckFake.m
@@ -45,15 +45,15 @@
 }
 
 - (nonnull NSString *)notificationAppNameKey {
-  return @"FakeAppCheckTokenDidChangeNotification";
+  return @"AppCheckFakeAppNameNotificationKey";
 }
 
 - (nonnull NSString *)notificationTokenKey {
-  return @"FakeTokenNotificationKey";
+  return @"AppCheckFakeTokenNotificationKey";
 }
 
 - (nonnull NSString *)tokenDidChangeNotificationName {
-  return @"FakeAppCheckTokenDidChangeNotification";
+  return @"AppCheckFakeTokenDidChangeNotification";
 }
 
 @end


### PR DESCRIPTION
* `FunctionsContextProvider.getContext(options:_:)` calls `AppCheckInterop.getLimitedUseToken(completion:)`, an *optional* protocol method
* When the method is not implemented, its completion handler doesn’t get called
* This closure is responsible for leaving the dispatch group, and when it’s not called, the group waits longer than needed
* This change introduces an explicit check for whether the method is implemented
* It also adds a test which makes sure the method doesn’t exceed the .1s time limit