### PR TITLE
[Vertex AI] Rename `CandidateResponse` to `Candidate`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -50,6 +50,8 @@
 - [changed] **Breaking Change**: The `FunctionCallingConfig` initializer and
   `Mode` enum are now internal; use one of the new type methods `auto()`,
   `any(allowedFunctionNames:)`, or `none()` to create a config. (#13873)
+- [changed] **Breaking Change**: The `CandidateResponse` type is now named
+  `Candidate`. (#13897)
 - [changed] The default request timeout is now 180 seconds instead of the
   platform-default value of 60 seconds for a `URLRequest`; this timeout may
   still be customized in `RequestOptions`. (#13722)

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorDetailsView.swift
@@ -162,7 +162,7 @@ struct ErrorDetailsView: View {
   let error = GenerateContentError.responseStoppedEarly(
     reason: .maxTokens,
     response: GenerateContentResponse(candidates: [
-      CandidateResponse(content: ModelContent(role: "model", parts:
+      Candidate(content: ModelContent(role: "model", parts:
         """
         A _hypothetical_ model response.
         Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.
@@ -212,7 +212,7 @@ struct ErrorDetailsView: View {
 #Preview("Prompt Blocked") {
   let error = GenerateContentError.promptBlocked(
     response: GenerateContentResponse(candidates: [
-      CandidateResponse(content: ModelContent(role: "model", parts:
+      Candidate(content: ModelContent(role: "model", parts:
         """
         A _hypothetical_ model response.
         Cillum ex aliqua amet aliquip labore amet eiusmod consectetur reprehenderit sit commodo.

--- a/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
+++ b/FirebaseVertexAI/Sample/ChatSample/Views/ErrorView.swift
@@ -38,7 +38,7 @@ struct ErrorView: View {
     let errorPromptBlocked = GenerateContentError.promptBlocked(
       response: GenerateContentResponse(
         candidates: [
-          CandidateResponse(
+          Candidate(
             content: ModelContent(role: "model", parts: [
               """
                 A _hypothetical_ model response.

--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -30,7 +30,7 @@ public struct GenerateContentResponse: Sendable {
   }
 
   /// A list of candidate response content, ordered from best to worst.
-  public let candidates: [CandidateResponse]
+  public let candidates: [Candidate]
 
   /// A value containing the safety ratings for the response, or, if the request was blocked, a
   /// reason for blocking the request.
@@ -82,7 +82,7 @@ public struct GenerateContentResponse: Sendable {
   }
 
   /// Initializer for SwiftUI previews or tests.
-  public init(candidates: [CandidateResponse], promptFeedback: PromptFeedback? = nil,
+  public init(candidates: [Candidate], promptFeedback: PromptFeedback? = nil,
               usageMetadata: UsageMetadata? = nil) {
     self.candidates = candidates
     self.promptFeedback = promptFeedback
@@ -93,7 +93,7 @@ public struct GenerateContentResponse: Sendable {
 /// A struct representing a possible reply to a content generation prompt. Each content generation
 /// prompt may produce multiple candidate responses.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct CandidateResponse: Sendable {
+public struct Candidate: Sendable {
   /// The response's content.
   public let content: ModelContent
 
@@ -279,7 +279,7 @@ extension GenerateContentResponse: Decodable {
     }
 
     if let candidates = try container.decodeIfPresent(
-      [CandidateResponse].self,
+      [Candidate].self,
       forKey: .candidates
     ) {
       self.candidates = candidates
@@ -309,7 +309,7 @@ extension GenerateContentResponse.UsageMetadata: Decodable {
 }
 
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension CandidateResponse: Decodable {
+extension Candidate: Decodable {
   enum CodingKeys: CodingKey {
     case content
     case safetyRatings

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -162,7 +162,7 @@ final class VertexAIAPITests: XCTestCase {
   func generateContentResponseAPI() {
     let response = GenerateContentResponse(candidates: [])
 
-    let _: [CandidateResponse] = response.candidates
+    let _: [Candidate] = response.candidates
     let _: PromptFeedback? = response.promptFeedback
 
     // Usage Metadata


### PR DESCRIPTION
Renamed `CandidateResponse` to `Candidate` to align with the [Android](https://github.com/firebase/firebase-android-sdk/blob/8869a14aeddfa2da17855938039cac4255fe4d8a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Candidate.kt#L29) and [Flutter](https://github.com/firebase/flutterfire/blob/b3822b4db1f982bf2b216d7129c55947201dbb45/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart#L281) SDKs.