### PR TITLE
Async `FunctionsContextProvider.context(options:)`

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
@@ -36,12 +36,53 @@ struct FunctionsContextProvider {
     self.appCheck = appCheck
   }
 
-  // TODO: Implement async await version
-//  @available(macOS 10.15.0, *)
-//  internal func getContext() async throws -> FunctionsContext {
-//    return FunctionsContext(authToken: nil, fcmToken: nil, appCheckToken: nil)
-//
-//  }
+  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
+  func context(options: HTTPSCallableOptions?) async throws -> FunctionsContext {
+    async let authToken = auth?.getToken(forcingRefresh: false)
+    async let appCheckToken = getAppCheckToken(options: options)
+    async let limitedUseAppCheckToken = getLimitedUseAppCheckToken(options: options)
+
+    // Only `authToken` is throwing, but the formatter script removes the `try`
+    // from `try authToken` and puts it in front of the initializer call.
+    return try await FunctionsContext(
+      authToken: authToken,
+      fcmToken: messaging?.fcmToken,
+      appCheckToken: appCheckToken,
+      limitedUseAppCheckToken: limitedUseAppCheckToken
+    )
+  }
+
+  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
+  private func getAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
+    guard
+      options?.requireLimitedUseAppCheckTokens != true,
+      let tokenResult = await appCheck?.getToken(forcingRefresh: false),
+      tokenResult.error == nil
+    else { return nil }
+    return tokenResult.token
+  }
+
+  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
+  private func getLimitedUseAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
+    // At the moment, `await` doesn’t get along with Objective-C’s optional protocol methods.
+    await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in
+      guard
+        options?.requireLimitedUseAppCheckTokens == true,
+        let appCheck,
+        // `getLimitedUseToken(completion:)` is an optional protocol method. Optional binding
+        // is performed to make sure `continuation` is called even if the method’s not implemented.
+        let limitedUseTokenClosure = appCheck.getLimitedUseToken
+      else {
+        return continuation.resume(returning: nil)
+      }
+
+      limitedUseTokenClosure { tokenResult in
+        // Make sure there’s no error and the token is valid:
+        guard tokenResult.error == nil else { return continuation.resume(returning: nil) }
+        continuation.resume(returning: tokenResult.token)
+      }
+    }
+  }
 
   func getContext(options: HTTPSCallableOptions? = nil,
                   _ completion: @escaping ((FunctionsContext, Error?) -> Void)) {


### PR DESCRIPTION
* Introduced `FunctionsContextProvider.context(options:)`, an async / await version of `getContext(options:_:)`
* Added tests