### PR TITLE
Firestore: review app check credentials provider tests

### DIFF
--- a/Firestore/core/test/unit/credentials/firebase_app_check_credentials_provider_test.mm
+++ b/Firestore/core/test/unit/credentials/firebase_app_check_credentials_provider_test.mm
@@ -181,7 +181,7 @@ TEST(FirebaseAppCheckCredentialsProviderTest, ListenForTokenChanges) {
 
 // Regression test for https://github.com/firebase/firebase-ios-sdk/issues/8895
 TEST(FirebaseAppCheckCredentialsProviderTest,
-     ListenForTokenChangesIgnoresUnrelatedNotifcations) {
+     ListenForTokenChangesIgnoresUnrelatedNotifications) {
   auto token_promise = std::make_shared<std::promise<std::string>>();
 
   FIRApp* app = testutil::AppForUnitTesting();


### PR DESCRIPTION
I haven't found any references to this, but please double-check if possible. Thanks!