### PR TITLE
[Config] Mark two `RCNConfigSettings` properties `atomic`

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Mark two internal properties as `atomic` to prevent concurrency
+  related crash. (#13898)
+
 # 11.0.0
 - [fixed] RemoteConfigValue stringValue is now `nonnull`. This may break some builds. (#10870)
 - [removed] **Breaking change**: The deprecated `FirebaseRemoteConfigSwift`

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
@@ -41,9 +41,11 @@
 /// Device data version of checkin information.
 @property(nonatomic, copy) NSString *deviceDataVersion;
 /// InstallationsID.
-@property(nonatomic, copy) NSString *configInstallationsIdentifier;
+/// @note The property is atomic because it is access across multiple threads.
+@property(atomic, copy) NSString *configInstallationsIdentifier;
 /// Installations token.
-@property(nonatomic, copy) NSString *configInstallationsToken;
+/// @note The property is atomic because it is access across multiple threads.
+@property(atomic, copy) NSString *configInstallationsToken;
 
 /// A list of successful fetch timestamps in milliseconds.
 /// TODO Not used anymore. Safe to remove.

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
@@ -41,10 +41,10 @@
 /// Device data version of checkin information.
 @property(nonatomic, copy) NSString *deviceDataVersion;
 /// InstallationsID.
-/// @note The property is atomic because it is access across multiple threads.
+/// @note The property is atomic because it is accessed across multiple threads.
 @property(atomic, copy) NSString *configInstallationsIdentifier;
 /// Installations token.
-/// @note The property is atomic because it is access across multiple threads.
+/// @note The property is atomic because it is accessed across multiple threads.
 @property(atomic, copy) NSString *configInstallationsToken;
 
 /// A list of successful fetch timestamps in milliseconds.


### PR DESCRIPTION
The crashing frame is on `objc_release_x0` so I'm thinking that that the instance is being over-released.
```
Thread 24 Queue 295: com.google.GoogleConfigService.FIRRemoteConfig (serial) [Crashed]:

0    libobjc.A.dylib                          0x1897da370     objc_release_x0 + 16
1    CoreFoundation                           0x18c495394     __CFBasicHashReplaceValue + 415
2    CoreFoundation                           0x18c493d04     CFDictionarySetValue + 207
3    CFNetwork                                0x18d9409bc     HTTPHeaderDict::setValue(HTTPHeaderKeyMixedValue const&, HTTPHeaderValueMixedValue const&) + 143
4    CFNetwork                                0x18d94082c     HTTPMessage::setHeaderFieldStringValue(__CFString const*, __CFString const*) + 99
5    CFNetwork                                0x18d93fbcc     CFURLRequestSetHTTPHeaderFieldValue + 127
6    FlexNetworkingProduction                 0x101729cb4     __53-[RCNConfigRealtime createRequestBodyWithCompletion:]_block_invoke + 183
7    libdispatch.dylib                        0x194164370     _dispatch_call_block_and_release + 31
8    libdispatch.dylib                        0x1941660d0     _dispatch_client_callout + 19
9    libdispatch.dylib                        0x19416d6d8     _dispatch_lane_serial_drain + 743
10   libdispatch.dylib                        0x19416e1e0     _dispatch_lane_invoke + 379
11   libdispatch.dylib                        0x194179258     _dispatch_root_queue_drain_deferred_wlh + 287
12   libdispatch.dylib                        0x194178aa4     _dispatch_workloop_worker_thread + 539
13   libsystem_pthread.dylib                  0x213857c7c     _pthread_wqthread + 287
14   libsystem_pthread.dylib                  0x213854488     start_wqthread + 7
```

These properties are never sent in `RCNConfigSettings`'s initialization but rather on one of two different queues:

https://github.com/firebase/firebase-ios-sdk/blob/8328630971a8fdd8072b36bb22bef732eb15e1f0/FirebaseRemoteConfig/Sources/RCNConfigFetch.m#L302-L311

https://github.com/firebase/firebase-ios-sdk/blob/8328630971a8fdd8072b36bb22bef732eb15e1f0/FirebaseRemoteConfig/Sources/RCNConfigRealtime.m#L263-L272

<img width="702" alt="Screenshot 2024-10-17 at 4 19 08 PM" src="https://github.com/user-attachments/assets/eb18da6b-6285-4457-9e2a-96227bc5bd47">

<img width="701" alt="Screenshot 2024-10-17 at 4 19 25 PM" src="https://github.com/user-attachments/assets/4fe0d554-b79b-46d0-846c-2d9503b1e470">

They are currently marked `nonatomic`, so my hypothesis is that concurrent sets lead to an object with an invalid retain count, and when the property is later accessed here. It causes a crash when trying to over-release the invalid instance.

I did some searching and [`atomic`](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocProperties.html) seemed to be an acceptable solution. Others were to add a queue inside `RCNConfigSettings` which seemed too heavyweight, as well as overwriting the getter and setter to use `@synchronized` which seemed reasonable but adding atomic was less LOC.

Fix #13898