### PR TITLE
[Core] Make instance manager conform to Swift 6 principles

### DIFF
--- a/FirebaseCore/Internal/Tests/Unit/HeartbeatStorageTests.swift
+++ b/FirebaseCore/Internal/Tests/Unit/HeartbeatStorageTests.swift
@@ -399,6 +399,45 @@ class HeartbeatStorageTests: XCTestCase {
     // Then
     wait(for: expectations, timeout: 1.0, enforceOrder: true)
   }
+
+  func testForMemoryLeakInInstanceManagemer() {
+    // Given
+    let id = "testID"
+    var weakRefs: [WeakContainer<HeartbeatStorage>] = []
+    // Lock is used to synchronize `weakRefs` during concurrent access.
+    let weakRefsLock = NSLock()
+
+    // When
+    // Simulate concurrent access. This will help expose race conditions that could cause a crash.
+    let group = DispatchGroup()
+    for _ in 0 ..< 100 {
+      group.enter()
+      DispatchQueue.global().async {
+        let instance = HeartbeatStorage.getInstance(id: id)
+        weakRefsLock.withLock {
+          weakRefs.append(WeakContainer(object: instance))
+        }
+        group.leave()
+      }
+    }
+    group.wait()
+
+    #if !os(macOS)
+      // Simulate memory pressure. This will force the system to more aggressively reclaim memory.
+      // This simulation makes the test more sensitive to potential leaks.
+      NotificationCenter.default.post(
+        name: UIApplication.didReceiveMemoryWarningNotification,
+        object: UIApplication.shared
+      )
+    #endif // !os(macOS)
+
+    // Then
+    // The `weakRefs` array's references should all be nil; otherwise, something is being
+    // unexpectedly strongly retained.
+    for weakRef in weakRefs {
+      XCTAssertNil(weakRef.object, "Potential memory leak detected.")
+    }
+  }
 }
 
 private class StorageFake: Storage {


### PR DESCRIPTION
Problem: `Static property 'cachedInstances' is not concurrency-safe because it is nonisolated global shared mutable state`

The fix-it to add `nonisolated(unsafe)` is for when it's okay to `Disable concurrency-safety checks if accesses are protected by an external synchronization mechanism`.

The "external synchronization mechanism" is the added lock. I went with `NSLock` of `os_unfair_lock` because the latter would need to be another `static var` and require an extra `nonisolated(unsafe)` attribute. This would be technically okay, but it looked cleaner to use the NSLock. NSLock is slightly slower but I think it would have a negligible effect based on the use case here.

Because core internal has < iOS 13 availability, structured concurrency cannot be used.

#no-changelog

