### PR TITLE
[Core] Make storage class conform to Sendable

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatStorage.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/HeartbeatStorage.swift
@@ -17,19 +17,20 @@ import Foundation
 /// A type that can perform atomic operations using block-based transformations.
 protocol HeartbeatStorageProtocol {
   func readAndWriteSync(using transform: (HeartbeatsBundle?) -> HeartbeatsBundle?)
-  func readAndWriteAsync(using transform: @escaping (HeartbeatsBundle?) -> HeartbeatsBundle?)
+  func readAndWriteAsync(using transform: @escaping @Sendable (HeartbeatsBundle?)
+    -> HeartbeatsBundle?)
   func getAndSet(using transform: (HeartbeatsBundle?) -> HeartbeatsBundle?) throws
     -> HeartbeatsBundle?
-  func getAndSetAsync(using transform: @escaping (HeartbeatsBundle?) -> HeartbeatsBundle?,
-                      completion: @escaping (Result<HeartbeatsBundle?, Error>) -> Void)
+  func getAndSetAsync(using transform: @escaping @Sendable (HeartbeatsBundle?) -> HeartbeatsBundle?,
+                      completion: @escaping @Sendable (Result<HeartbeatsBundle?, Error>) -> Void)
 }
 
 /// Thread-safe storage object designed for transforming heartbeat data that is persisted to disk.
-final class HeartbeatStorage: HeartbeatStorageProtocol {
+final class HeartbeatStorage: Sendable, HeartbeatStorageProtocol {
   /// The identifier used to differentiate instances.
   private let id: String
   /// The underlying storage container to read from and write to.
-  private let storage: Storage
+  private let storage: any Storage
   /// The encoder used for encoding heartbeat data.
   private let encoder: JSONEncoder = .init()
   /// The decoder used for decoding heartbeat data.
@@ -107,7 +108,8 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
   /// Asynchronously reads from and writes to storage using the given transform block.
   /// - Parameter transform: A block to transform the currently stored heartbeats bundle to a new
   /// heartbeats bundle value.
-  func readAndWriteAsync(using transform: @escaping (HeartbeatsBundle?) -> HeartbeatsBundle?) {
+  func readAndWriteAsync(using transform: @escaping @Sendable (HeartbeatsBundle?)
+    -> HeartbeatsBundle?) {
     queue.async { [self] in
       let oldHeartbeatsBundle = try? load(from: storage)
       let newHeartbeatsBundle = transform(oldHeartbeatsBundle)
@@ -143,8 +145,8 @@ final class HeartbeatStorage: HeartbeatStorageProtocol {
   ///   - completion: An escaping block used to process the heartbeat data that
   ///   was stored (before the `transform` was applied); otherwise, the error
   ///   that occurred.
-  func getAndSetAsync(using transform: @escaping (HeartbeatsBundle?) -> HeartbeatsBundle?,
-                      completion: @escaping (Result<HeartbeatsBundle?, Error>) -> Void) {
+  func getAndSetAsync(using transform: @escaping @Sendable (HeartbeatsBundle?) -> HeartbeatsBundle?,
+                      completion: @escaping @Sendable (Result<HeartbeatsBundle?, Error>) -> Void) {
     queue.async {
       do {
         let oldHeartbeatsBundle = try? self.load(from: self.storage)

--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/StorageFactory.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/StorageFactory.swift
@@ -56,11 +56,7 @@ extension FileManager {
 extension UserDefaultsStorage: StorageFactory {
   static func makeStorage(id: String) -> Storage {
     let suiteName = Constants.heartbeatUserDefaultsSuiteName
-    // It's safe to force unwrap the below defaults instance because the
-    // initializer only returns `nil` when the bundle id or `globalDomain`
-    // is passed in as the `suiteName`.
-    let defaults = UserDefaults(suiteName: suiteName)!
     let key = "heartbeats-\(id)"
-    return UserDefaultsStorage(defaults: defaults, key: key)
+    return UserDefaultsStorage(suiteName: suiteName, key: key)
   }
 }

--- a/FirebaseCore/Internal/Tests/Unit/StorageTests.swift
+++ b/FirebaseCore/Internal/Tests/Unit/StorageTests.swift
@@ -97,22 +97,23 @@ class FileStorageTests: XCTestCase {
 
 class UserDefaultsStorageTests: XCTestCase {
   var defaults: UserDefaults!
-  let suiteName = #file
+  let suiteName = "com.firebase.userdefaults.storageTests"
 
   override func setUpWithError() throws {
-    defaults = try XCTUnwrap(UserDefaultsFake(suiteName: suiteName))
+    // Clear the user default suite before testing.
+    UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
   }
 
   func testRead_WhenDefaultDoesNotExist_ThrowsError() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     // Then
     XCTAssertThrowsError(try defaultsStorage.read())
   }
 
   func testRead_WhenDefaultExists_ReturnsDefault() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     XCTAssertNoThrow(try defaultsStorage.write(Constants.testData))
     // When
     let storedData = try defaultsStorage.read()
@@ -122,7 +123,7 @@ class UserDefaultsStorageTests: XCTestCase {
 
   func testWriteData_WhenDefaultDoesNotExist_CreatesDefault() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     XCTAssertThrowsError(try defaultsStorage.read())
     // When
     XCTAssertNoThrow(try defaultsStorage.write(Constants.testData))
@@ -133,7 +134,7 @@ class UserDefaultsStorageTests: XCTestCase {
 
   func testWriteData_WhenDefaultExists_ModifiesDefault() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     XCTAssertNoThrow(try defaultsStorage.write(Constants.testData))
     // When
     let modifiedData = #function.data(using: .utf8)
@@ -146,7 +147,7 @@ class UserDefaultsStorageTests: XCTestCase {
 
   func testWriteNil_WhenDefaultDoesNotExist_RemovesDefault() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     XCTAssertThrowsError(try defaultsStorage.read())
     // When
     XCTAssertNoThrow(try defaultsStorage.write(nil))
@@ -156,25 +157,11 @@ class UserDefaultsStorageTests: XCTestCase {
 
   func testWriteNil_WhenDefaultExists_RemovesDefault() throws {
     // Given
-    let defaultsStorage = UserDefaultsStorage(defaults: defaults, key: #function)
+    let defaultsStorage = UserDefaultsStorage(suiteName: suiteName, key: #function)
     XCTAssertNoThrow(try defaultsStorage.write(Constants.testData))
     // When
     XCTAssertNoThrow(try defaultsStorage.write(nil))
     // Then
     XCTAssertThrowsError(try defaultsStorage.read())
-  }
-}
-
-// MARK: - Fakes
-
-private class UserDefaultsFake: UserDefaults {
-  private var defaults = [String: Any]()
-
-  override func object(forKey defaultName: String) -> Any? {
-    defaults[defaultName]
-  }
-
-  override func set(_ value: Any?, forKey defaultName: String) {
-    defaults[defaultName] = value
   }
 }


### PR DESCRIPTION
Addresses two more Swift 6 errors:
- 💥 Capture of 'self' with non-sendable type 'HeartbeatStorage' in a `@Sendable` closure
       let oldHeartbeatsBundle = try? load(from: storage)


Needed to conform `HeartbeatStorage` class to `Sendable` ([requirements](https://developer.apple.com/documentation/swift/sendable#Sendable-Classes)).

The problem was the second requirement: _Contain only stored properties that are immutable and sendable_

```swift
private let storage: any Storage // Also needed to be made Sendable
```

Jumping into the `Storage.swift` file, the two conforming classes, `FileStorage` and `UserDefaultsStorage`, wrapped Foundation APIs `FileManager` and `UserDefaults`, respectively. Both Foundation APIs are not Sendable and it would be risky for us to add such conformance. So, I followed the approach discussed in https://forums.developer.apple.com/forums/thread/757527 to remove them as stored properties and instead initialize them in each context they are needed. It's not great, but avoids having to use unchecked Sendable.

- 💥 Capture of 'transform' with non-sendable type '(HeartbeatsBundle?) -> HeartbeatsBundle?' in a `@Sendable` closure

This is straightforward– `DispatchQueue.async` takes an Sendable closure so we need to pass it one.

#no-changelog