### PR TITLE
Fixing upload-symbols run script argument order

### DIFF
--- a/Crashlytics/run
+++ b/Crashlytics/run
@@ -46,8 +46,8 @@ for i in "$@"; do
   ARGUMENTS="$ARGUMENTS \"$i\""
 done
 
-VALIDATE_ARGUMENTS="$ARGUMENTS --build-phase --validate"
-UPLOAD_ARGUMENTS="$ARGUMENTS --build-phase"
+VALIDATE_ARGUMENTS="--build-phase --validate $ARGUMENTS"
+UPLOAD_ARGUMENTS="--build-phase $ARGUMENTS "
 
 # Quote the path to handle folders with special characters
 COMMAND_PATH="\"$DIR/upload-symbols\" "


### PR DESCRIPTION
Changed argument order since the paths argument should be in the end of the arguments list. This fixes #13965

