### PR TITLE
[Vertex AI] Disable xcodebuild parallel testing

### DIFF
--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -18,8 +18,6 @@ import FirebaseStorage
 import FirebaseVertexAI
 import XCTest
 
-// TODO(andrewheard): Remove this after testing on CI.
-
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class IntegrationTests: XCTestCase {
   // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -18,6 +18,8 @@ import FirebaseStorage
 import FirebaseVertexAI
 import XCTest
 
+// TODO(andrewheard): Remove this after testing on CI.
+
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class IntegrationTests: XCTestCase {
   // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -508,6 +508,7 @@ case "$product-$platform-$method" in
       -project 'FirebaseVertexAI/Tests/TestApp/VertexAITestApp.xcodeproj' \
       -scheme "VertexAITestApp-SPM" \
       "${xcb_flags[@]}" \
+      -parallel-testing-enabled NO \
       build \
       test
     ;;


### PR DESCRIPTION
Set the `-parallel-testing-enabled` flag to `NO` in `xcodebuild` for the `vertexai / testapp-integration` tests. The integration tests likely shouldn't run in parallel and the output produced by parallel testing (the default in new Xcode projects) seems to be unsupported by `xcpretty` (https://github.com/xcpretty/xcpretty/issues/295). This fixes the logs, which now show [passing tests](https://github.com/firebase/firebase-ios-sdk/actions/runs/11565777796/job/32193359823?pr=13985#step:7:261).

#no-changelog