### PR TITLE
[Auth] Use constants for 'supportsSecureCoding' implementation

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
@@ -54,7 +54,7 @@ extension AuthDataResult: NSSecureCoding {}
   private let kUserCodingKey = "user"
   private let kCredentialCodingKey = "credential"
 
-  public static var supportsSecureCoding = true
+  public static let supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(user, forKey: kUserCodingKey)

--- a/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthTokenResult.swift
@@ -129,9 +129,7 @@ extension AuthTokenResult: NSSecureCoding {}
 
   private static let kTokenKey = "token"
 
-  public static var supportsSecureCoding: Bool {
-    return true
-  }
+  public static let supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(token, forKey: AuthTokenResult.kTokenKey)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -62,7 +62,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  static var supportsSecureCoding = true
+  static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(email, forKey: "email")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -48,7 +48,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  static var supportsSecureCoding = true
+  static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(accessToken, forKey: "accessToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -163,7 +163,7 @@
 
     // MARK: Secure Coding
 
-    static var supportsSecureCoding = true
+    static let supportsSecureCoding = true
 
     func encode(with coder: NSCoder) {
       coder.encode(playerID, forKey: "playerID")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
@@ -48,7 +48,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  public static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(token, forKey: "token")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -53,7 +53,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  static var supportsSecureCoding = true
+  static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(idToken, forKey: "idToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -96,7 +96,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding: Bool = true
+  public static let supportsSecureCoding: Bool = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(idToken, forKey: "IDToken")

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
@@ -39,7 +39,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  public static var supportsSecureCoding = true
+  public static let supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     switch credentialKind {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -52,7 +52,7 @@ import Foundation
 
   // MARK: Secure Coding
 
-  static var supportsSecureCoding = true
+  static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(token, forKey: "token")

--- a/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
+++ b/FirebaseAuth/Sources/Swift/MultiFactor/MultiFactor.swift
@@ -282,9 +282,7 @@ import Foundation
 
     private let kEnrolledFactorsCodingKey = "enrolledFactors"
 
-    public static var supportsSecureCoding: Bool {
-      true
-    }
+    public static let supportsSecureCoding = true
 
     public func encode(with coder: NSCoder) {
       coder.encode(enrolledFactors, forKey: kEnrolledFactorsCodingKey)

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift
@@ -38,9 +38,7 @@ class AuthAppCredential: NSObject, NSSecureCoding {
   private static let kReceiptKey = "receipt"
   private static let kSecretKey = "secret"
 
-  static var supportsSecureCoding: Bool {
-    true
-  }
+  static let supportsSecureCoding = true
 
   required convenience init?(coder: NSCoder) {
     guard let receipt = coder.decodeObject(of: NSString.self,

--- a/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
@@ -164,9 +164,7 @@ class SecureTokenService: NSObject, NSSecureCoding {
   private static let kAccessTokenKey = "accessToken"
   private static let kAccessTokenExpirationDateKey = "accessTokenExpirationDate"
 
-  static var supportsSecureCoding: Bool {
-    true
-  }
+  static let supportsSecureCoding = true
 
   required convenience init?(coder: NSCoder) {
     guard let refreshToken = coder.decodeObject(of: [NSString.self],

--- a/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
+++ b/FirebaseAuth/Sources/Swift/User/AdditionalUserInfo.swift
@@ -49,9 +49,7 @@ extension AdditionalUserInfo: NSSecureCoding {}
   private static let usernameCodingKey = "username"
   private static let newUserKey = "newUser"
 
-  public static var supportsSecureCoding: Bool {
-    return true
-  }
+  public static let supportsSecureCoding = true
 
   public required init?(coder aDecoder: NSCoder) {
     guard let providerID = aDecoder.decodeObject(

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1680,9 +1680,7 @@ extension User: NSSecureCoding {}
   private let kMultiFactorCodingKey = "multiFactor"
   private let kTenantIDCodingKey = "tenantID"
 
-  public static var supportsSecureCoding: Bool {
-    return true
-  }
+  public static let supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(uid, forKey: kUserIDCodingKey)

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -72,9 +72,7 @@ extension UserInfoImpl: NSSecureCoding {}
   private static let kEmailCodingKey = "email"
   private static let kPhoneNumberCodingKey = "phoneNumber"
 
-  static var supportsSecureCoding: Bool {
-    return true
-  }
+  static let supportsSecureCoding = true
 
   func encode(with coder: NSCoder) {
     coder.encode(providerID, forKey: UserInfoImpl.kProviderIDCodingKey)

--- a/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserMetadata.swift
@@ -36,9 +36,7 @@ extension UserMetadata: NSSecureCoding {}
   private static let kCreationDateCodingKey = "creationDate"
   private static let kLastSignInDateCodingKey = "lastSignInDate"
 
-  public static var supportsSecureCoding: Bool {
-    return true
-  }
+  public static let supportsSecureCoding = true
 
   public func encode(with coder: NSCoder) {
     coder.encode(creationDate, forKey: UserMetadata.kCreationDateCodingKey)


### PR DESCRIPTION
The static var does not compile in Swift 6 due to shared mutable state. To
work around, you can use a constant or a computed var. To standardize things,
I chose to go with a constant.

This should not affect how the types conform to NSSecureCoding as a constant
can be used to implement a protocol getter-only property. See
https://stackoverflow.com/a/38281420/9331576

#no-changelog
