### PR TITLE
CocoaPods 1.16.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.15.2'
+gem 'cocoapods', '1.16.0'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'
-
-# TODO: delete explicit xcodeproj after cocoapods goes beyond 1.15.2.
-gem 'xcodeproj', '1.25.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,10 @@ source 'https://rubygems.org'
 # favorite editor. See https://github.com/firebase/firebase-ios-sdk/pull/8498
 # for examples.
 
-gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "204b415"
+# gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "9cebcde577f56aa26f27d8aa501b51fdd4d6abdb"
+# gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
+# gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
+gem 'cocoapods', '1.16.0'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.16.0'
+gem 'cocoapods', '1.16.1'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,7 @@ source 'https://rubygems.org'
 # favorite editor. See https://github.com/firebase/firebase-ios-sdk/pull/8498
 # for examples.
 
-# gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "9cebcde577f56aa26f27d8aa501b51fdd4d6abdb"
-# gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
-# gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
+gem 'cocoapods', git: "https://github.com/CocoaPods/CocoaPods.git", ref: "204b415"
 
-gem 'cocoapods', '1.16.0'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '8.4.5'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ source 'https://rubygems.org'
 # gem 'cocoapods-core', git: "https://github.com/CocoaPods/Core.git", ref: "f7cf05720eab935d7d50e35224d263952176fb53"
 # gem 'xcodeproj', git: "https://github.com/CocoaPods/Xcodeproj.git", ref: "eeccae7275645753cbaf45d96fc4b23e4b8b3b9f"
 
-gem 'cocoapods', '1.16.1'
+gem 'cocoapods', '1.16.2'
 gem 'cocoapods-generate', '2.2.5'
-gem 'xcodeproj', '>= 1.27.0'
 gem 'danger', '8.4.5'

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '1.16.1'
 gem 'cocoapods-generate', '2.2.5'
+gem 'xcodeproj', '>= 1.27.0'
 gem 'danger', '8.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,27 @@
+GIT
+  remote: https://github.com/CocoaPods/CocoaPods.git
+  revision: 204b4158866900594790eb6d725cf80a642c0dbd
+  ref: 204b415
+  specs:
+    cocoapods (1.16.0)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.16.0)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.26.0, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -28,24 +52,6 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.16.0)
-      addressable (~> 2.8)
-      claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.16.0)
-      cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 2.1, < 3.0)
-      cocoapods-plugins (>= 1.0.0, < 2.0)
-      cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.6.0, < 2.0)
-      cocoapods-try (>= 1.1.0, < 2.0)
-      colored2 (~> 3.1)
-      escape (~> 0.0.4)
-      fourflusher (>= 2.3.0, < 3.0)
-      gh_inspector (~> 1.0)
-      molinillo (~> 0.8.0)
-      nap (~> 1.0)
-      ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.26.0, < 2.0)
     cocoapods-core (1.16.0)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
@@ -170,7 +176,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.16.0)
+  cocoapods!
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,18 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.4.2)
+    activesupport (7.1.5)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
       mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
@@ -22,16 +25,17 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
     claide-plugins (0.9.2)
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.16.1)
+    cocoapods (1.16.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.16.1)
+      cocoapods-core (= 1.16.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -45,8 +49,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.26.0, < 2.0)
-    cocoapods-core (1.16.1)
+      xcodeproj (>= 1.27.0, < 2.0)
+    cocoapods-core (1.16.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -125,11 +129,12 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.7.4)
+    json (2.7.5)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    logger (1.6.1)
     minitest (5.25.1)
     molinillo (0.8.0)
     multipart-post (2.4.1)
@@ -151,6 +156,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    securerandom (0.3.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     typhoeus (1.4.1)
@@ -170,10 +176,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.16.1)
+  cocoapods (= 1.16.2)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
-  xcodeproj (>= 1.27.0)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,10 +28,10 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.16.0)
+    cocoapods (1.16.1)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.16.0)
+      cocoapods-core (= 1.16.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -46,7 +46,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.26.0, < 2.0)
-    cocoapods-core (1.16.0)
+    cocoapods-core (1.16.1)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -170,7 +170,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.16.0)
+  cocoapods (= 1.16.1)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    xcodeproj (1.26.0)
+    xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -173,6 +173,7 @@ DEPENDENCIES
   cocoapods (= 1.16.1)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
+  xcodeproj (>= 1.27.0)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.3.4)
+    activesupport (7.1.4.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -28,10 +28,10 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.15.2)
+    cocoapods (1.16.0)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.15.2)
+      cocoapods-core (= 1.16.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -45,8 +45,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.15.2)
+      xcodeproj (>= 1.26.0, < 2.0)
+    cocoapods-core (1.16.0)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -69,7 +69,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     cork (0.3.0)
       colored2 (~> 3.1)
@@ -123,18 +123,18 @@ GEM
       addressable (~> 2.8)
       rchardet (~> 1.8)
     httpclient (2.8.3)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
+    json (2.7.4)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    minitest (5.24.1)
+    minitest (5.25.1)
     molinillo (0.8.0)
     multipart-post (2.4.1)
     mutex_m (0.2.0)
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
@@ -158,22 +158,21 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    xcodeproj (1.25.0)
+    xcodeproj (1.26.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.15.2)
+  cocoapods (= 1.16.0)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
-  xcodeproj (= 1.25.0)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,3 @@
-GIT
-  remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: 204b4158866900594790eb6d725cf80a642c0dbd
-  ref: 204b415
-  specs:
-    cocoapods (1.16.0)
-      addressable (~> 2.8)
-      claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.16.0)
-      cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 2.1, < 3.0)
-      cocoapods-plugins (>= 1.0.0, < 2.0)
-      cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.6.0, < 2.0)
-      cocoapods-try (>= 1.1.0, < 2.0)
-      colored2 (~> 3.1)
-      escape (~> 0.0.4)
-      fourflusher (>= 2.3.0, < 3.0)
-      gh_inspector (~> 1.0)
-      molinillo (~> 0.8.0)
-      nap (~> 1.0)
-      ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.26.0, < 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,6 +28,24 @@ GEM
       cork
       nap
       open4 (~> 1.3)
+    cocoapods (1.16.0)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.16.0)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.26.0, < 2.0)
     cocoapods-core (1.16.0)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
@@ -176,7 +170,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods!
+  cocoapods (= 1.16.0)
   cocoapods-generate (= 2.2.5)
   danger (= 8.4.5)
 


### PR DESCRIPTION
This PR worked through integration testing of CocoaPods 1.16.*, finding issues with 1.16.0 and 1.16.1 before settling on 1.16.2