### PR TITLE
[Vertex AI] Remove `format` for `double()` `Schema`

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [fixed] Fixed an issue where `VertexAI.vertexAI(app: app1)` and
   `VertexAI.vertexAI(app: app2)` would return the same instance if their
   `location` was the same, including the default `us-central1`. (#14007)
+- [changed] Removed `format: "double"` in `Schema.double()` since
+  double-precision accuracy isn't enforced by the model; continue using the
+  Swift `Double` type when decoding data produced with this schema. (#13990)
 
 # 11.4.0
 - [feature] Vertex AI in Firebase is now Generally Available (GA) and can be

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -178,7 +178,8 @@ public class Schema {
   public static func float(description: String? = nil, nullable: Bool = false) -> Schema {
     return self.init(
       type: .number,
-      format: "float",
+      // TODO(andrewheard): Revert this change when the backend accepts "float" as a format again.
+      // format: "float",
       description: description,
       nullable: nullable
     )
@@ -202,7 +203,8 @@ public class Schema {
   public static func double(description: String? = nil, nullable: Bool = false) -> Schema {
     return self.init(
       type: .number,
-      format: "double",
+      // TODO(andrewheard): Revert this change when the backend accepts "double" as a format again.
+      // format: "double",
       description: description,
       nullable: nullable
     )

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -178,22 +178,16 @@ public class Schema {
   public static func float(description: String? = nil, nullable: Bool = false) -> Schema {
     return self.init(
       type: .number,
-      // TODO(andrewheard): Revert this change when the backend accepts "float" as a format again.
-      // format: "float",
+      format: "float",
       description: description,
       nullable: nullable
     )
   }
 
-  /// Returns a `Schema` representing a double-precision floating-point number.
+  /// Returns a `Schema` representing a floating-point number.
   ///
-  /// This schema instructs the model to produce data of type `"NUMBER"` with the `format`
-  /// `"double"`, which is suitable for decoding into a Swift `Double` (or `Double?`, if `nullable`
-  /// is set to `true`).
-  ///
-  /// > Important: This `Schema` provides a hint to the model that it should generate a
-  /// > double-precision floating-point number, a `double`, but only guarantees that the value will
-  /// > be a number.
+  /// This schema instructs the model to produce data of type `"NUMBER"`, which is suitable for
+  /// decoding into a Swift `Double` (or `Double?`, if `nullable` is set to `true`).
   ///
   /// - Parameters:
   ///   - description: An optional description of what the number should contain or represent; may
@@ -203,8 +197,6 @@ public class Schema {
   public static func double(description: String? = nil, nullable: Bool = false) -> Schema {
     return self.init(
       type: .number,
-      // TODO(andrewheard): Revert this change when the backend accepts "double" as a format again.
-      // format: "double",
       description: description,
       nullable: nullable
     )


### PR DESCRIPTION
Removed the `"double"` format hint in `Schema.double()` since it is not enforced by the model. Developers should continue to decode the data produced into `Double` values to avoid losing precision where available.

Additionally, this works around a temporary backend issue where `format` is not accepted for numeric types. `Unable to submit request because one or more response schemas specified incorrect schema type field. For schema with format, schema type should be STRING. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output` (see #13977 for more details).

Note: This PR does not resolve the issue for `float()`; consider using `double()` until #13977 is resolved in the backend.