### PR TITLE
[Infra] Only compile core extension headers once

### DIFF
--- a/FirebaseCore/Extension/FIRAppInternal.h
+++ b/FirebaseCore/Extension/FIRAppInternal.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef FIREBASECORE_FIRAPPINTERNAL_H
+#define FIREBASECORE_FIRAPPINTERNAL_H
+
 #import <FirebaseCore/FIRApp.h>
 
 @class FIRComponentContainer;
@@ -175,3 +178,5 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRAPPINTERNAL_H

--- a/FirebaseCore/Extension/FIRComponent.h
+++ b/FirebaseCore/Extension/FIRComponent.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef FIREBASECORE_FIRCOMPONENT_H
+#define FIREBASECORE_FIRCOMPONENT_H
+
 #import <Foundation/Foundation.h>
 
 @class FIRApp;
@@ -82,3 +85,5 @@ NS_SWIFT_NAME(init(_:instantiationTiming:creationBlock:));
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRCOMPONENT_H

--- a/FirebaseCore/Extension/FIRComponentContainer.h
+++ b/FirebaseCore/Extension/FIRComponentContainer.h
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifndef FIREBASECORE_FIRCOMPONENTCONTAINER_H
+#define FIREBASECORE_FIRCOMPONENTCONTAINER_H
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -43,3 +47,5 @@ NS_SWIFT_NAME(FirebaseComponentContainer)
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRCOMPONENTCONTAINER_H

--- a/FirebaseCore/Extension/FIRComponentType.h
+++ b/FirebaseCore/Extension/FIRComponentType.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef FIREBASECORE_FIRCOMPONENTTYPE_H
+#define FIREBASECORE_FIRCOMPONENTTYPE_H
+
 #import <Foundation/Foundation.h>
 
 @class FIRComponentContainer;
@@ -33,3 +36,5 @@ NS_SWIFT_NAME(ComponentType)
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRCOMPONENTTYPE_H

--- a/FirebaseCore/Extension/FIRHeartbeatLogger.h
+++ b/FirebaseCore/Extension/FIRHeartbeatLogger.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef FIREBASECORE_FIRHEARTBEATLOGGER_H
+#define FIREBASECORE_FIRHEARTBEATLOGGER_H
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -102,3 +105,5 @@ NSString *_Nullable FIRHeaderValueFromHeartbeatsPayload(FIRHeartbeatsPayload *he
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRHEARTBEATLOGGER_H

--- a/FirebaseCore/Extension/FIRLibrary.h
+++ b/FirebaseCore/Extension/FIRLibrary.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef FIREBASECORE_FIRLIBRARY_H
+#define FIREBASECORE_FIRLIBRARY_H
+
 #ifndef FIRLibrary_h
 #define FIRLibrary_h
 
@@ -37,3 +40,5 @@ NS_SWIFT_NAME(Library)
 NS_ASSUME_NONNULL_END
 
 #endif /* FIRLibrary_h */
+
+#endif  // FIREBASECORE_FIRLIBRARY_H

--- a/FirebaseCore/Extension/FIRLogger.h
+++ b/FirebaseCore/Extension/FIRLogger.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef FIREBASECORE_FIRLOGGER_H
+#define FIREBASECORE_FIRLOGGER_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, FIRLoggerLevel);
@@ -191,3 +194,5 @@ NS_SWIFT_NAME(FirebaseLogger)
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif  // FIREBASECORE_FIRLOGGER_H

--- a/FirebaseCore/Extension/FirebaseCoreInternal.h
+++ b/FirebaseCore/Extension/FirebaseCoreInternal.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef FIREBASECORE_FIREBASECOREINTERNAL_H
+#define FIREBASECORE_FIREBASECOREINTERNAL_H
+
 @import FirebaseCore;
 
 #import "FIRAppInternal.h"
@@ -21,3 +24,5 @@
 #import "FIRHeartbeatLogger.h"
 #import "FIRLibrary.h"
 #import "FIRLogger.h"
+
+#endif  // FIREBASECORE_FIREBASECOREINTERNAL_H

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # To update, change version below, run bundle install, test,
+# touch
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 # To update, change version below, run bundle install, test,
-# touch
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 


### PR DESCRIPTION
A custom module map was too difficult. I couldn't get CocoaPods to respect the custom module map and stopped when I started to spin on things. I switched to guarding the headers against being included twice. It seems promising so far. I also tried with using `#pragma once` but that didn't work because (my guess) is that the problem is _not_ that the _same_ header is being included twice, it's that two different headers with the same content are _both_ being included (once in FirebaseCore and once in FirebaseCoreExtension).

Test cases and their results below:

1.  Below Podfile uses the current state and fails when building docs.
```
platform :ios, '13.0'

source 'https://github.com/firebase/SpecsDev.git'
source 'https://github.com/firebase/SpecsStaging.git'
source 'https://cdn.cocoapods.org/'

target 'tempDoc' do
  use_frameworks!

  # Pods for tempDoc
  pod 'FirebaseCrashlytics', '11.5.0'
end
```

2. Below Podfile uses updated `FirebaseCore` spec but `FirebaseCoreExtension` @ main. The framework target builds but the docs target does not build because of the `FirebaseCoreExtension` @ main does not have guarded headers.
```
platform :ios, '13.0'

source 'https://github.com/firebase/SpecsDev.git'
source 'https://github.com/firebase/SpecsStaging.git'
source 'https://cdn.cocoapods.org/'

target 'tempDoc' do
  use_frameworks!

  # Pods for tempDoc
  pod 'FirebaseCore', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCrashlytics', '11.5.0'
end
```

3. Below Podfile uses updated `FirebaseCore` spec AND updated `FirebaseCoreExtension` spec. The framework target builds AND the docs target builds.
```
platform :ios, '13.0'

source 'https://github.com/firebase/SpecsDev.git'
source 'https://github.com/firebase/SpecsStaging.git'
source 'https://cdn.cocoapods.org/'

target 'tempDoc' do
  use_frameworks!

  # Pods for tempDoc
  pod 'FirebaseCore', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCoreExtension', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCrashlytics', '11.5.0'
end
```

4. Below Podfile uses **old** product pod and floats to pick up updated `FirebaseCore` (the floating case). The framework target builds but the docs target does not build because of using the `FirebaseCoreExtension` @ main.
```
platform :ios, '13.0'

source 'https://github.com/firebase/SpecsDev.git'
source 'https://github.com/firebase/SpecsStaging.git'
source 'https://cdn.cocoapods.org/'

target 'tempDoc' do
  use_frameworks!

  # Pods for tempDoc
  pod 'FirebaseCore', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCrashlytics', '11.4.0' # older pod!
end
```

5. Below Podfile uses **old** product pod and floats to pick up updated `FirebaseCore` (the floating case). In this example, it floats to pick up FirebaseCoreExtension as well. The framework target builds and the docs target builds. 
```
platform :ios, '13.0'

source 'https://github.com/firebase/SpecsDev.git'
source 'https://github.com/firebase/SpecsStaging.git'
source 'https://cdn.cocoapods.org/'

target 'tempDoc' do
  use_frameworks!

  # Pods for tempDoc
  pod 'FirebaseCore', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCoreExtension', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'nc/dup-decls' 
  pod 'FirebaseCrashlytics', '11.4.0' # older pod!
end
```