### PR TITLE
[Auth] Prefer immutable properties and private access level in `*Request` types

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
@@ -48,7 +48,7 @@ class CreateAuthURIRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = CreateAuthURIResponse
 
   /// The email or federated ID of the user.
-  private let identifier: String
+  let identifier: String
 
   /// The URI to which the IDP redirects the user after the federated login flow.
   private let continueURI: String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
@@ -48,28 +48,28 @@ class CreateAuthURIRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = CreateAuthURIResponse
 
   /// The email or federated ID of the user.
-  let identifier: String
+  private let identifier: String
 
   /// The URI to which the IDP redirects the user after the federated login flow.
-  let continueURI: String
+  private let continueURI: String
 
   /// Optional realm for OpenID protocol. The sub string "scheme://domain:port" of the param
   ///   "continueUri" is used if this is not set.
-  var openIDRealm: String?
+  private let openIDRealm: String? = nil
 
   /// The IdP ID. For white listed IdPs it's a short domain name e.g. google.com, aol.com,
   ///    live.net and yahoo.com. For other OpenID IdPs it's the OP identifier.
-  var providerID: String?
+  private let providerID: String? = nil
 
   /// The relying party OAuth client ID.
-  var clientID: String?
+  private let clientID: String? = nil
 
   /// The opaque value used by the client to maintain context info between the authentication
   ///   request and the IDP callback.
-  var context: String?
+  private let context: String? = nil
 
   /// The iOS client application's bundle identifier.
-  var appID: String?
+  private let appID: String? = nil
 
   init(identifier: String, continueURI: String,
        requestConfiguration: AuthRequestConfiguration) {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -110,7 +110,7 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
   private let requestType: GetOOBConfirmationCodeRequestType
 
   /// The email of the user for password reset.
-  private let email: String?
+  let email: String?
 
   /// The new email to be updated for verifyBeforeUpdateEmail.
   private let updatedEmail: String?
@@ -119,7 +119,7 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
   private let accessToken: String?
 
   /// This URL represents the state/Continue URL in the form of a universal link.
-  private let continueURL: String?
+  let continueURL: String?
 
   /// The iOS bundle Identifier, if available.
   private let iOSBundleID: String?
@@ -135,16 +135,16 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
 
   /// Indicates whether the action code link will open the app directly or after being
   ///   redirected from a Firebase owned web widget.
-  private let handleCodeInApp: Bool
+  let handleCodeInApp: Bool
 
   /// The Firebase Dynamic Link domain used for out of band code flow.
   private let dynamicLinkDomain: String?
 
   /// Response to the captcha.
-  private(set) var captchaResponse: String?
+  var captchaResponse: String?
 
   /// The reCAPTCHA version.
-  private(set) var recaptchaVersion: String?
+  var recaptchaVersion: String?
 
   /// Designated initializer.
   /// - Parameter requestType: The types of OOB Confirmation Code to request.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -107,44 +107,44 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = GetOOBConfirmationCodeResponse
 
   /// The types of OOB Confirmation Code to request.
-  let requestType: GetOOBConfirmationCodeRequestType
+  private let requestType: GetOOBConfirmationCodeRequestType
 
   /// The email of the user for password reset.
-  private(set) var email: String?
+  private let email: String?
 
   /// The new email to be updated for verifyBeforeUpdateEmail.
-  private(set) var updatedEmail: String?
+  private let updatedEmail: String?
 
   /// The STS Access Token of the authenticated user for email change.
-  private(set) var accessToken: String?
+  private let accessToken: String?
 
   /// This URL represents the state/Continue URL in the form of a universal link.
-  private(set) var continueURL: String?
+  private let continueURL: String?
 
   /// The iOS bundle Identifier, if available.
-  private(set) var iOSBundleID: String?
+  private let iOSBundleID: String?
 
   /// The Android package name, if available.
-  private(set) var androidPackageName: String?
+  private let androidPackageName: String?
 
   /// The minimum Android version supported, if available.
-  private(set) var androidMinimumVersion: String?
+  private let androidMinimumVersion: String?
 
   /// Indicates whether or not the Android app should be installed if not already available.
-  private(set) var androidInstallApp: Bool
+  private let androidInstallApp: Bool
 
   /// Indicates whether the action code link will open the app directly or after being
   ///   redirected from a Firebase owned web widget.
-  private(set) var handleCodeInApp: Bool
+  private let handleCodeInApp: Bool
 
   /// The Firebase Dynamic Link domain used for out of band code flow.
-  private(set) var dynamicLinkDomain: String?
+  private let dynamicLinkDomain: String?
 
   /// Response to the captcha.
-  var captchaResponse: String?
+  private(set) var captchaResponse: String?
 
   /// The reCAPTCHA version.
-  var recaptchaVersion: String?
+  private(set) var recaptchaVersion: String?
 
   /// Designated initializer.
   /// - Parameter requestType: The types of OOB Confirmation Code to request.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
@@ -27,33 +27,47 @@ class FinalizeMFAEnrollmentRequest: IdentityToolkitRequest, AuthRPCRequest {
 
   let displayName: String?
 
-  var phoneVerificationInfo: AuthProtoFinalizeMFAPhoneRequestInfo?
+  let phoneVerificationInfo: AuthProtoFinalizeMFAPhoneRequestInfo?
 
-  var totpVerificationInfo: AuthProtoFinalizeMFATOTPEnrollmentRequestInfo?
+  let totpVerificationInfo: AuthProtoFinalizeMFATOTPEnrollmentRequestInfo?
 
-  init(idToken: String?, displayName: String?,
-       phoneVerificationInfo: AuthProtoFinalizeMFAPhoneRequestInfo?,
-       requestConfiguration: AuthRequestConfiguration) {
-    self.idToken = idToken
-    self.displayName = displayName
-    self.phoneVerificationInfo = phoneVerificationInfo
-    super.init(
-      endpoint: kFinalizeMFAEnrollmentEndPoint,
-      requestConfiguration: requestConfiguration,
-      useIdentityPlatform: true
+  convenience init(idToken: String?, displayName: String?,
+                   phoneVerificationInfo: AuthProtoFinalizeMFAPhoneRequestInfo?,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      idToken: idToken,
+      displayName: displayName,
+      phoneVerificationInfo: phoneVerificationInfo,
+      totpVerificationInfo: nil,
+      requestConfiguration: requestConfiguration
     )
   }
 
-  init(idToken: String?, displayName: String?,
-       totpVerificationInfo: AuthProtoFinalizeMFATOTPEnrollmentRequestInfo?,
-       requestConfiguration: AuthRequestConfiguration) {
+  convenience init(idToken: String?, displayName: String?,
+                   totpVerificationInfo: AuthProtoFinalizeMFATOTPEnrollmentRequestInfo?,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      idToken: idToken,
+      displayName: displayName,
+      phoneVerificationInfo: nil,
+      totpVerificationInfo: totpVerificationInfo,
+      requestConfiguration: requestConfiguration
+    )
+  }
+
+  private init(idToken: String?, displayName: String?,
+               phoneVerificationInfo: AuthProtoFinalizeMFAPhoneRequestInfo?,
+               totpVerificationInfo: AuthProtoFinalizeMFATOTPEnrollmentRequestInfo?,
+               requestConfiguration: AuthRequestConfiguration) {
     self.idToken = idToken
     self.displayName = displayName
+    self.phoneVerificationInfo = phoneVerificationInfo
     self.totpVerificationInfo = totpVerificationInfo
     super.init(
       endpoint: kFinalizeMFAEnrollmentEndPoint,
       requestConfiguration: requestConfiguration,
-      useIdentityPlatform: true
+      useIdentityPlatform: true,
+      useStaging: false
     )
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
@@ -24,30 +24,43 @@ class StartMFAEnrollmentRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = StartMFAEnrollmentResponse
 
   let idToken: String?
-  private(set) var phoneEnrollmentInfo: AuthProtoStartMFAPhoneRequestInfo?
-  private(set) var totpEnrollmentInfo: AuthProtoStartMFATOTPEnrollmentRequestInfo?
+  let phoneEnrollmentInfo: AuthProtoStartMFAPhoneRequestInfo?
+  let totpEnrollmentInfo: AuthProtoStartMFATOTPEnrollmentRequestInfo?
 
-  init(idToken: String?,
-       enrollmentInfo: AuthProtoStartMFAPhoneRequestInfo?,
-       requestConfiguration: AuthRequestConfiguration) {
-    self.idToken = idToken
-    phoneEnrollmentInfo = enrollmentInfo
-    super.init(
-      endpoint: kStartMFAEnrollmentEndPoint,
-      requestConfiguration: requestConfiguration,
-      useIdentityPlatform: true
+  convenience init(idToken: String?,
+                   enrollmentInfo: AuthProtoStartMFAPhoneRequestInfo?,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      idToken: idToken,
+      enrollmentInfo: enrollmentInfo,
+      totpEnrollmentInfo: nil,
+      requestConfiguration: requestConfiguration
     )
   }
 
-  init(idToken: String?,
-       totpEnrollmentInfo: AuthProtoStartMFATOTPEnrollmentRequestInfo?,
-       requestConfiguration: AuthRequestConfiguration) {
+  convenience init(idToken: String?,
+                   totpEnrollmentInfo: AuthProtoStartMFATOTPEnrollmentRequestInfo?,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      idToken: idToken,
+      enrollmentInfo: nil,
+      totpEnrollmentInfo: totpEnrollmentInfo,
+      requestConfiguration: requestConfiguration
+    )
+  }
+
+  private init(idToken: String?,
+               enrollmentInfo: AuthProtoStartMFAPhoneRequestInfo?,
+               totpEnrollmentInfo: AuthProtoStartMFATOTPEnrollmentRequestInfo?,
+               requestConfiguration: AuthRequestConfiguration) {
     self.idToken = idToken
+    phoneEnrollmentInfo = enrollmentInfo
     self.totpEnrollmentInfo = totpEnrollmentInfo
     super.init(
       endpoint: kStartMFAEnrollmentEndPoint,
       requestConfiguration: requestConfiguration,
-      useIdentityPlatform: true
+      useIdentityPlatform: true,
+      useStaging: false
     )
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
@@ -23,8 +23,8 @@ private let kTenantIDKey = "tenantId"
 class FinalizeMFASignInRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = FinalizeMFAEnrollmentResponse
 
-  var mfaPendingCredential: String?
-  var verificationInfo: AuthProto?
+  let mfaPendingCredential: String?
+  let verificationInfo: AuthProto?
 
   init(mfaPendingCredential: String?,
        verificationInfo: AuthProto?,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
@@ -24,9 +24,9 @@ private let kTenantIDKey = "tenantId"
 class StartMFASignInRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = StartMFASignInResponse
 
-  var MFAPendingCredential: String?
-  var MFAEnrollmentID: String?
-  var signInInfo: AuthProtoStartMFAPhoneRequestInfo?
+  let MFAPendingCredential: String?
+  let MFAEnrollmentID: String?
+  let signInInfo: AuthProtoStartMFAPhoneRequestInfo?
 
   init(MFAPendingCredential: String?, MFAEnrollmentID: String?,
        signInInfo: AuthProtoStartMFAPhoneRequestInfo?,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
@@ -23,8 +23,8 @@ private let kTenantIDKey = "tenantId"
 class WithdrawMFARequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = WithdrawMFAResponse
 
-  var idToken: String?
-  var mfaEnrollmentID: String?
+  let idToken: String?
+  let mfaEnrollmentID: String?
 
   init(idToken: String?,
        mfaEnrollmentID: String?,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -37,16 +37,16 @@ class RevokeTokenRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = RevokeTokenResponse
 
   /// The provider that issued the token to revoke.
-  private(set) var providerID: String
+  private let providerID: String
 
   /// The type of the token to revoke.
-  private(set) var tokenType: TokenType
+  private let tokenType: TokenType
 
   /// The token to be revoked.
-  private(set) var token: String
+  private let token: String
 
   /// The ID Token associated with this credential.
-  private(set) var idToken: String
+  private let idToken: String
 
   enum TokenType: Int {
     case unspecified = 0, refreshToken = 1, accessToken = 2, authorizationCode = 3

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -37,13 +37,13 @@ class RevokeTokenRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = RevokeTokenResponse
 
   /// The provider that issued the token to revoke.
-  private let providerID: String
+  let providerID: String
 
   /// The type of the token to revoke.
-  private let tokenType: TokenType
+  let tokenType: TokenType
 
   /// The token to be revoked.
-  private let token: String
+  let token: String
 
   /// The ID Token associated with this credential.
   private let idToken: String

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -64,16 +64,16 @@ class SecureTokenRequest: AuthRPCRequest {
 
   /// The type of grant requested.
   /// See FIRSecureTokenRequestGrantType
-  var grantType: SecureTokenRequestGrantType
+  let grantType: SecureTokenRequestGrantType
 
   /// The scopes requested (a comma-delimited list of scope strings).
-  var scope: String?
+  let scope: String?
 
   /// The client's refresh token.
-  var refreshToken: String?
+  let refreshToken: String?
 
   /// The client's authorization code (legacy Gitkit "ID Token").
-  var code: String?
+  let code: String?
 
   /// The client's API Key.
   let apiKey: String
@@ -107,8 +107,8 @@ class SecureTokenRequest: AuthRPCRequest {
     )
   }
 
-  init(grantType: SecureTokenRequestGrantType, scope: String?, refreshToken: String?,
-       code: String?, requestConfiguration: AuthRequestConfiguration) {
+  private init(grantType: SecureTokenRequestGrantType, scope: String?, refreshToken: String?,
+               code: String?, requestConfiguration: AuthRequestConfiguration) {
     self.grantType = grantType
     self.scope = scope
     self.refreshToken = refreshToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
@@ -89,47 +89,47 @@ class SetAccountInfoRequest: IdentityToolkitRequest, AuthRPCRequest {
   var displayName: String?
 
   /// The local ID of the user.
-  var localID: String?
+  private let localID: String? = nil
 
   /// The email of the user.
-  var email: String?
+  var email: String? = nil
 
   /// The photoURL of the user.
   var photoURL: URL?
 
   /// The new password of the user.
-  var password: String?
+  var password: String? = nil
 
   /// The associated identity providers of the user.
-  var providers: [String]?
+  private let providers: [String]? = nil
 
   /// The out-of-band code of the change email request.
   var oobCode: String?
 
   /// Whether to mark the email as verified or not.
-  var emailVerified: Bool = false
+  private let emailVerified: Bool = false
 
   /// Whether to mark the user to upgrade to federated login.
-  var upgradeToFederatedLogin: Bool = false
+  private let upgradeToFederatedLogin: Bool = false
 
   /// The captcha challenge.
-  var captchaChallenge: String?
+  private let captchaChallenge: String? = nil
 
   /// Response to the captcha.
-  var captchaResponse: String?
+  private let captchaResponse: String? = nil
 
   /// The list of user attributes to delete.
   ///
   /// Every element of the list must be one of the predefined constant starts with
   /// `SetAccountInfoUserAttribute`.
-  var deleteAttributes: [String]?
+  private let deleteAttributes: [String]? = nil
 
   /// The list of identity providers to delete.
   var deleteProviders: [String]?
 
   /// Whether the response should return access token and refresh token directly.
   /// The default value is `true` .
-  var returnSecureToken: Bool = true
+  private let returnSecureToken: Bool = true
 
   init(requestConfiguration: AuthRequestConfiguration) {
     super.init(endpoint: kSetAccountInfoEndpoint, requestConfiguration: requestConfiguration)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
@@ -89,7 +89,7 @@ class SetAccountInfoRequest: IdentityToolkitRequest, AuthRPCRequest {
   var displayName: String?
 
   /// The local ID of the user.
-  private let localID: String? = nil
+  var localID: String? = nil
 
   /// The email of the user.
   var email: String? = nil
@@ -101,37 +101,38 @@ class SetAccountInfoRequest: IdentityToolkitRequest, AuthRPCRequest {
   var password: String? = nil
 
   /// The associated identity providers of the user.
-  private let providers: [String]? = nil
+  var providers: [String]? = nil
 
   /// The out-of-band code of the change email request.
   var oobCode: String?
 
   /// Whether to mark the email as verified or not.
-  private let emailVerified: Bool = false
+  var emailVerified: Bool = false
 
   /// Whether to mark the user to upgrade to federated login.
-  private let upgradeToFederatedLogin: Bool = false
+  var upgradeToFederatedLogin: Bool = false
 
   /// The captcha challenge.
-  private let captchaChallenge: String? = nil
+  var captchaChallenge: String? = nil
 
   /// Response to the captcha.
-  private let captchaResponse: String? = nil
+  var captchaResponse: String? = nil
 
   /// The list of user attributes to delete.
   ///
   /// Every element of the list must be one of the predefined constant starts with
   /// `SetAccountInfoUserAttribute`.
-  private let deleteAttributes: [String]? = nil
+  var deleteAttributes: [String]? = nil
 
   /// The list of identity providers to delete.
   var deleteProviders: [String]?
 
   /// Whether the response should return access token and refresh token directly.
   /// The default value is `true` .
-  private let returnSecureToken: Bool = true
+  var returnSecureToken: Bool = true
 
-  init(requestConfiguration: AuthRequestConfiguration) {
+  init(accessToken: String? = nil, requestConfiguration: AuthRequestConfiguration) {
+    self.accessToken = accessToken
     super.init(endpoint: kSetAccountInfoEndpoint, requestConfiguration: requestConfiguration)
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
@@ -61,52 +61,76 @@ class VerifyPhoneNumberRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = VerifyPhoneNumberResponse
 
   /// The verification ID obtained from the response of `sendVerificationCode`.
-  var verificationID: String?
+  let verificationID: String?
 
   /// The verification code provided by the user.
-  var verificationCode: String?
+  let verificationCode: String?
 
   /// The STS Access Token for the authenticated user.
   var accessToken: String?
 
   /// The temporary proof code, previously returned from the backend.
-  var temporaryProof: String?
+  let temporaryProof: String?
 
   /// The phone number to be verified in the request.
-  var phoneNumber: String?
+  let phoneNumber: String?
 
   /// The type of operation triggering this verify phone number request.
-  var operation: AuthOperationType
+  let operation: AuthOperationType
 
-  /// Designated initializer.
+  /// Convenience initializer.
   /// - Parameter temporaryProof: The temporary proof sent by the backed.
   /// - Parameter phoneNumber: The phone number associated with the credential to be signed in .
   /// - Parameter operation: Indicates what operation triggered the verify phone number request.
   /// - Parameter requestConfiguration: An object containing configurations to be added to the
   /// request.
-  init(temporaryProof: String, phoneNumber: String, operation: AuthOperationType,
-       requestConfiguration: AuthRequestConfiguration) {
-    self.temporaryProof = temporaryProof
-    self.phoneNumber = phoneNumber
-    self.operation = operation
-    super.init(endpoint: kVerifyPhoneNumberEndPoint, requestConfiguration: requestConfiguration)
+  convenience init(temporaryProof: String, phoneNumber: String, operation: AuthOperationType,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      temporaryProof: temporaryProof,
+      phoneNumber: phoneNumber,
+      verificationID: nil,
+      verificationCode: nil,
+      operation: operation,
+      requestConfiguration: requestConfiguration
+    )
   }
 
-  /// Designated initializer.
+  /// Convenience initializer.
   /// - Parameter verificationID: The verification ID obtained from the response of
   /// `sendVerificationCode`.
   /// - Parameter verificationCode: The verification code provided by the user.
   /// - Parameter operation: Indicates what operation triggered the verify phone number request.
   /// - Parameter requestConfiguration: An object containing configurations to be added to the
   /// request.
-  init(verificationID: String,
-       verificationCode: String,
-       operation: AuthOperationType,
-       requestConfiguration: AuthRequestConfiguration) {
+  convenience init(verificationID: String,
+                   verificationCode: String,
+                   operation: AuthOperationType,
+                   requestConfiguration: AuthRequestConfiguration) {
+    self.init(
+      temporaryProof: nil,
+      phoneNumber: nil,
+      verificationID: verificationID,
+      verificationCode: verificationCode,
+      operation: operation,
+      requestConfiguration: requestConfiguration
+    )
+  }
+
+  private init(temporaryProof: String?, phoneNumber: String?, verificationID: String?,
+               verificationCode: String?, operation: AuthOperationType,
+               requestConfiguration: AuthRequestConfiguration) {
+    self.temporaryProof = temporaryProof
+    self.phoneNumber = phoneNumber
     self.verificationID = verificationID
     self.verificationCode = verificationCode
     self.operation = operation
-    super.init(endpoint: kVerifyPhoneNumberEndPoint, requestConfiguration: requestConfiguration)
+    super.init(
+      endpoint: kVerifyPhoneNumberEndPoint,
+      requestConfiguration: requestConfiguration,
+      useIdentityPlatform: false,
+      useStaging: false
+    )
   }
 
   func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
@@ -39,10 +39,10 @@ class VerifyClientRequest: IdentityToolkitRequest, AuthRPCRequest {
   }
 
   /// The APNS device token.
-  private(set) var appToken: String?
+  let appToken: String?
 
   /// The flag that denotes if the appToken  pertains to Sandbox or Production.
-  private(set) var isSandbox: Bool
+  let isSandbox: Bool
 
   init(withAppToken appToken: String?,
        isSandbox: Bool,

--- a/FirebaseAuth/Sources/Swift/User/UserProfileUpdate.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserProfileUpdate.swift
@@ -49,8 +49,9 @@ actor UserProfileUpdate {
 
   func unlink(user: User, fromProvider provider: String) async throws -> User {
     let accessToken = try await user.internalGetTokenAsync()
-    let request = SetAccountInfoRequest(requestConfiguration: user.requestConfiguration)
-    request.accessToken = accessToken
+    let request = SetAccountInfoRequest(
+      accessToken: accessToken, requestConfiguration: user.requestConfiguration
+    )
 
     if user.providerDataRaw[provider] == nil {
       throw AuthErrorUtils.noSuchProviderError()
@@ -108,8 +109,10 @@ actor UserProfileUpdate {
 
     // Mutate setAccountInfoRequest in block
     let setAccountInfoRequest =
-      SetAccountInfoRequest(requestConfiguration: user.requestConfiguration)
-    setAccountInfoRequest.accessToken = accessToken
+      SetAccountInfoRequest(
+        accessToken: accessToken,
+        requestConfiguration: user.requestConfiguration
+      )
     changeBlock(userAccountInfo, setAccountInfoRequest)
     do {
       let accountInfoResponse = try await AuthBackend.call(with: setAccountInfoRequest)

--- a/FirebaseAuth/Tests/Unit/SetAccountInfoTests.swift
+++ b/FirebaseAuth/Tests/Unit/SetAccountInfoTests.swift
@@ -221,6 +221,6 @@ class SetAccountInfoTests: RPCBaseTests {
   }
 
   private func setAccountInfoRequest() -> SetAccountInfoRequest {
-    return SetAccountInfoRequest(requestConfiguration: makeRequestConfiguration())
+    return SetAccountInfoRequest(accessToken: nil, requestConfiguration: makeRequestConfiguration())
   }
 }


### PR DESCRIPTION
This should be a no-op. Moving to `private` and `let`s where applicable. I'm working on moving these types to structs and thought this would be a good cleanup opportunity to minimize mutability.

#no-changelog