### PR TITLE
[Infra] Disable Auth deprecations warnings in SPM CI

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -21,6 +21,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
+env:
+  FIREBASE_CI: true
+
 jobs:
   spm-package-resolved:
     env:

--- a/Package.swift
+++ b/Package.swift
@@ -419,6 +419,7 @@ let package = Package(
         "ObjC", "Public",
       ],
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
+      swiftSettings: Context.environment["FIREBASE_CI"] != nil ? [.define("FIREBASE_CI")] : [],
       linkerSettings: [
         .linkedFramework("Security"),
         .linkedFramework("SafariServices", .when(platforms: [.iOS])),
@@ -464,9 +465,6 @@ let package = Package(
         "ObjCAPITests.m",
         "ObjCGlobalTests.m",
         "FIROAuthProviderTests.m",
-      ],
-      swiftSettings: [
-        .define("FIREBASE_CI"),
       ]
     ),
     .target(
@@ -1338,7 +1336,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
     return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: appMeasurementURL, exact: "11.4.0")
+  return .package(url: appMeasurementURL, branch: "main")
 }
 
 func abseilDependency() -> Package.Dependency {

--- a/Package.swift
+++ b/Package.swift
@@ -464,6 +464,9 @@ let package = Package(
         "ObjCAPITests.m",
         "ObjCGlobalTests.m",
         "FIROAuthProviderTests.m",
+      ],
+      swiftSettings: [
+        .define("FIREBASE_CI"),
       ]
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1336,7 +1336,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
     return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: appMeasurementURL, branch: "main")
+  return .package(url: appMeasurementURL, exact: "11.4.0")
 }
 
 func abseilDependency() -> Package.Dependency {


### PR DESCRIPTION
I enabled this for CocoaPods a while back and it works pretty well. Incrementally extending this to FirebaseAuth x SPM.

Example of usage:
https://github.com/firebase/firebase-ios-sdk/blob/ae2554220afb03a5d6fc389c28a86061a12c7caa/FirebaseAuth/Sources/Swift/Auth/Auth.swift#L282-L290

#no-changelog