### PR TITLE
Make Package.Swift Explicit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
     ),
     .library(
       name: "FirebasePerformance",
-      targets: ["FirebasePerformanceTarget"]
+      targets: ["FirebasePerformanceTarget", "FirebasePerformance"]
     ),
     .library(
       name: "FirebaseRemoteConfig",


### PR DESCRIPTION
#13998 issue 
## Description

This pull request addresses an issue with the FirebasePerformance library in Firebase project. Currently, the Target FirebasePerformance is not explicitly declared as a product target of "FirebasePerformance" library in the Package.swift file. As a result, tools designed to detect implicit dependencies are marking the import FirebasePerformance statement as an implicit dependency across projects that utilize the FirebasePerformance library.

## Proposed Change

To resolve this issue, I propose explicitly adding FirebasePerformance to FirebasePerformance library targets in the Package.swift file. This modification will ensure that there are no implicit dependencies related to FirebasePerformance, thereby enhancing clarity and maintaining strict dependency management.

## Benefits

- Reduces potential for dependency-related issues in the future.
- Simplifies maintenance and improves clarity of dependency declarations.
- Ensures compliance with best practices for Swift package management.

