### PR TITLE
[Auth] Fix casting error in Swift 6

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionResponse.swift
@@ -158,10 +158,10 @@ struct VerifyAssertionResponse: AuthRPCResponse, AuthMFAResponse {
     if let rawUserInfo = dictionary["rawUserInfo"] as? String,
        let data = rawUserInfo.data(using: .utf8) {
       if let info = try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves),
-         let profile = info as? [String: Any] {
+         let profile = info as? [String: any Sendable] {
         self.profile = profile
       }
-    } else if let profile = dictionary["rawUserInfo"] as? [String: Any] {
+    } else if let profile = dictionary["rawUserInfo"] as? [String: any Sendable] {
       self.profile = profile
     }
     username = dictionary["username"] as? String


### PR DESCRIPTION
<img width="647" alt="Screenshot 2024-11-04 at 4 54 14 PM" src="https://github.com/user-attachments/assets/7a6ad9d9-c755-466f-80cc-8882a35b0e57">

Based on some examples I found, it looks like this value should be JSON string. I did a test in playgrounds and it looks like it can be casted to `[String:Sendable]`

#no-changelog