### PR TITLE
[Vertex AI] Fix parallel function calling in sample

### DIFF
--- a/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/FirebaseVertexAI/Sample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -116,7 +116,7 @@ class FunctionCallingViewModel: ObservableObject {
       for functionResponse in functionResponses {
         messages.insert(functionResponse.chatMessage(), at: messages.count - 1)
       }
-      responseStream = try chat.sendMessageStream(functionResponses.modelContent())
+      responseStream = try chat.sendMessageStream([functionResponses.modelContent()])
     }
     for try await chunk in responseStream {
       processResponseContent(content: chunk)
@@ -132,7 +132,7 @@ class FunctionCallingViewModel: ObservableObject {
       for functionResponse in functionResponses {
         messages.insert(functionResponse.chatMessage(), at: messages.count - 1)
       }
-      response = try await chat.sendMessage(functionResponses.modelContent())
+      response = try await chat.sendMessage([functionResponses.modelContent()])
     }
     processResponseContent(content: response)
   }
@@ -249,7 +249,7 @@ private extension FunctionResponsePart {
 }
 
 private extension [FunctionResponsePart] {
-  func modelContent() -> [ModelContent] {
-    return self.map { ModelContent(role: "function", parts: [$0]) }
+  func modelContent() -> ModelContent {
+    return ModelContent(role: "function", parts: self)
   }
 }


### PR DESCRIPTION
Fixed the handling of parallel function calls in the Vertex AI in Firebase sample app. The backend enforces that all function response parts are provided in a single turn (`ModelContent`) when the multiple (parallel) function calls were generated in the previous turn. See https://github.com/firebase/firebase-ios-sdk/issues/14022 for context.

<details>
<summary>Example</summary>

![Parallel Function Calling Screenshot](https://github.com/user-attachments/assets/1ad5d0ee-aedb-4d95-8623-2a977e9718c9)
Note: Exchange rates are hardcoded, not accurate.

</details>

#no-changelog