### PR TITLE
[Vertex AI] Add `CustomNSError` conformance to `BackendError`

### DIFF
--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -18,4 +18,10 @@ import Foundation
 enum Constants {
   /// The Vertex AI backend endpoint URL.
   static let baseURL = "https://firebasevertexai.googleapis.com"
+
+  /// The base reverse-DNS name for `NSError` or `CustomNSError` error domains.
+  ///
+  /// - Important: A suffix must be appended to produce an error domain (e.g.,
+  ///   "com.google.firebase.vertexai.ExampleError").
+  static let baseErrorDomain = "com.google.firebase.vertexai"
 }

--- a/FirebaseVertexAI/Sources/Types/Internal/Errors/BackendError.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Errors/BackendError.swift
@@ -36,6 +36,27 @@ struct BackendError: Error {
   }
 }
 
+// MARK: - CustomNSError Conformance
+
+extension BackendError: CustomNSError {
+  public static var errorDomain: String {
+    return "\(Constants.baseErrorDomain).\(Self.self)"
+  }
+
+  var errorCode: Int {
+    return httpResponseCode
+  }
+
+  var errorUserInfo: [String: Any] {
+    return [
+      NSLocalizedDescriptionKey:
+        "\(message) (\(Self.errorDomain) - HTTP \(httpResponseCode) \(status.rawValue))",
+    ]
+  }
+}
+
+// MARK: - Decodable Conformance
+
 extension BackendError: Decodable {
   enum CodingKeys: CodingKey {
     case error

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -506,6 +506,12 @@ final class GenerativeModelTests: XCTestCase {
       XCTAssertEqual(error.httpResponseCode, 400)
       XCTAssertEqual(error.status, .invalidArgument)
       XCTAssertEqual(error.message, "API key not valid. Please pass a valid API key.")
+      XCTAssertTrue(error.localizedDescription.contains(error.message))
+      XCTAssertTrue(error.localizedDescription.contains(error.status.rawValue))
+      XCTAssertTrue(error.localizedDescription.contains("\(error.httpResponseCode)"))
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, "\(Constants.baseErrorDomain).\(BackendError.self)")
+      XCTAssertEqual(nsError.code, error.httpResponseCode)
       return
     } catch {
       XCTFail("Should throw GenerateContentError.internalError(RPCError); error thrown: \(error)")
@@ -853,6 +859,12 @@ final class GenerativeModelTests: XCTestCase {
       XCTAssertEqual(error.httpResponseCode, 400)
       XCTAssertEqual(error.status, .invalidArgument)
       XCTAssertEqual(error.message, "API key not valid. Please pass a valid API key.")
+      XCTAssertTrue(error.localizedDescription.contains(error.message))
+      XCTAssertTrue(error.localizedDescription.contains(error.status.rawValue))
+      XCTAssertTrue(error.localizedDescription.contains("\(error.httpResponseCode)"))
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, "\(Constants.baseErrorDomain).\(BackendError.self)")
+      XCTAssertEqual(nsError.code, error.httpResponseCode)
       return
     }
 


### PR DESCRIPTION
Added `CustomNSError` conformance to `BackendError`. This improves the string returned by `localizedDescription` and will also improve interoperability with Crashlytics (e.g., when [reporting non-fatal errors](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=ios#log-excepts), logged errors are grouped by `domain` and `code`).

Calling `error.localizedDescription`:
  - Before: `The operation couldn’t be completed. (FirebaseVertexAI.BackendError error 1.)`
  - Now: `"API key not valid. Please pass a valid API key. (com.google.firebase.vertexai.BackendError - HTTP 400 INVALID_ARGUMENT)"`

#no-changelog