### PR TITLE
[Release] Update `Unreleased` changelog entries for 11.5.0

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 11.5.0
 - [changed] Updated `upload-symbols` to version 3.19, removed all methods require CFRelease and switch to modern classes (#13420).
 
 # 11.4.0

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 11.5.0
 - [fixed] Improve token-fetch failure logging with detailed error info. (#13997).
 
 # 11.0.0

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 11.5.0
 - [fixed] Mark two internal properties as `atomic` to prevent concurrency
   related crash. (#13898)
 


### PR DESCRIPTION
Updated `Unreleased` to `11.5.0` in changelog entries in preparation for the next release.
