### PR TITLE
[Vertex AI] Replace legacy errors in `GenerativeAIService`

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -213,7 +213,7 @@ struct GenerativeAIService {
   private func httpResponse(urlResponse: URLResponse) throws -> HTTPURLResponse {
     // The following condition should always be true: "Whenever you make HTTP URL load requests, any
     // response objects you get back from the URLSession, NSURLConnection, or NSURLDownload class
-    // are instances of the HTTPURLResponse class.
+    // are instances of the HTTPURLResponse class."
     guard let response = urlResponse as? HTTPURLResponse else {
       VertexLog.error(
         code: .generativeAIServiceNonHTTPResponse,

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -211,15 +211,16 @@ struct GenerativeAIService {
   }
 
   private func httpResponse(urlResponse: URLResponse) throws -> HTTPURLResponse {
-    // Verify the status code is 200
+    // The following condition should always be true: "Whenever you make HTTP URL load requests, any
+    // response objects you get back from the URLSession, NSURLConnection, or NSURLDownload class
+    // are instances of the HTTPURLResponse class.
     guard let response = urlResponse as? HTTPURLResponse else {
       VertexLog.error(
         code: .generativeAIServiceNonHTTPResponse,
         "Response wasn't an HTTP response, internal error \(urlResponse)"
       )
-      throw NSError(
-        domain: "com.google.generative-ai",
-        code: -1,
+      throw URLError(
+        .badServerResponse,
         userInfo: [NSLocalizedDescriptionKey: "Response was not an HTTP response."]
       )
     }
@@ -229,14 +230,11 @@ struct GenerativeAIService {
 
   private func jsonData(jsonText: String) throws -> Data {
     guard let data = jsonText.data(using: .utf8) else {
-      let error = NSError(
-        domain: "com.google.generative-ai",
-        code: -1,
-        userInfo: [NSLocalizedDescriptionKey: "Could not parse response as UTF8."]
-      )
-      throw error
+      throw DecodingError.dataCorrupted(DecodingError.Context(
+        codingPath: [],
+        debugDescription: "Could not parse response as UTF8."
+      ))
     }
-
     return data
   }
 

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -740,6 +740,9 @@ final class GenerativeModelTests: XCTestCase {
       return
     }
     XCTAssertEqual(underlyingError.localizedDescription, "Response was not an HTTP response.")
+    let underlyingNSError = underlyingError as NSError
+    XCTAssertEqual(underlyingNSError.domain, NSURLErrorDomain)
+    XCTAssertEqual(underlyingNSError.code, URLError.Code.badServerResponse.rawValue)
   }
 
   func testGenerateContent_failure_invalidResponse() async throws {


### PR DESCRIPTION
Replaced `NSError` objects that originated from the `generative-ai-swift` SDK (`domain: "com.google.generative-ai"`).

#no-changelog