### PR TITLE
[Config] Prefer NSLock over objc_sync_enter for synchronizing value types

### DIFF
--- a/FirebaseRemoteConfig/SwiftNew/UserDefaultsManager.swift
+++ b/FirebaseRemoteConfig/SwiftNew/UserDefaultsManager.swift
@@ -73,6 +73,7 @@ public class UserDefaultsManager: NSObject {
     }
   }
 
+  private static let sharedInstanceMapLock = NSLock()
   private static var sharedInstanceMap: [String: UserDefaults] = [:]
 
   /// Returns the shared user defaults instance for the given bundle identifier.
@@ -81,14 +82,14 @@ public class UserDefaultsManager: NSObject {
   /// - Returns: The shared user defaults instance.
   @objc(sharedUserDefaultsForBundleIdentifier:)
   static func sharedUserDefaultsForBundleIdentifier(_ bundleIdentifier: String) -> UserDefaults {
-    objc_sync_enter(sharedInstanceMap)
-    defer { objc_sync_exit(sharedInstanceMap) }
-    if let instance = sharedInstanceMap[bundleIdentifier] {
-      return instance
+    sharedInstanceMapLock.withLock {
+      if let instance = sharedInstanceMap[bundleIdentifier] {
+        return instance
+      }
+      let userDefaults = UserDefaults(suiteName: userDefaultsSuiteName(for: bundleIdentifier))!
+      sharedInstanceMap[bundleIdentifier] = userDefaults
+      return userDefaults
     }
-    let userDefaults = UserDefaults(suiteName: userDefaultsSuiteName(for: bundleIdentifier))!
-    sharedInstanceMap[bundleIdentifier] = userDefaults
-    return userDefaults
   }
 
   /// Returns the user defaults suite name for the given bundle identifier.


### PR DESCRIPTION
`objc_sync_enter` shouldn't be used on value types (`[String: UserDefaults]`) because a struct's address is not stable (https://stackoverflow.com/a/70897304/9331576, https://straypixels.net/swift-dictionary-locking/).

I could demonstrate this in a playground using a simplified version of the class:
```swift
import Foundation

class UserDefaultsManager: NSObject {
  nonisolated(unsafe) private static var sharedInstanceMap: [String: UserDefaults] = [:]
  
  /// Returns the shared user defaults instance for the given bundle identifier.
  ///
  /// - Parameter bundleIdentifier: The bundle identifier of the app.
  /// - Returns: The shared user defaults instance.
  static func setValue(_ value: UserDefaults, key: String) -> UserDefaults {
    print("enter: \(ObjectIdentifier(Self.sharedInstanceMap as AnyObject))")
    objc_sync_enter(sharedInstanceMap)
    defer {
      print(" exit: \(ObjectIdentifier(Self.sharedInstanceMap as AnyObject))")
      objc_sync_exit(sharedInstanceMap)
    }
    sharedInstanceMap[key] = value
    return value
  }
}

UserDefaultsManager.setValue(.standard, key: "standard_1")
// enter: ObjectIdentifier(0x00000001ec706cf0)
//  exit: ObjectIdentifier(0x0000600000c32640)

UserDefaultsManager.setValue(.standard, key: "standard_2")
// enter: ObjectIdentifier(0x0000600000c32610)
//  exit: ObjectIdentifier(0x0000600000c32580)
```

Interesting reads on synchronization performance:
- https://swiftrocks.com/thread-safety-in-swift
- above article doesn't profile actors, but they are likely close to GCD: https://forums.swift.org/t/i-was-playing-with-measuring-actor-performance/75005 (see this response for a useful tip with regard to reducing suspensions: https://forums.swift.org/t/i-was-playing-with-measuring-actor-performance/75005/2)

#no-changelog