### PR TITLE
[Vertex AI] Fix `testCountTokens_jsonSchema` integration test

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [changed] The token counts from `GenerativeModel.countTokens(...)` now include
+  tokens from the schema for JSON output and function calling; reported token
+  counts will now be higher if using these features.
+
 # 11.5.0
 - [fixed] Fixed an issue where `VertexAI.vertexAI(app: app1)` and
   `VertexAI.vertexAI(app: app2)` would return the same instance if their

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -217,8 +217,8 @@ final class IntegrationTests: XCTestCase {
 
     let response = try await model.countTokens(prompt)
 
-    XCTAssertEqual(response.totalTokens, 34)
-    XCTAssertEqual(response.totalBillableCharacters, 59)
+    XCTAssertEqual(response.totalTokens, 58)
+    XCTAssertEqual(response.totalBillableCharacters, 160)
   }
 
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {


### PR DESCRIPTION
The Vertex AI backend now includes the `responseSchema` (from `GenerationConfig`; see #13813) in token counts. Although there are no SDK changes, I've added a changelog entry to describe the difference.