### PR TITLE
[Infra] Update zip workflow to use macOS 15 for Xcode 16 jobs

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,13 +111,13 @@ jobs:
       SDK: "ABTesting"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -173,11 +173,11 @@ jobs:
       SDK:  "Authentication"
     strategy:
       matrix:
-        os: [macos-14]
+        os: [macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -225,13 +225,13 @@ jobs:
       SDK: "Config"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -277,13 +277,13 @@ jobs:
       SDK: "Crashlytics"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -404,13 +404,13 @@ jobs:
       SDK: "DynamicLinks"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -464,13 +464,13 @@ jobs:
       SDK: "Firestore"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -549,13 +549,13 @@ jobs:
       SDK: "InAppMessaging"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -606,13 +606,13 @@ jobs:
       SDK: "Messaging"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -662,13 +662,13 @@ jobs:
       SDK: "Storage"
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         include:
           - os: macos-13
             xcode: Xcode_15.2
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -27,33 +27,33 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  package-release:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: package-release
-    - name: Xcode 15.2
-      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p release_zip_dir
-         sh -x scripts/build_zip.sh release_zip_dir \
-           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}" \
-           build-release \
-           static
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Firebase-release-zip-zip
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: release_zip_dir
+  # package-release:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   runs-on: macos-13
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: package-release
+  #   - name: Xcode 15.2
+  #     run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p release_zip_dir
+  #        sh -x scripts/build_zip.sh release_zip_dir \
+  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}" \
+  #          build-release \
+  #          static
+  #   - uses: actions/upload-artifact@v4
+  #     with:
+  #       name: Firebase-release-zip-zip
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: release_zip_dir
 
   build:
     # Don't run on private repo unless it is a PR.
@@ -68,42 +68,42 @@ jobs:
         cd ReleaseTooling
         swift build -v
 
-  package-head:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: build
-    strategy:
-      matrix:
-        linking_type: [static, dynamic]
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: package-head
-    - name: Xcode 15.2
-      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: ZipBuildingTest
-      run: |
-         mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh \
-           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-           build-head \
-           ${{ matrix.linking_type }}
-    - uses: actions/upload-artifact@v4
-      if: ${{ always() }}
-      with:
-        name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
-        # Zip the entire output directory since the builder adds subdirectories we don't know the
-        # name of.
-        path: zip_output_dir
+  # package-head:
+  #   # Don't run on private repo.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       linking_type: [static, dynamic]
+  #   runs-on: macos-13
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: package-head
+  #   - name: Xcode 15.2
+  #     run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: ZipBuildingTest
+  #     run: |
+  #        mkdir -p zip_output_dir
+  #        sh -x scripts/build_zip.sh \
+  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+  #          build-head \
+  #          ${{ matrix.linking_type }}
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ always() }}
+  #     with:
+  #       name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
+  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
+  #       # name of.
+  #       path: zip_output_dir
 
   quickstart_framework_abtesting:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -165,7 +165,7 @@ jobs:
 
   quickstart_framework_auth:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -217,7 +217,7 @@ jobs:
 
   quickstart_framework_config:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -269,7 +269,7 @@ jobs:
 
   quickstart_framework_crashlytics:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -396,7 +396,7 @@ jobs:
 
   quickstart_framework_dynamiclinks:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -456,7 +456,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -541,7 +541,7 @@ jobs:
 
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -598,7 +598,7 @@ jobs:
 
   quickstart_framework_messaging:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -654,7 +654,7 @@ jobs:
 
   quickstart_framework_storage:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -345,7 +345,7 @@ jobs:
   quickstart_framework_database:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -511,7 +511,7 @@ jobs:
   check_framework_firestore_symbols:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-13

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -345,7 +345,7 @@ jobs:
   quickstart_framework_database:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -511,7 +511,7 @@ jobs:
   check_framework_firestore_symbols:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-13

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,14 +111,13 @@ jobs:
       SDK: "ABTesting"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -134,7 +133,7 @@ jobs:
         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
     - uses: actions/checkout@v4
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup quickstart
       env:
         LEGACY: true
@@ -225,14 +224,13 @@ jobs:
       SDK: "Config"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -247,7 +245,7 @@ jobs:
         mkdir -p "${HOME}"/ios_frameworks/
         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup Swift Quickstart
 
       run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
@@ -277,14 +275,13 @@ jobs:
       SDK: "Crashlytics"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -300,7 +297,7 @@ jobs:
         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
     - uses: actions/checkout@v4
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup quickstart
       env:
         LEGACY: true
@@ -404,14 +401,13 @@ jobs:
       SDK: "DynamicLinks"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -430,7 +426,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup Swift Quickstart
       run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
     - name: Update Environment Variable For DynamicLinks
@@ -464,14 +460,13 @@ jobs:
       SDK: "Firestore"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -493,7 +488,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
         quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
@@ -505,7 +500,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.os }}
+        name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
         path: quickstart_artifacts_firestore.zip
 
   check_framework_firestore_symbols:
@@ -549,14 +544,13 @@ jobs:
       SDK: "InAppMessaging"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -577,7 +571,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup swift quickstart
       run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
     - name: Install Secret GoogleService-Info.plist
@@ -606,14 +600,13 @@ jobs:
       SDK: "Messaging"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -633,7 +626,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup swift quickstart
       run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
     - name: Install Secret GoogleService-Info.plist
@@ -662,14 +655,13 @@ jobs:
       SDK: "Storage"
     strategy:
       matrix:
-        os: [macos-13, macos-15]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
+        build-env:
           - os: macos-13
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Get framework dir
@@ -692,7 +684,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup swift quickstart
       env:
         LEGACY: true

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -104,7 +104,7 @@ jobs:
   quickstart_framework_abtesting:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -166,7 +166,7 @@ jobs:
   quickstart_framework_auth:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -218,7 +218,7 @@ jobs:
   quickstart_framework_config:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -270,7 +270,7 @@ jobs:
   quickstart_framework_crashlytics:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -397,7 +397,7 @@ jobs:
   quickstart_framework_dynamiclinks:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -457,7 +457,7 @@ jobs:
   quickstart_framework_firestore:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -542,7 +542,7 @@ jobs:
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -599,7 +599,7 @@ jobs:
   quickstart_framework_messaging:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -655,7 +655,7 @@ jobs:
   quickstart_framework_storage:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    # needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -104,7 +104,7 @@ jobs:
   quickstart_framework_abtesting:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -166,7 +166,7 @@ jobs:
   quickstart_framework_auth:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -218,7 +218,7 @@ jobs:
   quickstart_framework_config:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -270,7 +270,7 @@ jobs:
   quickstart_framework_crashlytics:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -397,7 +397,7 @@ jobs:
   quickstart_framework_dynamiclinks:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -457,7 +457,7 @@ jobs:
   quickstart_framework_firestore:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -542,7 +542,7 @@ jobs:
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -599,7 +599,7 @@ jobs:
   quickstart_framework_messaging:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -655,7 +655,7 @@ jobs:
   quickstart_framework_storage:
     # Don't run on private repo.
     # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    # needs: package-head
+    needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -27,33 +27,33 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # package-release:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   runs-on: macos-13
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: package-release
-  #   - name: Xcode 15.2
-  #     run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p release_zip_dir
-  #        sh -x scripts/build_zip.sh release_zip_dir \
-  #          "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}" \
-  #          build-release \
-  #          static
-  #   - uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Firebase-release-zip-zip
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: release_zip_dir
+  package-release:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: package-release
+    - name: Xcode 15.2
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p release_zip_dir
+         sh -x scripts/build_zip.sh release_zip_dir \
+           "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}" \
+           build-release \
+           static
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Firebase-release-zip-zip
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: release_zip_dir
 
   build:
     # Don't run on private repo unless it is a PR.
@@ -68,42 +68,42 @@ jobs:
         cd ReleaseTooling
         swift build -v
 
-  # package-head:
-  #   # Don't run on private repo.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-  #   needs: build
-  #   strategy:
-  #     matrix:
-  #       linking_type: [static, dynamic]
-  #   runs-on: macos-13
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: package-head
-  #   - name: Xcode 15.2
-  #     run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
-  #   - uses: ruby/setup-ruby@v1
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: ZipBuildingTest
-  #     run: |
-  #        mkdir -p zip_output_dir
-  #        sh -x scripts/build_zip.sh \
-  #          zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
-  #          build-head \
-  #          ${{ matrix.linking_type }}
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ always() }}
-  #     with:
-  #       name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
-  #       # Zip the entire output directory since the builder adds subdirectories we don't know the
-  #       # name of.
-  #       path: zip_output_dir
+  package-head:
+    # Don't run on private repo.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    needs: build
+    strategy:
+      matrix:
+        linking_type: [static, dynamic]
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: package-head
+    - name: Xcode 15.2
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
+    - uses: ruby/setup-ruby@v1
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: ZipBuildingTest
+      run: |
+         mkdir -p zip_output_dir
+         sh -x scripts/build_zip.sh \
+           zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \
+           build-head \
+           ${{ matrix.linking_type }}
+    - uses: actions/upload-artifact@v4
+      if: ${{ always() }}
+      with:
+        name: ${{ matrix.linking_type == 'static' && 'Firebase-actions-dir' || 'Firebase-actions-dir-dynamic' }}
+        # Zip the entire output directory since the builder adds subdirectories we don't know the
+        # name of.
+        path: zip_output_dir
 
   quickstart_framework_abtesting:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -165,7 +165,7 @@ jobs:
 
   quickstart_framework_auth:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -217,7 +217,7 @@ jobs:
 
   quickstart_framework_config:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -269,7 +269,7 @@ jobs:
 
   quickstart_framework_crashlytics:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -396,7 +396,7 @@ jobs:
 
   quickstart_framework_dynamiclinks:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -456,7 +456,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -541,7 +541,7 @@ jobs:
 
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -598,7 +598,7 @@ jobs:
 
   quickstart_framework_messaging:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -654,7 +654,7 @@ jobs:
 
   quickstart_framework_storage:
     # Don't run on private repo.
-    # if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/scripts/zip_quickstart_test.sh
+++ b/scripts/zip_quickstart_test.sh
@@ -30,11 +30,23 @@ if [[ ! -z "$LEGACY" ]]; then
   cd "Legacy${SAMPLE}Quickstart"
 fi
 
+xcode_version=$(xcodebuild -version | grep Xcode)
+xcode_version="${xcode_version/Xcode /}"
+xcode_major="${xcode_version/.*/}"
+
+if [[ "$xcode_major" -lt 15 ]]; then
+  device_name="iPhone 14"
+elif [[ "$xcode_major" -lt 16 ]]; then
+  device_name="iPhone 15"
+else
+  device_name="iPhone 16"
+fi
+
 (
 xcodebuild \
 -project ${SAMPLE}Example.xcodeproj \
 -scheme  ${SAMPLE}Example${SWIFT_SUFFIX} \
--destination 'platform=iOS Simulator,name=iPhone 14' "SWIFT_VERSION=5.3" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
+-destination "platform=iOS Simulator,name=$device_name" "SWIFT_VERSION=5.3" "OTHER_LDFLAGS=\$(OTHER_LDFLAGS) -ObjC" "FRAMEWORK_SEARCH_PATHS= \$(PROJECT_DIR)/Firebase/" HEADER_SEARCH_PATHS='$(PROJECT_DIR)/Firebase' \
 build \
 ) || EXIT_STATUS=$?
 


### PR DESCRIPTION
Updated the zip workflow to use `macos-15` for Xcode 16 jobs. Xcode 16.x is no longer available in macos-14 GitHub runner images resulting in [an error](https://github.com/firebase/firebase-ios-sdk/actions/runs/11716343768/job/32676678150#step:7:10) first noticed in #14044.

Also upgraded from Xcode 16.0 to Xcode 16.1 since it is [now available](https://github.com/actions/runner-images/blob/b4c921107cb265643b6517731f5cfe515e18a716/images/macos/macos-15-arm64-Readme.md?plain=1#L147) (note: the Xcode 16.1 RC has the same build number, `16B40`, as the final version and is symlinked as Xcode_16.1 in the runner images).

#no-changelog