### PR TITLE
[Infra] Update storage workflow to use macOS 15 for Xcode 16 jobs

### DIFF
--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -25,7 +25,7 @@ jobs:
         language: [Swift, ObjC]
         include:
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: ${{ matrix.os }}
@@ -96,22 +96,22 @@ jobs:
             xcode: Xcode_15.4
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: tvOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: macOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: watchOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: catalyst
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: visionOS
     runs-on: ${{ matrix.os }}
     steps:
@@ -200,8 +200,8 @@ jobs:
           - os: macos-14
             xcode: Xcode_15.3
             tests: --skip-tests
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
             tests: --test-specs=unit
     runs-on: ${{ matrix.os }}
     steps:
@@ -224,12 +224,12 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
-        os: [macos-14]
+        os: [macos-14, macos-15]
         include:
           - os: macos-14
             xcode: Xcode_15.3
-          - os: macos-14
-            xcode: Xcode_16
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     needs: pod-lib-lint
     steps:


### PR DESCRIPTION
Updated the `storage` workflow to use `macos-15` for Xcode 16 jobs. Xcode 16.x is no longer available in macos-14 GitHub runner images resulting in [an error](https://github.com/firebase/firebase-ios-sdk/actions/runs/11738278551/job/32700496142#step:6:7) first noticed in #14044.

Also upgraded from Xcode 16.0 to Xcode 16.1 since it is [now available](https://github.com/actions/runner-images/blob/b4c921107cb265643b6517731f5cfe515e18a716/images/macos/macos-15-arm64-Readme.md?plain=1#L147) (note: the Xcode 16.1 RC has the same build number, `16B40`, as the final version and is symlinked as Xcode_16.1 in the runner images).

#no-changelog