### PR TITLE
[Infra] Update database workflow to use macOS 15 for Xcode 16

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -26,8 +26,11 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos --skip-tests, watchos]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
+        include:
+          - os: macos-14
+            xcode: Xcode_15.2
+          - os: macos-15
+            xcode: Xcode_16.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -96,22 +99,22 @@ jobs:
             xcode: Xcode_15.4
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: tvOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: macOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: watchOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: catalyst
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: visionOS
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -26,19 +26,19 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos --skip-tests, watchos]
-        include:
+        build-env:
           - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDatabase.podspec --test-specs=unit --platforms=${{ matrix.target }}
 


### PR DESCRIPTION
Updated the `database ` workflow to use `macos-15` for Xcode 16 jobs. Xcode 16.x is no longer available in `macos-14` GitHub runner images resulting in [an error](https://github.com/firebase/firebase-ios-sdk/actions/runs/11740015069/job/32705718110#step:5:7) first noticed in #14044.

Also upgraded from Xcode 16.0 to Xcode 16.1 since it is [now available](https://github.com/actions/runner-images/blob/b4c921107cb265643b6517731f5cfe515e18a716/images/macos/macos-15-arm64-Readme.md?plain=1#L147) (note: the Xcode 16.1 RC has the same build number, `16B40`, as the final version and is symlinked as Xcode_16.1 in the runner images).

#no-changelog