### PR TITLE
Exempt the Data Connect FriendlyFlix Generated Code from style scripts

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -153,6 +153,9 @@ s%^./%%
 # Generated source
 \%/Firestore/core/src/util/config.h% d
 
+# Generated Code for Data Connect sample
+\%/Examples/FriendlyFlix/app/FriendlyFlixSDK/% d
+
 # Sources pulled in by travis bundler, with and without a leading slash
 \%^/?vendor/bundle/% d
 


### PR DESCRIPTION
Since the code generator keeps overwriting the formatted code, Peter requested we exempt the generated code folder from style checks. 


