### PR TITLE
[Infra] Fix missing Xcode 15 runs in `functions` and `storage` workflows

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -30,17 +30,17 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
-        include:
+        build-env:
           - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     # The integration tests are flaky on Xcode 15 so only run the unit tests. The integration tests still run with SPM.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -195,15 +195,14 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
-        os: [macos-14]
-        include:
+        build-env:
           - os: macos-14
             xcode: Xcode_15.3
             tests: --skip-tests
           - os: macos-15
             xcode: Xcode_16.1
             tests: --test-specs=unit
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
@@ -212,10 +211,10 @@ jobs:
     - name: Xcodes
       run: ls -l /Applications/Xcode*
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Build and test
       run: |
-       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec ${{ matrix.tests }} \
+       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec ${{ matrix.build-env.tests }} \
          --platforms=${{ matrix.target }}
 
   storage-cron-only:
@@ -224,13 +223,12 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
-        os: [macos-14, macos-15]
-        include:
+        build-env:
           - os: macos-14
             xcode: Xcode_15.3
           - os: macos-15
             xcode: Xcode_16.1
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build-env.os }}
     needs: pod-lib-lint
     steps:
     - uses: actions/checkout@v4
@@ -238,6 +236,6 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: PodLibLint Storage Cron
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} --use-static-frameworks --skip-tests


### PR DESCRIPTION
This addresses an issue, introduced in https://github.com/firebase/firebase-ios-sdk/pull/14056 and https://github.com/firebase/firebase-ios-sdk/pull/14051, where the `functions` and `storage` workflows were not running on Xcode 15 (see https://github.com/firebase/firebase-ios-sdk/pull/14062#discussion_r1835061889 for context). This uses the approach "A variable configuration in a matrix can be an `array` of `object`s" described in the [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-using-a-multi-dimension-matrix).

#no-changelog