### PR TITLE
[Infra] Update mlmodeldownloader workflow to use macOS 15 for Xcode 16

### DIFF
--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -22,9 +22,12 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
-        os: [macos-14]
-        xcode: [Xcode_15.2, Xcode_16]
-    runs-on: ${{ matrix.os }}
+        build-env:
+          - os: macos-14
+            xcode: Xcode_15.2
+          - os: macos-15
+            xcode: Xcode_16.1
+    runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
@@ -38,7 +41,7 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/MLModelDownloader/GoogleService-Info.plist.gpg \
           FirebaseMLModelDownloader/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
     - name: Build and test
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMLModelDownloader.podspec --platforms=${{ matrix.target }})
 
@@ -102,22 +105,22 @@ jobs:
             xcode: Xcode_15.4
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: iOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: tvOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: macOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: watchOS
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: catalyst
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.1
             target: visionOS
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Updated the `mlmodeldownloader` workflow to use `macos-15` for Xcode 16 jobs. Xcode 16.x is no longer available in `macos-14` GitHub runner images resulting in [an error](https://github.com/firebase/firebase-ios-sdk/actions/runs/11737614583/job/32698694865#step:7:8) first noticed in #14044.

Also upgraded from Xcode 16.0 to Xcode 16.1 since it is [now available](https://github.com/actions/runner-images/blob/b4c921107cb265643b6517731f5cfe515e18a716/images/macos/macos-15-arm64-Readme.md?plain=1#L147) (note: the Xcode 16.1 RC has the same build number, `16B40`, as the final version and is symlinked as Xcode_16.1 in the runner images).

#no-changelog