### PR TITLE
[auth] Fix logic inconsistency between 10.x and 11.x

### DIFF
--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1598,18 +1598,22 @@ extension User: NSSecureCoding {}
   /// Retrieves the Firebase authentication token, possibly refreshing it if it has expired.
   /// - Parameter forceRefresh
   func internalGetTokenAsync(forceRefresh: Bool = false) async throws -> String {
+    var keychainError = false
     do {
       let (token, tokenUpdated) = try await tokenService.fetchAccessToken(
         forcingRefresh: forceRefresh
       )
       if tokenUpdated {
         if let error = updateKeychain() {
+          keychainError = true
           throw error
         }
       }
       return token!
     } catch {
-      signOutIfTokenIsInvalid(withError: error)
+      if !keychainError {
+        signOutIfTokenIsInvalid(withError: error)
+      }
       throw error
     }
   }


### PR DESCRIPTION
While investigating #14026 I found the following logic inconsistency after a keychain error in `internalGetTokenAsync`. It was potentially signing out when Firebase 10 did not.

I'm not sure how this could cause #14026, but we should keep the logic consistent.

I'm also open to suggestions about a cleaner solution that doesn't require the new flag.

Here's the Firebase 10 version:
```
- (void)internalGetTokenForcingRefresh:(BOOL)forceRefresh
                              callback:(nonnull FIRAuthTokenCallback)callback {
  [_tokenService fetchAccessTokenForcingRefresh:forceRefresh
                                       callback:^(NSString *_Nullable token,
                                                  NSError *_Nullable error, BOOL tokenUpdated) {
                                         if (error) {
                                           [self signOutIfTokenIsInvalidWithError:error];
                                           callback(nil, error);
                                           return;
                                         }
                                         if (tokenUpdated) {
                                           if (![self updateKeychain:&error]) {
                                             callback(nil, error);
                                             return;
                                           }
                                         }
                                         callback(token, nil);
                                       }];
}
```