### PR TITLE
[Auth] Restore User decoding to pre-11 behavior

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting
+  logged out when upgrading from Firebase 8.10.0 or earlier to Firebase 11.
+  (#14011)
+
 # 11.4.0
 - [fixed] Restore Firebase 10 behavior by ignoring `nil` display names used
   during multi factor enrollment. (#13856)

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1704,11 +1704,6 @@ extension User: NSSecureCoding {}
 
   public required init?(coder: NSCoder) {
     guard let userID = coder.decodeObject(of: NSString.self, forKey: kUserIDCodingKey) as? String,
-          let apiKey = coder.decodeObject(of: NSString.self, forKey: kAPIKeyCodingKey) as? String,
-          let appID = coder.decodeObject(
-            of: NSString.self,
-            forKey: kFirebaseAppIDCodingKey
-          ) as? String,
           let tokenService = coder.decodeObject(of: SecureTokenService.self,
                                                 forKey: kTokenServiceCodingKey) else {
       return nil
@@ -1746,8 +1741,17 @@ extension User: NSSecureCoding {}
     self.phoneNumber = phoneNumber
     self.metadata = metadata ?? UserMetadata(withCreationDate: nil, lastSignInDate: nil)
     self.tenantID = tenantID
-    // The `heartbeatLogger` and `appCheck` will be set later via a property update.
-    requestConfiguration = AuthRequestConfiguration(apiKey: apiKey, appID: appID)
+
+    // Note, in practice, the caller will set the `auth` property of this user
+    // instance which will as a side-effect overwrite the request configuration.
+    // The assignment here is a best-effort placeholder.
+    let apiKey = coder.decodeObject(of: NSString.self, forKey: kAPIKeyCodingKey) as? String
+    let appID = coder.decodeObject(
+      of: NSString.self,
+      forKey: kFirebaseAppIDCodingKey
+    ) as? String
+    requestConfiguration = AuthRequestConfiguration(apiKey: apiKey ?? "", appID: appID ?? "")
+
     userProfileUpdate = UserProfileUpdate()
     #if os(iOS)
       self.multiFactor = multiFactor ?? MultiFactor()


### PR DESCRIPTION
The logging out was happening because the `User.init(coder:)` implementation in Firebase 11 was returning nil for cases where it previously hadn't in previous major versions.

Firebase 11 returned nil when any of the following was nil:
https://github.com/firebase/firebase-ios-sdk/blob/4e5fbe892e9e74c68725e54fdde5c28dc0fb60ba/FirebaseAuth/Sources/Swift/User/User.swift#L1706-L1715

But Firebase 10.29.0 returned nil in only 2 cases:
https://github.com/firebase/firebase-ios-sdk/blob/eca84fd638116dd6adb633b5a3f31cc7befcbb7d/FirebaseAuth/Sources/User/FIRUser.m#L360-L362

PR #9046 started encoding an app ID key to the user's archived format and that was first released in 8.11.0, so when updating from < 8.11 to 11+, the user instance would fail decoding with the early exit since the app ID couldn't be unarchived.

This failed silently through Firebase 10 because the Objective-C impl. didn't early exit and a `nil` decoding was silently allowed. 

Testing:
1. Auth QS with 8.8 -> sign in with a user
2. Auth QS with 11.4 -> confirmed user is logged out
3. Auth QS with 11.4 with this fix -> confirmed user logs in at app startup

Fixes #14011

#no-changelog