### PR TITLE
[Infra] Run Auth quickstart on macOS 15

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -221,7 +221,7 @@ jobs:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Updated the `quickstart` job in the `auth` workflow to run on `macos-15`. This matches the environment changes in https://github.com/firebase/quickstart-ios/pull/1630. This should resolve the [failure](https://github.com/firebase/firebase-ios-sdk/actions/runs/11775396507/job/32795766930#step:6:33) in https://github.com/firebase/firebase-ios-sdk/issues/14044.

#no-changelog