### PR TITLE
[Infra] Use macos-14 for the zip build

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -30,7 +30,7 @@ jobs:
   package-release:
     # Don't run on private repo.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -58,7 +58,7 @@ jobs:
   build:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Xcode 15.2
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         linking_type: [static, dynamic]
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -113,7 +113,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -226,7 +226,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -277,7 +277,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -349,7 +349,7 @@ jobs:
       SDK: "Database"
     strategy:
       matrix:
-        os: [macos-13]
+        os: [macos-14]
         xcode: [Xcode_15.2]
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
     runs-on: ${{ matrix.os }}
@@ -403,7 +403,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -462,7 +462,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -509,7 +509,7 @@ jobs:
     needs: package-head
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Xcode 15.2
         run: sudo xcode-select -s /Applications/Xcode_15.2.app/Contents/Developer
@@ -546,7 +546,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -602,7 +602,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1
@@ -657,7 +657,7 @@ jobs:
       matrix:
         artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
-          - os: macos-13
+          - os: macos-14
             xcode: Xcode_15.2
           - os: macos-15
             xcode: Xcode_16.1


### PR DESCRIPTION
We reverted back to using the much slower `macos-13` runner images in https://github.com/firebase/firebase-ios-sdk/pull/13562 because of frequent failures due to running out of disk space. This may no longer be an issue now that GitHub has limited `macos-14` runners to Xcode 15.x. Testing on CI.

#no-changelog