### PR TITLE
[Auth] Mark *Credential classes as Sendable

### DIFF
--- a/FirebaseAuth/Sources/Swift/AuthProvider/AuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/AuthCredential.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// Public representation of a credential.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthCredential) open class AuthCredential: NSObject {
+@objc(FIRAuthCredential) open class AuthCredential: NSObject, @unchecked Sendable {
   /// The name of the identity provider for the credential.
   @objc public let provider: String
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/EmailAuthProvider.swift
@@ -38,7 +38,8 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIREmailPasswordAuthCredential) class EmailAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIREmailPasswordAuthCredential) class EmailAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   let email: String
 
   enum EmailType {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/FacebookAuthProvider.swift
@@ -34,7 +34,8 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRFacebookAuthCredential) class FacebookAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRFacebookAuthCredential) class FacebookAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   let accessToken: String
 
   init(withAccessToken accessToken: String) {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GameCenterAuthProvider.swift
@@ -129,7 +129,7 @@
 
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   @objc(FIRGameCenterAuthCredential)
-  class GameCenterAuthCredential: AuthCredential, NSSecureCoding {
+  class GameCenterAuthCredential: AuthCredential, NSSecureCoding, @unchecked Sendable {
     let playerID: String
     let teamPlayerID: String?
     let gamePlayerID: String?

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GitHubAuthProvider.swift
@@ -34,7 +34,8 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRGitHubAuthCredential) class GitHubAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRGitHubAuthCredential) class GitHubAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   let token: String
 
   init(withToken token: String) {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/GoogleAuthProvider.swift
@@ -36,7 +36,8 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRGoogleAuthCredential) class GoogleAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRGoogleAuthCredential) class GoogleAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   let idToken: String
   let accessToken: String
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthCredential.swift
@@ -16,7 +16,8 @@ import Foundation
 
 /// Internal implementation of `AuthCredential` for generic credentials.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIROAuthCredential) open class OAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIROAuthCredential) open class OAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   /// The ID Token associated with this credential.
   @objc(IDToken) public let idToken: String?
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthCredential.swift
@@ -18,7 +18,8 @@ import Foundation
 ///
 /// This class is available on iOS only.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRPhoneAuthCredential) open class PhoneAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRPhoneAuthCredential) open class PhoneAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   enum CredentialKind {
     case phoneNumber(_ phoneNumber: String, _ temporaryProof: String)
     case verification(_ id: String, _ code: String)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/TwitterAuthProvider.swift
@@ -35,7 +35,8 @@ import Foundation
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRTwitterAuthCredential) class TwitterAuthCredential: AuthCredential, NSSecureCoding {
+@objc(FIRTwitterAuthCredential) class TwitterAuthCredential: AuthCredential, NSSecureCoding,
+  @unchecked Sendable {
   let token: String
   let secret: String
 

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthRecaptchaVerifier.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthRecaptchaVerifier.swift
@@ -44,7 +44,7 @@
   }
 
   @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AuthRecaptchaVerifier {
+  class AuthRecaptchaVerifier: @unchecked Sendable {
     private(set) weak var auth: Auth?
     private(set) var agentConfig: AuthRecaptchaConfig?
     private(set) var tenantConfigs: [String: AuthRecaptchaConfig] = [:]


### PR DESCRIPTION
These classes have no mutable state so they should meet the semantic requirements of Sendable. In Firebase 12, we should refactor to _checked_  Sendable. We can't currently do so without a breaking change because of the fact that the classes are `open` (Sendable classes may not be `open`).

Resolves:
<img width="857" alt="Screenshot 2024-11-12 at 4 45 07 PM" src="https://github.com/user-attachments/assets/725d80da-bfc8-4382-8d26-7a98469345b6">

<img width="826" alt="Screenshot 2024-11-12 at 4 45 25 PM" src="https://github.com/user-attachments/assets/97429d86-f226-4143-9630-c89615609681">

Because the APIs return the `AuthCredential` superclass, `AuthCredential` needs to be marked unchecked Sendable. All of it's subclasses need to then be marked unchecked Sendable or a warning will occur that the sendability of the superclass means the subclass should also explicitly mark itself as unchecked Sendable.

I added some API improvement ideas to the Firebase 12 gdoc.

#no-changelog