### PR TITLE
[Auth] Ignore concurrency warnings for global vars made for testing

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -20,12 +20,12 @@ private let kHttpProtocol = "http:"
 private let kEmulatorHostAndPrefixFormat = "%@/%@"
 
 #if compiler(>=6)
-/// Host for server API calls.
-private nonisolated(unsafe) var gAPIHost = "www.googleapis.com"
+  /// Host for server API calls.
+  private nonisolated(unsafe) var gAPIHost = "www.googleapis.com"
 #else
-/// Host for server API calls.
-private var gAPIHost = "www.googleapis.com"
-#endif  // compiler(>=6)
+  /// Host for server API calls.
+  private var gAPIHost = "www.googleapis.com"
+#endif // compiler(>=6)
 
 private let kFirebaseAuthAPIHost = "www.googleapis.com"
 private let kIdentityPlatformAPIHost = "identitytoolkit.googleapis.com"

--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -20,10 +20,12 @@ private let kHttpProtocol = "http:"
 private let kEmulatorHostAndPrefixFormat = "%@/%@"
 
 #if compiler(>=6)
-  /// Host for server API calls.
+  /// Host for server API calls. This should be changed via
+  /// `IdentityToolkitRequest.setHost(_ host:)` for testing purposes only.
   private nonisolated(unsafe) var gAPIHost = "www.googleapis.com"
 #else
-  /// Host for server API calls.
+  /// Host for server API calls. This should be changed via
+  /// `IdentityToolkitRequest.setHost(_ host:)` for testing purposes only.
   private var gAPIHost = "www.googleapis.com"
 #endif // compiler(>=6)
 

--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -19,7 +19,13 @@ private let kHttpProtocol = "http:"
 
 private let kEmulatorHostAndPrefixFormat = "%@/%@"
 
+#if compiler(>=6)
+/// Host for server API calls.
+private nonisolated(unsafe) var gAPIHost = "www.googleapis.com"
+#else
+/// Host for server API calls.
 private var gAPIHost = "www.googleapis.com"
+#endif  // compiler(>=6)
 
 private let kFirebaseAuthAPIHost = "www.googleapis.com"
 private let kIdentityPlatformAPIHost = "identitytoolkit.googleapis.com"

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -54,8 +54,13 @@ private let kRefreshTokenKey = "refreshToken"
 /// The key for the "code" parameter in the request.
 private let kCodeKey = "code"
 
+#if compiler(>=6)
+/// Host for server API calls.
+private nonisolated(unsafe) var gAPIHost = "securetoken.googleapis.com"
+#else
 /// Host for server API calls.
 private var gAPIHost = "securetoken.googleapis.com"
+#endif  // compiler(>=6)
 
 /// Represents the parameters for the token endpoint.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -55,12 +55,12 @@ private let kRefreshTokenKey = "refreshToken"
 private let kCodeKey = "code"
 
 #if compiler(>=6)
-/// Host for server API calls.
-private nonisolated(unsafe) var gAPIHost = "securetoken.googleapis.com"
+  /// Host for server API calls.
+  private nonisolated(unsafe) var gAPIHost = "securetoken.googleapis.com"
 #else
-/// Host for server API calls.
-private var gAPIHost = "securetoken.googleapis.com"
-#endif  // compiler(>=6)
+  /// Host for server API calls.
+  private var gAPIHost = "securetoken.googleapis.com"
+#endif // compiler(>=6)
 
 /// Represents the parameters for the token endpoint.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -55,10 +55,12 @@ private let kRefreshTokenKey = "refreshToken"
 private let kCodeKey = "code"
 
 #if compiler(>=6)
-  /// Host for server API calls.
+  /// Host for server API calls. This should be changed via
+  /// `SecureTokenRequest.setHost(_ host:)` for testing purposes only.
   private nonisolated(unsafe) var gAPIHost = "securetoken.googleapis.com"
 #else
-  /// Host for server API calls.
+  /// Host for server API calls. This should be changed via
+  /// `SecureTokenRequest.setHost(_ host:)` for testing purposes only.
   private var gAPIHost = "securetoken.googleapis.com"
 #endif // compiler(>=6)
 


### PR DESCRIPTION
These fixes address global mutable state errors. These are mutable so the Auth sample app can toggle between different hosts. I've so far tried to avoid using `nonisolated(unsafe)`, but I couldn't find a simpler way to address them for now.

If we introduce any global actors, we can synchronize them on a global actor. Until there is a need for that though, I feel it's fine to ignore the warnings via this PR.

#no-changelog