### PR TITLE
[Release] Add `FirebaseCombineSwift` to `FirebaseManifest`

### DIFF
--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCombineSwift'
-  s.version          = '11.0.0'
+  s.version          = '11.6.0'
   s.summary          = 'Swift extensions with Combine support for Firebase'
 
   s.description      = <<-DESC
@@ -51,7 +51,7 @@ for internal testing only. It should not be published.
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '11.5'
+  s.dependency 'FirebaseCore', '11.6.0'
   s.dependency 'FirebaseAuth', '~> 11.0'
   s.dependency 'FirebaseFunctions', '~> 11.0'
   s.dependency 'FirebaseFirestore', '~> 11.0'

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -55,8 +55,6 @@ public let shared = Manifest(
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
     Pod("FirebaseVertexAI", zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
-    Pod("FirebaseAuthTestingSupport", podVersion: "2.0.0", releasing: false, zip: false),
-    Pod("FirebaseFirestoreTestingSupport", podVersion: "1.0.0", releasing: false, zip: false),
     Pod("FirebaseCombineSwift", releasing: false, zip: false),
   ]
 )

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -55,6 +55,9 @@ public let shared = Manifest(
     Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
     Pod("FirebaseVertexAI", zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
+    Pod("FirebaseAuthTestingSupport", podVersion: "2.0.0", releasing: false, zip: false),
+    Pod("FirebaseFirestoreTestingSupport", podVersion: "1.0.0", releasing: false, zip: false),
+    Pod("FirebaseCombineSwift", releasing: false, zip: false),
   ]
 )
 
@@ -64,6 +67,7 @@ public struct Manifest {
   public let pods: [Pod]
 
   public func versionString(_ pod: Pod) -> String {
+    let version = pod.podVersion ?? self.version
     return pod.isBeta ? version + "-beta" : version
   }
 }

--- a/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
@@ -28,6 +28,8 @@ public struct Pod {
   public let allowWarnings: Bool
   /// Set of platforms (e.g. "ios", "macos", "tvos", or "watchos") to build this pod for.
   public let platforms: Set<String>
+  /// Allows overriding the ``Manifest/version`` for this pod; defaults to `nil`.
+  public let podVersion: String?
   /// Whether or not the pod is planned for publicly releasing (as some pods are for
   /// internal/testing use).
   public let releasing: Bool
@@ -47,6 +49,7 @@ public struct Pod {
     self.isBeta = isBeta
     self.allowWarnings = allowWarnings
     self.platforms = platforms
+    self.podVersion = podVersion
     self.releasing = releasing
     self.zip = zip
   }

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -361,7 +361,7 @@ struct ZipBuilder {
   /// - Throws: One of many errors that could have happened during the build phase.
   func buildAndAssembleFirebaseRelease(templateDir: URL) throws -> ReleaseArtifacts {
     let manifest = FirebaseManifest.shared
-    var podsToInstall = manifest.pods.map {
+    var podsToInstall = manifest.pods.filter { $0.releasing }.map {
       CocoaPodUtils.VersionedPod(name: $0.name,
                                  version: manifest.versionString($0),
                                  platforms: $0.platforms)


### PR DESCRIPTION
Added the `FirebaseCombineSwift` pod to the `FirebaseManifest` but specified as `releasing: false, zip: false`. Updated the `Pod` initializer to store `podVersion` if specified (previously ignored) and updated `Manifest.versionString(_:)` to use the `podVersion` (was intended for including `FirebaseAuthTestingSupport` and `FirebaseFirestoreTestingSupport` in the Manifest but not needed).

Note: The `combine` workflow is currently [failing](https://github.com/firebase/firebase-ios-sdk/actions/runs/11812265595/job/32907175474#step:7:88) (https://github.com/firebase/firebase-ios-sdk/issues/14106) because the release tooling did not update its dependency on `FirebaseCore` to the new version in https://github.com/firebase/firebase-ios-sdk/pull/14104 and the version requirements are now stricter.

#no-changelog