### PR TITLE
[Auth] Synchronize static method of AuthDefaultUIDelegate on main actor

### DIFF
--- a/FirebaseAuth/Sources/Swift/Utilities/AuthDefaultUIDelegate.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthDefaultUIDelegate.swift
@@ -26,10 +26,10 @@
   ///
   /// This class should be used in the case that a UIDelegate was expected and necessary to
   /// continue a given flow, but none was provided.
-  class AuthDefaultUIDelegate: NSObject, AuthUIDelegate {
+  final class AuthDefaultUIDelegate: NSObject, AuthUIDelegate {
     /// Returns a default AuthUIDelegate object.
     /// - Returns: The default AuthUIDelegate object.
-    class func defaultUIDelegate() -> AuthUIDelegate? {
+    @MainActor static func defaultUIDelegate() -> AuthUIDelegate? {
       if GULAppEnvironmentUtil.isAppExtension() {
         // iOS App extensions should not call [UIApplication sharedApplication], even if
         // UIApplication responds to it.


### PR DESCRIPTION
Method's Implementation uses a lot of main actor isolated APIs, so I think it makes sense to isolate the entire method on the main actor.

The caller of this API is in a DispatchQueue.main.async {} which is isolated on the main actor so no call sites need to change. 

<img width="878" alt="Screenshot 2024-11-13 at 2 11 46 PM" src="https://github.com/user-attachments/assets/b0464bf4-94df-404e-9cd8-38fcc87f8c19">

Other no-op changes were to make the class final and switch the method from a class method to a static method.

#no-changelog 