### PR TITLE
[Combine] Update FirebaseCore pod dep to allow patch updates

### DIFF
--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -51,7 +51,7 @@ for internal testing only. It should not be published.
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '11.5'
+  s.dependency 'FirebaseCore', '~> 11.6.0'
   s.dependency 'FirebaseAuth', '~> 11.0'
   s.dependency 'FirebaseFunctions', '~> 11.0'
   s.dependency 'FirebaseFirestore', '~> 11.0'


### PR DESCRIPTION
Updated the `FirebaseCore` dependency in the the `FirebaseCombineSwift` podspec to allow patch updates (`'~> 11.6.0'`). This was missed in https://github.com/firebase/firebase-ios-sdk/pull/14113 since the version was not updated from `'11.5'` by the release tooling; this is being addressed in https://github.com/firebase/firebase-ios-sdk/pull/14110.

#no-changelog