### PR TITLE
[Infra] Exclude pods that aren't releasing in GHAMatrixSpecCollector

### DIFF
--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   tests:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     runs-on: macos-14
     steps:

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   tests:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+        || github.event_name == 'workflow_dispatch'
 
     runs-on: macos-14
     steps:

--- a/.github/workflows/notice_generation.yml
+++ b/.github/workflows/notice_generation.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   generate_a_notice:
     # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.repository == 'Firebase/firebase-ios-sdk' || github.event_name == 'workflow_dispatch'
     runs-on: macos-14
     name: Generate NOTICES
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
   buildup_SpecsReleasing_repo:
     needs: [buildup_SpecsReleasing_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
-    if: github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.repository == 'Firebase/firebase-ios-sdk' || github.event_name == 'workflow_dispatch'
     runs-on: macos-14
     strategy:
       fail-fast: false

--- a/ReleaseTooling/Sources/ManifestParser/GHAMatrixSpecCollector.swift
+++ b/ReleaseTooling/Sources/ManifestParser/GHAMatrixSpecCollector.swift
@@ -31,11 +31,10 @@ struct SDKPodspec: Codable {
 struct GHAMatrixSpecCollector {
   var SDKRepoURL: URL
   var outputSpecFileURL: URL
-  var excludedSDKs: [String] = []
 
   func getPodsInManifest(_ manifest: Manifest) -> [String: SDKPodspec] {
     var podsMap: [String: SDKPodspec] = [:]
-    for pod in manifest.pods {
+    for pod in manifest.pods.filter({ $0.releasing }) {
       podsMap[pod.name] = SDKPodspec(podspec: pod.name, allowWarnings: pod.allowWarnings)
     }
     return podsMap

--- a/ReleaseTooling/Sources/ManifestParser/main.swift
+++ b/ReleaseTooling/Sources/ManifestParser/main.swift
@@ -42,15 +42,12 @@ struct ManifestParser: ParsableCommand {
           })
   var outputFilePath: URL
 
-  @Option(parsing: .upToNextOption, help: "Podspec files that will not be included.")
-  var excludedSpecs: [String]
-
   @Flag(help: "Parsing mode for manifest")
   var mode: ParsingMode
 
   func parsePodNames(_ manifest: Manifest) throws {
     var output: [String] = []
-    for pod in manifest.pods {
+    for pod in manifest.pods.filter({ $0.releasing }) {
       output.append(pod.name)
     }
     do {

--- a/ReleaseTooling/Sources/ManifestParser/main.swift
+++ b/ReleaseTooling/Sources/ManifestParser/main.swift
@@ -69,9 +69,7 @@ struct ManifestParser: ParsableCommand {
       try parsePodNames(FirebaseManifest.shared)
     case .forGHAMatrixGeneration:
       guard let sdkRepoURL = SDKRepoURL else {
-        throw fatalError(
-          "--sdk-repo-url should be specified when --for-gha-matrix-generation is on."
-        )
+        fatalError("--sdk-repo-url should be specified when --for-gha-matrix-generation is on.")
       }
       let specCollector = GHAMatrixSpecCollector(
         SDKRepoURL: sdkRepoURL,


### PR DESCRIPTION
Attempting to exclude `FirebaseCombineSwift.podspec` in `GHAMatrixSpecCollector` to resolve an [error](https://github.com/firebase/firebase-ios-sdk/actions/runs/11831032339/job/32992295914) in https://github.com/firebase/firebase-ios-sdk/issues/14106. Added workflow_dispatch options in multiple workflows to allow them to be trigger manually from https://github.com/firebase/firebase-ios-sdk/actions.

#no-changelog