### PR TITLE
[Infra] Update workflows from Python 3.10 to 3.11

### DIFF
--- a/.github/workflows/api_diff_report.yml
+++ b/.github/workflows/api_diff_report.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install Prerequisites
         run:  ~/api_diff_report/prerequisite.sh

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -130,7 +130,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake
@@ -180,7 +180,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firestore.plist.gpg \
@@ -259,7 +259,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake


### PR DESCRIPTION
Updated the `API Diff Report` and `firestore` workflows to use Python 3.11 instead of 3.10. Python 3.10 will be removed from GitHub runner images on 2024-11-18: https://github.com/actions/runner-images/issues/10812

#no-changelog