### PR TITLE
[Infra] Switch to iPhone 15 simulator in build_with_environment.sh

### DIFF
--- a/IntegrationTesting/CocoapodsIntegrationTest/scripts/build_with_environment.sh
+++ b/IntegrationTesting/CocoapodsIntegrationTest/scripts/build_with_environment.sh
@@ -36,7 +36,7 @@ function runXcodebuild() {
   parameters=("${buildcache_xcb_flags[@]}" "${parameters[@]}")
 
   echo xcodebuild "${parameters[@]}"
-  xcodebuild "${parameters[@]}" | xcpretty; result=$?
+  xcodebuild "${parameters[@]}" | xcbeautify --renderer github-actions; result=$?
 }
 
 # Configures bundler environment using Gemfile at the specified path.


### PR DESCRIPTION
The iPhone 14 simulator is no longer available in the `macos-14` GitHub [runner images](https://github.com/actions/runner-images/blob/d29e71f0c5a25e7f31f75ed76511b089decb45f0/images/macos/macos-14-arm64-Readme.md?plain=1#L204-L207). Switching to iPhone 15 fixes `cocoapods-integration.tests`.

#no-changelog