### PR TITLE
[Auth] Make AuthBackend and related types Sendable

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -22,12 +22,12 @@ import Foundation
 #endif
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-protocol AuthBackendProtocol {
+protocol AuthBackendProtocol: Sendable {
   func call<T: AuthRPCRequest>(with request: T) async throws -> T.Response
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthBackend: AuthBackendProtocol {
+final class AuthBackend: AuthBackendProtocol {
   static func authUserAgent() -> String {
     return "FirebaseAuth.iOS/\(FirebaseVersion()) \(GTMFetcherStandardUserAgentString(nil))"
   }

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
@@ -16,13 +16,13 @@ import FirebaseCore
 import FirebaseCoreExtension
 import Foundation
 #if COCOAPODS
-  import GTMSessionFetcher
+  @preconcurrency import GTMSessionFetcher
 #else
-  import GTMSessionFetcherCore
+  @preconcurrency import GTMSessionFetcherCore
 #endif
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-protocol AuthBackendRPCIssuerProtocol {
+protocol AuthBackendRPCIssuerProtocol: Sendable {
   /// Asynchronously send a HTTP request.
   /// - Parameter request: The request to be made.
   /// - Parameter body: Request body.
@@ -35,7 +35,7 @@ protocol AuthBackendRPCIssuerProtocol {
 }
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthBackendRPCIssuer: AuthBackendRPCIssuerProtocol {
+final class AuthBackendRPCIssuer: AuthBackendRPCIssuerProtocol {
   let fetcherService: GTMSessionFetcherService
 
   init() {

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -17,13 +17,12 @@ import XCTest
 
 @testable import FirebaseAuth
 
-// TODO: Investigate making this class support generics for the `request`.
-/** @class FakeBackendRPCIssuer
-    @brief An implementation of @c AuthBackendRPCIssuer which is used to test backend request,
-        response, and glue logic.
- */
+// TODO(ncooke3): Investigate making this class support generics for the `request`.
+// TODO(ncooke3): Refactor to make checked Sendable.
+/// An implementation of `AuthBackendRPCIssuerProtocol` which is used to test
+/// backend request, response, and glue logic.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class FakeBackendRPCIssuer: AuthBackendRPCIssuer {
+final class FakeBackendRPCIssuer: AuthBackendRPCIssuerProtocol, @unchecked Sendable {
   /** @property requestURL
       @brief The URL which was requested.
    */
@@ -77,8 +76,8 @@ class FakeBackendRPCIssuer: AuthBackendRPCIssuer {
   var secureTokenErrorString: String?
   var recaptchaSiteKey = "unset recaptcha siteKey"
 
-  override func asyncCallToURL<T>(with request: T, body: Data?,
-                                  contentType: String) async -> (Data?, Error?)
+  func asyncCallToURL<T>(with request: T, body: Data?,
+                         contentType: String) async -> (Data?, Error?)
     where T: FirebaseAuth.AuthRPCRequest {
     return await withCheckedContinuation { continuation in
       self.asyncCallToURL(with: request, body: body, contentType: contentType) { data, error in
@@ -172,7 +171,7 @@ class FakeBackendRPCIssuer: AuthBackendRPCIssuer {
   }
 
   func respond(serverErrorMessage errorMessage: String, error: NSError) throws {
-    let _ = try respond(withJSON: ["error": ["message": errorMessage]], error: error)
+    _ = try respond(withJSON: ["error": ["message": errorMessage]], error: error)
   }
 
   @discardableResult func respond(underlyingErrorMessage errorMessage: String,


### PR DESCRIPTION
Addresses a couple places where AuthBackend is being sent across concurrency domains. The class is immutable and should be ok to mark Sendable. It does have a dependency on GTMSessionFetcher so preconcurrency imports are being used for those imports to suppress warnings that those type are not sendable.

e.g. `Sending 'backend' risks causing data races`

#no-changelog