### PR TITLE
[Infra] Use macos-13 + Xcode 14 in inappmessaging workflow

### DIFF
--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -45,13 +45,13 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
 # TODO(#12770): Update to macos-14 when tests are updated for Xcode 15.
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
 # TODO(#8682): Reenable iPad after fixing Xcode 13 test failures.
 #        platform: [iOS, iPad]
         platform: [iOS]
-
+        xcode: [Xcode_14.2]
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
@@ -60,6 +60,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Prereqs
       run: scripts/install_prereqs.sh InAppMessaging ${{ matrix.platform }} xcodebuild
     - name: Build and test


### PR DESCRIPTION
Trying the FIAM tests job on macos-13 since Xcode 14.x is still available there.

#no-changelog