### PR TITLE
[Auth] Get 'currentUser' on Auth worker queue

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Restore Firebase 10 behavior by synchronizing access to the
+  `Auth.currentUser` API. This resolves some Firebase 11 issues where the
+  current user is unexpectedly `nil` at startup.
+
 # 11.5.0
 - [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting
   logged out when upgrading from Firebase 8.10.0 or earlier to Firebase 11.


### PR DESCRIPTION
In 10.x, the ivar _currentUser was not synchronized and use within the implementation. With this PR, the new ivar should be managed just like in 10.x. The public var is now synchronized. Note, if you search for `currentUser {` in 10.29, you can see that the synchronized current user is not used anywhere within the implementation: https://github.com/firebase/firebase-ios-sdk/blob/10.29.0/FirebaseAuth/Sources/Auth/FIRAuth.m

Fix for some scenarios in #13231 → https://github.com/firebase/firebase-ios-sdk/issues/13231#issuecomment-2356432490. Still investigating other cases.