### PR TITLE
[Auth] Remove httpMethod from AuthRequestConfiguration

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -60,15 +60,15 @@ final class AuthBackend: AuthBackendProtocol {
     }
   }
 
-  static func request(withURL url: URL,
-                      contentType: String,
-                      requestConfiguration: AuthRequestConfiguration) async -> URLRequest {
+  static func urlRequest(from rpcRequest: any AuthRPCRequest,
+                         contentType: String,
+                         requestConfiguration: AuthRequestConfiguration) async -> URLRequest {
     // Kick off tasks for the async header values.
     async let heartbeatsHeaderValue = requestConfiguration.heartbeatLogger?.asyncHeaderValue()
     async let appCheckTokenHeaderValue = requestConfiguration.appCheck?
       .getToken(forcingRefresh: true)
 
-    var request = URLRequest(url: url)
+    var request = URLRequest(url: rpcRequest.requestURL())
     request.setValue(contentType, forHTTPHeaderField: "Content-Type")
     let additionalFrameworkMarker = requestConfiguration
       .additionalFrameworkMarker ?? "FirebaseCore-iOS"
@@ -76,7 +76,7 @@ final class AuthBackend: AuthBackendProtocol {
     request.setValue(clientVersion, forHTTPHeaderField: "X-Client-Version")
     request.setValue(Bundle.main.bundleIdentifier, forHTTPHeaderField: "X-Ios-Bundle-Identifier")
     request.setValue(requestConfiguration.appID, forHTTPHeaderField: "X-Firebase-GMPID")
-    request.httpMethod = requestConfiguration.httpMethod
+    request.httpMethod = rpcRequest.containsPostBody ? "POST" : "GET"
     let preferredLocalizations = Bundle.main.preferredLocalizations
     if preferredLocalizations.count > 0 {
       request.setValue(preferredLocalizations.first, forHTTPHeaderField: "Accept-Language")

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -167,7 +167,6 @@ final class AuthBackend: AuthBackendProtocol {
     if let postBody = request.unencodedHTTPRequestBody {
       #if DEBUG
         let JSONWritingOptions = JSONSerialization.WritingOptions.prettyPrinted
-      )
       #else
         let JSONWritingOptions = JSONSerialization.WritingOptions(rawValue: 0)
       #endif

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
@@ -52,9 +52,11 @@ final class AuthBackendRPCIssuer: AuthBackendRPCIssuerProtocol {
                                          body: Data?,
                                          contentType: String) async -> (Data?, Error?) {
     let requestConfiguration = request.requestConfiguration()
-    let request = await AuthBackend.request(withURL: request.requestURL(),
-                                            contentType: contentType,
-                                            requestConfiguration: requestConfiguration)
+    let request = await AuthBackend.urlRequest(
+      from: request,
+      contentType: contentType,
+      requestConfiguration: requestConfiguration
+    )
     let fetcher = fetcherService.fetcher(with: request)
     if let _ = requestConfiguration.emulatorHostAndPort {
       fetcher.allowLocalhostRequest = true

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackendRPCIssuer.swift
@@ -52,8 +52,9 @@ final class AuthBackendRPCIssuer: AuthBackendRPCIssuerProtocol {
                                          body: Data?,
                                          contentType: String) async -> (Data?, Error?) {
     let requestConfiguration = request.requestConfiguration()
-    let request = await AuthBackend.urlRequest(
-      from: request,
+    let request = await AuthBackend.request(
+      for: request.requestURL(),
+      httpMethod: body == nil ? "GET" : "POST",
       contentType: contentType,
       requestConfiguration: requestConfiguration
     )

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRPCRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRPCRequest.swift
@@ -22,14 +22,11 @@ protocol AuthRPCRequest {
   /// Gets the request's full URL.
   func requestURL() -> URL
 
-  /// Returns whether the request contains a post body or not. Requests without a post body are
-  /// GET requests. A default implementation returns `true`.
-  var containsPostBody: Bool { get }
-
   /// Creates unencoded HTTP body representing the request.
-  /// - Throws: Any error which occurred constructing the request.
   /// - Returns: The HTTP body data representing the request before any encoding.
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable]
+  /// - Note: Requests with a post body are POST requests. Requests without a
+  /// post body are GET requests.
+  var unencodedHTTPRequestBody: [String: AnyHashable]? { get }
 
   /// The request configuration.
   func requestConfiguration() -> AuthRequestConfiguration
@@ -41,7 +38,6 @@ protocol AuthRPCRequest {
 // in Obj-C.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 extension AuthRPCRequest {
-  var containsPostBody: Bool { return true }
   func injectRecaptchaFields(recaptchaResponse: String?, recaptchaVersion: String) {
     fatalError("Internal FirebaseAuth Error: unimplemented injectRecaptchaFields")
   }

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
@@ -38,9 +38,6 @@ class AuthRequestConfiguration {
   /// The appCheck is used to generate a token.
   var appCheck: AppCheckInterop?
 
-  /// The HTTP method used in the request.
-  var httpMethod: String
-
   /// Additional framework marker that will be added as part of the header of every request.
   var additionalFrameworkMarker: String?
 
@@ -57,6 +54,5 @@ class AuthRequestConfiguration {
     self.auth = auth
     self.heartbeatLogger = heartbeatLogger
     self.appCheck = appCheck
-    httpMethod = "POST"
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/IdentityToolkitRequest.swift
@@ -70,8 +70,6 @@ class IdentityToolkitRequest {
     tenantID = requestConfiguration.auth?.tenantID
   }
 
-  var containsPostBody: Bool { return true }
-
   func queryParams() -> String {
     return ""
   }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/CreateAuthURIRequest.swift
@@ -78,7 +78,7 @@ class CreateAuthURIRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kCreateAuthURIEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [
       kIdentifierKey: identifier,
       kContinueURIKey: continueURI,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/DeleteAccountRequest.swift
@@ -41,7 +41,7 @@ class DeleteAccountRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kDeleteAccountEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     [
       kIDTokenKey: accessToken,
       kLocalIDKey: localID,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/EmailLinkSignInRequest.swift
@@ -51,7 +51,7 @@ class EmailLinkSignInRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kEmailLinkSigninEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [
       kEmailKey: email,
       kOOBCodeKey: oobCode,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetAccountInfoRequest.swift
@@ -39,7 +39,7 @@ class GetAccountInfoRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kGetAccountInfoEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     return [kIDTokenKey: accessToken]
   }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -228,7 +228,7 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
          requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [
       kRequestTypeKey: requestType.value,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
@@ -15,7 +15,6 @@
 import Foundation
 
 /// The "getProjectConfig" endpoint.
-
 private let kGetProjectConfigEndPoint = "getProjectConfig"
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
@@ -23,7 +22,6 @@ class GetProjectConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = GetProjectConfigResponse
 
   init(requestConfiguration: AuthRequestConfiguration) {
-    requestConfiguration.httpMethod = "GET"
     super.init(endpoint: kGetProjectConfigEndPoint, requestConfiguration: requestConfiguration)
   }
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetProjectConfigRequest.swift
@@ -25,10 +25,7 @@ class GetProjectConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kGetProjectConfigEndPoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
-    // TODO: Probably nicer to throw, but what should we throw?
-    fatalError()
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
+    nil
   }
-
-  override var containsPostBody: Bool { return false }
 }

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
@@ -55,11 +55,9 @@ class GetRecaptchaConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
-    return [:]
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
+    nil
   }
-
-  override var containsPostBody: Bool { return false }
 
   override func queryParams() -> String {
     var queryParams = "&\(kClientTypeKey)=\(clientType)&\(kVersionKey)=\(kRecaptchaVersion)"

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetRecaptchaConfigRequest.swift
@@ -48,7 +48,6 @@ class GetRecaptchaConfigRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = GetRecaptchaConfigResponse
 
   required init(requestConfiguration: AuthRequestConfiguration) {
-    requestConfiguration.httpMethod = "GET"
     super.init(
       endpoint: kGetRecaptchaConfigEndpoint,
       requestConfiguration: requestConfiguration,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/FinalizeMFAEnrollmentRequest.swift
@@ -71,7 +71,7 @@ class FinalizeMFAEnrollmentRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [:]
     if let idToken = idToken {
       body["idToken"] = idToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Enroll/StartMFAEnrollmentRequest.swift
@@ -64,7 +64,7 @@ class StartMFAEnrollmentRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [:]
     if let idToken = idToken {
       body["idToken"] = idToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/FinalizeMFASignInRequest.swift
@@ -36,7 +36,7 @@ class FinalizeMFASignInRequest: IdentityToolkitRequest, AuthRPCRequest {
                useIdentityPlatform: true)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [:]
     if let mfaPendingCredential = mfaPendingCredential {
       body["mfaPendingCredential"] = mfaPendingCredential

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/SignIn/StartMFASignInRequest.swift
@@ -41,7 +41,7 @@ class StartMFASignInRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [:]
     if let MFAPendingCredential = MFAPendingCredential {
       body["mfaPendingCredential"] = MFAPendingCredential

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/MultiFactor/Unenroll/WithdrawMFARequest.swift
@@ -36,7 +36,7 @@ class WithdrawMFARequest: IdentityToolkitRequest, AuthRPCRequest {
                useIdentityPlatform: true)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
     if let idToken = idToken {
       postBody["idToken"] = idToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/ResetPasswordRequest.swift
@@ -48,7 +48,7 @@ class ResetPasswordRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kResetPasswordEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
 
     postBody[kOOBCodeKey] = oobCode

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/RevokeTokenRequest.swift
@@ -71,7 +71,7 @@ class RevokeTokenRequest: IdentityToolkitRequest, AuthRPCRequest {
                useIdentityPlatform: true)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     let body: [String: AnyHashable] = [
       kProviderIDKey: providerID,
       kTokenTypeKey: "\(tokenType.rawValue)",

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SecureTokenRequest.swift
@@ -134,9 +134,7 @@ class SecureTokenRequest: AuthRPCRequest {
     return URL(string: urlString)!
   }
 
-  var containsPostBody: Bool { return true }
-
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [
       kGrantTypeKey: grantType.value,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SendVerificationTokenRequest.swift
@@ -60,7 +60,7 @@ class SendVerificationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
     postBody[kPhoneNumberKey] = phoneNumber
     switch codeIdentity {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SetAccountInfoRequest.swift
@@ -136,7 +136,7 @@ class SetAccountInfoRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kSetAccountInfoEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
     if let accessToken {
       postBody[kIDTokenKey] = accessToken

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignInWithGameCenterRequest.swift
@@ -76,7 +76,7 @@ class SignInWithGameCenterRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [
       "playerId": playerID,
       "publicKeyUrl": publicKeyURL.absoluteString,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/SignUpNewUserRequest.swift
@@ -89,7 +89,7 @@ class SignUpNewUserRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kSignupNewUserEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
     if let email {
       postBody[kEmailKey] = email

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyAssertionRequest.swift
@@ -135,7 +135,7 @@ class VerifyAssertionRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kVerifyAssertionEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var components = URLComponents()
     var queryItems: [URLQueryItem] = [URLQueryItem(name: kProviderIDKey, value: providerID)]
     if let providerIDToken = providerIDToken {

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyCustomTokenRequest.swift
@@ -40,7 +40,7 @@ class VerifyCustomTokenRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kVerifyCustomTokenEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [
       kTokenKey: token,
     ]

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPasswordRequest.swift
@@ -79,7 +79,7 @@ class VerifyPasswordRequest: IdentityToolkitRequest, AuthRPCRequest {
     super.init(endpoint: kVerifyPasswordEndpoint, requestConfiguration: requestConfiguration)
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var body: [String: AnyHashable] = [
       kEmailKey: email,
       kPasswordKey: password,

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/VerifyPhoneNumberRequest.swift
@@ -133,7 +133,7 @@ class VerifyPhoneNumberRequest: IdentityToolkitRequest, AuthRPCRequest {
     )
   }
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody: [String: AnyHashable] = [:]
     if let verificationID {
       postBody[kVerificationIDKey] = verificationID

--- a/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/VerifyClientRequest.swift
@@ -27,7 +27,7 @@ class VerifyClientRequest: IdentityToolkitRequest, AuthRPCRequest {
   /// The key for the isSandbox request parameter.
   private static let isSandboxKey = "isSandbox"
 
-  func unencodedHTTPRequestBody() throws -> [String: AnyHashable] {
+  var unencodedHTTPRequestBody: [String: AnyHashable]? {
     var postBody = [String: AnyHashable]()
     if let appToken = appToken {
       postBody[Self.appTokenKey] = appToken

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -149,8 +149,9 @@ final class FakeBackendRPCIssuer: AuthBackendRPCIssuerProtocol, @unchecked Senda
       // be verified during testing.
       completeRequest = Task {
         await AuthBackend
-          .urlRequest(
-            from: request,
+          .request(
+            for: request.requestURL(),
+            httpMethod: requestData == nil ? "GET" : "POST",
             contentType: contentType,
             requestConfiguration: request.requestConfiguration()
           )

--- a/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
+++ b/FirebaseAuth/Tests/Unit/Fakes/FakeBackendRPCIssuer.swift
@@ -148,9 +148,12 @@ final class FakeBackendRPCIssuer: AuthBackendRPCIssuerProtocol, @unchecked Senda
       // Use the real implementation so that the complete request can
       // be verified during testing.
       completeRequest = Task {
-        await AuthBackend.request(withURL: requestURL!,
-                                  contentType: contentType,
-                                  requestConfiguration: request.requestConfiguration())
+        await AuthBackend
+          .urlRequest(
+            from: request,
+            contentType: contentType,
+            requestConfiguration: request.requestConfiguration()
+          )
       }
       decodedRequest = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
     }

--- a/FirebaseAuth/Tests/Unit/GetRecaptchaConfigTests.swift
+++ b/FirebaseAuth/Tests/Unit/GetRecaptchaConfigTests.swift
@@ -25,7 +25,7 @@ class GetRecaptchaConfigTests: RPCBaseTests {
   func testGetRecaptchaConfigRequest() async throws {
     let request = GetRecaptchaConfigRequest(requestConfiguration: makeRequestConfiguration())
     //    let _ = try await authBackend.call(with: request)
-    XCTAssertFalse(request.containsPostBody)
+    XCTAssertNil(request.unencodedHTTPRequestBody)
 
     // Confirm that the request has no decoded body as it is get request.
     XCTAssertNil(rpcIssuer.decodedRequest)

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -91,7 +91,7 @@ class RPCBaseTests: XCTestCase {
     rpcIssuer.respondBlock = {
       XCTAssertEqual(self.rpcIssuer.requestURL?.absoluteString, expected)
       if checkPostBody {
-        XCTAssertFalse(request.containsPostBody)
+        XCTAssertNil(request.unencodedHTTPRequestBody)
       } else if let requestDictionary = self.rpcIssuer.decodedRequest as? [String: AnyHashable] {
         XCTAssertEqual(requestDictionary[key], value)
       } else {


### PR DESCRIPTION
1. The `AuthRequestConfiguration`'s properties should not be specific to an individual request.
2. Clean up AuthRPCRequest protocol to remove throwing method and remove containsPostBody API.

In practice, the request is passed to GTMSessionFetcher which will change the httpMethod as necessary: https://github.com/google/gtm-session-fetcher/blob/ef9a60ba09dff71540c8bf612fb778a3af790a7e/Sources/Core/GTMSessionFetcher.m#L721-L732

#no-changelog