### PR TITLE
[Infra] Add check for unexpected test failures in build.sh

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -145,6 +145,7 @@ jobs:
           path: .build
           key: ${{ steps.generate_cache_key.outputs.cache_key }}
   spm:
+    # TODO: Remove before merging; triggering CI run.
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     needs: [spm-package-resolved]

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -145,7 +145,6 @@ jobs:
           path: .build
           key: ${{ steps.generate_cache_key.outputs.cache_key }}
   spm:
-    # TODO: Remove before merging; triggering CI run.
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     needs: [spm-package-resolved]

--- a/FirebasePerformance/Tests/Unit/Timer/FPRCounterListTest.m
+++ b/FirebasePerformance/Tests/Unit/Timer/FPRCounterListTest.m
@@ -19,10 +19,6 @@
 #import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRPerformance.h"
 #import "FirebasePerformance/Sources/Timer/FPRCounterList.h"
 
-// This test requires the UNSWIZZLE_AVAILABLE preprocessor macro to be defined in order to complete
-// successfully. See FPRSelectorInstrumentor.m for more details.
-#ifdef UNSWIZZLE_AVAILABLE
-
 @interface FPRCounterListTest : XCTestCase
 
 @end
@@ -33,14 +29,18 @@
   [super setUp];
   FIRPerformance *performance = [FIRPerformance sharedInstance];
   [performance setDataCollectionEnabled:YES];
+#ifdef UNSWIZZLE_AVAILABLE
   [[FPRClient sharedInstance] disableInstrumentation];
+#endif  // UNSWIZZLE_AVAILABLE
 }
 
 + (void)tearDown {
   [super tearDown];
   FIRPerformance *performance = [FIRPerformance sharedInstance];
   [performance setDataCollectionEnabled:NO];
+#ifdef UNSWIZZLE_AVAILABLE
   [[FPRClient sharedInstance] disableInstrumentation];
+#endif  // UNSWIZZLE_AVAILABLE
 }
 
 /** Validates counterlist object creation. */
@@ -166,5 +166,3 @@
 }
 
 @end
-
-#endif  // UNSWIZZLE_AVAILABLE

--- a/FirebasePerformance/Tests/Unit/Timer/FPRCounterListTest.m
+++ b/FirebasePerformance/Tests/Unit/Timer/FPRCounterListTest.m
@@ -19,6 +19,10 @@
 #import "FirebasePerformance/Sources/Public/FirebasePerformance/FIRPerformance.h"
 #import "FirebasePerformance/Sources/Timer/FPRCounterList.h"
 
+// This test requires the UNSWIZZLE_AVAILABLE preprocessor macro to be defined in order to complete
+// successfully. See FPRSelectorInstrumentor.m for more details.
+#ifdef UNSWIZZLE_AVAILABLE
+
 @interface FPRCounterListTest : XCTestCase
 
 @end
@@ -162,3 +166,5 @@
 }
 
 @end
+
+#endif  // UNSWIZZLE_AVAILABLE


### PR DESCRIPTION
When `xcodebuild test` fails due to a crash ([example](https://github.com/firebase/firebase-ios-sdk/actions/runs/11862154195/job/33061011258?pr=14131#step:6:893)), instead of a typical test failure, the exit code is `0` (success). These show up as passing in our CI jobs. Added a regex check to detect this scenario.

#no-changelog