### PR TITLE
[Auth] Mark AuthRequestConfiguration as final and reduce its mutability

### DIFF
--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -71,8 +71,7 @@ final class AuthBackend: AuthBackendProtocol {
 
     var request = URLRequest(url: url)
     request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-    let additionalFrameworkMarker = requestConfiguration
-      .additionalFrameworkMarker ?? "FirebaseCore-iOS"
+    let additionalFrameworkMarker = requestConfiguration.additionalFrameworkMarker
     let clientVersion = "iOS/FirebaseSDK/\(FirebaseVersion())/\(additionalFrameworkMarker)"
     request.setValue(clientVersion, forHTTPHeaderField: "X-Client-Version")
     request.setValue(Bundle.main.bundleIdentifier, forHTTPHeaderField: "X-Ios-Bundle-Identifier")

--- a/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthRequestConfiguration.swift
@@ -19,7 +19,7 @@ import FirebaseCoreExtension
 
 /// Defines configurations to be added to a request to Firebase Auth's backend.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-class AuthRequestConfiguration {
+final class AuthRequestConfiguration {
   /// The Firebase Auth API key used in the request.
   let apiKey: String
 
@@ -33,13 +33,13 @@ class AuthRequestConfiguration {
   weak var auth: Auth?
 
   /// The heartbeat logger used to add heartbeats to the corresponding request's header.
-  var heartbeatLogger: FIRHeartbeatLoggerProtocol?
+  let heartbeatLogger: FIRHeartbeatLoggerProtocol?
 
   /// The appCheck is used to generate a token.
   var appCheck: AppCheckInterop?
 
   /// Additional framework marker that will be added as part of the header of every request.
-  var additionalFrameworkMarker: String?
+  let additionalFrameworkMarker: String = "FirebaseCore-iOS"
 
   /// If set, the local emulator host and port to point to instead of the remote backend.
   var emulatorHostAndPort: String?


### PR DESCRIPTION
`AuthRequestConfiguration` will eventually need to be Sendable. Gradually addressing the low hanging fruit based on its usage.

#no-changelog