### PR TITLE
[Auth] Remove unnecessary throws on internal methods

### DIFF
--- a/FirebaseAuth/Sources/Swift/Storage/AuthUserDefaults.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthUserDefaults.swift
@@ -35,7 +35,7 @@ class AuthUserDefaults {
     storage = UserDefaults()
   }
 
-  func data(forKey key: String) throws -> Data? {
+  func data(forKey key: String) -> Data? {
     guard let allData = storage.persistentDomain(forName: persistentDomainName)
     else { return nil }
     if let data = allData[key] as? Data {
@@ -44,13 +44,13 @@ class AuthUserDefaults {
     return nil
   }
 
-  func setData(_ data: Data, forKey key: String) throws {
+  func setData(_ data: Data, forKey key: String) {
     var allData = storage.persistentDomain(forName: persistentDomainName) ?? [:]
     allData[key] = data
     storage.setPersistentDomain(allData, forName: persistentDomainName)
   }
 
-  func removeData(forKey key: String) throws {
+  func removeData(forKey key: String) {
     guard var allData = storage.persistentDomain(forName: persistentDomainName) else { return }
     allData.removeValue(forKey: key)
     storage.setPersistentDomain(allData, forName: persistentDomainName)

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthStoredUserManager.swift
@@ -43,7 +43,7 @@ class AuthStoredUserManager {
   /// Get the user access group stored locally.
   /// - Returns: The stored user access group; otherwise, `nil`.
   func getStoredUserAccessGroup() -> String? {
-    if let data = try? userDefaults.data(forKey: Self.storedUserAccessGroupKey) {
+    if let data = userDefaults.data(forKey: Self.storedUserAccessGroupKey) {
       let userAccessGroup = String(data: data, encoding: .utf8)
       return userAccessGroup
     } else {
@@ -55,9 +55,9 @@ class AuthStoredUserManager {
   /// - Parameter accessGroup: The access group to be store.
   func setStoredUserAccessGroup(accessGroup: String?) {
     if let data = accessGroup?.data(using: .utf8) {
-      try? userDefaults.setData(data, forKey: Self.storedUserAccessGroupKey)
+      userDefaults.setData(data, forKey: Self.storedUserAccessGroupKey)
     } else {
-      try? userDefaults.removeData(forKey: Self.storedUserAccessGroupKey)
+      userDefaults.removeData(forKey: Self.storedUserAccessGroupKey)
     }
   }
 

--- a/FirebaseAuth/Tests/Unit/AuthUserDefaultsTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthUserDefaultsTests.swift
@@ -32,7 +32,7 @@ class AuthUserDefaultsTests: XCTestCase {
       @brief Tests reading non-existing storage item.
    */
   func testReadNonexisting() throws {
-    XCTAssertNil(try storage.data(forKey: kKey))
+    XCTAssertNil(storage.data(forKey: kKey))
   }
 
   /** @fn testWriteRead
@@ -40,7 +40,7 @@ class AuthUserDefaultsTests: XCTestCase {
    */
   func testWriteRead() throws {
     try storage.setData(dataFromString(kData), forKey: kKey)
-    XCTAssertEqual(try storage.data(forKey: kKey), try dataFromString(kData))
+    XCTAssertEqual(storage.data(forKey: kKey), try dataFromString(kData))
   }
 
   /** @fn testOverwrite
@@ -50,7 +50,7 @@ class AuthUserDefaultsTests: XCTestCase {
     let kOtherData = "OTHER_DATA"
     try storage.setData(dataFromString(kData), forKey: kKey)
     try storage.setData(dataFromString(kOtherData), forKey: kKey)
-    XCTAssertEqual(try storage.data(forKey: kKey), try dataFromString(kOtherData))
+    XCTAssertEqual(storage.data(forKey: kKey), try dataFromString(kOtherData))
   }
 
   /** @fn testRemove
@@ -67,7 +67,7 @@ class AuthUserDefaultsTests: XCTestCase {
   func testServices() throws {
     try storage.setData(dataFromString(kData), forKey: kKey)
     storage = AuthUserDefaults(service: "Other service")
-    XCTAssertNil(try storage.data(forKey: kKey))
+    XCTAssertNil(storage.data(forKey: kKey))
   }
 
   /** @fn testStandardUserDefaults


### PR DESCRIPTION
Methods don't throw, so remove the `throws` keyword.

#no-changelog