### PR TITLE
[Firestore] Label '@MainActor' isolated APIs of 'FirestoreQuery'

### DIFF
--- a/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
+++ b/Firestore/Swift/Source/PropertyWrapper/FirestoreQuery.swift
@@ -143,12 +143,12 @@ public struct FirestoreQuery<T>: DynamicProperty {
   /// The results of the query.
   ///
   /// This property returns an empty collection when there are no matching results.
-  public var wrappedValue: T {
+  @MainActor @preconcurrency public var wrappedValue: T {
     firestoreQueryObservable.items
   }
 
   /// A binding to the request's mutable configuration properties
-  public var projectedValue: Configuration {
+  @MainActor @preconcurrency public var projectedValue: Configuration {
     get {
       firestoreQueryObservable.configuration
     }


### PR DESCRIPTION
This PR addresses the following errors in Swift 6 mode:
```swift
// FirestoreQuery.swift
@available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *)
@propertyWrapper
public struct FirestoreQuery<T>: DynamicProperty {
  @StateObject private var firestoreQueryObservable: FirestoreQueryObservable<T>

// <--snip-->

  public var wrappedValue: T {
    firestoreQueryObservable.items // 💥 Main actor-isolated property 'firestoreQueryObservable' can not be referenced from a nonisolated context
  }

  /// A binding to the request's mutable configuration properties
  @MainActor @preconcurrency public var projectedValue: Configuration {
    get {
      firestoreQueryObservable.configuration // 💥 Main actor-isolated property 'firestoreQueryObservable' can not be referenced from a nonisolated context
    }
    nonmutating set {
      firestoreQueryObservable.objectWillChange.send() // 💥 Main actor-isolated property 'firestoreQueryObservable' can not be referenced from a nonisolated context
      firestoreQueryObservable.configuration = newValue // 💥 Main actor-isolated property 'firestoreQueryObservable' can not be referenced from a nonisolated context
    }
  }

// <--snip-->

}
```
The issue is that `firestoreQueryObservable` is decorated with `@StateObject` which is labeled `@MainActor` in Xcode 16.1:
```swift
@MainActor @frozen @propertyWrapper @preconcurrency public struct StateObject<ObjectType> : DynamicProperty where ObjectType : ObservableObject { ... }
```

So the property is isolated to the main actor and cannot be referenced from a non-main-actor-isolated context.

### Backwards compatibility

I found that adding `@MainActor` causes a warning in Xcode 16+ for cases where `@FirestoreQuery` is used inside a non-isolated class. The warning is not ideal (and a little unexpected, see https://www.jessesquires.com/blog/2024/06/05/swift-concurrency-non-sendable-closures/), but I think it's unlikely developers will face them as the `@FirestoreQuery` is likely going to be used in a SwiftUI view which has the correct `@MainActor` isolation by default.

For Xcode 15, this PR doesn't seem to make a difference in behavior.

```swift
class MyNonIsolatedClass {
  @FirestoreQuery(
    collectionPath: "fruits",
    predicates: [
      .where("isFavourite", isEqualTo: true),
    ]
  ) fileprivate var fruitResults: [Fruit]
  
  nonisolated func nonisolatedFunc() {
    // Xcode 15.2
    // Doesn't compile currently with or without `@MainActor @preconcurrency`
    // 💥 Main actor-isolated property 'fruitResults' can not be referenced from a nonisolated context
    
    // Xcode 16.1
    // Currently, without this PR's `@MainActor @preconcurrency`, this PR causes a warning:
    // ⚠️ Main actor-isolated property 'fruitResults' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
    // Without @preconcurrency, this PR causes an error:
    // 💥 Main actor-isolated property 'fruitResults' can not be referenced from a nonisolated context
    // With @preconcurrency, this PR causes a warning:
    // ⚠️ Main actor-isolated property 'fruitResults' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode
    
    // Xcode 16.2 b2
    // Same behavior as 16.1

    print(fruitResults)
  }
  
  func defaultIsolationFunc() {
    // Xcode 15.2
    // No error/warn, with @preconcurrency or not
    
    // Xcode 16.1
    // Same as Xcode 15.2

    // Xcode 16.2 b2
    // Same as Xcode 16.1

    print(fruitResults)
  }
}
```

#no-changelog