### PR TITLE
[Auth] Add objc attribute to UserInfoImpl so legacy decoding works

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [fixed] Restore Firebase 10 behavior by synchronizing access to the
   `Auth.currentUser` API. This resolves some Firebase 11 issues where the
   current user is unexpectedly `nil` at startup.
+- [fixed] Restore Firebase 10 behavior decoding behavior to prevent user
+  provider data from being decoded as `nil`. (#14011)
 
 # 11.5.0
 - [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -2,8 +2,8 @@
 - [fixed] Restore Firebase 10 behavior by synchronizing access to the
   `Auth.currentUser` API. This resolves some Firebase 11 issues where the
   current user is unexpectedly `nil` at startup.
-- [fixed] Restore Firebase 10 behavior decoding behavior to prevent user
-  provider data from being decoded as `nil`. (#14011)
+- [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
+  from being decoded as `nil`. (#14011)
 
 # 11.5.0
 - [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -18,6 +18,7 @@ import Foundation
 extension UserInfoImpl: NSSecureCoding {}
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+@objc(FIRUserInfoImpl) // objc Needed for decoding old versions
 class UserInfoImpl: NSObject, UserInfo {
   /// A convenience factory method for constructing a `UserInfo` instance from data
   /// returned by the getAccountInfo endpoint.


### PR DESCRIPTION
The class names was changed from `FIRUserInfoImpl` to `UserInfoImpl`, but the unarchiving older copies (pre name change) requires knowing the original ObjC name. The rest of the direct/transitive types from the `User` class's `init?(coder:)` look okay.

We actually do this for other classes, I just had to make the connection that the class wasn't being decoded because the pre-11 archive didn't have a blob mapping to "UserInfoImpl". The blob was mapping to "FIRUserInfoImpl".

https://github.com/firebase/firebase-ios-sdk/blob/700fd6803d50275be326c356b400704f2ea8b481/FirebaseAuth/Sources/Swift/SystemService/AuthAppCredential.swift#L18-L19

Fix #14011