### PR TITLE
[Auth] Add default values for decoding nil properties in UserInfoImpl

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -6,10 +6,10 @@
   current user is unexpectedly `nil` at startup.
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
   from always being decoded as `nil` . Note that this fix was only needed for
-  cases Firebase 11 was reading data written by Firebase 10. (#14011)
+  cases where Firebase 11 was reading data written by Firebase 10. (#14011)
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
   from being decoded as `nil` when a user has multiple linked providers. Note
-  that this fix was only needed for cases Firebase 11 was reading data written
+  that this fix was only needed for cases where Firebase 11 was reading data written
   by Firebase 10. Note that this fix will not be in the 11.6.0 zip and
   Carthage distributions, but will be included from 11.6.0 onwards. (#14011)
 

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -5,11 +5,13 @@
   `Auth.currentUser` API. This resolves some Firebase 11 issues where the
   current user is unexpectedly `nil` at startup.
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
-  from always being decoded as `nil` when reading Firebase 10 data. (#14011)
+  from always being decoded as `nil` . Note that this fix was only needed for
+  cases Firebase 11 was reading data written by Firebase 10. (#14011)
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
   from being decoded as `nil` when a user has multiple linked providers. Note
-  that this fix will not be in the 11.6.0 zip and Carthage distributions, but
-  will be included from 11.6.0 onwards. (#14011)
+  that this fix was only needed for cases Firebase 11 was reading data written
+  by Firebase 10. Note that this fix will not be in the 11.6.0 zip and
+  Carthage distributions, but will be included from 11.6.0 onwards. (#14011)
 
 # 11.5.0
 - [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -9,8 +9,8 @@
   cases where Firebase 11 was reading data written by Firebase 10. (#14011)
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
   from being decoded as `nil` when a user has multiple linked providers. Note
-  that this fix was only needed for cases where Firebase 11 was reading data written
-  by Firebase 10. Note that this fix will not be in the 11.6.0 zip and
+  that this fix was only needed for cases where Firebase 11 was reading data
+  written by Firebase 10. Note that this fix will not be in the 11.6.0 zip and
   Carthage distributions, but will be included from 11.6.0 onwards. (#14011)
 
 # 11.5.0

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -5,7 +5,7 @@
   `Auth.currentUser` API. This resolves some Firebase 11 issues where the
   current user is unexpectedly `nil` at startup.
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
-  from being always decoded as `nil` when reading Firebase 10 data. (#14011)
+  from always being decoded as `nil` when reading Firebase 10 data. (#14011)
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
   from being decoded as `nil` when a user has multiple linked providers. Note
   that this fix will not be in the 11.6.0 zip and Carthage distributions, but

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -5,7 +5,11 @@
   `Auth.currentUser` API. This resolves some Firebase 11 issues where the
   current user is unexpectedly `nil` at startup.
 - [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
-  from being decoded as `nil`. (#14011)
+  from being always decoded as `nil` when reading Firebase 10 data. (#14011)
+- [fixed] Restore Firebase 10 decoding behavior to prevent user provider data
+  from being decoded as `nil` when a user has multiple linked providers. Note
+  that this fix will not be in the 11.6.0 zip and Carthage distributions, but
+  will be included from 11.6.0 onwards. (#14011)
 
 # 11.5.0
 - [fixed] Restore pre-Firebase 11 decoding behavior to prevent users getting

--- a/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
+++ b/FirebaseAuth/Sources/Swift/User/UserInfoImpl.swift
@@ -88,17 +88,16 @@ class UserInfoImpl: NSObject, UserInfo {
   }
 
   required convenience init?(coder: NSCoder) {
-    guard let providerID = coder.decodeObject(
+    let providerID = coder.decodeObject(
       of: [NSString.self],
       forKey: UserInfoImpl.kProviderIDCodingKey
-    ) as? String,
-      let userID = coder.decodeObject(
-        of: [NSString.self],
-        forKey: UserInfoImpl.kUserIDCodingKey
-      ) as? String
-    else {
-      return nil
-    }
+    ) as? String ?? ""
+    // Not all providers have a corresponding user ID (e.g. phone auth), so
+    // fall back to an empty string.
+    let userID = coder.decodeObject(
+      of: [NSString.self],
+      forKey: UserInfoImpl.kUserIDCodingKey
+    ) as? String ?? ""
     let displayName = coder.decodeObject(
       of: [NSString.self],
       forKey: UserInfoImpl.kDisplayNameCodingKey


### PR DESCRIPTION
Address https://github.com/firebase/firebase-ios-sdk/issues/14011#issuecomment-2500281393

If a `UserInfoImpl` instance fails to decode, the entire `[String: UserInfoImpl]` collection (below snippet) will fail to decode, which will make the `user.providerData` property `nil`.

https://github.com/firebase/firebase-ios-sdk/blob/2176e99cc68856131241e584c1a1f22668c846e3/FirebaseAuth/Sources/Swift/User/User.swift#L1736-L1737

The below snippet is the `GetAccountInfoResponseProviderUserInfo` response object for an account with email and phone providers enabled. The `phone` provider does not have a `federatedID` and therefore its corresponding `UserInfoImpl` instance does not have a `uid`.  It's possible a more useful default could be given, but will have to further investigate this. cc: @Xiaoshouzi-gh 

<img width="278" alt="Screenshot 2024-11-27 at 7 09 59 PM" src="https://github.com/user-attachments/assets/48034533-0727-4b47-bc8a-b8872ec405a9">

Falling back to "" is slightly safer than the ObjC implementation, that would bridge to an implicit nil because of `UserInfo`'s non-null `uid` interface (`UserInfoImpl` conforms to `UserInfo`). 