### PR TITLE
[Vertex AI] Add ImageGenerationInstance for input to predict call

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationInstance.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationInstance.swift
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+struct ImageGenerationInstance {
+  let prompt: String
+}
+
+// MARK: - Codable Conformance
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationInstance: Encodable {}

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationInstanceTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationInstanceTests.swift
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class ImageGenerationInstanceTests: XCTestCase {
+  let encoder = JSONEncoder()
+
+  override func setUp() {
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+  }
+
+  // MARK: - Encoding Tests
+
+  func testEncodeInstance() throws {
+    let prompt = "An astronaut riding a horse."
+    let instance = ImageGenerationInstance(prompt: prompt)
+
+    let jsonData = try encoder.encode(instance)
+
+    let json = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+    XCTAssertEqual(json, """
+    {
+      "prompt" : "\(prompt)"
+    }
+    """)
+  }
+}


### PR DESCRIPTION
Added an encodable type `ImageGenerationInstance` that is passed in `instances[]` in a [`predict`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.publishers.models/predict#request-body) request. The schema ([download](https://storage.mtls.cloud.google.com/google-cloud-aiplatform/schema/predict/instance/vision_generative_model_1.0.0.yaml)) supports other fields, such as `image` and `mask`, but we are only using `prompt` at this time.

<details>
<summary>VisionGenerativeModel Instance Schema Reference</summary>

```
title: VisionGenerativeModel
type: object
required:
- prompt
properties:
  prompt:
    type: string
    description: >
      The text prompt for guiding how vision model generate the images.
      This field is required for both generation and editing.
  image:
    type: object
    description: >
      Image for editing. This field is required for editing. Not needed for generation.
    oneof:
    - bytesBase64Encoded
    - gcsUri
    properties:
      bytesBase64Encoded:
        type: string
        description: Image bytes encoded in base64 string.
      gcsUri:
        type: string
        description: >
          The Google Cloud Storage location of the image on which to perform the editing.
        pattern: '^gs:\/\/(.+)\/(.+)$'
      mimeType:
        type: string
        description: >
          The MIME type of the content of the image. Only the images in below listed
          MIME types are supported.
        enum:
        - image/jpeg
        - image/png
  mask:
    type: object
    description: >
      Mask where to edit. This is an optional field for editing. No need for generation.
    oneof:
    - image
    - polygonList
    properties:
      polygonList:
        type: array
        description: Multiple polygon masks.
        items:
          type: array
          description: >
            All of the vertices that form the single polygon mask.
          items:
            type: object
            description: >
              Single vertex with `x` and `y` coordinates that describes a point in 2D plane.
            properties:
              x:
                type: number
                format: float
                minimum: 0.0
                maximum: 1.0
                description: The x coordinate of the vertex.
              y:
                type: number
                format: float
                minimum: 0.0
                maximum: 1.0
                description: The y coordinate of the vertex.

```

</details>

#no-changelog