### PR TITLE
[Vertex AI] Add ImageGenerationResponse for decoding PredictResponse

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/DecodableImagenImage.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/DecodableImagenImage.swift
@@ -1,0 +1,62 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+protocol DecodableImagenImage: ImagenImage, Decodable {
+  init(mimeType: String, bytesBase64Encoded: String?, gcsURI: String?)
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+enum ImagenImageCodingKeys: String, CodingKey {
+  case mimeType
+  case bytesBase64Encoded
+  case gcsURI = "gcsUri"
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension DecodableImagenImage {
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: ImagenImageCodingKeys.self)
+    let mimeType = try container.decode(String.self, forKey: .mimeType)
+    let bytesBase64Encoded = try container.decodeIfPresent(
+      String.self,
+      forKey: .bytesBase64Encoded
+    )
+    let gcsURI = try container.decodeIfPresent(String.self, forKey: .gcsURI)
+    guard bytesBase64Encoded != nil || gcsURI != nil else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: [ImagenImageCodingKeys.bytesBase64Encoded, ImagenImageCodingKeys.gcsURI],
+          debugDescription: """
+          Expected one of \(ImagenImageCodingKeys.bytesBase64Encoded.rawValue) or \
+          \(ImagenImageCodingKeys.gcsURI.rawValue); both are nil.
+          """
+        )
+      )
+    }
+    guard bytesBase64Encoded == nil || gcsURI == nil else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: [ImagenImageCodingKeys.bytesBase64Encoded, ImagenImageCodingKeys.gcsURI],
+          debugDescription: """
+          Expected one of \(ImagenImageCodingKeys.bytesBase64Encoded.rawValue) or \
+          \(ImagenImageCodingKeys.gcsURI.rawValue); both are specified.
+          """
+        )
+      )
+    }
+
+    self.init(mimeType: mimeType, bytesBase64Encoded: bytesBase64Encoded, gcsURI: gcsURI)
+  }
+}

--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationResponse.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationResponse.swift
@@ -1,0 +1,124 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+struct ImageGenerationResponse {
+  let images: [Image]
+  let raiFilteredReason: String?
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationResponse {
+  struct Image: Equatable {
+    let mimeType: String
+    let bytesBase64Encoded: String?
+    let gcsURI: String?
+  }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationResponse {
+  struct RAIFilteredReason {
+    let raiFilteredReason: String
+  }
+}
+
+// MARK: - Codable Conformances
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationResponse.Image: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case mimeType
+    case bytesBase64Encoded
+    case gcsURI = "gcsUri"
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    mimeType = try container.decode(String.self, forKey: .mimeType)
+    bytesBase64Encoded = try container.decodeIfPresent(String.self, forKey: .bytesBase64Encoded)
+    gcsURI = try container.decodeIfPresent(String.self, forKey: .gcsURI)
+    guard bytesBase64Encoded != nil || gcsURI != nil else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: [CodingKeys.bytesBase64Encoded, CodingKeys.gcsURI],
+          debugDescription: """
+          Expected one of \(CodingKeys.bytesBase64Encoded.rawValue) or \
+          \(CodingKeys.gcsURI.rawValue); both are nil.
+          """
+        )
+      )
+    }
+    guard bytesBase64Encoded == nil || gcsURI == nil else {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: [CodingKeys.bytesBase64Encoded, CodingKeys.gcsURI],
+          debugDescription: """
+          Expected one of \(CodingKeys.bytesBase64Encoded.rawValue) or \
+          \(CodingKeys.gcsURI.rawValue); both are specified.
+          """
+        )
+      )
+    }
+  }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationResponse.RAIFilteredReason: Decodable {
+  enum CodingKeys: CodingKey {
+    case raiFilteredReason
+  }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension ImageGenerationResponse: Decodable {
+  enum CodingKeys: CodingKey {
+    case predictions
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    guard container.contains(.predictions) else {
+      images = []
+      raiFilteredReason = nil
+      // TODO: Log warning if no predictions.
+      return
+    }
+    var predictionsContainer = try container.nestedUnkeyedContainer(forKey: .predictions)
+
+    var images = [Image]()
+    var raiFilteredReasons = [String]()
+    while !predictionsContainer.isAtEnd {
+      if let image = try? predictionsContainer.decode(Image.self) {
+        images.append(image)
+      } else if let filterReason = try? predictionsContainer.decode(RAIFilteredReason.self) {
+        raiFilteredReasons.append(filterReason.raiFilteredReason)
+      } else if let _ = try? predictionsContainer.decode(JSONObject.self) {
+        // TODO: Log or throw unsupported prediction type
+      } else {
+        // This should never be thrown since JSONObject accepts any valid JSON.
+        throw DecodingError.dataCorruptedError(
+          in: predictionsContainer,
+          debugDescription: "Failed to decode Prediction."
+        )
+      }
+    }
+
+    self.images = images
+    raiFilteredReason = raiFilteredReasons.first
+    // TODO: Log if more than one RAI Filtered Reason; unexpected behaviour.
+  }
+}

--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationResponse.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/ImageGenerationResponse.swift
@@ -16,72 +16,11 @@ import Foundation
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct ImageGenerationResponse {
-  let images: [Image]
+  let images: [InternalImagenImage]
   let raiFilteredReason: String?
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension ImageGenerationResponse {
-  struct Image: Equatable {
-    let mimeType: String
-    let bytesBase64Encoded: String?
-    let gcsURI: String?
-  }
-}
-
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension ImageGenerationResponse {
-  struct RAIFilteredReason {
-    let raiFilteredReason: String
-  }
-}
-
 // MARK: - Codable Conformances
-
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension ImageGenerationResponse.Image: Decodable {
-  enum CodingKeys: String, CodingKey {
-    case mimeType
-    case bytesBase64Encoded
-    case gcsURI = "gcsUri"
-  }
-
-  init(from decoder: any Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    mimeType = try container.decode(String.self, forKey: .mimeType)
-    bytesBase64Encoded = try container.decodeIfPresent(String.self, forKey: .bytesBase64Encoded)
-    gcsURI = try container.decodeIfPresent(String.self, forKey: .gcsURI)
-    guard bytesBase64Encoded != nil || gcsURI != nil else {
-      throw DecodingError.dataCorrupted(
-        DecodingError.Context(
-          codingPath: [CodingKeys.bytesBase64Encoded, CodingKeys.gcsURI],
-          debugDescription: """
-          Expected one of \(CodingKeys.bytesBase64Encoded.rawValue) or \
-          \(CodingKeys.gcsURI.rawValue); both are nil.
-          """
-        )
-      )
-    }
-    guard bytesBase64Encoded == nil || gcsURI == nil else {
-      throw DecodingError.dataCorrupted(
-        DecodingError.Context(
-          codingPath: [CodingKeys.bytesBase64Encoded, CodingKeys.gcsURI],
-          debugDescription: """
-          Expected one of \(CodingKeys.bytesBase64Encoded.rawValue) or \
-          \(CodingKeys.gcsURI.rawValue); both are specified.
-          """
-        )
-      )
-    }
-  }
-}
-
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension ImageGenerationResponse.RAIFilteredReason: Decodable {
-  enum CodingKeys: CodingKey {
-    case raiFilteredReason
-  }
-}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ImageGenerationResponse: Decodable {
@@ -99,10 +38,10 @@ extension ImageGenerationResponse: Decodable {
     }
     var predictionsContainer = try container.nestedUnkeyedContainer(forKey: .predictions)
 
-    var images = [Image]()
+    var images = [InternalImagenImage]()
     var raiFilteredReasons = [String]()
     while !predictionsContainer.isAtEnd {
-      if let image = try? predictionsContainer.decode(Image.self) {
+      if let image = try? predictionsContainer.decode(InternalImagenImage.self) {
         images.append(image)
       } else if let filterReason = try? predictionsContainer.decode(RAIFilteredReason.self) {
         raiFilteredReasons.append(filterReason.raiFilteredReason)

--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/InternalImagenImage.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/InternalImagenImage.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+struct InternalImagenImage {
+  let mimeType: String
+  let bytesBase64Encoded: String?
+  let gcsURI: String?
+
+  init(mimeType: String, bytesBase64Encoded: String?, gcsURI: String?) {
+    self.mimeType = mimeType
+    self.bytesBase64Encoded = bytesBase64Encoded
+    self.gcsURI = gcsURI
+  }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension InternalImagenImage: DecodableImagenImage {}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension InternalImagenImage: Equatable {}

--- a/FirebaseVertexAI/Sources/Types/Internal/Imagen/RAIFilteredReason.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/Imagen/RAIFilteredReason.swift
@@ -1,0 +1,25 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+struct RAIFilteredReason {
+  let raiFilteredReason: String
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension RAIFilteredReason: Decodable {
+  enum CodingKeys: CodingKey {
+    case raiFilteredReason
+  }
+}

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImage.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImage.swift
@@ -1,0 +1,22 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public protocol ImagenImage: ImagenImageRepresentable {
+  var mimeType: String { get }
+  var bytesBase64Encoded: String? { get }
+  var gcsURI: String? { get }
+}

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImageRepresentable.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImageRepresentable.swift
@@ -1,0 +1,27 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public protocol ImagenImageRepresentable {
+  var imagenImage: any ImagenImage { get }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public extension ImagenImage {
+  var imagenImage: any ImagenImage {
+    return self
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationResponseTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationResponseTests.swift
@@ -1,0 +1,376 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class ImageGenerationResponseTests: XCTestCase {
+  let decoder = JSONDecoder()
+
+  // MARK: - Image Decoding
+
+  func testDecodeImage_bytesBase64Encoded() throws {
+    let mimeType = "image/png"
+    let bytesBase64Encoded = "test-base64-bytes"
+    let json = """
+    {
+      "bytesBase64Encoded": "\(bytesBase64Encoded)",
+      "mimeType": "\(mimeType)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let image = try decoder.decode(ImageGenerationResponse.Image.self, from: jsonData)
+
+    XCTAssertEqual(image.mimeType, mimeType)
+    XCTAssertEqual(image.bytesBase64Encoded, bytesBase64Encoded)
+    XCTAssertNil(image.gcsURI)
+  }
+
+  func testDecodeImage_gcsURI() throws {
+    let gcsURI = "gs://test-bucket/images/123456789/sample_0.png"
+    let mimeType = "image/jpeg"
+    let json = """
+    {
+      "mimeType": "\(mimeType)",
+      "gcsUri": "\(gcsURI)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let image = try decoder.decode(ImageGenerationResponse.Image.self, from: jsonData)
+
+    XCTAssertEqual(image.mimeType, mimeType)
+    XCTAssertEqual(image.gcsURI, gcsURI)
+    XCTAssertNil(image.bytesBase64Encoded)
+  }
+
+  func testDecodeImage_missingBytesBase64EncodedAndGCSURI_throws() throws {
+    let json = """
+    {
+      "mimeType": "image/jpeg"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(ImageGenerationResponse.Image.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.dataCorrupted(context) {
+      let codingPath = try XCTUnwrap(context
+        .codingPath as? [ImageGenerationResponse.Image.CodingKeys])
+      XCTAssertEqual(codingPath, [.bytesBase64Encoded, .gcsURI])
+      XCTAssertTrue(context.debugDescription.contains("both are nil"))
+    } catch {
+      XCTFail("Expected a DecodingError.dataCorrupted error; got \(error).")
+    }
+  }
+
+  func testDecodeImage_bothBytesBase64EncodedAndGCSURI_throws() throws {
+    let json = """
+    {
+      "bytesBase64Encoded": "test-base64-bytes",
+      "mimeType": "image/png",
+      "gcsUri": "gs://test-bucket/images/123456789/sample_0.png"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(ImageGenerationResponse.Image.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.dataCorrupted(context) {
+      let codingPath = try XCTUnwrap(context
+        .codingPath as? [ImageGenerationResponse.Image.CodingKeys])
+      XCTAssertEqual(codingPath, [.bytesBase64Encoded, .gcsURI])
+      XCTAssertTrue(context.debugDescription.contains("both are specified"))
+    } catch {
+      XCTFail("Expected a DecodingError.dataCorrupted error; got \(error).")
+    }
+  }
+
+  // MARK: - RAI Filtered Reason Decoding
+
+  func testDecodeRAIFilteredReason() throws {
+    let raiFilteredReason = """
+    Unable to show generated images. All images were filtered out because they violated Vertex \
+    AI's usage guidelines. You will not be charged for blocked images. Try rephrasing the prompt. \
+    If you think this was an error, send feedback. Support codes: 1234567
+    """
+    let json = """
+    {
+      "raiFilteredReason": "\(raiFilteredReason)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let filterReason = try decoder.decode(
+      ImageGenerationResponse.RAIFilteredReason.self,
+      from: jsonData
+    )
+
+    XCTAssertEqual(filterReason.raiFilteredReason, raiFilteredReason)
+  }
+
+  func testDecodeRAIFilteredReason_reasonNotSpecified_throws() throws {
+    let json = """
+    {
+      "otherField": "test-value"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(ImageGenerationResponse.RAIFilteredReason.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.keyNotFound(codingKey, _) {
+      let codingKey = try XCTUnwrap(
+        codingKey as? ImageGenerationResponse.RAIFilteredReason.CodingKeys
+      )
+      XCTAssertEqual(codingKey, .raiFilteredReason)
+    } catch {
+      XCTFail("Expected a DecodingError.keyNotFound error; got \(error).")
+    }
+  }
+
+  // MARK: - Image Generation Response Decoding
+
+  func testDecodeResponse_oneBase64Image_noneFiltered() throws {
+    let mimeType = "image/png"
+    let bytesBase64Encoded = "test-base64-bytes"
+    let image = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded,
+      gcsURI: nil
+    )
+    let json = """
+    {
+      "predictions": [
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded)",
+          "mimeType": "\(mimeType)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [image])
+    XCTAssertNil(response.raiFilteredReason)
+  }
+
+  func testDecodeResponse_multipleBase64Images_noneFiltered() throws {
+    let mimeType = "image/png"
+    let bytesBase64Encoded1 = "test-base64-bytes-1"
+    let bytesBase64Encoded2 = "test-base64-bytes-2"
+    let bytesBase64Encoded3 = "test-base64-bytes-3"
+    let image1 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded1,
+      gcsURI: nil
+    )
+    let image2 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded2,
+      gcsURI: nil
+    )
+    let image3 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded3,
+      gcsURI: nil
+    )
+    let json = """
+    {
+      "predictions": [
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded1)",
+          "mimeType": "\(mimeType)"
+        },
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded2)",
+          "mimeType": "\(mimeType)"
+        },
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded3)",
+          "mimeType": "\(mimeType)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [image1, image2, image3])
+    XCTAssertNil(response.raiFilteredReason)
+  }
+
+  func testDecodeResponse_multipleBase64Images_someFiltered() throws {
+    let mimeType = "image/png"
+    let bytesBase64Encoded1 = "test-base64-bytes-1"
+    let bytesBase64Encoded2 = "test-base64-bytes-2"
+    let image1 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded1,
+      gcsURI: nil
+    )
+    let image2 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: bytesBase64Encoded2,
+      gcsURI: nil
+    )
+    let raiFilteredReason = """
+    Your current safety filter threshold filtered out 2 generated images. You will not be charged \
+    for blocked images. Try rephrasing the prompt. If you think this was an error, send feedback.
+    """
+    let json = """
+    {
+      "predictions": [
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded1)",
+          "mimeType": "\(mimeType)"
+        },
+        {
+          "bytesBase64Encoded": "\(bytesBase64Encoded2)",
+          "mimeType": "\(mimeType)"
+        },
+        {
+          "raiFilteredReason": "\(raiFilteredReason)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [image1, image2])
+    XCTAssertEqual(response.raiFilteredReason, raiFilteredReason)
+  }
+
+  func testDecodeResponse_multipleGCSImages_noneFiltered() throws {
+    let mimeType = "image/png"
+    let gcsURI1 = "gs://test-bucket/images/123456789/sample_0.png"
+    let gcsURI2 = "gs://test-bucket/images/123456789/sample_1.png"
+    let image1 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: nil,
+      gcsURI: gcsURI1
+    )
+    let image2 = ImageGenerationResponse.Image(
+      mimeType: mimeType,
+      bytesBase64Encoded: nil,
+      gcsURI: gcsURI2
+    )
+    let json = """
+    {
+      "predictions": [
+        {
+          "gcsUri": "\(gcsURI1)",
+          "mimeType": "\(mimeType)"
+        },
+        {
+          "gcsUri": "\(gcsURI2)",
+          "mimeType": "\(mimeType)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [image1, image2])
+    XCTAssertNil(response.raiFilteredReason)
+  }
+
+  func testDecodeResponse_noImages_allFiltered() throws {
+    let raiFilteredReason = """
+    Unable to show generated images. All images were filtered out because they violated Vertex \
+    AI's usage guidelines. You will not be charged for blocked images. Try rephrasing the prompt. \
+    If you think this was an error, send feedback. Support codes: 1234567
+    """
+    let json = """
+    {
+      "predictions": [
+        {
+          "raiFilteredReason": "\(raiFilteredReason)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [])
+    XCTAssertEqual(response.raiFilteredReason, raiFilteredReason)
+  }
+
+  func testDecodeResponse_noImagesAnd_noFilteredReason() throws {
+    let json = "{}"
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [])
+    XCTAssertNil(response.raiFilteredReason)
+  }
+
+  func testDecodeResponse_multipleFilterReasons_returnsFirst() throws {
+    let raiFilteredReason1 = "filtered-reason-1"
+    let raiFilteredReason2 = "filtered-reason-2"
+    let json = """
+    {
+      "predictions": [
+        {
+          "raiFilteredReason": "\(raiFilteredReason1)"
+        },
+        {
+          "raiFilteredReason": "\(raiFilteredReason2)"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [])
+    XCTAssertEqual(response.raiFilteredReason, raiFilteredReason1)
+    XCTAssertNotEqual(response.raiFilteredReason, raiFilteredReason2)
+  }
+
+  func testDecodeResponse_unknownPrediction() throws {
+    let json = """
+    {
+      "predictions": [
+        {
+          "someField": "some-value"
+        },
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try decoder.decode(ImageGenerationResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.images, [])
+    XCTAssertNil(response.raiFilteredReason)
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/InternalImagenImageTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/InternalImagenImageTests.swift
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class InternalImagenImageTests: XCTestCase {
+  let decoder = JSONDecoder()
+
+  func testDecodeImage_bytesBase64Encoded() throws {
+    let mimeType = "image/png"
+    let bytesBase64Encoded = "test-base64-bytes"
+    let json = """
+    {
+      "bytesBase64Encoded": "\(bytesBase64Encoded)",
+      "mimeType": "\(mimeType)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let image = try decoder.decode(InternalImagenImage.self, from: jsonData)
+
+    XCTAssertEqual(image.mimeType, mimeType)
+    XCTAssertEqual(image.bytesBase64Encoded, bytesBase64Encoded)
+    XCTAssertNil(image.gcsURI)
+  }
+
+  func testDecodeImage_gcsURI() throws {
+    let gcsURI = "gs://test-bucket/images/123456789/sample_0.png"
+    let mimeType = "image/jpeg"
+    let json = """
+    {
+      "mimeType": "\(mimeType)",
+      "gcsUri": "\(gcsURI)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let image = try decoder.decode(InternalImagenImage.self, from: jsonData)
+
+    XCTAssertEqual(image.mimeType, mimeType)
+    XCTAssertEqual(image.gcsURI, gcsURI)
+    XCTAssertNil(image.bytesBase64Encoded)
+  }
+
+  func testDecodeImage_missingBytesBase64EncodedAndGCSURI_throws() throws {
+    let json = """
+    {
+      "mimeType": "image/jpeg"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(InternalImagenImage.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.dataCorrupted(context) {
+      let codingPath = try XCTUnwrap(context
+        .codingPath as? [ImagenImageCodingKeys])
+      XCTAssertEqual(codingPath, [.bytesBase64Encoded, .gcsURI])
+      XCTAssertTrue(context.debugDescription.contains("both are nil"))
+    } catch {
+      XCTFail("Expected a DecodingError.dataCorrupted error; got \(error).")
+    }
+  }
+
+  func testDecodeImage_bothBytesBase64EncodedAndGCSURI_throws() throws {
+    let json = """
+    {
+      "bytesBase64Encoded": "test-base64-bytes",
+      "mimeType": "image/png",
+      "gcsUri": "gs://test-bucket/images/123456789/sample_0.png"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(InternalImagenImage.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.dataCorrupted(context) {
+      let codingPath = try XCTUnwrap(context.codingPath as? [ImagenImageCodingKeys])
+      XCTAssertEqual(codingPath, [.bytesBase64Encoded, .gcsURI])
+      XCTAssertTrue(context.debugDescription.contains("both are specified"))
+    } catch {
+      XCTFail("Expected a DecodingError.dataCorrupted error; got \(error).")
+    }
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/RAIFilteredReasonTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/RAIFilteredReasonTests.swift
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class RAIFilteredReasonTests: XCTestCase {
+  let decoder = JSONDecoder()
+
+  func testDecodeRAIFilteredReason() throws {
+    let raiFilteredReason = """
+    Unable to show generated images. All images were filtered out because they violated Vertex \
+    AI's usage guidelines. You will not be charged for blocked images. Try rephrasing the prompt. \
+    If you think this was an error, send feedback. Support codes: 1234567
+    """
+    let json = """
+    {
+      "raiFilteredReason": "\(raiFilteredReason)"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let filterReason = try decoder.decode(
+      RAIFilteredReason.self,
+      from: jsonData
+    )
+
+    XCTAssertEqual(filterReason.raiFilteredReason, raiFilteredReason)
+  }
+
+  func testDecodeRAIFilteredReason_reasonNotSpecified_throws() throws {
+    let json = """
+    {
+      "otherField": "test-value"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    do {
+      _ = try decoder.decode(RAIFilteredReason.self, from: jsonData)
+      XCTFail("Expected an error; none thrown.")
+    } catch let DecodingError.keyNotFound(codingKey, _) {
+      let codingKey = try XCTUnwrap(
+        codingKey as? RAIFilteredReason.CodingKeys
+      )
+      XCTAssertEqual(codingKey, .raiFilteredReason)
+    } catch {
+      XCTFail("Expected a DecodingError.keyNotFound error; got \(error).")
+    }
+  }
+}


### PR DESCRIPTION
Added a type `ImageGenerationResponse` for decoding the [`PredictResponse`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/PredictResponse) from an image generation request.

Added `ImagenImage` and `ImagenImageRepresentable`, which are analogous to [`Part`](https://github.com/firebase/firebase-ios-sdk/blob/16381c753c8ff2fe2900fd75b050ac27dacda2ef/FirebaseVertexAI/Sources/Types/Public/Part.swift#L17-L21) and [`PartsRepresentable`](https://github.com/firebase/firebase-ios-sdk/blob/16381c753c8ff2fe2900fd75b050ac27dacda2ef/FirebaseVertexAI/Sources/PartsRepresentable.swift#L17-L22) for `GenerativeModel`. The types we vend in the public API will conform to `ImagenImageRepresentable`, allowing them to be used as input to other operations like image upscaling and image editing. Additionally, we can make system types like `UIImage` or `CIImage` conform to `ImagenImageRepresentable`, like [`PartsRepresentable`](https://github.com/firebase/firebase-ios-sdk/blob/16381c753c8ff2fe2900fd75b050ac27dacda2ef/FirebaseVertexAI/Sources/PartsRepresentable%2BImage.swift#L38-L110), to allow these types as input in the future.

Note: Naming is all to be TBD.

#no-changelog
