### PR TITLE
[Vertex AI] Add `ImagenModel` with `generateImages` functions

### DIFF
--- a/FirebaseVertexAI/Sources/GenerationConfig.swift
+++ b/FirebaseVertexAI/Sources/GenerationConfig.swift
@@ -162,4 +162,17 @@ public struct GenerationConfig {
 // MARK: - Codable Conformances
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension GenerationConfig: Encodable {}
+extension GenerationConfig: Encodable {
+  enum CodingKeys: String, CodingKey {
+    case temperature
+    case topP
+    case topK
+    case candidateCount
+    case maxOutputTokens
+    case presencePenalty
+    case frequencyPenalty
+    case stopSequences
+    case responseMIMEType = "responseMimeType"
+    case responseSchema
+  }
+}

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -203,7 +203,6 @@ struct GenerativeAIService {
     }
 
     let encoder = JSONEncoder()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
     urlRequest.httpBody = try encoder.encode(request)
     urlRequest.timeoutInterval = request.options.timeout
 

--- a/FirebaseVertexAI/Sources/Types/Internal/InternalPart.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/InternalPart.swift
@@ -34,6 +34,11 @@ struct FileData: Codable, Equatable, Sendable {
     self.fileURI = fileURI
     self.mimeType = mimeType
   }
+
+  enum CodingKeys: String, CodingKey {
+    case fileURI = "fileUri"
+    case mimeType
+  }
 }
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImageGenerationResponse.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImageGenerationResponse.swift
@@ -33,7 +33,7 @@ extension ImageGenerationResponse: Decodable where ImageType: Decodable {
     guard container.contains(.predictions) else {
       images = []
       raiFilteredReason = nil
-      // TODO: Log warning if no predictions.
+      // TODO(#14221): Log warning if no predictions.
       return
     }
     var predictionsContainer = try container.nestedUnkeyedContainer(forKey: .predictions)

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import FirebaseAppCheckInterop
 import FirebaseAuthInterop
 import Foundation

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -1,0 +1,78 @@
+import FirebaseAppCheckInterop
+import FirebaseAuthInterop
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public final class ImagenModel {
+  /// The resource name of the model in the backend; has the format "models/model-name".
+  let modelResourceName: String
+
+  /// The backing service responsible for sending and receiving model requests to the backend.
+  let generativeAIService: GenerativeAIService
+
+  /// Configuration parameters for sending requests to the backend.
+  let requestOptions: RequestOptions
+
+  init(name: String,
+       projectID: String,
+       apiKey: String,
+       requestOptions: RequestOptions,
+       appCheck: AppCheckInterop?,
+       auth: AuthInterop?,
+       urlSession: URLSession = .shared) {
+    modelResourceName = name
+    generativeAIService = GenerativeAIService(
+      projectID: projectID,
+      apiKey: apiKey,
+      appCheck: appCheck,
+      auth: auth,
+      urlSession: urlSession
+    )
+    self.requestOptions = requestOptions
+  }
+
+  public func generateImages(prompt: String) async throws
+    -> ImageGenerationResponse<ImagenInlineDataImage> {
+    return try await generateImages(
+      prompt: prompt,
+      parameters: imageGenerationParameters(storageURI: nil)
+    )
+  }
+
+  public func generateImages(prompt: String, storageURI: String) async throws
+    -> ImageGenerationResponse<ImagenFileDataImage> {
+    return try await generateImages(
+      prompt: prompt,
+      parameters: imageGenerationParameters(storageURI: storageURI)
+    )
+  }
+
+  func generateImages<T: Decodable>(prompt: String,
+                                    parameters: ImageGenerationParameters) async throws
+    -> ImageGenerationResponse<T> {
+    let request = ImageGenerationRequest<T>(
+      model: modelResourceName,
+      options: requestOptions,
+      instances: [ImageGenerationInstance(prompt: prompt)],
+      parameters: parameters
+    )
+
+    return try await generativeAIService.loadRequest(request: request)
+  }
+
+  func imageGenerationParameters(storageURI: String?) -> ImageGenerationParameters {
+    // TODO(#14221): Add support for configuring these parameters.
+    return ImageGenerationParameters(
+      sampleCount: 1,
+      storageURI: storageURI,
+      seed: nil,
+      negativePrompt: nil,
+      aspectRatio: nil,
+      safetyFilterLevel: nil,
+      personGeneration: nil,
+      outputOptions: nil,
+      addWatermark: nil,
+      includeResponsibleAIFilterReason: true
+    )
+  }
+}

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -104,6 +104,18 @@ public class VertexAI {
     )
   }
 
+  public func imagenModel(modelName: String, requestOptions: RequestOptions = RequestOptions())
+    -> ImagenModel {
+    return ImagenModel(
+      name: modelResourceName(modelName: modelName),
+      projectID: projectID,
+      apiKey: apiKey,
+      requestOptions: requestOptions,
+      appCheck: appCheck,
+      auth: auth
+    )
+  }
+
   /// Class to enable VertexAI to register via the Objective-C based Firebase component system
   /// to include VertexAI in the userAgent.
   @objc(FIRVertexAIComponent) class FirebaseVertexAIComponent: NSObject {}

--- a/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerationConfigTests.swift
@@ -73,7 +73,7 @@ final class GenerationConfigTests: XCTestCase {
       "frequencyPenalty" : \(frequencyPenalty),
       "maxOutputTokens" : \(maxOutputTokens),
       "presencePenalty" : \(presencePenalty),
-      "responseMIMEType" : "\(responseMIMEType)",
+      "responseMimeType" : "\(responseMIMEType)",
       "responseSchema" : {
         "items" : {
           "nullable" : false,
@@ -109,7 +109,7 @@ final class GenerationConfigTests: XCTestCase {
     let json = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
     XCTAssertEqual(json, """
     {
-      "responseMIMEType" : "\(mimeType)",
+      "responseMimeType" : "\(mimeType)",
       "responseSchema" : {
         "nullable" : false,
         "properties" : {

--- a/FirebaseVertexAI/Tests/Unit/PartTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/PartTests.swift
@@ -132,7 +132,7 @@ final class PartTests: XCTestCase {
     XCTAssertEqual(json, """
     {
       "fileData" : {
-        "fileURI" : "\(fileURI)",
+        "fileUri" : "\(fileURI)",
         "mimeType" : "\(mimeType)"
       }
     }


### PR DESCRIPTION
Added an `ImagenModel` class with support for generating images using Imagen 3. #14221
- Stopped encoding JSON fields as snake_case in `GenerativeAIService` (Imagen requires the parameters to be camelCase, Gemini supports both)
  - Fixed encoding issues that were found after making this transition (will need to audit all field names though).
- Added an integration test to verify basic image generation functionality.

#no-changelog