### PR TITLE
Fix Installations access on background queue

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed an issue where Installations was sometimes invoked off the main queue (#13961).
+
 # 11.5.0
 - [changed] Updated `upload-symbols` to version 3.19, removed all methods require CFRelease and switch to modern classes (#13420).
 

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed an issue where Installations was sometimes invoked off the main queue (#13961).
+
 # 11.6.0
 - [fixed] Fix a crash related to registering for notifications when the app is between foreground or background states. (#13174)
 


### PR DESCRIPTION
May address #13961, but we won't know without a repro. Installations has some locking in it so it's possible it's intended to be thread-safe, but it's not documented as such. Let me know if this fix should be moved into Installations instead.