### PR TITLE
[Vertex AI] Bypass proxy for testing against staging

### DIFF
--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Constants associated with the Vertex AI for Firebase SDK.
 enum Constants {
   /// The Vertex AI backend endpoint URL.
-  static let baseURL = "https://firebasevertexai.googleapis.com"
+  static let baseURL = "staging-aiplatform.sandbox.googleapis.com"
 
   /// The base reverse-DNS name for `NSError` or `CustomNSError` error domains.
   ///

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -17,6 +17,7 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct CountTokensRequest {
   let model: String
+  let location: String
 
   let contents: [ModelContent]
   let systemInstruction: ModelContent?
@@ -31,7 +32,9 @@ extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
   var url: URL {
-    URL(string: "\(Constants.baseURL)/\(options.apiVersion)/\(model):countTokens")!
+    URL(
+      string: "https://\(location)-\(Constants.baseURL)/\(options.apiVersion)/\(model):countTokens"
+    )!
   }
 }
 

--- a/FirebaseVertexAI/Sources/GenerateContentRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentRequest.swift
@@ -18,6 +18,7 @@ import Foundation
 struct GenerateContentRequest {
   /// Model name.
   let model: String
+  let location: String
   let contents: [ModelContent]
   let generationConfig: GenerationConfig?
   let safetySettings: [SafetySetting]?
@@ -45,7 +46,7 @@ extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 
   var url: URL {
-    let modelURL = "\(Constants.baseURL)/\(options.apiVersion)/\(model)"
+    let modelURL = "https://\(location)-\(Constants.baseURL)/\(options.apiVersion)/\(model)"
     if isStreaming {
       return URL(string: "\(modelURL):streamGenerateContent?alt=sse")!
     } else {

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -31,7 +31,7 @@ public struct RequestOptions {
   let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
-  let apiVersion = "v1beta"
+  let apiVersion = "v1beta1"
 
   /// Initializes a request options object.
   ///

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -26,6 +26,8 @@ public final class GenerativeModel {
   /// The backing service responsible for sending and receiving model requests to the backend.
   let generativeAIService: GenerativeAIService
 
+  let location: String
+
   /// Configuration parameters used for the MultiModalModel.
   let generationConfig: GenerationConfig?
 
@@ -61,6 +63,7 @@ public final class GenerativeModel {
   init(name: String,
        projectID: String,
        apiKey: String,
+       location: String = "us-central1",
        generationConfig: GenerationConfig? = nil,
        safetySettings: [SafetySetting]? = nil,
        tools: [Tool]?,
@@ -78,6 +81,7 @@ public final class GenerativeModel {
       auth: auth,
       urlSession: urlSession
     )
+    self.location = location
     self.generationConfig = generationConfig
     self.safetySettings = safetySettings
     self.tools = tools
@@ -125,6 +129,7 @@ public final class GenerativeModel {
     try content.throwIfError()
     let response: GenerateContentResponse
     let generateContentRequest = GenerateContentRequest(model: modelResourceName,
+                                                        location: location,
                                                         contents: content,
                                                         generationConfig: generationConfig,
                                                         safetySettings: safetySettings,
@@ -182,6 +187,7 @@ public final class GenerativeModel {
     -> AsyncThrowingStream<GenerateContentResponse, Error> {
     try content.throwIfError()
     let generateContentRequest = GenerateContentRequest(model: modelResourceName,
+                                                        location: location,
                                                         contents: content,
                                                         generationConfig: generationConfig,
                                                         safetySettings: safetySettings,
@@ -253,6 +259,7 @@ public final class GenerativeModel {
   public func countTokens(_ content: [ModelContent]) async throws -> CountTokensResponse {
     let countTokensRequest = CountTokensRequest(
       model: modelResourceName,
+      location: location,
       contents: content,
       systemInstruction: systemInstruction,
       tools: tools,

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -93,6 +93,7 @@ public class VertexAI {
       name: modelResourceName(modelName: modelName),
       projectID: projectID,
       apiKey: apiKey,
+      location: location,
       generationConfig: generationConfig,
       safetySettings: safetySettings,
       tools: tools,


### PR DESCRIPTION
Do not submit, for temporary testing against the Vertex AI staging API. To use, run `gcloud auth print-access-token` and set the printed value to the environment variable `GCLOUD_ACCESS_TOKEN` in Xcode.

cURL Example:
```
curl \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H "Content-Type: application/json" \
  'https://us-central1-staging-aiplatform.sandbox.googleapis.com/v1beta1/projects/{PROJECT_ID}/locations/us-central1/publishers/google/models/{MODEL_NAME}:generateContent' \
--data-binary @- << EOF
{
  "contents": [
    {
      "role": "user",
      "parts": { "text": "Why is the sky blue?" }
    }
  ]
}
EOF
```

#no-changelog