### PR TITLE
Fix: sort document reference by long type id

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -816,6 +816,7 @@
     @"__id-2__" : @{@"a" : @1},
     @"__id1_" : @{@"a" : @1},
     @"_id1__" : @{@"a" : @1},
+    @"__id" : @{@"a" : @1},
     @"__id9223372036854775807__" : @{@"a" : @1},
     @"__id-9223372036854775808__" : @{@"a" : @1},
   }];
@@ -823,7 +824,7 @@
   FIRQuery *query = [collRef queryOrderedByFieldPath:[FIRFieldPath documentID]];
   NSArray<NSString *> *expectedDocs = @[
     @"__id-9223372036854775808__", @"__id-2__", @"__id7__", @"__id12__",
-    @"__id9223372036854775807__", @"12", @"7", @"A", @"Aa", @"__id1_", @"_id1__", @"a"
+    @"__id9223372036854775807__", @"12", @"7", @"A", @"Aa", @"__id", @"__id1_", @"_id1__", @"a"
   ];
   FIRQuerySnapshot *getSnapshot = [self readDocumentSetForRef:query];
   XCTAssertEqualObjects(FIRQuerySnapshotGetIDs(getSnapshot), expectedDocs);
@@ -848,6 +849,7 @@
     @"__id-2__" : @{@"a" : @1},
     @"__id1_" : @{@"a" : @1},
     @"_id1__" : @{@"a" : @1},
+    @"__id" : @{@"a" : @1},
     @"__id9223372036854775807__" : @{@"a" : @1},
     @"__id-9223372036854775808__" : @{@"a" : @1},
   }];
@@ -881,6 +883,7 @@
     @"__id-2__" : @{@"a" : @1},
     @"__id1_" : @{@"a" : @1},
     @"_id1__" : @{@"a" : @1},
+    @"__id" : @{@"a" : @1},
     @"__id9223372036854775807__" : @{@"a" : @1},
     @"__id-9223372036854775808__" : @{@"a" : @1},
   }];
@@ -888,8 +891,8 @@
   [self checkOnlineAndOfflineQuery:[collRef queryOrderedByFieldPath:[FIRFieldPath documentID]]
                      matchesResult:@[
                        @"__id-9223372036854775808__", @"__id-2__", @"__id7__", @"__id12__",
-                       @"__id9223372036854775807__", @"12", @"7", @"A", @"Aa", @"__id1_", @"_id1__",
-                       @"a"
+                       @"__id9223372036854775807__", @"12", @"7", @"A", @"Aa", @"__id", @"__id1_",
+                       @"_id1__", @"a"
                      ]];
 }
 

--- a/Firestore/core/src/model/base_path.h
+++ b/Firestore/core/src/model/base_path.h
@@ -206,7 +206,7 @@ class BasePath {
            segment.substr(segment.size() - 2) == "__";
   }
 
-  static long extractNumericId(const std::string& segment) {
+  static int64_t extractNumericId(const std::string& segment) {
     return std::stol(segment.substr(4, segment.size() - 2));
   }
 };


### PR DESCRIPTION
Document ID supports strings and well as long integers in the format of "id" . When sorting documents by document ID, it should be sorted in the following order:
1. Long (numeric order)
2. String (lexicographic order)

#no-changelog