### PR TITLE
[Config] Move away from private typedef

### DIFF
--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
@@ -27,9 +27,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Completion handler invoked by NSSessionFetcher.
-typedef void (^RCNConfigFetcherCompletion)(NSData *data, NSURLResponse *response, NSError *error);
-
 /// Completion handler invoked after a fetch that contains the updated keys
 typedef void (^RCNConfigFetchCompletion)(FIRRemoteConfigFetchStatus status,
                                          FIRRemoteConfigUpdate *update,

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -423,8 +423,7 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
 
   FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000040", @"Start config fetch.");
   __weak RCNConfigFetch *weakSelf = self;
-  RCNConfigFetcherCompletion fetcherCompletion = ^(NSData *data, NSURLResponse *response,
-                                                   NSError *error) {
+  __auto_type fetcherCompletion = ^(NSData *data, NSURLResponse *response, NSError *error) {
     FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000050",
                 @"config fetch completed. Error: %@ StatusCode: %ld", (error ? error : @"nil"),
                 (long)[((NSHTTPURLResponse *)response) statusCode]);
@@ -651,7 +650,9 @@ static NSInteger const kRCNFetchResponseHTTPStatusCodeGatewayTimeout = 504;
 - (NSURLSessionDataTask *)URLSessionDataTaskWithContent:(NSData *)content
                                         fetchTypeHeader:(NSString *)fetchTypeHeader
                                       completionHandler:
-                                          (RCNConfigFetcherCompletion)fetcherCompletion {
+                                          (void (^)(NSData *data,
+                                                    NSURLResponse *response,
+                                                    NSError *error))fetcherCompletion {
   NSURL *URL = [NSURL URLWithString:[self constructServerURL]];
   FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000046", @"%@",
               [NSString stringWithFormat:@"Making config request: %@", [URL absoluteString]]);

--- a/FirebaseRemoteConfig/Tests/Unit/RCNPersonalizationTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNPersonalizationTest.m
@@ -32,8 +32,9 @@
 @interface RCNConfigFetch (ForTest)
 - (NSURLSessionDataTask *)URLSessionDataTaskWithContent:(NSData *)content
                                         fetchTypeHeader:(NSString *)fetchTypeHeader
-                                      completionHandler:
-                                          (RCNConfigFetcherCompletion)fetcherCompletion;
+                                      completionHandler:(void (^)(NSData *data,
+                                                                  NSURLResponse *response,
+                                                                  NSError *error))fetcherCompletion;
 
 - (void)fetchWithUserProperties:(NSDictionary *)userProperties
                 fetchTypeHeader:(NSString *)fetchTypeHeader

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -49,8 +49,9 @@
                                completionHandler:(FIRAInteropUserPropertiesCallback)block;
 - (NSURLSessionDataTask *)URLSessionDataTaskWithContent:(NSData *)content
                                         fetchTypeHeader:(NSString *)fetchTypeHeader
-                                      completionHandler:
-                                          (RCNConfigFetcherCompletion)fetcherCompletion;
+                                      completionHandler:(void (^)(NSData *data,
+                                                                  NSURLResponse *response,
+                                                                  NSError *error))fetcherCompletion;
 - (void)fetchConfigWithExpirationDuration:(NSTimeInterval)expirationDuration
                         completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler;
 - (void)realtimeFetchConfigWithNoExpirationDuration:(NSInteger)fetchAttemptNumber


### PR DESCRIPTION
This is going into the `rc-swift` branch for the RC Swift port. The typedefs interfere with translation into Swift. The typedef is defined in a private header so should be OK to remove.

#no-changelog