### PR TITLE
add explanation of how alloc works

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -256,6 +256,21 @@ pb_bytes_array_t *FIRCLSEncodeString(NSString *string) {
  * @param data The data to copy into the new bytes array.
  */
 pb_bytes_array_t *FIRCLSEncodeData(NSData *data) {
+  // We have received couple security tickets before for using malloc here.
+  // Here is a short explaination on how it is calculated so buffer overflow is prevented:
+  // We will alloc an amount of memeory for struct `pb_bytes_array_t`, this struct contains two
+  // attributes:
+  //    pb_size_t size
+  //    pb_byte_t bytes[1]
+  // It contains the size the of the data and the actually data information in byte form (which
+  // is represented by a pointer), for more information check the declaration in nanopb/pb.h.
+
+  // For size, NSData return size in `unsigned long` type which is the same size as `pb_size_t` and
+  // it is declared in compile time depending on the arch of system. If overflow happened it should
+  // happend at NSData level first when user trying to inserting data to NSData.
+  // For bytes, it is just a strict memeory copy of the data in NSData.
+  // The whole structure will be freed as a part of process for deallocing report in dealloc() of
+  // this class
   pb_bytes_array_t *pbBytes = malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
   if (pbBytes == NULL) {
     return NULL;


### PR DESCRIPTION
Adding explanation on how memory allocation is made and the reason it will not have buffer overflow.

#no-changelog
