### PR TITLE
Bump Python version from 3.7 to 3.11 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/firestore-nightly.yml
+++ b/.github/workflows/firestore-nightly.yml
@@ -71,7 +71,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.11'
 
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firestore-nightly.plist.gpg \

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -15,6 +15,7 @@
 name: firestore
 
 on:
+  workflow_dispatch:
   pull_request:
   schedule:
     # Run every day at 12am (PST) - cron uses UTC times
@@ -311,7 +312,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.7'
+        python-version: '3.11'
 
     - name: Setup build
       run:  scripts/install_prereqs.sh Firestore ${{ runner.os }} cmake


### PR DESCRIPTION
Fix the following error from the `setup-python` steps by upgrading Python from 3.7 to 3.11, which is what all of the other `setup-python` steps use:

```
Version 3.7 was not found in the local cache
##[error]The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

#no-changelog