### PR TITLE
Firestore: string_format.h: fix use-after-free bug when internally formatting strings

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed use-after-free bug when internally formatting strings. (#14306)
+
 # 11.6.0
 - [fixed] Add conditional `Sendable` conformance so `ServerTimestamp<T>` is
   `Sendable` if `T` is `Sendable`. (#14042)

--- a/Firestore/core/src/util/string_format.h
+++ b/Firestore/core/src/util/string_format.h
@@ -65,8 +65,11 @@ struct FormatChoice<5> {};
 class FormatArg : public absl::AlphaNum {
  public:
   template <typename T>
-  FormatArg(T&& value)  // NOLINT(runtime/explicit)
-      : FormatArg{std::forward<T>(value), internal::FormatChoice<0>{}} {
+  FormatArg(T&& value,
+            absl::strings_internal::StringifySink&& sink =
+                {})  // NOLINT(runtime/explicit)
+      : FormatArg{std::forward<T>(value), std::move(sink),
+                  internal::FormatChoice<0>{}} {
   }
 
  private:
@@ -79,7 +82,9 @@ class FormatArg : public absl::AlphaNum {
    */
   template <typename T,
             typename = typename std::enable_if<std::is_same<bool, T>{}>::type>
-  FormatArg(T bool_value, internal::FormatChoice<0>)
+  FormatArg(T bool_value,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<0>)
       : AlphaNum(bool_value ? "true" : "false") {
   }
 
@@ -90,7 +95,9 @@ class FormatArg : public absl::AlphaNum {
   template <
       typename T,
       typename = typename std::enable_if<objc::is_objc_pointer<T>{}>::type>
-  FormatArg(T object, internal::FormatChoice<1>)
+  FormatArg(T object,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<1>)
       : AlphaNum(MakeStringView([object description])) {
   }
 
@@ -98,7 +105,9 @@ class FormatArg : public absl::AlphaNum {
    * Creates a FormatArg from any Objective-C Class type. Objective-C Class
    * types are a special struct that aren't of a type derived from NSObject.
    */
-  FormatArg(Class object, internal::FormatChoice<1>)
+  FormatArg(Class object,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<1>)
       : AlphaNum(MakeStringView(NSStringFromClass(object))) {
   }
 #endif
@@ -108,7 +117,10 @@ class FormatArg : public absl::AlphaNum {
    * handled specially to avoid ambiguity with generic pointers, which are
    * handled differently.
    */
-  FormatArg(std::nullptr_t, internal::FormatChoice<2>) : AlphaNum("null") {
+  FormatArg(std::nullptr_t,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<2>)
+      : AlphaNum("null") {
   }
 
   /**
@@ -116,7 +128,9 @@ class FormatArg : public absl::AlphaNum {
    * handled specially to avoid ambiguity with generic pointers, which are
    * handled differently.
    */
-  FormatArg(const char* string_value, internal::FormatChoice<3>)
+  FormatArg(const char* string_value,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<3>)
       : AlphaNum(string_value == nullptr ? "null" : string_value) {
   }
 
@@ -125,8 +139,11 @@ class FormatArg : public absl::AlphaNum {
    * hexadecimal integer literal.
    */
   template <typename T>
-  FormatArg(T* pointer_value, internal::FormatChoice<4>)
-      : AlphaNum(absl::Hex(reinterpret_cast<uintptr_t>(pointer_value))) {
+  FormatArg(T* pointer_value,
+            absl::strings_internal::StringifySink&& sink,
+            internal::FormatChoice<4>)
+      : AlphaNum(absl::Hex(reinterpret_cast<uintptr_t>(pointer_value)),
+                 std::move(sink)) {
   }
 
   /**
@@ -134,7 +151,9 @@ class FormatArg : public absl::AlphaNum {
    * absl::AlphaNum accepts.
    */
   template <typename T>
-  FormatArg(T&& value, internal::FormatChoice<5>)
+  FormatArg(T&& value,
+            absl::strings_internal::StringifySink&&,
+            internal::FormatChoice<5>)
       : AlphaNum(std::forward<T>(value)) {
   }
 };

--- a/Firestore/core/src/util/string_format.h
+++ b/Firestore/core/src/util/string_format.h
@@ -65,14 +65,15 @@ struct FormatChoice<5> {};
 class FormatArg final : public absl::AlphaNum {
  public:
   template <typename T>
-  FormatArg(T&& value,
-    // TODO(b/388888512) Remove the usage of StringifySink since it is not part
-    //  of absl's public API. Moreover, subclassing AlphaNum is not supported
-    //  either, so find a way to do this without these two caveats.
-    //  See https://github.com/firebase/firebase-ios-sdk/pull/14331 for a
-    //  partial proposal.
-            absl::strings_internal::StringifySink&& sink =
-                {})  // NOLINT(runtime/explicit)
+  FormatArg(
+      T&& value,
+      // TODO(b/388888512) Remove the usage of StringifySink since it is not
+      //  part of absl's public API. Moreover, subclassing AlphaNum is not
+      //  supported either, so find a way to do this without these two caveats.
+      //  See https://github.com/firebase/firebase-ios-sdk/pull/14331 for a
+      //  partial proposal.
+      absl::strings_internal::StringifySink&& sink =
+          {})  // NOLINT(runtime/explicit)
       : FormatArg{std::forward<T>(value), std::move(sink),
                   internal::FormatChoice<0>{}} {
   }

--- a/Firestore/core/src/util/string_format.h
+++ b/Firestore/core/src/util/string_format.h
@@ -66,6 +66,11 @@ class FormatArg final : public absl::AlphaNum {
  public:
   template <typename T>
   FormatArg(T&& value,
+    // TODO(b/388888512) Remove the usage of StringifySink since it is not part
+    //  of absl's public API. Moreover, subclassing AlphaNum is not supported
+    //  either, so find a way to do this without these two caveats.
+    //  See https://github.com/firebase/firebase-ios-sdk/pull/14331 for a
+    //  partial proposal.
             absl::strings_internal::StringifySink&& sink =
                 {})  // NOLINT(runtime/explicit)
       : FormatArg{std::forward<T>(value), std::move(sink),

--- a/Firestore/core/src/util/string_format.h
+++ b/Firestore/core/src/util/string_format.h
@@ -62,7 +62,7 @@ struct FormatChoice<5> {};
  *     formatting of the value as an unsigned integer.
  *   * Otherwise the value is interpreted as anything absl::AlphaNum accepts.
  */
-class FormatArg : public absl::AlphaNum {
+class FormatArg final : public absl::AlphaNum {
  public:
   template <typename T>
   FormatArg(T&& value,

--- a/Firestore/core/test/unit/util/string_format_test.cc
+++ b/Firestore/core/test/unit/util/string_format_test.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/util/string_format.h"
 
 #include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -72,12 +73,16 @@ TEST(StringFormatTest, Bool) {
   EXPECT_EQ("Hello false", StringFormat("Hello %s", false));
 }
 
-TEST(StringFormatTest, Pointer) {
-  // pointers implicitly convert to bool. Make sure this doesn't happen in
-  // this API.
-  int value = 4;
-  EXPECT_NE("Hello true", StringFormat("Hello %s", &value));
+TEST(StringFormatTest, NullPointer) {
+  // pointers implicitly convert to bool. Make sure this doesn't happen here.
   EXPECT_EQ("Hello null", StringFormat("Hello %s", nullptr));
+}
+
+TEST(StringFormatTest, NonNullPointer) {
+  // pointers implicitly convert to bool. Make sure this doesn't happen here.
+  int value = 4;
+  EXPECT_THAT(StringFormat("Hello %s", &value),
+              testing::MatchesRegex("Hello (0x)?[0123456789abcdefABCDEF]+"));
 }
 
 TEST(StringFormatTest, Mixed) {


### PR DESCRIPTION
This PR fixes the following use-after-free bug detected by the test [`TEST(StringFormatTest, Pointer)`](https://github.com/firebase/firebase-ios-sdk/blob/c092c02dd2840782132e61dfc77558729bf63450/Firestore/core/test/unit/util/string_format_test.cc#L79) when run under ASAN:

```
11: =================================================================
11: ==22796==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f2c74931b50 at pc 0x7f2c778fb42e bp 0x7ffd9a727650 sp 0x7ffd9a726df8
11: READ of size 12 at 0x7f2c74931b50 thread T0
11:     #0 0x7f2c778fb42d in memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
11:     #1 0x7f2c76f68754 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x168754) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
11:     #2 0x7f2c76f6a04f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long) (/lib/x86_64-linux-gnu/libstdc++.so.6+0x16a04f) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
11:     #3 0x5614e57b39ba in operator() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/src/util/string_format.cc:51
11:     #4 0x5614e57b3ead in operator() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/src/util/string_format.cc:75
11:     #5 0x5614e57b40af in firebase::firestore::util::internal::StringFormatPieces[abi:cxx11](char const*, std::initializer_list<absl::lts_20240116::string_view>) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/src/util/string_format.cc:109
11:     #6 0x5614e5438c42 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > firebase::firestore::util::StringFormat<int*>(char const*, int* const&) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/src/util/string_format.h:161
11:     #7 0x5614e54312cc in firebase::firestore::util::StringFormatTest_Pointer_Test::TestBody() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/test/unit/util/string_format_test.cc:79
11:     #8 0x5614e557ad6a in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2653
11:     #9 0x5614e5569d7c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2689
11:     #10 0x5614e5514a1d in testing::Test::Run() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2728
11:     #11 0x5614e5516094 in testing::TestInfo::Run() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2874
11:     #12 0x5614e5517266 in testing::TestSuite::Run() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:3052
11:     #13 0x5614e553e811 in testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:6020
11:     #14 0x5614e557e31a in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2653
11:     #15 0x5614e556cb59 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:2689
11:     #16 0x5614e553afc5 in testing::UnitTest::Run() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest.cc:5599
11:     #17 0x5614e55ab633 in RUN_ALL_TESTS() /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/include/gtest/gtest.h:2334
11:     #18 0x5614e55ab57f in main /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/external/src/googletest/googletest/src/gtest_main.cc:64
11:     #19 0x7f2c76a2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
11:     #20 0x7f2c76a2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
11:     #21 0x5614e506e074 in _start (/home/runner/work/firebase-ios-sdk/firebase-ios-sdk/build/Firestore/core/test/unit/util/firestore_util_test+0x14b074) (BuildId: eefa62cc1c83814a55da36f74af7d7609da19e60)
11: 
11: Address 0x7f2c74931b50 is located in stack of thread T0 at offset 80 in frame
11:     #0 0x5614e543b899 in firebase::firestore::util::FormatArg::FormatArg<int>(int*, firebase::firestore::util::internal::FormatChoice<4>) /home/runner/work/firebase-ios-sdk/firebase-ios-sdk/Firestore/core/src/util/string_format.h:128
11: 
11:   This frame has 2 object(s):
11:     [32, 48) '<unknown>'
11:     [64, 96) '<unknown>' <== Memory access at offset 80 is inside this variable
11: HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
11:       (longjmp and C++ exceptions *are* supported)
11: SUMMARY: AddressSanitizer: stack-use-after-return ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115 in memcpy
11: Shadow bytes around the buggy address:
11:   0x7f2c74931880: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931900: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931980: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931a00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931a80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11: =>0x7f2c74931b00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5[f5]f5 f5 f5 f5 f5
11:   0x7f2c74931b80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931c00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931c80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931d00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11:   0x7f2c74931d80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00
11: Shadow byte legend (one shadow byte represents 8 application bytes):
11:   Addressable:           00
11:   Partially addressable: 01 02 03 04 05 06 07 
11:   Heap left redzone:       fa
11:   Freed heap region:       fd
11:   Stack left redzone:      f1
11:   Stack mid redzone:       f2
11:   Stack right redzone:     f3
11:   Stack after return:      f5
11:   Stack use after scope:   f8
11:   Global redzone:          f9
11:   Global init order:       f6
11:   Poisoned by user:        f7
11:   Container overflow:      fc
11:   Array cookie:            ac
11:   Intra object redzone:    bb
11:   ASan internal:           fe
11:   Left alloca redzone:     ca
11:   Right alloca redzone:    cb
11: ==22796==ABORTING
```

The real issue here is that Firestore is using the class `absl::AlphaNum` in a way that it was not intended to be used. Namely, `AlphaNum` explicitly documents that 

> The `AlphaNum` class acts as the main parameter type for `StrCat()` and
> `StrAppend()`, providing efficient conversion of numeric, boolean, decimal,
> and hexadecimal values (through the `Dec` and `Hex` types) into strings.
> `AlphaNum` should only be used as a function parameter. Do not instantiate
>  `AlphaNum` directly as a stack variable.

https://github.com/abseil/abseil-cpp/blob/506f1072c03dc35ba7bc447fd9651cc90e22e816/absl/strings/str_cat.h#L311C1-L315C45

However, the Firestore SDK uses it in a different way, by creating a _subclass_ of it, named `FormatArg`: https://github.com/firebase/firebase-ios-sdk/blob/c092c02dd2840782132e61dfc77558729bf63450/Firestore/core/src/util/string_format.h#L65

The problem is that one of the constructors of `FormatArg` calls through to a constructor of `AlphaNum` that relies on the lifetime extension of a C++ temporary used as function argument for a reference-type parameter. This works just fine when `AlphaNum` is used as a direct argument to `StrCat()`, as is intended. However, when used in that way that Firestore does, the `StringifySink` temporary argument is destroyed prematurely, causing a dangling reference to its internal `std::string`, causing a use-after-free bug when that dangling reference is used.

Although use-after-free is technically _undefined behavior_, it manifested in my case by this code

```cpp
int value = 4;
StringFormat("Hello %s", &value);
```

returning `"Hello \x90\x15#T\xFD\x7F\0\0\x88\x15#T"` instead of the expected `"Hello 7ffffdc94440"`. Notice how the text after "Hello" is "garbage" in the former case, but is the expected hex-formatted memory address in the latter case. The latter case was produced with the fix in this PR applied.

This fix works by having the `StringifySink` be created by the _caller_ of the `FormatArg` constructor (by virtue of it being a default parameter with a default value) and passing along a reference to that `StringifySink`. This gains the correct lifetime extension of the `StringifySink` object and fixes the use-after-free.

There are, however, two drawbacks to this fix: (a) the `StringifySink` class is an internal, implementation detail of absl that really should not be used by Firestore and (b) it incurs the cost of creating and destroying a `StringifySink` object even for constructors that don't need it. With respect to (a), since we have pinned to a specific version of absl we should be good and with respect to (b) I hope that the compiler will elide the `StringifySink` constructor calls altogether when the object is not needed since its constructors and destructor have no apparent side effects.

I had originally thought that this was a bug in absl; however, after discussion with the absl developers, the root cause was identified as unintended use of the `AlphaNum` class. Googlers can see b/388000898 for the whole discussion.