### PR TITLE
[Vertex AI] Refactor `ImagenSafetySettings`

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -98,7 +98,7 @@ public final class ImagenModel {
       negativePrompt: generationConfig?.negativePrompt,
       aspectRatio: generationConfig?.aspectRatio?.rawValue,
       safetyFilterLevel: safetySettings?.safetyFilterLevel?.rawValue,
-      personGeneration: safetySettings?.personGeneration?.rawValue,
+      personGeneration: safetySettings?.personFilterLevel?.rawValue,
       outputOptions: generationConfig?.imageFormat.map {
         ImageGenerationOutputOptions(
           mimeType: $0.mimeType,
@@ -106,7 +106,7 @@ public final class ImagenModel {
         )
       },
       addWatermark: generationConfig?.addWatermark,
-      includeResponsibleAIFilterReason: safetySettings?.includeFilterReason ?? true
+      includeResponsibleAIFilterReason: true
     )
   }
 }

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenPersonFilterLevel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenPersonFilterLevel.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct ImagenSafetySettings {
-  let safetyFilterLevel: ImagenSafetyFilterLevel?
-  let personFilterLevel: ImagenPersonFilterLevel?
-
-  public init(safetyFilterLevel: ImagenSafetyFilterLevel? = nil,
-              personFilterLevel: ImagenPersonFilterLevel? = nil) {
-    self.safetyFilterLevel = safetyFilterLevel
-    self.personFilterLevel = personFilterLevel
+public struct ImagenPersonFilterLevel: ProtoEnum {
+  enum Kind: String {
+    case blockAll = "dont_allow"
+    case allowAdult = "allow_adult"
+    case allowAll = "allow_all"
   }
+
+  public static let blockAll = ImagenPersonFilterLevel(kind: .blockAll)
+  public static let allowAdult = ImagenPersonFilterLevel(kind: .allowAdult)
+  public static let allowAll = ImagenPersonFilterLevel(kind: .allowAll)
+
+  let rawValue: String
 }

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenSafetyFilterLevel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenSafetyFilterLevel.swift
@@ -1,0 +1,30 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public struct ImagenSafetyFilterLevel: ProtoEnum {
+  enum Kind: String {
+    case blockLowAndAbove = "block_low_and_above"
+    case blockMediumAndAbove = "block_medium_and_above"
+    case blockOnlyHigh = "block_only_high"
+    case blockNone = "block_none"
+  }
+
+  public static let blockLowAndAbove = ImagenSafetyFilterLevel(kind: .blockLowAndAbove)
+  public static let blockMediumAndAbove = ImagenSafetyFilterLevel(kind: .blockMediumAndAbove)
+  public static let blockOnlyHigh = ImagenSafetyFilterLevel(kind: .blockOnlyHigh)
+  public static let blockNone = ImagenSafetyFilterLevel(kind: .blockNone)
+
+  let rawValue: String
+}

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -65,7 +65,7 @@ final class IntegrationTests: XCTestCase {
       modelName: "imagen-3.0-fast-generate-001",
       safetySettings: ImagenSafetySettings(
         safetyFilterLevel: .blockLowAndAbove,
-        personGeneration: .blockAll
+        personFilterLevel: .blockAll
       )
     )
 

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationParametersTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationParametersTests.swift
@@ -111,13 +111,11 @@ final class ImageGenerationParametersTests: XCTestCase {
   }
 
   func testDefaultParameters_includeSafetySettings() throws {
-    let safetyFilterLevel = ImagenSafetySettings.SafetyFilterLevel.blockOnlyHigh
-    let personGeneration = ImagenSafetySettings.PersonGeneration.allowAll
-    let includeFilterReason = false
+    let safetyFilterLevel = ImagenSafetyFilterLevel.blockOnlyHigh
+    let personFilterLevel = ImagenPersonFilterLevel.allowAll
     let safetySettings = ImagenSafetySettings(
       safetyFilterLevel: safetyFilterLevel,
-      includeFilterReason: includeFilterReason,
-      personGeneration: personGeneration
+      personFilterLevel: personFilterLevel
     )
     let expectedParameters = ImageGenerationParameters(
       sampleCount: 1,
@@ -125,10 +123,10 @@ final class ImageGenerationParametersTests: XCTestCase {
       negativePrompt: nil,
       aspectRatio: nil,
       safetyFilterLevel: safetyFilterLevel.rawValue,
-      personGeneration: personGeneration.rawValue,
+      personGeneration: personFilterLevel.rawValue,
       outputOptions: nil,
       addWatermark: nil,
-      includeResponsibleAIFilterReason: includeFilterReason
+      includeResponsibleAIFilterReason: true
     )
 
     let parameters = ImagenModel.imageGenerationParameters(
@@ -156,13 +154,11 @@ final class ImageGenerationParametersTests: XCTestCase {
       imageFormat: imageFormat,
       addWatermark: addWatermark
     )
-    let safetyFilterLevel = ImagenSafetySettings.SafetyFilterLevel.blockNone
-    let personGeneration = ImagenSafetySettings.PersonGeneration.blockAll
-    let includeFilterReason = false
+    let safetyFilterLevel = ImagenSafetyFilterLevel.blockNone
+    let personFilterLevel = ImagenPersonFilterLevel.blockAll
     let safetySettings = ImagenSafetySettings(
       safetyFilterLevel: safetyFilterLevel,
-      includeFilterReason: includeFilterReason,
-      personGeneration: personGeneration
+      personFilterLevel: personFilterLevel
     )
     let expectedParameters = ImageGenerationParameters(
       sampleCount: sampleCount,
@@ -170,13 +166,13 @@ final class ImageGenerationParametersTests: XCTestCase {
       negativePrompt: negativePrompt,
       aspectRatio: aspectRatio.rawValue,
       safetyFilterLevel: safetyFilterLevel.rawValue,
-      personGeneration: personGeneration.rawValue,
+      personGeneration: personFilterLevel.rawValue,
       outputOptions: ImageGenerationOutputOptions(
         mimeType: imageFormat.mimeType,
         compressionQuality: imageFormat.compressionQuality
       ),
       addWatermark: addWatermark,
-      includeResponsibleAIFilterReason: includeFilterReason
+      includeResponsibleAIFilterReason: true
     )
 
     let parameters = ImagenModel.imageGenerationParameters(


### PR DESCRIPTION
- Renamed `ImagenSafetySettings.PersonGeneration` to `ImagenPersonFilterLevel` since it does not control whether people are generated, only whether they get filtered out after generation.
- Renamed `ImagenSafetySettings.SafetyFilterLevel` to `ImagenSafetyFilterLevel` to align with other platforms.
- Removed `includeFilterReason` since we've decided to hardcode it to `true` (when `false`, [no feedback is provided](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images#safety-filters) when images are filtered).

#14221
#no-changelog