### PR TITLE
Update RCE flow to skip checking status if appVerificationDisabledForTesting is set

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -4,6 +4,7 @@
   for decoding `nil` values. (#14212)
 - [fixed] Address Xcode 16.2 concurrency compile time issues. (#14279)
 - [fixed] Fix handling of cloud blocking function errors. (#14052)
+- [fixed] Fix phone auth flow to skip RCE verification if appVerificationDisabledForTesting is set. (#14242)
 
 # 11.6.0
 - [added] Added reCAPTCHA Enterprise support for app verification during phone

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -203,6 +203,21 @@ import Foundation
       }
 
       let recaptchaVerifier = AuthRecaptchaVerifier.shared(auth: auth)
+      
+      if let settings = auth.settings,
+         settings.isAppVerificationDisabledForTesting {
+        // If app verification is disabled for testing
+        // do not fetch recaptcha config, as this is not implemented in emulator
+        // Treat this same as RCE enable status off
+          
+        return try await verifyClAndSendVerificationCode(
+          toPhoneNumber: phoneNumber,
+          retryOnInvalidAppCredential: true,
+          multiFactorSession: multiFactorSession,
+          uiDelegate: uiDelegate
+        )
+      }
+        
       try await recaptchaVerifier.retrieveRecaptchaConfig(forceRefresh: true)
 
       switch recaptchaVerifier.enablementStatus(forProvider: .phone) {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -203,13 +203,13 @@ import Foundation
       }
 
       let recaptchaVerifier = AuthRecaptchaVerifier.shared(auth: auth)
-      
+
       if let settings = auth.settings,
          settings.isAppVerificationDisabledForTesting {
         // If app verification is disabled for testing
         // do not fetch recaptcha config, as this is not implemented in emulator
         // Treat this same as RCE enable status off
-          
+
         return try await verifyClAndSendVerificationCode(
           toPhoneNumber: phoneNumber,
           retryOnInvalidAppCredential: true,
@@ -217,7 +217,7 @@ import Foundation
           uiDelegate: uiDelegate
         )
       }
-        
+
       try await recaptchaVerifier.retrieveRecaptchaConfig(forceRefresh: true)
 
       switch recaptchaVerifier.enablementStatus(forProvider: .phone) {


### PR DESCRIPTION
### Discussion

Fix #14242 

If the flag is set we will bypass RCE flow and treat it similar to RCE enablement status off.

### Testing

Ran PhoneAuthProvider tests with emulator and verified that this error no longer occurs.