### PR TITLE
[Config] Conditionally mark closures as Sendable for Xcode 16

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 11.7.0
 - [fixed] Mark ConfigUpdateListenerRegistration Sendable. (#14215)
+- [fixed] Mark completion handlers as Sendable in RemoteConfig class. (#14257)
 
 # 11.5.0
 - [fixed] Mark two internal properties as `atomic` to prevent concurrency

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 11.7.0
 - [fixed] Mark ConfigUpdateListenerRegistration Sendable. (#14215)
 - [fixed] Mark completion handlers as Sendable in RemoteConfig class. (#14257)
-- [feature] Added support for custom signal targeting in Remote Config. Use 
+- [feature] Added support for custom signal targeting in Remote Config. Use
   `setCustomSignals` API for setting custom signals and use them to build
   custom targeting conditions in Remote Config. (#13976)
 

--- a/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
@@ -223,6 +223,22 @@ NS_SWIFT_NAME(RemoteConfig)
 - (void)ensureInitializedWithCompletionHandler:
     (void (^_Nonnull)(NSError *_Nullable initializationError))completionHandler;
 #pragma mark - Fetch
+
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000)
+/// Fetches Remote Config data with a callback. Call `activate()` to make fetched data
+/// available to your app.
+///
+/// Note: This method uses a Firebase Installations token to identify the app instance, and once
+/// it's called, it periodically sends data to the Firebase backend. (see
+/// `Installations.authToken(completion:)`).
+/// To stop the periodic sync, call `Installations.delete(completion:)`
+/// and avoid calling this method again.
+///
+/// @param completionHandler Fetch operation callback with status and error parameters.
+- (void)fetchWithCompletionHandler:
+    (void (^_Nullable NS_SWIFT_SENDABLE)(FIRRemoteConfigFetchStatus status,
+                                         NSError *_Nullable error))completionHandler;
+#else
 /// Fetches Remote Config data with a callback. Call `activate()` to make fetched data
 /// available to your app.
 ///
@@ -235,7 +251,27 @@ NS_SWIFT_NAME(RemoteConfig)
 /// @param completionHandler Fetch operation callback with status and error parameters.
 - (void)fetchWithCompletionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
                                                       NSError *_Nullable error))completionHandler;
+#endif
 
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000)
+/// Fetches Remote Config data and sets a duration that specifies how long config data lasts.
+/// Call `activateWithCompletion:` to make fetched data available to your app.
+///
+/// Note: This method uses a Firebase Installations token to identify the app instance, and once
+/// it's called, it periodically sends data to the Firebase backend. (see
+/// `Installations.authToken(completion:)`).
+/// To stop the periodic sync, call `Installations.delete(completion:)`
+/// and avoid calling this method again.
+///
+/// @param expirationDuration  Override the (default or optionally set `minimumFetchInterval`
+/// property in RemoteConfigSettings) `minimumFetchInterval` for only the current request, in
+/// seconds. Setting a value of 0 seconds will force a fetch to the backend.
+/// @param completionHandler   Fetch operation callback with status and error parameters.
+- (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration
+                  completionHandler:(void (^_Nullable NS_SWIFT_SENDABLE)(
+                                        FIRRemoteConfigFetchStatus status,
+                                        NSError *_Nullable error))completionHandler;
+#else
 /// Fetches Remote Config data and sets a duration that specifies how long config data lasts.
 /// Call `activateWithCompletion:` to make fetched data available to your app.
 ///
@@ -252,7 +288,23 @@ NS_SWIFT_NAME(RemoteConfig)
 - (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration
                   completionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
                                                        NSError *_Nullable error))completionHandler;
+#endif
 
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000)
+/// Fetches Remote Config data and if successful, activates fetched data. Optional completion
+/// handler callback is invoked after the attempted activation of data, if the fetch call succeeded.
+///
+/// Note: This method uses a Firebase Installations token to identify the app instance, and once
+/// it's called, it periodically sends data to the Firebase backend. (see
+/// `Installations.authToken(completion:)`).
+/// To stop the periodic sync, call `Installations.delete(completion:)`
+/// and avoid calling this method again.
+///
+/// @param completionHandler Fetch operation callback with status and error parameters.
+- (void)fetchAndActivateWithCompletionHandler:
+    (void (^_Nullable NS_SWIFT_SENDABLE)(FIRRemoteConfigFetchAndActivateStatus status,
+                                         NSError *_Nullable error))completionHandler;
+#else
 /// Fetches Remote Config data and if successful, activates fetched data. Optional completion
 /// handler callback is invoked after the attempted activation of data, if the fetch call succeeded.
 ///
@@ -266,14 +318,23 @@ NS_SWIFT_NAME(RemoteConfig)
 - (void)fetchAndActivateWithCompletionHandler:
     (void (^_Nullable)(FIRRemoteConfigFetchAndActivateStatus status,
                        NSError *_Nullable error))completionHandler;
+#endif
 
 #pragma mark - Apply
 
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000)
+/// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
+/// of the app to take effect (depending on how config data is used in the app).
+/// @param completion Activate operation callback with changed and error parameters.
+- (void)activateWithCompletion:
+    (void (^_Nullable NS_SWIFT_SENDABLE)(BOOL changed, NSError *_Nullable error))completion;
+#else
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
 /// of the app to take effect (depending on how config data is used in the app).
 /// @param completion Activate operation callback with changed and error parameters.
 - (void)activateWithCompletion:(void (^_Nullable)(BOOL changed,
                                                   NSError *_Nullable error))completion;
+#endif
 
 #pragma mark - Get Config
 /// Enables access to configuration values by using object subscripting syntax.


### PR DESCRIPTION
I downloaded last Xcode 15 version, Xcode 15.4, to test and found that adding Sendable to the closure params created a warning when the call site inherited an isolation domain (main actor, global actor, etc.). The warning is more disruptive to Xcode 15 users since Xcode 15 does not include Swift 6 language version.

In Xcode 16, the same warning appears for Swift 5 users and is an error in Swift 6.

<img width="701" alt="Screenshot 2025-01-07 at 3 29 19 PM" src="https://github.com/user-attachments/assets/6696fc7e-9899-4aae-a23f-69c3d446c455" />

Conclusion– no new warnings for Xcode 15. New warnings for Xcode 16 where newly Sendable completion handler will warn about changing properties belonging to other isolation domains (see screenshot). New warnings are errors in Swift 6 mode in Xcode 16.


Fixes #14257