### PR TITLE
[Vertex AI] Add `ImagenModelConfig` for model-level config params

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -24,6 +24,8 @@ public final class ImagenModel {
   /// The backing service responsible for sending and receiving model requests to the backend.
   let generativeAIService: GenerativeAIService
 
+  let modelConfig: ImagenModelConfig?
+
   let safetySettings: ImagenSafetySettings?
 
   /// Configuration parameters for sending requests to the backend.
@@ -32,6 +34,7 @@ public final class ImagenModel {
   init(name: String,
        projectID: String,
        apiKey: String,
+       modelConfig: ImagenModelConfig?,
        safetySettings: ImagenSafetySettings?,
        requestOptions: RequestOptions,
        appCheck: AppCheckInterop?,
@@ -45,6 +48,7 @@ public final class ImagenModel {
       auth: auth,
       urlSession: urlSession
     )
+    self.modelConfig = modelConfig
     self.safetySettings = safetySettings
     self.requestOptions = requestOptions
   }
@@ -57,6 +61,7 @@ public final class ImagenModel {
       parameters: ImagenModel.imageGenerationParameters(
         storageURI: nil,
         generationConfig: generationConfig,
+        modelConfig: modelConfig,
         safetySettings: safetySettings
       )
     )
@@ -70,6 +75,7 @@ public final class ImagenModel {
       parameters: ImagenModel.imageGenerationParameters(
         storageURI: storageURI,
         generationConfig: generationConfig,
+        modelConfig: modelConfig,
         safetySettings: safetySettings
       )
     )
@@ -90,6 +96,7 @@ public final class ImagenModel {
 
   static func imageGenerationParameters(storageURI: String?,
                                         generationConfig: ImagenGenerationConfig?,
+                                        modelConfig: ImagenModelConfig?,
                                         safetySettings: ImagenSafetySettings?)
     -> ImageGenerationParameters {
     return ImageGenerationParameters(
@@ -99,13 +106,13 @@ public final class ImagenModel {
       aspectRatio: generationConfig?.aspectRatio?.rawValue,
       safetyFilterLevel: safetySettings?.safetyFilterLevel?.rawValue,
       personGeneration: safetySettings?.personFilterLevel?.rawValue,
-      outputOptions: generationConfig?.imageFormat.map {
+      outputOptions: modelConfig?.imageFormat.map {
         ImageGenerationOutputOptions(
           mimeType: $0.mimeType,
           compressionQuality: $0.compressionQuality
         )
       },
-      addWatermark: generationConfig?.addWatermark,
+      addWatermark: modelConfig?.addWatermark,
       includeResponsibleAIFilterReason: true
     )
   }

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModelConfig.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModelConfig.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +13,12 @@
 // limitations under the License.
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct ImagenGenerationConfig {
-  public var numberOfImages: Int?
-  public var negativePrompt: String?
-  public var aspectRatio: ImagenAspectRatio?
+public struct ImagenModelConfig {
+  let imageFormat: ImagenImageFormat?
+  let addWatermark: Bool?
 
-  public init(numberOfImages: Int? = nil, negativePrompt: String? = nil,
-              aspectRatio: ImagenAspectRatio? = nil) {
-    self.numberOfImages = numberOfImages
-    self.negativePrompt = negativePrompt
-    self.aspectRatio = aspectRatio
+  public init(imageFormat: ImagenImageFormat? = nil, addWatermark: Bool? = nil) {
+    self.imageFormat = imageFormat
+    self.addWatermark = addWatermark
   }
 }

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -104,12 +104,14 @@ public class VertexAI {
     )
   }
 
-  public func imagenModel(modelName: String, safetySettings: ImagenSafetySettings? = nil,
+  public func imagenModel(modelName: String, modelConfig: ImagenModelConfig? = nil,
+                          safetySettings: ImagenSafetySettings? = nil,
                           requestOptions: RequestOptions = RequestOptions()) -> ImagenModel {
     return ImagenModel(
       name: modelResourceName(modelName: modelName),
       projectID: projectID,
       apiKey: apiKey,
+      modelConfig: modelConfig,
       safetySettings: safetySettings,
       requestOptions: requestOptions,
       appCheck: appCheck,

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -63,6 +63,7 @@ final class IntegrationTests: XCTestCase {
     )
     imagenModel = vertex.imagenModel(
       modelName: "imagen-3.0-fast-generate-001",
+      modelConfig: ImagenModelConfig(imageFormat: .jpeg(compressionQuality: 70)),
       safetySettings: ImagenSafetySettings(
         safetyFilterLevel: .blockLowAndAbove,
         personFilterLevel: .blockAll
@@ -253,9 +254,7 @@ final class IntegrationTests: XCTestCase {
     overlooking a vast African savanna at sunset. Golden hour light, long shadows, sharp focus on
     the lion, shallow depth of field, detailed fur texture, DSLR, 85mm lens.
     """
-    var generationConfig = ImagenGenerationConfig()
-    generationConfig.aspectRatio = .landscape16x9
-    generationConfig.imageFormat = .jpeg(compressionQuality: 70)
+    let generationConfig = ImagenGenerationConfig(aspectRatio: .landscape16x9)
 
     let response = try await imagenModel.generateImages(
       prompt: imagePrompt,

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationParametersTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImageGenerationParametersTests.swift
@@ -40,6 +40,7 @@ final class ImageGenerationParametersTests: XCTestCase {
     let parameters = ImagenModel.imageGenerationParameters(
       storageURI: nil,
       generationConfig: nil,
+      modelConfig: nil,
       safetySettings: nil
     )
 
@@ -63,31 +64,23 @@ final class ImageGenerationParametersTests: XCTestCase {
     let parameters = ImagenModel.imageGenerationParameters(
       storageURI: storageURI,
       generationConfig: nil,
+      modelConfig: nil,
       safetySettings: nil
     )
 
     XCTAssertEqual(parameters, expectedParameters)
   }
 
-  func testParameters_includeGenerationConfig() throws {
-    let sampleCount = 2
-    let negativePrompt = "test-negative-prompt"
-    let aspectRatio = ImagenAspectRatio.landscape16x9
+  func testParameters_includeModelConfig() throws {
     let compressionQuality = 80
     let imageFormat = ImagenImageFormat.jpeg(compressionQuality: compressionQuality)
     let addWatermark = true
-    let generationConfig = ImagenGenerationConfig(
-      numberOfImages: sampleCount,
-      negativePrompt: negativePrompt,
-      aspectRatio: aspectRatio,
-      imageFormat: imageFormat,
-      addWatermark: addWatermark
-    )
+    let modelConfig = ImagenModelConfig(imageFormat: imageFormat, addWatermark: addWatermark)
     let expectedParameters = ImageGenerationParameters(
-      sampleCount: sampleCount,
+      sampleCount: 1,
       storageURI: nil,
-      negativePrompt: negativePrompt,
-      aspectRatio: aspectRatio.rawValue,
+      negativePrompt: nil,
+      aspectRatio: nil,
       safetyFilterLevel: nil,
       personGeneration: nil,
       outputOptions: ImageGenerationOutputOptions(
@@ -100,14 +93,44 @@ final class ImageGenerationParametersTests: XCTestCase {
 
     let parameters = ImagenModel.imageGenerationParameters(
       storageURI: nil,
+      generationConfig: nil,
+      modelConfig: modelConfig,
+      safetySettings: nil
+    )
+
+    XCTAssertEqual(parameters, expectedParameters)
+  }
+
+  func testParameters_includeGenerationConfig() throws {
+    let sampleCount = 2
+    let negativePrompt = "test-negative-prompt"
+    let aspectRatio = ImagenAspectRatio.landscape16x9
+    let generationConfig = ImagenGenerationConfig(
+      numberOfImages: sampleCount,
+      negativePrompt: negativePrompt,
+      aspectRatio: aspectRatio
+    )
+    let expectedParameters = ImageGenerationParameters(
+      sampleCount: sampleCount,
+      storageURI: nil,
+      negativePrompt: negativePrompt,
+      aspectRatio: aspectRatio.rawValue,
+      safetyFilterLevel: nil,
+      personGeneration: nil,
+      outputOptions: nil,
+      addWatermark: nil,
+      includeResponsibleAIFilterReason: true
+    )
+
+    let parameters = ImagenModel.imageGenerationParameters(
+      storageURI: nil,
       generationConfig: generationConfig,
+      modelConfig: nil,
       safetySettings: nil
     )
 
     XCTAssertEqual(parameters, expectedParameters)
     XCTAssertEqual(parameters.aspectRatio, "16:9")
-    XCTAssertEqual(parameters.outputOptions?.mimeType, "image/jpeg")
-    XCTAssertEqual(parameters.outputOptions?.compressionQuality, compressionQuality)
   }
 
   func testDefaultParameters_includeSafetySettings() throws {
@@ -132,6 +155,7 @@ final class ImageGenerationParametersTests: XCTestCase {
     let parameters = ImagenModel.imageGenerationParameters(
       storageURI: nil,
       generationConfig: nil,
+      modelConfig: nil,
       safetySettings: safetySettings
     )
 
@@ -145,15 +169,14 @@ final class ImageGenerationParametersTests: XCTestCase {
     let sampleCount = 4
     let negativePrompt = "test-negative-prompt"
     let aspectRatio = ImagenAspectRatio.portrait3x4
-    let imageFormat = ImagenImageFormat.png()
-    let addWatermark = false
     let generationConfig = ImagenGenerationConfig(
       numberOfImages: sampleCount,
       negativePrompt: negativePrompt,
-      aspectRatio: aspectRatio,
-      imageFormat: imageFormat,
-      addWatermark: addWatermark
+      aspectRatio: aspectRatio
     )
+    let imageFormat = ImagenImageFormat.png()
+    let addWatermark = false
+    let modelConfig = ImagenModelConfig(imageFormat: imageFormat, addWatermark: addWatermark)
     let safetyFilterLevel = ImagenSafetyFilterLevel.blockNone
     let personFilterLevel = ImagenPersonFilterLevel.blockAll
     let safetySettings = ImagenSafetySettings(
@@ -178,6 +201,7 @@ final class ImageGenerationParametersTests: XCTestCase {
     let parameters = ImagenModel.imageGenerationParameters(
       storageURI: storageURI,
       generationConfig: generationConfig,
+      modelConfig: modelConfig,
       safetySettings: safetySettings
     )
 


### PR DESCRIPTION
- Added an `ImagenModelConfig` type for setting model-level (as opposed to request-level) configuration parameters for image generation.
- Moved `imageFormat` and `addWatermark` from `ImagenGenerationConfig` to `ImagenModelConfig`.

#14236
#no-changelog