### PR TITLE
Firestore: add a test for formatting an objective-c Class objects

### DIFF
--- a/Firestore/core/test/unit/util/string_format_apple_test.mm
+++ b/Firestore/core/test/unit/util/string_format_apple_test.mm
@@ -55,6 +55,11 @@ TEST(StringFormatTest, FSTDescribable) {
   EXPECT_EQ("Hello description", StringFormat("Hello %s", desc_id));
 }
 
+TEST(StringFormatTest, ObjectiveCClass) {
+  FSTDescribable* desc = [[FSTDescribable alloc] init];
+  EXPECT_EQ("Hello FSTDescribable", StringFormat("Hello %s", [desc class]));
+}
+
 }  //  namespace util
 }  //  namespace firestore
 }  //  namespace firebase


### PR DESCRIPTION
Add a test for formatting an objective-c `Class` object in`string_format_apple_test.mm`. The test suite previously covered formatting Objective-C _objects_, but not the specific override for formatting `Class` objects. With this PR, the tests were improved to also cover this missing case.

#no-changelog