### PR TITLE
DO NOT SUBMIT: Firestore: string_format.h: avoid using the absl internal StringifySink class, and also subclassing AlphaNum (which is not supported), as suggested by qrczak@ in cl/713272563

### DIFF
--- a/Firestore/core/src/util/string_format.cc
+++ b/Firestore/core/src/util/string_format.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include "absl/strings/escaping.h"
 #include "absl/strings/string_view.h"
+#include <algorithm>
 
 namespace firebase {
 namespace firestore {
@@ -28,39 +29,22 @@ namespace internal {
 static const char* kMissing = "<missing>";
 static const char* kInvalid = "<invalid>";
 
-// Disable asan for this function because of the way it manages stack
-// (nested closure) is flagged with stack underflow by clang on Ubuntu.
-#if defined(_MSC_VER)
-__declspec(no_sanitize_address) std::string StringFormatPieces(
-#else
-__attribute__((no_sanitize_address)) std::string StringFormatPieces(
-#endif
-    const char* format, std::initializer_list<absl::string_view> pieces) {
+std::string StringFormatArgs(const char* format,
+                             std::initializer_list<FormatArg> args) {
   std::string result;
 
   const char* format_iter = format;
   const char* format_end = format + strlen(format);
 
-  auto pieces_iter = pieces.begin();
-  auto pieces_end = pieces.end();
-  auto append_next_string_piece = [&](std::string* dest) {
-    if (pieces_iter == pieces_end) {
+  auto args_iter = args.begin();
+  auto args_end = args.end();
+  auto append_next_piece = [&](std::string* dest) {
+    if (args_iter == args_end) {
       dest->append(kMissing);
     } else {
-      // Pass a piece through
-      dest->append(pieces_iter->data(), pieces_iter->size());
-      ++pieces_iter;
-    }
-  };
-
-  auto append_next_hex_piece = [&](std::string* dest) {
-    if (pieces_iter == pieces_end) {
-      dest->append(kMissing);
-    } else {
-      std::string hex =
-          absl::BytesToHexString(absl::string_view(pieces_iter->data()));
-      dest->append(hex.data(), hex.size());
-      ++pieces_iter;
+      // Append an argument
+      args_iter->AppendTo(dest);
+      ++args_iter;
     }
   };
 
@@ -72,12 +56,7 @@ __attribute__((no_sanitize_address)) std::string StringFormatPieces(
         break;
 
       case 's': {
-        append_next_string_piece(&result);
-        break;
-      }
-
-      case 'x': {
-        append_next_hex_piece(&result);
+        append_next_piece(&result);
         break;
       }
 

--- a/Firestore/core/src/util/to_string.h
+++ b/Firestore/core/src/util/to_string.h
@@ -176,8 +176,8 @@ std::string ToStringImpl(const T& value, ToStringChoice<5>) {
 // Fallback
 template <typename T>
 std::string ToStringImpl(const T& value, ToStringChoice<6>) {
-  FormatArg arg{value};
-  return std::string{arg.data(), arg.data() + arg.size()};
+  std::string result;
+  FormatArg{value}.AppendTo(&result);
 }
 
 }  // namespace impl


### PR DESCRIPTION
DO NOT SUBMIT