### PR TITLE
[Vertex AI] Test SDK with `v1` API instead of `v1beta`

### DIFF
--- a/FirebaseVertexAI/Sources/Constants.swift
+++ b/FirebaseVertexAI/Sources/Constants.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Constants associated with the Vertex AI for Firebase SDK.
 enum Constants {
   /// The Vertex AI backend endpoint URL.
-  static let baseURL = "https://firebasevertexai.googleapis.com"
+  static let baseURL = "https://staging-firebasevertexai.sandbox.googleapis.com"
 
   /// The base reverse-DNS name for `NSError` or `CustomNSError` error domains.
   ///

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -31,7 +31,7 @@ public struct RequestOptions {
   let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
-  let apiVersion = "v1beta"
+  let apiVersion = "v1"
 
   /// Initializes a request options object.
   ///

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -75,6 +75,19 @@ final class IntegrationTests: XCTestCase {
     XCTAssertEqual(text, "Mountain View")
   }
 
+  func testGenerateContentStream() async throws {
+    let prompt = "Where is Google headquarters located? Answer with the city name only."
+
+    var text = ""
+    let contentStream = try model.generateContentStream(prompt)
+    for try await chunk in contentStream {
+      text += try XCTUnwrap(chunk.text)
+    }
+
+    text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    XCTAssertEqual(text, "Mountain View")
+  }
+
   func testGenerateContent_appCheckNotConfigured_shouldFail() async throws {
     let app = try FirebaseApp.defaultNamedCopy(name: TestAppCheckProviderFactory.notConfiguredName)
     addTeardownBlock { await app.delete() }

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -84,7 +84,7 @@ final class IntegrationTests: XCTestCase {
     XCTAssertNotNil(response.text)
   }
 
-  func testGenerateContent_image_fileData_requiresUserAuth_wrongUser_permissionDenied() async throws {
+  func testGenerateContent_imageData_requiresAuth_wrongUser_permissionDenied() async throws {
     let userID = "3MjEzU6JIobWvHdCYHicnDMcPpQ2"
     let storageRef = storage.reference(withPath: "vertexai/authenticated/user/\(userID)/pink.webp")
 
@@ -144,7 +144,7 @@ final class IntegrationTests: XCTestCase {
     XCTAssertFalse(text.isEmpty)
   }
 
-  func testGenerateContentStream_image_fileData_requiresUserAuth_wrongUser_permissionDenied() async throws {
+  func testGenContentStream_image_fileData_requiresAuth_wrongUser_permissionDenied() async throws {
     let userID = "3MjEzU6JIobWvHdCYHicnDMcPpQ2"
     let storageRef = storage.reference(withPath: "vertexai/authenticated/user/\(userID)/pink.webp")
 


### PR DESCRIPTION
Do not merge. Testing the Vertex AI SDK with the `v1` version of the API (instead of `v1beta`).

#no-changelog
