### PR TITLE
Firestore: Remove obsolete NOLINT comments

### DIFF
--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -23,7 +23,7 @@
 #include <string>
 
 #if !defined(_STLPORT_VERSION)
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #endif             // !defined(_STLPORT_VERSION)
 
 namespace firebase {

--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -24,7 +24,7 @@
 
 #if !defined(_STLPORT_VERSION)
 #include <chrono>
-#endif             // !defined(_STLPORT_VERSION)
+#endif  // !defined(_STLPORT_VERSION)
 
 namespace firebase {
 

--- a/Firestore/core/src/api/document_reference.cc
+++ b/Firestore/core/src/api/document_reference.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/api/document_reference.h"
 
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 
 #include "Firestore/core/src/api/collection_reference.h"

--- a/Firestore/core/src/api/firestore.h
+++ b/Firestore/core/src/api/firestore.h
@@ -18,7 +18,7 @@
 #define FIRESTORE_CORE_SRC_API_FIRESTORE_H_
 
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 
 #include "Firestore/core/src/api/api_fwd.h"

--- a/Firestore/core/src/api/load_bundle_task.cc
+++ b/Firestore/core/src/api/load_bundle_task.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/api/load_bundle_task.h"
 
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <utility>
 
 #include "Firestore/core/src/util/autoid.h"

--- a/Firestore/core/src/api/load_bundle_task.h
+++ b/Firestore/core/src/api/load_bundle_task.h
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>

--- a/Firestore/core/src/api/query_core.cc
+++ b/Firestore/core/src/api/query_core.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/api/query_core.h"
 
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/Firestore/core/src/core/event_listener.h
+++ b/Firestore/core/src/core/event_listener.h
@@ -18,7 +18,7 @@
 #define FIRESTORE_CORE_SRC_CORE_EVENT_LISTENER_H_
 
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <utility>
 
 #include "Firestore/core/src/util/executor.h"

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -17,7 +17,7 @@
 #include "Firestore/core/src/core/firestore_client.h"
 
 #include <functional>
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 #include <string>
 #include <utility>

--- a/Firestore/core/src/credentials/firebase_app_check_credentials_provider_apple.h
+++ b/Firestore/core/src/credentials/firebase_app_check_credentials_provider_apple.h
@@ -24,7 +24,7 @@
 #import <Foundation/Foundation.h>
 
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 #include <utility>
 

--- a/Firestore/core/src/credentials/firebase_auth_credentials_provider_apple.h
+++ b/Firestore/core/src/credentials/firebase_auth_credentials_provider_apple.h
@@ -24,7 +24,7 @@
 #import <Foundation/Foundation.h>
 
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <utility>
 
 #include "Firestore/core/src/credentials/credentials_provider.h"

--- a/Firestore/core/src/local/leveldb_remote_document_cache.cc
+++ b/Firestore/core/src/local/leveldb_remote_document_cache.cc
@@ -17,7 +17,7 @@
 #include "Firestore/core/src/local/leveldb_remote_document_cache.h"
 
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 #include <utility>
 
 #include "Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.h"

--- a/Firestore/core/src/local/leveldb_remote_document_cache.h
+++ b/Firestore/core/src/local/leveldb_remote_document_cache.h
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 #include <vector>
 
 #include "Firestore/core/src/core/query.h"

--- a/Firestore/core/src/local/lru_garbage_collector.cc
+++ b/Firestore/core/src/local/lru_garbage_collector.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/local/lru_garbage_collector.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <queue>
 #include <string>
 #include <utility>

--- a/Firestore/core/src/remote/exponential_backoff.h
+++ b/Firestore/core/src/remote/exponential_backoff.h
@@ -17,7 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_REMOTE_EXPONENTIAL_BACKOFF_H_
 #define FIRESTORE_CORE_SRC_REMOTE_EXPONENTIAL_BACKOFF_H_
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <memory>
 
 #include "Firestore/core/src/util/async_queue.h"

--- a/Firestore/core/src/remote/grpc_completion.h
+++ b/Firestore/core/src/remote/grpc_completion.h
@@ -17,9 +17,9 @@
 #ifndef FIRESTORE_CORE_SRC_REMOTE_GRPC_COMPLETION_H_
 #define FIRESTORE_CORE_SRC_REMOTE_GRPC_COMPLETION_H_
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <functional>
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 #include <utility>
 

--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -19,7 +19,7 @@
 #include <cstdlib>
 
 #include <algorithm>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 #include <utility>
 

--- a/Firestore/core/src/remote/grpc_stream.cc
+++ b/Firestore/core/src/remote/grpc_stream.cc
@@ -16,8 +16,8 @@
 
 #include "Firestore/core/src/remote/grpc_stream.h"
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <future>  // NOLINT(build/c++11)
+#include <chrono>
+#include <future>
 
 #include "Firestore/core/src/remote/grpc_connection.h"
 #include "Firestore/core/src/remote/grpc_util.h"

--- a/Firestore/core/src/remote/online_state_tracker.cc
+++ b/Firestore/core/src/remote/online_state_tracker.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/remote/online_state_tracker.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 
 #include "Firestore/core/src/util/executor.h"
 #include "Firestore/core/src/util/hard_assert.h"

--- a/Firestore/core/src/remote/stream.cc
+++ b/Firestore/core/src/remote/stream.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/remote/stream.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <utility>
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"

--- a/Firestore/core/src/util/async_queue.h
+++ b/Firestore/core/src/util/async_queue.h
@@ -18,10 +18,10 @@
 #define FIRESTORE_CORE_SRC_UTIL_ASYNC_QUEUE_H_
 
 #include <atomic>
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <functional>
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <vector>
 
 #include "Firestore/core/src/util/executor.h"

--- a/Firestore/core/src/util/background_queue.h
+++ b/Firestore/core/src/util/background_queue.h
@@ -17,9 +17,9 @@
 #ifndef FIRESTORE_CORE_SRC_UTIL_BACKGROUND_QUEUE_H_
 #define FIRESTORE_CORE_SRC_UTIL_BACKGROUND_QUEUE_H_
 
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <condition_variable>
 #include <functional>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/util/executor.h
+++ b/Firestore/core/src/util/executor.h
@@ -17,7 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_UTIL_EXECUTOR_H_
 #define FIRESTORE_CORE_SRC_UTIL_EXECUTOR_H_
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>

--- a/Firestore/core/src/util/executor_libdispatch.h
+++ b/Firestore/core/src/util/executor_libdispatch.h
@@ -19,11 +19,11 @@
 
 #include <dispatch/dispatch.h>
 
-#include <chrono>              // NOLINT(build/c++11)
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/Firestore/core/src/util/executor_std.cc
+++ b/Firestore/core/src/util/executor_std.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/util/executor_std.h"
 
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 #include <sstream>
 

--- a/Firestore/core/src/util/executor_std.h
+++ b/Firestore/core/src/util/executor_std.h
@@ -19,12 +19,12 @@
 
 #include <algorithm>
 #include <atomic>
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <condition_variable>
 #include <deque>
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/Firestore/core/src/util/schedule.h
+++ b/Firestore/core/src/util/schedule.h
@@ -18,9 +18,9 @@
 #define FIRESTORE_CORE_SRC_UTIL_SCHEDULE_H_
 
 #include <algorithm>
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <condition_variable>
 #include <deque>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <vector>
 
 #include "Firestore/core/src/util/executor.h"

--- a/Firestore/core/src/util/task.cc
+++ b/Firestore/core/src/util/task.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/util/task.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <cstdint>
 #include <utility>
 

--- a/Firestore/core/src/util/task.h
+++ b/Firestore/core/src/util/task.h
@@ -18,10 +18,10 @@
 #define FIRESTORE_CORE_SRC_UTIL_TASK_H_
 
 #include <atomic>
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <condition_variable>
 #include <memory>
-#include <mutex>   // NOLINT(build/c++11)
-#include <thread>  // NOLINT(build/c++11)
+#include <mutex>
+#include <thread>
 
 #include "Firestore/core/src/util/executor.h"
 

--- a/Firestore/core/src/util/testing_hooks.cc
+++ b/Firestore/core/src/util/testing_hooks.cc
@@ -17,7 +17,7 @@
 #include "Firestore/core/src/util/testing_hooks.h"
 
 #include <functional>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>

--- a/Firestore/core/src/util/testing_hooks.h
+++ b/Firestore/core/src/util/testing_hooks.h
@@ -19,7 +19,7 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <string>
 #include <unordered_map>
 

--- a/Firestore/core/src/util/thread_safe_memoizer.h
+++ b/Firestore/core/src/util/thread_safe_memoizer.h
@@ -18,7 +18,7 @@
 #define FIRESTORE_CORE_SRC_UTIL_THREAD_SAFE_MEMOIZER_H_
 
 #include <functional>
-#include <mutex>  // NOLINT(build/c++11)
+#include <mutex>
 #include <vector>
 
 namespace firebase {

--- a/Firestore/core/test/unit/api/load_bundle_task_test.cc
+++ b/Firestore/core/test/unit/api/load_bundle_task_test.cc
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <mutex>   // NOLINT(build/c++11)
+#include <chrono>
+#include <mutex>
 #include <queue>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/api/load_bundle_task.h"

--- a/Firestore/core/test/unit/core/query_listener_test.cc
+++ b/Firestore/core/test/unit/core/query_listener_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/core/query_listener.h"
 
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/Firestore/core/test/unit/credentials/firebase_app_check_credentials_provider_test.mm
+++ b/Firestore/core/test/unit/credentials/firebase_app_check_credentials_provider_test.mm
@@ -18,8 +18,8 @@
 
 #import <FirebaseAppCheckInterop/FirebaseAppCheckInterop.h>
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <future>  // NOLINT(build/c++11)
+#include <chrono>
+#include <future>
 
 #import "FirebaseCore/Extension/FIRAppInternal.h"
 

--- a/Firestore/core/test/unit/credentials/firebase_auth_credentials_provider_test.mm
+++ b/Firestore/core/test/unit/credentials/firebase_auth_credentials_provider_test.mm
@@ -16,8 +16,8 @@
 
 #include "Firestore/core/src/credentials/firebase_auth_credentials_provider_apple.h"
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <future>  // NOLINT(build/c++11)
+#include <chrono>
+#include <future>
 #include <memory>
 
 #import "FirebaseAuth/Interop/Public/FirebaseAuthInterop/FIRAuthInterop.h"

--- a/Firestore/core/test/unit/local/local_store_test.cc
+++ b/Firestore/core/test/unit/local/local_store_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/test/unit/local/local_store_test.h"
 
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/Firestore/core/test/unit/remote/exponential_backoff_test.cc
+++ b/Firestore/core/test/unit/remote/exponential_backoff_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/remote/exponential_backoff.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 
 #include "Firestore/core/src/util/async_queue.h"
 #include "Firestore/core/src/util/executor.h"

--- a/Firestore/core/test/unit/remote/grpc_stream_tester.h
+++ b/Firestore/core/test/unit/remote/grpc_stream_tester.h
@@ -18,7 +18,7 @@
 #define FIRESTORE_CORE_TEST_UNIT_REMOTE_GRPC_STREAM_TESTER_H_
 
 #include <functional>
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <initializer_list>
 #include <memory>
 #include <string>

--- a/Firestore/core/test/unit/testutil/async_testing.h
+++ b/Firestore/core/test/unit/testutil/async_testing.h
@@ -17,12 +17,12 @@
 #ifndef FIRESTORE_CORE_TEST_UNIT_TESTUTIL_ASYNC_TESTING_H_
 #define FIRESTORE_CORE_TEST_UNIT_TESTUTIL_ASYNC_TESTING_H_
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <functional>
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <memory>
-#include <mutex>   // NOLINT(build/c++11)
-#include <thread>  // NOLINT(build/c++11)
+#include <mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/Firestore/core/test/unit/testutil/testutil.cc
+++ b/Firestore/core/test/unit/testutil/testutil.cc
@@ -17,7 +17,7 @@
 #include "Firestore/core/test/unit/testutil/testutil.h"
 
 #include <algorithm>
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <set>
 
 #include "Firestore/core/include/firebase/firestore/geo_point.h"

--- a/Firestore/core/test/unit/testutil/time_testing.h
+++ b/Firestore/core/test/unit/testutil/time_testing.h
@@ -17,7 +17,7 @@
 #ifndef FIRESTORE_CORE_TEST_UNIT_TESTUTIL_TIME_TESTING_H_
 #define FIRESTORE_CORE_TEST_UNIT_TESTUTIL_TIME_TESTING_H_
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 

--- a/Firestore/core/test/unit/util/async_queue_test.cc
+++ b/Firestore/core/test/unit/util/async_queue_test.cc
@@ -16,8 +16,8 @@
 
 #include "Firestore/core/test/unit/util/async_queue_test.h"
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <future>  // NOLINT(build/c++11)
+#include <chrono>
+#include <future>
 #include <string>
 
 #include "Firestore/core/src/util/executor.h"

--- a/Firestore/core/test/unit/util/executor_test.cc
+++ b/Firestore/core/test/unit/util/executor_test.cc
@@ -16,9 +16,10 @@
 
 #include "Firestore/core/test/unit/util/executor_test.h"
 
+#include <cstdlib>
+
 #include <chrono>
 #include <condition_variable>
-#include <cstdlib>
 #include <future>
 #include <string>
 #include <thread>

--- a/Firestore/core/test/unit/util/executor_test.cc
+++ b/Firestore/core/test/unit/util/executor_test.cc
@@ -16,12 +16,12 @@
 
 #include "Firestore/core/test/unit/util/executor_test.h"
 
-#include <chrono>              // NOLINT(build/c++11)
-#include <condition_variable>  // NOLINT(build/c++11)
+#include <chrono>
+#include <condition_variable>
 #include <cstdlib>
-#include <future>  // NOLINT(build/c++11)
+#include <future>
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 
 #include "Firestore/core/src/util/executor.h"
 #include "Firestore/core/src/util/task.h"

--- a/Firestore/core/test/unit/util/schedule_test.cc
+++ b/Firestore/core/test/unit/util/schedule_test.cc
@@ -16,8 +16,9 @@
 
 #include "Firestore/core/src/util/schedule.h"
 
-#include <chrono>
 #include <cstdlib>
+
+#include <chrono>
 #include <string>
 
 #include "Firestore/core/src/util/task.h"

--- a/Firestore/core/test/unit/util/schedule_test.cc
+++ b/Firestore/core/test/unit/util/schedule_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/util/schedule.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 #include <cstdlib>
 #include <string>
 

--- a/Firestore/core/test/unit/util/task_test.cc
+++ b/Firestore/core/test/unit/util/task_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/util/task.h"
 
-#include <chrono>  // NOLINT(build/c++11)
+#include <chrono>
 
 #include "Firestore/core/src/util/defer.h"
 #include "Firestore/core/src/util/hard_assert.h"

--- a/Firestore/core/test/unit/util/testing_hooks_test.cc
+++ b/Firestore/core/test/unit/util/testing_hooks_test.cc
@@ -16,11 +16,11 @@
 
 #include "Firestore/core/src/util/testing_hooks.h"
 
-#include <chrono>  // NOLINT(build/c++11)
-#include <future>  // NOLINT(build/c++11)
+#include <chrono>
+#include <future>
 #include <memory>
 #include <string>
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 
 #include "Firestore/core/src/api/listener_registration.h"
 #include "Firestore/core/src/nanopb/byte_string.h"
@@ -34,7 +34,7 @@
 
 namespace {
 
-using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+using namespace std::chrono_literals;
 
 using firebase::firestore::api::ListenerRegistration;
 using firebase::firestore::nanopb::ByteString;

--- a/Firestore/core/test/unit/util/thread_safe_memoizer_test.cc
+++ b/Firestore/core/test/unit/util/thread_safe_memoizer_test.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/util/thread_safe_memoizer.h"
 
-#include <thread>  // NOLINT(build/c++11)
+#include <thread>
 #include "gtest/gtest.h"
 
 namespace firebase {

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -269,9 +269,6 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit|sed|gsed]
 # here!  cpplint_unittest.py should tell you if you forget to do this.
 _ERROR_CATEGORIES = [
     'build/class',
-    'build/c++11',
-    'build/c++14',
-    'build/c++tr1',
     'build/deprecated',
     'build/endif_comment',
     'build/explicit_make_pair',
@@ -283,7 +280,6 @@ _ERROR_CATEGORIES = [
     'build/include_order',
     'build/include_what_you_use',
     'build/namespaces_headers',
-    'build/namespaces_literals',
     'build/namespaces',
     'build/printf_format',
     'build/storage_class',


### PR DESCRIPTION
This PR removes `NOLINT` comments from the code base that are obsolete as of #14320, which deleted obsolete c++11 and c++14 lint checks.

#no-changelog