### PR TITLE
Firestore: Remove vestigial mentions of STLport

### DIFF
--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -19,12 +19,10 @@
 
 #include <cstdint>
 #include <ctime>
+
+#include <chrono>  // NOLINT(build/c++11)
 #include <iosfwd>
 #include <string>
-
-#if !defined(_STLPORT_VERSION)
-#include <chrono>  // NOLINT(build/c++11)
-#endif             // !defined(_STLPORT_VERSION)
 
 namespace firebase {
 
@@ -117,7 +115,6 @@ class Timestamp {
    */
   static Timestamp FromTimeT(time_t seconds_since_unix_epoch);
 
-#if !defined(_STLPORT_VERSION)
   /**
    * Converts `std::chrono::time_point` to a `Timestamp`.
    *
@@ -145,7 +142,6 @@ class Timestamp {
   template <typename Clock = std::chrono::system_clock,
             typename Duration = std::chrono::microseconds>
   std::chrono::time_point<Clock, Duration> ToTimePoint() const;
-#endif  // !defined(_STLPORT_VERSION)
 
   /**
    * Returns a string representation of this `Timestamp` for logging/debugging
@@ -205,8 +201,6 @@ inline bool operator==(const Timestamp& lhs, const Timestamp& rhs) {
   return !(lhs != rhs);
 }
 
-#if !defined(_STLPORT_VERSION)
-
 // Make sure the header compiles even when included after `<windows.h>` without
 // `NOMINMAX` defined. `push/pop_macro` pragmas are supported by Visual Studio
 // as well as Clang and GCC.
@@ -238,8 +232,6 @@ std::chrono::time_point<Clock, Duration> Timestamp::ToTimePoint() const {
 
 #pragma pop_macro("max")
 #pragma pop_macro("min")
-
-#endif  // !defined(_STLPORT_VERSION)
 
 }  // namespace firebase
 

--- a/Firestore/core/src/timestamp.cc
+++ b/Firestore/core/src/timestamp.cc
@@ -77,7 +77,7 @@ Timestamp Timestamp::Now() {
 #else
   // Use the standard <chrono> library from C++11.
   return FromTimePoint(std::chrono::system_clock::now());
-#endif
+#endif  // defined(__APPLE__)
 }
 
 Timestamp Timestamp::FromTimeT(const time_t seconds_since_unix_epoch) {

--- a/Firestore/core/src/timestamp.cc
+++ b/Firestore/core/src/timestamp.cc
@@ -20,8 +20,6 @@
 
 #if defined(__APPLE__)
 #import <CoreFoundation/CoreFoundation.h>
-#elif defined(_STLPORT_VERSION)
-#include <ctime>
 #endif
 
 #include "Firestore/core/src/util/hard_assert.h"
@@ -76,29 +74,16 @@ Timestamp Timestamp::Now() {
   auto nanos = static_cast<int32_t>(fraction * kNanosPerSecond);
   return MakeNormalizedTimestamp(seconds, nanos);
 
-#elif !defined(_STLPORT_VERSION)
-  // Use the standard <chrono> library from C++11 if possible.
-  return FromTimePoint(std::chrono::system_clock::now());
 #else
-  // If <chrono> is unavailable, use clock_gettime from POSIX, which supports
-  // up to nanosecond resolution. Note that it's a non-standard function
-  // contained in <time.h>.
-  //
-  // Note: it's possible to check for availability of POSIX clock_gettime using
-  // macros (see "Availability" at https://linux.die.net/man/3/clock_gettime).
-  // However, the only platform where <chrono> isn't available is Android with
-  // STLPort standard library, where clock_gettime is known to be available.
-  timespec now;
-  clock_gettime(CLOCK_REALTIME, &now);
-  return MakeNormalizedTimestamp(now.tv_sec, now.tv_nsec);
-#endif  // !defined(_STLPORT_VERSION)
+  // Use the standard <chrono> library from C++11.
+  return FromTimePoint(std::chrono::system_clock::now());
+#endif
 }
 
 Timestamp Timestamp::FromTimeT(const time_t seconds_since_unix_epoch) {
   return {seconds_since_unix_epoch, 0};
 }
 
-#if !defined(_STLPORT_VERSION)
 Timestamp Timestamp::FromTimePoint(
     const std::chrono::time_point<std::chrono::system_clock> time_point) {
   namespace chr = std::chrono;
@@ -110,8 +95,6 @@ Timestamp Timestamp::FromTimePoint(
   result.ValidateBounds();
   return result;
 }
-
-#endif  // !defined(_STLPORT_VERSION)
 
 std::string Timestamp::ToString() const {
   return absl::StrCat("Timestamp(seconds=", seconds_,

--- a/Firestore/core/src/util/firestore_exceptions.h
+++ b/Firestore/core/src/util/firestore_exceptions.h
@@ -27,26 +27,11 @@
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 
-#if defined(__ANDROID__)
-// Abseil does not support STLPort, so avoid their config.h here.
-//
-// TODO(b/163140650): Remove once the Firebase support floor moves to NDK R18.
-//
-// Meanwhile, NDK R16b (the current minimum) includes Clang 5.0.3 and GCC 4.9.
-// While Clang supports `__cpp_exceptions` at that version, GCC does not. Both
-// support `__EXCEPTIONS`.
-#if __EXCEPTIONS
-#define FIRESTORE_HAVE_EXCEPTIONS 1
-#endif
-
-#else  // !defined(__ANDROID__)
-// On any other supported platform, just take Abseil's word for it.
 #include "absl/base/config.h"
 
 #if ABSL_HAVE_EXCEPTIONS
 #define FIRESTORE_HAVE_EXCEPTIONS 1
 #endif
-#endif  // defined(__ANDROID__)
 
 namespace firebase {
 namespace firestore {


### PR DESCRIPTION
This PR removes some vestigial cruft pertaining to STLPort, whose support was dropped in July 2021 (3.5 years ago at the time of writing) in https://github.com/firebase/firebase-cpp-sdk/pull/510.

#no-changelog