### PR TITLE
shared_ptr instead of unique_ptr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,8 @@ FirebaseAppCheck/Apps/AppCheckCustomProvideApp/AppCheckCustomProvideApp/GoogleSe
 /Example/FirestoreSample/firebase-debug.log
 
 # generated Terraform docs
+Firestore/.terraform/*
+Firestore/.terraform.lock.hcl
 .terraform/*
 .terraform.lock.hcl
 *.tfstate

--- a/Firestore/Protos/nanopb/firestore/bundle.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/bundle.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/bundle.nanopb.h
+++ b/Firestore/Protos/nanopb/firestore/bundle.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.h
+++ b/Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.h
+++ b/Firestore/Protos/nanopb/firestore/local/mutation.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/target.nanopb.cc
+++ b/Firestore/Protos/nanopb/firestore/local/target.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/firestore/local/target.nanopb.h
+++ b/Firestore/Protos/nanopb/firestore/local/target.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/annotations.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/api/annotations.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/annotations.nanopb.h
+++ b/Firestore/Protos/nanopb/google/api/annotations.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/http.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/api/http.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/http.nanopb.h
+++ b/Firestore/Protos/nanopb/google/api/http.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/resource.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/api/resource.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/api/resource.nanopb.h
+++ b/Firestore/Protos/nanopb/google/api/resource.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/admin/index.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/aggregation_result.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/aggregation_result.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/aggregation_result.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/aggregation_result.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/bloom_filter.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/bloom_filter.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/bloom_filter.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/bloom_filter.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/common.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/document.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/firestore.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/query.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.h
+++ b/Firestore/Protos/nanopb/google/firestore/v1/write.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/any.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/any.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/any.nanopb.h
+++ b/Firestore/Protos/nanopb/google/protobuf/any.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.h
+++ b/Firestore/Protos/nanopb/google/protobuf/empty.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.h
+++ b/Firestore/Protos/nanopb/google/protobuf/struct.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.h
+++ b/Firestore/Protos/nanopb/google/protobuf/timestamp.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.h
+++ b/Firestore/Protos/nanopb/google/protobuf/wrappers.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/rpc/status.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/rpc/status.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/rpc/status.nanopb.h
+++ b/Firestore/Protos/nanopb/google/rpc/status.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/type/latlng.nanopb.cc
+++ b/Firestore/Protos/nanopb/google/type/latlng.nanopb.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Protos/nanopb/google/type/latlng.nanopb.h
+++ b/Firestore/Protos/nanopb/google/type/latlng.nanopb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Source/Public/FirebaseFirestore/FIRCallbackWrapper.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRCallbackWrapper.h
@@ -52,7 +52,7 @@ NS_SWIFT_NAME(CallbackWrapper)
 // are invoked on a different thread than the one they were originally defined in. If this callback
 // is expected to be called on a different thread, it should be marked as `Sendable` to ensure
 // thread safety.
-+ (std::unique_ptr<core::EventListener<std::vector<api::PipelineResult>>>)
++ (std::shared_ptr<core::EventListener<std::vector<api::PipelineResult>>>)
     wrapPipelineCallback:(std::shared_ptr<api::Firestore>)firestore
               completion:(void (^NS_SWIFT_SENDABLE)(
                              std::shared_ptr<std::vector<api::PipelineResult>> result,

--- a/Firestore/core/interfaceForSwift/api/pipeline.h
+++ b/Firestore/core/interfaceForSwift/api/pipeline.h
@@ -35,7 +35,7 @@ class Firestore;
 class PipelineResult;
 
 using PipelineSnapshotListener =
-    std::unique_ptr<core::EventListener<std::vector<PipelineResult>>>;
+    std::shared_ptr<core::EventListener<std::vector<PipelineResult>>>;
 
 class Pipeline {
  public:


### PR DESCRIPTION
Use shared_ptr instead of unique_ptr as Swift cannot use unique_ptr directly.

Also adding some minor changes picked up by tools.