### PR TITLE
Don't cache FCM registration token operations.

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Don't cache FCM registration token operations. (#14352).
+
 # 11.5.0
 - [fixed] Improve token-fetch failure logging with detailed error info. (#13997).
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenDeleteOperation.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenDeleteOperation.m
@@ -77,7 +77,7 @@
         [self handleResponseWithData:data response:response error:error];
       };
 
-  NSURLSessionConfiguration *config = NSURLSessionConfiguration.defaultSessionConfiguration;
+  NSURLSessionConfiguration *config = NSURLSessionConfiguration.ephemeralSessionConfiguration;
   config.timeoutIntervalForResource = 60.0f;  // 1 minute
   NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
   self.dataTask = [session dataTaskWithRequest:request completionHandler:requestHandler];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenFetchOperation.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenFetchOperation.m
@@ -108,7 +108,7 @@ NSString *const kFIRMessagingFirebaseHeartbeatKey = @"X-firebase-client-log-type
         FIRMessaging_STRONGIFY(self);
         [self handleResponseWithData:data response:response error:error];
       };
-  NSURLSessionConfiguration *config = NSURLSessionConfiguration.defaultSessionConfiguration;
+  NSURLSessionConfiguration *config = NSURLSessionConfiguration.ephemeralSessionConfiguration;
   config.timeoutIntervalForResource = 60.0f;  // 1 minute
   NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
   self.dataTask = [session dataTaskWithRequest:request completionHandler:requestHandler];


### PR DESCRIPTION
We are using `defaultSessionConfiguration` as the HTTP session configuration for FCM registration token operations. https://github.com/firebase/firebase-ios-sdk/blob/a34d7ae4ed3ce143bc22d57cbda9e9341fee3df6/FirebaseMessaging/Sources/Token/FIRMessagingTokenFetchOperation.m#L111C65-L111C92

As a result, HTTP requests and responses are cached in the `Cache.db` file.

This probably isn't a security risk. Other apps cannot access the file, and even if someone got the FCM registration token, they couldn't do anything with it. They cannot just send notifications with the token alone. https://firebase.google.com/docs/cloud-messaging/auth-server

But still, caching the HTTP requests and responses are unnecessary. We don't use the cache in any way.

Fix #14352

