### PR TITLE
[Vertex AI] Add internal `apiVersion` parameter to `RequestOptions`

### DIFF
--- a/FirebaseVertexAI/Sources/APIVersion.swift
+++ b/FirebaseVertexAI/Sources/APIVersion.swift
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct APIVersion: ExpressibleByStringLiteral {
-  public static let v1 = APIVersion("v1")
-  public static let v1beta = APIVersion("v1beta")
+public struct APIVersion {
+  public static let v1 = APIVersion(versionIdentifier: "v1")
+  public static let v1beta = APIVersion(versionIdentifier: "v1beta")
 
   let versionIdentifier: String
 
-  public init(stringLiteral versionIdentifier: String) {
-    guard !versionIdentifier.isEmpty else {
-      fatalError("The API version identifier must not be empty.")
-    }
+  init(versionIdentifier: String) {
     self.versionIdentifier = versionIdentifier
   }
 }

--- a/FirebaseVertexAI/Sources/APIVersion.swift
+++ b/FirebaseVertexAI/Sources/APIVersion.swift
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public struct APIVersion: ExpressibleByStringLiteral {
+  public static let v1 = APIVersion("v1")
+  public static let v1beta = APIVersion("v1beta")
+
+  let versionIdentifier: String
+
+  public init(stringLiteral versionIdentifier: String) {
+    guard !versionIdentifier.isEmpty else {
+      fatalError("The API version identifier must not be empty.")
+    }
+    self.versionIdentifier = versionIdentifier
+  }
+}

--- a/FirebaseVertexAI/Sources/APIVersion.swift
+++ b/FirebaseVertexAI/Sources/APIVersion.swift
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Versions of the Vertex AI in Firebase server API.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct APIVersion {
-  public static let v1 = APIVersion(versionIdentifier: "v1")
-  public static let v1beta = APIVersion(versionIdentifier: "v1beta")
+// TODO(#14405): Make `APIVersion`, `v1` and `v1beta` public in Firebase 12.
+struct APIVersion {
+  /// The stable channel for version 1 of the API.
+  static let v1 = APIVersion(versionIdentifier: "v1")
+
+  /// The beta channel for version 1 of the API.
+  static let v1beta = APIVersion(versionIdentifier: "v1beta")
 
   let versionIdentifier: String
 

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -36,7 +36,8 @@ public struct RequestOptions {
   /// Initializes a request options object.
   ///
   /// - Parameters:
-  ///   - timeout The request’s timeout interval in seconds; defaults to 180 seconds.
+  ///   - timeout: The request’s timeout interval in seconds; defaults to 180 seconds.
+  ///   - apiVersion: The API version to use in requests to the backend; defaults to v1beta.
   public init(timeout: TimeInterval = 180.0, apiVersion: APIVersion = .v1beta) {
     self.timeout = timeout
     self.apiVersion = apiVersion.versionIdentifier

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -25,6 +25,7 @@ protocol GenerativeAIRequest: Encodable {
 
 /// Configuration parameters for sending requests to the backend.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+// TODO(#14405): Make the `apiVersion` constructor public in Firebase 12 with a default of `.v1`.
 public struct RequestOptions {
   /// The request’s timeout interval in seconds; if not specified uses the default value for a
   /// `URLRequest`.
@@ -37,9 +38,17 @@ public struct RequestOptions {
   ///
   /// - Parameters:
   ///   - timeout: The request’s timeout interval in seconds; defaults to 180 seconds.
-  ///   - apiVersion: The API version to use in requests to the backend; defaults to v1beta.
-  public init(timeout: TimeInterval = 180.0, apiVersion: APIVersion = .v1beta) {
+  ///   - apiVersion: The API version to use in requests to the backend.
+  init(timeout: TimeInterval = 180.0, apiVersion: APIVersion) {
     self.timeout = timeout
     self.apiVersion = apiVersion.versionIdentifier
+  }
+
+  /// Initializes a request options object.
+  ///
+  /// - Parameters:
+  ///   - timeout: The request’s timeout interval in seconds; defaults to 180 seconds.
+  public init(timeout: TimeInterval = 180.0) {
+    self.init(timeout: timeout, apiVersion: .v1beta)
   }
 }

--- a/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIRequest.swift
@@ -31,13 +31,14 @@ public struct RequestOptions {
   let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
-  let apiVersion = "v1beta"
+  let apiVersion: String
 
   /// Initializes a request options object.
   ///
   /// - Parameters:
   ///   - timeout The request’s timeout interval in seconds; defaults to 180 seconds.
-  public init(timeout: TimeInterval = 180.0) {
+  public init(timeout: TimeInterval = 180.0, apiVersion: APIVersion = .v1beta) {
     self.timeout = timeout
+    self.apiVersion = apiVersion.versionIdentifier
   }
 }

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -19,6 +19,7 @@ import FirebaseVertexAI
 import VertexAITestApp
 import XCTest
 
+// TODO(#14405): Migrate to Swift Testing and parameterize tests to run on both `v1` and `v1beta`.
 final class IntegrationTests: XCTestCase {
   // Set temperature, topP and topK to lowest allowed values to make responses more deterministic.
   let generationConfig = GenerationConfig(

--- a/FirebaseVertexAI/Tests/Unit/APIVersionTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/APIVersionTests.swift
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class APIVersionTests: XCTestCase {
+  func testInitialize_stringLiteral() {
+    let apiVersion = APIVersion("test-version")
+
+    XCTAssertEqual(apiVersion.versionIdentifier, "test-version")
+  }
+
+  func testInitialize_stringConstant() {
+    let expectedVersion = "test-version"
+
+    let apiVersion = APIVersion(stringLiteral: expectedVersion)
+
+    XCTAssertEqual(apiVersion.versionIdentifier, expectedVersion)
+  }
+
+  func testInitialize_v1() {
+    let apiVersion: APIVersion = .v1
+
+    XCTAssertEqual(apiVersion.versionIdentifier, "v1")
+  }
+
+  func testInitialize_v1beta() {
+    let apiVersion: APIVersion = .v1beta
+
+    XCTAssertEqual(apiVersion.versionIdentifier, "v1beta")
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/APIVersionTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/APIVersionTests.swift
@@ -18,20 +18,6 @@ import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class APIVersionTests: XCTestCase {
-  func testInitialize_stringLiteral() {
-    let apiVersion = APIVersion("test-version")
-
-    XCTAssertEqual(apiVersion.versionIdentifier, "test-version")
-  }
-
-  func testInitialize_stringConstant() {
-    let expectedVersion = "test-version"
-
-    let apiVersion = APIVersion(stringLiteral: expectedVersion)
-
-    XCTAssertEqual(apiVersion.versionIdentifier, expectedVersion)
-  }
-
   func testInitialize_v1() {
     let apiVersion: APIVersion = .v1
 

--- a/FirebaseVertexAI/Tests/Unit/RequestOptionsTest.swift
+++ b/FirebaseVertexAI/Tests/Unit/RequestOptionsTest.swift
@@ -37,22 +37,6 @@ final class RequestOptionsTests: XCTestCase {
     XCTAssertEqual(requestOptions.apiVersion, defaultAPIVersion)
   }
 
-  func testInitialize_apiVersion_stringLiteral() {
-    let requestOptions = RequestOptions(apiVersion: "test-version")
-
-    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
-    XCTAssertEqual(requestOptions.apiVersion, "test-version")
-  }
-
-  func testInitialize_apiVersion_stringConstant() {
-    let expectedVersion = "test-version"
-
-    let requestOptions = RequestOptions(apiVersion: APIVersion(stringLiteral: expectedVersion))
-
-    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
-    XCTAssertEqual(requestOptions.apiVersion, expectedVersion)
-  }
-
   func testInitialize_apiVersion_v1() {
     let requestOptions = RequestOptions(apiVersion: .v1)
 

--- a/FirebaseVertexAI/Tests/Unit/RequestOptionsTest.swift
+++ b/FirebaseVertexAI/Tests/Unit/RequestOptionsTest.swift
@@ -1,0 +1,79 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseVertexAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class RequestOptionsTests: XCTestCase {
+  let defaultTimeout: TimeInterval = 180.0
+  let defaultAPIVersion = APIVersion.v1beta.versionIdentifier
+
+  func testInitialize_defaultValues() {
+    let requestOptions = RequestOptions()
+
+    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, defaultAPIVersion)
+  }
+
+  func testInitialize_timeout() {
+    let expectedTimeout = 60.0
+
+    let requestOptions = RequestOptions(timeout: expectedTimeout)
+
+    XCTAssertEqual(requestOptions.timeout, expectedTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, defaultAPIVersion)
+  }
+
+  func testInitialize_apiVersion_stringLiteral() {
+    let requestOptions = RequestOptions(apiVersion: "test-version")
+
+    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, "test-version")
+  }
+
+  func testInitialize_apiVersion_stringConstant() {
+    let expectedVersion = "test-version"
+
+    let requestOptions = RequestOptions(apiVersion: APIVersion(stringLiteral: expectedVersion))
+
+    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, expectedVersion)
+  }
+
+  func testInitialize_apiVersion_v1() {
+    let requestOptions = RequestOptions(apiVersion: .v1)
+
+    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, APIVersion.v1.versionIdentifier)
+  }
+
+  func testInitialize_apiVersion_v1beta() {
+    let requestOptions = RequestOptions(apiVersion: .v1beta)
+
+    XCTAssertEqual(requestOptions.timeout, defaultTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, APIVersion.v1beta.versionIdentifier)
+  }
+
+  func testInitialize_allOptions() {
+    let expectedTimeout = 30.0
+    let expectedAPIVersion = APIVersion.v1
+
+    let requestOptions = RequestOptions(timeout: expectedTimeout, apiVersion: expectedAPIVersion)
+
+    XCTAssertEqual(requestOptions.timeout, expectedTimeout)
+    XCTAssertEqual(requestOptions.apiVersion, expectedAPIVersion.versionIdentifier)
+  }
+}

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -38,14 +38,10 @@ final class VertexAIAPITests: XCTestCase {
       parts: TextPart("Talk like a pirate.")
     )
 
-    let apiVersionID = "v1"
-    let apiVersion = APIVersion.v1
-    let _ = RequestOptions()
+    let requestOptions = RequestOptions()
+    let _ = RequestOptions(timeout: 30.0)
     let _ = RequestOptions(apiVersion: .v1)
-    let _ = RequestOptions(apiVersion: "v1")
-    let _ = RequestOptions(apiVersion: APIVersion(stringLiteral: "v1"))
-    let _ = RequestOptions(apiVersion: APIVersion(stringLiteral: apiVersionID))
-    let _ = RequestOptions(apiVersion: apiVersion)
+    let _ = RequestOptions(timeout: 60.0, apiVersion: .v1)
 
     // Instantiate Vertex AI SDK - Default App
     let vertexAI = VertexAI.vertexAI()
@@ -79,7 +75,8 @@ final class VertexAIAPITests: XCTestCase {
       modelName: "gemini-1.0-pro",
       generationConfig: config, // Optional
       safetySettings: filters, // Optional
-      systemInstruction: systemInstruction // Optional
+      systemInstruction: systemInstruction, // Optional
+      requestOptions: requestOptions // Optional
     )
 
     // Full Typed Usage

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -38,6 +38,15 @@ final class VertexAIAPITests: XCTestCase {
       parts: TextPart("Talk like a pirate.")
     )
 
+    let apiVersionID = "v1"
+    let apiVersion = APIVersion.v1
+    let _ = RequestOptions()
+    let _ = RequestOptions(apiVersion: .v1)
+    let _ = RequestOptions(apiVersion: "v1")
+    let _ = RequestOptions(apiVersion: APIVersion(stringLiteral: "v1"))
+    let _ = RequestOptions(apiVersion: APIVersion(stringLiteral: apiVersionID))
+    let _ = RequestOptions(apiVersion: apiVersion)
+
     // Instantiate Vertex AI SDK - Default App
     let vertexAI = VertexAI.vertexAI()
     let _ = VertexAI.vertexAI(location: "my-location")

--- a/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexAIAPITests.swift
@@ -40,8 +40,6 @@ final class VertexAIAPITests: XCTestCase {
 
     let requestOptions = RequestOptions()
     let _ = RequestOptions(timeout: 30.0)
-    let _ = RequestOptions(apiVersion: .v1)
-    let _ = RequestOptions(timeout: 60.0, apiVersion: .v1)
 
     // Instantiate Vertex AI SDK - Default App
     let vertexAI = VertexAI.vertexAI()


### PR DESCRIPTION
Added an internal constructor for `RequestOptions` that supports specifying an API version (e.g., `v1` or `v1beta`).

See [go/firebase-vertex-set-api-version](https://goto.corp.google.com/firebase-vertex-set-api-version) (Google-internal only) for more details.

#14405
#no-changelog