### PR TITLE
[rc-swift] Custom Signals and Sendable

### DIFF
--- a/FirebaseRemoteConfig/Swift/CustomSignals.swift
+++ b/FirebaseRemoteConfig/Swift/CustomSignals.swift
@@ -53,7 +53,7 @@ public struct CustomSignalValue {
     Self(kind: .double(double))
   }
 
-  fileprivate func toNSObject() -> NSObject {
+  func toNSObject() -> NSObject {
     switch kind {
     case let .string(string):
       return string as NSString
@@ -80,28 +80,5 @@ extension CustomSignalValue: ExpressibleByIntegerLiteral {
 extension CustomSignalValue: ExpressibleByFloatLiteral {
   public init(floatLiteral value: Double) {
     self = .double(value)
-  }
-}
-
-@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-public extension RemoteConfig {
-  /// Sets custom signals for this Remote Config instance.
-  /// - Parameter customSignals: A dictionary mapping string keys to custom
-  /// signals to be set for the app instance.
-  ///
-  /// When a new key is provided, a new key-value pair is added to the custom signals.
-  /// If an existing key is provided with a new value, the corresponding signal is updated.
-  /// If the value for a key is `nil`, the signal associated with that key is removed.
-  func setCustomSignals(_ customSignals: [String: CustomSignalValue?]) async throws {
-    return try await withCheckedThrowingContinuation { continuation in
-      let customSignals = customSignals.mapValues { $0?.toNSObject() ?? NSNull() }
-      self.__setCustomSignals(customSignals) { error in
-        if let error {
-          continuation.resume(throwing: error)
-        } else {
-          continuation.resume()
-        }
-      }
-    }
   }
 }

--- a/FirebaseRemoteConfig/SwiftNew/ConfigConstants.swift
+++ b/FirebaseRemoteConfig/SwiftNew/ConfigConstants.swift
@@ -25,8 +25,11 @@ enum ConfigConstants {
 
   /// Remote Config Error Domain.
   static let remoteConfigErrorDomain = "com.google.remoteconfig.ErrorDomain"
-  // Remote Config Realtime Error Domain
+  /// Remote Config Realtime Error Domain
   static let remoteConfigUpdateErrorDomain = "com.google.remoteconfig.update.ErrorDomain"
+  /// Error domain for custom signals errors.
+  static let remoteConfigCustomSignalsErrorDomain =
+    "com.google.remoteconfig.customsignals.ErrorDomain"
 
   // MARK: - Fetch Response Keys
 

--- a/FirebaseRemoteConfig/SwiftNew/ConfigSettings.swift
+++ b/FirebaseRemoteConfig/SwiftNew/ConfigSettings.swift
@@ -458,6 +458,13 @@ let RCNHTTPDefaultConnectionTimeout: TimeInterval = 60
           // Ignore JSON serialization error.
         }
       }
+      if customSignals.count > 0,
+         let jsonData = try? JSONSerialization.data(withJSONObject: customSignals),
+         let jsonString = String(data: jsonData, encoding: .utf8) {
+        request += ", custom_signals:\(jsonString)"
+        // Log the keys of the custom signals sent during fetch.
+        RCLog.debug("I-RCN000078", "Keys of custom signals during fetch: \(customSignals.keys)")
+      }
     }
     request += "}"
     return request
@@ -521,6 +528,14 @@ let RCNHTTPDefaultConnectionTimeout: TimeInterval = 60
         namespace: _FIRNamespace,
         values: [newValue]
       )
+    }
+  }
+
+  /// A dictionary to hold custom signals set by the developer.
+  @objc public var customSignals: [String: String] {
+    get { _userDefaultsManager.customSignals }
+    set {
+      _userDefaultsManager.customSignals = newValue
     }
   }
 

--- a/FirebaseRemoteConfig/SwiftNew/UserDefaultsManager.swift
+++ b/FirebaseRemoteConfig/SwiftNew/UserDefaultsManager.swift
@@ -49,6 +49,7 @@ public class UserDefaultsManager: NSObject {
   let kRCNUserDefaultsKeyNameCurrentRealtimeThrottlingRetryInterval =
     "currentRealtimeThrottlingRetryInterval"
   let kRCNUserDefaultsKeyNameRealtimeRetryCount = "realtimeRetryCount"
+  let kRCNUserDefaultsKeyCustomSignals = "customSignals"
 
   // Delete when ObjC tests are gone.
   @objc public convenience init(appName: String, bundleID: String, namespace: String) {
@@ -109,6 +110,13 @@ public class UserDefaultsManager: NSObject {
   @objc(userDefaultsSuiteNameForBundleIdentifier:)
   public static func userDefaultsSuiteName(for bundleIdentifier: String) -> String {
     return "\(kRCNGroupPrefix).\(bundleIdentifier).\(kRCNGroupSuffix)"
+  }
+
+  @objc public var customSignals: [String: String] {
+    get { instanceUserDefaults[kRCNUserDefaultsKeyCustomSignals] as? [String: String] ?? [:] }
+    set {
+      setInstanceUserDefaultsValue(newValue, forKey: kRCNUserDefaultsKeyCustomSignals)
+    }
   }
 
   /// The last ETag received from the server.

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1949,7 +1949,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
     [_configInstances[i] setCustomSignals:testSignals1
                            withCompletion:^(NSError *_Nullable error) {
                              XCTAssertNil(error);
-                             [_configInstances[i]
+                             [self->_configInstances[i]
                                  setCustomSignals:testSignals2
                                    withCompletion:^(NSError *_Nullable error) {
                                      XCTAssertNil(error);


### PR DESCRIPTION
After rebasing `rc-swift` on latest `main`, this PR reimplements custom signals changes from #13976 and Sendable changes from #14314