### PR TITLE
No suspend threads for on-demand fatal

### DIFF
--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -235,7 +235,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
       FIRCLSExceptionWrite(&file, type, name, reason, frames, nil);
 
       // We only want to do this work if we have the expectation that we'll actually crash
-      FIRCLSHandler(&file, mach_thread_self(), NULL);
+      FIRCLSHandler(&file, mach_thread_self(), NULL, YES);
 
       FIRCLSFileClose(&file);
     });
@@ -353,7 +353,7 @@ NSString *FIRCLSExceptionRecordOnDemand(FIRCLSExceptionType type,
     return nil;
   }
   FIRCLSExceptionWrite(&file, type, name, reason, frames, nil);
-  FIRCLSHandler(&file, mach_thread_self(), NULL);
+  FIRCLSHandler(&file, mach_thread_self(), NULL, NO);
   FIRCLSFileClose(&file);
 
   // Return the path to the new report.

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.h
@@ -20,6 +20,6 @@
 
 __BEGIN_DECLS
 
-void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid);
+void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid, bool isNativeFatal);
 
 __END_DECLS

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
@@ -22,12 +22,14 @@
 
 #import "Crashlytics/Crashlytics/Controllers/FIRCLSReportManager_Private.h"
 
-void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid) {
+void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid, bool isNativeFatal) {
   FIRCLSProcess process;
 
   FIRCLSProcessInit(&process, crashedThread, uapVoid);
 
-  FIRCLSProcessSuspendAllOtherThreads(&process);
+  if (isNativeFatal) {
+    FIRCLSProcessSuspendAllOtherThreads(&process);
+  }
 
   FIRCLSProcessRecordAllThreads(&process, file);
 
@@ -45,5 +47,7 @@ void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid) {
   // Store a crash file marker to indicate that a crash has occurred
   FIRCLSCreateCrashedMarkerFile();
 
-  FIRCLSProcessResumeAllOtherThreads(&process);
+  if (isNativeFatal) {
+    FIRCLSProcessResumeAllOtherThreads(&process);
+  }
 }

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -520,7 +520,7 @@ static bool FIRCLSMachExceptionRecord(FIRCLSMachExceptionReadContext* context,
 
   FIRCLSFileWriteSectionEnd(&file);
 
-  FIRCLSHandler(&file, message->thread.name, NULL);
+  FIRCLSHandler(&file, message->thread.name, NULL, true);
 
   FIRCLSFileClose(&file);
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -286,7 +286,7 @@ static void FIRCLSSignalRecordSignal(int savedErrno, siginfo_t *info, void *uapV
 
   FIRCLSFileWriteSectionEnd(&file);
 
-  FIRCLSHandler(&file, mach_thread_self(), uapVoid);
+  FIRCLSHandler(&file, mach_thread_self(), uapVoid, true);
 
   FIRCLSFileClose(&file);
 }


### PR DESCRIPTION
For on-demand fatal we don't want to do suspend then record the threads info.

eg. If there is an audio thread, user might experiencing audio glitch during crash recording