### PR TITLE
Undo xcscheme change to fix CI error

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -38,13 +37,6 @@
             ReferencedContainer = "container:Firestore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,7 +54,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Firestore/core/src/nanopb/byte_string.cc
+++ b/Firestore/core/src/nanopb/byte_string.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/nanopb/byte_string.h"
 
 #include <cctype>
+// NOLINTNEXTLINE(build/include_order)
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>

--- a/Firestore/core/test/unit/nanopb/byte_string_test.cc
+++ b/Firestore/core/test/unit/nanopb/byte_string_test.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/nanopb/byte_string.h"
 
 #include <cstdint>
+// NOLINTNEXTLINE(build/include_order)
 #include <cstdlib>
 
 #include "Firestore/core/src/nanopb/nanopb_util.h"


### PR DESCRIPTION
Now xcodebuild fails with:

Error:     Restarting after unexpected exit, crash, or test timeout in PipelineTests.testCreatePipeline(); summary will include totals from previous launches.