### PR TITLE
[Vertex AI] Remove outdated `Preview` notice from README

### DIFF
--- a/FirebaseVertexAI/README.md
+++ b/FirebaseVertexAI/README.md
@@ -1,9 +1,5 @@
 # Vertex AI for Firebase SDK
 
-**Preview**: Vertex AI for Firebase is in Public Preview, which means that the product is
-not subject to any SLA or deprecation policy and could change in backwards-incompatible
-ways.
-
 - For developer documentation, please visit https://firebase.google.com/docs/vertex-ai.
 - Try out the [sample app](Sample/README.md) to get started.
 
@@ -11,7 +7,7 @@ ways.
 
 After following the Swift Package Manager
 [setup instructions](https://github.com/firebase/firebase-ios-sdk#swift-package-manager-1),
-choose the `FirebaseVertexAI-Preview` scheme to build the SDK.
+choose the `FirebaseVertexAI` scheme to build the SDK.
 
 ### Unit Tests
 
@@ -26,5 +22,5 @@ Choose the `FirebaseVertexAIUnit` scheme to build and run the unit tests.
 To update the mock responses, create a PR in the
 [`vertexai-sdk-test-data`](https://github.com/FirebaseExtended/vertexai-sdk-test-data)
 repo. After it is merged, re-run the
-[script](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
-above to download the updated files.
+[`update_vertexai_responses.sh`](https://github.com/firebase/firebase-ios-sdk/blob/main/scripts/update_vertexai_responses.sh)
+script to download the updated files.


### PR DESCRIPTION
Removed the outdated README message about Vertex AI in Firebase being in Public Preview and fixed the SPM product name.

Context: Vertex AI in Firebase became GA in the https://github.com/firebase/firebase-ios-sdk/releases/tag/11.4.0.

#no-changelog