### PR TITLE
[NFC] Update spacing in FirebaseAuth's sample app delegate

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/AppDelegate.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/AppDelegate.swift
@@ -20,8 +20,8 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication
-                     .LaunchOptionsKey: Any]?) -> Bool {
+                   didFinishLaunchingWithOptions launchOptions:
+                   [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     configureApplicationAppearance()
 
     // [START firebase_configure]


### PR DESCRIPTION
As is, adding a new line within the function's implementation will give it an awkward indentation. This small change fixes it.

#no-changelog