### PR TITLE
Prepare 11.8.1

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '11.8.0'
+  s.version          = '11.8.1'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -43,7 +43,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '~> 11.8.0'
+    ss.dependency 'FirebaseCore', '~> 11.8.1'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -110,7 +110,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Auth' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAuth', '~> 11.8.0'
+    ss.dependency 'FirebaseAuth', '~> 11.8.1'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '13.0'
     ss.osx.deployment_target = '10.15'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
-  s.version          = '11.8.0'
+  s.version          = '11.8.1'
   s.summary          = 'Apple platform client for Firebase Authentication'
 
   s.description      = <<-DESC

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 11.8.1
+- [fixed] Suppress deprecation build warning introduced in 11.8.0.
+
 # 11.8.0
 - [added] Added `ActionCodeSettings.linkDomain` to customize the Firebase Hosting link domain
   that is used in out-of-band email action flows.

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -105,6 +105,12 @@ private let kClientType = "clientType"
 /// The key for the "recaptchaVersion" value in the request.
 private let kRecaptchaVersion = "recaptchaVersion"
 
+protocol SuppressWarning {
+  var dynamicLinkDomain: String? { get set }
+}
+
+extension ActionCodeSettings: SuppressWarning {}
+
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
   typealias Response = GetOOBConfirmationCodeResponse
@@ -177,7 +183,12 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
     androidMinimumVersion = actionCodeSettings?.androidMinimumVersion
     androidInstallApp = actionCodeSettings?.androidInstallIfNotAvailable ?? false
     handleCodeInApp = actionCodeSettings?.handleCodeInApp ?? false
-    dynamicLinkDomain = actionCodeSettings?.dynamicLinkDomain
+    dynamicLinkDomain =
+      if let actionCodeSettings {
+        (actionCodeSettings as SuppressWarning).dynamicLinkDomain
+      } else {
+        nil
+      }
     linkDomain = actionCodeSettings?.linkDomain
 
     super.init(

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '11.8.0'
+  s.version          = '11.8.1'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-let firebaseVersion = "11.8.0"
+let firebaseVersion = "11.8.1"
 
 let package = Package(
   name: "Firebase",


### PR DESCRIPTION
Make a CocoaPods and Swift PM patch release for a build warning in FirebaseAuth that released in 11.8.0