### PR TITLE
Restore socket rocket

### DIFF
--- a/CoreOnly/NOTICES
+++ b/CoreOnly/NOTICES
@@ -1007,6 +1007,64 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+--------------------------
+SocketRocket
+--------------------------
+Copyright 2012 Square Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+$OpenBSD: base64.c,v 1.5 2006/10/21 09:55:03 otto Exp $
+
+Copyright (c) 1996 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+Portions Copyright (c) 1995 by International Business Machines, Inc.
+
+International Business Machines, Inc. (hereinafter called IBM) grants
+permission under its copyrights to use, copy, modify, and distribute this
+Software with or without fee, provided that the above copyright notice and
+all paragraphs of this notice appear in all copies, and that the name of IBM
+not be used in connection with the marketing of any product incorporating
+the Software or modifications thereof, without specific, written prior
+permission.
+
+To the extent it has a right to do so, IBM grants an immunity from suit
+under its patents, if any, for the use, sale or manufacture of products to
+the extent that such products are used for performing Domain Name System
+dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+granted for any product per se or for any other function of any product.
+
+THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+
 FirebaseFirestore
 FirebaseFirestoreInternal
 

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -36,6 +36,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.source_files = [
     base_dir + '**/*.[mh]',
     base_dir + 'third_party/Wrap-leveldb/APLevelDB.mm',
+    base_dir + 'third_party/SocketRocket/fbase64.c',
     'FirebaseDatabase/Swift/Sources/**/*.swift',
     'FirebaseAuth/Interop/**/*.h',
     'FirebaseCore/Extension/*.h',

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [fixed] Fix connection failure issue introduced in 10.27.0 by restoring the
   Socket Rocket implementation instead of `NSURLSessionWebSocket`. Note that
   this may expose a Thread Performance Checker Warning (#12883).
-  (#14188, 13877, #13855, #13529)
+  (#14188, #13877, #13855, #13529)
 
 # 11.2.0
 - [fixed] Fix temporary disconnects when the app goes inactive. The issue was

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [fixed] Fix connection failure issue introduced in 10.27.0 by restoring the
+  Socket Rocket implementation instead of `NSURLSessionWebSocket`. Note that
+  this may expose a Thread Performance Checker Warning (#12883).
+  (#14188, 13877, #13855, #13529)
+
 # 11.2.0
 - [fixed] Fix temporary disconnects when the app goes inactive. The issue was
   introduced in 10.27.0. (#13529)

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -7,8 +7,6 @@
   module has been removed. See
   https://firebase.google.com/docs/ios/swift-migration for migration
   instructions.
-- [removed] Socket Rocket has been removed from the implementation. There should
-  be no impact on functionality. (#13100)
 
 # 10.27.0
 - [changed] Update internal socket implementation to use `NSURLSessionWebSocket` where

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -7,6 +7,8 @@
   module has been removed. See
   https://firebase.google.com/docs/ios/swift-migration for migration
   instructions.
+- [removed] Socket Rocket has been removed from the implementation. There should
+  be no impact on functionality. (#13100)
 
 # 10.27.0
 - [changed] Update internal socket implementation to use `NSURLSessionWebSocket` where

--- a/FirebaseDatabase/LICENSE
+++ b/FirebaseDatabase/LICENSE
@@ -277,3 +277,61 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+--------------------------
+SocketRocket
+--------------------------
+Copyright 2012 Square Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+$OpenBSD: base64.c,v 1.5 2006/10/21 09:55:03 otto Exp $
+
+Copyright (c) 1996 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+Portions Copyright (c) 1995 by International Business Machines, Inc.
+
+International Business Machines, Inc. (hereinafter called IBM) grants
+permission under its copyrights to use, copy, modify, and distribute this
+Software with or without fee, provided that the above copyright notice and
+all paragraphs of this notice appear in all copies, and that the name of IBM
+not be used in connection with the marketing of any product incorporating
+the Software or modifications thereof, without specific, written prior
+permission.
+
+To the extent it has a right to do so, IBM grants an immunity from suit
+under its patents, if any, for the use, sale or manufacture of products to
+the extent that such products are used for performing Domain Name System
+dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+granted for any product per se or for any other function of any product.
+
+THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -553,6 +553,24 @@ typedef enum {
     [self.realtime open];
 }
 
+#if !TARGET_OS_WATCH
+static void reachabilityCallback(SCNetworkReachabilityRef ref,
+                                 SCNetworkReachabilityFlags flags, void *info) {
+    if (flags & kSCNetworkReachabilityFlagsReachable) {
+        FFLog(@"I-RDB034014",
+              @"Network became reachable. Trigger a connection attempt");
+        FPersistentConnection *self = (__bridge FPersistentConnection *)info;
+        // Reset reconnect delay
+        [self.retryHelper signalSuccess];
+        if (self->connectionState == ConnectionStateDisconnected) {
+            [self tryScheduleReconnect];
+        }
+    } else {
+        FFLog(@"I-RDB034015", @"Network is not reachable");
+    }
+}
+#endif // !TARGET_OS_WATCH
+
 - (void)enteringForeground {
     dispatch_async(self.dispatchQueue, ^{
       // Reset reconnect delay
@@ -565,15 +583,45 @@ typedef enum {
 
 - (void)setupNotifications {
 #if TARGET_OS_WATCH
-    __weak FPersistentConnection *weakSelf = self;
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center addObserverForName:WKApplicationWillEnterForegroundNotification
-                        object:nil
-                         queue:nil
-                    usingBlock:^(NSNotification *_Nonnull note) {
-                      [weakSelf enteringForeground];
-                    }];
-#endif // TARGET_OS_WATCH
+    if (@available(watchOS 7.0, *)) {
+        __weak FPersistentConnection *weakSelf = self;
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserverForName:WKApplicationWillEnterForegroundNotification
+                            object:nil
+                             queue:nil
+                        usingBlock:^(NSNotification *_Nonnull note) {
+                          [weakSelf enteringForeground];
+                        }];
+    }
+#else
+    NSString *const *foregroundConstant = (NSString *const *)dlsym(
+        RTLD_DEFAULT, "UIApplicationWillEnterForegroundNotification");
+    if (foregroundConstant) {
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(enteringForeground)
+                   name:*foregroundConstant
+                 object:nil];
+    }
+    // An empty address is interpreted a generic internet access
+    struct sockaddr_in zeroAddress;
+    bzero(&zeroAddress, sizeof(zeroAddress));
+    zeroAddress.sin_len = sizeof(zeroAddress);
+    zeroAddress.sin_family = AF_INET;
+    reachability = SCNetworkReachabilityCreateWithAddress(
+        kCFAllocatorDefault, (const struct sockaddr *)&zeroAddress);
+    SCNetworkReachabilityContext ctx = {0, (__bridge void *)(self), NULL, NULL,
+                                        NULL};
+    if (SCNetworkReachabilitySetCallback(reachability, reachabilityCallback,
+                                         &ctx)) {
+        SCNetworkReachabilitySetDispatchQueue(reachability, self.dispatchQueue);
+    } else {
+        FFLog(@"I-RDB034016",
+              @"Failed to set up network reachability monitoring");
+        CFRelease(reachability);
+        reachability = NULL;
+    }
+#endif // !TARGET_OS_WATCH
 }
 
 - (void)sendAuthAndRestoreStateAfterComplete:(BOOL)restoreStateAfterComplete {

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -34,9 +34,11 @@
 #import "FirebaseDatabase/Sources/Utilities/FUtilities.h"
 #import "FirebaseDatabase/Sources/Utilities/Tuples/FTupleCallbackStatus.h"
 #import "FirebaseDatabase/Sources/Utilities/Tuples/FTupleOnDisconnect.h"
-#if !TARGET_OS_WATCH
+#if TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
+#else
 #import <SystemConfiguration/SystemConfiguration.h>
-#endif // !TARGET_OS_WATCH
+#endif // TARGET_OS_WATCH
 #import <dlfcn.h>
 #import <netinet/in.h>
 
@@ -166,6 +168,7 @@ typedef enum {
                         retryExponent:kPersistentConnReconnectMultiplier
                          jitterFactor:0.7];
 
+        [self setupNotifications];
         // Make sure we don't actually connect until open is called
         [self interruptForReason:kFInterruptReasonWaitingForOpen];
     }
@@ -548,6 +551,29 @@ typedef enum {
                                     appCheckToken:context.appCheckToken];
     self.realtime.delegate = self;
     [self.realtime open];
+}
+
+- (void)enteringForeground {
+    dispatch_async(self.dispatchQueue, ^{
+      // Reset reconnect delay
+      [self.retryHelper signalSuccess];
+      if (self->connectionState == ConnectionStateDisconnected) {
+          [self tryScheduleReconnect];
+      }
+    });
+}
+
+- (void)setupNotifications {
+#if TARGET_OS_WATCH
+    __weak FPersistentConnection *weakSelf = self;
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserverForName:WKApplicationWillEnterForegroundNotification
+                        object:nil
+                         queue:nil
+                    usingBlock:^(NSNotification *_Nonnull note) {
+                      [weakSelf enteringForeground];
+                    }];
+#endif // TARGET_OS_WATCH
 }
 
 - (void)sendAuthAndRestoreStateAfterComplete:(BOOL)restoreStateAfterComplete {

--- a/FirebaseDatabase/Sources/Public/FirebaseDatabase/FIRDatabase.h
+++ b/FirebaseDatabase/Sources/Public/FirebaseDatabase/FIRDatabase.h
@@ -27,13 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
  * read or write data, use `FIRDatabase.reference()`.
  */
 NS_SWIFT_NAME(Database) __attribute__((availability(
-    watchos, introduced = 7.0, deprecated = 9.0,
+    watchos, introduced = 6.0, deprecated = 9.0,
     message = "Socket connections are not supported on watchOS 9.0 and higher. "
               "Use the Firebase Database REST API instead. See "
               "github.com/firebase/firebase-ios-sdk/issues/10195 "
               "for more details.")))
-API_AVAILABLE(ios(12.0), macos(10.15), macCatalyst(13), tvos(13.0),
-              watchos(7.0)) @interface FIRDatabase : NSObject
+@interface FIRDatabase : NSObject
 
 /**
  * The NSObject initializer that has been marked as unavailable. Use the

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h
@@ -15,11 +15,19 @@
  */
 
 #import "FirebaseDatabase/Sources/Utilities/FUtilities.h"
+#if !TARGET_OS_WATCH
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.h"
+#endif // !TARGET_OS_WATCH
 #import <Foundation/Foundation.h>
 
 @protocol FWebSocketDelegate;
 
+#if !TARGET_OS_WATCH
+@interface FWebSocketConnection
+    : NSObject <FSRWebSocketDelegate, NSURLSessionWebSocketDelegate>
+#else
 @interface FWebSocketConnection : NSObject <NSURLSessionWebSocketDelegate>
+#endif // else !TARGET_OS_WATCH
 
 @property(nonatomic, weak) id<FWebSocketDelegate> delegate;
 
@@ -33,6 +41,20 @@
 - (void)close;
 - (void)start;
 - (void)send:(NSDictionary *)dictionary;
+
+// Ignore FSRWebSocketDelegate calls on watchOS.
+#if !TARGET_OS_WATCH
+- (void)webSocket:(FSRWebSocket *)webSocket didReceiveMessage:(id)message;
+
+// Exclude the `webSocket` argument since it isn't used in this codebase and it
+// allows for better code sharing with watchOS.
+- (void)webSocketDidOpen;
+- (void)webSocket:(FSRWebSocket *)webSocket didFailWithError:(NSError *)error;
+- (void)webSocket:(FSRWebSocket *)webSocket
+    didCloseWithCode:(NSInteger)code
+              reason:(NSString *)reason
+            wasClean:(BOOL)wasClean;
+#endif // !TARGET_OS_WATCH
 
 @end
 

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h
@@ -23,8 +23,7 @@
 @protocol FWebSocketDelegate;
 
 #if !TARGET_OS_WATCH
-@interface FWebSocketConnection
-    : NSObject <FSRWebSocketDelegate, NSURLSessionWebSocketDelegate>
+@interface FWebSocketConnection : NSObject <FSRWebSocketDelegate>
 #else
 @interface FWebSocketConnection : NSObject <NSURLSessionWebSocketDelegate>
 #endif // else !TARGET_OS_WATCH

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -26,17 +26,16 @@
 #import "FirebaseDatabase/Sources/Realtime/FWebSocketConnection.h"
 #import "FirebaseDatabase/Sources/Utilities/FStringUtilities.h"
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
+#if TARGET_OS_IOS || TARGET_OS_TV ||                                           \
+    (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #import <UIKit/UIKit.h>
+#endif // TARGET_OS_IOS || TARGET_OS_TV || (defined(TARGET_OS_VISION) &&
+       // TARGET_OS_VISION)
 
-#elif TARGET_OS_WATCH
-#import <WatchKit/WatchKit.h>
-
-#elif TARGET_OS_OSX
-#import <AppKit/NSApplication.h>
-#endif
-
+#if TARGET_OS_WATCH
 #import <Network/Network.h>
+#import <WatchKit/WatchKit.h>
+#endif // TARGET_OS_WATCH
 
 static NSString *const kAppCheckTokenHeader = @"X-Firebase-AppCheck";
 static NSString *const kUserAgentHeader = @"User-Agent";
@@ -53,10 +52,9 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 - (void)onClosed;
 - (void)closeIfNeverConnected;
 
-@property(nonatomic, strong)
-    NSURLSessionWebSocketTask *webSocketTask API_AVAILABLE(
-        macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
-#if !TARGET_OS_WATCH
+#if TARGET_OS_WATCH
+@property(nonatomic, strong) NSURLSessionWebSocketTask *webSocketTask;
+#else
 @property(nonatomic, strong) FSRWebSocket *webSocket;
 #endif // TARGET_OS_WATCH
 @property(nonatomic, strong) NSNumber *connectionId;
@@ -102,56 +100,40 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
                                                      userAgent:userAgent
                                                    googleAppID:googleAppID
                                                  appCheckToken:appCheckToken];
+#if TARGET_OS_WATCH
+        // Regular NSURLSession websocket.
+        NSOperationQueue *opQueue = [[NSOperationQueue alloc] init];
+        opQueue.underlyingQueue = queue;
+        NSURLSession *session = [NSURLSession
+            sessionWithConfiguration:[NSURLSessionConfiguration
+                                         defaultSessionConfiguration]
+                            delegate:self
+                       delegateQueue:opQueue];
+        NSURLSessionWebSocketTask *task =
+            [session webSocketTaskWithRequest:req];
+        self.webSocketTask = task;
 
-        if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                       watchOS 6.0, *)) {
-            // Regular NSURLSession websocket.
-            NSOperationQueue *opQueue = [[NSOperationQueue alloc] init];
-            opQueue.underlyingQueue = queue;
-            NSURLSession *session = [NSURLSession
-                sessionWithConfiguration:[NSURLSessionConfiguration
-                                             defaultSessionConfiguration]
-                                delegate:self
-                           delegateQueue:opQueue];
-            NSURLSessionWebSocketTask *task =
-                [session webSocketTaskWithRequest:req];
-            self.webSocketTask = task;
-
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION || TARGET_OS_MACCATALYST
-            NSString *resignName = UIApplicationWillResignActiveNotification;
-#elif TARGET_OS_OSX
-            NSString *resignName = NSApplicationWillResignActiveNotification;
-#elif TARGET_OS_WATCH
-            NSString *resignName = WKApplicationWillResignActiveNotification;
-#elif
-#error("missing platform")
-#endif
-            if (@available(watchOS 7.0, *)) {
-                [[NSNotificationCenter defaultCenter]
-                    addObserverForName:resignName
-                                object:nil
-                                 queue:opQueue
-                            usingBlock:^(NSNotification *_Nonnull note) {
-                              FFLog(@"I-RDB083015",
-                                    @"Received notification that application "
-                                    @"will resign, "
-                                    @"closing web socket.");
-                              [self onClosed];
-                            }];
-            }
+        if (@available(watchOS 7.0, *)) {
+            [[NSNotificationCenter defaultCenter]
+                addObserverForName:WKApplicationWillResignActiveNotification
+                            object:nil
+                             queue:opQueue
+                        usingBlock:^(NSNotification *_Nonnull note) {
+                          FFLog(@"I-RDB083015",
+                                @"Received watchOS background notification, "
+                                @"closing web socket.");
+                          [self onClosed];
+                        }];
         }
-#if !TARGET_OS_WATCH
-        else {
-            // TODO(mmaksym): Remove googleAppID and userAgent from FSRWebSocket
-            // as they are passed via NSURLRequest.
-            self.webSocket =
-                [[FSRWebSocket alloc] initWithURLRequest:req
-                                                   queue:queue
-                                             googleAppID:googleAppID
-                                            andUserAgent:userAgent];
-            [self.webSocket setDelegateDispatchQueue:queue];
-            self.webSocket.delegate = self;
-        }
+#else
+        // TODO(mmaksym): Remove googleAppID and userAgent from FSRWebSocket as
+        // they are passed via NSURLRequest.
+        self.webSocket = [[FSRWebSocket alloc] initWithURLRequest:req
+                                                            queue:queue
+                                                      googleAppID:googleAppID
+                                                     andUserAgent:userAgent];
+        [self.webSocket setDelegateDispatchQueue:queue];
+        self.webSocket.delegate = self;
 #endif // TARGET_OS_WATCH
     }
     return self;
@@ -212,17 +194,13 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     assert(delegate);
     everConnected = NO;
     // TODO Assert url
-    if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                   watchOS 6.0, *)) {
-        [self.webSocketTask resume];
-        // We need to request data from the web socket in order for it to start
-        // sending data.
-        [self receiveWebSocketData];
-    }
-#if !TARGET_OS_WATCH
-    else {
-        [self.webSocket open];
-    }
+#if TARGET_OS_WATCH
+    [self.webSocketTask resume];
+    // We need to request data from the web socket in order for it to start
+    // sending data.
+    [self receiveWebSocketData];
+#else
+    [self.webSocket open];
 #endif // TARGET_OS_WATCH
     dispatch_time_t when = dispatch_time(
         DISPATCH_TIME_NOW, kWebsocketConnectTimeout * NSEC_PER_SEC);
@@ -235,16 +213,12 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     FFLog(@"I-RDB083003", @"(wsc:%@) FWebSocketConnection is being closed.",
           self.connectionId);
     isClosed = YES;
-    if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                   watchOS 6.0, *)) {
-        [self.webSocketTask
-            cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure
-                         reason:nil];
-    }
-#if !TARGET_OS_WATCH
-    else {
-        [self.webSocket close];
-    }
+#if TARGET_OS_WATCH
+    [self.webSocketTask
+        cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure
+                     reason:nil];
+#else
+    [self.webSocket close];
 #endif // TARGET_OS_WATCH
 }
 
@@ -347,27 +321,25 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 }
 
 #pragma mark -
-#pragma mark URLSessionWebSocketDelegate implementation
+#pragma mark URLSessionWebSocketDelegate watchOS implementation
+#if TARGET_OS_WATCH
 
 - (void)URLSession:(NSURLSession *)session
           webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask
-    didOpenWithProtocol:(NSString *)protocol
-    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) {
+    didOpenWithProtocol:(NSString *)protocol {
     [self webSocketDidOpen];
 }
 
 - (void)URLSession:(NSURLSession *)session
        webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask
     didCloseWithCode:(NSURLSessionWebSocketCloseCode)closeCode
-              reason:(NSData *)reason
-    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) {
+              reason:(NSData *)reason {
     FFLog(@"I-RDB083011", @"(wsc:%@) didCloseWithCode: %ld %@",
           self.connectionId, (long)closeCode, reason);
     [self onClosed];
 }
 
-- (void)receiveWebSocketData API_AVAILABLE(macos(10.15), ios(13.0),
-                                           watchos(6.0), tvos(13.0)) {
+- (void)receiveWebSocketData {
     __weak __auto_type weakSelf = self;
     [self.webSocketTask receiveMessageWithCompletionHandler:^(
                             NSURLSessionWebSocketMessage *_Nullable message,
@@ -391,7 +363,7 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     }];
 }
 
-#if !TARGET_OS_WATCH
+#else
 
 #pragma mark SRWebSocketDelegate implementation
 
@@ -414,7 +386,7 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     [self onClosed];
 }
 
-#endif // !TARGET_OS_WATCH
+#endif // TARGET_OS_WATCH
 
 // Common to both SRWebSocketDelegate and URLSessionWebSocketDelegate.
 
@@ -440,26 +412,21 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 
 /** Sends a string through the open web socket. */
 - (void)sendStringToWebSocket:(NSString *)string {
-    if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                   watchOS 6.0, *)) {
-        // Use built-in URLSessionWebSocket functionality.
-        [self.webSocketTask
-                  sendMessage:[[NSURLSessionWebSocketMessage alloc]
-                                  initWithString:string]
-            completionHandler:^(NSError *_Nullable error) {
-              if (error) {
-                  FFWarn(@"I-RDB083016", @"Error sending web socket data: %@.",
-                         error);
-                  return;
-              }
-            }];
-    }
-#if !TARGET_OS_WATCH
-    else {
-        // Use existing SocketRocket implementation.
-        [self.webSocket send:string];
-    }
-#endif // !TARGET_OS_WATCH
+#if TARGET_OS_WATCH
+    // Use built-in URLSessionWebSocket functionality.
+    [self.webSocketTask sendMessage:[[NSURLSessionWebSocketMessage alloc]
+                                        initWithString:string]
+                  completionHandler:^(NSError *_Nullable error) {
+                    if (error) {
+                        FFWarn(@"I-RDB083016",
+                               @"Error sending web socket data: %@.", error);
+                        return;
+                    }
+                  }];
+#else
+    // Use existing SocketRocket implementation.
+    [self.webSocket send:string];
+#endif // TARGET_OS_WATCH
 }
 
 /**
@@ -478,17 +445,12 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     if (!everConnected) {
         FFLog(@"I-RDB083012", @"(wsc:%@) Websocket timed out on connect",
               self.connectionId);
-        if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                       watchOS 6.0, *)) {
-            [self.webSocketTask
-                cancelWithCloseCode:
-                    NSURLSessionWebSocketCloseCodeNoStatusReceived
-                             reason:nil];
-        }
-#if !TARGET_OS_WATCH
-        else {
-            [self.webSocket close];
-        }
+#if TARGET_OS_WATCH
+        [self.webSocketTask
+            cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNoStatusReceived
+                         reason:nil];
+#else
+        [self.webSocket close];
 #endif // TARGET_OS_WATCH
     }
 }
@@ -505,11 +467,9 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
         FFLog(@"I-RDB083013", @"Websocket is closing itself");
         [self shutdown];
     }
-    if (@available(iOS 13.0, macOS 10.15, macCatalyst 13.1, tvOS 13.0,
-                   watchOS 6.0, *)) {
-        self.webSocketTask = nil;
-    }
-#if !TARGET_OS_WATCH
+#if TARGET_OS_WATCH
+    self.webSocketTask = nil;
+#else
     self.webSocket = nil;
 #endif // TARGET_OS_WATCH
     if (keepAlive.isValid) {

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -56,6 +56,9 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 @property(nonatomic, strong)
     NSURLSessionWebSocketTask *webSocketTask API_AVAILABLE(
         macos(10.15), ios(13.0), watchos(6.0), tvos(13.0));
+#if !TARGET_OS_WATCH
+@property(nonatomic, strong) FSRWebSocket *webSocket;
+#endif // TARGET_OS_WATCH
 @property(nonatomic, strong) NSNumber *connectionId;
 @property(nonatomic, readwrite) int totalFrames;
 @property(nonatomic, readonly) BOOL buffering;
@@ -69,6 +72,9 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 @implementation FWebSocketConnection
 
 @synthesize delegate;
+#if !TARGET_OS_WATCH
+@synthesize webSocket;
+#endif // !TARGET_OS_WATCH
 @synthesize connectionId;
 
 - (instancetype)initWith:(FRepoInfo *)repoInfo
@@ -120,18 +126,33 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
 #elif
 #error("missing platform")
 #endif
-            [[NSNotificationCenter defaultCenter]
-                addObserverForName:resignName
-                            object:nil
-                             queue:opQueue
-                        usingBlock:^(NSNotification *_Nonnull note) {
-                          FFLog(@"I-RDB083015",
-                                @"Received notification that application "
-                                @"will resign, "
-                                @"closing web socket.");
-                          [self onClosed];
-                        }];
+            if (@available(watchOS 7.0, *)) {
+                [[NSNotificationCenter defaultCenter]
+                    addObserverForName:resignName
+                                object:nil
+                                 queue:opQueue
+                            usingBlock:^(NSNotification *_Nonnull note) {
+                              FFLog(@"I-RDB083015",
+                                    @"Received notification that application "
+                                    @"will resign, "
+                                    @"closing web socket.");
+                              [self onClosed];
+                            }];
+            }
         }
+#if !TARGET_OS_WATCH
+        else {
+            // TODO(mmaksym): Remove googleAppID and userAgent from FSRWebSocket
+            // as they are passed via NSURLRequest.
+            self.webSocket =
+                [[FSRWebSocket alloc] initWithURLRequest:req
+                                                   queue:queue
+                                             googleAppID:googleAppID
+                                            andUserAgent:userAgent];
+            [self.webSocket setDelegateDispatchQueue:queue];
+            self.webSocket.delegate = self;
+        }
+#endif // TARGET_OS_WATCH
     }
     return self;
 }
@@ -198,6 +219,11 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
         // sending data.
         [self receiveWebSocketData];
     }
+#if !TARGET_OS_WATCH
+    else {
+        [self.webSocket open];
+    }
+#endif // TARGET_OS_WATCH
     dispatch_time_t when = dispatch_time(
         DISPATCH_TIME_NOW, kWebsocketConnectTimeout * NSEC_PER_SEC);
     dispatch_after(when, self.dispatchQueue, ^{
@@ -215,6 +241,11 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
             cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure
                          reason:nil];
     }
+#if !TARGET_OS_WATCH
+    else {
+        [self.webSocket close];
+    }
+#endif // TARGET_OS_WATCH
 }
 
 - (void)start {
@@ -360,6 +391,31 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
     }];
 }
 
+#if !TARGET_OS_WATCH
+
+#pragma mark SRWebSocketDelegate implementation
+
+- (void)webSocket:(FSRWebSocket *)webSocket didReceiveMessage:(id)message {
+    [self handleIncomingFrame:message];
+}
+
+- (void)webSocket:(FSRWebSocket *)webSocket didFailWithError:(NSError *)error {
+    FFLog(@"I-RDB083010", @"(wsc:%@) didFailWithError didFailWithError: %@",
+          self.connectionId, [error description]);
+    [self onClosed];
+}
+
+- (void)webSocket:(FSRWebSocket *)webSocket
+    didCloseWithCode:(NSInteger)code
+              reason:(NSString *)reason
+            wasClean:(BOOL)wasClean {
+    FFLog(@"I-RDB083011", @"(wsc:%@) didCloseWithCode: %ld %@",
+          self.connectionId, (long)code, reason);
+    [self onClosed];
+}
+
+#endif // !TARGET_OS_WATCH
+
 // Common to both SRWebSocketDelegate and URLSessionWebSocketDelegate.
 
 - (void)webSocketDidOpen {
@@ -398,6 +454,12 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
               }
             }];
     }
+#if !TARGET_OS_WATCH
+    else {
+        // Use existing SocketRocket implementation.
+        [self.webSocket send:string];
+    }
+#endif // !TARGET_OS_WATCH
 }
 
 /**
@@ -423,6 +485,11 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
                     NSURLSessionWebSocketCloseCodeNoStatusReceived
                              reason:nil];
         }
+#if !TARGET_OS_WATCH
+        else {
+            [self.webSocket close];
+        }
+#endif // TARGET_OS_WATCH
     }
 }
 
@@ -442,6 +509,9 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
                    watchOS 6.0, *)) {
         self.webSocketTask = nil;
     }
+#if !TARGET_OS_WATCH
+    self.webSocket = nil;
+#endif // TARGET_OS_WATCH
     if (keepAlive.isValid) {
         [keepAlive invalidate];
     }

--- a/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
+++ b/FirebaseDatabase/Sources/Realtime/FWebSocketConnection.m
@@ -110,6 +110,27 @@ static NSString *const kGoogleAppIDHeader = @"X-Firebase-GMPID";
             NSURLSessionWebSocketTask *task =
                 [session webSocketTaskWithRequest:req];
             self.webSocketTask = task;
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION || TARGET_OS_MACCATALYST
+            NSString *resignName = UIApplicationWillResignActiveNotification;
+#elif TARGET_OS_OSX
+            NSString *resignName = NSApplicationWillResignActiveNotification;
+#elif TARGET_OS_WATCH
+            NSString *resignName = WKApplicationWillResignActiveNotification;
+#elif
+#error("missing platform")
+#endif
+            [[NSNotificationCenter defaultCenter]
+                addObserverForName:resignName
+                            object:nil
+                             queue:opQueue
+                        usingBlock:^(NSNotification *_Nonnull note) {
+                          FFLog(@"I-RDB083015",
+                                @"Received notification that application "
+                                @"will resign, "
+                                @"closing web socket.");
+                          [self onClosed];
+                        }];
         }
     }
     return self;

--- a/FirebaseDatabase/Sources/Utilities/FStringUtilities.m
+++ b/FirebaseDatabase/Sources/Utilities/FStringUtilities.m
@@ -15,6 +15,7 @@
  */
 
 #import "FirebaseDatabase/Sources/Utilities/FStringUtilities.h"
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.h"
 #import <CommonCrypto/CommonDigest.h>
 
 @implementation FStringUtilities
@@ -31,7 +32,7 @@
     CC_SHA1(data.bytes, (unsigned int)data.length, digest);
     NSData *output = [[NSData alloc] initWithBytes:digest
                                             length:CC_SHA1_DIGEST_LENGTH];
-    return [output base64EncodedStringWithOptions:0];
+    return [FSRUtilities base64EncodedStringFromData:output];
 }
 
 + (NSString *)urlDecoded:(NSString *)url {

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.h
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.h
@@ -1,0 +1,112 @@
+//
+//   Copyright 2012 Square Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+#if !TARGET_OS_WATCH
+#import <Foundation/Foundation.h>
+#import <Security/SecCertificate.h>
+
+typedef enum {
+    SR_CONNECTING   = 0,
+    SR_OPEN         = 1,
+    SR_CLOSING      = 2,
+    SR_CLOSED       = 3,
+
+} FSRReadyState;
+
+@class FSRWebSocket;
+
+extern NSString *const FSRWebSocketErrorDomain;
+
+@protocol FSRWebSocketDelegate;
+
+@interface FSRWebSocket : NSObject <NSStreamDelegate>
+
+@property (nonatomic, weak) id <FSRWebSocketDelegate> delegate;
+
+@property (nonatomic, readonly) FSRReadyState readyState;
+@property (nonatomic, readonly, retain) NSURL *url;
+
+// This returns the negotiated protocol.
+// It will be niluntil after the handshake completes.
+@property (nonatomic, readonly, copy) NSString *protocol;
+
+// Protocols should be an array of strings that turn into Sec-WebSocket-Protocol
+- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols queue:(dispatch_queue_t)queue googleAppID:(NSString*)googleAppID andUserAgent:(NSString *)userAgent;
+- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
+- (id)initWithURLRequest:(NSURLRequest *)request queue:(dispatch_queue_t)queue googleAppID:(NSString*)googleAppID andUserAgent:(NSString *)userAgent;
+- (id)initWithURLRequest:(NSURLRequest *)request;
+
+// Some helper constructors
+- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
+- (id)initWithURL:(NSURL *)url;
+
+// Delegate queue will be dispatch_main_queue by default.
+// You cannot set both OperationQueue and dispatch_queue.
+- (void)setDelegateOperationQueue:(NSOperationQueue*) queue;
+- (void)setDelegateDispatchQueue:(dispatch_queue_t)queue;
+
+// By default, it will schedule itself on +[NSRunLoop SR_networkRunLoop] using defaultModes.
+- (void)scheduleInRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+- (void)unscheduleFromRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+
+// SRWebSockets are intended one-time-use only.  Open should be called once and only once
+- (void)open;
+
+- (void)close;
+- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
+
+// Send a UTF8 String or Data
+- (void)send:(id)data;
+
+@end
+
+@protocol FSRWebSocketDelegate <NSObject>
+
+// message will either be an NSString if the server is using text
+// or NSData if the server is using binary
+- (void)webSocket:(FSRWebSocket *)webSocket didReceiveMessage:(id)message;
+
+@optional
+
+// Exclude the `webSocket` argument since it isn't used in this codebase and it allows for better
+// code sharing with watchOS.
+- (void)webSocketDidOpen;
+- (void)webSocket:(FSRWebSocket *)webSocket didFailWithError:(NSError *)error;
+- (void)webSocket:(FSRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
+
+@end
+
+
+@interface NSURLRequest (FCertificateAdditions)
+
+@property (nonatomic, retain, readonly) NSArray *FSR_SSLPinnedCertificates;
+
+@end
+
+
+@interface NSMutableURLRequest (FCertificateAdditions)
+
+@property (nonatomic, retain) NSArray *FSR_SSLPinnedCertificates;
+
+@end
+
+@interface NSRunLoop (FSRWebSocket)
+
++ (NSRunLoop *)FSR_networkRunLoop;
+
+@end
+
+#endif  // TARGET_OS_WATCH

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.m
@@ -1,0 +1,1884 @@
+//
+//   Copyright 2012 Square Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/FSRWebSocket.h"
+
+#if __has_include(<unicode/utf8.h>)
+#define HAS_ICU
+#endif
+
+#import <sys/socket.h>
+
+#ifdef HAS_ICU
+#import <unicode/utf8.h>
+#endif
+
+#if __has_include(<Endian.h>)
+#import <Endian.h>
+#else
+#import <CoreServices/CoreServices.h>
+#endif
+
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/SecRandom.h>
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.h"
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.h"
+
+#if OS_OBJECT_USE_OBJC_RETAIN_RELEASE
+#define sr_dispatch_retain(x)
+#define sr_dispatch_release(x)
+#define maybe_bridge(x) ((__bridge void *) x)
+#else
+#define sr_dispatch_retain(x) dispatch_retain(x)
+#define sr_dispatch_release(x) dispatch_release(x)
+#define maybe_bridge(x) (x)
+#endif
+
+#if !TARGET_OS_WATCH
+typedef enum  {
+    SROpCodeTextFrame = 0x1,
+    SROpCodeBinaryFrame = 0x2,
+    //3-7Reserved
+    SROpCodeConnectionClose = 0x8,
+    SROpCodePing = 0x9,
+    SROpCodePong = 0xA,
+    //B-F reserved
+} FSROpCode;
+
+typedef enum {
+    SRStatusCodeNormal = 1000,
+    SRStatusCodeGoingAway = 1001,
+    SRStatusCodeProtocolError = 1002,
+    SRStatusCodeUnhandledType = 1003,
+    // 1004 reserved
+    SRStatusNoStatusReceived = 1005,
+    // 1004-1006 reserved
+    SRStatusCodeInvalidUTF8 = 1007,
+    SRStatusCodePolicyViolated = 1008,
+    SRStatusCodeMessageTooBig = 1009,
+} FSRStatusCode;
+
+typedef struct {
+    BOOL fin;
+//  BOOL rsv1;
+//  BOOL rsv2;
+//  BOOL rsv3;
+    uint8_t opcode;
+    BOOL masked;
+    uint64_t payload_length;
+} frame_header;
+
+static NSString *const SRWebSocketAppendToSecKeyString = @"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+static inline int32_t validate_dispatch_data_partial_string(NSData *data);
+static inline void SRFastLog(NSString *format, ...);
+
+@interface NSData (FSRWebSocket)
+
+- (NSString *)stringBySHA1ThenBase64Encoding;
+
+@end
+
+
+@interface NSString (FSRWebSocket)
+
+- (NSString *)stringBySHA1ThenBase64Encoding;
+
+@end
+
+
+@interface NSURL (FSRWebSocket)
+
+// The origin isn't really applicable for a native application
+// So instead, just map ws -> http and wss -> https
+- (NSString *)SR_origin;
+
+@end
+
+@interface _FSRRunLoopThread : NSThread
+
+@property (nonatomic, readonly) NSRunLoop *runLoop;
+
+@end
+
+static NSString *newSHA1String(const char *bytes, size_t length) {
+    uint8_t md[CC_SHA1_DIGEST_LENGTH];
+
+    CC_SHA1(bytes, (int)length, md);
+
+    size_t buffer_size = ((sizeof(md) * 3 + 2) / 2);
+
+    char *buffer =  (char *)malloc(buffer_size);
+
+    int len = f_b64_ntop(md, CC_SHA1_DIGEST_LENGTH, buffer, buffer_size);
+    if (len == -1) {
+        free(buffer);
+        return nil;
+    } else{
+        return [[NSString alloc] initWithBytesNoCopy:buffer length:len encoding:NSASCIIStringEncoding freeWhenDone:YES];
+    }
+}
+
+@implementation NSData (FSRWebSocket)
+
+- (NSString *)stringBySHA1ThenBase64Encoding;
+{
+    return newSHA1String(self.bytes, self.length);
+}
+
+@end
+
+
+@implementation NSString (FSRWebSocket)
+
+- (NSString *)stringBySHA1ThenBase64Encoding;
+{
+    return newSHA1String(self.UTF8String, self.length);
+}
+
+@end
+
+NSString *const FSRWebSocketErrorDomain = @"FSRWebSocketErrorDomain";
+
+// Returns number of bytes consumed. returning 0 means you didn't match.
+// Sends bytes to callback handler;
+typedef size_t (^stream_scanner)(NSData *collected_data);
+
+typedef void (^data_callback)(FSRWebSocket *webSocket,  NSData *data);
+
+@interface FSRIOConsumer : NSObject {
+    stream_scanner _scanner;
+    data_callback _handler;
+    size_t _bytesNeeded;
+    BOOL _readToCurrentFrame;
+    BOOL _unmaskBytes;
+}
+@property (nonatomic, copy, readonly) stream_scanner consumer;
+@property (nonatomic, copy, readonly) data_callback handler;
+@property (nonatomic, assign) size_t bytesNeeded;
+@property (nonatomic, assign, readonly) BOOL readToCurrentFrame;
+@property (nonatomic, assign, readonly) BOOL unmaskBytes;
+
+@end
+
+// This class is not thread-safe, and is expected to always be run on the same queue.
+@interface FSRIOConsumerPool : NSObject
+
+- (id)initWithBufferCapacity:(NSUInteger)poolSize;
+
+- (FSRIOConsumer *)consumerWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+- (void)returnConsumer:(FSRIOConsumer *)consumer;
+
+@end
+
+@interface FSRWebSocket ()  <NSStreamDelegate>
+
+- (void)_writeData:(NSData *)data;
+- (void)_closeWithProtocolError:(NSString *)message;
+- (void)_failWithError:(NSError *)error;
+
+- (void)_disconnect;
+
+- (void)_readFrameNew;
+- (void)_readFrameContinue;
+
+- (void)_pumpScanner;
+
+- (void)_pumpWriting;
+
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback;
+- (void)_addConsumerWithDataLength:(size_t)dataLength callback:(data_callback)callback readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback dataLength:(size_t)dataLength;
+- (void)_readUntilBytes:(const void *)bytes length:(size_t)length callback:(data_callback)dataHandler;
+- (void)_readUntilHeaderCompleteWithCallback:(data_callback)dataHandler;
+
+- (void)_sendFrameWithOpcode:(FSROpCode)opcode data:(id)data;
+
+- (BOOL)_checkHandshake:(CFHTTPMessageRef)httpMessage;
+- (void)_SR_commonInit;
+
+- (void)_initializeStreams;
+- (void)_connect;
+
+@property (nonatomic) FSRReadyState readyState;
+
+@property (nonatomic) NSOperationQueue *delegateOperationQueue;
+@property (nonatomic) dispatch_queue_t delegateDispatchQueue;
+
+@end
+
+
+@implementation FSRWebSocket {
+    NSInteger _webSocketVersion;
+
+    NSOperationQueue *_delegateOperationQueue;
+    dispatch_queue_t _delegateDispatchQueue;
+    dispatch_queue_t _workQueue;
+    NSMutableArray *_consumers;
+
+    NSInputStream *_inputStream;
+    NSOutputStream *_outputStream;
+
+    NSMutableData *_readBuffer;
+    NSInteger _readBufferOffset;
+
+    NSMutableData *_outputBuffer;
+    NSInteger _outputBufferOffset;
+
+    uint8_t _currentFrameOpcode;
+    size_t _currentFrameCount;
+    size_t _readOpCount;
+    uint32_t _currentStringScanPosition;
+    NSMutableData *_currentFrameData;
+
+    NSString *_closeReason;
+
+    NSString *_secKey;
+
+    BOOL _pinnedCertFound;
+
+    uint8_t _currentReadMaskKey[4];
+    size_t _currentReadMaskOffset;
+
+    BOOL _consumerStopped;
+
+    BOOL _closeWhenFinishedWriting;
+    BOOL _failed;
+
+    BOOL _secure;
+    NSURLRequest *_urlRequest;
+    NSString *_userAgent;
+    NSString *_googleAppID;
+
+    CFHTTPMessageRef _receivedHTTPHeaders;
+
+    BOOL _sentClose;
+    BOOL _didFail;
+    BOOL _cleanupScheduled;
+    int _closeCode;
+
+    BOOL _isPumping;
+
+    NSMutableSet *_scheduledRunloops;
+
+    // We use this to retain ourselves.
+    __strong FSRWebSocket *_selfRetain;
+
+    NSArray *_requestedProtocols;
+    FSRIOConsumerPool *_consumerPool;
+}
+
+@synthesize delegate = _delegate;
+@synthesize url = _url;
+@synthesize readyState = _readyState;
+@synthesize protocol = _protocol;
+
+static __strong NSData *CRLFCRLF;
+
++ (void)initialize;
+{
+    CRLFCRLF = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
+}
+
+- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols queue:(dispatch_queue_t)queue
+             googleAppID:(NSString *)googleAppID andUserAgent:(NSString *)userAgent;
+{
+    self = [super init];
+    if (self) {
+        assert(request.URL);
+        _url = request.URL;
+        NSString *scheme = [_url scheme];
+
+        _requestedProtocols = [protocols copy];
+        _googleAppID = googleAppID;
+        _userAgent = userAgent;
+
+        assert([scheme isEqualToString:@"ws"] || [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"wss"] || [scheme isEqualToString:@"https"]);
+        _urlRequest = request;
+
+        if ([scheme isEqualToString:@"wss"] || [scheme isEqualToString:@"https"]) {
+            _secure = YES;
+        }
+
+        if (!queue) {
+            _delegateDispatchQueue = dispatch_get_main_queue();
+        } else {
+            _delegateDispatchQueue = queue;
+        }
+
+        [self _SR_commonInit];
+    }
+
+    return self;
+}
+
+- (id)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray *)protocols;
+{
+    return [self initWithURLRequest:request protocols:nil queue:nil googleAppID:nil andUserAgent:nil];
+}
+
+- (id)initWithURLRequest:(NSURLRequest *)request queue:(dispatch_queue_t)queue
+             googleAppID:(NSString *)googleAppID andUserAgent:(NSString *)userAgent;
+{
+    return [self initWithURLRequest:request protocols:nil queue:queue googleAppID:googleAppID
+                       andUserAgent:userAgent];
+}
+
+- (id)initWithURLRequest:(NSURLRequest *)request;
+{
+    return [self initWithURLRequest:request protocols:nil];
+}
+
+- (id)initWithURL:(NSURL *)url;
+{
+    return [self initWithURL:url protocols:nil];
+}
+
+- (id)initWithURL:(NSURL *)url protocols:(NSArray *)protocols;
+{
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    return [self initWithURLRequest:request protocols:protocols];
+}
+
+- (void)_SR_commonInit;
+{
+    _readyState = SR_CONNECTING;
+
+    _consumerStopped = YES;
+
+    _webSocketVersion = 13;
+
+    _workQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+
+    // Going to set a specific on the queue so we can validate we're on the work queue
+    dispatch_queue_set_specific(_workQueue, (__bridge void *)self, maybe_bridge(_workQueue), NULL);
+
+    sr_dispatch_retain(_delegateDispatchQueue);
+
+    _readBuffer = [[NSMutableData alloc] init];
+    _outputBuffer = [[NSMutableData alloc] init];
+
+    _currentFrameData = [[NSMutableData alloc] init];
+
+    _consumers = [[NSMutableArray alloc] init];
+
+    _consumerPool = [[FSRIOConsumerPool alloc] init];
+
+    _scheduledRunloops = [[NSMutableSet alloc] init];
+
+    [self _initializeStreams];
+
+    // default handlers
+}
+
+- (void)assertOnWorkQueue;
+{
+    assert(dispatch_get_specific((__bridge void *)self) == maybe_bridge(_workQueue));
+}
+
+- (void)dealloc
+{
+    _inputStream.delegate = nil;
+    _outputStream.delegate = nil;
+
+    [_inputStream close];
+    [_outputStream close];
+
+    sr_dispatch_release(_workQueue);
+    _workQueue = NULL;
+
+    if (_receivedHTTPHeaders) {
+        CFRelease(_receivedHTTPHeaders);
+        _receivedHTTPHeaders = NULL;
+    }
+
+    if (_delegateDispatchQueue) {
+        sr_dispatch_release(_delegateDispatchQueue);
+        _delegateDispatchQueue = NULL;
+    }
+}
+
+#ifndef NDEBUG
+
+- (void)setReadyState:(FSRReadyState)aReadyState;
+{
+    [self willChangeValueForKey:@"readyState"];
+    assert(aReadyState > _readyState);
+    _readyState = aReadyState;
+    [self didChangeValueForKey:@"readyState"];
+}
+
+#endif
+
+- (void)open;
+{
+    assert(_url);
+    NSAssert(_readyState == SR_CONNECTING, @"Cannot call -(void)open on SRWebSocket more than once");
+
+    _selfRetain = self;
+
+    [self _connect];
+}
+
+// Calls block on delegate queue
+- (void)_performDelegateBlock:(dispatch_block_t)block;
+{
+    if (_delegateOperationQueue) {
+        [_delegateOperationQueue addOperationWithBlock:block];
+    } else {
+        assert(_delegateDispatchQueue);
+        dispatch_async(_delegateDispatchQueue, block);
+    }
+}
+
+- (void)setDelegateDispatchQueue:(dispatch_queue_t)queue;
+{
+    if (queue) {
+        sr_dispatch_retain(queue);
+    }
+
+    if (_delegateDispatchQueue) {
+        sr_dispatch_release(_delegateDispatchQueue);
+    }
+
+    _delegateDispatchQueue = queue;
+}
+
+- (BOOL)_checkHandshake:(CFHTTPMessageRef)httpMessage;
+{
+    NSString *acceptHeader = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(httpMessage, CFSTR("Sec-WebSocket-Accept")));
+
+    if (acceptHeader == nil) {
+        return NO;
+    }
+
+    NSString *concattedString = [_secKey stringByAppendingString:SRWebSocketAppendToSecKeyString];
+    NSString *expectedAccept = [concattedString stringBySHA1ThenBase64Encoding];
+
+    return [acceptHeader isEqualToString:expectedAccept];
+}
+
+- (void)_HTTPHeadersDidFinish;
+{
+    NSInteger responseCode = CFHTTPMessageGetResponseStatusCode(_receivedHTTPHeaders);
+
+    if (responseCode >= 400) {
+        SRFastLog(@"Request failed with response code %d", responseCode);
+        [self _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:2132 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"received bad response code from server %u", (int)responseCode] forKey:NSLocalizedDescriptionKey]]];
+        return;
+
+    }
+
+    if(![self _checkHandshake:_receivedHTTPHeaders]) {
+        [self _failWithError:[NSError errorWithDomain:FSRWebSocketErrorDomain code:2133 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid Sec-WebSocket-Accept response"] forKey:NSLocalizedDescriptionKey]]];
+        return;
+    }
+
+    NSString *negotiatedProtocol = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(_receivedHTTPHeaders, CFSTR("Sec-WebSocket-Protocol")));
+    if (negotiatedProtocol) {
+        // Make sure we requested the protocol
+        if ([_requestedProtocols indexOfObject:negotiatedProtocol] == NSNotFound) {
+            [self _failWithError:[NSError errorWithDomain:FSRWebSocketErrorDomain code:2133 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Server specified Sec-WebSocket-Protocol that wasn't requested"] forKey:NSLocalizedDescriptionKey]]];
+            return;
+        }
+
+        _protocol = negotiatedProtocol;
+    }
+
+    self.readyState = SR_OPEN;
+
+    if (!_didFail) {
+        [self _readFrameNew];
+    }
+
+    [self _performDelegateBlock:^{
+        if ([self.delegate respondsToSelector:@selector(webSocketDidOpen)]) {
+            [self.delegate webSocketDidOpen];
+        };
+    }];
+}
+
+
+- (void)_readHTTPHeader;
+{
+    if (_receivedHTTPHeaders == NULL) {
+        _receivedHTTPHeaders = CFHTTPMessageCreateEmpty(NULL, NO);
+    }
+
+    [self _readUntilHeaderCompleteWithCallback:^(FSRWebSocket *self,  NSData *data) {
+        CFHTTPMessageAppendBytes(self->_receivedHTTPHeaders, (const UInt8 *)data.bytes, data.length);
+
+        if (CFHTTPMessageIsHeaderComplete(self->_receivedHTTPHeaders)) {
+            SRFastLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_receivedHTTPHeaders)));
+            [self _HTTPHeadersDidFinish];
+        } else {
+            [self _readHTTPHeader];
+        }
+    }];
+}
+
+- (void)didConnect
+{
+    SRFastLog(@"Connected");
+    CFHTTPMessageRef request = CFHTTPMessageCreateRequest(NULL, CFSTR("GET"), (__bridge CFURLRef)_url, kCFHTTPVersion1_1);
+
+    // Set host first so it defaults
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)
+                                     (_url.port != nil ? [NSString stringWithFormat:@"%@:%@",
+                                                          _url.host, _url.port] : _url.host));
+
+    NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
+    int __unused result =
+        SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    assert(result == 0);
+    _secKey = [FSRUtilities base64EncodedStringFromData:keyBytes];
+    assert([_secKey length] == 24);
+
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Upgrade"), CFSTR("websocket"));
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Connection"), CFSTR("Upgrade"));
+    if (_userAgent) {
+        CFHTTPMessageSetHeaderFieldValue(request, CFSTR("User-Agent"), (__bridge CFStringRef)_userAgent);
+    }
+
+    if (_googleAppID) {
+        CFHTTPMessageSetHeaderFieldValue(request, CFSTR("X-Firebase-GMPID"), (__bridge CFStringRef)_googleAppID);
+    }
+
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Sec-WebSocket-Key"), (__bridge CFStringRef)_secKey);
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Sec-WebSocket-Version"), (__bridge CFStringRef)[NSString stringWithFormat:@"%u", (int)_webSocketVersion]);
+
+    CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Origin"), (__bridge CFStringRef)_url.SR_origin);
+
+    if (_requestedProtocols) {
+        CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Sec-WebSocket-Protocol"), (__bridge CFStringRef)[_requestedProtocols componentsJoinedByString:@", "]);
+    }
+
+    [_urlRequest.allHTTPHeaderFields enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        CFHTTPMessageSetHeaderFieldValue(request, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
+    }];
+
+    NSData *message = CFBridgingRelease(CFHTTPMessageCopySerializedMessage(request));
+
+    CFRelease(request);
+
+    [self _writeData:message];
+    [self _readHTTPHeader];
+}
+
+//- (void)_connectToHost:(NSString *)host port:(NSInteger)port;
+- (void)_initializeStreams;
+{
+    NSInteger port = _url.port.integerValue;
+    if (port == 0) {
+        if (!_secure) {
+            port = 80;
+        } else {
+            port = 443;
+        }
+    }
+    NSString *host = _url.host;
+
+    CFReadStreamRef readStream = NULL;
+    CFWriteStreamRef writeStream = NULL;
+
+    CFStreamCreatePairWithSocketToHost(NULL, (__bridge CFStringRef)host, (int)port, &readStream, &writeStream);
+
+    // XXX
+    CFReadStreamSetProperty(readStream,  kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+    CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+
+    _outputStream = CFBridgingRelease(writeStream);
+    _inputStream = CFBridgingRelease(readStream);
+
+
+    if (_secure) {
+        NSMutableDictionary *SSLOptions = [[NSMutableDictionary alloc] init];
+
+        [_outputStream setProperty:(__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL forKey:(__bridge id)kCFStreamPropertySocketSecurityLevel];
+
+        // If we're using pinned certs, don't validate the certificate chain
+        if ([_urlRequest FSR_SSLPinnedCertificates].count) {
+            [SSLOptions setValue:[NSNumber numberWithBool:NO] forKey:(__bridge id)kCFStreamSSLValidatesCertificateChain];
+        }
+
+        [_outputStream setProperty:SSLOptions
+                            forKey:(__bridge id)kCFStreamPropertySSLSettings];
+    }
+
+    _inputStream.delegate = self;
+    _outputStream.delegate = self;
+
+    [_outputStream open];
+    [_inputStream open];
+}
+
+- (void)_connect;
+{
+    if (!_scheduledRunloops.count) {
+        [self scheduleInRunLoop:[NSRunLoop FSR_networkRunLoop] forMode:NSDefaultRunLoopMode];
+    }
+
+
+    [_outputStream open];
+    [_inputStream open];
+}
+
+- (void)scheduleInRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+{
+    [_outputStream scheduleInRunLoop:aRunLoop forMode:mode];
+    [_inputStream scheduleInRunLoop:aRunLoop forMode:mode];
+
+    [_scheduledRunloops addObject:@[aRunLoop, mode]];
+}
+
+- (void)unscheduleFromRunLoop:(NSRunLoop *)aRunLoop forMode:(NSString *)mode;
+{
+    [_outputStream removeFromRunLoop:aRunLoop forMode:mode];
+    [_inputStream removeFromRunLoop:aRunLoop forMode:mode];
+
+    [_scheduledRunloops removeObject:@[aRunLoop, mode]];
+}
+
+- (void)close;
+{
+    [self closeWithCode:-1 reason:nil];
+}
+
+- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
+{
+    assert(code);
+    dispatch_async(_workQueue, ^{
+        if (self.readyState == SR_CLOSING || self.readyState == SR_CLOSED) {
+            return;
+        }
+
+        BOOL wasConnecting = self.readyState == SR_CONNECTING;
+
+        self.readyState = SR_CLOSING;
+
+        SRFastLog(@"Closing with code %d reason %@", code, reason);
+
+        if (wasConnecting) {
+            [self _disconnect];
+            return;
+        }
+
+        size_t maxMsgSize = [reason maximumLengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        NSMutableData *mutablePayload = [[NSMutableData alloc] initWithLength:sizeof(uint16_t) + maxMsgSize];
+        NSData *payload = mutablePayload;
+
+        ((uint16_t *)mutablePayload.mutableBytes)[0] = EndianU16_BtoN(code);
+
+        if (reason) {
+            NSRange remainingRange = {0};
+
+            NSUInteger usedLength = 0;
+
+            BOOL __unused success =
+                [reason getBytes:(char *)mutablePayload.mutableBytes + sizeof(uint16_t)
+                       maxLength:payload.length - sizeof(uint16_t)
+                      usedLength:&usedLength
+                        encoding:NSUTF8StringEncoding
+                         options:NSStringEncodingConversionExternalRepresentation
+                           range:NSMakeRange(0, reason.length)
+                  remainingRange:&remainingRange];
+
+            assert(success);
+            assert(remainingRange.length == 0);
+
+            if (usedLength != maxMsgSize) {
+                payload = [payload subdataWithRange:NSMakeRange(0, usedLength + sizeof(uint16_t))];
+            }
+        }
+
+
+        [self _sendFrameWithOpcode:SROpCodeConnectionClose data:payload];
+    });
+}
+
+- (void)_closeWithProtocolError:(NSString *)message;
+{
+    // Need to shunt this on the _callbackQueue first to see if they received any messages
+    [self _performDelegateBlock:^{
+        [self closeWithCode:SRStatusCodeProtocolError reason:message];
+        dispatch_async(self->_workQueue, ^{
+            [self _disconnect];
+        });
+    }];
+}
+
+- (void)_failWithError:(NSError *)error;
+{
+    dispatch_async(_workQueue, ^{
+        if (self.readyState != SR_CLOSED) {
+            self->_failed = YES;
+            [self _performDelegateBlock:^{
+                if ([self.delegate respondsToSelector:@selector(webSocket:didFailWithError:)]) {
+                    [self.delegate webSocket:self didFailWithError:error];
+                }
+            }];
+
+            self.readyState = SR_CLOSED;
+
+            SRFastLog(@"Failing with error %@", error.localizedDescription);
+
+            [self _disconnect];
+            [self _scheduleCleanup];
+        }
+    });
+}
+
+- (void)_writeData:(NSData *)data;
+{
+    [self assertOnWorkQueue];
+
+    if (_closeWhenFinishedWriting) {
+            return;
+    }
+    [_outputBuffer appendData:data];
+    [self _pumpWriting];
+}
+- (void)send:(id)data;
+{
+    SRFastLog(@"Sending data %@", data);
+    NSAssert(self.readyState != SR_CONNECTING, @"Invalid State: Cannot call send: until connection is open");
+    // TODO: maybe not copy this for performance
+    data = [data copy];
+    dispatch_async(_workQueue, ^{
+        if ([data isKindOfClass:[NSString class]]) {
+            [self _sendFrameWithOpcode:SROpCodeTextFrame data:[(NSString *)data dataUsingEncoding:NSUTF8StringEncoding]];
+        } else if ([data isKindOfClass:[NSData class]]) {
+            [self _sendFrameWithOpcode:SROpCodeBinaryFrame data:data];
+        } else if (data == nil) {
+            [self _sendFrameWithOpcode:SROpCodeTextFrame data:data];
+        } else {
+            assert(NO);
+        }
+    });
+}
+
+- (void)handlePing:(NSData *)pingData;
+{
+    // Need to pingpong this off _callbackQueue first to make sure messages happen in order
+    [self _performDelegateBlock:^{
+        dispatch_async(self->_workQueue, ^{
+            [self _sendFrameWithOpcode:SROpCodePong data:pingData];
+        });
+    }];
+}
+
+- (void)handlePong;
+{
+    // NOOP
+}
+
+- (void)_handleMessage:(id)message
+{
+    SRFastLog(@"Received message");
+    [self _performDelegateBlock:^{
+        if ([self.delegate respondsToSelector:@selector(webSocket:didReceiveMessage:)]) {
+            [self.delegate webSocket:self didReceiveMessage:message];
+        }
+    }];
+}
+
+
+static inline BOOL closeCodeIsValid(int closeCode) {
+    if (closeCode < 1000) {
+        return NO;
+    }
+
+    if (closeCode >= 1000 && closeCode <= 1011) {
+        if (closeCode == 1004 ||
+            closeCode == 1005 ||
+            closeCode == 1006) {
+            return NO;
+        }
+        return YES;
+    }
+
+    if (closeCode >= 3000 && closeCode <= 3999) {
+        return YES;
+    }
+
+    if (closeCode >= 4000 && closeCode <= 4999) {
+        return YES;
+    }
+
+    return NO;
+}
+
+//  Note from RFC:
+//
+//  If there is a body, the first two
+//  bytes of the body MUST be a 2-byte unsigned integer (in network byte
+//  order) representing a status code with value /code/ defined in
+//  Section 7.4.  Following the 2-byte integer the body MAY contain UTF-8
+//  encoded data with value /reason/, the interpretation of which is not
+//  defined by this specification.
+
+- (void)handleCloseWithData:(NSData *)data;
+{
+    size_t dataSize = data.length;
+    __block uint16_t closeCode = 0;
+
+    SRFastLog(@"Received close frame");
+
+    if (dataSize == 1) {
+        // TODO handle error
+        [self _closeWithProtocolError:@"Payload for close must be larger than 2 bytes"];
+        return;
+    } else if (dataSize >= 2) {
+        [data getBytes:&closeCode length:sizeof(closeCode)];
+        _closeCode = EndianU16_BtoN(closeCode);
+        if (!closeCodeIsValid(_closeCode)) {
+            [self _closeWithProtocolError:[NSString stringWithFormat:@"Cannot have close code of %d", _closeCode]];
+            return;
+        }
+        if (dataSize > 2) {
+            _closeReason = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(2, dataSize - 2)] encoding:NSUTF8StringEncoding];
+            if (!_closeReason) {
+                [self _closeWithProtocolError:@"Close reason MUST be valid UTF-8"];
+                return;
+            }
+        }
+    } else {
+        _closeCode = SRStatusNoStatusReceived;
+    }
+
+    [self assertOnWorkQueue];
+
+    if (self.readyState == SR_OPEN) {
+        [self closeWithCode:1000 reason:nil];
+    }
+    dispatch_async(_workQueue, ^{
+        [self _disconnect];
+    });
+}
+
+- (void)_disconnect;
+{
+    [self assertOnWorkQueue];
+    SRFastLog(@"Trying to disconnect");
+    _closeWhenFinishedWriting = YES;
+    [self _pumpWriting];
+}
+
+- (void)_handleFrameWithData:(NSData *)frameData opCode:(NSInteger)opcode;
+{
+    // Check that the current data is valid UTF8
+
+    BOOL isControlFrame = (opcode == SROpCodePing || opcode == SROpCodePong || opcode == SROpCodeConnectionClose);
+    if (!isControlFrame) {
+        [self _readFrameNew];
+    } else {
+        dispatch_async(_workQueue, ^{
+            [self _readFrameContinue];
+        });
+    }
+
+    switch (opcode) {
+        case SROpCodeTextFrame: {
+            NSString *str = [[NSString alloc] initWithData:frameData encoding:NSUTF8StringEncoding];
+            if (str == nil && frameData) {
+                [self closeWithCode:SRStatusCodeInvalidUTF8 reason:@"Text frames must be valid UTF-8"];
+                dispatch_async(_workQueue, ^{
+                    [self _disconnect];
+                });
+
+                return;
+            }
+            [self _handleMessage:str];
+            break;
+        }
+        case SROpCodeBinaryFrame:
+            [self _handleMessage:[frameData copy]];
+            break;
+        case SROpCodeConnectionClose:
+            [self handleCloseWithData:frameData];
+            break;
+        case SROpCodePing:
+            [self handlePing:frameData];
+            break;
+        case SROpCodePong:
+            [self handlePong];
+            break;
+        default:
+            [self _closeWithProtocolError:[NSString stringWithFormat:@"Unknown opcode %u", (int)opcode]];
+            // TODO: Handle invalid opcode
+            break;
+    }
+}
+
+- (void)_handleFrameHeader:(frame_header)frame_header curData:(NSData *)curData;
+{
+    assert(frame_header.opcode != 0);
+
+    if (self.readyState != SR_OPEN) {
+        return;
+    }
+
+
+    BOOL isControlFrame = (frame_header.opcode == SROpCodePing || frame_header.opcode == SROpCodePong || frame_header.opcode == SROpCodeConnectionClose);
+
+    if (isControlFrame && !frame_header.fin) {
+        [self _closeWithProtocolError:@"Fragmented control frames not allowed"];
+        return;
+    }
+
+    if (isControlFrame && frame_header.payload_length >= 126) {
+        [self _closeWithProtocolError:@"Control frames cannot have payloads larger than 126 bytes"];
+        return;
+    }
+
+    if (!isControlFrame) {
+        _currentFrameOpcode = frame_header.opcode;
+        _currentFrameCount += 1;
+    }
+
+    if (frame_header.payload_length == 0) {
+        if (isControlFrame) {
+            [self _handleFrameWithData:curData opCode:frame_header.opcode];
+        } else {
+            if (frame_header.fin) {
+                [self _handleFrameWithData:_currentFrameData opCode:frame_header.opcode];
+            } else {
+                // TODO add assert that opcode is not a control;
+                [self _readFrameContinue];
+            }
+        }
+    } else {
+        [self _addConsumerWithDataLength:(size_t)frame_header.payload_length callback:^(FSRWebSocket *self, NSData *newData) {
+            if (isControlFrame) {
+                [self _handleFrameWithData:newData opCode:frame_header.opcode];
+            } else {
+                if (frame_header.fin) {
+                    [self _handleFrameWithData:self->_currentFrameData opCode:frame_header.opcode];
+                } else {
+                    // TODO add assert that opcode is not a control;
+                    [self _readFrameContinue];
+                }
+
+            }
+        } readToCurrentFrame:!isControlFrame unmaskBytes:frame_header.masked];
+    }
+}
+
+/* From RFC:
+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ +-+-+-+-+-------+-+-------------+-------------------------------+
+ |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+ |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+ |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+ | |1|2|3|       |K|             |                               |
+ +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+ |     Extended payload length continued, if payload len == 127  |
+ + - - - - - - - - - - - - - - - +-------------------------------+
+ |                               |Masking-key, if MASK set to 1  |
+ +-------------------------------+-------------------------------+
+ | Masking-key (continued)       |          Payload Data         |
+ +-------------------------------- - - - - - - - - - - - - - - - +
+ :                     Payload Data continued ...                :
+ + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
+ |                     Payload Data continued ...                |
+ +---------------------------------------------------------------+
+ */
+
+static const uint8_t SRFinMask          = 0x80;
+static const uint8_t SROpCodeMask       = 0x0F;
+static const uint8_t SRRsvMask          = 0x70;
+static const uint8_t SRMaskMask         = 0x80;
+static const uint8_t SRPayloadLenMask   = 0x7F;
+
+
+- (void)_readFrameContinue;
+{
+    assert((_currentFrameCount == 0 && _currentFrameOpcode == 0) || (_currentFrameCount > 0 && _currentFrameOpcode > 0));
+
+    [self _addConsumerWithDataLength:2 callback:^(FSRWebSocket *self, NSData *data) {
+        __block frame_header header = {0};
+
+        const uint8_t *headerBuffer = data.bytes;
+        assert(data.length >= 2);
+
+        if (headerBuffer[0] & SRRsvMask) {
+            [self _closeWithProtocolError:@"Server used RSV bits"];
+            return;
+        }
+
+        uint8_t receivedOpcode = (SROpCodeMask & headerBuffer[0]);
+
+        BOOL isControlFrame = (receivedOpcode == SROpCodePing || receivedOpcode == SROpCodePong || receivedOpcode == SROpCodeConnectionClose);
+
+        if (!isControlFrame && receivedOpcode != 0 && self->_currentFrameCount > 0) {
+            [self _closeWithProtocolError:@"all data frames after the initial data frame must have opcode 0"];
+            return;
+        }
+
+        if (receivedOpcode == 0 && self->_currentFrameCount == 0) {
+            [self _closeWithProtocolError:@"cannot continue a message"];
+            return;
+        }
+
+        header.opcode = receivedOpcode == 0 ? self->_currentFrameOpcode : receivedOpcode;
+
+        header.fin = !!(SRFinMask & headerBuffer[0]);
+
+
+        header.masked = !!(SRMaskMask & headerBuffer[1]);
+        header.payload_length = SRPayloadLenMask & headerBuffer[1];
+
+        headerBuffer = NULL;
+
+        if (header.masked) {
+            [self _closeWithProtocolError:@"Client must receive unmasked data"];
+        }
+
+        size_t extra_bytes_needed = header.masked ? sizeof(self->_currentReadMaskKey) : 0;
+
+        if (header.payload_length == 126) {
+            extra_bytes_needed += sizeof(uint16_t);
+        } else if (header.payload_length == 127) {
+            extra_bytes_needed += sizeof(uint64_t);
+        }
+
+        if (extra_bytes_needed == 0) {
+            [self _handleFrameHeader:header curData:self->_currentFrameData];
+        } else {
+            [self _addConsumerWithDataLength:extra_bytes_needed callback:^(FSRWebSocket *self, NSData *data) {
+                size_t __unused mapped_size = data.length;
+                const void *mapped_buffer = data.bytes;
+                size_t offset = 0;
+
+                if (header.payload_length == 126) {
+                    assert(mapped_size >= sizeof(uint16_t));
+                    uint16_t newLen = EndianU16_BtoN(*(uint16_t *)(mapped_buffer));
+                    header.payload_length = newLen;
+                    offset += sizeof(uint16_t);
+                } else if (header.payload_length == 127) {
+                    assert(mapped_size >= sizeof(uint64_t));
+                    header.payload_length = EndianU64_BtoN(*(uint64_t *)(mapped_buffer));
+                    offset += sizeof(uint64_t);
+                } else {
+                    assert(header.payload_length < 126 && header.payload_length >= 0);
+                }
+
+
+                if (header.masked) {
+                    assert(mapped_size >= sizeof(self->_currentReadMaskOffset) + offset);
+                    memcpy(self->_currentReadMaskKey, ((uint8_t *)mapped_buffer) + offset, sizeof(self->_currentReadMaskKey));
+                }
+
+                [self _handleFrameHeader:header curData:self->_currentFrameData];
+            } readToCurrentFrame:NO unmaskBytes:NO];
+        }
+    } readToCurrentFrame:NO unmaskBytes:NO];
+}
+
+- (void)_readFrameNew;
+{
+    dispatch_async(_workQueue, ^{
+        [self->_currentFrameData setLength:0];
+
+        self->_currentFrameOpcode = 0;
+        self->_currentFrameCount = 0;
+        self->_readOpCount = 0;
+        self->_currentStringScanPosition = 0;
+
+        [self _readFrameContinue];
+    });
+}
+
+- (void)_pumpWriting;
+{
+    [self assertOnWorkQueue];
+
+    NSUInteger dataLength = _outputBuffer.length;
+    if (dataLength - _outputBufferOffset > 0 && _outputStream.hasSpaceAvailable) {
+        NSUInteger bytesWritten = [_outputStream write:_outputBuffer.bytes + _outputBufferOffset maxLength:dataLength - _outputBufferOffset];
+        if (bytesWritten == -1) {
+            [self _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:2145 userInfo:[NSDictionary dictionaryWithObject:@"Error writing to stream" forKey:NSLocalizedDescriptionKey]]];
+             return;
+        }
+
+        _outputBufferOffset += bytesWritten;
+
+        if (_outputBufferOffset > 4096 && _outputBufferOffset > (_outputBuffer.length >> 1)) {
+            _outputBuffer = [[NSMutableData alloc] initWithBytes:(char *)_outputBuffer.bytes + _outputBufferOffset length:_outputBuffer.length - _outputBufferOffset];
+            _outputBufferOffset = 0;
+        }
+    }
+
+    if (_closeWhenFinishedWriting &&
+        _outputBuffer.length - _outputBufferOffset == 0 &&
+        (_inputStream.streamStatus != NSStreamStatusNotOpen &&
+         _inputStream.streamStatus != NSStreamStatusClosed) &&
+        !_sentClose) {
+        _sentClose = YES;
+
+        @synchronized (self) {
+            [_outputStream close];
+            [_inputStream close];
+
+            // TODO: Why are we missing the SocketRocket code to call unscheduleFromRunLoop???
+        }
+
+        if (!_failed) {
+            [self _performDelegateBlock:^{
+                if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
+                    [self.delegate webSocket:self didCloseWithCode:self->_closeCode reason:self->_closeReason wasClean:YES];
+                }
+            }];
+        }
+        [self _scheduleCleanup];
+    }
+}
+
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback;
+{
+    [self assertOnWorkQueue];
+    [self _addConsumerWithScanner:consumer callback:callback dataLength:0];
+}
+
+- (void)_addConsumerWithDataLength:(size_t)dataLength callback:(data_callback)callback readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+{
+    [self assertOnWorkQueue];
+    assert(dataLength);
+
+    [_consumers addObject:[_consumerPool consumerWithScanner:nil handler:callback bytesNeeded:dataLength readToCurrentFrame:readToCurrentFrame unmaskBytes:unmaskBytes]];
+    [self _pumpScanner];
+}
+
+- (void)_addConsumerWithScanner:(stream_scanner)consumer callback:(data_callback)callback dataLength:(size_t)dataLength;
+{
+    [self assertOnWorkQueue];
+    [_consumers addObject:[_consumerPool consumerWithScanner:consumer handler:callback bytesNeeded:dataLength readToCurrentFrame:NO unmaskBytes:NO]];
+    [self _pumpScanner];
+}
+
+
+- (void)_scheduleCleanup
+{
+    @synchronized(self) {
+        if (_cleanupScheduled) {
+            return;
+        }
+
+        _cleanupScheduled = YES;
+
+        // Cleanup NSStream delegate's in the same RunLoop used by the streams themselves:
+        // This way we'll prevent race conditions between handleEvent and SRWebsocket's dealloc
+        NSTimer *timer = [NSTimer timerWithTimeInterval:(0.0f) target:self selector:@selector(_cleanupSelfReference:) userInfo:nil repeats:NO];
+        [[NSRunLoop FSR_networkRunLoop] addTimer:timer forMode:NSDefaultRunLoopMode];
+    }
+}
+
+- (void)_cleanupSelfReference:(NSTimer *)timer
+{
+    @synchronized(self) {
+        // Nuke NSStream delegate's
+        _inputStream.delegate = nil;
+        _outputStream.delegate = nil;
+
+        // Remove the streams, right now, from the networkRunLoop
+        [_inputStream close];
+        [_outputStream close];
+    }
+
+    // Cleanup selfRetain in the same GCD queue as usual
+    dispatch_async(_workQueue, ^{
+        self->_selfRetain = nil;
+    });
+}
+
+
+static const char CRLFCRLFBytes[] = {'\r', '\n', '\r', '\n'};
+
+- (void)_readUntilHeaderCompleteWithCallback:(data_callback)dataHandler;
+{
+    [self _readUntilBytes:CRLFCRLFBytes length:sizeof(CRLFCRLFBytes) callback:dataHandler];
+}
+
+- (void)_readUntilBytes:(const void *)bytes length:(size_t)length callback:(data_callback)dataHandler;
+{
+    // TODO optimize so this can continue from where we last searched
+    stream_scanner consumer = ^size_t(NSData *data) {
+        __block size_t found_size = 0;
+        __block size_t match_count = 0;
+
+        size_t size = data.length;
+        const unsigned char *buffer = data.bytes;
+        for (int i = 0; i < size; i++ ) {
+            if (((const unsigned char *)buffer)[i] == ((const unsigned char *)bytes)[match_count]) {
+                match_count += 1;
+                if (match_count == length) {
+                    found_size = i + 1;
+                    break;
+                }
+            } else {
+                match_count = 0;
+            }
+        }
+        return found_size;
+    };
+    [self _addConsumerWithScanner:consumer callback:dataHandler];
+}
+
+
+// Returns true if did work
+- (BOOL)_innerPumpScanner {
+
+    BOOL didWork = NO;
+
+    if (self.readyState >= SR_CLOSING) {
+        return didWork;
+    }
+
+    if (!_consumers.count) {
+        return didWork;
+    }
+
+    size_t curSize = _readBuffer.length - _readBufferOffset;
+    if (!curSize) {
+        return didWork;
+    }
+
+    FSRIOConsumer *consumer = [_consumers objectAtIndex:0];
+
+    size_t bytesNeeded = consumer.bytesNeeded;
+
+    size_t foundSize = 0;
+    if (consumer.consumer) {
+        NSData *tempView = [NSData dataWithBytesNoCopy:(char *)_readBuffer.bytes + _readBufferOffset length:_readBuffer.length - _readBufferOffset freeWhenDone:NO];
+        foundSize = consumer.consumer(tempView);
+    } else {
+        assert(consumer.bytesNeeded);
+        if (curSize >= bytesNeeded) {
+            foundSize = bytesNeeded;
+        } else if (consumer.readToCurrentFrame) {
+            foundSize = curSize;
+        }
+    }
+
+    NSData *slice = nil;
+    if (consumer.readToCurrentFrame || foundSize) {
+        NSRange sliceRange = NSMakeRange(_readBufferOffset, foundSize);
+        slice = [_readBuffer subdataWithRange:sliceRange];
+
+        _readBufferOffset += foundSize;
+
+        if (_readBufferOffset > 4096 && _readBufferOffset > (_readBuffer.length >> 1)) {
+            _readBuffer = [[NSMutableData alloc] initWithBytes:(char *)_readBuffer.bytes + _readBufferOffset length:_readBuffer.length - _readBufferOffset];            _readBufferOffset = 0;
+        }
+
+        if (consumer.unmaskBytes) {
+            NSMutableData *mutableSlice = [slice mutableCopy];
+
+            NSUInteger len = mutableSlice.length;
+            uint8_t *bytes = mutableSlice.mutableBytes;
+
+            for (int i = 0; i < len; i++) {
+                bytes[i] = bytes[i] ^ _currentReadMaskKey[_currentReadMaskOffset % sizeof(_currentReadMaskKey)];
+                _currentReadMaskOffset += 1;
+            }
+
+            slice = mutableSlice;
+        }
+
+        if (consumer.readToCurrentFrame) {
+            [_currentFrameData appendData:slice];
+
+            _readOpCount += 1;
+
+            if (_currentFrameOpcode == SROpCodeTextFrame) {
+                // Validate UTF8 stuff.
+                size_t currentDataSize = _currentFrameData.length;
+                if (_currentFrameOpcode == SROpCodeTextFrame && currentDataSize > 0) {
+                    // TODO: Optimize the crap out of this.  Don't really have to copy all the data each time
+
+                    size_t scanSize = currentDataSize - _currentStringScanPosition;
+
+                    NSData *scan_data = [_currentFrameData subdataWithRange:NSMakeRange(_currentStringScanPosition, scanSize)];
+                    int32_t valid_utf8_size = validate_dispatch_data_partial_string(scan_data);
+
+                    if (valid_utf8_size == -1) {
+                        [self closeWithCode:SRStatusCodeInvalidUTF8 reason:@"Text frames must be valid UTF-8"];
+                        dispatch_async(_workQueue, ^{
+                            [self _disconnect];
+                        });
+                        return didWork;
+                    } else {
+                        _currentStringScanPosition += valid_utf8_size;
+                    }
+                }
+
+            }
+
+            consumer.bytesNeeded -= foundSize;
+
+            if (consumer.bytesNeeded == 0) {
+                [_consumers removeObjectAtIndex:0];
+                consumer.handler(self, nil);
+                didWork = YES;
+            }
+        } else if (foundSize) {
+            [_consumers removeObjectAtIndex:0];
+            consumer.handler(self, slice);
+            didWork = YES;
+        }
+    }
+    return didWork;
+}
+
+-(void)_pumpScanner;
+{
+    [self assertOnWorkQueue];
+
+    if (!_isPumping) {
+        _isPumping = YES;
+    } else {
+        return;
+    }
+
+    while ([self _innerPumpScanner]) {
+
+    }
+
+    _isPumping = NO;
+}
+
+//#define NOMASK
+
+static const size_t SRFrameHeaderOverhead = 32;
+
+- (void)_sendFrameWithOpcode:(FSROpCode)opcode data:(id)data;
+{
+    [self assertOnWorkQueue];
+
+    if (data == nil) {
+        return;
+    }
+
+    NSAssert([data isKindOfClass:[NSData class]] || [data isKindOfClass:[NSString class]], @"Function expects nil, NSString or NSData");
+
+    size_t payloadLength = [data isKindOfClass:[NSString class]] ? [(NSString *)data lengthOfBytesUsingEncoding:NSUTF8StringEncoding] : [data length];
+
+    NSMutableData *frame = [[NSMutableData alloc] initWithLength:payloadLength + SRFrameHeaderOverhead];
+    if (!frame) {
+        [self closeWithCode:SRStatusCodeMessageTooBig reason:@"Message too big"];
+        return;
+    }
+    uint8_t *frame_buffer = (uint8_t *)[frame mutableBytes];
+
+    // set fin
+    frame_buffer[0] = SRFinMask | opcode;
+
+    BOOL useMask = YES;
+
+#endif  // !TARGET_OS_WATCH
+#ifdef NOMASK
+    useMask = NO;
+#endif
+#if !TARGET_OS_WATCH
+
+    if (useMask) {
+    // set the mask and header
+        frame_buffer[1] |= SRMaskMask;
+    }
+
+    size_t frame_buffer_size = 2;
+
+    const uint8_t *unmasked_payload = NULL;
+    if ([data isKindOfClass:[NSData class]]) {
+        unmasked_payload = (uint8_t *)[data bytes];
+    } else if ([data isKindOfClass:[NSString class]]) {
+        unmasked_payload =  (const uint8_t *)[data UTF8String];
+    } else {
+        assert(NO);
+    }
+
+    if (payloadLength < 126) {
+        frame_buffer[1] |= payloadLength;
+    } else if (payloadLength <= UINT16_MAX) {
+        frame_buffer[1] |= 126;
+        *((uint16_t *)(frame_buffer + frame_buffer_size)) = EndianU16_BtoN((uint16_t)payloadLength);
+        frame_buffer_size += sizeof(uint16_t);
+    } else {
+        frame_buffer[1] |= 127;
+        *((uint64_t *)(frame_buffer + frame_buffer_size)) = EndianU64_BtoN((uint64_t)payloadLength);
+        frame_buffer_size += sizeof(uint64_t);
+    }
+
+    if (!useMask) {
+        for (int i = 0; i < payloadLength; i++) {
+            frame_buffer[frame_buffer_size] = unmasked_payload[i];
+            frame_buffer_size += 1;
+        }
+    } else {
+        uint8_t *mask_key = frame_buffer + frame_buffer_size;
+        int __unused result =
+                  SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), (uint8_t *)mask_key);
+        assert(result == 0);
+        frame_buffer_size += sizeof(uint32_t);
+
+        // TODO: could probably optimize this with SIMD
+        for (int i = 0; i < payloadLength; i++) {
+            frame_buffer[frame_buffer_size] = unmasked_payload[i] ^ mask_key[i % sizeof(uint32_t)];
+            frame_buffer_size += 1;
+        }
+    }
+
+    assert(frame_buffer_size <= [frame length]);
+    frame.length = frame_buffer_size;
+
+    [self _writeData:frame];
+}
+
+- (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode;
+{
+    __weak __typeof__(self) weakSelf = self;
+
+    // turn on keep-alive for the output stream.
+    if (eventCode == NSStreamEventOpenCompleted && aStream == _outputStream) {
+        CFDataRef socketData = CFWriteStreamCopyProperty((CFWriteStreamRef)_outputStream, kCFStreamPropertySocketNativeHandle);
+        // In rare cases socketData might be nil (there are crash reports out there), in which case we'll have to just
+        // live without keep-alive :(
+        if (socketData != nil) {
+            CFSocketNativeHandle socket;
+            CFDataGetBytes(socketData, CFRangeMake(0, sizeof(CFSocketNativeHandle)), (UInt8 *)&socket);
+            CFRelease(socketData);
+
+            int keepAliveOn = 1;
+            if (setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &keepAliveOn, sizeof(keepAliveOn)) == -1) {
+                SRFastLog(@"Failed to turn on TCP keepalive for websocket");
+            }
+        }
+    }
+
+    if (_secure && !_pinnedCertFound && (eventCode == NSStreamEventHasBytesAvailable || eventCode == NSStreamEventHasSpaceAvailable)) {
+
+        NSArray *sslCerts = [_urlRequest FSR_SSLPinnedCertificates];
+        if (sslCerts) {
+            SecTrustRef secTrust = (__bridge SecTrustRef)[aStream propertyForKey:(__bridge id)kCFStreamPropertySSLPeerTrust];
+            if (secTrust) {
+                NSInteger numCerts = SecTrustGetCertificateCount(secTrust);
+                for (NSInteger i = 0; i < numCerts && !_pinnedCertFound; i++) {
+                    SecCertificateRef cert = SecTrustGetCertificateAtIndex(secTrust, i);
+                    NSData *certData = CFBridgingRelease(SecCertificateCopyData(cert));
+
+                    for (id ref in sslCerts) {
+                        SecCertificateRef trustedCert = (__bridge SecCertificateRef)ref;
+                        NSData *trustedCertData = CFBridgingRelease(SecCertificateCopyData(trustedCert));
+
+                        if ([trustedCertData isEqualToData:certData]) {
+                            _pinnedCertFound = YES;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!_pinnedCertFound) {
+                dispatch_async(_workQueue, ^{
+                    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : @"Invalid server cert" };
+                    [weakSelf _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:23556 userInfo:userInfo]];
+                });
+                return;
+            }
+        }
+    }
+
+    //    SRFastLog(@"%@ Got stream event %d", aStream, eventCode);
+    dispatch_async(_workQueue, ^{
+        [weakSelf safeHandleEvent:eventCode stream:aStream];
+    });
+}
+
+- (void)safeHandleEvent:(NSStreamEvent)eventCode stream:(NSStream *)aStream
+{
+    switch (eventCode) {
+        case NSStreamEventOpenCompleted: {
+            SRFastLog(@"NSStreamEventOpenCompleted %@", aStream);
+            if (self.readyState >= SR_CLOSING) {
+                return;
+            }
+
+
+            assert(_readBuffer);
+
+            if (self.readyState == SR_CONNECTING && aStream == _inputStream) {
+                [self didConnect];
+            }
+            [self _pumpWriting];
+            [self _pumpScanner];
+            break;
+        }
+
+        case NSStreamEventErrorOccurred: {
+            // Note: The upstream code for SocketRocket logs the error message, but this causes
+            // crashes on iOS 13 (https://github.com/firebase/firebase-ios-sdk/issues/3950)
+            SRFastLog(@"NSStreamEventErrorOccurred %@", aStream);
+            /// TODO specify error better!
+                    [self _failWithError:aStream.streamError];
+            _readBufferOffset = 0;
+            [_readBuffer setLength:0];
+            break;
+
+        }
+
+        case NSStreamEventEndEncountered: {
+            [self _pumpScanner];
+            SRFastLog(@"NSStreamEventEndEncountered %@", aStream);
+            if (aStream.streamError) {
+                [self _failWithError:aStream.streamError];
+            } else {
+                dispatch_async(_workQueue, ^{
+                    if (self.readyState != SR_CLOSED) {
+                        self.readyState = SR_CLOSED;
+                        [self _scheduleCleanup];
+                    }
+
+                    if (!self->_sentClose && !self->_failed) {
+                        self->_sentClose = YES;
+                        // If we get closed in this state it's probably not clean because we should be sending this when we send messages
+                        [self _performDelegateBlock:^{
+                            if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
+                                [self.delegate webSocket:self didCloseWithCode:0 reason:@"Stream end encountered" wasClean:NO];
+                            }
+                        }];
+                    }
+                });
+            }
+
+            break;
+        }
+
+        case NSStreamEventHasBytesAvailable: {
+            SRFastLog(@"NSStreamEventHasBytesAvailable %@", aStream);
+
+            #define FSRWEB_SOCKET_BUFFER_SIZE 2048
+            uint8_t buffer[FSRWEB_SOCKET_BUFFER_SIZE];
+
+
+            while (_inputStream.hasBytesAvailable) {
+                NSInteger bytes_read = [_inputStream read:buffer maxLength:FSRWEB_SOCKET_BUFFER_SIZE];
+
+                if (bytes_read > 0) {
+                    [_readBuffer appendBytes:buffer length:bytes_read];
+                } else if (bytes_read < 0) {
+                    [self _failWithError:_inputStream.streamError];
+                }
+
+                if (bytes_read != FSRWEB_SOCKET_BUFFER_SIZE) {
+                    break;
+                }
+            };
+            [self _pumpScanner];
+            break;
+        }
+
+        case NSStreamEventHasSpaceAvailable: {
+            SRFastLog(@"NSStreamEventHasSpaceAvailable %@", aStream);
+            [self _pumpWriting];
+            break;
+        }
+
+        default:
+            SRFastLog(@"(default)  %@", aStream);
+            break;
+    }
+}
+
+@end
+
+
+@implementation FSRIOConsumer
+
+@synthesize bytesNeeded = _bytesNeeded;
+@synthesize consumer = _scanner;
+@synthesize handler = _handler;
+@synthesize readToCurrentFrame = _readToCurrentFrame;
+@synthesize unmaskBytes = _unmaskBytes;
+
+- (void)setupWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+{
+    _scanner = [scanner copy];
+    _handler = [handler copy];
+    _bytesNeeded = bytesNeeded;
+    _readToCurrentFrame = readToCurrentFrame;
+    _unmaskBytes = unmaskBytes;
+    assert(_scanner || _bytesNeeded);
+}
+
+@end
+
+@implementation FSRIOConsumerPool {
+    NSUInteger _poolSize;
+    NSMutableArray *_bufferedConsumers;
+}
+
+- (id)initWithBufferCapacity:(NSUInteger)poolSize;
+{
+    self = [super init];
+    if (self) {
+        _poolSize = poolSize;
+        _bufferedConsumers = [[NSMutableArray alloc] initWithCapacity:poolSize];
+    }
+    return self;
+}
+
+- (id)init
+{
+    return [self initWithBufferCapacity:8];
+}
+
+- (FSRIOConsumer *)consumerWithScanner:(stream_scanner)scanner handler:(data_callback)handler bytesNeeded:(size_t)bytesNeeded readToCurrentFrame:(BOOL)readToCurrentFrame unmaskBytes:(BOOL)unmaskBytes;
+{
+    FSRIOConsumer *consumer = nil;
+    if (_bufferedConsumers.count) {
+        consumer = [_bufferedConsumers lastObject];
+        [_bufferedConsumers removeLastObject];
+    } else {
+        consumer = [[FSRIOConsumer alloc] init];
+    }
+
+    [consumer setupWithScanner:scanner handler:handler bytesNeeded:bytesNeeded readToCurrentFrame:readToCurrentFrame unmaskBytes:unmaskBytes];
+
+    return consumer;
+}
+
+- (void)returnConsumer:(FSRIOConsumer *)consumer;
+{
+    if (_bufferedConsumers.count < _poolSize) {
+        [_bufferedConsumers addObject:consumer];
+    }
+}
+
+@end
+
+@implementation  NSURLRequest (FCertificateAdditions)
+
+- (NSArray *)FSR_SSLPinnedCertificates;
+{
+    return [NSURLProtocol propertyForKey:@"FSR_SSLPinnedCertificates" inRequest:self];
+}
+
+@end
+
+@implementation  NSMutableURLRequest (FCertificateAdditions)
+
+- (NSArray *)FSR_SSLPinnedCertificates;
+{
+    return [NSURLProtocol propertyForKey:@"FSR_SSLPinnedCertificates" inRequest:self];
+}
+
+- (void)setFSR_SSLPinnedCertificates:(NSArray *)FSR_SSLPinnedCertificates;
+{
+    [NSURLProtocol setProperty:FSR_SSLPinnedCertificates forKey:@"FSR_SSLPinnedCertificates" inRequest:self];
+}
+
+@end
+
+@implementation NSURL (FSRWebSocket)
+
+- (NSString *)SR_origin;
+{
+    NSString *scheme = [self.scheme lowercaseString];
+
+    if ([scheme isEqualToString:@"wss"]) {
+        scheme = @"https";
+    } else if ([scheme isEqualToString:@"ws"]) {
+        scheme = @"http";
+    }
+
+    if (self.port != nil) {
+        return [NSString stringWithFormat:@"%@://%@:%@/", scheme, self.host, self.port];
+    } else {
+        return [NSString stringWithFormat:@"%@://%@/", scheme, self.host];
+    }
+}
+
+@end
+
+// #define SR_ENABLE_LOG
+
+static inline void SRFastLog(NSString *format, ...)  {
+#ifdef SR_ENABLE_LOG
+    __block va_list arg_list;
+    va_start (arg_list, format);
+
+    NSString *formattedString = [[NSString alloc] initWithFormat:format arguments:arg_list];
+
+    va_end(arg_list);
+
+    NSLog(@"[SR] %@", formattedString);
+#endif
+}
+
+
+#ifdef HAS_ICU
+
+static inline int32_t validate_dispatch_data_partial_string(NSData *data) {
+
+    const void * contents = [data bytes];
+    long size = [data length];
+
+    const uint8_t *str = (const uint8_t *)contents;
+
+
+    UChar32 codepoint = 1;
+    int32_t offset = 0;
+    int32_t lastOffset = 0;
+    while(offset < size && codepoint > 0)  {
+        lastOffset = offset;
+        U8_NEXT(str, offset, size, codepoint);
+    }
+
+    if (codepoint == -1) {
+        // Check to see if the last byte is valid or whether it was just continuing
+        if (!U8_IS_LEAD(str[lastOffset]) || U8_COUNT_TRAIL_BYTES(str[lastOffset]) + lastOffset < (int32_t)size) {
+
+            size = -1;
+        } else {
+            uint8_t leadByte = str[lastOffset];
+            U8_MASK_LEAD_BYTE(leadByte, U8_COUNT_TRAIL_BYTES(leadByte));
+
+            for (int i = lastOffset + 1; i < offset; i++) {
+
+                if (U8_IS_SINGLE(str[i]) || U8_IS_LEAD(str[i]) || !U8_IS_TRAIL(str[i])) {
+                    size = -1;
+                }
+            }
+
+            if (size != -1) {
+                size = lastOffset;
+            }
+        }
+    }
+
+    if (size != -1 && ![[NSString alloc] initWithBytesNoCopy:(char *)[data bytes] length:size encoding:NSUTF8StringEncoding freeWhenDone:NO]) {
+        size = -1;
+    }
+
+    return (int32_t)size;
+}
+
+#else
+
+// This is a hack, and probably not optimal
+static inline int32_t validate_dispatch_data_partial_string(NSData *data) {
+    static const int maxCodepointSize = 3;
+
+    for (int i = 0; i < maxCodepointSize; i++) {
+        NSString *str = [[NSString alloc] initWithBytesNoCopy:(char *)data.bytes length:data.length - i encoding:NSUTF8StringEncoding freeWhenDone:NO];
+        if (str) {
+            return (int)(data.length - i);
+        }
+    }
+
+    return -1;
+}
+
+#endif
+
+static _FSRRunLoopThread *networkThread = nil;
+static NSRunLoop *networkRunLoop = nil;
+
+@implementation NSRunLoop (FSRWebSocket)
+
++ (NSRunLoop *)FSR_networkRunLoop {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        networkThread = [[_FSRRunLoopThread alloc] init];
+        networkThread.name = @"com.squareup.SocketRocket.NetworkThread";
+        networkThread.qualityOfService = NSQualityOfServiceUserInitiated;
+        [networkThread start];
+        networkRunLoop = networkThread.runLoop;
+    });
+
+    return networkRunLoop;
+}
+
+@end
+
+
+@implementation _FSRRunLoopThread {
+    dispatch_group_t _waitGroup;
+}
+
+@synthesize runLoop = _runLoop;
+
+- (void)dealloc
+{
+    sr_dispatch_release(_waitGroup);
+}
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        _waitGroup = dispatch_group_create();
+        dispatch_group_enter(_waitGroup);
+    }
+    return self;
+}
+
+
+/**
+ * This is the main method of the thread on which the socket events are scheduled in a run loop.
+ */
+- (void)main;
+{
+    @autoreleasepool {
+        _runLoop = [NSRunLoop currentRunLoop];
+        dispatch_group_leave(_waitGroup);
+
+        // Add an empty run loop source to prevent runloop from spinning.
+        CFRunLoopSourceContext sourceCtx = {
+            .version = 0,
+            .info = NULL,
+            .retain = NULL,
+            .release = NULL,
+            .copyDescription = NULL,
+            .equal = NULL,
+            .hash = NULL,
+            .schedule = NULL,
+            .cancel = NULL,
+            .perform = NULL
+        };
+        CFRunLoopSourceRef source = CFRunLoopSourceCreate(NULL, 0, &sourceCtx);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
+        CFRelease(source);
+
+        while ([_runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]) {
+
+        }
+        assert(NO);
+    }
+}
+
+- (NSRunLoop *)runLoop;
+{
+    dispatch_group_wait(_waitGroup, DISPATCH_TIME_FOREVER);
+    return _runLoop;
+}
+
+@end
+#endif  // TARGET_OS_WATCH

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/LICENSE
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/LICENSE
@@ -1,0 +1,53 @@
+Copyright 2012 Square Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+$OpenBSD: base64.c,v 1.5 2006/10/21 09:55:03 otto Exp $
+
+Copyright (c) 1996 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+Portions Copyright (c) 1995 by International Business Machines, Inc.
+
+International Business Machines, Inc. (hereinafter called IBM) grants
+permission under its copyrights to use, copy, modify, and distribute this
+Software with or without fee, provided that the above copyright notice and
+all paragraphs of this notice appear in all copies, and that the name of IBM
+not be used in connection with the marketing of any product incorporating
+the Software or modifications thereof, without specific, written prior
+permission.
+
+To the extent it has a right to do so, IBM grants an immunity from suit
+under its patents, if any, for the use, sale or manufacture of products to
+the extent that such products are used for performing Domain Name System
+dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+granted for any product per se or for any other function of any product.
+
+THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.h
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.h
@@ -1,0 +1,23 @@
+//
+//   Copyright 2012 Square Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface FSRUtilities : NSObject
+
++ (NSString *)base64EncodedStringFromData:(NSData *)data;
+
+@end

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.m
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.m
@@ -1,0 +1,37 @@
+//
+//   Copyright 2012 Square Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/NSData+SRB64Additions.h"
+#import "FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.h"
+
+@implementation FSRUtilities
+
++ (NSString *)base64EncodedStringFromData:(NSData *)data {
+    size_t buffer_size = ((data.length * 3 + 2) / 2);
+
+    char *buffer = (char *)malloc(buffer_size);
+
+    int len = f_b64_ntop(data.bytes, data.length, buffer, buffer_size);
+
+    if (len == -1) {
+        free(buffer);
+        return nil;
+    } else{
+        return [[NSString alloc] initWithBytesNoCopy:buffer length:len encoding:NSUTF8StringEncoding freeWhenDone:YES];
+    }
+}
+
+@end

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/aa2297808c225710e267afece4439c256f6efdb3
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/aa2297808c225710e267afece4439c256f6efdb3
@@ -1,0 +1,3 @@
+Fri Aug  3 15:45:39 PDT 2012
+Github commit: aa2297808c225710e267afece4439c256f6efdb3
+

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.c
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.c
@@ -1,0 +1,318 @@
+/*	$OpenBSD: base64.c,v 1.5 2006/10/21 09:55:03 otto Exp $	*/
+
+/*
+ * Copyright (c) 1996 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+/*
+ * Portions Copyright (c) 1995 by International Business Machines, Inc.
+ *
+ * International Business Machines, Inc. (hereinafter called IBM) grants
+ * permission under its copyrights to use, copy, modify, and distribute this
+ * Software with or without fee, provided that the above copyright notice and
+ * all paragraphs of this notice appear in all copies, and that the name of IBM
+ * not be used in connection with the marketing of any product incorporating
+ * the Software or modifications thereof, without specific, written prior
+ * permission.
+ *
+ * To the extent it has a right to do so, IBM grants an immunity from suit
+ * under its patents, if any, for the use, sale or manufacture of products to
+ * the extent that such products are used for performing Domain Name System
+ * dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+ * granted for any product per se or for any other function of any product.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+ * DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+ * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/net/base64.c */
+
+
+//
+//   Distributed with modifications by Firebase ( https://www.firebase.com )
+//
+
+#if (!defined(HAVE_B64_NTOP) && !defined(HAVE___B64_NTOP)) || (!defined(HAVE_B64_PTON) && !defined(HAVE___B64_PTON))
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <ctype.h>
+#include <stdio.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.h"
+
+static const char Base64[] =
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char Pad64 = '=';
+
+/* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
+ The following encoding technique is taken from RFC 1521 by Borenstein
+ and Freed.  It is reproduced here in a slightly edited form for
+ convenience.
+
+ A 65-character subset of US-ASCII is used, enabling 6 bits to be
+ represented per printable character. (The extra 65th character, "=",
+ is used to signify a special processing function.)
+
+ The encoding process represents 24-bit groups of input bits as output
+ strings of 4 encoded characters. Proceeding from left to right, a
+ 24-bit input group is formed by concatenating 3 8-bit input groups.
+ These 24 bits are then treated as 4 concatenated 6-bit groups, each
+ of which is translated into a single digit in the base64 alphabet.
+
+ Each 6-bit group is used as an index into an array of 64 printable
+ characters. The character referenced by the index is placed in the
+ output string.
+
+ Table 1: The Base64 Alphabet
+
+ Value Encoding  Value Encoding  Value Encoding  Value Encoding
+ 0 A            17 R            34 i            51 z
+ 1 B            18 S            35 j            52 0
+ 2 C            19 T            36 k            53 1
+ 3 D            20 U            37 l            54 2
+ 4 E            21 V            38 m            55 3
+ 5 F            22 W            39 n            56 4
+ 6 G            23 X            40 o            57 5
+ 7 H            24 Y            41 p            58 6
+ 8 I            25 Z            42 q            59 7
+ 9 J            26 a            43 r            60 8
+ 10 K            27 b            44 s            61 9
+ 11 L            28 c            45 t            62 +
+ 12 M            29 d            46 u            63 /
+ 13 N            30 e            47 v
+ 14 O            31 f            48 w         (pad) =
+ 15 P            32 g            49 x
+ 16 Q            33 h            50 y
+
+ Special processing is performed if fewer than 24 bits are available
+ at the end of the data being encoded.  A full encoding quantum is
+ always completed at the end of a quantity.  When fewer than 24 input
+ bits are available in an input group, zero bits are added (on the
+ right) to form an integral number of 6-bit groups.  Padding at the
+ end of the data is performed using the '=' character.
+
+ Since all base64 input is an integral number of octets, only the
+ -------------------------------------------------
+ following cases can arise:
+
+ (1) the final quantum of encoding input is an integral
+ multiple of 24 bits; here, the final unit of encoded
+ output will be an integral multiple of 4 characters
+ with no "=" padding,
+ (2) the final quantum of encoding input is exactly 8 bits;
+ here, the final unit of encoded output will be two
+ characters followed by two "=" padding characters, or
+ (3) the final quantum of encoding input is exactly 16 bits;
+ here, the final unit of encoded output will be three
+ characters followed by one "=" padding character.
+ */
+
+#if !defined(HAVE_B64_NTOP) && !defined(HAVE___B64_NTOP)
+int
+f_b64_ntop(u_char const *src, size_t srclength, char *target, size_t targsize)
+{
+    size_t datalength = 0;
+	u_char input[3];
+	u_char output[4];
+	u_int i;
+
+	while (2 < srclength) {
+		input[0] = *src++;
+		input[1] = *src++;
+		input[2] = *src++;
+		srclength -= 3;
+
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[3] = input[2] & 0x3f;
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		target[datalength++] = Base64[output[2]];
+		target[datalength++] = Base64[output[3]];
+	}
+
+	/* Now we worry about padding. */
+	if (0 != srclength) {
+		/* Get what's left. */
+		input[0] = input[1] = input[2] = '\0';
+		for (i = 0; i < srclength; i++)
+			input[i] = *src++;
+
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		if (srclength == 1)
+			target[datalength++] = Pad64;
+		else
+			target[datalength++] = Base64[output[2]];
+		target[datalength++] = Pad64;
+	}
+	if (datalength >= targsize)
+		return (-1);
+	target[datalength] = '\0';	/* Returned value doesn't count \0. */
+	return (int)(datalength);
+}
+#endif /* !defined(HAVE_B64_NTOP) && !defined(HAVE___B64_NTOP) */
+
+#if !defined(HAVE_B64_PTON) && !defined(HAVE___B64_PTON)
+
+/* skips all whitespace anywhere.
+ converts characters, four at a time, starting at (or after)
+ src from base - 64 numbers into three 8 bit bytes in the target area.
+ it returns the number of data bytes stored at the target, or -1 on error.
+ */
+
+int
+f_b64_pton(char const *src, u_char *target, size_t targsize)
+{
+	u_int tarindex, state;
+	int ch;
+	char *pos;
+
+	state = 0;
+	tarindex = 0;
+
+	while ((ch = *src++) != '\0') {
+		if (isspace(ch))	/* Skip whitespace anywhere. */
+			continue;
+
+		if (ch == Pad64)
+			break;
+
+		pos = strchr(Base64, ch);
+		if (pos == 0) 		/* A non-base64 character. */
+			return (-1);
+
+		switch (state) {
+            case 0:
+                if (target) {
+                    if (tarindex >= targsize)
+                        return (-1);
+                    target[tarindex] = (pos - Base64) << 2;
+                }
+                state = 1;
+                break;
+            case 1:
+                if (target) {
+                    if (tarindex + 1 >= targsize)
+                        return (-1);
+                    target[tarindex]   |=  (pos - Base64) >> 4;
+                    target[tarindex+1]  = ((pos - Base64) & 0x0f)
+                    << 4 ;
+                }
+                tarindex++;
+                state = 2;
+                break;
+            case 2:
+                if (target) {
+                    if (tarindex + 1 >= targsize)
+                        return (-1);
+                    target[tarindex]   |=  (pos - Base64) >> 2;
+                    target[tarindex+1]  = ((pos - Base64) & 0x03)
+                    << 6;
+                }
+                tarindex++;
+                state = 3;
+                break;
+            case 3:
+                if (target) {
+                    if (tarindex >= targsize)
+                        return (-1);
+                    target[tarindex] |= (pos - Base64);
+                }
+                tarindex++;
+                state = 0;
+                break;
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+            case 0:		/* Invalid = in first position */
+            case 1:		/* Invalid = in second position */
+                return (-1);
+
+            case 2:		/* Valid, means one byte of info */
+                /* Skip any number of spaces. */
+                for (; ch != '\0'; ch = *src++)
+                    if (!isspace(ch))
+                        break;
+                /* Make sure there is another trailing = sign. */
+                if (ch != Pad64)
+                    return (-1);
+                ch = *src++;		/* Skip the = */
+                /* Fall through to "single trailing =" case. */
+                /* FALLTHROUGH */
+
+            case 3:		/* Valid, means two bytes of info */
+                /*
+                 * We know this char is an =.  Is there anything but
+                 * whitespace after it?
+                 */
+                for (; ch != '\0'; ch = *src++)
+                    if (!isspace(ch))
+                        return (-1);
+
+                /*
+                 * Now make sure for cases 2 and 3 that the "extra"
+                 * bits that slopped past the last full byte were
+                 * zeros.  If we don't check them, they become a
+                 * subliminal channel.
+                 */
+                if (target && target[tarindex] != 0)
+                    return (-1);
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+
+#endif /* !defined(HAVE_B64_PTON) && !defined(HAVE___B64_PTON) */
+#endif

--- a/FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.h
+++ b/FirebaseDatabase/Sources/third_party/SocketRocket/fbase64.h
@@ -1,0 +1,33 @@
+//   Copyright 2012 Square Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+#ifndef FSocketRocket_base64_h
+#define FSocketRocket_base64_h
+
+#include <sys/types.h>
+
+extern int
+f_b64_ntop(u_char const *src,
+         size_t srclength,
+         char *target,
+         size_t targsize);
+
+extern int
+f_b64_pton(char const *src,
+         u_char *target,
+         size_t targsize);
+
+
+#endif

--- a/FirebaseDatabase/Tests/Integration/FData.m
+++ b/FirebaseDatabase/Tests/Integration/FData.m
@@ -2197,7 +2197,9 @@ XCTAssertTrue([target isEqualTo:recvd], @"Expected %@ to match %@", target, recv
   }];
 }
 
-- (void)testUpdateReplacesChildrenAndIsNotRecursive {
+// TODO: On arm hardware Macs, the following test hangs with the emulator, but passes with a real
+// project.
+- (void)SKIPtestUpdateReplacesChildrenAndIsNotRecursive {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *reader = refs.one;
   FIRDatabaseReference *writer = refs.two;

--- a/FirebaseDatabase/Tests/Integration/FData.m
+++ b/FirebaseDatabase/Tests/Integration/FData.m
@@ -2197,9 +2197,7 @@ XCTAssertTrue([target isEqualTo:recvd], @"Expected %@ to match %@", target, recv
   }];
 }
 
-// TODO: On arm hardware Macs, the following test hangs with the emulator, but passes with a real
-// project.
-- (void)SKIPtestUpdateReplacesChildrenAndIsNotRecursive {
+- (void)testUpdateReplacesChildrenAndIsNotRecursive {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *reader = refs.one;
   FIRDatabaseReference *writer = refs.two;

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
@@ -4419,9 +4419,7 @@
   }
 }
 
-// TODO: On arm hardware Macs, the following test hangs with the emulator, but passes with a real
-// project.
-- (void)SKIPtestGetSkipsPersistenceCacheWhenOnline {
+- (void)testGetSkipsPersistenceCacheWhenOnline {
   FIRDatabase* db = [self databaseForURL:self.databaseURL name:[[NSUUID UUID] UUIDString]];
   FIRDatabase* db2 = [self databaseForURL:self.databaseURL name:[[NSUUID UUID] UUIDString]];
 

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let firebaseVersion = "11.9.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v12), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
+  platforms: [.iOS(.v12), .macCatalyst(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",
@@ -414,7 +414,10 @@ let package = Package(
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
       ],
-      path: "FirebaseAuth/Sources/Swift",
+      path: "FirebaseAuth/Sources",
+      exclude: [
+        "ObjC", "Public",
+      ],
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       swiftSettings: Context.environment["FIREBASE_CI"] != nil ? [.define("FIREBASE_CI")] : [],
       linkerSettings: [
@@ -429,7 +432,7 @@ let package = Package(
       ],
       path: "FirebaseAuth/Sources",
       exclude: [
-        "Swift",
+        "Swift", "Resources",
       ],
       publicHeadersPath: "Public",
       cSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let firebaseVersion = "11.9.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v12), .macCatalyst(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
+  platforms: [.iOS(.v12), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAnalytics",
@@ -414,10 +414,7 @@ let package = Package(
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
         .product(name: "GTMSessionFetcherCore", package: "gtm-session-fetcher"),
       ],
-      path: "FirebaseAuth/Sources",
-      exclude: [
-        "ObjC", "Public",
-      ],
+      path: "FirebaseAuth/Sources/Swift",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")],
       swiftSettings: Context.environment["FIREBASE_CI"] != nil ? [.define("FIREBASE_CI")] : [],
       linkerSettings: [
@@ -432,7 +429,7 @@ let package = Package(
       ],
       path: "FirebaseAuth/Sources",
       exclude: [
-        "Swift", "Resources",
+        "Swift",
       ],
       publicHeadersPath: "Public",
       cSettings: [
@@ -586,7 +583,9 @@ let package = Package(
       path: "FirebaseDatabase/Sources",
       exclude: [
         "third_party/Wrap-leveldb/LICENSE",
+        "third_party/SocketRocket/LICENSE",
         "third_party/FImmutableSortedDictionary/LICENSE",
+        "third_party/SocketRocket/aa2297808c225710e267afece4439c256f6efdb3",
       ],
       publicHeadersPath: "Public",
       cSettings: [


### PR DESCRIPTION
Fix connection failure issue introduced in 10.27.0 by restoring the Socket Rocket implementation instead of `NSURLSessionWebSocket`. 

Note that this may expose a Thread Performance Checker Warning (#12883)

Fixes #14188, #13877, #13855, #13529