### PR TITLE
[Vertex AI] Add Imagen warning for invalid JPEG compression quality

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImageFormat.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenImageFormat.swift
@@ -45,6 +45,12 @@ public struct ImagenImageFormat {
   ///     compression (lowest image quality, smallest file size) and `100` is the lowest level of
   ///     compression (highest image quality, largest file size); defaults to `75`.
   public static func jpeg(compressionQuality: Int? = nil) -> ImagenImageFormat {
+    if let compressionQuality, compressionQuality < 0 || compressionQuality > 100 {
+      VertexLog.warning(code: .imagenInvalidJPEGCompressionQuality, """
+      Invalid JPEG compression quality of \(compressionQuality) specified; the supported range is \
+      [0, 100].
+      """)
+    }
     return ImagenImageFormat(mimeType: "image/jpeg", compressionQuality: compressionQuality)
   }
 }

--- a/FirebaseVertexAI/Sources/VertexLog.swift
+++ b/FirebaseVertexAI/Sources/VertexLog.swift
@@ -31,8 +31,11 @@ enum VertexLog {
     // API Enablement Errors
     case vertexAIInFirebaseAPIDisabled = 200
 
-    // Model Configuration
+    // Generative Model Configuration
     case generativeModelInitialized = 1000
+
+    // Imagen Model Configuration
+    case imagenInvalidJPEGCompressionQuality = 1201
 
     // Network Errors
     case generativeAIServiceNonHTTPResponse = 2000


### PR DESCRIPTION
Added a warning log message if a value outside the range `[0, 100]` is specified for the JPEG compression quality in `ImagenImageFormat.jpeg(compressionQuality:)`. Values outside this range seem to be treated as 0 or 100 by the backend and were likely set by accident. See [b/395693541](https://b.corp.google.com/issues/395693541) (Google internal) for more details.

#14221
#no-changelog