### PR TITLE
[Vertex AI] Update integration tests to Gemini 2.0 Flash

### DIFF
--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -54,7 +54,7 @@ final class IntegrationTests: XCTestCase {
 
     vertex = VertexAI.vertexAI()
     model = vertex.generativeModel(
-      modelName: "gemini-1.5-flash",
+      modelName: "gemini-2.0-flash",
       generationConfig: generationConfig,
       safetySettings: safetySettings,
       tools: [],
@@ -80,7 +80,7 @@ final class IntegrationTests: XCTestCase {
     let app = try FirebaseApp.defaultNamedCopy(name: TestAppCheckProviderFactory.notConfiguredName)
     addTeardownBlock { await app.delete() }
     let vertex = VertexAI.vertexAI(app: app)
-    let model = vertex.generativeModel(modelName: "gemini-1.5-flash")
+    let model = vertex.generativeModel(modelName: "gemini-2.0-flash")
     let prompt = "Where is Google headquarters located? Answer with the city name only."
 
     do {
@@ -183,7 +183,7 @@ final class IntegrationTests: XCTestCase {
       parameters: ["x": .integer(), "y": .integer()]
     )
     model = vertex.generativeModel(
-      modelName: "gemini-1.5-flash",
+      modelName: "gemini-2.0-flash",
       tools: [.functionDeclarations([sumDeclaration])],
       toolConfig: .init(functionCallingConfig: .any(allowedFunctionNames: ["sum"]))
     )
@@ -203,7 +203,7 @@ final class IntegrationTests: XCTestCase {
 
   func testCountTokens_jsonSchema() async throws {
     model = vertex.generativeModel(
-      modelName: "gemini-1.5-flash",
+      modelName: "gemini-2.0-flash",
       generationConfig: GenerationConfig(
         responseMIMEType: "application/json",
         responseSchema: Schema.object(properties: [
@@ -226,7 +226,7 @@ final class IntegrationTests: XCTestCase {
     let app = try FirebaseApp.defaultNamedCopy(name: TestAppCheckProviderFactory.notConfiguredName)
     addTeardownBlock { await app.delete() }
     let vertex = VertexAI.vertexAI(app: app)
-    let model = vertex.generativeModel(modelName: "gemini-1.5-flash")
+    let model = vertex.generativeModel(modelName: "gemini-2.0-flash")
     let prompt = "Why is the sky blue?"
 
     do {


### PR DESCRIPTION
Updated the Vertex AI GenerativeModel integration tests to use `gemini-2.0-flash` instead of `gemini-1.5-flash`. Note: One test remains on `gemini-1.5-pro` since `gemini-2.0-pro` has not yet been released.

#no-changelog