### PR TITLE
firestore_exceptions.h: remove dependency on absl to set FIRESTORE_HAVE_EXCEPTIONS

### DIFF
--- a/Firestore/core/src/util/firestore_exceptions.h
+++ b/Firestore/core/src/util/firestore_exceptions.h
@@ -29,9 +29,10 @@
 
 #if defined(__ANDROID__)
 // The firebase-cpp-sdk has issues compiling Abseil on Android in some cases;
-// therefore, just use `__EXCEPTIONS`, which is known to be set by both clang
-// and gcc in Android NDK r16b. In the future, consider, instead, using
-// `__cpp_exceptions` when support for this old NDK version r16b is dropped.
+// therefore, use `__EXCEPTIONS`, which is known to be set by clang in Android
+// NDK r21e, instead of using `ABSL_HAVE_EXCEPTIONS`. In the future, consider
+// using `__cpp_exceptions` instead, as the internet seems to suggest that it
+// is more reliable with modern c++ compilers, such as those in NDK r21e.
 #if __EXCEPTIONS
 #define FIRESTORE_HAVE_EXCEPTIONS 1
 #endif

--- a/Firestore/core/src/util/firestore_exceptions.h
+++ b/Firestore/core/src/util/firestore_exceptions.h
@@ -27,11 +27,23 @@
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 
+#if defined(__ANDROID__)
+// The firebase-cpp-sdk has issues compiling Abseil on Android in some cases;
+// therefore, just use `__EXCEPTIONS`, which is known to be set by both clang
+// and gcc in Android NDK r16b. In the future, consider, instead, using
+// `__cpp_exceptions` when support for this old NDK version r16b is dropped.
+#if __EXCEPTIONS
+#define FIRESTORE_HAVE_EXCEPTIONS 1
+#endif
+
+#else  // !defined(__ANDROID__)
+// On any other supported platform, just take Abseil's word for it.
 #include "absl/base/config.h"
 
 #if ABSL_HAVE_EXCEPTIONS
 #define FIRESTORE_HAVE_EXCEPTIONS 1
 #endif
+#endif  // defined(__ANDROID__)
 
 namespace firebase {
 namespace firestore {


### PR DESCRIPTION
firebase-cpp-sdk has some issues compiling absl-dependent code on Android; therefore, remove the dependency on absl from firestore_exceptions.h, as it was before #14348.

See https://github.com/firebase/firebase-ios-sdk/pull/14348/files/1989942cffe222e986230c1539908a9fd105360c#r1950085884

#no-changelog