### PR TITLE
[VertexAI] Add support for token-based usage metrics

### DIFF
--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -30,10 +30,10 @@ public struct GenerateContentResponse: Sendable {
     public let totalTokenCount: Int
 
     /// The breakdown, by modality, of how many tokens are consumed by the prompt
-    public let promptTokensDetails: [ModalityTokenCount]?
+    public let promptTokensDetails: [ContentModality: ModalityTokenDetails]
 
     /// The breakdown, by modality, of how many tokens are consumed by the candidates
-    public let candidatesTokensDetails: [ModalityTokenCount]?
+    public let candidatesTokensDetails: [ContentModality: ModalityTokenDetails]
   }
 
   /// A list of candidate response content, ordered from best to worst.
@@ -315,10 +315,14 @@ extension GenerateContentResponse.UsageMetadata: Decodable {
     candidatesTokenCount = try container
       .decodeIfPresent(Int.self, forKey: .candidatesTokenCount) ?? 0
     totalTokenCount = try container.decodeIfPresent(Int.self, forKey: .totalTokenCount) ?? 0
-    promptTokensDetails = try container
-      .decodeIfPresent([ModalityTokenCount].self, forKey: .promptTokensDetails)
-    candidatesTokensDetails = try container
-      .decodeIfPresent([ModalityTokenCount].self, forKey: .candidatesTokensDetails)
+
+    let promptModalityTokenCounts = try container
+      .decodeIfPresent([ModalityTokenCount].self, forKey: .promptTokensDetails) ?? []
+    promptTokensDetails = promptModalityTokenCounts.asModalityTokenDetails()
+
+    let candidatesModalityTokenCounts = try container
+      .decodeIfPresent([ModalityTokenCount].self, forKey: .candidatesTokensDetails) ?? []
+    candidatesTokensDetails = candidatesModalityTokenCounts.asModalityTokenDetails()
   }
 }
 

--- a/FirebaseVertexAI/Sources/Types/Internal/ModalityTokenCount.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/ModalityTokenCount.swift
@@ -12,50 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
 /// Represents token counting info for a single modality.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct ModalityTokenCount: Sendable {
+struct ModalityTokenCount: Sendable {
   /// The modality associated with this token count.
-  public let modality: ContentModality
+  let modality: ContentModality
 
   /// The number of tokens counted.
-  public let tokenCount: Int
+  let tokenCount: Int
 }
 
-/// Content part modality.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct ContentModality: DecodableProtoEnum, Hashable, Sendable {
-  enum Kind: String {
-    case text = "TEXT"
-    case image = "IMAGE"
-    case video = "VIDEO"
-    case audio = "AUDIO"
-    case document = "DOCUMENT"
+extension [ModalityTokenCount] {
+  func asModalityTokenDetails() -> [ContentModality: ModalityTokenDetails] {
+    var modalityTokenDetails = [ContentModality: ModalityTokenDetails]()
+    for modalityTokenCount in self {
+      modalityTokenDetails[modalityTokenCount.modality] =
+        ModalityTokenDetails(tokenCount: modalityTokenCount.tokenCount)
+    }
+
+    return modalityTokenDetails
   }
-
-  /// Plain text.
-  public static let text = ContentModality(kind: .text)
-
-  /// Image.
-  public static let image = ContentModality(kind: .image)
-
-  /// Video.
-  public static let video = ContentModality(kind: .video)
-
-  /// Audio.
-  public static let audio = ContentModality(kind: .audio)
-
-  /// Document, e.g. PDF.
-  public static let document = ContentModality(kind: .document)
-
-  /// Returns the raw string representation of the `ContentModality` value.
-  public let rawValue: String
-
-  static let unrecognizedValueMessageCode =
-    VertexLog.MessageCode.generateContentResponseUnrecognizedContentModality
 }
+
+// MARK: - Codable Conformance
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ModalityTokenCount: Decodable {}

--- a/FirebaseVertexAI/Sources/Types/Public/ModalityTokenDetails.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/ModalityTokenDetails.swift
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Represents token counting info for a single modality.
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public struct ModalityTokenDetails: Sendable {
+  /// The number of tokens counted.
+  public let tokenCount: Int
+}
+
+/// Content part modality.
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public struct ContentModality: DecodableProtoEnum, Hashable, Sendable {
+  enum Kind: String {
+    case text = "TEXT"
+    case image = "IMAGE"
+    case video = "VIDEO"
+    case audio = "AUDIO"
+    case document = "DOCUMENT"
+  }
+
+  /// Plain text.
+  public static let text = ContentModality(kind: .text)
+
+  /// Image.
+  public static let image = ContentModality(kind: .image)
+
+  /// Video.
+  public static let video = ContentModality(kind: .video)
+
+  /// Audio.
+  public static let audio = ContentModality(kind: .audio)
+
+  /// Document, e.g. PDF.
+  public static let document = ContentModality(kind: .document)
+
+  /// Returns the raw string representation of the `ContentModality` value.
+  public let rawValue: String
+
+  static let unrecognizedValueMessageCode =
+    VertexLog.MessageCode.generateContentResponseUnrecognizedContentModality
+}

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -141,10 +141,17 @@ final class GenerativeModelTests: XCTestCase {
     let candidate = try XCTUnwrap(response.candidates.first)
     let finishReason = try XCTUnwrap(candidate.finishReason)
     XCTAssertEqual(finishReason, .stop)
-    XCTAssertEqual(response.usageMetadata?.promptTokensDetails?[0].modality, .image)
-    XCTAssertEqual(response.usageMetadata?.promptTokensDetails?[0].tokenCount, 1806)
-    XCTAssertEqual(response.usageMetadata?.candidatesTokensDetails?[0].modality, .text)
-    XCTAssertEqual(response.usageMetadata?.candidatesTokensDetails?[0].tokenCount, 76)
+    let usageMetadata = try XCTUnwrap(response.usageMetadata)
+    XCTAssertEqual(usageMetadata.promptTokensDetails[.text]?.tokenCount, 76)
+    XCTAssertEqual(usageMetadata.promptTokensDetails[.image]?.tokenCount, 1806)
+    XCTAssertNil(usageMetadata.promptTokensDetails[.audio])
+    XCTAssertNil(usageMetadata.promptTokensDetails[.video])
+    XCTAssertNil(usageMetadata.promptTokensDetails[.document])
+    XCTAssertEqual(usageMetadata.candidatesTokensDetails[.text]?.tokenCount, 76)
+    XCTAssertNil(usageMetadata.candidatesTokensDetails[.image])
+    XCTAssertNil(usageMetadata.candidatesTokensDetails[.audio])
+    XCTAssertNil(usageMetadata.candidatesTokensDetails[.video])
+    XCTAssertNil(usageMetadata.candidatesTokensDetails[.document])
   }
 
   func testGenerateContent_success_citations() async throws {
@@ -1355,10 +1362,11 @@ final class GenerativeModelTests: XCTestCase {
 
     XCTAssertEqual(response.totalTokens, 1837)
     XCTAssertEqual(response.totalBillableCharacters, 117)
-    XCTAssertEqual(response
-      .promptTokensDetails?[0].modality, ContentModality.image)
-    XCTAssertEqual(response
-      .promptTokensDetails?[0].tokenCount, 1806)
+    XCTAssertEqual(response.promptTokensDetails[.text]?.tokenCount, 31)
+    XCTAssertEqual(response.promptTokensDetails[.image]?.tokenCount, 1806)
+    XCTAssertNil(response.promptTokensDetails[.audio])
+    XCTAssertNil(response.promptTokensDetails[.video])
+    XCTAssertNil(response.promptTokensDetails[.document])
   }
 
   func testCountTokens_succeeds_allOptions() async throws {


### PR DESCRIPTION
WIP - do not merge

Prototype of `promptTokensDetails` and `candidatesTokensDetails` as dictionaries keyed by the `ContentModality` instead of an array. This may make it easier to inspect token counts for a specific modality.

#no-changelog