### PR TITLE
Migrate FCM codebase to new NSKeyedUnarchiver APIs.

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Migrate FCM codebase to new NSKeyedUnarchiver APIs. (#14424).
+
 # 11.8.0
 - [fixed] Don't cache FCM registration token operations. (#14352).
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -176,13 +176,13 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
     // users have upgraded to at least 10.19.0. Perhaps, after privacy manifests have been required
     // for awhile?
     @try {
-      [NSKeyedUnarchiver setClass:[FIRMessagingAPNSInfo class]
-                     forClassName:@"FIRInstanceIDAPNSInfo"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      rawAPNSInfo = [NSKeyedUnarchiver unarchiveObjectWithData:(NSData *)rawAPNSInfo];
+      NSKeyedUnarchiver *unarchiver =
+          [[NSKeyedUnarchiver alloc] initForReadingFromData:(NSData *)rawAPNSInfo error:nil];
+      unarchiver.requiresSecureCoding = NO;
+      [unarchiver setClass:[FIRMessagingAPNSInfo class] forClassName:@"FIRInstanceIDAPNSInfo"];
+      rawAPNSInfo = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+      [unarchiver finishDecoding];
       needsMigration = YES;
-#pragma clang diagnostic pop
     } @catch (NSException *exception) {
       FIRMessagingLoggerInfo(kFIRMessagingMessageCodeTokenInfoBadAPNSInfo,
                              @"Could not parse raw APNS Info while parsing archived token info.");

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenStore.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenStore.m
@@ -99,19 +99,14 @@ static NSString *const kFIRMessagingTokenKeychainId = @"com.google.iid-tokens";
 + (nullable FIRMessagingTokenInfo *)tokenInfoFromKeychainItem:(NSData *)item {
   // Check if it is saved as an archived FIRMessagingTokenInfo, otherwise return nil.
   FIRMessagingTokenInfo *tokenInfo = nil;
-  // NOTE: Passing in nil to unarchiveObjectWithData will result in an iOS error logged
-  // in the console on iOS 10 and below. Avoid by checking item.data's existence.
   if (item) {
-    // TODO(chliangGoogle: Use the new API and secureCoding protocol.
     @try {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      [NSKeyedUnarchiver setClass:[FIRMessagingTokenInfo class]
-                     forClassName:@"FIRInstanceIDTokenInfo"];
-      tokenInfo = [NSKeyedUnarchiver unarchiveObjectWithData:item];
-
-#pragma clang diagnostic pop
-
+      NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:item
+                                                                                  error:nil];
+      unarchiver.requiresSecureCoding = NO;
+      [unarchiver setClass:[FIRMessagingTokenInfo class] forClassName:@"FIRInstanceIDTokenInfo"];
+      tokenInfo = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+      [unarchiver finishDecoding];
     } @catch (NSException *exception) {
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTokenStoreExceptionUnarchivingTokenInfo,
                               @"Unable to parse token info from Keychain item; item was in an "


### PR DESCRIPTION
`unarchiveObjectWithData` is [deprecated](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/1413894-unarchiveobjectwithdata). Move the codebase to use the new and more secure `NSKeyedUnarchiver` APIs.

This PR only modifies the API used; it does not affect behavior.

This is expected to fix #14424.