### PR TITLE
[Functions] Pass placeholder app check tokens on error

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
@@ -56,9 +56,9 @@ struct FunctionsContextProvider {
   private func getAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
     guard
       options?.requireLimitedUseAppCheckTokens != true,
-      let tokenResult = await appCheck?.getToken(forcingRefresh: false),
-      tokenResult.error == nil
+      let tokenResult = await appCheck?.getToken(forcingRefresh: false)
     else { return nil }
+    // The placeholder token should be used in the case of App Check error.
     return tokenResult.token
   }
 
@@ -77,8 +77,7 @@ struct FunctionsContextProvider {
       }
 
       limitedUseTokenClosure { tokenResult in
-        // Make sure there’s no error and the token is valid:
-        guard tokenResult.error == nil else { return continuation.resume(returning: nil) }
+        // The placeholder token should be used in the case of App Check error.
         continuation.resume(returning: tokenResult.token)
       }
     }
@@ -111,10 +110,8 @@ struct FunctionsContextProvider {
         // If it’s not implemented, we still need to leave the dispatch group.
         if let limitedUseTokenClosure = appCheck.getLimitedUseToken {
           limitedUseTokenClosure { tokenResult in
-            // Send only valid token to functions.
-            if tokenResult.error == nil {
-              limitedUseAppCheckToken = tokenResult.token
-            }
+            // In the case of an error, the token will be the placeholder token.
+            limitedUseAppCheckToken = tokenResult.token
             dispatchGroup.leave()
           }
         } else {
@@ -122,10 +119,8 @@ struct FunctionsContextProvider {
         }
       } else {
         appCheck.getToken(forcingRefresh: false) { tokenResult in
-          // Send only valid token to functions.
-          if tokenResult.error == nil {
-            appCheckToken = tokenResult.token
-          }
+          // In the case of an error, the token will be the placeholder token.
+          appCheckToken = tokenResult.token
           dispatchGroup.leave()
         }
       }


### PR DESCRIPTION
Currently, the Functions SDK does not pass the App Check placeholder token for cases where the App Check integration fails to fetch an App Check token.

Before:
<img width="1675" alt="Screenshot 2025-02-18 at 7 21 58 PM" src="https://github.com/user-attachments/assets/946dac41-0709-4dc2-abf8-5f599910dc87" />

After:
<img width="1156" alt="Screenshot 2025-02-18 at 7 20 45 PM" src="https://github.com/user-attachments/assets/55682c62-de39-40cc-9555-c23cc8030e73" /> 