### PR TITLE
[Auth] Add `@discardableResult` to avoid warnings

### DIFF
--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -1605,6 +1605,7 @@ extension Auth: AuthInterop {
     /// so the caller should ignore the URL from further processing, and `false` means the
     /// the URL is for the app (or another library) so the caller should continue handling
     /// this URL as usual.
+    @discardableResult
     @objc(canHandleURL:) open func canHandle(_ url: URL) -> Bool {
       kAuthGlobalWorkQueue.sync {
         guard let authURLPresenter = self.authURLPresenter as? AuthURLPresenter else {


### PR DESCRIPTION
This PR adds `@discardableResult` to avoid warnings, as described in #13649 