### PR TITLE
[VertexAI] Add Swift 6 testing to CI

### DIFF
--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -128,8 +128,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     strategy:
       matrix:
-        target: [ios]
-        os: [macos-14, macos-15]
         include:
           - os: macos-14
             xcode: Xcode_15.2

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -137,10 +137,11 @@ jobs:
             xcode: Xcode_16.2
             swift_version: 5.9
             warnings:
+          #TODO: Fix remaining warning in GenerativeAIService and remove --allow-warnings.
           - os: macos-15
             xcode: Xcode_16.2
             swift_version: 6.0
-            warnings:
+            warnings: --allow-warnings
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/vertexai.yml
+++ b/.github/workflows/vertexai.yml
@@ -133,9 +133,15 @@ jobs:
         include:
           - os: macos-14
             xcode: Xcode_15.2
+            swift_version: 5.9
             warnings: --allow-warnings
           - os: macos-15
             xcode: Xcode_16.2
+            swift_version: 5.9
+            warnings:
+          - os: macos-15
+            xcode: Xcode_16.2
+            swift_version: 6.0
             warnings:
     runs-on: ${{ matrix.os }}
     steps:
@@ -147,6 +153,8 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Set Swift swift_version
+      run: sed -i "" "s#s.swift_version = '5.9'#s.swift_version = '${{ matrix.swift_version}}'#" FirebaseVertexAI.podspec
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseVertexAI.podspec --platforms=${{ matrix.target }} ${{ matrix.warnings }}
 

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [feature] The Firebase Vertex AI SDK now builds in Swift 6 mode.
+- [feature] The Firebase Vertex AI SDK no longer requires `@preconcurrency` when imported in Swift 6.
 
 # 11.9.0
 - [feature] **Public Preview**: Added support for generating images using the

--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [feature] The Firebase Vertex AI SDK now builds in Swift 6 mode.
+
 # 11.9.0
 - [feature] **Public Preview**: Added support for generating images using the
   Imagen 3 model.

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -17,10 +17,17 @@ import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class MockURLProtocol: URLProtocol, @unchecked Sendable {
-  static var requestHandler: ((URLRequest) throws -> (
-    URLResponse,
-    AsyncLineSequence<URL.AsyncBytes>?
-  ))?
+  #if compiler(>=6)
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (
+      URLResponse,
+      AsyncLineSequence<URL.AsyncBytes>?
+    ))?
+  #else
+    static var requestHandler: ((URLRequest) throws -> (
+      URLResponse,
+      AsyncLineSequence<URL.AsyncBytes>?
+    ))?
+  #endif
   override class func canInit(with request: URLRequest) -> Bool {
     #if os(watchOS)
       print("MockURLProtocol cannot be used on watchOS.")

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -17,11 +17,17 @@ import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class MockURLProtocol: URLProtocol, @unchecked Sendable {
-  nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (
-    URLResponse,
-    AsyncLineSequence<URL.AsyncBytes>?
-  ))?
-
+  #if compiler(>=6)
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (
+      URLResponse,
+      AsyncLineSequence<URL.AsyncBytes>?
+    ))?
+  #else
+    static var requestHandler: ((URLRequest) throws -> (
+      URLResponse,
+      AsyncLineSequence<URL.AsyncBytes>?
+    ))?
+  #endif
   override class func canInit(with request: URLRequest) -> Bool {
     #if os(watchOS)
       print("MockURLProtocol cannot be used on watchOS.")

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -17,17 +17,10 @@ import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 class MockURLProtocol: URLProtocol, @unchecked Sendable {
-  #if compiler(>=6)
-    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (
-      URLResponse,
-      AsyncLineSequence<URL.AsyncBytes>?
-    ))?
-  #else
-    static var requestHandler: ((URLRequest) throws -> (
-      URLResponse,
-      AsyncLineSequence<URL.AsyncBytes>?
-    ))?
-  #endif
+  static var requestHandler: ((URLRequest) throws -> (
+    URLResponse,
+    AsyncLineSequence<URL.AsyncBytes>?
+  ))?
   override class func canInit(with request: URLRequest) -> Bool {
     #if os(watchOS)
       print("MockURLProtocol cannot be used on watchOS.")

--- a/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseVertexAI/Tests/Unit/MockURLProtocol.swift
@@ -16,8 +16,8 @@ import Foundation
 import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-class MockURLProtocol: URLProtocol {
-  static var requestHandler: ((URLRequest) throws -> (
+class MockURLProtocol: URLProtocol, @unchecked Sendable {
+  nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (
     URLResponse,
     AsyncLineSequence<URL.AsyncBytes>?
   ))?

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseCore
+@preconcurrency import FirebaseCore
 import Foundation
 import XCTest
 


### PR DESCRIPTION
- Add Swift 6 testing to CI
- Update unit tests to build in Swift 
- Add Changelog note
- Workaround remaining warning(s) see below
- A first pass at fixing the warning is in #14504

![Screenshot 2025-02-26 at 11 53 10 AM](https://github.com/user-attachments/assets/1f2743d9-d764-46bc-9515-9ca7f0904c09)
