### PR TITLE
[Vertex AI] Refactor generateContentStream to fix Swift 6 warning

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -153,34 +153,14 @@ struct GenerativeAIService {
             extraLines += line
           }
         }
-        for try await line in stream.lines {
-          if line.hasPrefix("data:") {
-            let jsonText = String(line.dropFirst(5))
-            let data: Data
-            do {
-              data = try jsonData(jsonText: jsonText)
-            } catch {
-              continuation.finish(throwing: error)
-              return
-            }
-            do {
-              let content = try parseResponse(T.Response.self, from: data)
-              continuation.yield(content)
-            } catch {
-              continuation.finish(throwing: error)
-              return
-            }
-          } else {}
 
-          if !extraLines.isEmpty {
-            continuation.finish(throwing: parseError(responseBody: extraLines))
-            return
-          }
-
-          continuation.finish(throwing: nil)
+        if extraLines.count > 0 {
+          continuation.finish(throwing: parseError(responseBody: extraLines))
+          return
         }
+
+        continuation.finish(throwing: nil)
       }
-      continuation.finish(throwing: nil)
     }
   }
 

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -153,8 +153,29 @@ struct GenerativeAIService {
             extraLines += line
           }
         }
-
-        if extraLines.count > 0 {
+          for try await line in stream.lines {
+              if line.hasPrefix("data:") {
+                  let jsonText = String(line.dropFirst(5))
+                  let data: Data
+                  do {
+                      data = try jsonData(jsonText: jsonText)
+                  } catch {
+                      continuation.finish(throwing: error)
+                      return
+                  }
+                  do {
+                      let content = try parseResponse(T.Response.self, from: data)
+                      continuation.yield(content)
+                  } catch {
+                      continuation.finish(throwing: error)
+                      return
+                  }
+              }
+              else {
+                  
+          }
+          
+        if !extraLines.isEmpty {
           continuation.finish(throwing: parseError(responseBody: extraLines))
           return
         }
@@ -162,6 +183,8 @@ struct GenerativeAIService {
         continuation.finish(throwing: nil)
       }
     }
+    continuation.finish(throwing: nil)
+  }
   }
 
   // MARK: - Private Helpers

--- a/FirebaseVertexAI/Sources/GenerativeAIService.swift
+++ b/FirebaseVertexAI/Sources/GenerativeAIService.swift
@@ -153,38 +153,35 @@ struct GenerativeAIService {
             extraLines += line
           }
         }
-          for try await line in stream.lines {
-              if line.hasPrefix("data:") {
-                  let jsonText = String(line.dropFirst(5))
-                  let data: Data
-                  do {
-                      data = try jsonData(jsonText: jsonText)
-                  } catch {
-                      continuation.finish(throwing: error)
-                      return
-                  }
-                  do {
-                      let content = try parseResponse(T.Response.self, from: data)
-                      continuation.yield(content)
-                  } catch {
-                      continuation.finish(throwing: error)
-                      return
-                  }
-              }
-              else {
-                  
-          }
-          
-        if !extraLines.isEmpty {
-          continuation.finish(throwing: parseError(responseBody: extraLines))
-          return
-        }
+        for try await line in stream.lines {
+          if line.hasPrefix("data:") {
+            let jsonText = String(line.dropFirst(5))
+            let data: Data
+            do {
+              data = try jsonData(jsonText: jsonText)
+            } catch {
+              continuation.finish(throwing: error)
+              return
+            }
+            do {
+              let content = try parseResponse(T.Response.self, from: data)
+              continuation.yield(content)
+            } catch {
+              continuation.finish(throwing: error)
+              return
+            }
+          } else {}
 
-        continuation.finish(throwing: nil)
+          if !extraLines.isEmpty {
+            continuation.finish(throwing: parseError(responseBody: extraLines))
+            return
+          }
+
+          continuation.finish(throwing: nil)
+        }
       }
+      continuation.finish(throwing: nil)
     }
-    continuation.finish(throwing: nil)
-  }
   }
 
   // MARK: - Private Helpers

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -185,34 +185,28 @@ public final class GenerativeModel: Sendable {
                                                         isStreaming: true,
                                                         options: requestOptions)
 
-    var responseIterator = generativeAIService.loadRequestStream(request: generateContentRequest)
-      .makeAsyncIterator()
-    return AsyncThrowingStream {
-      let response: GenerateContentResponse?
-      do {
-        response = try await responseIterator.next()
-      } catch {
-        throw GenerativeModel.generateContentError(from: error)
-      }
+    return AsyncThrowingStream { continuation in
+      let responseIterator = generativeAIService.loadRequestStream(request: generateContentRequest)
+      Task{
+          for try await response in responseIterator {
+            // Check the prompt feedback to see if the prompt was blocked.
+            if response.promptFeedback?.blockReason != nil {
+              throw GenerateContentError.promptBlocked(response: response)
+            }
 
-      // The responseIterator will return `nil` when it's done.
-      guard let response = response else {
-        // This is the end of the stream! Signal it by sending `nil`.
-        return nil
-      }
-
-      // Check the prompt feedback to see if the prompt was blocked.
-      if response.promptFeedback?.blockReason != nil {
-        throw GenerateContentError.promptBlocked(response: response)
-      }
-
-      // If the stream ended early unexpectedly, throw an error.
-      if let finishReason = response.candidates.first?.finishReason, finishReason != .stop {
-        throw GenerateContentError.responseStoppedEarly(reason: finishReason, response: response)
-      } else {
-        // Response was valid content, pass it along and continue.
-        return response
-      }
+            // If the stream ended early unexpectedly, throw an error.
+            if let finishReason = response.candidates.first?.finishReason, finishReason != .stop {
+              throw GenerateContentError.responseStoppedEarly(reason: finishReason, response: response)
+            }
+            
+              continuation.yield(response)
+          }
+        } catch {
+          continuation.finish(throwing: GenerativeModel.generateContentError(from: error))
+          return
+        }
+        
+        continuation.finish(throwing: nil)
     }
   }
 

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -205,12 +205,12 @@ public final class GenerativeModel: Sendable {
 
             continuation.yield(response)
           }
+          continuation.finish()
         } catch {
           continuation.finish(throwing: GenerativeModel.generateContentError(from: error))
           return
         }
       }
-      continuation.finish(throwing: nil)
     }
   }
 

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -186,10 +186,10 @@ public final class GenerativeModel: Sendable {
                                                         options: requestOptions)
 
     return AsyncThrowingStream { continuation in
-      let responseIterator = generativeAIService.loadRequestStream(request: generateContentRequest)
+      let responseStream = generativeAIService.loadRequestStream(request: generateContentRequest)
       Task {
         do {
-          for try await response in responseIterator {
+          for try await response in responseStream {
             // Check the prompt feedback to see if the prompt was blocked.
             if response.promptFeedback?.blockReason != nil {
               throw GenerateContentError.promptBlocked(response: response)


### PR DESCRIPTION
Refactored `GenerativeModel.generateContentStream(...)` to use [`init(_:bufferingPolicy:_:)`](https://developer.apple.com/documentation/swift/asyncthrowingstream/init(_:bufferingpolicy:_:)) (`AsyncStream.Continuation` approach) instead of [`init(unfolding:)`](https://developer.apple.com/documentation/swift/asyncthrowingstream/init(unfolding:)) to resolve the Swift 6 warning "`Capture of responseIterator with non-Sendable type AsyncThrowingStream<GenerateContentResponse, Error>`" discussed in #14503.

#no-changelog
