### PR TITLE
[CI] Run `buildup_SpecsTesting_repo` job on `macos-15`

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -112,7 +112,7 @@ jobs:
     needs: [buildup_SpecsTesting_repo_FirebaseCore, specs_checking]
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch'
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.specs_checking.outputs.matrix)}}


### PR DESCRIPTION
Updated the `buildup_SpecsTesting_repo` job to run on `macos-15` instead of `macos-14`. This resolves the failure in [`buildup_SpecsTesting_repo (FirebaseVertexAI, false)`](https://github.com/firebase/firebase-ios-sdk/actions/runs/13559317720/job/37932304944#step:5:539) from #14505.

Note: The `prerelease` workflow was not invoked by this PR but passed [manually](https://github.com/firebase/firebase-ios-sdk/actions/runs/13571327172/job/37937874410).

#no-changelog
