### PR TITLE
docs: fix the word `equivalent`

### DIFF
--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMClearcutUploader.m
@@ -109,7 +109,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
                                                  object:nil];
     }
     _userDefaults = userDefaults ? userDefaults : [GULUserDefaults standardUserDefaults];
-    // it would be 0 if it does not exist, which is equvilent to saying that
+    // it would be 0 if it does not exist, which is equivalent to saying that
     // you can send now
     _nextValidSendTimeInMills = (int64_t)[_userDefaults
         doubleForKey:FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills];


### PR DESCRIPTION
Fix a simple typo in Firebase In App Messaging source file. The change is backward compatible 