### PR TITLE
chore: remove unused `user defaults key for remove user property time in seconds` property

### DIFF
--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
@@ -51,11 +51,6 @@ static NSString *const kFAEventNameForDismiss = @"firebase_in_app_message_dismis
 static NSString *const kFAUserPropertyForLastNotification = @"_ln";
 static NSString *const kFAUserPropertyPrefixForFIAM = @"fiam:";
 
-// This user defaults key is for the entry to tell when we should remove the private user
-// property from a prior action url click to stop conversion attribution for a campaign
-static NSString *const kFIAMUserDefaultsKeyForRemoveUserPropertyTimeInSeconds =
-    @"firebase-iam-conversion-tracking-expires-in-seconds";
-
 @implementation FIRIAMAnalyticsEventLoggerImpl {
   id<FIRAnalyticsInterop> _analytics;
 }

--- a/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
+++ b/FirebaseInAppMessaging/Sources/Analytics/FIRIAMAnalyticsEventLoggerImpl.m
@@ -53,7 +53,7 @@ static NSString *const kFAUserPropertyPrefixForFIAM = @"fiam:";
 
 // This user defaults key is for the entry to tell when we should remove the private user
 // property from a prior action url click to stop conversion attribution for a campaign
-static NSString *const kFIAMUserDefaualtsKeyForRemoveUserPropertyTimeInSeconds =
+static NSString *const kFIAMUserDefaultsKeyForRemoveUserPropertyTimeInSeconds =
     @"firebase-iam-conversion-tracking-expires-in-seconds";
 
 @implementation FIRIAMAnalyticsEventLoggerImpl {


### PR DESCRIPTION
Fix a typo in a static constant name. I couldn't see any use of this static property. Please double check and let me know if we should update elsewhere related to this property as well.
Thanks