### PR TITLE
Refactored `FunctionsSerializer.decode(_:)`

### DIFF
--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -541,10 +541,8 @@ enum FunctionsConstants {
   private func callableResult(fromResponseData data: Data) throws -> HTTPSCallableResult {
     let processedData = try processedData(fromResponseData: data)
     let json = try responseDataJSON(from: processedData)
-    // TODO: Refactor `decode(_:)` so it either returns a non-optional object or throws
     let payload = try serializer.decode(json)
-    // TODO: Remove `as Any` once `decode(_:)` is refactored
-    return HTTPSCallableResult(data: payload as Any)
+    return HTTPSCallableResult(data: payload)
   }
 
   private func processedData(fromResponseData data: Data) throws -> Data {

--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -58,7 +58,7 @@ final class FunctionsSerializer {
     }
   }
 
-  func decode(_ object: Any) throws -> AnyObject? {
+  func decode(_ object: Any) throws -> Any {
     // Return these types as is. PORTING NOTE: Moved from the bottom of the func for readability.
     if let dict = object as? NSDictionary {
       if let requestedType = dict["@type"] as? String {
@@ -66,8 +66,9 @@ final class FunctionsSerializer {
           // Seems like we should throw here - but this maintains compatibility.
           return dict
         }
-        let result = try decodeWrappedType(requestedType, value)
-        if result != nil { return result }
+        if let result = try decodeWrappedType(requestedType, value) {
+          return result
+        }
 
         // Treat unknown types as dictionaries, so we don't crash old clients when we add types.
       }


### PR DESCRIPTION
* The method no longer returns an optional
* Changed `AnyObject` to `Any`