### PR TITLE
add Sendable to AuthDataResult

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [added] Made `AuthDataResult` conform to `Sendable` (#14515).
+
 # 11.9.0
 - [changed] Using reCAPTCHA Enterprise and Firebase Auth requires reCAPTCHA
   Enterprise 18.7.0 or later.

--- a/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AuthDataResult.swift
@@ -22,7 +22,7 @@ extension AuthDataResult: NSSecureCoding {}
 ///
 /// It contains references to a `User` instance and an `AdditionalUserInfo` instance.
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-@objc(FIRAuthDataResult) open class AuthDataResult: NSObject {
+@objc(FIRAuthDataResult) open class AuthDataResult: NSObject, Sendable {
   /// The signed in user.
   @objc public let user: User
 


### PR DESCRIPTION
Prevents calls like `try await Auth.auth().signInAnonymously()` from erroring. `AuthDataResult` has only immutable properties, so this conformance requires no other code changes.