### PR TITLE
Refactored `FunctionsSerializer.encode(_:)`

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -31,28 +31,23 @@ extension FunctionsSerializer {
 final class FunctionsSerializer {
   // MARK: - Internal APIs
 
-  func encode(_ object: Any) throws -> AnyObject {
+  func encode(_ object: Any) throws -> Any {
     if object is NSNull {
-      return object as AnyObject
+      return object
     } else if object is NSNumber {
       return try encodeNumber(object as! NSNumber)
     } else if object is NSString {
-      return object as AnyObject
-    } else if object is NSDictionary {
-      let dict = object as! NSDictionary
+      return object
+    } else if let dict = object as? NSDictionary {
       let encoded = NSMutableDictionary()
       try dict.forEach { key, value in
         encoded[key] = try encode(value)
       }
       return encoded
-    } else if object is NSArray {
-      let array = object as! NSArray
-      let encoded = NSMutableArray()
-      try array.forEach { element in
-        try encoded.add(encode(element))
+    } else if let array = object as? NSArray {
+      return try array.map { element in
+        try encode(element)
       }
-      return encoded
-
     } else {
       throw Error.unsupportedType(typeName: typeName(of: object))
     }


### PR DESCRIPTION
* Fewer reference types
* Fewer mutable objects