### PR TITLE
[Config] Add encoder and decoder param to public codable APIs

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Codable APIs now accept optional `FirebaseDataEncoder` and
+  `FirebaseDataDecoder` parameters, allowing for customization of
+  encoding/decoding behavior. (#14368)
+
 # 11.9.0
 - [fixed] Mark internal `fetchSession` property as `atomic` to prevent a concurrency
   related crash. (#14449)

--- a/FirebaseRemoteConfig/Swift/Codable.swift
+++ b/FirebaseRemoteConfig/Swift/Codable.swift
@@ -47,19 +47,21 @@ public extension RemoteConfig {
   /// Decodes a struct from the respective Remote Config values.
   ///
   /// - Parameter asType: The type to decode to.
-  func decoded<Value: Decodable>(asType: Value.Type = Value.self) throws -> Value {
+  func decoded<Value: Decodable>(asType: Value.Type = Value.self,
+                                 decoder: FirebaseDataDecoder = .init()) throws -> Value {
     let keys = allKeys(from: RemoteConfigSource.default) + allKeys(from: RemoteConfigSource.remote)
     let config = keys.reduce(into: [String: FirebaseRemoteConfigValueDecoderHelper]()) {
       $0[$1] = FirebaseRemoteConfigValueDecoderHelper(value: configValue(forKey: $1))
     }
-    return try FirebaseDataDecoder().decode(Value.self, from: config)
+    return try decoder.decode(Value.self, from: config)
   }
 
   /// Sets config defaults from an encodable struct.
   ///
   /// - Parameter value: The object to use to set the defaults.
-  func setDefaults<Value: Encodable>(from value: Value) throws {
-    guard let encoded = try FirebaseDataEncoder().encode(value) as? [String: NSObject] else {
+  func setDefaults<Value: Encodable>(from value: Value,
+                                     encoder: FirebaseDataEncoder = .init()) throws {
+    guard let encoded = try encoder.encode(value) as? [String: NSObject] else {
       throw RemoteConfigCodableError.invalidSetDefaultsInput(
         "The setDefaults input: \(value), must be a Struct that encodes to a Dictionary"
       )

--- a/FirebaseRemoteConfig/Swift/Codable.swift
+++ b/FirebaseRemoteConfig/Swift/Codable.swift
@@ -28,7 +28,8 @@ public extension RemoteConfigValue {
   /// Extracts a RemoteConfigValue JSON-encoded object and decodes it to the requested type.
   ///
   /// - Parameter asType: The type to decode the JSON-object to
-  func decoded<Value: Decodable>(asType: Value.Type = Value.self) throws -> Value {
+  func decoded<Value: Decodable>(asType: Value.Type = Value.self,
+                                 decoder: FirebaseDataDecoder = .init()) throws -> Value {
     if asType == Date.self {
       throw RemoteConfigValueCodableError
         .unsupportedType("Date type is not currently supported for " +

--- a/FirebaseRemoteConfig/Swift/Codable.swift
+++ b/FirebaseRemoteConfig/Swift/Codable.swift
@@ -28,8 +28,7 @@ public extension RemoteConfigValue {
   /// Extracts a RemoteConfigValue JSON-encoded object and decodes it to the requested type.
   ///
   /// - Parameter asType: The type to decode the JSON-object to
-  func decoded<Value: Decodable>(asType: Value.Type = Value.self,
-                                 decoder: FirebaseDataDecoder = .init()) throws -> Value {
+  func decoded<Value: Decodable>(asType: Value.Type = Value.self) throws -> Value {
     if asType == Date.self {
       throw RemoteConfigValueCodableError
         .unsupportedType("Date type is not currently supported for " +

--- a/FirebaseRemoteConfig/Swift/Value.swift
+++ b/FirebaseRemoteConfig/Swift/Value.swift
@@ -18,6 +18,7 @@ import Foundation
 #if SWIFT_PACKAGE
   @_exported import FirebaseRemoteConfigInternal
 #endif // SWIFT_PACKAGE
+import FirebaseSharedSwift
 
 /// Implements subscript overloads to enable Remote Config values to be accessed
 /// in a type-safe way directly from the current config.
@@ -25,8 +26,8 @@ public extension RemoteConfig {
   /// Return a typed RemoteConfigValue for a key.
   /// - Parameter key: A Remote Config key.
   /// - Returns: A typed RemoteConfigValue.
-  subscript<T: Decodable>(decodedValue key: String) -> T? {
-    return try? configValue(forKey: key).decoded()
+  subscript<T: Decodable>(decodedValue key: String, decoder: FirebaseDataDecoder = .init()) -> T? {
+    return try? configValue(forKey: key).decoded(decoder: decoder)
   }
 
   /// Return a Dictionary for a RemoteConfig JSON key.

--- a/FirebaseRemoteConfig/Swift/Value.swift
+++ b/FirebaseRemoteConfig/Swift/Value.swift
@@ -18,7 +18,6 @@ import Foundation
 #if SWIFT_PACKAGE
   @_exported import FirebaseRemoteConfigInternal
 #endif // SWIFT_PACKAGE
-import FirebaseSharedSwift
 
 /// Implements subscript overloads to enable Remote Config values to be accessed
 /// in a type-safe way directly from the current config.
@@ -26,8 +25,8 @@ public extension RemoteConfig {
   /// Return a typed RemoteConfigValue for a key.
   /// - Parameter key: A Remote Config key.
   /// - Returns: A typed RemoteConfigValue.
-  subscript<T: Decodable>(decodedValue key: String, decoder: FirebaseDataDecoder = .init()) -> T? {
-    return try? configValue(forKey: key).decoded(decoder: decoder)
+  subscript<T: Decodable>(decodedValue key: String) -> T? {
+    return try? configValue(forKey: key).decoded()
   }
 
   /// Return a Dictionary for a RemoteConfig JSON key.

--- a/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
@@ -210,7 +210,7 @@ class CodableTests: APITestBase {
 
   // MARK: - Test using injected encoder/decoder.
 
-  func testDateEncodingAndDecodingWithISO8601() throws {
+  func testDateEncodingAndDecodingWithNonDefaultCoders() throws {
     // Given
     struct DateDefaults: Codable {
       let date: Date

--- a/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
@@ -238,40 +238,4 @@ class CodableTests: APITestBase {
       toGranularity: .second
     ))
   }
-
-  func testDateEncodingAndDecodingWithNonDefaultCoders_1() throws {
-    struct DateWrapper: Codable {
-      let date: Date
-    }
-    struct MyDefaults: Codable {
-      let dateWrapper: DateWrapper
-    }
-
-    let defaults = MyDefaults(dateWrapper: DateWrapper(date: Date()))
-
-    // When
-    let encoder = FirebaseDataEncoder()
-    encoder.dateEncodingStrategy = .iso8601
-    try config.setDefaults(from: defaults, encoder: encoder)
-
-    XCTAssertThrowsError(try config.configValue(forKey: "dateWrapper").decoded() as DateWrapper)
-    XCTAssertNil(config[decodedValue: "dateWrapper"] as DateWrapper?)
-
-    // Then
-    let decoder = FirebaseDataDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-    // 💥 Throws unexpected error:
-    //  error: -[FirebaseRemoteConfig_Unit_swift_api_tests.CodableTests testDateEncodingAndDecodingWithNonDefaultCoders_1] : failed: caught error: "typeMismatch(Swift.Double, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "date", intValue: nil)], debugDescription: "Expected to decode Double but found a string/data instead.", underlyingError: nil))"
-    let decodedWrapper: DateWrapper = try config.configValue(forKey: "dateWrapper")
-      .decoded(decoder: decoder)
-    XCTAssert(Calendar.current.isDate(
-      decodedWrapper.date,
-      equalTo: defaults.dateWrapper.date,
-      toGranularity: .second
-    ))
-
-    XCTAssertNil(config[decodedValue: "dateWrapper"] as DateWrapper?)
-    // 🔥 Compile time error: `Extraneous argument label 'decoder:' in subscript`
-//    XCTAssertNotNil(config[decodedValue: "dateWrapper", decoder: decoder] as DateWrapper?)
-  }
 }

--- a/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
+++ b/FirebaseRemoteConfig/Tests/Swift/SwiftAPI/Codable.swift
@@ -238,4 +238,40 @@ class CodableTests: APITestBase {
       toGranularity: .second
     ))
   }
+
+  func testDateEncodingAndDecodingWithNonDefaultCoders_1() throws {
+    struct DateWrapper: Codable {
+      let date: Date
+    }
+    struct MyDefaults: Codable {
+      let dateWrapper: DateWrapper
+    }
+
+    let defaults = MyDefaults(dateWrapper: DateWrapper(date: Date()))
+
+    // When
+    let encoder = FirebaseDataEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    try config.setDefaults(from: defaults, encoder: encoder)
+
+    XCTAssertThrowsError(try config.configValue(forKey: "dateWrapper").decoded() as DateWrapper)
+    XCTAssertNil(config[decodedValue: "dateWrapper"] as DateWrapper?)
+
+    // Then
+    let decoder = FirebaseDataDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    // 💥 Throws unexpected error:
+    //  error: -[FirebaseRemoteConfig_Unit_swift_api_tests.CodableTests testDateEncodingAndDecodingWithNonDefaultCoders_1] : failed: caught error: "typeMismatch(Swift.Double, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "date", intValue: nil)], debugDescription: "Expected to decode Double but found a string/data instead.", underlyingError: nil))"
+    let decodedWrapper: DateWrapper = try config.configValue(forKey: "dateWrapper")
+      .decoded(decoder: decoder)
+    XCTAssert(Calendar.current.isDate(
+      decodedWrapper.date,
+      equalTo: defaults.dateWrapper.date,
+      toGranularity: .second
+    ))
+
+    XCTAssertNil(config[decodedValue: "dateWrapper"] as DateWrapper?)
+    // 🔥 Compile time error: `Extraneous argument label 'decoder:' in subscript`
+//    XCTAssertNotNil(config[decodedValue: "dateWrapper", decoder: decoder] as DateWrapper?)
+  }
 }


### PR DESCRIPTION
Fix #14368

Relevant: https://github.com/firebase/firebase-ios-sdk/pull/9084#issue-1077876345

I did not update the following APIs because I wasn't able to get a test case working (See be0616a3f9b772947da3edca8e8b9e43d85842b1). I think it's reasonable to limit the scope of exposing the `FirebaseData*coder`s in the public API since it needs some re-thinking).
- https://github.com/firebase/firebase-ios-sdk/blob/ea8fb07f37a3dc647bb494a7a6b17b9eb6f78c26/FirebaseRemoteConfig/Swift/Codable.swift#L31-L40
- https://github.com/firebase/firebase-ios-sdk/blob/ea8fb07f37a3dc647bb494a7a6b17b9eb6f78c26/FirebaseRemoteConfig/Swift/Value.swift#L25-L30
