### PR TITLE
Add DataConnect product definition to build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -700,6 +700,15 @@ case "$product-$platform-$method" in
       test
     ;;
 
+  FirebaseDataConnect-*-spm)
+    RunXcodebuild \
+      -scheme $product \
+      "${xcb_flags[@]}" \
+      IPHONEOS_DEPLOYMENT_TARGET=15.0 \
+      TVOS_DEPLOYMENT_TARGET=15.0 \
+      test
+    ;;
+
   # Note that the combine tests require setting the minimum iOS and tvOS version to 13.0
   *-*-spm)
     RunXcodebuild \


### PR DESCRIPTION
The build script is reused by DataConnect which needs a min deployment target of 15.0. Without this, some integration tests are failing due to version check.

FYI -
Workflow definition where the build script is invoked
https://github.com/firebase/data-connect-ios-sdk/blob/main/.github/workflows/spm.yml#L77

Error -> 
https://github.com/firebase/data-connect-ios-sdk/actions/runs/13660926083/job/38191785059?pr=43#step:7:1814
