### PR TITLE
[Vertex AI] Remove unused `finishMessage` coding key

### DIFF
--- a/FirebaseVertexAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseVertexAI/Sources/GenerateContentResponse.swift
@@ -330,7 +330,6 @@ extension Candidate: Decodable {
     case content
     case safetyRatings
     case finishReason
-    case finishMessage
     case citationMetadata
   }
 


### PR DESCRIPTION
Removed an unused `finishMessage` `CodingKey` from the `Candidate` type.

#no-changelog