### PR TITLE
[Vertex AI] Update DocC links to Firebase docsite where available

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -141,7 +141,7 @@
   instead of the `Any` type. (#13575)
 - [added] Added support for specifying a JSON `responseSchema` in
   `GenerationConfig`; see
-  [control generated output](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)
+  [control generated output](https://firebase.google.com/docs/vertex-ai/structured-output?platform=ios)
   for more details. (#13576)
 
 # 10.29.0

--- a/FirebaseVertexAI/Sources/CountTokensRequest.swift
+++ b/FirebaseVertexAI/Sources/CountTokensRequest.swift
@@ -46,7 +46,7 @@ public struct CountTokensResponse {
   /// The total number of billable characters in the text input given to the model as a prompt.
   ///
   /// > Important: This does not include billable image, video or other non-text input. See
-  /// [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing) for details.
+  /// [Vertex AI pricing](https://firebase.google.com/docs/vertex-ai/pricing) for details.
   public let totalBillableCharacters: Int?
 
   /// The breakdown, by modality, of how many tokens are consumed by the prompt.

--- a/FirebaseVertexAI/Sources/FunctionCalling.swift
+++ b/FirebaseVertexAI/Sources/FunctionCalling.swift
@@ -68,8 +68,8 @@ public struct Tool: Sendable {
   /// Function calling can be used to provide data to the model that was not known at the time it
   /// was trained (for example, the current date or weather conditions) or to allow it to interact
   /// with external systems (for example, making an API request or querying/updating a database).
-  /// For more details and use cases, see [Introduction to function
-  /// calling](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling).
+  /// For more details and use cases, see [Function calling using the Gemini
+  /// API](http://firebase.google.com/docs/vertex-ai/function-calling?platform=ios).
   ///
   /// - Parameters:
   ///   - functionDeclarations: A list of `FunctionDeclarations` available to the model that can be

--- a/FirebaseVertexAI/Sources/GenerationConfig.swift
+++ b/FirebaseVertexAI/Sources/GenerationConfig.swift
@@ -66,7 +66,7 @@ public struct GenerationConfig: Sendable {
   ///     > of variation is still possible.
   ///
   ///     > Important: The range of supported temperature values depends on the model; see the
-  ///     > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  ///     > [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#temperature)
   ///     > for more details.
   ///   - topP: Controls diversity of generated text. Higher values (e.g., 0.9) produce more diverse
   ///     text, while lower values (e.g., 0.5) make the output more focused.
@@ -74,8 +74,8 @@ public struct GenerationConfig: Sendable {
   ///     The supported range is 0.0 to 1.0.
   ///
   ///     > Important: The default `topP` value depends on the model; see the
-  ///     [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  ///     for more details.
+  ///     > [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#top-p)
+  ///     > for more details.
   ///   - topK: Limits the number of highest probability words the model considers when generating
   ///     text. For example, a topK of 40 means only the 40 most likely words are considered for the
   ///     next token. A higher value increases diversity, while a lower value makes the output more
@@ -84,7 +84,7 @@ public struct GenerationConfig: Sendable {
   ///     The supported range is 1 to 40.
   ///
   ///     > Important: Support for `topK` and the default value depends on the model; see the
-  ///     [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  ///     [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#top-k)
   ///     for more details.
   ///   - candidateCount: The number of response variations to return; defaults to 1 if not set.
   ///     Support for multiple candidates depends on the model; see the
@@ -137,8 +137,9 @@ public struct GenerationConfig: Sendable {
   ///     - `application/json`: Schema for JSON response.
   ///
   ///     Refer to the
-  ///     [Control generated output](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)
-  ///     guide for more details.
+  ///     [Generate structured
+  ///     output](https://firebase.google.com/docs/vertex-ai/structured-output?platform=ios) guide
+  ///     for more details.
   public init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil,
               candidateCount: Int? = nil, maxOutputTokens: Int? = nil,
               presencePenalty: Float? = nil, frequencyPenalty: Float? = nil,

--- a/FirebaseVertexAI/Sources/Safety.swift
+++ b/FirebaseVertexAI/Sources/Safety.swift
@@ -145,6 +145,10 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
 
 /// A type used to specify a threshold for harmful content, beyond which the model will return a
 /// fallback response instead of generated content.
+///
+/// See [safety settings for Gemini
+/// models](https://firebase.google.com/docs/vertex-ai/safety-settings?platform=ios#gemini) for
+/// more details.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct SafetySetting: Sendable {
   /// Block at and beyond a specified ``SafetyRating/HarmProbability``.

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenGenerationConfig.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenGenerationConfig.swift
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 /// Configuration options for generating images with Imagen.
+///
+/// See [Parameters for Imagen
+/// models](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#imagen) to
+/// learn about parameters available for use with Imagen models, including how to configure them.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ImagenGenerationConfig {
   /// Specifies elements to exclude from the generated image.

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -18,9 +18,10 @@ import Foundation
 
 /// Represents a remote Imagen model with the ability to generate images using text prompts.
 ///
-/// See the [Cloud
-/// documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/image/generate-images) for
-/// more details about the image generation capabilities offered by the Imagen model.
+/// See the [generate images
+/// documentation](https://firebase.google.com/docs/vertex-ai/generate-images-imagen?platform=ios)
+/// for more details about the image generation capabilities offered by the Imagen model in the
+/// Vertex AI in Firebase SDK.
 ///
 /// > Warning: For Vertex AI in Firebase, image generation using Imagen 3 models is in Public
 /// Preview, which means that the feature is not subject to any SLA or deprecation policy and

--- a/FirebaseVertexAI/Sources/Types/Public/Part.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Part.swift
@@ -89,9 +89,9 @@ public struct FileDataPart: Part {
   ///   - uri: The `"gs://"`-prefixed URI of the file in Cloud Storage for Firebase, for example,
   ///     `"gs://bucket-name/path/image.jpg"`.
   ///   - mimeType: The IANA standard MIME type of the uploaded file, for example, `"image/jpeg"`
-  ///     or `"video/mp4"`; see [media requirements
-  ///     ](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/send-multimodal-prompts#media_requirements)
-  ///     for supported values.
+  ///     or `"video/mp4"`; see [supported input files and
+  ///     requirements](https://firebase.google.com/docs/vertex-ai/input-file-requirements) for
+  ///     supported values.
   public init(uri: String, mimeType: String) {
     self.init(FileData(fileURI: uri, mimeType: mimeType))
   }

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -93,9 +93,8 @@ public class VertexAI {
   ///
   /// - Parameters:
   ///   - modelName: The name of the Imagen 3 model to use, for example `"imagen-3.0-generate-002"`;
-  ///     see [model
-  ///     versions](https://cloud.google.com/vertex-ai/generative-ai/docs/image/model-versioning)
-  ///     for a list of supported Imagen 3 models.
+  ///     see [model versions](https://firebase.google.com/docs/vertex-ai/models) for a list of
+  ///     supported Imagen 3 models.
   ///   - generationConfig: Configuration options for generating images with Imagen.
   ///   - safetySettings: Settings describing what types of potentially harmful content your model
   ///     should allow.


### PR DESCRIPTION
Updated DocC links in the Vertex AI in Firebase SDK to refer to resources on the Firebase documentation site (`https://firebase.google.com/docs/vertex-ai`), instead of Google Cloud, where equivalent pages are available.