### PR TITLE
[Vertex AI] Set `ModelContent.role` to `nil` in system instructions

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [feature] The Vertex AI Sample App now includes an image generation example.
 - [changed] The Vertex AI Sample App is now part of the
   [quickstart-ios repo](https://github.com/firebase/quickstart-ios/tree/main/vertexai).
+- [changed] The `role` in system instructions is now ignored; no code changes
+  are required. (#14558)
 
 # 11.9.0
 - [feature] **Public Preview**: Added support for generating images using the

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -81,7 +81,13 @@ public final class GenerativeModel: Sendable {
     self.safetySettings = safetySettings
     self.tools = tools
     self.toolConfig = toolConfig
-    self.systemInstruction = systemInstruction
+    self.systemInstruction = systemInstruction.map {
+      // The `role` defaults to "user" but is ignored in system instructions. However, it is
+      // erroneously counted towards the prompt and total token count in `countTokens` when using
+      // the Developer API backend; set to `nil` to avoid token count discrepancies between
+      // `countTokens` and `generateContent`.
+      ModelContent(role: nil, parts: $0.parts)
+    }
     self.requestOptions = requestOptions
 
     if VertexLog.additionalLoggingEnabled() {

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -218,6 +218,7 @@ class VertexComponentTests: XCTestCase {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let vertex = VertexAI.vertexAI(app: app, location: location)
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
+    let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 
     let generativeModel = vertex.generativeModel(
       modelName: modelName,
@@ -225,7 +226,7 @@ class VertexComponentTests: XCTestCase {
     )
 
     XCTAssertEqual(generativeModel.modelResourceName, modelResourceName)
-    XCTAssertEqual(generativeModel.systemInstruction, systemInstruction)
+    XCTAssertEqual(generativeModel.systemInstruction, expectedSystemInstruction)
     XCTAssertEqual(generativeModel.apiConfig, VertexAI.defaultVertexAIAPIConfig)
   }
 
@@ -237,6 +238,7 @@ class VertexComponentTests: XCTestCase {
     )
     let vertex = VertexAI.vertexAI(app: app, location: nil, apiConfig: apiConfig)
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
+    let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 
     let generativeModel = vertex.generativeModel(
       modelName: modelName,
@@ -244,7 +246,7 @@ class VertexComponentTests: XCTestCase {
     )
 
     XCTAssertEqual(generativeModel.modelResourceName, modelResourceName)
-    XCTAssertEqual(generativeModel.systemInstruction, systemInstruction)
+    XCTAssertEqual(generativeModel.systemInstruction, expectedSystemInstruction)
     XCTAssertEqual(generativeModel.apiConfig, apiConfig)
   }
 }


### PR DESCRIPTION
The `role` property in `ModelContent` is now ignored (explicitly set to `nil`) in system instructions. This aligns with the [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions#gemini-system-instructions-code-samples-drest) documentation (and the [Developer API](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions#gemini-system-instructions-code-samples-drest)). This works around an issue where the `role` is counted in the prompt token count in `countTokens(...)` but is not in `generateContent(...)`. No code changes are required for developers.

Note: Although not shown in this PR, system instructions are used in most of the integration tests.

