### PR TITLE
[Infra] Add write permissions to notice_generation.yml and prerelease.yml

### DIFF
--- a/.github/workflows/notice_generation.yml
+++ b/.github/workflows/notice_generation.yml
@@ -1,5 +1,8 @@
 name: generate_notices
 
+permissions:
+  pull-requests: write
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,8 @@
 name: prerelease
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     # closed will be triggered when a pull request is merged. This is to keep https://github.com/firebase/SpecsTesting up to date.


### PR DESCRIPTION
I noticed our prerelease tags hadn't been moved in awhile. I think the workflow needs permissions. So does `notice_generation.yml` for it to generate a pull request.