### PR TITLE
[Vertex AI] Add placeholders for `vertexai-sdk-test-data` files

### DIFF
--- a/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
+++ b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses
@@ -1,4 +1,0 @@
-Placeholder file for Package.swift - required to prevent a warning.
-
-It should be replaced before running the FirebaseVertexAI unit tests by
-running `scripts/update_vertexai_responses.sh`.

--- a/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses/developerapi
+++ b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses/developerapi
@@ -1,0 +1,4 @@
+Placeholder file for Package.swift - required to prevent a warning.
+
+Run `scripts/update_vertexai_responses.sh` to fetch mock Vertex AI responses
+from https://github.com/FirebaseExtended/vertexai-sdk-test-data.

--- a/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses/vertexai
+++ b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses/vertexai
@@ -1,0 +1,4 @@
+Placeholder file for Package.swift - required to prevent a warning.
+
+Run `scripts/update_vertexai_responses.sh` to fetch mock Vertex AI responses
+from https://github.com/FirebaseExtended/vertexai-sdk-test-data.


### PR DESCRIPTION
Added placeholder files for the [`vertexai`](https://github.com/FirebaseExtended/vertexai-sdk-test-data/tree/bdf8af9e8f34157a31faeb712822f12e6feab31a/mock-responses/vertexai) and [`developerapi`](https://github.com/FirebaseExtended/vertexai-sdk-test-data/tree/bdf8af9e8f34157a31faeb712822f12e6feab31a/mock-responses/developerapi) folders from the https://github.com/FirebaseExtended/vertexai-sdk-test-data repo. Since the subfolders are now referenced in [`Package.swift`](https://github.com/firebase/firebase-ios-sdk/blob/3bc52e3fc1086b7477a645a1ed2cc4a6d59b185b/Package.swift#L1321), the previous placeholder at [`mock-responses`](https://github.com/firebase/firebase-ios-sdk/blob/3bc52e3fc1086b7477a645a1ed2cc4a6d59b185b/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/mock-responses) no longer silences the SPM warning
> Invalid Resource 'vertexai-sdk-test-data/mock-responses/vertexai': File not found.

Note: `developerapi` is not yet referenced but soon will be.

#no-changelog
