### PR TITLE
[Swift 6] Add AtomicBox to CoreInternal

### DIFF
--- a/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
+++ b/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
@@ -1,0 +1,43 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public final class AtomicBox<T> {
+  private var _value: T
+  private let lock = NSLock()
+
+  public init(_ value: T) {
+    _value = value
+  }
+
+  public func value() -> T {
+    lock.withLock {
+      _value
+    }
+  }
+
+  @discardableResult
+  public func withLock(_ mutatingBody: (_ value: inout T) -> Void) -> T {
+    lock.withLock {
+      mutatingBody(&_value)
+      return _value
+    }
+  }
+
+  @discardableResult
+  public func withLock<R>(_ mutatingBody: (_ value: inout T) throws -> R) rethrows -> R {
+    try lock.withLock {
+      try mutatingBody(&_value)
+    }
+  }
+}

--- a/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
+++ b/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public final class AtomicBox<T> {
+final class AtomicBox<T> {
   private var _value: T
   private let lock = NSLock()
 

--- a/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
+++ b/FirebaseCore/Internal/Sources/Utilities/AtomicBox.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
+
 final class AtomicBox<T> {
   private var _value: T
   private let lock = NSLock()


### PR DESCRIPTION
Plan: Add AtomicBox to each module as needed as part of addressing Swift 6 warnings. Then, when we move to Xcode 16, delete all definitions of AtomicBox apart from the one defined in this PR, in FirebaseCoreInternal. Reason being is that Xcode 16 gives us Swift 6 support for `internal import FirebaseCoreInternal` in other product SDKs that can then get `AtomicBox`.

#no-changelog