### PR TITLE
[Vertex AI] Log warning for unsupported model names

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 11.11.0
+- [added] Emits a warning when attempting to use an incompatible model with
+  `GenerativeModel` or `ImagenModel`. (#14610)
+
 # 11.10.0
 - [feature] The Vertex AI SDK no longer requires `@preconcurrency` when imported in Swift 6.
 - [feature] The Vertex AI Sample App now includes an image generation example.

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -20,6 +20,9 @@ import Foundation
 /// content based on various input types.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public final class GenerativeModel: Sendable {
+  /// Model name prefix to identify Gemini models.
+  static let geminiModelNamePrefix = "gemini-"
+
   /// The resource name of the model in the backend; has the format "models/model-name".
   let modelResourceName: String
 
@@ -71,6 +74,13 @@ public final class GenerativeModel: Sendable {
        systemInstruction: ModelContent? = nil,
        requestOptions: RequestOptions,
        urlSession: URLSession = .shared) {
+    if !name.starts(with: GenerativeModel.geminiModelNamePrefix) {
+      VertexLog.warning(code: .unsupportedGeminiModel, """
+      Unsupported Gemini model "\(name)"; see \
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
+      """)
+    }
+
     modelResourceName = name
     self.apiConfig = apiConfig
     generativeAIService = GenerativeAIService(
@@ -89,13 +99,6 @@ public final class GenerativeModel: Sendable {
       ModelContent(role: nil, parts: $0.parts)
     }
     self.requestOptions = requestOptions
-
-    if !name.starts(with: "gemini-") {
-      VertexLog.warn(code: .unsupportedModelName, """
-        Unsupported Gemini model "\(name)"; see \
-        https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
-        """)
-    }
 
     if VertexLog.additionalLoggingEnabled() {
       VertexLog.debug(code: .verboseLoggingEnabled, "Verbose logging enabled.")

--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -90,6 +90,13 @@ public final class GenerativeModel: Sendable {
     }
     self.requestOptions = requestOptions
 
+    if !name.starts(with: "gemini-") {
+      VertexLog.warn(code: .unsupportedModelName, """
+        Unsupported Gemini model "\(name)"; see \
+        https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
+        """)
+    }
+
     if VertexLog.additionalLoggingEnabled() {
       VertexLog.debug(code: .verboseLoggingEnabled, "Verbose logging enabled.")
     } else {

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -60,6 +60,13 @@ public final class ImagenModel {
     self.generationConfig = generationConfig
     self.safetySettings = safetySettings
     self.requestOptions = requestOptions
+
+    if !name.starts(with: "imagen-") {
+      VertexLog.warn(code: .unsupportedModelName, """
+        Unsupported Imagen model "\(name)"; see \
+        https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
+        """)
+    }
   }
 
   /// **[Public Preview]** Generates images using the Imagen model and returns them as inline data.

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -28,6 +28,9 @@ import Foundation
 /// could change in backwards-incompatible ways.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public final class ImagenModel {
+  /// Model name prefix to identify Imagen models.
+  static let imagenModelNamePrefix = "imagen-"
+
   /// The resource name of the model in the backend; has the format "models/model-name".
   let modelResourceName: String
 
@@ -51,6 +54,13 @@ public final class ImagenModel {
        safetySettings: ImagenSafetySettings?,
        requestOptions: RequestOptions,
        urlSession: URLSession = .shared) {
+    if !name.starts(with: ImagenModel.imagenModelNamePrefix) {
+      VertexLog.warning(code: .unsupportedImagenModel, """
+      Unsupported Imagen model "\(name)"; see \
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
+      """)
+    }
+
     modelResourceName = name
     self.apiConfig = apiConfig
     generativeAIService = GenerativeAIService(
@@ -60,13 +70,6 @@ public final class ImagenModel {
     self.generationConfig = generationConfig
     self.safetySettings = safetySettings
     self.requestOptions = requestOptions
-
-    if !name.starts(with: "imagen-") {
-      VertexLog.warn(code: .unsupportedModelName, """
-        Unsupported Imagen model "\(name)"; see \
-        https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
-        """)
-    }
   }
 
   /// **[Public Preview]** Generates images using the Imagen model and returns them as inline data.

--- a/FirebaseVertexAI/Sources/VertexLog.swift
+++ b/FirebaseVertexAI/Sources/VertexLog.swift
@@ -33,9 +33,11 @@ enum VertexLog {
 
     // Generative Model Configuration
     case generativeModelInitialized = 1000
+    case unsupportedGeminiModel = 1001
 
     // Imagen Model Configuration
     case imagenInvalidJPEGCompressionQuality = 1201
+    case unsupportedImagenModel = 1200
 
     // Network Errors
     case generativeAIServiceNonHTTPResponse = 2000

--- a/FirebaseVertexAI/Sources/VertexLog.swift
+++ b/FirebaseVertexAI/Sources/VertexLog.swift
@@ -36,8 +36,8 @@ enum VertexLog {
     case unsupportedGeminiModel = 1001
 
     // Imagen Model Configuration
-    case imagenInvalidJPEGCompressionQuality = 1201
     case unsupportedImagenModel = 1200
+    case imagenInvalidJPEGCompressionQuality = 1201
 
     // Network Errors
     case generativeAIServiceNonHTTPResponse = 2000


### PR DESCRIPTION
Added a warning message to the initializers of `GenerativeModel` and `ImagenModel` that is logged when the provided model name does not start with the expected prefix (`"gemini-"` for `GenerativeModel` and `"imagen-"` for `ImagenModel`). The warning message includes a link to the documentation for supported models.

Note: No error is thrown in case the naming scheme is changed in the future, though we would want to update the logic/message at that time.