### PR TITLE
[Vertex AI] Swift Testing `generateContentStream` integration test

### DIFF
--- a/FirebaseVertexAI/Tests/TestApp/Sources/FirebaseAppUtils.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Sources/FirebaseAppUtils.swift
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseCore
+
+extension FirebaseApp {
+  static func configure(appName: String, plistName: String) {
+    guard let plistPath =
+      Bundle.main.path(forResource: plistName, ofType: "plist") else {
+      fatalError("The file '\(plistName).plist' was not found.")
+    }
+    guard let options = FirebaseOptions(contentsOfFile: plistPath) else {
+      fatalError("Failed to parse options from '\(plistName).plist'.")
+    }
+    FirebaseApp.configure(name: appName, options: options)
+  }
+}

--- a/FirebaseVertexAI/Tests/TestApp/Sources/TestApp.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Sources/TestApp.swift
@@ -24,15 +24,14 @@ struct TestApp: App {
     // Configure default Firebase App
     FirebaseApp.configure()
 
+    // Configure a Firebase App that is the same as the default app but without App Check.
+    FirebaseApp.configure(
+      appName: FirebaseAppNames.appCheckNotConfigured,
+      plistName: "GoogleService-Info"
+    )
+
     // Configure a Firebase App without a billing account (i.e., the "Spark" plan).
-    guard let plistPath =
-      Bundle.main.path(forResource: "GoogleService-Info-Spark", ofType: "plist") else {
-      fatalError("The file 'GoogleService-Info-Spark.plist' was not found.")
-    }
-    guard let options = FirebaseOptions(contentsOfFile: plistPath) else {
-      fatalError("Failed to parse options from 'GoogleService-Info-Spark.plist'.")
-    }
-    FirebaseApp.configure(name: FirebaseAppNames.spark, options: options)
+    FirebaseApp.configure(appName: FirebaseAppNames.spark, plistName: "GoogleService-Info-Spark")
   }
 
   var body: some Scene {

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -67,23 +67,6 @@ final class IntegrationTests: XCTestCase {
     storage = Storage.storage()
   }
 
-  // MARK: - Generate Content
-
-  func testGenerateContent_appCheckNotConfigured_shouldFail() async throws {
-    let app = try FirebaseApp.defaultNamedCopy(name: FirebaseAppNames.appCheckNotConfigured)
-    addTeardownBlock { await app.delete() }
-    let vertex = VertexAI.vertexAI(app: app)
-    let model = vertex.generativeModel(modelName: "gemini-2.0-flash")
-    let prompt = "Where is Google headquarters located? Answer with the city name only."
-
-    do {
-      _ = try await model.generateContent(prompt)
-      XCTFail("Expected a Firebase App Check error; none thrown.")
-    } catch let GenerateContentError.internalError(error) {
-      XCTAssertTrue(String(describing: error).contains("Firebase App Check token is invalid"))
-    }
-  }
-
   // MARK: - Count Tokens
 
   func testCountTokens_text() async throws {

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -69,45 +69,6 @@ final class IntegrationTests: XCTestCase {
 
   // MARK: - Generate Content
 
-  func testGenerateContentStream() async throws {
-    let expectedText = """
-    1.  Mercury
-    2.  Venus
-    3.  Earth
-    4.  Mars
-    5.  Jupiter
-    6.  Saturn
-    7.  Uranus
-    8.  Neptune
-    """
-    let prompt = """
-    What are the names of the planets in the solar system, ordered from closest to furthest from
-    the sun? Answer with a Markdown numbered list of the names and no other text.
-    """
-    let chat = model.startChat()
-
-    let stream = try chat.sendMessageStream(prompt)
-    var textValues = [String]()
-    for try await value in stream {
-      try textValues.append(XCTUnwrap(value.text))
-    }
-
-    let userHistory = try XCTUnwrap(chat.history.first)
-    XCTAssertEqual(userHistory.role, "user")
-    XCTAssertEqual(userHistory.parts.count, 1)
-    let promptTextPart = try XCTUnwrap(userHistory.parts.first as? TextPart)
-    XCTAssertEqual(promptTextPart.text, prompt)
-    let modelHistory = try XCTUnwrap(chat.history.last)
-    XCTAssertEqual(modelHistory.role, "model")
-    XCTAssertEqual(modelHistory.parts.count, 1)
-    let modelTextPart = try XCTUnwrap(modelHistory.parts.first as? TextPart)
-    let modelText = modelTextPart.text.trimmingCharacters(in: .whitespacesAndNewlines)
-    XCTAssertEqual(modelText, expectedText)
-    XCTAssertGreaterThan(textValues.count, 1)
-    let text = textValues.joined().trimmingCharacters(in: .whitespacesAndNewlines)
-    XCTAssertEqual(text, expectedText)
-  }
-
   func testGenerateContent_appCheckNotConfigured_shouldFail() async throws {
     let app = try FirebaseApp.defaultNamedCopy(name: FirebaseAppNames.appCheckNotConfigured)
     addTeardownBlock { await app.delete() }

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -34,6 +34,15 @@ struct InstanceConfig {
   )
   static let allConfigs = [vertexV1, vertexV1Beta, developerV1, developerV1Beta]
 
+  static let vertexV1AppCheckNotConfigured = InstanceConfig(
+    appName: FirebaseAppNames.appCheckNotConfigured,
+    apiConfig: APIConfig(service: .vertexAI, version: .v1)
+  )
+  static let vertexV1BetaAppCheckNotConfigured = InstanceConfig(
+    appName: FirebaseAppNames.appCheckNotConfigured,
+    apiConfig: APIConfig(service: .vertexAI, version: .v1beta)
+  )
+
   let appName: String?
   let location: String?
   let apiConfig: APIConfig

--- a/FirebaseVertexAI/Tests/TestApp/VertexAITestApp.xcodeproj/project.pbxproj
+++ b/FirebaseVertexAI/Tests/TestApp/VertexAITestApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		8692F29E2CC9477800539E8F /* FirebaseVertexAI in Frameworks */ = {isa = PBXBuildFile; productRef = 8692F29D2CC9477800539E8F /* FirebaseVertexAI */; };
 		8698D7462CD3CF3600ABA833 /* FirebaseAppTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D7452CD3CF2F00ABA833 /* FirebaseAppTestUtils.swift */; };
 		8698D7482CD4332B00ABA833 /* TestAppCheckProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D7472CD4332B00ABA833 /* TestAppCheckProviderFactory.swift */; };
+		86CC31352D91EE9E0087E964 /* FirebaseAppUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CC31342D91EE9E0087E964 /* FirebaseAppUtils.swift */; };
 		86D77DFC2D7A5340003D155D /* GenerateContentIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D77DFB2D7A5340003D155D /* GenerateContentIntegrationTests.swift */; };
 		86D77DFE2D7B5C86003D155D /* GoogleService-Info-Spark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 86D77DFD2D7B5C86003D155D /* GoogleService-Info-Spark.plist */; };
 		86D77E022D7B63AF003D155D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D77E012D7B63AC003D155D /* Constants.swift */; };
@@ -55,6 +56,7 @@
 		868A7C552CCC271300E449DD /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 		8698D7452CD3CF2F00ABA833 /* FirebaseAppTestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAppTestUtils.swift; sourceTree = "<group>"; };
 		8698D7472CD4332B00ABA833 /* TestAppCheckProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppCheckProviderFactory.swift; sourceTree = "<group>"; };
+		86CC31342D91EE9E0087E964 /* FirebaseAppUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAppUtils.swift; sourceTree = "<group>"; };
 		86D77DFB2D7A5340003D155D /* GenerateContentIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateContentIntegrationTests.swift; sourceTree = "<group>"; };
 		86D77DFD2D7B5C86003D155D /* GoogleService-Info-Spark.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Spark.plist"; sourceTree = "<group>"; };
 		86D77E012D7B63AC003D155D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				8698D7472CD4332B00ABA833 /* TestAppCheckProviderFactory.swift */,
 				8661385D2CC943DD00F4B78E /* ContentView.swift */,
 				86D77E012D7B63AC003D155D /* Constants.swift */,
+				86CC31342D91EE9E0087E964 /* FirebaseAppUtils.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				86CC31352D91EE9E0087E964 /* FirebaseAppUtils.swift in Sources */,
 				8661385E2CC943DD00F4B78E /* ContentView.swift in Sources */,
 				8661385C2CC943DD00F4B78E /* TestApp.swift in Sources */,
 				8698D7482CD4332B00ABA833 /* TestAppCheckProviderFactory.swift in Sources */,


### PR DESCRIPTION
Migrated the `testGenerateContentStream` and `testGenerateContent_appCheckNotConfigured_shouldFail` integration tests from `XCTest` to Swift Testing (in `GenerateContentIntegrationTests`) and parameterized them to run on all of their supported backend APIs.

#no-changelog