### PR TITLE
[Vertex AI] Fix typo in 11.9.0 changelog and add link to guide

### DIFF
--- a/FirebaseVertexAI/CHANGELOG.md
+++ b/FirebaseVertexAI/CHANGELOG.md
@@ -11,12 +11,12 @@
   are required. (#14558)
 
 # 11.9.0
-- [feature] **Public Preview**: Added support for generating images using the
-  Imagen 3 model.
+- [feature] **Public Preview**: Added support for
+  [generating images](https://firebase.google.com/docs/vertex-ai/generate-images-imagen?platform=ios)
+  using the Imagen 3 models.
   <br /><br />
-  Note: This feature is in Public Preview, which means that the it is not
-  subject to any SLA or deprecation policy and could change in
-  backwards-incompatible ways.
+  Note: This feature is in Public Preview, which means that it is not subject to
+  any SLA or deprecation policy and could change in backwards-incompatible ways.
 - [feature] Added support for modality-based token count. (#14406)
 
 # 11.6.0


### PR DESCRIPTION
Fixed a typo (`"the it is"`) in the Vertex AI in Firebase 11.9.0 changelog entry and added a link to the [guide](https://firebase.google.com/docs/vertex-ai/generate-images-imagen?platform=ios). This brings it in alignment with [cl/740299138](https://critique.corp.google.com/cl/740299138) (Google-internal).