### PR TITLE
consolidate FIRCLSRedactUUID tests for clarity

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -77,56 +77,60 @@
   XCTAssertEqualObjects([NSString stringWithUTF8String:string], @"52d04e1f", @"");
 }
 
-- (void)testRedactUUIDWithExpectedPattern {
-  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
-                         "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - "
-                         "DeviceType: iPhone SE (2nd generation)";
-  size_t len = strlen(readonly);
-  char message[len];
-  strcpy(message, readonly);
+- (void)testRedactUUID {
+  // Define a local struct to hold the test data
+  struct TestCase {
+    const char *name;      // Name of the test case
+    const char *readonly;  // Input string
+    const char *expected;  // Expected output string
+  };
 
-  FIRCLSRedactUUID(message);
+  // Initialize an array of test cases
+  struct TestCase tests[] = {
+      {.name = "Test with valid UUID",
+       .readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                   "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - "
+                   "DeviceType: iPhone SE (2nd generation)",
+       .expected = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                   "(********-****-****-****-************) - Runtime: iOS 13.4 (17E8260) - "
+                   "DeviceType: iPhone SE (2nd generation)"},
+      {.name = "Test with no UUID",
+       .readonly = "Example with no UUID",
+       .expected = "Example with no UUID"},
+      {.name = "Test with only UUID",
+       .readonly = "(12345678-1234-1234-1234-123456789012)",
+       .expected = "(********-****-****-****-************)"},
+      {.name = "Test with malformed UUID pattern",
+       .readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                   "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6",
+       .expected = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                   "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6"},
+      {.name = "Test with other error string",
+       .readonly = "Fatal error: file "
+                   "/Users/test/src/foo/bar/ViewController.swift, line 25",
+       .expected = "Fatal error: file "
+                   "/Users/test/src/foo/bar/ViewController.swift, line 25"},
+      {.name = "Test with NULL input", .readonly = NULL, .expected = NULL}};
 
-  NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
-                       @"(********-****-****-****-************) - Runtime: iOS 13.4 (17E8260) - "
-                       @"DeviceType: iPhone SE (2nd generation)";
+  // Loop over the array of test cases
+  for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+    if (tests[i].readonly == NULL) {
+      XCTAssertNoThrow(FIRCLSRedactUUID(NULL));
+      continue;
+    }
 
-  XCTAssertEqualObjects(actual, expected);
-}
+    // copy the message because the function modifies the input
+    // and the input is const
+    char message[256];
+    snprintf(message, sizeof(message), "%s", tests[i].readonly);
 
-- (void)testRedactUUIDWithMalformedPattern {
-  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
-                         "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
-  size_t len = strlen(readonly);
-  char message[len];
-  strcpy(message, readonly);
+    // Redact the UUID
+    FIRCLSRedactUUID(message);
 
-  FIRCLSRedactUUID(message);
-
-  NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
-                       @"(45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
-
-  XCTAssertEqualObjects(actual, expected);
-}
-
-- (void)testRedactUUIDWithoutUUID {
-  const char* readonly = "Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
-  size_t len = strlen(readonly);
-  char message[len];
-  strcpy(message, readonly);
-
-  FIRCLSRedactUUID(message);
-
-  NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = @"Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
-
-  XCTAssertEqualObjects(actual, expected);
-}
-
-- (void)testRedactUUIDWithNull {
-  char* message = NULL;
-  XCTAssertNoThrow(FIRCLSRedactUUID(message));
+    // Compare the result with the expected output
+    NSString *actual = [NSString stringWithUTF8String:message];
+    NSString *expected = [NSString stringWithUTF8String:tests[i].expected];
+    XCTAssertEqualObjects(actual, expected, @"Test named: '%s' failed", tests[i].name);
+  }
 }
 @end


### PR DESCRIPTION
* consolidates tests to make them easier to follow
* switches from `strcpy` to `snprintf` because `check.sh` complains about `strcpy`

### Testing
I was hoping CI would run the tests because my machine is too old to run a new enough Xcode version.

