### PR TITLE
[Vertex AI] Fix unsupported model name check introduced in #14610

### DIFF
--- a/FirebaseVertexAI/Sources/GenerativeModel.swift
+++ b/FirebaseVertexAI/Sources/GenerativeModel.swift
@@ -53,7 +53,8 @@ public final class GenerativeModel: Sendable {
   /// Initializes a new remote model with the given parameters.
   ///
   /// - Parameters:
-  ///   - name: The name of the model to use, for example `"gemini-1.0-pro"`.
+  ///   - modelResourceName: The resource name of the model to use, for example
+  ///     `"projects/{project-id}/locations/{location-id}/publishers/google/models/{model-name}"`.
   ///   - firebaseInfo: Firebase data used by the SDK, including project ID and API key.
   ///   - apiConfig: Configuration for the backend API used by this model.
   ///   - generationConfig: The content generation parameters your model should use.
@@ -64,7 +65,7 @@ public final class GenerativeModel: Sendable {
   ///     only text content is supported.
   ///   - requestOptions: Configuration parameters for sending requests to the backend.
   ///   - urlSession: The `URLSession` to use for requests; defaults to `URLSession.shared`.
-  init(name: String,
+  init(modelResourceName: String,
        firebaseInfo: FirebaseInfo,
        apiConfig: APIConfig,
        generationConfig: GenerationConfig? = nil,
@@ -74,14 +75,7 @@ public final class GenerativeModel: Sendable {
        systemInstruction: ModelContent? = nil,
        requestOptions: RequestOptions,
        urlSession: URLSession = .shared) {
-    if !name.starts(with: GenerativeModel.geminiModelNamePrefix) {
-      VertexLog.warning(code: .unsupportedGeminiModel, """
-      Unsupported Gemini model "\(name)"; see \
-      https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
-      """)
-    }
-
-    modelResourceName = name
+    self.modelResourceName = modelResourceName
     self.apiConfig = apiConfig
     generativeAIService = GenerativeAIService(
       firebaseInfo: firebaseInfo,
@@ -108,7 +102,7 @@ public final class GenerativeModel: Sendable {
       `\(VertexLog.enableArgumentKey)` as a launch argument in Xcode.
       """)
     }
-    VertexLog.debug(code: .generativeModelInitialized, "Model \(name) initialized.")
+    VertexLog.debug(code: .generativeModelInitialized, "Model \(modelResourceName) initialized.")
   }
 
   /// Generates content from String and/or image inputs, given to the model as a prompt, that are

--- a/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Imagen/ImagenModel.swift
@@ -47,21 +47,14 @@ public final class ImagenModel {
   /// Configuration parameters for sending requests to the backend.
   let requestOptions: RequestOptions
 
-  init(name: String,
+  init(modelResourceName: String,
        firebaseInfo: FirebaseInfo,
        apiConfig: APIConfig,
        generationConfig: ImagenGenerationConfig?,
        safetySettings: ImagenSafetySettings?,
        requestOptions: RequestOptions,
        urlSession: URLSession = .shared) {
-    if !name.starts(with: ImagenModel.imagenModelNamePrefix) {
-      VertexLog.warning(code: .unsupportedImagenModel, """
-      Unsupported Imagen model "\(name)"; see \
-      https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
-      """)
-    }
-
-    modelResourceName = name
+    self.modelResourceName = modelResourceName
     self.apiConfig = apiConfig
     generativeAIService = GenerativeAIService(
       firebaseInfo: firebaseInfo,

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -70,8 +70,15 @@ public class VertexAI {
                               systemInstruction: ModelContent? = nil,
                               requestOptions: RequestOptions = RequestOptions())
     -> GenerativeModel {
+    if !modelName.starts(with: GenerativeModel.geminiModelNamePrefix) {
+      VertexLog.warning(code: .unsupportedGeminiModel, """
+      Unsupported Gemini model "\(modelName)"; see \
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.
+      """)
+    }
+
     return GenerativeModel(
-      name: modelResourceName(modelName: modelName),
+      modelResourceName: modelResourceName(modelName: modelName),
       firebaseInfo: firebaseInfo,
       apiConfig: apiConfig,
       generationConfig: generationConfig,
@@ -102,8 +109,15 @@ public class VertexAI {
   public func imagenModel(modelName: String, generationConfig: ImagenGenerationConfig? = nil,
                           safetySettings: ImagenSafetySettings? = nil,
                           requestOptions: RequestOptions = RequestOptions()) -> ImagenModel {
+    if !modelName.starts(with: ImagenModel.imagenModelNamePrefix) {
+      VertexLog.warning(code: .unsupportedImagenModel, """
+      Unsupported Imagen model "\(modelName)"; see \
+      https://firebase.google.com/docs/vertex-ai/models for a list supported Imagen model names.
+      """)
+    }
+
     return ImagenModel(
-      name: modelResourceName(modelName: modelName),
+      modelResourceName: modelResourceName(modelName: modelName),
       firebaseInfo: firebaseInfo,
       apiConfig: apiConfig,
       generationConfig: generationConfig,

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -59,7 +59,7 @@ final class ChatTests: XCTestCase {
                           options: FirebaseOptions(googleAppID: "ignore",
                                                    gcmSenderID: "ignore"))
     let model = GenerativeModel(
-      name: "my-model",
+      modelResourceName: "my-model",
       firebaseInfo: FirebaseInfo(
         projectID: "my-project-id",
         apiKey: "API_KEY",

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -70,7 +70,7 @@ final class GenerativeModelTests: XCTestCase {
     configuration.protocolClasses = [MockURLProtocol.self]
     urlSession = try XCTUnwrap(URLSession(configuration: configuration))
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       tools: nil,
@@ -276,7 +276,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let model = GenerativeModel(
       // Model name is prefixed with "models/".
-      name: "models/test-model",
+      modelResourceName: "models/test-model",
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       tools: nil,
@@ -399,7 +399,7 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContent_appCheck_validToken() async throws {
     let appCheckToken = "test-valid-token"
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(appCheck: AppCheckInteropFake(token: appCheckToken)),
       apiConfig: apiConfig,
       tools: nil,
@@ -420,7 +420,7 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContent_dataCollectionOff() async throws {
     let appCheckToken = "test-valid-token"
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(appCheck: AppCheckInteropFake(token: appCheckToken),
                                      privateAppID: true),
       apiConfig: apiConfig,
@@ -442,7 +442,7 @@ final class GenerativeModelTests: XCTestCase {
 
   func testGenerateContent_appCheck_tokenRefreshError() async throws {
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(appCheck: AppCheckInteropFake(error: AppCheckErrorFake())),
       apiConfig: apiConfig,
       tools: nil,
@@ -463,7 +463,7 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContent_auth_validAuthToken() async throws {
     let authToken = "test-valid-token"
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(auth: AuthInteropFake(token: authToken)),
       apiConfig: apiConfig,
       tools: nil,
@@ -483,7 +483,7 @@ final class GenerativeModelTests: XCTestCase {
 
   func testGenerateContent_auth_nilAuthToken() async throws {
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(auth: AuthInteropFake(token: nil)),
       apiConfig: apiConfig,
       tools: nil,
@@ -503,7 +503,7 @@ final class GenerativeModelTests: XCTestCase {
 
   func testGenerateContent_auth_authTokenRefreshError() async throws {
     model = GenerativeModel(
-      name: "my-model",
+      modelResourceName: "my-model",
       firebaseInfo: testFirebaseInfo(auth: AuthInteropFake(error: AuthErrorFake())),
       apiConfig: apiConfig,
       tools: nil,
@@ -900,7 +900,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let requestOptions = RequestOptions(timeout: expectedTimeout)
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       tools: nil,
@@ -1204,7 +1204,7 @@ final class GenerativeModelTests: XCTestCase {
   func testGenerateContentStream_appCheck_validToken() async throws {
     let appCheckToken = "test-valid-token"
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(appCheck: AppCheckInteropFake(token: appCheckToken)),
       apiConfig: apiConfig,
       tools: nil,
@@ -1225,7 +1225,7 @@ final class GenerativeModelTests: XCTestCase {
 
   func testGenerateContentStream_appCheck_tokenRefreshError() async throws {
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(appCheck: AppCheckInteropFake(error: AppCheckErrorFake())),
       apiConfig: apiConfig,
       tools: nil,
@@ -1375,7 +1375,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let requestOptions = RequestOptions(timeout: expectedTimeout)
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       tools: nil,
@@ -1451,7 +1451,7 @@ final class GenerativeModelTests: XCTestCase {
       parts: "You are a calculator. Use the provided tools."
     )
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       generationConfig: generationConfig,
@@ -1511,7 +1511,7 @@ final class GenerativeModelTests: XCTestCase {
       )
     let requestOptions = RequestOptions(timeout: expectedTimeout)
     model = GenerativeModel(
-      name: testModelResourceName,
+      modelResourceName: testModelResourceName,
       firebaseInfo: testFirebaseInfo(),
       apiConfig: apiConfig,
       tools: nil,


### PR DESCRIPTION
The model name checks introduced in #14610 were checking that the model resource name, not the model name, started with `gemini-` or `imagen-`. This resulted in the log warning always being emitted since the model resource name (e.g., `projects/my-project-id/locations/us-central-1/publishers/google/models/gemini-2.0-flash`) never starts with `gemini-`.

This PR moves the check into `VertexAI` before the model name is converted to a model resource name. Also updated the parameter names in the `GenerativeModel` and `ImagenModel` constructors to be `modelResourceName` instead of `name` to _reduce_ confusion.

#no-changelog