### PR TITLE
Firestore: minor tweaks to ThreadSafeMemozier code in response to code review feedback

### DIFF
--- a/Firestore/core/src/core/filter.h
+++ b/Firestore/core/src/core/filter.h
@@ -164,7 +164,7 @@ class Filter {
      * Memoized list of all field filters that can be found by
      * traversing the tree of filters contained in this composite filter.
      */
-    mutable util::ThreadSafeMemoizer<std::vector<FieldFilter>>
+    mutable util::ThreadSafeMemoizer<const std::vector<FieldFilter>>
         memoized_flattened_filters_;
   };
 

--- a/Firestore/core/src/core/query.cc
+++ b/Firestore/core/src/core/query.cc
@@ -92,7 +92,7 @@ absl::optional<Operator> Query::FindOpInsideFilters(
   return absl::nullopt;
 }
 
-std::shared_ptr<std::vector<OrderBy>> Query::CalculateNormalizedOrderBys()
+std::shared_ptr<const std::vector<OrderBy>> Query::CalculateNormalizedOrderBys()
     const {
   // Any explicit order by fields should be added as is.
   auto result = std::make_shared<std::vector<OrderBy>>(explicit_order_bys_);

--- a/Firestore/core/src/core/query.h
+++ b/Firestore/core/src/core/query.h
@@ -299,14 +299,10 @@ class Query {
 
   Target ToTarget(const std::vector<OrderBy>& order_bys) const;
 
-  // For properties below, use a `std::shared_ptr<ThreadSafeMemoizer>` rather
-  // than using `ThreadSafeMemoizer` directly so that this class is copyable
-  // (`ThreadSafeMemoizer` is not copyable because of its `std::once_flag`
-  // member variable, which is not copyable).
-
   // The memoized list of sort orders.
-  std::shared_ptr<std::vector<OrderBy>> CalculateNormalizedOrderBys() const;
-  mutable util::ThreadSafeMemoizer<std::vector<OrderBy>>
+  std::shared_ptr<const std::vector<OrderBy>> CalculateNormalizedOrderBys()
+      const;
+  mutable util::ThreadSafeMemoizer<const std::vector<OrderBy>>
       memoized_normalized_order_bys_;
 
   // The corresponding Target of this Query instance.

--- a/Firestore/core/test/unit/util/thread_safe_memoizer_testing.cc
+++ b/Firestore/core/test/unit/util/thread_safe_memoizer_testing.cc
@@ -81,7 +81,7 @@ CountingFunc::CountingFunc(std::vector<std::string> chunks)
 std::function<std::shared_ptr<std::string>()> CountingFunc::func(
     std::string cookie) {
   return [this, cookie = std::move(cookie)] {
-    return std::make_shared<std::string>(Next(cookie));
+    return std::make_shared<std::string>(NextFuncReturnValue(cookie));
   };
 }
 
@@ -89,7 +89,7 @@ int CountingFunc::invocation_count() const {
   return count_.load(std::memory_order_acquire);
 }
 
-std::string CountingFunc::Next(const std::string& cookie) {
+std::string CountingFunc::NextFuncReturnValue(const std::string& cookie) {
   const int id = count_.fetch_add(1, std::memory_order_acq_rel);
   std::ostringstream ss;
   for (const std::string& chunk : chunks_) {

--- a/Firestore/core/test/unit/util/thread_safe_memoizer_testing.h
+++ b/Firestore/core/test/unit/util/thread_safe_memoizer_testing.h
@@ -97,7 +97,7 @@ class CountingFunc {
   std::vector<std::string> chunks_;
 
   explicit CountingFunc(std::vector<std::string> chunks);
-  std::string Next(const std::string& cookie);
+  std::string NextFuncReturnValue(const std::string& cookie);
 };
 
 /**


### PR DESCRIPTION
This PR addresses some minor feedback in https://github.com/firebase/firebase-ios-sdk/pull/14300, the refactor of `ThreadSafeMemoizer` to fix the apparent "memory leak" detected by Xcode.

The changes are as follows:
1. Rename `CountingFunc::Next()` to `CountingFunc::NextFuncReturnValue()`.
2. Use `const` vectors for memoized values; that is, change `std::shared_ptr<std::vector<T>>` to `std::shared_ptr<const std::vector<T>>`.
3. Remove an obsolete inline comment about an implementation choice pertaining to the _old_ implementation of ThreadSafeMemoizer.