### PR TITLE
[Vertex AI] Add integration tests for staging endpoint

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseVertexAI/Sources/Types/Internal/APIConfig.swift
@@ -45,7 +45,7 @@ extension APIConfig {
     /// See the [Cloud
     /// docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) for
     /// more details.
-    case vertexAI
+    case vertexAI(endpoint: Endpoint)
 
     /// The Gemini Developer API provided by Google AI.
     ///
@@ -57,8 +57,8 @@ extension APIConfig {
     /// This must correspond with the API set in `service`.
     var endpoint: Endpoint {
       switch self {
-      case .vertexAI:
-        return .firebaseVertexAIProd
+      case let .vertexAI(endpoint: endpoint):
+        return endpoint
       case let .developer(endpoint: endpoint):
         return endpoint
       }

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -38,6 +38,8 @@ public class VertexAI {
   public static func vertexAI(app: FirebaseApp? = nil,
                               location: String = "us-central1") -> VertexAI {
     let vertexInstance = vertexAI(app: app, location: location, apiConfig: defaultVertexAIAPIConfig)
+    // Verify that the `VertexAI` instance is always configured with the production endpoint since
+    // this is the public API surface for creating an instance.
     assert(vertexInstance.apiConfig.service == .vertexAI(endpoint: .firebaseVertexAIProd))
     assert(vertexInstance.apiConfig.service.endpoint == .firebaseVertexAIProd)
     assert(vertexInstance.apiConfig.version == .v1beta)

--- a/FirebaseVertexAI/Sources/VertexAI.swift
+++ b/FirebaseVertexAI/Sources/VertexAI.swift
@@ -38,7 +38,7 @@ public class VertexAI {
   public static func vertexAI(app: FirebaseApp? = nil,
                               location: String = "us-central1") -> VertexAI {
     let vertexInstance = vertexAI(app: app, location: location, apiConfig: defaultVertexAIAPIConfig)
-    assert(vertexInstance.apiConfig.service == .vertexAI)
+    assert(vertexInstance.apiConfig.service == .vertexAI(endpoint: .firebaseVertexAIProd))
     assert(vertexInstance.apiConfig.service.endpoint == .firebaseVertexAIProd)
     assert(vertexInstance.apiConfig.version == .v1beta)
 
@@ -155,7 +155,10 @@ public class VertexAI {
 
   let location: String?
 
-  static let defaultVertexAIAPIConfig = APIConfig(service: .vertexAI, version: .v1beta)
+  static let defaultVertexAIAPIConfig = APIConfig(
+    service: .vertexAI(endpoint: .firebaseVertexAIProd),
+    version: .v1beta
+  )
 
   static func vertexAI(app: FirebaseApp?, location: String?, apiConfig: APIConfig) -> VertexAI {
     guard let app = app ?? FirebaseApp.app() else {

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
@@ -71,7 +71,9 @@ struct CountTokensIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexV1,
+    InstanceConfig.vertexV1Staging,
     InstanceConfig.vertexV1Beta,
+    InstanceConfig.vertexV1BetaStaging,
     /* System instructions are not supported on the v1 Developer API. */
     InstanceConfig.developerV1Beta,
   ])

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -78,7 +78,9 @@ struct GenerateContentIntegrationTests {
     "Generate an enum and provide a system instruction",
     arguments: [
       InstanceConfig.vertexV1,
+      InstanceConfig.vertexV1Staging,
       InstanceConfig.vertexV1Beta,
+      InstanceConfig.vertexV1BetaStaging,
       /* System instructions are not supported on the v1 Developer API. */
       InstanceConfig.developerV1Beta,
     ]

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -20,9 +20,17 @@ import VertexAITestApp
 @testable import class FirebaseVertexAI.VertexAI
 
 struct InstanceConfig {
-  static let vertexV1 = InstanceConfig(apiConfig: APIConfig(service: .vertexAI, version: .v1))
+  static let vertexV1 = InstanceConfig(
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1)
+  )
+  static let vertexV1Staging = InstanceConfig(
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIStaging), version: .v1)
+  )
   static let vertexV1Beta = InstanceConfig(
-    apiConfig: APIConfig(service: .vertexAI, version: .v1beta)
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1beta)
+  )
+  static let vertexV1BetaStaging = InstanceConfig(
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIStaging), version: .v1beta)
   )
   static let developerV1 = InstanceConfig(
     appName: FirebaseAppNames.spark,
@@ -32,15 +40,22 @@ struct InstanceConfig {
     appName: FirebaseAppNames.spark,
     apiConfig: APIConfig(service: .developer(endpoint: .generativeLanguage), version: .v1beta)
   )
-  static let allConfigs = [vertexV1, vertexV1Beta, developerV1, developerV1Beta]
+  static let allConfigs = [
+    vertexV1,
+    vertexV1Staging,
+    vertexV1Beta,
+    vertexV1BetaStaging,
+    developerV1,
+    developerV1Beta,
+  ]
 
   static let vertexV1AppCheckNotConfigured = InstanceConfig(
     appName: FirebaseAppNames.appCheckNotConfigured,
-    apiConfig: APIConfig(service: .vertexAI, version: .v1)
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1)
   )
   static let vertexV1BetaAppCheckNotConfigured = InstanceConfig(
     appName: FirebaseAppNames.appCheckNotConfigured,
-    apiConfig: APIConfig(service: .vertexAI, version: .v1beta)
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1beta)
   )
 
   let appName: String?

--- a/FirebaseVertexAI/Tests/Unit/ChatTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/ChatTests.swift
@@ -66,7 +66,7 @@ final class ChatTests: XCTestCase {
         firebaseAppID: "My app ID",
         firebaseApp: app
       ),
-      apiConfig: APIConfig(service: .vertexAI, version: .v1beta),
+      apiConfig: VertexAI.defaultVertexAIAPIConfig,
       tools: nil,
       requestOptions: RequestOptions(),
       urlSession: urlSession

--- a/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/GenerativeModelTests.swift
@@ -58,7 +58,7 @@ final class GenerativeModelTests: XCTestCase {
   ].sorted()
   let testModelResourceName =
     "projects/test-project-id/locations/test-location/publishers/google/models/test-model"
-  let apiConfig = APIConfig(service: .vertexAI, version: .v1beta)
+  let apiConfig = VertexAI.defaultVertexAIAPIConfig
 
   let vertexSubdirectory = "vertexai"
 

--- a/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImagenGenerationRequestTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Imagen/ImagenGenerationRequestTests.swift
@@ -36,7 +36,7 @@ final class ImagenGenerationRequestTests: XCTestCase {
     addWatermark: nil,
     includeResponsibleAIFilterReason: includeResponsibleAIFilterReason
   )
-  let apiConfig = APIConfig(service: .vertexAI, version: .v1beta)
+  let apiConfig = VertexAI.defaultVertexAIAPIConfig
 
   let instance = ImageGenerationInstance(prompt: "test-prompt")
 

--- a/FirebaseVertexAI/Tests/Unit/Types/Internal/APIConfigTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Internal/APIConfigTests.swift
@@ -19,16 +19,37 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 final class APIConfigTests: XCTestCase {
   func testInitialize_vertexAI_prod_v1() {
-    let apiConfig = APIConfig(service: .vertexAI, version: .v1)
+    let apiConfig = APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1)
 
     XCTAssertEqual(apiConfig.service.endpoint.rawValue, "https://firebasevertexai.googleapis.com")
     XCTAssertEqual(apiConfig.version.rawValue, "v1")
   }
 
   func testInitialize_vertexAI_prod_v1beta() {
-    let apiConfig = APIConfig(service: .vertexAI, version: .v1beta)
+    let apiConfig = APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1beta)
 
     XCTAssertEqual(apiConfig.service.endpoint.rawValue, "https://firebasevertexai.googleapis.com")
+    XCTAssertEqual(apiConfig.version.rawValue, "v1beta")
+  }
+
+  func testInitialize_vertexAI_staging_v1() {
+    let apiConfig = APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIStaging), version: .v1)
+
+    XCTAssertEqual(
+      apiConfig.service.endpoint.rawValue, "https://staging-firebasevertexai.sandbox.googleapis.com"
+    )
+    XCTAssertEqual(apiConfig.version.rawValue, "v1")
+  }
+
+  func testInitialize_vertexAI_staging_v1beta() {
+    let apiConfig = APIConfig(
+      service: .vertexAI(endpoint: .firebaseVertexAIStaging),
+      version: .v1beta
+    )
+
+    XCTAssertEqual(
+      apiConfig.service.endpoint.rawValue, "https://staging-firebasevertexai.sandbox.googleapis.com"
+    )
     XCTAssertEqual(apiConfig.version.rawValue, "v1beta")
   }
 

--- a/FirebaseVertexAI/Tests/Unit/Types/Internal/Requests/CountTokensRequestTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/Types/Internal/Requests/CountTokensRequestTests.swift
@@ -23,7 +23,7 @@ final class CountTokensRequestTests: XCTestCase {
 
   let modelResourceName = "models/test-model-name"
   let textPart = TextPart("test-prompt")
-  let vertexAPIConfig = APIConfig(service: .vertexAI, version: .v1beta)
+  let vertexAPIConfig = VertexAI.defaultVertexAIAPIConfig
   let developerAPIConfig = APIConfig(
     service: .developer(endpoint: .firebaseVertexAIProd),
     version: .v1beta

--- a/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseVertexAI/Tests/Unit/VertexComponentTests.swift
@@ -59,7 +59,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(vertex.location, "us-central1")
-    XCTAssertEqual(vertex.apiConfig.service, .vertexAI)
+    XCTAssertEqual(vertex.apiConfig.service, .vertexAI(endpoint: .firebaseVertexAIProd))
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseVertexAIProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
   }
@@ -73,7 +73,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(vertex.location, location)
-    XCTAssertEqual(vertex.apiConfig.service, .vertexAI)
+    XCTAssertEqual(vertex.apiConfig.service, .vertexAI(endpoint: .firebaseVertexAIProd))
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseVertexAIProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
   }
@@ -86,7 +86,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(vertex.location, location)
-    XCTAssertEqual(vertex.apiConfig.service, .vertexAI)
+    XCTAssertEqual(vertex.apiConfig.service, .vertexAI(endpoint: .firebaseVertexAIProd))
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseVertexAIProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
   }
@@ -138,12 +138,12 @@ class VertexComponentTests: XCTestCase {
     let vertex1 = VertexAI.vertexAI(
       app: VertexComponentTests.app,
       location: location,
-      apiConfig: APIConfig(service: .vertexAI, version: .v1beta)
+      apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1beta)
     )
     let vertex2 = VertexAI.vertexAI(
       app: VertexComponentTests.app,
       location: location,
-      apiConfig: APIConfig(service: .vertexAI, version: .v1)
+      apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1)
     )
 
     // Ensure they are different instances.


### PR DESCRIPTION
Updated `CountTokensIntegrationTests` and `GenerateContentIntegrationTests` to test against the `staging` endpoint in addition to the existing `prod` tests. This will allow us to catch any regressions before backend builds reach `prod`.

#no-changelog