### PR TITLE
[Functions] 'call' API's completion handler should be called on the main thread

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fix regression from 11.6.0 where `HTTPSCallable` did not invoke
+  completion block on main thread (#14653).
+
 # 11.10.0
 - [added] Streaming callable functions are now supported.
 

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -79,12 +79,16 @@ open class HTTPSCallable: NSObject {
                                                    completion: @escaping (HTTPSCallableResult?,
                                                                           Error?) -> Void) {
     if #available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *) {
-      Task { @MainActor in
+      Task {
         do {
           let result = try await call(data)
-          completion(result, nil)
+          await MainActor.run {
+            completion(result, nil)
+          }
         } catch {
-          completion(nil, error)
+          await MainActor.run {
+            completion(nil, error)
+          }
         }
       }
     } else {

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -79,7 +79,7 @@ open class HTTPSCallable: NSObject {
                                                    completion: @escaping (HTTPSCallableResult?,
                                                                           Error?) -> Void) {
     if #available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *) {
-      Task {
+      Task { @MainActor in
         do {
           let result = try await call(data)
           completion(result, nil)

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -867,6 +867,38 @@ class IntegrationTests: XCTestCase {
       XCTAssertEqual(response, expected)
     }
   }
+
+  func testFunctionsReturnsOnMainThread() {
+    let expectation = expectation(description: #function)
+    functions.httpsCallable(
+      "scalarTest",
+      requestAs: Int16.self,
+      responseAs: Int.self
+    ).call(17) { result in
+      guard case .success = result else {
+        return XCTFail("Unexpected failure.")
+      }
+      XCTAssert(Thread.isMainThread)
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 5)
+  }
+
+  func testFunctionsThrowsOnMainThread() {
+    let expectation = expectation(description: #function)
+    functions.httpsCallable(
+      "httpErrorTest",
+      requestAs: [Int].self,
+      responseAs: Int.self
+    ).call([]) { result in
+      guard case .failure = result else {
+        return XCTFail("Unexpected failure.")
+      }
+      XCTAssert(Thread.isMainThread)
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 5)
+  }
 }
 
 // MARK: - Streaming

--- a/FirebaseFunctions/Tests/ObjCIntegration/FIRIntegrationTests.m
+++ b/FirebaseFunctions/Tests/ObjCIntegration/FIRIntegrationTests.m
@@ -290,4 +290,28 @@ static NSString *const kDefaultProjectID = @"functions-integration-test";
   [self waitForExpectations:@[ expectation ] timeout:10];
 }
 
+- (void)testFunctionsReturnsOnMainThread {
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] init];
+  FIRHTTPSCallable *function = [_functions HTTPSCallableWithName:@"scalarTest"];
+  [function callWithObject:@17
+                completion:^(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error) {
+                  XCTAssert(NSThread.isMainThread);
+                  XCTAssertNotNil(result);
+                  [expectation fulfill];
+                }];
+  [self waitForExpectations:@[ expectation ] timeout:10];
+}
+
+- (void)testFunctionErrorsOnMainThread {
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] init];
+  FIRHTTPSCallable *function = [_functions HTTPSCallableWithName:@"httpErrorTest"];
+  [function callWithObject:@{}
+                completion:^(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error) {
+                  XCTAssert(NSThread.isMainThread);
+                  XCTAssertNotNil(error);
+                  [expectation fulfill];
+                }];
+  [self waitForExpectations:@[ expectation ] timeout:10];
+}
+
 @end

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -290,7 +290,7 @@ class FunctionsTests: XCTestCase {
         }
 
         XCTAssertEqual(error as NSError, networkError)
-
+        XCTAssert(Thread.isMainThread)
         completionExpectation.fulfill()
       }
 


### PR DESCRIPTION
ObjC regression tests (after deflaking): https://github.com/firebase/firebase-ios-sdk/actions/runs/14314286364/job/40119407605?pr=14667

Fix #14653
