### PR TITLE
[Sessions] Migrate to import access modifiers

### DIFF
--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -26,7 +26,7 @@ jobs:
         target: [ios, tvos, macos, watchos]
         build-env:
           - os: macos-14
-            xcode: Xcode_15.3
+            xcode: Xcode_16.2
             tests:
           # Flaky tests on CI
           - os: macos-15
@@ -51,11 +51,13 @@ jobs:
   spm-package-resolved:
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-14
+    runs-on: macos-15
     outputs:
       cache_key: ${{ steps.generate_cache_key.outputs.cache_key }}
     steps:
       - uses: actions/checkout@v4
+      - name: Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
       - name: Generate Swift Package.resolved
         id: swift_package_resolve
         run: |
@@ -78,11 +80,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
-            xcode: Xcode_15.2
-            target: iOS
           - os: macos-14
-            xcode: Xcode_15.4
+            xcode: Xcode_16.2
             target: iOS
           - os: macos-15
             xcode: Xcode_16.2
@@ -134,6 +133,8 @@ jobs:
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
         cache_key: catalyst${{ matrix.os }}
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -127,14 +127,12 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
         cache_key: catalyst${{ matrix.os }}
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Setup Bundler
       run: scripts/setup_bundler.sh

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -127,7 +127,7 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126

--- a/FirebaseSessions/Sources/ApplicationInfo.swift
+++ b/FirebaseSessions/Sources/ApplicationInfo.swift
@@ -15,16 +15,16 @@
 
 import Foundation
 
-@_implementationOnly import FirebaseCore
+internal import FirebaseCore
 
 #if SWIFT_PACKAGE
   import FirebaseSessionsObjC
 #endif // SWIFT_PACKAGE
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 /// Development environment for the application.

--- a/FirebaseSessions/Sources/EventGDTLogger.swift
+++ b/FirebaseSessions/Sources/EventGDTLogger.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@_implementationOnly import GoogleDataTransport
+internal import GoogleDataTransport
 
 protocol EventGDTLoggerProtocol {
   func logEvent(event: SessionStartEvent, completion: @escaping (Result<Void, Error>) -> Void)

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -15,16 +15,16 @@
 import Foundation
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
-@_implementationOnly import FirebaseCoreExtension
-@_implementationOnly import FirebaseInstallations
-@_implementationOnly import GoogleDataTransport
+internal import FirebaseCoreExtension
+internal import FirebaseInstallations
+internal import GoogleDataTransport
 
 #if swift(>=6.0)
   internal import Promises
 #elseif swift(>=5.10)
   import Promises
 #else
-  @_implementationOnly import Promises
+  internal import Promises
 #endif
 
 private enum GoogleDataTransportConfig {

--- a/FirebaseSessions/Sources/GoogleDataTransport+GoogleDataTransportProtocol.swift
+++ b/FirebaseSessions/Sources/GoogleDataTransport+GoogleDataTransportProtocol.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@_implementationOnly import GoogleDataTransport
+internal import GoogleDataTransport
 
 enum GoogleDataTransportProtocolErrors: Error {
   case writeFailure

--- a/FirebaseSessions/Sources/Installations+InstallationsProtocol.swift
+++ b/FirebaseSessions/Sources/Installations+InstallationsProtocol.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@_implementationOnly import FirebaseInstallations
+internal import FirebaseInstallations
 
 protocol InstallationsProtocol {
   var installationsWaitTimeInSecond: Int { get }

--- a/FirebaseSessions/Sources/Logger.swift
+++ b/FirebaseSessions/Sources/Logger.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@_implementationOnly import FirebaseCoreExtension
+internal import FirebaseCoreExtension
 
 ///
 /// Logger is responsible for printing console logs

--- a/FirebaseSessions/Sources/NetworkInfo.swift
+++ b/FirebaseSessions/Sources/NetworkInfo.swift
@@ -20,9 +20,9 @@ import Foundation
 #endif // SWIFT_PACKAGE
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 protocol NetworkInfoProtocol {

--- a/FirebaseSessions/Sources/SessionGenerator.swift
+++ b/FirebaseSessions/Sources/SessionGenerator.swift
@@ -15,7 +15,7 @@
 
 import Foundation
 
-@_implementationOnly import FirebaseInstallations
+internal import FirebaseInstallations
 
 struct SessionInfo {
   let sessionId: String

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -15,16 +15,16 @@
 
 import Foundation
 
-@_implementationOnly import GoogleDataTransport
+internal import GoogleDataTransport
 
 #if SWIFT_PACKAGE
   import FirebaseSessionsObjC
 #endif // SWIFT_PACKAGE
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 ///

--- a/FirebaseSessions/Sources/Settings/SettingsCacheClient.swift
+++ b/FirebaseSessions/Sources/Settings/SettingsCacheClient.swift
@@ -16,9 +16,9 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_UserDefaults
+  internal import GoogleUtilities_UserDefaults
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 /// CacheKey is like a "key" to a "safe". It provides necessary metadata about the current cache to

--- a/FirebaseSessions/Sources/Settings/SettingsDownloadClient.swift
+++ b/FirebaseSessions/Sources/Settings/SettingsDownloadClient.swift
@@ -16,9 +16,9 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 protocol SettingsDownloadClient {

--- a/FirebaseSessions/Tests/TestApp/Shared/MockSubscriberSDK.swift
+++ b/FirebaseSessions/Tests/TestApp/Shared/MockSubscriberSDK.swift
@@ -17,7 +17,7 @@ import FirebaseSessions
 import Foundation
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
-@_implementationOnly import FirebaseCoreExtension
+internal import FirebaseCoreExtension
 
 @objc(FIRMockSubscriberSDKProtocol)
 protocol MockSubscriberSDKProtocol {

--- a/FirebaseSessions/Tests/Unit/Mocks/MockApplicationInfo.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockApplicationInfo.swift
@@ -16,9 +16,9 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 @testable import FirebaseSessions

--- a/FirebaseSessions/Tests/Unit/Mocks/MockInstallationsProtocol.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockInstallationsProtocol.swift
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@_implementationOnly import FirebaseInstallations
+internal import FirebaseInstallations
 
 @testable import FirebaseSessions
 

--- a/FirebaseSessions/Tests/Unit/Mocks/MockNetworkInfo.swift
+++ b/FirebaseSessions/Tests/Unit/Mocks/MockNetworkInfo.swift
@@ -16,9 +16,9 @@
 import Foundation
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 @testable import FirebaseSessions

--- a/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionStartEventTests.swift
@@ -20,9 +20,9 @@ import XCTest
 #endif // SWIFT_PACKAGE
 
 #if SWIFT_PACKAGE
-  @_implementationOnly import GoogleUtilities_Environment
+  internal import GoogleUtilities_Environment
 #else
-  @_implementationOnly import GoogleUtilities
+  internal import GoogleUtilities
 #endif // SWIFT_PACKAGE
 
 @testable import FirebaseSessions


### PR DESCRIPTION
My plan: In the first pass, I'm going to use the explicit `internal` as a marker that I've audited the import. After I'm done migrating the `implementationOnly` -> `internal`, I can audit the un-prefixed `import` we have remaining as those may need to be marked `internal` or `public` (or are unused). After that audit, we can turn on internal by default.

#no-changelog