### PR TITLE
[Infra] Add `workflow_dispatch` trigger to enable manual dispatch of workflows.

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -1,6 +1,7 @@
 name: abtesting
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseABTesting**'

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -1,6 +1,7 @@
 name: analytics
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseAnalytics**'

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -1,6 +1,7 @@
 name: appdistribution
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseAppDistribution**'

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -1,6 +1,7 @@
 name: archiving
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - '.github/workflows/archiving.yml'

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -1,6 +1,7 @@
 name: auth
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseAuth**'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: check
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
     - 'Firestore/**'

--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -1,6 +1,7 @@
 name: client_app
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/client_app.yml"

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -1,6 +1,7 @@
 name: cocoapods-integration
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'IntegrationTesting/CocoapodsIntegrationTest/**'

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -15,6 +15,7 @@
 name: combine
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     # Combine sources

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,6 +1,7 @@
 name: core
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseCore**'

--- a/.github/workflows/core_extension.yml
+++ b/.github/workflows/core_extension.yml
@@ -1,6 +1,7 @@
 name: core_extension
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseCoreExtension.podspec'

--- a/.github/workflows/core_internal.yml
+++ b/.github/workflows/core_internal.yml
@@ -1,6 +1,7 @@
 name: core_internal
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'FirebaseCoreInternal.podspec'

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -1,6 +1,7 @@
 name: crashlytics
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - 'Crashlytics**'


### PR DESCRIPTION
This change adds the `workflow_dispatch` trigger to the following workflow files:
- .github/workflows/abtesting.yml
- .github/workflows/analytics.yml
- .github/workflows/appdistribution.yml
- .github/workflows/archiving.yml
- .github/workflows/auth.yml
- .github/workflows/check.yml
- .github/workflows/client_app.yml
- .github/workflows/cocoapods-integration.yml
- .github/workflows/combine.yml
- .github/workflows/core.yml
- .github/workflows/core_extension.yml
- .github/workflows/core_internal.yml
- .github/workflows/crashlytics.yml

This allows these workflows to be manually triggered in addition to their existing triggers.