### PR TITLE
[Sessions] Fix test app crash

### DIFF
--- a/FirebaseSessions/Tests/TestApp/Shared/AppQualityDevAppApp.swift
+++ b/FirebaseSessions/Tests/TestApp/Shared/AppQualityDevAppApp.swift
@@ -18,8 +18,8 @@ import FirebaseSessions
 import SwiftUI
 
 @main
-class AppQualityDevAppApp: App {
-  required init() {
+struct AppQualityDevAppApp: App {
+  init() {
     // In other Product SDKs, this is called via `+ load`, but
     // we're faking that here because Swift doesn't have `+ load`
     MockSubscriberSDK.addDependency()


### PR DESCRIPTION
Fixes runtime exception: `SwiftUI/App.swift:132: Fatal error: apps must be value types; AppQualityDevAppApp is a class.`

This exception was obscured in this failing log: https://github.com/firebase/firebase-ios-sdk/actions/runs/14370249342/job/40291840387?pr=14698

#no-changelog