### PR TITLE
fix: remove null value inclusion from `isNotEqualTo` and `notIn` filter results

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed the `null` value handling in `isNotEqualTo` and `notIn` filters.
+
 # 11.11.0
 - [fixed] Fixed the customized priority queue compare function used cache index manager. (#14496)
 

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -560,6 +560,10 @@
 
   [self checkOnlineAndOfflineQuery:[collection queryWhereField:@"zip" isNotEqualTo:@(NAN)]
                      matchesResult:@[ @"b", @"c", @"d", @"e", @"f", @"g", @"h" ]];
+
+  [self checkOnlineAndOfflineQuery:[collection queryWhereField:@"zip"
+                                                  isNotEqualTo:@[ [NSNull null] ]]
+                     matchesResult:@[ @"a", @"b", @"c", @"d", @"e", @"f", @"g", @"h" ]];
 }
 
 - (void)testQueriesCanUseArrayContainsFilters {

--- a/Firestore/core/src/core/field_filter.cc
+++ b/Firestore/core/src/core/field_filter.cc
@@ -157,7 +157,8 @@ bool FieldFilter::Rep::Matches(const model::Document& doc) const {
 
   // Types do not have to match in NotEqual filters.
   if (op_ == Operator::NotEqual) {
-    return MatchesComparison(Compare(lhs, *value_rhs_));
+    return lhs.which_value_type != google_firestore_v1_Value_null_value_tag &&
+           MatchesComparison(Compare(lhs, *value_rhs_));
   }
 
   // Only compare types with matching backend order (such as double and int).

--- a/Firestore/core/src/core/not_in_filter.cc
+++ b/Firestore/core/src/core/not_in_filter.cc
@@ -62,7 +62,10 @@ bool NotInFilter::Rep::Matches(const Document& doc) const {
     return false;
   }
   absl::optional<google_firestore_v1_Value> maybe_lhs = doc->field(field());
-  return maybe_lhs && !Contains(array_value, *maybe_lhs);
+  return maybe_lhs &&
+         maybe_lhs->which_value_type !=
+             google_firestore_v1_Value_null_value_tag &&
+         !Contains(array_value, *maybe_lhs);
 }
 
 }  // namespace core

--- a/Firestore/core/test/unit/core/query_test.cc
+++ b/Firestore/core/test/unit/core/query_test.cc
@@ -279,7 +279,7 @@ TEST(QueryTest, NanFilter) {
   EXPECT_THAT(query, Matches(doc3));
   EXPECT_THAT(query, Matches(doc4));
   EXPECT_THAT(query, Matches(doc5));
-  EXPECT_THAT(query, Matches(doc6));
+  EXPECT_THAT(query, Not(Matches(doc6)));
 }
 
 TEST(QueryTest, ArrayContainsFilter) {
@@ -383,7 +383,7 @@ TEST(QueryTest, NotInFilters) {
 
   // Null match.
   doc = Doc("collection/1", 0, Map("zip", nullptr));
-  EXPECT_THAT(query, Matches(doc));
+  EXPECT_THAT(query, Not(Matches(doc)));
 
   // NAN match.
   doc = Doc("collection/1", 0, Map("zip", NAN));


### PR DESCRIPTION
Server does not include `null` values into the query results when calling on `isNotEqualTo` or `notIn` filters.  SDK should be consistent with it.