### PR TITLE
[VertexAI] Add minimum, maximum, title, and propertyOrdering to schema

### DIFF
--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -68,7 +68,9 @@ public final class Schema: Sendable {
   /// The format of the data.
   public let format: String?
 
-  /// A brief description of the parameter.
+  /// A human-readable explanation of the purpose of the schema or property. While not strictly
+  /// enforced on the value itself, good descriptions significantly help the model understand the
+  /// context and generate more relevant and accurate output.
   public let description: String?
 
   /// A human-readable name/summary for the schema or a specific property. This helps document the
@@ -82,13 +84,15 @@ public final class Schema: Sendable {
   /// Possible values of the element of type "STRING" with "enum" format.
   public let enumValues: [String]?
 
-  /// Schema of the elements of type `"ARRAY"`.
+  /// Defines the schema for the elements within the `"ARRAY"`. All items in the generated array
+  /// must conform to this schema definition. This can be a simple type (like .string) or a complex
+  /// nested object schema.
   public let items: Schema?
 
-  /// The minimum number of items (elements) in a schema of type `"ARRAY"`.
+  /// An integer specifying the minimum number of items the generated `"ARRAY"` must contain.
   public let minItems: Int?
 
-  /// The maximum number of items (elements) in a schema of type `"ARRAY"`.
+  /// An integer specifying the maximum number of items the generated `"ARRAY"` must contain.
   public let maxItems: Int?
 
   /// The minimum value of a numeric type.
@@ -97,10 +101,14 @@ public final class Schema: Sendable {
   /// The maximum value of a numeric type.
   public let maximum: Double?
 
-  /// Properties of type `"OBJECT"`.
+  /// Defines the members (key-value pairs) expected within an object. It's a dictionary where keys
+  /// are the property names (strings) and values are nested `Schema` definitions describing each
+  /// property's type and constraints.
   public let properties: [String: Schema]?
 
-  /// Required properties of type `"OBJECT"`.
+  /// An array of strings, where each string is the name of a property defined in the `properties`
+  /// dictionary that must be present in the generated object. If a property is listed here, the
+  /// model must include it in the output.
   public let requiredProperties: [String]?
 
   /// A specific hint provided to the Gemini model, suggesting the order in which the keys should
@@ -111,7 +119,8 @@ public final class Schema: Sendable {
   /// serialization.
   public let propertyOrdering: [String]?
 
-  required init(type: DataType, format: String? = nil, description: String? = nil, title: String? = nil,
+  required init(type: DataType, format: String? = nil, description: String? = nil,
+                title: String? = nil,
                 nullable: Bool = false, enumValues: [String]? = nil, items: Schema? = nil,
                 minItems: Int? = nil, maxItems: Int? = nil, minimum: Double? = nil,
                 maximum: Double? = nil, properties: [String: Schema]? = nil,

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -222,7 +222,7 @@ public final class Schema: Sendable {
   ///   - maximum: If specified, instructs the model that the value should be less than or equal
   ///     to the specified maximum.
   public static func float(description: String? = nil, nullable: Bool = false,
-                           minimum: Double? = nil, maximum: Double? = nil) -> Schema {
+                           minimum: Float? = nil, maximum: Float? = nil) -> Schema {
     return self.init(
       type: .number,
       format: "float",

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -86,6 +86,12 @@ public final class Schema: Sendable {
   /// The maximum number of items (elements) in a schema of type `"ARRAY"`.
   public let maxItems: Int?
 
+  /// The minimum value of a numeric type.
+  public let minimum: Double?
+
+  /// The maximum value of a numeric type.
+  public let maximum: Double?
+
   /// Properties of type `"OBJECT"`.
   public let properties: [String: Schema]?
 
@@ -94,8 +100,9 @@ public final class Schema: Sendable {
 
   required init(type: DataType, format: String? = nil, description: String? = nil,
                 nullable: Bool = false, enumValues: [String]? = nil, items: Schema? = nil,
-                minItems: Int? = nil, maxItems: Int? = nil,
-                properties: [String: Schema]? = nil, requiredProperties: [String]? = nil) {
+                minItems: Int? = nil, maxItems: Int? = nil, minimum: Double? = nil,
+                maximum: Double? = nil, properties: [String: Schema]? = nil,
+                requiredProperties: [String]? = nil) {
     dataType = type
     self.format = format
     self.description = description
@@ -104,6 +111,8 @@ public final class Schema: Sendable {
     self.items = items
     self.minItems = minItems
     self.maxItems = maxItems
+    self.minimum = minimum
+    self.maximum = maximum
     self.properties = properties
     self.requiredProperties = requiredProperties
   }
@@ -184,12 +193,19 @@ public final class Schema: Sendable {
   ///     use Markdown format.
   ///   - nullable: If `true`, instructs the model that it may generate `null` instead of a number;
   ///     defaults to `false`, enforcing that a number is generated.
-  public static func float(description: String? = nil, nullable: Bool = false) -> Schema {
+  ///   - minimum: If specified, instructs the model that the value should be greater than or
+  ///     equal to the specified minimum.
+  ///   - maximum: If specified, instructs the model that the value should be less than or equal
+  ///     to the specified maximum.
+  public static func float(description: String? = nil, nullable: Bool = false,
+                            minimum: Double? = nil, maximum: Double? = nil) -> Schema {
     return self.init(
       type: .number,
       format: "float",
       description: description,
-      nullable: nullable
+      nullable: nullable,
+      minimum: minimum,
+      maximum: maximum
     )
   }
 
@@ -203,11 +219,18 @@ public final class Schema: Sendable {
   ///     use Markdown format.
   ///   - nullable: If `true`, instructs the model that it may return `null` instead of a number;
   ///     defaults to `false`, enforcing that a number is returned.
-  public static func double(description: String? = nil, nullable: Bool = false) -> Schema {
+  ///   - minimum: If specified, instructs the model that the value should be greater than or
+  ///     equal to the specified minimum.
+  ///   - maximum: If specified, instructs the model that the value should be less than or equal
+  ///     to the specified maximum.
+  public static func double(description: String? = nil, nullable: Bool = false,
+                             minimum: Double? = nil, maximum: Double? = nil) -> Schema {
     return self.init(
       type: .number,
       description: description,
-      nullable: nullable
+      nullable: nullable,
+      minimum: minimum,
+      maximum: maximum
     )
   }
 
@@ -349,6 +372,8 @@ extension Schema: Encodable {
     case items
     case minItems
     case maxItems
+    case minimum
+    case maximum
     case properties
     case requiredProperties = "required"
   }

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -286,8 +286,8 @@ public final class Schema: Sendable {
       format: format?.rawValue,
       description: description,
       nullable: nullable.self,
-      minimum: minimum != nil ? Double(minimum!) : nil,
-      maximum: maximum != nil ? Double(maximum!) : nil
+      minimum: minimum.map { Double($0) },
+      maximum: maximum.map { Double($0) }
     )
   }
 

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -198,7 +198,7 @@ public final class Schema: Sendable {
   ///   - maximum: If specified, instructs the model that the value should be less than or equal
   ///     to the specified maximum.
   public static func float(description: String? = nil, nullable: Bool = false,
-                            minimum: Double? = nil, maximum: Double? = nil) -> Schema {
+                           minimum: Double? = nil, maximum: Double? = nil) -> Schema {
     return self.init(
       type: .number,
       format: "float",
@@ -224,7 +224,7 @@ public final class Schema: Sendable {
   ///   - maximum: If specified, instructs the model that the value should be less than or equal
   ///     to the specified maximum.
   public static func double(description: String? = nil, nullable: Bool = false,
-                             minimum: Double? = nil, maximum: Double? = nil) -> Schema {
+                            minimum: Double? = nil, maximum: Double? = nil) -> Schema {
     return self.init(
       type: .number,
       description: description,
@@ -255,12 +255,15 @@ public final class Schema: Sendable {
   ///     formats ``IntegerFormat/int32`` and ``IntegerFormat/int64`` are supported; custom values
   ///     may be specified using ``IntegerFormat/custom(_:)`` but may be ignored by the model.
   public static func integer(description: String? = nil, nullable: Bool = false,
-                             format: IntegerFormat? = nil) -> Schema {
+                             format: IntegerFormat? = nil,
+                             minimum: Int? = nil, maximum: Int? = nil) -> Schema {
     return self.init(
       type: .integer,
       format: format?.rawValue,
       description: description,
-      nullable: nullable
+      nullable: nullable.self,
+      minimum: minimum != nil ? Double(minimum!) : nil,
+      maximum: maximum != nil ? Double(maximum!) : nil
     )
   }
 

--- a/FirebaseVertexAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseVertexAI/Sources/Types/Public/Schema.swift
@@ -228,8 +228,8 @@ public final class Schema: Sendable {
       format: "float",
       description: description,
       nullable: nullable,
-      minimum: minimum,
-      maximum: maximum
+      minimum: minimum.map { Double($0) },
+      maximum: maximum.map { Double($0) }
     )
   }
 

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
@@ -79,10 +79,10 @@ struct SchemaTests {
       modelName: ModelNames.gemini2FlashLite,
       generationConfig: GenerationConfig(
         responseMIMEType: "application/json",
-        responseSchema: .double(
+        responseSchema: .integer(
           description: "A number",
-          minimum: 110.0,
-          maximum: 120.0
+          minimum: 110,
+          maximum: 120
         )
       ),
       safetySettings: safetySettings

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
@@ -127,6 +127,8 @@ struct SchemaTests {
               maximum: 5
             ),
           ],
+          propertyOrdering: ["salePrice", "rating", "price", "productName"],
+          title: "ProductInfo"
         ),
       ),
       safetySettings: safetySettings

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
@@ -55,12 +55,12 @@ struct SchemaTests {
       generationConfig: GenerationConfig(
         responseMIMEType: "application/json",
         responseSchema:
-            .array(
-              items: .string(description: "The name of the city"),
-              description: "A list of city names",
-              minItems: 3,
-              maxItems: 5
-            )
+        .array(
+          items: .string(description: "The name of the city"),
+          description: "A list of city names",
+          minItems: 3,
+          maxItems: 5
+        )
       ),
       safetySettings: safetySettings
     )
@@ -71,5 +71,79 @@ struct SchemaTests {
     let decodedJSON = try JSONDecoder().decode([String].self, from: jsonData)
     #expect(decodedJSON.count >= 3, "Expected at least 3 cities, but got \(decodedJSON.count)")
     #expect(decodedJSON.count <= 5, "Expected at most 5 cities, but got \(decodedJSON.count)")
+  }
+
+  @Test(arguments: InstanceConfig.allConfigsExceptDeveloperV1)
+  func generateContentSchemaNumberRange(_ config: InstanceConfig) async throws {
+    let model = VertexAI.componentInstance(config).generativeModel(
+      modelName: ModelNames.gemini2FlashLite,
+      generationConfig: GenerationConfig(
+        responseMIMEType: "application/json",
+        responseSchema: .double(
+          description: "A number",
+          minimum: 110.0,
+          maximum: 120.0
+        )
+      ),
+      safetySettings: safetySettings
+    )
+    let prompt = "Give me a number"
+    let response = try await model.generateContent(prompt)
+    let text = try #require(response.text).trimmingCharacters(in: .whitespacesAndNewlines)
+    let jsonData = try #require(text.data(using: .utf8))
+    let decodedNumber = try JSONDecoder().decode(Double.self, from: jsonData)
+    #expect(decodedNumber >= 110.0, "Expected a number >= 110, but got \(decodedNumber)")
+    #expect(decodedNumber <= 120.0, "Expected a number <= 120, but got \(decodedNumber)")
+  }
+
+  @Test(arguments: InstanceConfig.allConfigsExceptDeveloperV1)
+  func generateContentSchemaNumberRangeMultiType(_ config: InstanceConfig) async throws {
+    struct ProductInfo: Codable {
+      let productName: String
+      let rating: Int // Will correspond to .integer in schema
+      let price: Double // Will correspond to .double in schema
+      let salePrice: Float // Will correspond to .float in schema
+    }
+    let model = VertexAI.componentInstance(config).generativeModel(
+      modelName: ModelNames.gemini2FlashLite,
+      generationConfig: GenerationConfig(
+        responseMIMEType: "application/json",
+        responseSchema: .object(
+          properties: [
+            "productName": .string(description: "The name of the product"),
+            "price": .double(
+              description: "A price",
+              minimum: 10.00,
+              maximum: 120.00
+            ),
+            "salePrice": .float(
+              description: "A sale price",
+              minimum: 5.00,
+              maximum: 90.00
+            ),
+            "rating": .integer(
+              description: "A rating",
+              minimum: 1,
+              maximum: 5
+            ),
+          ],
+        ),
+      ),
+      safetySettings: safetySettings
+    )
+    let prompt = "Describe a premium wireless headphone, including a user rating and price."
+    let response = try await model.generateContent(prompt)
+    let text = try #require(response.text).trimmingCharacters(in: .whitespacesAndNewlines)
+    let jsonData = try #require(text.data(using: .utf8))
+    let decodedProduct = try JSONDecoder().decode(ProductInfo.self, from: jsonData)
+    let price = decodedProduct.price
+    let salePrice = decodedProduct.salePrice
+    let rating = decodedProduct.rating
+    #expect(price >= 10.0, "Expected a price >= 10.00, but got \(price)")
+    #expect(price <= 120.0, "Expected a price <= 120.00, but got \(price)")
+    #expect(salePrice >= 5.0, "Expected a salePrice >= 5.00, but got \(salePrice)")
+    #expect(salePrice <= 90.0, "Expected a salePrice <= 90.00, but got \(salePrice)")
+    #expect(rating >= 1, "Expected a rating >= 1, but got \(rating)")
+    #expect(rating <= 5, "Expected a rating <= 5, but got \(rating)")
   }
 }


### PR DESCRIPTION
Add support for `title`, `propertyOrdering`, `minimum` and `maximum` schema specifications,

`title` and `propertyOrdering` are only hints so we only test that they get recognized. `propertyOrdering` did do the right thing when I examined the generated JSON in the debugger.

#no-changelog Changelog will come after a series of Schema PRs