### PR TITLE
[Infra] Remove `macos-13` from `messaging-cron-only` job

### DIFF
--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -230,7 +230,7 @@ jobs:
     strategy:
       matrix:
         target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
-        os: [macos-14, macos-13]
+        os: [macos-14, macos-15]
         include:
           - os: macos-15
             xcode: Xcode_16.2


### PR DESCRIPTION
Attempting to fix the CI failure from the messaging nightly (#14661) which is attempting to run on `macos-13`: https://github.com/firebase/firebase-ios-sdk/actions/runs/14438577257/job/40483828819

#no-changelog