### PR TITLE
[Infra] Fix `appdistribution` workflow `pod-lib-lint` `macos` versions

### DIFF
--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-15
+          - os: macos-14
             xcode: Xcode_16.2
-          - os: macos-16
+          - os: macos-15
             xcode: Xcode_16.3
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This job was accidentally using `macos-16`, which doesn't exist yet and caused it to hang.

#no-changelog