### PR TITLE
[Infra] Add `--legacy` flag to `xcresulttool`

### DIFF
--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -246,7 +246,10 @@ def export_log(xcresult_path, log_id):
     The logged output, as a string.
   """
   # Note: --legacy is required for Xcode 16.
-  contents = xcresulttool_json('get', '--path', xcresult_path, '--id', log_id, '--legacy')
+  contents = xcresulttool_json(
+    'get', '--path', xcresult_path, '--id', log_id, '--legacy'
+  )
+
 
   result = []
   collect_log_output(contents, result)

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -250,7 +250,6 @@ def export_log(xcresult_path, log_id):
     'get', '--path', xcresult_path, '--id', log_id, '--legacy'
   )
 
-
   result = []
   collect_log_output(contents, result)
   return ''.join(result)

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -245,7 +245,8 @@ def export_log(xcresult_path, log_id):
   Returns:
     The logged output, as a string.
   """
-  contents = xcresulttool_json('get', '--path', xcresult_path, '--id', log_id)
+  # Note: --legacy is required for Xcode 16.
+  contents = xcresulttool_json('get', '--path', xcresult_path, '--id', log_id, '--legacy')
 
   result = []
   collect_log_output(contents, result)

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -247,7 +247,7 @@ def export_log(xcresult_path, log_id):
   """
   # Note: --legacy is required for Xcode 16.
   contents = xcresulttool_json(
-    'get', '--path', xcresult_path, '--id', log_id, '--legacy'
+      'get', '--path', xcresult_path, '--id', log_id, '--legacy'
   )
 
   result = []


### PR DESCRIPTION
Added `--legacy` to the invocation of `xcresulttool` to temporarily fix the following error: 

```
xcrun xcresulttool get --path /Users/runner/Library/Developer/Xcode/DerivedData/FirebaseCombineSwift-gkzikpntrmtrlteyoawsixkbxldq/Logs/Test/Test-FirebaseCombineSwift-Unit-integration-2025.04.15_07-24-19-+0000.xcresult --format json
Error: This command is deprecated and will be removed in a future release, --legacy flag is required to use it.
Usage: xcresulttool get object [--legacy] --path <path> [--id <id>] [--version <version>] [--format <format>]
  See 'xcresulttool get object --help' for more information.
```

Note: We'll need to find an alternative eventually since "command is deprecated and will be removed in a future release".

(cherry picked from commit 9b630144a63d49d4e5b68df954fe77dca7b027b1)

#no-changelog