### PR TITLE
[Vertex AI] Temporarily disable proxied Dev API integration tests

### DIFF
--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
@@ -143,7 +143,7 @@ struct CountTokensIntegrationTests {
     switch config.apiConfig.service {
     case .vertexAI:
       #expect(response.totalTokens == 65)
-      #expect(response.totalBillableCharacters == 165)
+      #expect(response.totalBillableCharacters == 170)
     case .developer:
       // The Developer API erroneously ignores the `responseSchema` when counting tokens, resulting
       // in a lower total count than Vertex AI.

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
@@ -69,14 +69,10 @@ struct CountTokensIntegrationTests {
     #expect(promptTokensDetails.tokenCount == response.totalTokens)
   }
 
-  @Test(arguments: [
-    InstanceConfig.vertexV1,
-    InstanceConfig.vertexV1Staging,
-    InstanceConfig.vertexV1Beta,
-    InstanceConfig.vertexV1BetaStaging,
+  @Test(
     /* System instructions are not supported on the v1 Developer API. */
-    InstanceConfig.developerV1Beta,
-  ])
+    arguments: InstanceConfig.allConfigsExceptDeveloperV1
+  )
   func countTokens_text_systemInstruction(_ config: InstanceConfig) async throws {
     let model = VertexAI.componentInstance(config).generativeModel(
       modelName: ModelNames.gemini2Flash,
@@ -122,14 +118,10 @@ struct CountTokensIntegrationTests {
     )
   }
 
-  @Test(arguments: [
-    InstanceConfig.vertexV1,
-    InstanceConfig.vertexV1Staging,
-    InstanceConfig.vertexV1Beta,
-    InstanceConfig.vertexV1BetaStaging,
+  @Test(
     /* System instructions are not supported on the v1 Developer API. */
-    InstanceConfig.developerV1Beta,
-  ])
+    arguments: InstanceConfig.allConfigsExceptDeveloperV1
+  )
   func countTokens_jsonSchema(_ config: InstanceConfig) async throws {
     let model = VertexAI.componentInstance(config).generativeModel(
       modelName: ModelNames.gemini2Flash,

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -77,14 +77,8 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     "Generate an enum and provide a system instruction",
-    arguments: [
-      InstanceConfig.vertexV1,
-      InstanceConfig.vertexV1Staging,
-      InstanceConfig.vertexV1Beta,
-      InstanceConfig.vertexV1BetaStaging,
-      /* System instructions are not supported on the v1 Developer API. */
-      InstanceConfig.developerV1Beta,
-    ]
+    /* System instructions are not supported on the v1 Developer API. */
+    arguments: InstanceConfig.allConfigsExceptDeveloperV1
   )
   func generateContentEnum(_ config: InstanceConfig) async throws {
     let model = VertexAI.componentInstance(config).generativeModel(
@@ -122,7 +116,8 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexV1Beta,
-    InstanceConfig.developerV1Beta,
+    // Temporarily disabled due to Firebase Proxy issues.
+    // InstanceConfig.developerV1Beta,
   ])
   func generateImage(_ config: InstanceConfig) async throws {
     let generationConfig = GenerationConfig(

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -35,6 +35,9 @@ struct InstanceConfig {
   static let developerV1Beta = InstanceConfig(
     apiConfig: APIConfig(service: .developer(endpoint: .firebaseVertexAIProd), version: .v1beta)
   )
+  static let developerV1BetaStaging = InstanceConfig(
+    apiConfig: APIConfig(service: .developer(endpoint: .firebaseVertexAIStaging), version: .v1beta)
+  )
   static let developerV1Spark = InstanceConfig(
     appName: FirebaseAppNames.spark,
     apiConfig: APIConfig(service: .developer(endpoint: .generativeLanguage), version: .v1)
@@ -48,7 +51,9 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    developerV1Beta,
+    // Temporarily disabled due to Firebase Proxy issues:
+    // developerV1Beta,
+    // developerV1BetaStaging,
     developerV1Spark,
     developerV1BetaSpark,
   ]
@@ -58,6 +63,9 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
+    // Temporarily disabled due to Firebase Proxy issues:
+    // developerV1Beta,
+    // developerV1BetaStaging,
     developerV1BetaSpark,
   ]
 


### PR DESCRIPTION
Temporarily disabled the Developer API integration test configurations that are using the Firebase proxy; failing due to a backend issue.

#no-changelog