### PR TITLE
[Vertex AI] Re-enable Developer API staging integration tests

### DIFF
--- a/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -116,8 +116,9 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexV1Beta,
-    // Temporarily disabled due to Firebase Proxy issues.
+    // TODO(andrewheard): Prod config temporarily disabled due to backend issue.
     // InstanceConfig.developerV1Beta,
+    InstanceConfig.developerV1BetaStaging, // Remove after re-enabling `developerV1Beta` config.
   ])
   func generateImage(_ config: InstanceConfig) async throws {
     let generationConfig = GenerationConfig(

--- a/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseVertexAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -51,9 +51,9 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // Temporarily disabled due to Firebase Proxy issues:
+    // TODO(andrewheard): Prod config temporarily disabled due to backend issue:
     // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1BetaStaging,
     developerV1Spark,
     developerV1BetaSpark,
   ]
@@ -63,9 +63,9 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // Temporarily disabled due to Firebase Proxy issues:
+    // TODO(andrewheard): Prod config temporarily disabled due to backend issue:
     // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1BetaStaging,
     developerV1BetaSpark,
   ]
 


### PR DESCRIPTION
Re-enabled Developer API integration tests through the staging proxy.

#no-changelog