### PR TITLE
[Infra] Move `--legacy` flag into `xcresulttool_json` function

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -44,6 +44,7 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDatabase.podspec --test-specs=unit --platforms=${{ matrix.target }}
 
   integration:
+    # TODO: Remove this comment after testing.
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-15

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -44,7 +44,6 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDatabase.podspec --test-specs=unit --platforms=${{ matrix.target }}
 
   integration:
-    # TODO: Remove this comment after testing.
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macos-15

--- a/scripts/xcresult_logs.py
+++ b/scripts/xcresult_logs.py
@@ -245,10 +245,7 @@ def export_log(xcresult_path, log_id):
   Returns:
     The logged output, as a string.
   """
-  # Note: --legacy is required for Xcode 16.
-  contents = xcresulttool_json(
-      'get', '--path', xcresult_path, '--id', log_id, '--legacy'
-  )
+  contents = xcresulttool_json('get', '--path', xcresult_path, '--id', log_id)
 
   result = []
   collect_log_output(contents, result)
@@ -284,7 +281,8 @@ def xcresulttool(*args):
 
 def xcresulttool_json(*args):
   """Runs xcresulttool and its output as parsed JSON."""
-  args = list(args) + ['--format', 'json']
+  # Note: --legacy is required for Xcode 16.
+  args = list(args) + ['--format', 'json', '--legacy']
   contents = xcresulttool(*args)
   return json.loads(contents)
 


### PR DESCRIPTION
PR #14717 didn't cover the following codepath: https://github.com/firebase/firebase-ios-sdk/blob/3636aa7b7d5793584c0757897fd59a7059053f20/scripts/xcresult_logs.py#L220-L229

In this case the `--legacy` flag wasn't getting added, resulting in the failures in #14661 (e.g., https://github.com/firebase/firebase-ios-sdk/actions/runs/14510030575/job/40734103865#step:10:9303). Moving the `--legacy` flag into `xcresulttool_json(...)` should fix the remaining failures.

#no-changelog