### PR TITLE
Make Crashlytics context Init unblocking main

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Improved startup time by putting some initialization steps on a background. (#13675, #13232)
+
 # 11.9.0
 - [fixed] Made on-demand fatal recording thread suspension configurable through setting to improve performance and avoid audio glitch on Unity. Change is for framework only.
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.h
@@ -39,6 +39,7 @@ __BEGIN_DECLS
 @class FIRCLSInstallIdentifierModel;
 @class FIRCLSFileManager;
 @class FIRCLSContextInitData;
+@class FBLPromise;
 #endif
 
 typedef struct {
@@ -82,7 +83,8 @@ typedef struct {
   FIRCLSAllocatorRef allocator;
 } FIRCLSContext;
 #ifdef __OBJC__
-bool FIRCLSContextInitialize(FIRCLSContextInitData* initData, FIRCLSFileManager* fileManager);
+FBLPromise* FIRCLSContextInitialize(FIRCLSContextInitData* initData,
+                                    FIRCLSFileManager* fileManager);
 FIRCLSContextInitData* FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
                                                   FIRCLSSettings* settings,
                                                   FIRCLSFileManager* fileManager,

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.h
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// a new Session ID.
 @property(nonatomic, copy) NSString *appQualitySessionId;
 
-- (BOOL)setupContextWithReport:(FIRCLSInternalReport *)report
-                      settings:(FIRCLSSettings *)settings
-                   fileManager:(FIRCLSFileManager *)fileManager;
+- (FBLPromise *)setupContextWithReport:(FIRCLSInternalReport *)report
+                              settings:(FIRCLSSettings *)settings
+                           fileManager:(FIRCLSFileManager *)fileManager;
 
 @end
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSContextManager.m
@@ -40,9 +40,9 @@
   return self;
 }
 
-- (BOOL)setupContextWithReport:(FIRCLSInternalReport *)report
-                      settings:(FIRCLSSettings *)settings
-                   fileManager:(FIRCLSFileManager *)fileManager {
+- (FBLPromise *)setupContextWithReport:(FIRCLSInternalReport *)report
+                              settings:(FIRCLSSettings *)settings
+                           fileManager:(FIRCLSFileManager *)fileManager {
   _report = report;
   _settings = settings;
   _fileManager = fileManager;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -289,15 +289,26 @@ typedef NSNumber FIRCLSWrappedReportAction;
 
   BOOL launchFailure = [self.launchMarker checkForAndCreateLaunchMarker];
 
-  FIRCLSInternalReport *report = [self setupCurrentReport:executionIdentifier];
+  __block FIRCLSInternalReport *report = [self setupCurrentReport:executionIdentifier];
   if (!report) {
     FIRCLSErrorLog(@"Unable to setup a new report");
   }
 
-  if (![self startCrashReporterWithProfilingReport:report]) {
-    FIRCLSErrorLog(@"Unable to start crash reporter");
-    report = nil;
-  }
+  FBLPromise<NSNumber *> *reportProfilingPromise;
+  reportProfilingPromise =
+      [[self startCrashReporterWithProfilingReport:report] then:^id _Nullable(id _Nullable value) {
+        if ([value isEqual:@NO]) {
+          FIRCLSErrorLog(@"Unable to start crash reporter");
+          report = nil;
+          return [FBLPromise resolvedWith:@NO];
+        }
+
+        // empty for disabled start-up time
+        dispatch_async(FIRCLSGetLoggingQueue(), ^{
+          FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSStartTimeKey, @"");
+        });
+        return [FBLPromise resolvedWith:@YES];
+      }];
 
 #if CLS_METRICKIT_SUPPORTED
   if (@available(iOS 15, *)) {
@@ -317,9 +328,12 @@ typedef NSNumber FIRCLSWrappedReportAction;
     [self beginSettingsWithToken:dataCollectionToken];
 
     // Wait for MetricKit data to be available, then continue to send reports and resolve promise.
-    promise = [[self waitForMetricKitData]
+    promise = [[reportProfilingPromise onQueue:_dispatchQueue
+                                          then:^id _Nullable(id _Nullable value) {
+                                            return [self waitForMetricKitData];
+                                          }]
         onQueue:_dispatchQueue
-           then:^id _Nullable(id _Nullable metricKitValue) {
+           then:^id _Nullable(id _Nullable value) {
              [self beginReportUploadsWithToken:dataCollectionToken blockingSend:launchFailure];
 
              // If data collection is enabled, the SDK will not notify the user
@@ -335,36 +349,33 @@ typedef NSNumber FIRCLSWrappedReportAction;
 
     // Wait for an action to get sent, either from processReports: or automatic data collection,
     // and for MetricKit data to be available.
-    promise = [[FBLPromise all:@[ [self waitForReportAction], [self waitForMetricKitData] ]]
+    promise = [[reportProfilingPromise
         onQueue:_dispatchQueue
-           then:^id _Nullable(NSArray *_Nullable wrappedActionAndData) {
-             // Process the actions for the reports on disk.
-             FIRCLSReportAction action = [[wrappedActionAndData firstObject] reportActionValue];
+           then:^id _Nullable(id _Nullable value) {
+             return [FBLPromise all:@[ [self waitForReportAction], [self waitForMetricKitData] ]];
+           }] onQueue:_dispatchQueue
+                 then:^id _Nullable(NSArray *_Nullable wrappedActionAndData) {
+                   // Process the actions for the reports on disk.
+                   FIRCLSReportAction action =
+                       [[wrappedActionAndData firstObject] reportActionValue];
 
-             if (action == FIRCLSReportActionSend) {
-               FIRCLSDebugLog(@"Sending unsent reports.");
-               FIRCLSDataCollectionToken *dataCollectionToken =
-                   [FIRCLSDataCollectionToken validToken];
+                   if (action == FIRCLSReportActionSend) {
+                     FIRCLSDebugLog(@"Sending unsent reports.");
+                     FIRCLSDataCollectionToken *dataCollectionToken =
+                         [FIRCLSDataCollectionToken validToken];
 
-               [self beginSettingsWithToken:dataCollectionToken];
+                     [self beginSettingsWithToken:dataCollectionToken];
 
-               [self beginReportUploadsWithToken:dataCollectionToken blockingSend:NO];
+                     [self beginReportUploadsWithToken:dataCollectionToken blockingSend:NO];
 
-             } else if (action == FIRCLSReportActionDelete) {
-               FIRCLSDebugLog(@"Deleting unsent reports.");
-               [self.existingReportManager deleteUnsentReports];
-             } else {
-               FIRCLSErrorLog(@"Unknown report action: %d", action);
-             }
-             return @(report != nil);
-           }];
-  }
-
-  if (report != nil) {
-    // empty for disabled start-up time
-    dispatch_async(FIRCLSGetLoggingQueue(), ^{
-      FIRCLSUserLoggingWriteInternalKeyValue(FIRCLSStartTimeKey, @"");
-    });
+                   } else if (action == FIRCLSReportActionDelete) {
+                     FIRCLSDebugLog(@"Deleting unsent reports.");
+                     [self.existingReportManager deleteUnsentReports];
+                   } else {
+                     FIRCLSErrorLog(@"Unknown report action: %d", action);
+                   }
+                   return @(report != nil);
+                 }];
   }
 
   // To make the code more predictable and therefore testable, don't resolve the startup promise
@@ -412,24 +423,23 @@ typedef NSNumber FIRCLSWrappedReportAction;
   }
 }
 
-- (BOOL)startCrashReporterWithProfilingReport:(FIRCLSInternalReport *)report {
+- (FBLPromise<NSNumber *> *)startCrashReporterWithProfilingReport:(FIRCLSInternalReport *)report {
   if (!report) {
-    return NO;
+    return [FBLPromise resolvedWith:@NO];
   }
 
-  if (![self.contextManager setupContextWithReport:report
-                                          settings:self.settings
-                                       fileManager:_fileManager]) {
-    return NO;
-  }
+  return [[self.contextManager setupContextWithReport:report
+                                             settings:self.settings
+                                          fileManager:_fileManager]
+      then:^id _Nullable(id _Nullable value) {
+        [self.notificationManager registerNotificationListener];
 
-  [self.notificationManager registerNotificationListener];
+        [self.analyticsManager registerAnalyticsListener];
 
-  [self.analyticsManager registerAnalyticsListener];
+        [self crashReportingSetupCompleted];
 
-  [self crashReportingSetupCompleted];
-
-  return YES;
+        return [FBLPromise resolvedWith:@YES];
+      }];
 }
 
 - (void)crashReportingSetupCompleted {

--- a/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
@@ -68,9 +68,10 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 }
 
 - (void)test_notSettingSessionID_protoHasNilSessionID {
-  [self.contextManager setupContextWithReport:self.report
-                                     settings:self.mockSettings
-                                  fileManager:self.fileManager];
+  FBLPromiseAwait([self.contextManager setupContextWithReport:self.report
+                                                     settings:self.mockSettings
+                                                  fileManager:self.fileManager],
+                  nil);
 
   FIRCLSReportAdapter *adapter = [[FIRCLSReportAdapter alloc] initWithPath:self.report.path
                                                                googleAppId:@"TestGoogleAppID"
@@ -84,9 +85,10 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 - (void)test_settingSessionIDMultipleTimes_protoHasLastSessionID {
   [self.contextManager setAppQualitySessionId:TestContextSessionID];
 
-  [self.contextManager setupContextWithReport:self.report
-                                     settings:self.mockSettings
-                                  fileManager:self.fileManager];
+  FBLPromiseAwait([self.contextManager setupContextWithReport:self.report
+                                                     settings:self.mockSettings
+                                                  fileManager:self.fileManager],
+                  nil);
 
   [self.contextManager setAppQualitySessionId:TestContextSessionID2];
 
@@ -101,9 +103,10 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 }
 
 - (void)test_settingSessionIDOutOfOrder_protoHasLastSessionID {
-  [self.contextManager setupContextWithReport:self.report
-                                     settings:self.mockSettings
-                                  fileManager:self.fileManager];
+  FBLPromiseAwait([self.contextManager setupContextWithReport:self.report
+                                                     settings:self.mockSettings
+                                                  fileManager:self.fileManager],
+                  nil);
 
   [self.contextManager setAppQualitySessionId:TestContextSessionID];
 

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -98,9 +98,10 @@
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
   FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
-  [contextManager setupContextWithReport:report
-                                settings:self.mockSettings
-                             fileManager:self.fileManager];
+  FBLPromiseAwait([contextManager setupContextWithReport:report
+                                                settings:self.mockSettings
+                                             fileManager:self.fileManager],
+                  nil);
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -54,9 +54,10 @@
                              executionIdentifier:@"TEST_EXECUTION_IDENTIFIER"];
 
   FIRCLSContextManager *contextManager = [[FIRCLSContextManager alloc] init];
-  [contextManager setupContextWithReport:report
-                                settings:self.mockSettings
-                             fileManager:self.fileManager];
+  FBLPromiseAwait([contextManager setupContextWithReport:report
+                                                settings:self.mockSettings
+                                             fileManager:self.fileManager],
+                  nil);
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
 #import "Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.h"
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
@@ -22,10 +28,10 @@
 
 @implementation FIRCLSMockReportManager
 
-- (BOOL)startCrashReporterWithProfilingReport:(FIRCLSInternalReport *)report {
+- (FBLPromise<NSNumber *> *)startCrashReporterWithProfilingReport:(FIRCLSInternalReport *)report {
   NSLog(@"Crash Reporting system disabled for testing");
 
-  return YES;
+  return [FBLPromise resolvedWith:@YES];
 }
 
 - (BOOL)installCrashReportingHandlers:(FIRCLSContextInitData *)initData {


### PR DESCRIPTION
Covert `dispatch_group_wait `to use `promise` to avoid blocking on main

Profiling and verified `FIRCLSContextInit` is gone from main call stack trace: https://screenshot.googleplex.com/8hPfVTxvxnh9X2b

Related issues: #13675 #13232 