### PR TITLE
[Infra] Add support for manual dispatch to new re-usable SPM workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -56,9 +56,8 @@ jobs:
           key: ${{ steps.generate_cache_key.outputs.cache_key }}
 
   spm:
-    if: |
-      (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || \
-      contains(['pull_request', 'workflow_dispatch'], github.event_name)
+    # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
+    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(['pull_request', 'workflow_dispatch'], github.event_name)
     needs: [spm-package-resolved]
     strategy:
       matrix:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -57,7 +57,7 @@ jobs:
 
   spm:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(['pull_request', 'workflow_dispatch'], github.event_name)
+    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     needs: [spm-package-resolved]
     strategy:
       matrix:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -56,8 +56,9 @@ jobs:
           key: ${{ steps.generate_cache_key.outputs.cache_key }}
 
   spm:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: |
+      (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || \
+      contains(['pull_request', 'workflow_dispatch'], github.event_name)
     needs: [spm-package-resolved]
     strategy:
       matrix:


### PR DESCRIPTION
I recently added manual workflow dispatch to all workflows. But since our jobs run on a condition (only scheduled Firebase CI or pull requests), we need to update all the conditions. The reusable workflow makes this easy since it's shared for all jobs.

Example invocation in https://github.com/firebase/firebase-ios-sdk/actions/runs/14620856096

#no-changelog