### PR TITLE
[Functions] Address more Swift 6 warnings

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -28,7 +28,7 @@ extension FunctionsSerializer {
   }
 }
 
-final class FunctionsSerializer {
+final class FunctionsSerializer: Sendable {
   // MARK: - Internal APIs
 
   func encode(_ object: Any) throws -> Any {


### PR DESCRIPTION
Note: module is not yet 100% Swift 6 compliant.

1. This was the first error I sought to fix.
<img width="812" alt="Screenshot 2025-04-24 at 6 10 47 PM" src="https://github.com/user-attachments/assets/d8d29250-65b6-47a5-ab97-111ce865bb50" />

2. I added `@MainActor` so the compiler enforces that the completion handler can only be called on the main actor. This address the error in step 1.

3. The new `@MainActor` attribute needed to bubble up to signature of a function that called the first one.
<img width="819" alt="Screenshot 2025-04-24 at 6 15 55 PM" src="https://github.com/user-attachments/assets/e1ffd75b-80f6-4090-a600-a1d79c7db81b" />

4. Next, the compiler enforces the completion is only called on main actor.
<img width="827" alt="Screenshot 2025-04-24 at 6 17 37 PM" src="https://github.com/user-attachments/assets/db87b45a-ee29-4a2b-8a39-b8b6d6a69e28" />

5. That's fixable by wrapping in a main queue dispatch block.
<img width="398" alt="Screenshot 2025-04-24 at 6 19 38 PM" src="https://github.com/user-attachments/assets/e0c5835e-2feb-49f0-8ca5-629807a7085b" />

6. The next appears back in the first function that was changed. The source of the error is that line 487 returns a `HTTPSCallableResult` which is not Sendable, so sending it could cause data races.
<img width="809" alt="Screenshot 2025-04-24 at 6 20 23 PM" src="https://github.com/user-attachments/assets/5852d06b-4c2a-4664-85d6-eae81f753580" />

7. It doesn't seem safe to mark `HTTPSCallableResult` as Sendable (it would have to be unchecked) because it retains an `Any`. While our SDK could be audited to verify that it doesn't access the `Any` reference, there'd be no way to enforce that it isn't accessed unsafely in SDK or client code.
<img width="591" alt="Screenshot 2025-04-24 at 6 22 07 PM" src="https://github.com/user-attachments/assets/87cf6a12-284e-4150-baf7-6bfd9bffaec9" />

8. To fix the error, we can specify that the returned `HTTPSCallableResult` is `sending` which indicates that it isn't accessed after being returned to the calling context. 
<img width="817" alt="Screenshot 2025-04-24 at 6 25 33 PM" src="https://github.com/user-attachments/assets/9db9824e-b20a-410a-8f9b-580396787f28" />

9. The new `Task or actor isolated value cannot be sent` error in the above screenshot is tricky. The following fixes appear to address it. I think the issue is that we need to indicate that the `Any` value is only owned in the current context. To do that, we mark `responseDataJSON` to return a `sending Any`. Marking `FunctionsSerializer` as `Sendable` is the final piece. I'm less sure why it resolves it though? Previously, I added `sending` to `FunctionsSerializer`'s `decode`API but that led to errors down a rabbit hole that I ultimately couldn't solve simply.
<img width="1108" alt="Screenshot 2025-04-24 at 6 31 16 PM" src="https://github.com/user-attachments/assets/1364b77f-e250-4c66-b034-740259a2d21e" />

#no-changelog