### PR TITLE
[Firebase AI] Add Swift package product library `FirebaseAI`

### DIFF
--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -35,7 +35,11 @@ public final class FirebaseAI: Sendable {
   /// - Returns: A `FirebaseAI` instance, configured with the custom `FirebaseApp`.
   public static func firebaseAI(app: FirebaseApp? = nil,
                                 backend: Backend = .googleAI()) -> FirebaseAI {
-    let instance = firebaseAI(app: app, location: backend.location, apiConfig: backend.apiConfig)
+    let instance = createInstance(
+      app: app,
+      location: backend.location,
+      apiConfig: backend.apiConfig
+    )
     // Verify that the `FirebaseAI` instance is always configured with the production endpoint since
     // this is the public API surface for creating an instance.
     assert(instance.apiConfig.service.endpoint == .firebaseVertexAIProd)
@@ -159,7 +163,8 @@ public final class FirebaseAI: Sendable {
     version: .v1beta
   )
 
-  static func firebaseAI(app: FirebaseApp?, location: String?, apiConfig: APIConfig) -> FirebaseAI {
+  static func createInstance(app: FirebaseApp?, location: String?,
+                             apiConfig: APIConfig) -> FirebaseAI {
     guard let app = app ?? FirebaseApp.app() else {
       fatalError("No instance of the default Firebase app was found.")
     }

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -127,7 +127,7 @@ extension FirebaseAI {
     switch instanceConfig.apiConfig.service {
     case .vertexAI:
       let location = instanceConfig.location ?? "us-central1"
-      return FirebaseAI.firebaseAI(
+      return FirebaseAI.createInstance(
         app: instanceConfig.app,
         location: location,
         apiConfig: instanceConfig.apiConfig
@@ -137,7 +137,7 @@ extension FirebaseAI {
         instanceConfig.location == nil,
         "The Developer API is global and does not support `location`."
       )
-      return FirebaseAI.firebaseAI(
+      return FirebaseAI.createInstance(
         app: instanceConfig.app,
         location: nil,
         apiConfig: instanceConfig.apiConfig

--- a/FirebaseAI/Tests/TestApp/VertexAITestApp.xcodeproj/project.pbxproj
+++ b/FirebaseAI/Tests/TestApp/VertexAITestApp.xcodeproj/project.pbxproj
@@ -17,16 +17,16 @@
 		868A7C4F2CCC229F00E449DD /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868A7C4D2CCC1F4700E449DD /* Credentials.swift */; };
 		868A7C522CCC263300E449DD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 868A7C502CCC263300E449DD /* Preview Assets.xcassets */; };
 		868A7C542CCC26B500E449DD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 868A7C532CCC26B500E449DD /* Assets.xcassets */; };
-		8692F2982CC9477800539E8F /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 8692F2972CC9477800539E8F /* FirebaseAppCheck */; };
-		8692F29A2CC9477800539E8F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 8692F2992CC9477800539E8F /* FirebaseAuth */; };
-		8692F29C2CC9477800539E8F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 8692F29B2CC9477800539E8F /* FirebaseStorage */; };
-		8692F29E2CC9477800539E8F /* FirebaseVertexAI in Frameworks */ = {isa = PBXBuildFile; productRef = 8692F29D2CC9477800539E8F /* FirebaseVertexAI */; };
 		8698D7482CD4332B00ABA833 /* TestAppCheckProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D7472CD4332B00ABA833 /* TestAppCheckProviderFactory.swift */; };
 		86CC31352D91EE9E0087E964 /* FirebaseAppUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CC31342D91EE9E0087E964 /* FirebaseAppUtils.swift */; };
 		86D77DFC2D7A5340003D155D /* GenerateContentIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D77DFB2D7A5340003D155D /* GenerateContentIntegrationTests.swift */; };
 		86D77DFE2D7B5C86003D155D /* GoogleService-Info-Spark.plist in Resources */ = {isa = PBXBuildFile; fileRef = 86D77DFD2D7B5C86003D155D /* GoogleService-Info-Spark.plist */; };
 		86D77E022D7B63AF003D155D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D77E012D7B63AC003D155D /* Constants.swift */; };
 		86D77E042D7B6C9D003D155D /* InstanceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D77E032D7B6C95003D155D /* InstanceConfig.swift */; };
+		86E8505B2DBAFBC3002E8D94 /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505A2DBAFBC3002E8D94 /* FirebaseAI */; };
+		86E8505D2DBAFBC3002E8D94 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */; };
+		86E8505F2DBAFBC3002E8D94 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505E2DBAFBC3002E8D94 /* FirebaseAuth */; };
+		86E850612DBAFBC3002E8D94 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 86E850602DBAFBC3002E8D94 /* FirebaseStorage */; };
 		DEF0BB4F2DA74F680093E9F4 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF0BB4E2DA74F460093E9F4 /* TestHelpers.swift */; };
 		DEF0BB512DA9B7450093E9F4 /* SchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF0BB502DA9B7400093E9F4 /* SchemaTests.swift */; };
 /* End PBXBuildFile section */
@@ -70,10 +70,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8692F2982CC9477800539E8F /* FirebaseAppCheck in Frameworks */,
-				8692F29E2CC9477800539E8F /* FirebaseVertexAI in Frameworks */,
-				8692F29A2CC9477800539E8F /* FirebaseAuth in Frameworks */,
-				8692F29C2CC9477800539E8F /* FirebaseStorage in Frameworks */,
+				86E8505D2DBAFBC3002E8D94 /* FirebaseAppCheck in Frameworks */,
+				86E850612DBAFBC3002E8D94 /* FirebaseStorage in Frameworks */,
+				86E8505F2DBAFBC3002E8D94 /* FirebaseAuth in Frameworks */,
+				86E8505B2DBAFBC3002E8D94 /* FirebaseAI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -187,10 +187,10 @@
 			);
 			name = "VertexAITestApp-SPM";
 			packageProductDependencies = (
-				8692F2972CC9477800539E8F /* FirebaseAppCheck */,
-				8692F2992CC9477800539E8F /* FirebaseAuth */,
-				8692F29B2CC9477800539E8F /* FirebaseStorage */,
-				8692F29D2CC9477800539E8F /* FirebaseVertexAI */,
+				86E8505A2DBAFBC3002E8D94 /* FirebaseAI */,
+				86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */,
+				86E8505E2DBAFBC3002E8D94 /* FirebaseAuth */,
+				86E850602DBAFBC3002E8D94 /* FirebaseStorage */,
 			);
 			productName = VertexAITestApp;
 			productReference = 866138582CC943DD00F4B78E /* VertexAITestApp-SPM.app */;
@@ -243,7 +243,7 @@
 			);
 			mainGroup = 8661384F2CC943DD00F4B78E;
 			packageReferences = (
-				8692F2962CC9477800539E8F /* XCLocalSwiftPackageReference "../../.." */,
+				86E850592DBAFBC3002E8D94 /* XCLocalSwiftPackageReference "../../.." */,
 			);
 			productRefGroup = 866138592CC943DD00F4B78E /* Products */;
 			projectDirPath = "";
@@ -585,28 +585,28 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		8692F2962CC9477800539E8F /* XCLocalSwiftPackageReference "../../.." */ = {
+		86E850592DBAFBC3002E8D94 /* XCLocalSwiftPackageReference "../../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../..;
+			relativePath = "../../..";
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		8692F2972CC9477800539E8F /* FirebaseAppCheck */ = {
+		86E8505A2DBAFBC3002E8D94 /* FirebaseAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FirebaseAI;
+		};
+		86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirebaseAppCheck;
 		};
-		8692F2992CC9477800539E8F /* FirebaseAuth */ = {
+		86E8505E2DBAFBC3002E8D94 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirebaseAuth;
 		};
-		8692F29B2CC9477800539E8F /* FirebaseStorage */ = {
+		86E850602DBAFBC3002E8D94 /* FirebaseStorage */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FirebaseStorage;
-		};
-		8692F29D2CC9477800539E8F /* FirebaseVertexAI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = FirebaseVertexAI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -152,12 +152,12 @@ class VertexComponentTests: XCTestCase {
   }
 
   func testSameAppAndDifferentAPI_newInstanceCreated() throws {
-    let vertex1 = FirebaseAI.firebaseAI(
+    let vertex1 = FirebaseAI.createInstance(
       app: VertexComponentTests.app,
       location: location,
       apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1beta)
     )
-    let vertex2 = FirebaseAI.firebaseAI(
+    let vertex2 = FirebaseAI.createInstance(
       app: VertexComponentTests.app,
       location: location,
       apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseVertexAIProd), version: .v1)
@@ -208,7 +208,7 @@ class VertexComponentTests: XCTestCase {
   func testModelResourceName_developerAPI_generativeLanguage() throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let apiConfig = APIConfig(service: .developer(endpoint: .generativeLanguage), version: .v1beta)
-    let vertex = FirebaseAI.firebaseAI(app: app, location: nil, apiConfig: apiConfig)
+    let vertex = FirebaseAI.createInstance(app: app, location: nil, apiConfig: apiConfig)
     let model = "test-model-name"
 
     let modelResourceName = vertex.modelResourceName(modelName: model)
@@ -222,7 +222,7 @@ class VertexComponentTests: XCTestCase {
       service: .developer(endpoint: .firebaseVertexAIStaging),
       version: .v1beta
     )
-    let vertex = FirebaseAI.firebaseAI(app: app, location: nil, apiConfig: apiConfig)
+    let vertex = FirebaseAI.createInstance(app: app, location: nil, apiConfig: apiConfig)
     let model = "test-model-name"
     let projectID = vertex.firebaseInfo.projectID
 
@@ -253,7 +253,7 @@ class VertexComponentTests: XCTestCase {
       service: .developer(endpoint: .firebaseVertexAIStaging),
       version: .v1beta
     )
-    let vertex = FirebaseAI.firebaseAI(app: app, location: nil, apiConfig: apiConfig)
+    let vertex = FirebaseAI.createInstance(app: app, location: nil, apiConfig: apiConfig)
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,18 @@ let package = Package(
   platforms: [.iOS(.v12), .macCatalyst(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
+      name: "FirebaseAI",
+      targets: ["FirebaseAI"]
+    ),
+    // Backwards-compatibility library for existing "Vertex AI in Firebase" users.
+    .library(
+      name: "FirebaseVertexAI",
+      targets: [
+        "FirebaseAI",
+        "FirebaseVertexAI",
+      ]
+    ),
+    .library(
       name: "FirebaseAnalytics",
       targets: ["FirebaseAnalyticsTarget"]
     ),
@@ -121,10 +133,6 @@ let package = Package(
       name: "FirebaseStorage",
       targets: ["FirebaseStorage"]
     ),
-    .library(
-      name: "FirebaseVertexAI",
-      targets: ["FirebaseVertexAI"]
-    ),
   ],
   dependencies: [
     .package(
@@ -179,6 +187,55 @@ let package = Package(
       path: "CoreOnly/Sources",
       publicHeadersPath: "./"
     ),
+
+    // MARK: - Firebase AI
+
+    .target(
+      name: "FirebaseAI",
+      dependencies: [
+        "FirebaseAppCheckInterop",
+        "FirebaseAuthInterop",
+        "FirebaseCore",
+        "FirebaseCoreExtension",
+      ],
+      path: "FirebaseAI/Sources"
+    ),
+    .testTarget(
+      name: "FirebaseAIUnit",
+      dependencies: [
+        "FirebaseAI",
+        "FirebaseStorage",
+      ],
+      path: "FirebaseAI/Tests/Unit",
+      resources: [
+        .copy("vertexai-sdk-test-data/mock-responses/vertexai"),
+        .process("Resources"),
+      ],
+      cSettings: [
+        .headerSearchPath("../../../"),
+      ]
+    ),
+    // Backwards-compatibility targets for existing "Vertex AI in Firebase" users.
+    .target(
+      name: "FirebaseVertexAI",
+      dependencies: [
+        "FirebaseAI",
+      ],
+      path: "FirebaseVertexAI/Sources"
+    ),
+    .testTarget(
+      name: "FirebaseVertexAIUnit",
+      dependencies: [
+        "FirebaseVertexAI",
+      ],
+      path: "FirebaseVertexAI/Tests/Unit",
+      resources: [
+        .process("Resources"),
+      ]
+    ),
+
+    // MARK: - Firebase Core
+
     .target(
       name: "FirebaseCore",
       dependencies: [
@@ -1295,54 +1352,6 @@ let package = Package(
       path: "FirebaseTestingSupport/Firestore/Tests",
       cSettings: [
         .headerSearchPath("../../.."),
-      ]
-    ),
-
-    // MARK: - Firebase AI
-
-    .target(
-      name: "FirebaseAI",
-      dependencies: [
-        "FirebaseAppCheckInterop",
-        "FirebaseAuthInterop",
-        "FirebaseCore",
-        "FirebaseCoreExtension",
-      ],
-      path: "FirebaseAI/Sources"
-    ),
-    .testTarget(
-      name: "FirebaseAIUnit",
-      dependencies: [
-        "FirebaseAI",
-        "FirebaseStorage",
-      ],
-      path: "FirebaseAI/Tests/Unit",
-      resources: [
-        .copy("vertexai-sdk-test-data/mock-responses/vertexai"),
-        .process("Resources"),
-      ],
-      cSettings: [
-        .headerSearchPath("../../../"),
-      ]
-    ),
-
-    // MARK: - Firebase Vertex AI
-
-    .target(
-      name: "FirebaseVertexAI",
-      dependencies: [
-        "FirebaseAI",
-      ],
-      path: "FirebaseVertexAI/Sources"
-    ),
-    .testTarget(
-      name: "FirebaseVertexAIUnit",
-      dependencies: [
-        "FirebaseVertexAI",
-      ],
-      path: "FirebaseVertexAI/Tests/Unit",
-      resources: [
-        .process("Resources"),
       ]
     ),
   ] + firestoreTargets(),

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -261,7 +261,6 @@ xcb_flags=("${xcb_flags[@]}" "${buildcache_xcb_flags[@]}")
 cmake_options=(
   -Wdeprecated
   -DCMAKE_BUILD_TYPE=Debug
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
 if [[ -n "${SANITIZERS:-}" ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -261,6 +261,7 @@ xcb_flags=("${xcb_flags[@]}" "${buildcache_xcb_flags[@]}")
 cmake_options=(
   -Wdeprecated
   -DCMAKE_BUILD_TYPE=Debug
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 )
 
 if [[ -n "${SANITIZERS:-}" ]]; then


### PR DESCRIPTION
- Added a new `library` for `FirebaseAI` to the public `products` in `Package.swift`.
- Re-ordered Package.swift to put `FirebaseAI` in alphabetical order (`FirebaseVertexAI` kept nearby but will be removed in a breaking change).
- Updated the integration test app to depend on the new library.
- Renamed the internal static function `firebaseAI` to `createInstance` in `FirebaseAI`.
  - This was intended for the previous PR but missed it in my local client. This addresses the Gemini finding in #14765:
**Naming Consistency**: The naming of the internal initializer `firebaseAI(app:location:apiConfig:)` in `FirebaseAI.swift` is a bit confusing, as it shares the same name as the public API. Consider renaming the internal initializer to something more descriptive, like `createFirebaseAIInstance`.