### PR TITLE
[Firebase AI] Return default proto values with `$outputDefaults`

### DIFF
--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -167,7 +167,8 @@ public final class GenerativeModel: Sendable {
     }
 
     // Check to see if an error should be thrown for stop reason.
-    if let reason = response.candidates.first?.finishReason, reason != .stop {
+    if let reason = response.candidates.first?.finishReason, reason != .stop,
+       reason.rawValue != FinishReason.Kind.unspecified.rawValue {
       throw GenerateContentError.responseStoppedEarly(reason: reason, response: response)
     }
 

--- a/FirebaseAI/Sources/Safety.swift
+++ b/FirebaseAI/Sources/Safety.swift
@@ -78,6 +78,7 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
   public struct HarmProbability: DecodableProtoEnum, Hashable, Sendable {
     enum Kind: String {
+      case unspecified = "HARM_CATEGORY_UNSPECIFIED"
       case negligible = "NEGLIGIBLE"
       case low = "LOW"
       case medium = "MEDIUM"
@@ -114,6 +115,7 @@ public struct SafetyRating: Equatable, Hashable, Sendable {
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
   public struct HarmSeverity: DecodableProtoEnum, Hashable, Sendable {
     enum Kind: String {
+      case unspecified = "HARM_SEVERITY_UNSPECIFIED"
       case negligible = "HARM_SEVERITY_NEGLIGIBLE"
       case low = "HARM_SEVERITY_LOW"
       case medium = "HARM_SEVERITY_MEDIUM"
@@ -234,6 +236,7 @@ public struct SafetySetting: Sendable {
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct HarmCategory: CodableProtoEnum, Hashable, Sendable {
   enum Kind: String {
+    case unspecified = "HARM_CATEGORY_UNSPECIFIED"
     case harassment = "HARM_CATEGORY_HARASSMENT"
     case hateSpeech = "HARM_CATEGORY_HATE_SPEECH"
     case sexuallyExplicit = "HARM_CATEGORY_SEXUALLY_EXPLICIT"

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -116,9 +116,8 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexV1Beta,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue.
-    // InstanceConfig.developerV1Beta,
-    // InstanceConfig.developerV1BetaStaging
+    InstanceConfig.developerV1Beta,
+    InstanceConfig.developerV1BetaStaging,
     InstanceConfig.developerV1BetaSpark,
   ])
   func generateImage(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -190,12 +190,12 @@ final class IntegrationTests: XCTestCase {
       ModelContent(role: "function", parts: sumResponse),
     ])
 
-    XCTAssertEqual(response.totalTokens, 24)
+    XCTAssertEqual(response.totalTokens, 30)
     XCTAssertEqual(response.totalBillableCharacters, 71)
     XCTAssertEqual(response.promptTokensDetails.count, 1)
     let promptTokensDetails = try XCTUnwrap(response.promptTokensDetails.first)
     XCTAssertEqual(promptTokensDetails.modality, .text)
-    XCTAssertEqual(promptTokensDetails.tokenCount, 24)
+    XCTAssertEqual(promptTokensDetails.tokenCount, response.totalTokens)
   }
 
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -51,9 +51,8 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue:
-    // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1Beta,
+    developerV1BetaStaging,
     developerV1Spark,
     developerV1BetaSpark,
   ]
@@ -63,9 +62,8 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue:
-    // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1Beta,
+    developerV1BetaStaging,
     developerV1BetaSpark,
   ]
 


### PR DESCRIPTION
Updated requests in Firebase AI to set the `$outputDefaults` [system parameter](https://cloud.google.com/apis/docs/system-parameters#definitions) to `true`. This prevents the backend from omitting default values when serializing JSON and fixes a decoding issue in the `GenerateContentIntegrationTests.generateImage` test.

#no-changelog