### PR TITLE
[Firebase AI] Fix integration tests and re-enable Dev API configs

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -115,7 +115,9 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    InstanceConfig.vertexV1Beta,
+    // TODO(andrewheard): Vertex AI configs temporarily disabled to due empty SafetyRatings bug.
+    // InstanceConfig.vertexV1,
+    // InstanceConfig.vertexV1Beta,
     InstanceConfig.developerV1Beta,
     InstanceConfig.developerV1BetaStaging,
     InstanceConfig.developerV1BetaSpark,

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -116,9 +116,8 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexV1Beta,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue.
-    // InstanceConfig.developerV1Beta,
-    // InstanceConfig.developerV1BetaStaging
+    InstanceConfig.developerV1Beta,
+    InstanceConfig.developerV1BetaStaging,
     InstanceConfig.developerV1BetaSpark,
   ])
   func generateImage(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -190,12 +190,12 @@ final class IntegrationTests: XCTestCase {
       ModelContent(role: "function", parts: sumResponse),
     ])
 
-    XCTAssertEqual(response.totalTokens, 24)
+    XCTAssertGreaterThan(response.totalTokens, 0)
     XCTAssertEqual(response.totalBillableCharacters, 71)
     XCTAssertEqual(response.promptTokensDetails.count, 1)
     let promptTokensDetails = try XCTUnwrap(response.promptTokensDetails.first)
     XCTAssertEqual(promptTokensDetails.modality, .text)
-    XCTAssertEqual(promptTokensDetails.tokenCount, 24)
+    XCTAssertEqual(promptTokensDetails.tokenCount, response.totalTokens)
   }
 
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -51,9 +51,8 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue:
-    // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1Beta,
+    developerV1BetaStaging,
     developerV1Spark,
     developerV1BetaSpark,
   ]
@@ -63,9 +62,8 @@ struct InstanceConfig {
     vertexV1Staging,
     vertexV1Beta,
     vertexV1BetaStaging,
-    // TODO(andrewheard): Configs temporarily disabled due to backend issue:
-    // developerV1Beta,
-    // developerV1BetaStaging,
+    developerV1Beta,
+    developerV1BetaStaging,
     developerV1BetaSpark,
   ]
 


### PR DESCRIPTION
- Updated `testCountTokens_functionCalling` to check that the token count is `> 0`.
  - This will make the test more resilient to backend changes in token counting.
- Re-enabled Developer API configs since the backend issues have been resolved.
- Disabled Vertex AI configs for `generateImage` since the backend returns empty `SafetyRatings` in the array, which breaks our decoding.
  - Note 1: This behaviour does not appear to occur with production models -- this test uses the experimental Gemini 2.0 Flash model with Image Generation support (`gemini-2.0-flash-exp`).
  - Note 2: This issue is not observed on Google AI (Developer API).

#no-changelog