### PR TITLE
[Infra] Use 18.3.1 simulator for Combine integration tests

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -14,6 +14,9 @@
 
 name: combine
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:
@@ -72,31 +75,34 @@ jobs:
     - name: Build and test
       run:  scripts/third_party/travis/retry.sh scripts/build.sh CombineSwift ${{ matrix.target }} xcodebuild
 
-  storage-combine-integration:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
-          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
-    - name: Install Credentials.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
-          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
-    - name: Install Credentials.swift
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
-          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
-    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh StorageCombine all)
+# TODO: These tests started failing in Xcode 16. Using the iOS 18.4 simulator
+# crashes locally due to its networking issues. Using the iOS 18.3.1 simulator
+# works locally, but crashes on CI.
+#  storage-combine-integration:
+#    # Don't run on private repo unless it is a PR.
+#    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+#    env:
+#      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+#    runs-on: macos-15
+#    steps:
+#    - uses: actions/checkout@v4
+#    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+#      with:
+#        cache_key: ${{ matrix.os }}
+#    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+#    - name: Setup Bundler
+#      run: scripts/setup_bundler.sh
+#    - name: Install xcpretty
+#      run: gem install xcpretty
+#    - name: Install Secret GoogleService-Info.plist
+#      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+#          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
+#    - name: Install Credentials.h
+#      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
+#          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
+#    - name: Install Credentials.swift
+#      run: |
+#        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
+#          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
+#    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+#      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh StorageCombine all)

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   xcodebuild:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     runs-on: macos-15
 
     strategy:
@@ -74,7 +74,7 @@ jobs:
 
   storage-combine-integration:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -75,34 +75,31 @@ jobs:
     - name: Build and test
       run:  scripts/third_party/travis/retry.sh scripts/build.sh CombineSwift ${{ matrix.target }} xcodebuild
 
-# TODO: These tests started failing in Xcode 16. Using the iOS 18.4 simulator
-# crashes locally due to its networking issues. Using the iOS 18.3.1 simulator
-# works locally, but crashes on CI.
-#  storage-combine-integration:
-#    # Don't run on private repo unless it is a PR.
-#    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
-#    env:
-#      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-#    runs-on: macos-15
-#    steps:
-#    - uses: actions/checkout@v4
-#    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-#      with:
-#        cache_key: ${{ matrix.os }}
-#    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-#    - name: Setup Bundler
-#      run: scripts/setup_bundler.sh
-#    - name: Install xcpretty
-#      run: gem install xcpretty
-#    - name: Install Secret GoogleService-Info.plist
-#      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
-#          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
-#    - name: Install Credentials.h
-#      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
-#          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
-#    - name: Install Credentials.swift
-#      run: |
-#        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
-#          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
-#    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-#      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh StorageCombine all)
+  storage-combine-integration:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
+    - name: Install Credentials.h
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
+          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
+    - name: Install Credentials.swift
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
+          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh StorageCombine all)

--- a/FirebaseCombineSwift/Tests/Integration/Storage/StorageIntegration.swift
+++ b/FirebaseCombineSwift/Tests/Integration/Storage/StorageIntegration.swift
@@ -634,7 +634,7 @@ class StorageIntegration: XCTestCase {
   }
 
   private func waitForExpectations() {
-    let kFIRStorageIntegrationTestTimeout = 60.0 // seconds
+    let kFIRStorageIntegrationTestTimeout = 30.0
     waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
                         handler: { error in
                           if let error {

--- a/FirebaseCombineSwift/Tests/Integration/Storage/StorageIntegration.swift
+++ b/FirebaseCombineSwift/Tests/Integration/Storage/StorageIntegration.swift
@@ -634,7 +634,7 @@ class StorageIntegration: XCTestCase {
   }
 
   private func waitForExpectations() {
-    let kFIRStorageIntegrationTestTimeout = 30.0
+    let kFIRStorageIntegrationTestTimeout = 60.0 // seconds
     waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
                         handler: { error in
                           if let error {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -327,8 +327,7 @@ case "$product-$platform-$method" in
       -workspace 'gen/FirebaseCombineSwift/FirebaseCombineSwift.xcworkspace' \
       -scheme "FirebaseCombineSwift-Unit-unit" \
       "${xcb_flags[@]}" \
-      build \
-      test
+      build
     ;;
 
   # TODO(#14760): s/build/test after addressing UI test flakes on CI.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -605,8 +605,8 @@ case "$product-$platform-$method" in
       RunXcodebuild \
         -workspace 'gen/FirebaseCombineSwift/FirebaseCombineSwift.xcworkspace' \
         -scheme "FirebaseCombineSwift-Unit-integration" \
-        "${ios_flags[@]}" \
-        "${xcb_flags[@]}" \
+        -sdk 'iphonesimulator' \
+        -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' \
         test
       fi
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -321,14 +321,13 @@ case "$product-$platform-$method" in
     fi
     ;;
 
-  # TODO(ncooke3): Avoids 18.4 failures. Remove -sdk and -destination flags and replace with "${xcb_flags[@]}"
   CombineSwift-*-xcodebuild)
     pod_gen FirebaseCombineSwift.podspec --platforms=ios
     RunXcodebuild \
       -workspace 'gen/FirebaseCombineSwift/FirebaseCombineSwift.xcworkspace' \
       -scheme "FirebaseCombineSwift-Unit-unit" \
-      -sdk 'iphonesimulator' \
-      -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' \
+      "${xcb_flags[@]}" \
+      build \
       test
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -321,13 +321,14 @@ case "$product-$platform-$method" in
     fi
     ;;
 
+  # TODO(ncooke3): Avoids 18.4 failures. Remove -sdk and -destination flags and replace with "${xcb_flags[@]}"
   CombineSwift-*-xcodebuild)
     pod_gen FirebaseCombineSwift.podspec --platforms=ios
     RunXcodebuild \
       -workspace 'gen/FirebaseCombineSwift/FirebaseCombineSwift.xcworkspace' \
       -scheme "FirebaseCombineSwift-Unit-unit" \
-      "${xcb_flags[@]}" \
-      build \
+      -sdk 'iphonesimulator' \
+      -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' \
       test
     ;;
 


### PR DESCRIPTION
Trying to fix the failures in the Combine nightlies. I've tried but have been unable to reproduce.

Update –– Was reproducing a crash locally. Traced it back to an assertion Combine API that was checking for errors. The 18.4 sim's networking is flaky and the pipeline assertion crashes the testing suite. Moving down to 18.3.1 sim for testing.

Fix #14787