### PR TITLE
[Firebase AI] Handle decoding `Candidate` with no content

### DIFF
--- a/FirebaseAI/Sources/ModelContent.swift
+++ b/FirebaseAI/Sources/ModelContent.swift
@@ -112,6 +112,14 @@ extension ModelContent: Codable {
     case role
     case internalParts = "parts"
   }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.role = try container.decodeIfPresent(String.self, forKey: .role)
+    self.internalParts = try container.decodeIfPresent(
+      [ModelContent.InternalPart].self, forKey: .internalParts
+    ) ?? []
+  }
 }
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)


### PR DESCRIPTION
WIP - This is a workaround for Gemma 3 models when using `generateContentStream`.