### PR TITLE
[CI] Run swiftformat in style.sh on Linux

### DIFF
--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -45,7 +45,7 @@ public final class FirebaseAI: Sendable {
     assert(instance.apiConfig.service.endpoint == .firebaseProxyProd)
     assert(instance.apiConfig.version == .v1beta)
     return instance
-                           }   // Test style issue
+  }
 
   /// Initializes a generative model with the given parameters.
   ///

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -45,7 +45,7 @@ public final class FirebaseAI: Sendable {
     assert(instance.apiConfig.service.endpoint == .firebaseProxyProd)
     assert(instance.apiConfig.version == .v1beta)
     return instance
-  }
+                           }   // Test style issue
 
   /// Initializes a generative model with the given parameters.
   ///

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -180,14 +180,10 @@ s%^./%%
 needs_formatting=false
 for f in $files; do
   if [[ "${f: -6}" == '.swift' ]]; then
-    if [[ "$system" == 'Darwin' ]]; then
-      # Match output that says:
-      # 1/1 files would have been formatted.  (with --dryrun)
-      # 1/1 files formatted.                  (without --dryrun)
-      mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
-    else
-      false
-    fi
+    # Match output that says:
+    # 1/1 files would have been formatted.  (with --dryrun)
+    # 1/1 files formatted.                  (without --dryrun)
+    mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
   else
     "$clang_format_bin" "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
   fi


### PR DESCRIPTION
Fixed the `style.sh` script to run on Linux. The `check` workflow now runs on Ubuntu and was ignoring Swift style issues since the script checked `"$system" == 'Darwin'`.

#no-changelog
