### PR TITLE
Investigate swiftformat on Linux CI

### DIFF
--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -25,7 +25,7 @@ enum AILog {
   /// being truncated in log messages.
   enum MessageCode: Int {
     // Logging Configuration
-    case verboseLoggingDisabled = 100
+     case verboseLoggingDisabled = 100
     case verboseLoggingEnabled = 101
 
     // API Enablement Errors

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -25,7 +25,7 @@ enum AILog {
   /// being truncated in log messages.
   enum MessageCode: Int {
     // Logging Configuration
-     case verboseLoggingDisabled = 100
+    case verboseLoggingDisabled = 100
     case verboseLoggingEnabled = 101
 
     // API Enablement Errors

--- a/FirebaseAuth/Sources/Swift/User/User.swift
+++ b/FirebaseAuth/Sources/Swift/User/User.swift
@@ -1081,7 +1081,8 @@ extension User: NSSecureCoding {}
                           anonymous: Bool) async throws -> User {
     guard let accessToken = accessToken,
           let refreshToken = refreshToken else {
-      throw AuthErrorUtils.invalidUserTokenError(message: "Invalid user token: accessToken or refreshToken is nil")
+      throw AuthErrorUtils
+        .invalidUserTokenError(message: "Invalid user token: accessToken or refreshToken is nil")
     }
     let tokenService = SecureTokenService(withRequestConfiguration: auth.requestConfiguration,
                                           accessToken: accessToken,

--- a/FirebaseAuth/Tests/Unit/ActionCodeURLTests.swift
+++ b/FirebaseAuth/Tests/Unit/ActionCodeURLTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 /// Unit tests for ActionCodeURL
 class ActionCodeURLTests: XCTestCase {
-
   /// Tests parsing a valid URL with resetPassword mode.
   func testParseURL() {
     let urlString = "https://www.example.com?apiKey=API_KEY&mode=resetPassword&oobCode=OOB_CODE"

--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -282,7 +282,7 @@ public extension Callable where Request: Sendable, Response: Sendable {
               // `StreamResponseProtocol`, we know the `Response` generic argument
               // is `StreamResponse<_, _>`.
               let responseJSON = switch response {
-              case .message(let json), .result(let json): json
+              case let .message(json), let .result(json): json
               }
               let response = try decoder.decode(Response.self, from: responseJSON)
               if response is StreamResponseProtocol {

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -461,7 +461,8 @@ enum FunctionsConstants {
                             options: HTTPSCallableOptions?,
                             timeout: TimeInterval,
                             context: FunctionsContext,
-                            completion: @escaping @MainActor (Result<HTTPSCallableResult, Error>) -> Void) {
+                            completion: @escaping @MainActor (Result<HTTPSCallableResult, Error>)
+                              -> Void) {
     let fetcher: GTMSessionFetcher
     do {
       fetcher = try makeFetcher(

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -77,7 +77,8 @@ open class HTTPSCallable: NSObject {
   ///   - completion: The block to call when the HTTPS request has completed.
   @objc(callWithObject:completion:) open func call(_ data: Any? = nil,
                                                    completion: @escaping @MainActor (HTTPSCallableResult?,
-                                                                          Error?) -> Void) {
+                                                                                     Error?)
+                                                     -> Void) {
     if #available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *) {
       Task {
         do {

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -180,14 +180,10 @@ s%^./%%
 needs_formatting=false
 for f in $files; do
   if [[ "${f: -6}" == '.swift' ]]; then
-    if [[ "$system" == 'Darwin' ]]; then
-      # Match output that says:
-      # 1/1 files would have been formatted.  (with --dryrun)
-      # 1/1 files formatted.                  (without --dryrun)
-      mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
-    else
-      false
-    fi
+    # Match output that says:
+    # 1/1 files would have been formatted.  (with --dryrun)
+    # 1/1 files formatted.                  (without --dryrun)
+    mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
   else
     "$clang_format_bin" "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
   fi


### PR DESCRIPTION
Fixed the `style.sh` script to run on Linux. The `check` workflow now runs on Ubuntu and was ignoring Swift style issues since the script checked `"$system" == 'Darwin'`.

#no-changelog