### PR TITLE
[Firebase AI] Add support for Gemma models with Developer API

### DIFF
--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -72,7 +72,8 @@ public final class FirebaseAI: Sendable {
                               systemInstruction: ModelContent? = nil,
                               requestOptions: RequestOptions = RequestOptions())
     -> GenerativeModel {
-    if !modelName.starts(with: GenerativeModel.geminiModelNamePrefix) {
+    if !modelName.starts(with: GenerativeModel.geminiModelNamePrefix)
+      && !modelName.starts(with: GenerativeModel.gemmaModelNamePrefix) {
       AILog.warning(code: .unsupportedGeminiModel, """
       Unsupported Gemini model "\(modelName)"; see \
       https://firebase.google.com/docs/vertex-ai/models for a list supported Gemini model names.

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -23,6 +23,9 @@ public final class GenerativeModel: Sendable {
   /// Model name prefix to identify Gemini models.
   static let geminiModelNamePrefix = "gemini-"
 
+  /// Model name prefix to identify Gemma models.
+  static let gemmaModelNamePrefix = "gemma-"
+
   /// The name of the model, for example "gemini-2.0-flash".
   let modelName: String
 

--- a/FirebaseAI/Sources/ModelContent.swift
+++ b/FirebaseAI/Sources/ModelContent.swift
@@ -112,6 +112,12 @@ extension ModelContent: Codable {
     case role
     case internalParts = "parts"
   }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    role = try container.decodeIfPresent(String.self, forKey: .role)
+    internalParts = try container.decodeIfPresent([InternalPart].self, forKey: .internalParts) ?? []
+  }
 }
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)

--- a/FirebaseAI/Tests/TestApp/Sources/Constants.swift
+++ b/FirebaseAI/Tests/TestApp/Sources/Constants.swift
@@ -24,4 +24,5 @@ public enum ModelNames {
   public static let gemini2Flash = "gemini-2.0-flash-001"
   public static let gemini2FlashLite = "gemini-2.0-flash-lite-001"
   public static let gemini2FlashExperimental = "gemini-2.0-flash-exp"
+  public static let gemma3_27B = "gemma-3-27b-it"
 }

--- a/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
@@ -918,6 +918,9 @@ final class GenerativeModelVertexAITests: XCTestCase {
   func testGenerateContent_failure_malformedContent() async throws {
     MockURLProtocol
       .requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+        // Note: Although this file does not contain `parts` in `content`, it is not actually
+        // malformed. The `invalid-field` in the payload could be added, as a non-breaking change to
+        // the proto API. Therefore, this test checks for the `emptyContent` error instead.
         forResource: "unary-failure-malformed-content",
         withExtension: "json",
         subdirectory: vertexSubdirectory
@@ -939,13 +942,13 @@ final class GenerativeModelVertexAITests: XCTestCase {
       return
     }
     let invalidCandidateError = try XCTUnwrap(underlyingError as? InvalidCandidateError)
-    guard case let .malformedContent(malformedContentUnderlyingError) = invalidCandidateError else {
-      XCTFail("Not a malformed content error: \(invalidCandidateError)")
+    guard case let .emptyContent(emptyContentUnderlyingError) = invalidCandidateError else {
+      XCTFail("Not an empty content error: \(invalidCandidateError)")
       return
     }
     _ = try XCTUnwrap(
-      malformedContentUnderlyingError as? DecodingError,
-      "Not a decoding error: \(malformedContentUnderlyingError)"
+      emptyContentUnderlyingError as? DecodingError,
+      "Not a decoding error: \(emptyContentUnderlyingError)"
     )
   }
 
@@ -1446,6 +1449,9 @@ final class GenerativeModelVertexAITests: XCTestCase {
   func testGenerateContentStream_malformedContent() async throws {
     MockURLProtocol
       .requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+        // Note: Although this file does not contain `parts` in `content`, it is not actually
+        // malformed. The `invalid-field` in the payload could be added, as a non-breaking change to
+        // the proto API. Therefore, this test checks for the `emptyContent` error instead.
         forResource: "streaming-failure-malformed-content",
         withExtension: "txt",
         subdirectory: vertexSubdirectory
@@ -1457,8 +1463,8 @@ final class GenerativeModelVertexAITests: XCTestCase {
         XCTFail("Unexpected content in stream: \(content)")
       }
     } catch let GenerateContentError.internalError(underlyingError as InvalidCandidateError) {
-      guard case let .malformedContent(contentError) = underlyingError else {
-        XCTFail("Not a malformed content error: \(underlyingError)")
+      guard case let .emptyContent(contentError) = underlyingError else {
+        XCTFail("Not an empty content error: \(underlyingError)")
         return
       }
 


### PR DESCRIPTION
Added support for [Gemma models](https://ai.google.dev/gemma/docs/get_started#models-list) in the Firebase AI SDK when using the [Gemini Developer API](https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api).

Note: These models are primarily intended for [testing](https://ai.google.dev/gemma/docs/get_started#gemma-in-ais).

#no-changelog