### PR TITLE
[Firebase AI] Update error domain constant for renamed SDK

### DIFF
--- a/FirebaseAI/Sources/Constants.swift
+++ b/FirebaseAI/Sources/Constants.swift
@@ -19,6 +19,6 @@ enum Constants {
   /// The base reverse-DNS name for `NSError` or `CustomNSError` error domains.
   ///
   /// - Important: A suffix must be appended to produce an error domain (e.g.,
-  ///   "com.google.firebase.vertexai.ExampleError").
-  static let baseErrorDomain = "com.google.firebase.vertexai"
+  ///   "com.google.firebase.firebaseai.ExampleError").
+  static let baseErrorDomain = "com.google.firebase.firebaseai"
 }

--- a/FirebaseAI/Tests/TestApp/Sources/Constants.swift
+++ b/FirebaseAI/Tests/TestApp/Sources/Constants.swift
@@ -24,5 +24,5 @@ public enum ModelNames {
   public static let gemini2Flash = "gemini-2.0-flash-001"
   public static let gemini2FlashLite = "gemini-2.0-flash-lite-001"
   public static let gemini2FlashExperimental = "gemini-2.0-flash-exp"
-  public static let gemma3_27B = "gemma-3-27b-it"
+  public static let gemma3_4B = "gemma-3-4b-it"
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -82,7 +82,7 @@ struct GenerateContentIntegrationTests {
     #expect(promptTokensDetails.modality == .text)
     #expect(promptTokensDetails.tokenCount == usageMetadata.promptTokenCount)
     // The field `candidatesTokensDetails` is not included when using Gemma models.
-    if modelName == ModelNames.gemma3_27B {
+    if modelName == ModelNames.gemma3_4B {
       #expect(usageMetadata.candidatesTokensDetails.isEmpty)
     } else {
       #expect(usageMetadata.candidatesTokensDetails.count == 1)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -53,12 +53,12 @@ struct GenerateContentIntegrationTests {
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2FlashLite),
     (InstanceConfig.vertexAI_v1beta_staging, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_4B),
     (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemma3_4B),
     (InstanceConfig.googleAI_v1_freeTier_bypassProxy, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemma3_4B),
   ])
   func generateContent(_ config: InstanceConfig, modelName: String) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
@@ -191,12 +191,12 @@ struct GenerateContentIntegrationTests {
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2FlashLite),
     (InstanceConfig.vertexAI_v1beta_staging, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_4B),
     (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemma3_4B),
     (InstanceConfig.googleAI_v1_freeTier_bypassProxy, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemini2FlashLite),
-    (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemma3_27B),
+    (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemma3_4B),
   ])
   func generateContentStream(_ config: InstanceConfig, modelName: String) async throws {
     let expectedResponse = [

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -25,6 +25,10 @@ XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
 if grep -q "branch = main;" "$XCODEPROJ"; then
   sed -i "" "s#branch = main;#branch = $BRANCH_NAME;#" "$XCODEPROJ"
+
+  # Point SPM CI to the tip of `main` of
+  # https://github.com/google/GoogleAppMeasurement so that the release process
+  # can defer publishing the `GoogleAppMeasurement` tag until after testing.
   export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
 else
   echo "Failed to update quickstart's Xcode project to the current branch"

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -25,6 +25,7 @@ XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
 if grep -q "branch = main;" "$XCODEPROJ"; then
   sed -i "" "s#branch = main;#branch = $BRANCH_NAME;#" "$XCODEPROJ"
+  export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
 else
   echo "Failed to update quickstart's Xcode project to the current branch"
   exit 1


### PR DESCRIPTION
Updated the error domain (for use with `NSError`) from `com.google.firebase.vertexai` to `com.google.firebase.firebaseai` to reflect the new SDK name.

Notes:
- Updated integration tests to use Gemma 4B instead of 27B (seems to have better availability).
- Updated `scripts/quickstart_spm_xcodeproj.sh` to set `FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT`.

#no-changelog