### PR TITLE
[Auth] Add Swift 6 conformance to `FirebaseAuth/Sources/Swift/ActionCode/` directory

### DIFF
--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Manages information regarding action codes.
-@objc(FIRActionCodeInfo) open class ActionCodeInfo: NSObject {
+@objc(FIRActionCodeInfo) public final class ActionCodeInfo: NSObject, Sendable {
   /// The operation being performed.
   @objc public let operation: ActionCodeOperation
 

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift
@@ -14,8 +14,11 @@
 
 import Foundation
 
+// TODO(Swift 6 Breaking): This type is immutable. Consider removing `open` at
+// breaking change so checked Sendable can be used.
+
 /// Manages information regarding action codes.
-@objc(FIRActionCodeInfo) public final class ActionCodeInfo: NSObject, Sendable {
+@objc(FIRActionCodeInfo) open class ActionCodeInfo: NSObject, @unchecked Sendable {
   /// The operation being performed.
   @objc public let operation: ActionCodeOperation
 

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeOperation.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeOperation.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Operations which can be performed with action codes.
-@objc(FIRActionCodeOperation) public enum ActionCodeOperation: Int, @unchecked Sendable {
+@objc(FIRActionCodeOperation) public enum ActionCodeOperation: Int, Sendable {
   /// Action code for unknown operation.
   case unknown = 0
 

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
@@ -15,7 +15,8 @@
 import Foundation
 
 /// Used to set and retrieve settings related to handling action codes.
-@objc(FIRActionCodeSettings) open class ActionCodeSettings: NSObject {
+@objc(FIRActionCodeSettings) open class ActionCodeSettings: NSObject,
+  @unchecked Sendable /* TODO: sendable */ {
   /// This URL represents the state/Continue URL in the form of a universal link.
   ///
   /// This URL can should be constructed as a universal link that would either directly open

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
@@ -14,8 +14,11 @@
 
 import Foundation
 
+// TODO(Swift 6 Breaking): This type is immutable. Consider removing `open` at
+// breaking change so checked Sendable can be used.
+
 /// This class will allow developers to easily extract information about out of band links.
-@objc(FIRActionCodeURL) open class ActionCodeURL: NSObject {
+@objc(FIRActionCodeURL) open class ActionCodeURL: NSObject, @unchecked Sendable {
   /// Returns the API key from the link. nil, if not provided.
   @objc(APIKey) public let apiKey: String?
 

--- a/FirebaseCore/Internal/Sources/Utilities/FIRAllocatedUnfairLock.swift
+++ b/FirebaseCore/Internal/Sources/Utilities/FIRAllocatedUnfairLock.swift
@@ -42,6 +42,12 @@ public final class FIRAllocatedUnfairLock<State>: @unchecked Sendable {
     os_unfair_lock_unlock(lockPointer)
   }
 
+  public func value() -> State {
+    lock()
+    defer { unlock() }
+    return state
+  }
+
   @discardableResult
   public func withLock<R>(_ body: (inout State) throws -> R) rethrows -> R {
     let value: R


### PR DESCRIPTION
Going to use the TODO tag `TODO(Swift 6 Breaking)` to keep track of Swift 6 related breaking changes that should be made.

#no-changelog