### PR TITLE
[Firebase AI] Upload `xcodebuild` logs in integration tests

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -131,8 +131,8 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Run IntegrationTests
       run: scripts/build.sh FirebaseAIIntegration ${{ matrix.target }}
-    - name: Upload xcodebuild.log
-      if: always()
+    - name: Upload xcodebuild logs
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: xcodebuild-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log

--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -135,8 +135,10 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: xcodebuild.log
-        path: xcodebuild.log
+        name: xcodebuild-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
+        path: xcodebuild-*.log
+        retention-days: 3
+        compression-level: 9
 
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -137,8 +137,7 @@ jobs:
       with:
         name: xcodebuild-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
         path: xcodebuild-*.log
-        retention-days: 3
-        compression-level: 9
+        retention-days: 2
 
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -131,6 +131,12 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Run IntegrationTests
       run: scripts/build.sh FirebaseAIIntegration ${{ matrix.target }}
+    - name: Upload xcodebuild.log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: xcodebuild.log
+        path: xcodebuild.log
 
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -110,7 +110,7 @@ source scripts/check_secrets.sh
 function RunXcodebuild() {
   echo xcodebuild "$@"
   local xcodebuild_args=("$@")
-  local buildaction="${xcodebuild_args[-1]}" # The buildaction is the last arg
+  local buildaction="${xcodebuild_args[$# - 1]}" # buildaction is the last arg
   local log_filename="xcodebuild-${buildaction}.log"
 
   local xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -116,7 +116,7 @@ function RunXcodebuild() {
   local xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
 
   local result=0
-  NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee "$log_filename" 2>&1 | \
+  NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee "$log_filename" | \
     "${xcbeautify_cmd[@]}" && CheckUnexpectedFailures "$log_filename" \
     || result=$?
 
@@ -127,7 +127,7 @@ function RunXcodebuild() {
     sleep 5
 
     result=0
-    NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee "$log_filename" 2>&1 | \
+    NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee "$log_filename" | \
       "${xcbeautify_cmd[@]}" && CheckUnexpectedFailures "$log_filename" \
       || result=$?
   fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -109,12 +109,13 @@ source scripts/check_secrets.sh
 # If xcodebuild fails with known error codes, retries once.
 function RunXcodebuild() {
   echo xcodebuild "$@"
-  for buildaction in "$@"; do :; done
-  log_filename="xcodebuild-${buildaction}.log"
+  local xcodebuild_args=("$@")
+  local buildaction="${xcodebuild_args[-1]}" # The buildaction is the last arg
+  local log_filename="xcodebuild-${buildaction}.log"
 
-  xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
+  local xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
 
-  result=0
+  local result=0
   NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee "$log_filename" 2>&1 | \
     "${xcbeautify_cmd[@]}" && CheckUnexpectedFailures "$log_filename" \
     || result=$?

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -110,7 +110,7 @@ source scripts/check_secrets.sh
 function RunXcodebuild() {
   echo xcodebuild "$@"
 
-  xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
+  xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging --preserve-unbeautified)
 
   result=0
   NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee xcodebuild.log 2>&1 \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -113,8 +113,8 @@ function RunXcodebuild() {
   xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
 
   result=0
-  xcodebuild "$@" | tee xcodebuild.log | "${xcbeautify_cmd[@]}" \
-    && CheckUnexpectedFailures xcodebuild.log \
+  NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee xcodebuild.log 2>&1 \
+  | "${xcbeautify_cmd[@]}" && CheckUnexpectedFailures xcodebuild.log \
     || result=$?
 
   if [[ $result == 65 ]]; then
@@ -124,8 +124,8 @@ function RunXcodebuild() {
     sleep 5
 
     result=0
-    xcodebuild "$@" | tee xcodebuild.log | "${xcbeautify_cmd[@]}" \
-      && CheckUnexpectedFailures xcodebuild.log \
+    NSUnbufferedIO=YES xcodebuild "$@" 2>&1 | tee xcodebuild.log 2>&1 | \
+      "${xcbeautify_cmd[@]}" && CheckUnexpectedFailures xcodebuild.log \
       || result=$?
   fi
 


### PR DESCRIPTION
- Added a step in the `testapp-integration` job of the `firebaseai` workflow to upload the raw `xcodebuild` log on failure to help with debugging.
  - Context: `xcbeautify` filters out a lot of the important details in parameterized Swift Testing-based tests.
  - Split the `xcodebuild.log` into `build` and `test` logs. The test log is a fraction of the size so it's easier to see the test failures when split.
- Followed the `xcbeautify` guidance for piping the output https://github.com/cpisciotta/xcbeautify#usage.

#no-changelog
