### PR TITLE
[Firestore] On SPM, import FirebaseFirestoreInternalWrapper

### DIFF
--- a/Firestore/Swift/Source/SwiftAPI/Stages.swift
+++ b/Firestore/Swift/Source/SwiftAPI/Stages.swift
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-import FirebaseFirestoreInternal
 import Foundation
+
+#if SWIFT_PACKAGE
+  @_exported import FirebaseFirestoreInternalWrapper
+#else
+  @_exported import FirebaseFirestoreInternal
+#endif // SWIFT_PACKAGE
 
 protocol Stage {
   var name: String { get }


### PR DESCRIPTION
In SPM, the Swift `FirebaseFirestore` actually depends on `FirebaseFirestoreInternalWrapper`, not `FirebaseFirestoreInternal`.
#no-changelog