### PR TITLE
Bind rmqID instead of using stringWithFormat.

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
@@ -277,17 +277,24 @@ NSString *_Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 - (FIRMessagingPersistentSyncMessage *)querySyncMessageWithRmqID:(NSString *)rmqID {
   __block FIRMessagingPersistentSyncMessage *persistentMessage;
   dispatch_sync(_databaseOperationQueue, ^{
-    NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ = '%@'";
+    NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ = ?";
     NSString *query =
         [NSString stringWithFormat:queryFormat,
                                    kSyncMessagesColumns,  // SELECT (rmq_id, expiration_ts,
                                                           // apns_recv, mcs_recv)
                                    kTableSyncMessages,    // FROM sync_rmq
-                                   kRmqIdColumn,          // WHERE rmq_id
-                                   rmqID];
+                                   kRmqIdColumn           // WHERE rmq_id
+    ];
 
     sqlite3_stmt *stmt;
     if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+      [self logError];
+      sqlite3_finalize(stmt);
+      return;
+    }
+
+    if (sqlite3_bind_text(stmt, 1, [rmqID UTF8String], (int)[rmqID length], SQLITE_STATIC) !=
+        SQLITE_OK) {
       [self logError];
       sqlite3_finalize(stmt);
       return;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingRmqManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingRmqManagerTest.m
@@ -81,6 +81,19 @@ static NSString *const kRmqDatabaseName = @"rmq-test-db";
   XCTAssertFalse(persistentMessage.mcsReceived);
 }
 
+- (void)testQuerySyncMessageWithRmqID {
+  // This is to make sure there is no sql injection vulnerability.
+  NSString *rmqID = @"' --";
+  int64_t expirationTime = FIRMessagingCurrentTimestampInSeconds() + 1;
+  [self.rmqManager saveSyncMessageWithRmqID:rmqID expirationTime:expirationTime];
+
+  FIRMessagingPersistentSyncMessage *persistentMessage =
+      [self.rmqManager querySyncMessageWithRmqID:rmqID];
+  XCTAssertEqual(persistentMessage.expirationTime, expirationTime);
+  XCTAssertTrue(persistentMessage.apnsReceived);
+  XCTAssertFalse(persistentMessage.mcsReceived);
+}
+
 /**
  *  Test updating a sync message initially received via MCS, now being received via APNS.
  */


### PR DESCRIPTION
When populating SQL queries to find messages by ID, `stringWithFormat` is currently being used. https://github.com/firebase/firebase-ios-sdk/blob/1deb75c4cf16217459e0021cb8125a264194c0ef/FirebaseMessaging/Sources/FIRMessagingRmqManager.m#L280-L287

This is a potential SQL injection vulnerability. Even though it's very unlikely to be exploited since the `rmqID` is not user input, but a Google generated ID, we should follow best practices and use `sqlite3_bind_text` to bind the value instead.

This PR introduces no behavioral changes. It just changes how the SQL query is populated.
#14846.
