### PR TITLE
[Infra] Update Xcode versions in remoteconfig.yml

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -64,7 +64,7 @@ jobs:
       run: ([ -z $plist_secret ] || scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
           FirebaseRemoteConfig/Tests/Swift/AccessToken.json)
     - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
     - name: Fake Console API Tests
       run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} fakeconsole
     - name: IntegrationTest
@@ -84,8 +84,6 @@ jobs:
         build-env:
           - os: macos-14
             xcode: Xcode_16.2
-#            # TODO(#13078): Fix testing infra to enforce warnings again.
-#            tests: --allow-warnings
           # Flaky tests on CI
           - os: macos-15
             xcode: Xcode_16.3
@@ -114,7 +112,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
     - name: Setup quickstart
       run: scripts/setup_quickstart.sh config
     - name: Install Secret GoogleService-Info.plist
@@ -185,7 +183,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: PodLibLint RemoteConfig Cron

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -88,7 +88,7 @@ jobs:
 #            tests: --allow-warnings
           # Flaky tests on CI
           - os: macos-15
-            xcode: Xcode_16.2
+            xcode: Xcode_16.3
             tests: --skip-tests
     runs-on: ${{ matrix.build-env.os }}
     steps:


### PR DESCRIPTION
I propose doing the following:
- on macos-14, test with Xcode 16.2 (represents min. macos x min. Xcode)
- on macos-15, test with latest Xcode available on runners

#no-changelog