### PR TITLE
[Firebase AI] Run quickstart build test using branch

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -175,11 +175,9 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAI.podspec --platforms=${{ matrix.target }} ${{ matrix.warnings }}
 
   quickstart:
-    # Verifies the quickstart builds with this PR. Only run on pulls where branch is available.
-    if: github.event_name == 'pull_request'
     runs-on: macos-15
     env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}
     steps:
     - uses: actions/checkout@v4
     - name: Build Quickstart

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -31,11 +31,13 @@ XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 #	    minimumVersion = xx.yy.zz;
 #	  };
 # };
-REQUIREMENT_REGEX='({\s*isa = XCRemoteSwiftPackageReference;\
-\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";\
-\s*requirement = {\s*)kind = upToNextMajorVersion;\
-\s*minimumVersion = \d+\.\d+\.\d+;(\s*};\
-(\s*};\s*};)'
+REQUIREMENT_REGEX='({'\
+'\s*isa = XCRemoteSwiftPackageReference;'\
+'\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";'\
+'\s*requirement = {\s*)kind = upToNextMajorVersion;'\
+'\s*minimumVersion = \d+\.\d+\.\d+;'\
+'(\s*};'\
+'\s*};)'
 
 # Replaces the minimumVersion requirement with a branch requirement.
 REPLACEMENT_REGEX="\1branch = $BRANCH_NAME;\n\t\t\t\tkind = branch;\2"

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -25,7 +25,7 @@ XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
 REQUIREMENT_REGEX='({\s*isa = XCRemoteSwiftPackageReference;\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";\s*requirement = {\s*)kind = upToNextMajorVersion;\s*minimumVersion = 11.13.0;(\s*};\s*};)'
 REPLACEMENT_REGEX="\1branch = $BRANCH_NAME;\n\t\t\t\tkind = branch;\2"
-perl -0777 -pe "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#s" "$XCODEPROJ"
+perl -i -0777 -pe "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#g" "$XCODEPROJ"
 
 # Point SPM CI to the tip of `main` of
 # https://github.com/google/GoogleAppMeasurement so that the release process

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -20,7 +20,8 @@
 set -xeuo pipefail
 
 SAMPLE=$1
-XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
+SAMPLE_DIR=$(echo "$SAMPLE" | perl -ne 'print lc')
+XCODEPROJ=${SAMPLE_DIR}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
 # Regex matches SemVer `firebase-ios-sdk` dependency in project.pbxproj:
 # {
@@ -48,7 +49,7 @@ REPLACEMENT_REGEX="\1branch = $BRANCH_NAME;\n\t\t\t\tkind = branch;\2"
 # -p Causes Perl to loop through the input line by line.
 # -i Edits the file in place.
 # -e Provides the expression to execute.
-perl -0777 -pie "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#g" "$XCODEPROJ" || {
+perl -0777 -i -pe "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#g" "$XCODEPROJ" || {
   echo "Failed to update quickstart's Xcode project to the branch: $BRANCH_NAME"
   exit 1
 }

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -23,14 +23,11 @@ set -xeuo pipefail
 SAMPLE=$1
 XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
-if grep -q "branch = main;" "$XCODEPROJ"; then
-  sed -i "" "s#branch = main;#branch = $BRANCH_NAME;#" "$XCODEPROJ"
+REQUIREMENT_REGEX='({\s*isa = XCRemoteSwiftPackageReference;\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";\s*requirement = {\s*)kind = upToNextMajorVersion;\s*minimumVersion = 11.13.0;(\s*};\s*};)'
+REPLACEMENT_REGEX="\1branch = $BRANCH_NAME;\n\t\t\t\tkind = branch;\2"
+perl -0777 -pe "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#s" "$XCODEPROJ"
 
-  # Point SPM CI to the tip of `main` of
-  # https://github.com/google/GoogleAppMeasurement so that the release process
-  # can defer publishing the `GoogleAppMeasurement` tag until after testing.
-  export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1
-else
-  echo "Failed to update quickstart's Xcode project to the current branch"
-  exit 1
-fi
+# Point SPM CI to the tip of `main` of
+# https://github.com/google/GoogleAppMeasurement so that the release process
+# can defer publishing the `GoogleAppMeasurement` tag until after testing.
+export FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1

--- a/scripts/quickstart_spm_xcodeproj.sh
+++ b/scripts/quickstart_spm_xcodeproj.sh
@@ -16,16 +16,40 @@
 
 
 # Modify a .xcodeproj to use a specific branch.
-# TODO: Update to transform from a release, as well as from `main`.
 
 set -xeuo pipefail
 
 SAMPLE=$1
 XCODEPROJ=${SAMPLE}/${SAMPLE}Example.xcodeproj/project.pbxproj
 
-REQUIREMENT_REGEX='({\s*isa = XCRemoteSwiftPackageReference;\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";\s*requirement = {\s*)kind = upToNextMajorVersion;\s*minimumVersion = 11.13.0;(\s*};\s*};)'
+# Regex matches SemVer `firebase-ios-sdk` dependency in project.pbxproj:
+# {
+#   isa = XCRemoteSwiftPackageReference;
+#	  repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+#   requirement = {
+#     kind = upToNextMajorVersion;
+#	    minimumVersion = xx.yy.zz;
+#	  };
+# };
+REQUIREMENT_REGEX='({\s*isa = XCRemoteSwiftPackageReference;\
+\s*repositoryURL = "https://github\.com/firebase/firebase-ios-sdk\.git";\
+\s*requirement = {\s*)kind = upToNextMajorVersion;\
+\s*minimumVersion = \d+\.\d+\.\d+;(\s*};\
+(\s*};\s*};)'
+
+# Replaces the minimumVersion requirement with a branch requirement.
 REPLACEMENT_REGEX="\1branch = $BRANCH_NAME;\n\t\t\t\tkind = branch;\2"
-perl -i -0777 -pe "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#g" "$XCODEPROJ"
+
+# Performs the replacement using Perl.
+#
+# -0777 Enables reading all input in one go (slurp), rather than line-by-line.
+# -p Causes Perl to loop through the input line by line.
+# -i Edits the file in place.
+# -e Provides the expression to execute.
+perl -0777 -pie "s#$REQUIREMENT_REGEX#$REPLACEMENT_REGEX#g" "$XCODEPROJ" || {
+  echo "Failed to update quickstart's Xcode project to the branch: $BRANCH_NAME"
+  exit 1
+}
 
 # Point SPM CI to the tip of `main` of
 # https://github.com/google/GoogleAppMeasurement so that the release process


### PR DESCRIPTION
Updated the `quickstart_spm_xcodeproj.sh` script to replace the `minimumVersion` requirement for the `firebase-ios-sdk` SPM dependency to a `branch` requirement. This is used to test that the `FirebaseAI` quickstart builds against the PR's branch or `main` for scheduled jobs. 

#no-changelog