### PR TITLE
New and clearer FirebaseAnalytics subspecs

### DIFF
--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'Default'
 
     s.subspec 'Default' do |ss|
-        ss.dependency 'GoogleAppMeasurement', '11.14.0'
+        ss.dependency 'GoogleAppMeasurement/Default', '11.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'Default'
 
     s.subspec 'Default' do |ss|
-        ss.dependency 'GoogleAppMeasurement/Default', '11.14.0'
+        ss.dependency 'GoogleAppMeasurement', '11.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -34,13 +34,30 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/Network', '~> 8.1'
     s.dependency 'nanopb', '~> 3.30910.0'
 
-    s.default_subspecs = 'AdIdSupport'
+    s.default_subspecs = 'Default'
 
-    s.subspec 'AdIdSupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement', '11.14.0'
+    s.subspec 'Default' do |ss|
+        ss.dependency 'GoogleAppMeasurement/Default', '11.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 
+    s.subspec 'Core' do |ss|
+        ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
+        ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
+    end
+
+    s.subspec 'IdentitySupport' do |ss|
+        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '11.14.0'
+        ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
+    end
+
+    # Deprecated. Use IdentitySupport subspec instead.
+    s.subspec 'AdIdSupport' do |ss|
+        ss.dependency 'GoogleAppMeasurement/AdIdSupport', '11.14.0'
+        ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
+    end
+
+    # Deprecated. Use Core subspec instead.
     s.subspec 'WithoutAdIdSupport' do |ss|
         ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '11.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'

--- a/FirebaseAnalyticsCoreWrapper/dummy.m
+++ b/FirebaseAnalyticsCoreWrapper/dummy.m
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Swift Package Manager needs at least one source file.

--- a/FirebaseAnalyticsCoreWrapper/include/dummy.h
+++ b/FirebaseAnalyticsCoreWrapper/include/dummy.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Swift Package Manager needs at least one header to prevent a warning. See
+// https://github.com/firebase/firebase-ios-sdk/pull/6504.

--- a/FirebaseAnalyticsIdentitySupportWrapper/dummy.m
+++ b/FirebaseAnalyticsIdentitySupportWrapper/dummy.m
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Swift Package Manager needs at least one source file.

--- a/FirebaseAnalyticsIdentitySupportWrapper/include/dummy.h
+++ b/FirebaseAnalyticsIdentitySupportWrapper/include/dummy.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Swift Package Manager needs at least one header to prevent a warning. See
+// https://github.com/firebase/firebase-ios-sdk/pull/6504.

--- a/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
+++ b/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
@@ -16,4 +16,4 @@
 
 // Swift Package Manager needs at least one source file.
 
-#warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion instead."
+// #warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion instead."

--- a/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
+++ b/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
@@ -15,3 +15,5 @@
  */
 
 // Swift Package Manager needs at least one source file.
+
+#warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion instead."

--- a/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
+++ b/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
@@ -16,4 +16,5 @@
 
 // Swift Package Manager needs at least one source file.
 
-// #warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion from https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead."
+// #warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion from
+// https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead."

--- a/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
+++ b/FirebaseAnalyticsOnDeviceConversionWrapper/dummy.m
@@ -16,4 +16,4 @@
 
 // Swift Package Manager needs at least one source file.
 
-// #warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion instead."
+// #warning "FirebaseAnalyticsOnDeviceConversion is deprecated. Use GoogleAdsOnDeviceConversion from https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead."

--- a/FirebaseAnalyticsWithoutAdIdSupportWrapper/dummy.m
+++ b/FirebaseAnalyticsWithoutAdIdSupportWrapper/dummy.m
@@ -15,3 +15,5 @@
  */
 
 // Swift Package Manager needs at least one source file.
+
+#warning "FirebaseAnalyticsWithoutAdIdSupport is deprecated. Use FirebaseAnalyticsCore instead."

--- a/FirebaseAnalyticsWithoutAdIdSupportWrapper/dummy.m
+++ b/FirebaseAnalyticsWithoutAdIdSupportWrapper/dummy.m
@@ -16,4 +16,4 @@
 
 // Swift Package Manager needs at least one source file.
 
-#warning "FirebaseAnalyticsWithoutAdIdSupport is deprecated. Use FirebaseAnalyticsCore instead."
+// #warning "FirebaseAnalyticsWithoutAdIdSupport is deprecated. Use FirebaseAnalyticsCore instead."

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -34,17 +34,13 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/Network', '~> 8.1'
     s.dependency 'nanopb', '~> 3.30910.0'
 
-    s.default_subspecs = ['Default', 'GoogleAdsOnDeviceConversion']
+    s.default_subspecs = 'Default'
 
     s.subspec 'Default' do |ss|
         ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
         ss.dependency 'GoogleAppMeasurement/IdentitySupport', '11.14.0'
-    end
-
-    s.subspec 'GoogleAdsOnDeviceConversion' do |ss|
-        ss.ios.deployment_target  = '12.0'
         # TODO Update to 2.0.0
-        ss.dependency 'GoogleAdsOnDeviceConversion', '1.3.0'
+        ss.ios.dependency 'GoogleAdsOnDeviceConversion', '1.3.0'
     end
 
     s.subspec 'Core' do |ss|

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -34,11 +34,15 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/Network', '~> 8.1'
     s.dependency 'nanopb', '~> 3.30910.0'
 
-    s.default_subspecs = 'Default'
+    s.default_subspecs = ['Default', 'GoogleAdsOnDeviceConversion']
 
     s.subspec 'Default' do |ss|
         ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
         ss.dependency 'GoogleAppMeasurement/IdentitySupport', '11.14.0'
+    end
+
+    s.subspec 'GoogleAdsOnDeviceConversion' do |ss|
+        ss.ios.deployment_target  = '12.0'
         # TODO Update to 2.0.0
         ss.dependency 'GoogleAdsOnDeviceConversion', '1.3.0'
     end
@@ -61,5 +65,4 @@ Pod::Spec.new do |s|
     s.subspec 'WithoutAdIdSupport' do |ss|
         ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
     end
-
 end

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -34,15 +34,32 @@ Pod::Spec.new do |s|
     s.dependency 'GoogleUtilities/Network', '~> 8.1'
     s.dependency 'nanopb', '~> 3.30910.0'
 
-    s.default_subspecs = 'AdIdSupport'
+    s.default_subspecs = 'Default'
 
-    s.subspec 'AdIdSupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement/WithoutAdIdSupport', '11.14.0'
+    s.subspec 'Default' do |ss|
+        ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
+        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '11.14.0'
+        # TODO Update to 2.0.0
+        ss.dependency 'GoogleAdsOnDeviceConversion', '1.3.0'
+    end
+
+    s.subspec 'Core' do |ss|
+        ss.vendored_frameworks = 'Frameworks/GoogleAppMeasurement.xcframework'
+    end
+
+    s.subspec 'IdentitySupport' do |ss|
+        ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
         ss.vendored_frameworks = 'Frameworks/GoogleAppMeasurementIdentitySupport.xcframework'
     end
 
+    # Deprecated. Use IdentitySupport subspec instead.
+    s.subspec 'AdIdSupport' do |ss|
+        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '11.14.0'
+    end
+
+    # Deprecated. Use Core subspec instead.
     s.subspec 'WithoutAdIdSupport' do |ss|
-        ss.vendored_frameworks = 'Frameworks/GoogleAppMeasurement.xcframework'
+        ss.dependency 'GoogleAppMeasurement/Core', '11.14.0'
     end
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
       name: "FirebaseAnalyticsWithoutAdIdSupport",
       targets: ["FirebaseAnalyticsWithoutAdIdSupportTarget"]
     ),
-    // Deprecated. Use GoogleAdsOnDeviceConversion instead.
+    // Deprecated. Use GoogleAdsOnDeviceConversion from https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead.
     // Adding this library to your project is enough for it to take effect. The module
     // does not need to be imported into any source files.
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -44,9 +44,23 @@ let package = Package(
     // Adding this library to your project is enough for it to take effect. The module
     // does not need to be imported into any source files.
     .library(
+      name: "FirebaseAnalyticsCore",
+      targets: ["FirebaseAnalyticsCoreTarget"]
+    ),
+    // Adding this library to your project is enough for it to take effect. The module
+    // does not need to be imported into any source files.
+    .library(
+      name: "FirebaseAnalyticsIdentitySupport",
+      targets: ["FirebaseAnalyticsIdentitySupportTarget"]
+    ),
+    // Deprecated. Use FirebaseAnalyticsCore instead.
+    // Adding this library to your project is enough for it to take effect. The module
+    // does not need to be imported into any source files.
+    .library(
       name: "FirebaseAnalyticsWithoutAdIdSupport",
       targets: ["FirebaseAnalyticsWithoutAdIdSupportTarget"]
     ),
+    // Deprecated. Use GoogleAdsOnDeviceConversion instead.
     // Adding this library to your project is enough for it to take effect. The module
     // does not need to be imported into any source files.
     .library(
@@ -372,6 +386,66 @@ let package = Package(
       name: "AnalyticsObjCAPI",
       dependencies: ["FirebaseAnalyticsTarget"],
       path: "FirebaseAnalytics/Tests/ObjCAPI"
+    ),
+
+    .target(
+      name: "FirebaseAnalyticsCoreTarget",
+      dependencies: [.target(name: "FirebaseAnalyticsCoreWrapper",
+                             condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseAnalyticsCoreWrap"
+    ),
+    .target(
+      name: "FirebaseAnalyticsCoreWrapper",
+      dependencies: [
+        .target(
+          name: "FirebaseAnalytics",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
+        .product(name: "GoogleAppMeasurementCore",
+                 package: "GoogleAppMeasurement",
+                 condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])),
+        "FirebaseCore",
+        "FirebaseInstallations",
+        .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
+        .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
+        .product(name: "GULNSData", package: "GoogleUtilities"),
+        .product(name: "GULNetwork", package: "GoogleUtilities"),
+        .product(name: "nanopb", package: "nanopb"),
+      ],
+      path: "FirebaseAnalyticsCoreWrapper",
+      linkerSettings: [
+        .linkedLibrary("sqlite3"),
+        .linkedLibrary("c++"),
+        .linkedLibrary("z"),
+        .linkedFramework("StoreKit"),
+      ]
+    ),
+
+    .target(
+      name: "FirebaseAnalyticsIdentitySupportTarget",
+      dependencies: [
+        .target(
+          name: "FirebaseAnalytics",
+          condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])
+        ),
+        .product(name: "GoogleAppMeasurementIdentitySupport",
+                 package: "GoogleAppMeasurement",
+                 condition: .when(platforms: [.iOS, .macCatalyst, .macOS, .tvOS])),
+        "FirebaseCore",
+        "FirebaseInstallations",
+        .product(name: "GULAppDelegateSwizzler", package: "GoogleUtilities"),
+        .product(name: "GULMethodSwizzler", package: "GoogleUtilities"),
+        .product(name: "GULNSData", package: "GoogleUtilities"),
+        .product(name: "GULNetwork", package: "GoogleUtilities"),
+        .product(name: "nanopb", package: "nanopb"),
+      ],
+      path: "FirebaseAnalyticsIdentitySupportWrapper",
+      linkerSettings: [
+        .linkedLibrary("sqlite3"),
+        .linkedLibrary("c++"),
+        .linkedLibrary("z"),
+        .linkedFramework("StoreKit"),
+      ]
     ),
 
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,8 @@ let package = Package(
       name: "FirebaseAnalyticsWithoutAdIdSupport",
       targets: ["FirebaseAnalyticsWithoutAdIdSupportTarget"]
     ),
-    // Deprecated. Use GoogleAdsOnDeviceConversion from https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead.
+    // Deprecated. Use GoogleAdsOnDeviceConversion from
+    // https://github.com/googleads/google-ads-on-device-conversion-ios-sdk/ instead.
     // Adding this library to your project is enough for it to take effect. The module
     // does not need to be imported into any source files.
     .library(

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsCoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsCoreWrap/dummy.m
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Analytics does not support the watchOS platform"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsCoreWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsCoreWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.


### PR DESCRIPTION
The new subspecs: Default, Core, and IdentitySupport.

The previous subspecs that are now deprecated: AdIdSupport (use IdentitySupport) and WithoutAdIdSupport (use Core).

#no-changelog