### PR TITLE
Refactored Number Coding in `FunctionsSerializer`

### DIFF
--- a/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsSerializer.swift
@@ -17,7 +17,7 @@ import Foundation
 extension FunctionsSerializer {
   enum Error: Swift.Error {
     case unsupportedType(typeName: String)
-    case failedToParseWrappedNumber(WrappedNumber)
+    case failedToParseWrappedNumber(value: String, type: String)
   }
 }
 
@@ -109,12 +109,18 @@ final class FunctionsSerializer: Sendable {
     switch wrapped.type {
     case .long:
       guard let n = Int(wrapped.value) else {
-        throw .failedToParseWrappedNumber(wrapped)
+        throw .failedToParseWrappedNumber(
+          value: wrapped.value,
+          type: wrapped.type.rawValue
+        )
       }
       return n
     case .unsignedLong:
       guard let n = UInt(wrapped.value) else {
-        throw .failedToParseWrappedNumber(wrapped)
+        throw .failedToParseWrappedNumber(
+          value: wrapped.value,
+          type: wrapped.type.rawValue
+        )
       }
       return n
     }
@@ -124,7 +130,7 @@ final class FunctionsSerializer: Sendable {
 // MARK: - WrappedNumber
 
 extension FunctionsSerializer {
-  struct WrappedNumber {
+  private struct WrappedNumber {
     let type: NumberType
     let value: String
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsSerializerTests.swift
@@ -98,9 +98,9 @@ class FunctionsSerializerTests: XCTestCase {
     let dictLowLong = ["@type": typeString, "value": badVal]
     do {
       _ = try serializer.decode(dictLowLong) as? NSNumber
-    } catch let FunctionsSerializer.Error.failedToParseWrappedNumber(wrapped) {
-      XCTAssertEqual(wrapped.value, badVal)
-      XCTAssertEqual(wrapped.type.rawValue, typeString)
+    } catch let FunctionsSerializer.Error.failedToParseWrappedNumber(value, type) {
+      XCTAssertEqual(value, badVal)
+      XCTAssertEqual(type, typeString)
       return
     }
     XCTFail()
@@ -136,9 +136,9 @@ class FunctionsSerializerTests: XCTestCase {
     let coded = ["@type": typeString, "value": tooHighVal]
     do {
       _ = try serializer.decode(coded) as? NSNumber
-    } catch let FunctionsSerializer.Error.failedToParseWrappedNumber(wrapped) {
-      XCTAssertEqual(wrapped.value, tooHighVal)
-      XCTAssertEqual(wrapped.type.rawValue, typeString)
+    } catch let FunctionsSerializer.Error.failedToParseWrappedNumber(value, type) {
+      XCTAssertEqual(value, tooHighVal)
+      XCTAssertEqual(type, typeString)
       return
     }
     XCTFail()


### PR DESCRIPTION
* Introduced `WrappedNumber` as a type-safe wrapper for numeric values which have to be encoded / decoded to fit JS limits
* Since numbers other than big integers don’t need special encoding, it’s not necessary to process them separately for each type—all numbers except `q` and `Q` are returned as is (just as before)
* For decoding, wrapped numbers are parsed using Swift types `Int` and `UInt`
* These changes further reduce the usage of Objective-C types, and make it easier to (de)serialize Functions payloads using `Codable` in the future