### PR TITLE
[Infra] Fix logic used to find transitive dependencies

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -365,7 +365,10 @@ enum CocoaPodUtils {
     repeat {
       var foundDeps = Set<String>()
       for dep in newDeps {
-        let childDeps = installedPods[dep]?.dependencies ?? []
+        // The `dep` may be a subspec, so get root spec name to lookup it's
+        // dependencies in the `installedPods` dictionary.
+        let rootDep = dep.components(separatedBy: "/")[0]
+        let childDeps = installedPods[rootDep]?.dependencies ?? []
         foundDeps.formUnion(Set(childDeps))
       }
       newDeps = foundDeps.subtracting(returnDeps)


### PR DESCRIPTION
This should pull in the new `GoogleAdsOnDeviceConversion.xcframework` in the `FirebaseAnalytics/` of the `Firebase.zip`. Without this PR, `GoogleAdsOnDeviceConversion` is not found when doing a transitive dependency search because the dictionary used to store the dependency graph is keyed by root specs names instead of subspec names, which the dependency names being indexed are the subspec names. The fix was index with the root spec name instead of the subspec name.

Debug commands:
- For building Analytics:
```
swift run --package-path ReleaseTooling zip-builder \
  --pods FirebaseAnalytics \
  --platforms ios
  --local-podspec-path /Users/nickcooke/Developer/firebase-ios-sdk \
  --custom-spec-repos https://github.com/firebase/SpecsStaging.git https://github.com/firebase/SpecsDev.git \
  --no-dynamic \
  --keep-build-artifacts \
  --output-dir /Users/nickcooke/Developer/firebase-ios-sdk/zip_output_dir \
  --disable-carthage-version-check \
  --no-include-catalyst \
  --no-update-pod-repo
```

- For building zip:
```
swift run --package-path ReleaseTooling zip-builder \
  --keep-build-artifacts \
  --update-pod-repo \
  --no-dynamic \
  --local-podspec-path /Users/nickcooke/Developer/firebase-ios-sdk \
  --output-dir /Users/nickcooke/Developer/firebase-ios-sdk/zip_output_dir/ \
  --disable-carthage-version-check \
  --custom-spec-repos https://github.com/firebase/SpecsStaging.git https://github.com/firebase/SpecsDev.git \
  --platforms ios macos \
  --no-include-catalyst  \
  --no-update-pod-repo
```

cc: @pcfba 

#no-changelog