### PR TITLE
[Auth] Re-add `import Foundation` in `SecureTokenService.swift`

### DIFF
--- a/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/SecureTokenService.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import FirebaseCoreInternal
+import Foundation
 
 private let kFiveMinutes = 5 * 60.0
 


### PR DESCRIPTION
Re-added the `import Foundation` in `SecureTokenService.swift` to resolve an error when building in google3 (stricter enforcement of directly importing what we use). Context: `Foundation` is needed for `NSObject` in `SecureTokenService`.

#no-changelog