### PR TITLE
[Firebase AI] Add Firebase AI Logic SDK to Carthage docs

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -31,6 +31,7 @@ Firebase components that you want to include in your app. Note that
 
 ```
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAIBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAppCheckBinary.json"
@@ -48,6 +49,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseVertexAIBinary.json"
 ```
 - Run `carthage update`
 - Use Finder to open `Carthage/Build`.


### PR DESCRIPTION
Added `FirebaseAIBinary.json` and `FirebaseVertexAIBinary.json` to the `Cartfile` sample.

#no-changelog