### PR TITLE
[FirebaseAI] Implicit caching support

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -23,6 +23,9 @@ public struct GenerateContentResponse: Sendable {
     /// The number of tokens in the request prompt.
     public let promptTokenCount: Int
 
+    /// Number of tokens in the cached part of the prompt (the cached content)
+    public let cachedContentTokenCount: Int
+
     /// The total number of tokens across the generated response candidates.
     public let candidatesTokenCount: Int
 
@@ -31,6 +34,9 @@ public struct GenerateContentResponse: Sendable {
 
     /// The breakdown, by modality, of how many tokens are consumed by the prompt
     public let promptTokensDetails: [ModalityTokenCount]
+
+    /// The breakdown, by modality, of how many tokens are consumed by the cachedContent
+    public let cacheTokensDetails: [ModalityTokenCount]
 
     /// The breakdown, by modality, of how many tokens are consumed by the candidates
     public let candidatesTokensDetails: [ModalityTokenCount]
@@ -329,20 +335,25 @@ extension GenerateContentResponse: Decodable {
 extension GenerateContentResponse.UsageMetadata: Decodable {
   enum CodingKeys: CodingKey {
     case promptTokenCount
+    case cacheContentTokenCount
     case candidatesTokenCount
     case totalTokenCount
     case promptTokensDetails
+    case cacheTokensDetails
     case candidatesTokensDetails
   }
 
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     promptTokenCount = try container.decodeIfPresent(Int.self, forKey: .promptTokenCount) ?? 0
+    cachedContentTokenCount = try container.decodeIfPresent(Int.self, forKey: .cacheContentTokenCount) ?? 0
     candidatesTokenCount =
       try container.decodeIfPresent(Int.self, forKey: .candidatesTokenCount) ?? 0
     totalTokenCount = try container.decodeIfPresent(Int.self, forKey: .totalTokenCount) ?? 0
     promptTokensDetails =
       try container.decodeIfPresent([ModalityTokenCount].self, forKey: .promptTokensDetails) ?? []
+    cacheTokensDetails =
+      try container.decodeIfPresent([ModalityTokenCount].self, forKey: .cacheTokensDetails) ?? []
     candidatesTokensDetails = try container.decodeIfPresent(
       [ModalityTokenCount].self,
       forKey: .candidatesTokensDetails

--- a/FirebaseAI/Tests/Unit/APITests.swift
+++ b/FirebaseAI/Tests/Unit/APITests.swift
@@ -176,6 +176,7 @@ final class APITests: XCTestCase {
     // Usage Metadata
     guard let usageMetadata = response.usageMetadata else { fatalError() }
     let _: Int = usageMetadata.promptTokenCount
+    let _: Int = usageMetadata.cachedContentTokenCount
     let _: Int = usageMetadata.candidatesTokenCount
     let _: Int = usageMetadata.totalTokenCount
 


### PR DESCRIPTION
2.5 models will do implicit caching automatically.

This PR adds support to log the token count and details from the responses usageMetadata.

TODO: integration tests