### PR TITLE
[Firebase AI] Make `GenerativeAIRequest.Response` `Sendable`

### DIFF
--- a/FirebaseAI/Sources/GenerativeAIRequest.swift
+++ b/FirebaseAI/Sources/GenerativeAIRequest.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 protocol GenerativeAIRequest: Sendable, Encodable {
-  associatedtype Response: Decodable
+  associatedtype Response: Sendable, Decodable
 
   var url: URL { get }
 


### PR DESCRIPTION
Updated the `Response` associated type for `GenerativeAIRequest` to require `Sendable` conformance. This resolves the warning `Capture of non-sendable type 'T.Response.Type' in an isolated closure; this is an error in the Swift 6 language mode` in Xcode 26 Beta 1.

#no-changelog