### PR TITLE
[Firebase AI] Upgrade Gemini 1.x models in integration tests 

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -67,7 +67,7 @@ final class IntegrationTests: XCTestCase {
   func testCountTokens_text() async throws {
     let prompt = "Why is the sky blue?"
     model = vertex.generativeModel(
-      modelName: "gemini-1.5-pro",
+      modelName: ModelNames.gemini2Flash,
       generationConfig: generationConfig,
       safetySettings: [
         SafetySetting(harmCategory: .harassment, threshold: .blockLowAndAbove, method: .severity),


### PR DESCRIPTION
Since Gemini 1.5 Pro is now [retired](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#expandable-1), upgraded to Gemini 2.0 Flash in the integration tests.

Note: Only found one instance of a Gemini 1.x model in the tests.

#no-changelog