### PR TITLE
[Firebase AI] Fix JSON formatting issue in `Schema` unit tests

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 - [fixed] Fixed `Sendable` warnings introduced in the Xcode 26 beta. (#14947)
+- [added] Added support for setting `title` in string, number and array `Schema`
+  types. (#14971)
 
 # 11.13.0
 - [feature] Initial release of the Firebase AI Logic SDK (`FirebaseAI`). This

--- a/FirebaseAI/Tests/Unit/Types/SchemaTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/SchemaTests.swift
@@ -60,7 +60,7 @@ final class SchemaTests: XCTestCase {
       "description" : "\(description)",
       "format" : "date-time",
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "STRING"
     }
     """)
@@ -114,7 +114,7 @@ final class SchemaTests: XCTestCase {
       ],
       "format" : "enum",
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "STRING"
     }
     """)
@@ -160,7 +160,7 @@ final class SchemaTests: XCTestCase {
       "maximum" : \(maximum),
       "minimum" : \(minimum),
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "NUMBER"
     }
     """)
@@ -204,7 +204,7 @@ final class SchemaTests: XCTestCase {
       "maximum" : \(maximum),
       "minimum" : \(minimum),
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "NUMBER"
     }
     """)
@@ -251,7 +251,7 @@ final class SchemaTests: XCTestCase {
       "maximum" : \(maximum),
       "minimum" : \(minimum),
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "INTEGER"
     }
     """)
@@ -285,7 +285,7 @@ final class SchemaTests: XCTestCase {
     {
       "description" : "\(description)",
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "BOOLEAN"
     }
     """)
@@ -341,7 +341,7 @@ final class SchemaTests: XCTestCase {
       "maxItems" : \(maxItems),
       "minItems" : \(minItems),
       "nullable" : true,
-      "title": "\(title)",
+      "title" : "\(title)",
       "type" : "ARRAY"
     }
     """)


### PR DESCRIPTION
- Fixed a minor JSON formatting issue in the `Schema` unit tests (spacing around the ` : ` character).
- Added a changelog entry for the new feature (`title` support for all remaining `Schema` types)
  - Previously only `object` supported `title`.