### PR TITLE
[Firebase AI] Add integration tests for `global` endpoint

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -49,6 +49,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2FlashLite),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2FlashLite),
     (InstanceConfig.vertexAI_v1beta_staging, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_4B),
@@ -136,9 +137,8 @@ struct GenerateContentIntegrationTests {
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashPreview, 0),
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashPreview, 24576),
-    // TODO: Add Vertex AI Gemini 2.5 Pro tests when available.
-    // (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_ProPreview, 128),
-    // (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_ProPreview, 32768),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_ProPreview, 128),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_ProPreview, 32768),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashPreview, 0),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashPreview, 24576),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_ProPreview, 128),
@@ -197,6 +197,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexAI_v1beta,
+    InstanceConfig.vertexAI_v1beta_global,
     InstanceConfig.googleAI_v1beta,
     InstanceConfig.googleAI_v1beta_staging,
     InstanceConfig.googleAI_v1beta_freeTier_bypassProxy,
@@ -250,6 +251,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2FlashLite),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2FlashLite),
     (InstanceConfig.vertexAI_v1beta_staging, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma3_4B),

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -197,7 +197,6 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexAI_v1beta,
-    InstanceConfig.vertexAI_v1beta_global,
     InstanceConfig.googleAI_v1beta,
     InstanceConfig.googleAI_v1beta_staging,
     InstanceConfig.googleAI_v1beta_freeTier_bypassProxy,

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -23,6 +23,10 @@ struct InstanceConfig: Equatable, Encodable {
   static let vertexAI_v1beta = InstanceConfig(
     apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseProxyProd), version: .v1beta)
   )
+  static let vertexAI_v1beta_global = InstanceConfig(
+    location: "global",
+    apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseProxyProd), version: .v1beta)
+  )
   static let vertexAI_v1beta_staging = InstanceConfig(
     apiConfig: APIConfig(service: .vertexAI(endpoint: .firebaseProxyStaging), version: .v1beta)
   )
@@ -43,6 +47,7 @@ struct InstanceConfig: Equatable, Encodable {
 
   static let allConfigs = [
     vertexAI_v1beta,
+    vertexAI_v1beta_global,
     vertexAI_v1beta_staging,
     googleAI_v1beta,
     googleAI_v1beta_staging,


### PR DESCRIPTION
Updated the Firebase AI Logic integration tests to cover the [`global`](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#global-endpoint) endpoint in addition to the default (`us-central1`). Developers can use the `global` endpoint by specifying it as the location when using the Vertex AI backend:
```
let ai = FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
```

#no-changelog
