### PR TITLE
[Core] Deprecate '-[FIROptions deepLinkURLScheme]' API

### DIFF
--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -384,7 +384,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
   // Note: `self.analyticsOptionsDictionary` was left out here since it solely relies on the
   // contents of the main bundle's `Info.plist`. We should avoid reading that file and the contents
   // should be identical.
-  return self->_deepLinkURLScheme.hash ^ self->_deepLinkURLScheme.hash ^ self.appGroupID.hash;
+  return self.optionsDictionary.hash ^ self->_deepLinkURLScheme.hash ^ self.appGroupID.hash;
 }
 
 #pragma mark - Internal instance methods

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -160,7 +160,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
   FIROptions *newOptions = [(FIROptions *)[[self class] allocWithZone:zone]
       initInternalWithOptionsDictionary:self.optionsDictionary];
   if (newOptions) {
-    newOptions.deepLinkURLScheme = self.deepLinkURLScheme;
+    newOptions->_deepLinkURLScheme = self->_deepLinkURLScheme;
     newOptions.appGroupID = self.appGroupID;
     newOptions.editingLocked = self.isEditingLocked;
     newOptions.usingOptionsFromDefaultPlist = self.usingOptionsFromDefaultPlist;
@@ -357,8 +357,8 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 
   // Validate extra properties not contained in the dictionary. Only validate it if one of the
   // objects has the property set.
-  if ((options.deepLinkURLScheme != nil || self.deepLinkURLScheme != nil) &&
-      ![options.deepLinkURLScheme isEqualToString:self.deepLinkURLScheme]) {
+  if ((options->_deepLinkURLScheme != nil || self->_deepLinkURLScheme != nil) &&
+      ![options->_deepLinkURLScheme isEqualToString:self->_deepLinkURLScheme]) {
     return NO;
   }
 
@@ -384,7 +384,7 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
   // Note: `self.analyticsOptionsDictionary` was left out here since it solely relies on the
   // contents of the main bundle's `Info.plist`. We should avoid reading that file and the contents
   // should be identical.
-  return self.optionsDictionary.hash ^ self.deepLinkURLScheme.hash ^ self.appGroupID.hash;
+  return self->_deepLinkURLScheme.hash ^ self->_deepLinkURLScheme.hash ^ self.appGroupID.hash;
 }
 
 #pragma mark - Internal instance methods

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -83,7 +83,7 @@ NS_SWIFT_NAME(FirebaseOptions)
 /**
  * The URL scheme used to set up Durable Deep Link service.
  */
-@property(nonatomic, copy, nullable) NSString *deepLinkURLScheme;
+@property(nonatomic, copy, nullable) NSString *deepLinkURLScheme DEPRECATED_ATTRIBUTE;
 
 /**
  * The Google Cloud Storage bucket name, e.g. @"abc-xyz-123.storage.firebase.com".


### PR DESCRIPTION
Mentioned here: https://firebase.google.com/docs/dynamic-links/ios/create#specifying-a-custom-url-scheme-for-dynamic-links