### PR TITLE
[Core] Remove testing usage of Options.deepLinkURLScheme

### DIFF
--- a/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/CoreAPITests.swift
@@ -129,10 +129,6 @@ final class CoreAPITests {
         // ...
       }
 
-      if let _ /* deepLinkURLScheme */ = options.deepLinkURLScheme {
-        // ...
-      }
-
       if let _ /* storageBucket */ = options.storageBucket {
         // ...
       }

--- a/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
@@ -144,7 +144,6 @@ class FirebaseAppTests: XCTestCase {
   func testConfigureMultipleApps() throws {
     let options1 = FirebaseOptions(googleAppID: Constants.Options.googleAppID,
                                    gcmSenderID: Constants.Options.gcmSenderID)
-    options1.deepLinkURLScheme = Constants.Options.deepLinkURLScheme
 
     expectAppConfigurationNotification(appName: Constants.testAppName1, isDefaultApp: false)
 
@@ -154,7 +153,6 @@ class FirebaseAppTests: XCTestCase {
     XCTAssertEqual(app1.name, Constants.testAppName1)
     XCTAssertEqual(app1.options.googleAppID, Constants.Options.googleAppID)
     XCTAssertEqual(app1.options.gcmSenderID, Constants.Options.gcmSenderID)
-    XCTAssertEqual(app1.options.deepLinkURLScheme, Constants.Options.deepLinkURLScheme)
     XCTAssertTrue(FirebaseApp.allApps?.count == 1)
 
     // Configure a different app with valid customized options.
@@ -288,8 +286,6 @@ class FirebaseAppTests: XCTestCase {
 
     let options = FirebaseOptions(googleAppID: Constants.Options.googleAppID,
                                   gcmSenderID: Constants.Options.gcmSenderID)
-    let superSecretURLScheme = "com.supersecret.googledeeplinkurl"
-    options.deepLinkURLScheme = superSecretURLScheme
     FirebaseApp.configure(name: Constants.testAppName1, options: options)
 
     let app = try XCTUnwrap(
@@ -299,7 +295,6 @@ class FirebaseAppTests: XCTestCase {
     XCTAssertEqual(app.name, Constants.testAppName1)
     XCTAssertEqual(app.options.googleAppID, Constants.Options.googleAppID)
     XCTAssertEqual(app.options.gcmSenderID, Constants.Options.gcmSenderID)
-    XCTAssertEqual(app.options.deepLinkURLScheme, superSecretURLScheme)
   }
 
   func testFirebaseDataCollectionDefaultEnabled() throws {

--- a/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
@@ -91,10 +91,6 @@ class FirebaseOptionsTests: XCTestCase {
     options.googleAppID = newGoogleAppID
     XCTAssertEqual(options.googleAppID, newGoogleAppID)
 
-    XCTAssertNil(options.deepLinkURLScheme)
-    options.deepLinkURLScheme = Constants.Options.deepLinkURLScheme
-    XCTAssertEqual(options.deepLinkURLScheme, Constants.Options.deepLinkURLScheme)
-
     XCTAssertNil(options.appGroupID)
     options.appGroupID = Constants.Options.appGroupID
     XCTAssertEqual(options.appGroupID, Constants.Options.appGroupID)
@@ -110,12 +106,6 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertEqual(options.apiKey, apiKey)
     apiKey = "000000000"
     XCTAssertNotEqual(options.apiKey, apiKey)
-
-    var deepLinkURLScheme = "comdeeplinkurl"
-    options.deepLinkURLScheme = deepLinkURLScheme
-    XCTAssertEqual(options.deepLinkURLScheme, deepLinkURLScheme)
-    deepLinkURLScheme = "comlinkurl"
-    XCTAssertNotEqual(options.deepLinkURLScheme, deepLinkURLScheme)
   }
 
   func testOptionsEquality() throws {
@@ -146,7 +136,6 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertEqual(options.projectID, Constants.Options.projectID)
     XCTAssertEqual(options.googleAppID, Constants.Options.googleAppID)
     XCTAssertEqual(options.databaseURL, Constants.Options.databaseURL)
-    XCTAssertNil(options.deepLinkURLScheme)
     XCTAssertEqual(options.storageBucket, Constants.Options.storageBucket)
     XCTAssertNil(options.appGroupID)
   }
@@ -156,7 +145,6 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertNil(options.clientID)
     XCTAssertNil(options.projectID)
     XCTAssertNil(options.databaseURL)
-    XCTAssertNil(options.deepLinkURLScheme)
     XCTAssertNil(options.storageBucket)
     XCTAssertNil(options.appGroupID)
   }

--- a/FirebaseCore/Tests/SwiftUnit/SwiftTestingUtilities/Constants.swift
+++ b/FirebaseCore/Tests/SwiftUnit/SwiftTestingUtilities/Constants.swift
@@ -28,7 +28,6 @@ public enum Constants {
     static let projectID = "abc-xyz-123"
     static let googleAppID = "1:123:ios:123abc"
     static let databaseURL = "https://abc-xyz-123.firebaseio.com"
-    static let deepLinkURLScheme = "comgoogledeeplinkurl"
     static let storageBucket = "project-id-123.storage.firebase.com"
     static let appGroupID: String? = nil
   }

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -222,8 +222,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 - (void)testConfigureWithMultipleApps {
   FIROptions *options1 = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
                                                      GCMSenderID:kGCMSenderID];
-  options1.deepLinkURLScheme = kDeepLinkURLScheme;
-
   NSDictionary *expectedUserInfo1 = [self expectedUserInfoWithAppName:kFIRTestAppName1
                                                          isDefaultApp:NO];
   XCTestExpectation *configExpectation1 =

--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -48,11 +48,7 @@ extern NSString *const kFIRLibraryVersionID;
   NSDictionary *optionsDictionary = [FIROptions defaultOptionsDictionary];
   FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
-  XCTAssertNil(options.deepLinkURLScheme);
   XCTAssertTrue(options.usingOptionsFromDefaultPlist);
-
-  options.deepLinkURLScheme = kDeepLinkURLScheme;
-  XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
 }
 
 - (void)testDefaultOptionsDictionaryWithNilFilePath {
@@ -77,11 +73,7 @@ extern NSString *const kFIRLibraryVersionID;
   [FIROptionsMock mockFIROptions];
   FIROptions *options = [FIROptions defaultOptions];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
-  XCTAssertNil(options.deepLinkURLScheme);
   XCTAssertTrue(options.usingOptionsFromDefaultPlist);
-
-  options.deepLinkURLScheme = kDeepLinkURLScheme;
-  XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
 }
 
 #ifndef SWIFT_PACKAGE
@@ -124,7 +116,6 @@ extern NSString *const kFIRLibraryVersionID;
   NSString *filePath = [self validGoogleServicesInfoPlistPath];
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
-  XCTAssertNil(options.deepLinkURLScheme);
   XCTAssertFalse(options.usingOptionsFromDefaultPlist);
 
 #pragma clang diagnostic push
@@ -145,11 +136,9 @@ extern NSString *const kFIRLibraryVersionID;
   options.bundleID = kBundleID;
   options.clientID = kClientID;
   options.databaseURL = kDatabaseURL;
-  options.deepLinkURLScheme = kDeepLinkURLScheme;
   options.projectID = kProjectID;
   options.storageBucket = kStorageBucket;
   [self assertOptionsMatchDefaults:options andProjectID:YES];
-  XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
   XCTAssertFalse(options.usingOptionsFromDefaultPlist);
 }
 
@@ -210,11 +199,6 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertEqualObjects(options.databaseURL, @"1");
 
   mutableString = [[NSMutableString alloc] initWithString:@"1"];
-  options.deepLinkURLScheme = mutableString;
-  [mutableString appendString:@"2"];
-  XCTAssertEqualObjects(options.deepLinkURLScheme, @"1");
-
-  mutableString = [[NSMutableString alloc] initWithString:@"1"];
   options.storageBucket = mutableString;
   [mutableString appendString:@"2"];
   XCTAssertEqualObjects(options.storageBucket, @"1");
@@ -223,30 +207,6 @@ extern NSString *const kFIRLibraryVersionID;
   options.appGroupID = mutableString;
   [mutableString appendString:@"2"];
   XCTAssertEqualObjects(options.appGroupID, @"1");
-}
-
-- (void)testCopyWithZone {
-  [FIROptionsMock mockFIROptions];
-  // default options
-  FIROptions *options = [FIROptions defaultOptions];
-  options.deepLinkURLScheme = kDeepLinkURLScheme;
-  XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
-
-  FIROptions *newOptions = [options copy];
-  XCTAssertEqualObjects(newOptions.deepLinkURLScheme, kDeepLinkURLScheme);
-
-  [options setDeepLinkURLScheme:kNewDeepLinkURLScheme];
-  XCTAssertEqualObjects(options.deepLinkURLScheme, kNewDeepLinkURLScheme);
-  XCTAssertEqualObjects(newOptions.deepLinkURLScheme, kDeepLinkURLScheme);
-
-  // customized options
-  FIROptions *customizedOptions = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                              GCMSenderID:kGCMSenderID];
-  customizedOptions.deepLinkURLScheme = kDeepLinkURLScheme;
-  FIROptions *copyCustomizedOptions = [customizedOptions copy];
-  [copyCustomizedOptions setDeepLinkURLScheme:kNewDeepLinkURLScheme];
-  XCTAssertEqualObjects(customizedOptions.deepLinkURLScheme, kDeepLinkURLScheme);
-  XCTAssertEqualObjects(copyCustomizedOptions.deepLinkURLScheme, kNewDeepLinkURLScheme);
 }
 
 - (void)testAnalyticsConstants {
@@ -588,7 +548,6 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertThrows(options.bundleID = @"should_throw");
   XCTAssertThrows(options.clientID = @"should_throw");
   XCTAssertThrows(options.databaseURL = @"should_throw");
-  XCTAssertThrows(options.deepLinkURLScheme = @"should_throw");
   XCTAssertThrows(options.GCMSenderID = @"should_throw");
   XCTAssertThrows(options.googleAppID = @"should_throw");
   XCTAssertThrows(options.projectID = @"should_throw");


### PR DESCRIPTION
Only changes tests. Should be safe to merge post-code freeze.

Fixes #15003

#no-changelog