### PR TITLE
[Firebase AI] Update models used in integration tests

### DIFF
--- a/FirebaseAI/Tests/TestApp/Sources/Constants.swift
+++ b/FirebaseAI/Tests/TestApp/Sources/Constants.swift
@@ -23,8 +23,8 @@ public enum FirebaseAppNames {
 public enum ModelNames {
   public static let gemini2Flash = "gemini-2.0-flash-001"
   public static let gemini2FlashLite = "gemini-2.0-flash-lite-001"
-  public static let gemini2FlashExperimental = "gemini-2.0-flash-exp"
-  public static let gemini2_5_FlashPreview = "gemini-2.5-flash-preview-05-20"
-  public static let gemini2_5_ProPreview = "gemini-2.5-pro-preview-06-05"
+  public static let gemini2FlashPreviewImageGeneration = "gemini-2.0-flash-preview-image-generation"
+  public static let gemini2_5_Flash = "gemini-2.5-flash"
+  public static let gemini2_5_Pro = "gemini-2.5-pro"
   public static let gemma3_4B = "gemma-3-4b-it"
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -135,16 +135,16 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashPreview, 0),
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashPreview, 24576),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_ProPreview, 128),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_ProPreview, 32768),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashPreview, 0),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashPreview, 24576),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_ProPreview, 128),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_ProPreview, 32768),
-    (InstanceConfig.googleAI_v1beta_freeTier, ModelNames.gemini2_5_FlashPreview, 0),
-    (InstanceConfig.googleAI_v1beta_freeTier, ModelNames.gemini2_5_FlashPreview, 24576),
+    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash, 0),
+    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash, 24576),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, 128),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, 32768),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Flash, 0),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Flash, 24576),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Pro, 128),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Pro, 32768),
+    (InstanceConfig.googleAI_v1beta_freeTier, ModelNames.gemini2_5_Flash, 0),
+    (InstanceConfig.googleAI_v1beta_freeTier, ModelNames.gemini2_5_Flash, 24576),
   ])
   func generateContentThinking(_ config: InstanceConfig, modelName: String,
                                thinkingBudget: Int) async throws {
@@ -197,6 +197,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.vertexAI_v1beta,
+    InstanceConfig.vertexAI_v1beta_global,
     InstanceConfig.googleAI_v1beta,
     InstanceConfig.googleAI_v1beta_staging,
     InstanceConfig.googleAI_v1beta_freeTier_bypassProxy,
@@ -209,7 +210,7 @@ struct GenerateContentIntegrationTests {
       responseModalities: [.text, .image]
     )
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2FlashExperimental,
+      modelName: ModelNames.gemini2FlashPreviewImageGeneration,
       generationConfig: generationConfig,
       safetySettings: safetySettings
     )


### PR DESCRIPTION
- Replaced Gemini 2.5 Preview models with GA versions in the integration tests.
- Replaced `gemini-2.0-flash-exp` with the newer `gemini-2.0-flash-preview-image-generation`.
  -  `gemini-2.0-flash-exp` is not available on the `global` endpoint but `gemini-2.0-flash-preview-image-generation` works.

#no-changelog