### PR TITLE
[Core] Remove `Options.androidClientID` and `Options.trackingID`

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [removed] **Breaking change**: Removed the `Options.deepLinkURLScheme`
   property. This API was exclusively used by the Dynamic Links SDK, which
   has been removed.
+- Removed `androidClientID` and `trackingID` from FirebaseOptions.
 
 # Firebase 11.15.0
 - [fixed] Remove c99 as the required C language standard. (#14950)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,10 +2,9 @@
 - [removed] **Breaking change**: Removed the `Options.deepLinkURLScheme`
   property. This API was exclusively used by the Dynamic Links SDK, which
   has been removed.
-- [removed] **Breaking change**: Removed the `Options.androidClientID`
-  property. This API was unused.
-- [removed] **Breaking change**: Removed the `Options.trackingID`
-  property. This API was unused.
+- [removed] **Breaking change**: Removed the following unused API.
+  - `Options.androidClientID`
+  - `Options.trackingID`
 
 # Firebase 11.15.0
 - [fixed] Remove c99 as the required C language standard. (#14950)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,7 +2,10 @@
 - [removed] **Breaking change**: Removed the `Options.deepLinkURLScheme`
   property. This API was exclusively used by the Dynamic Links SDK, which
   has been removed.
-- Removed `androidClientID` and `trackingID` from FirebaseOptions.
+- [removed] **Breaking change**: Removed the `Options.androidClientID`
+  property. This API was unused.
+- [removed] **Breaking change**: Removed the `Options.trackingID`
+  property. This API was unused.
 
 # Firebase 11.15.0
 - [fixed] Remove c99 as the required C language standard. (#14950)

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -20,11 +20,9 @@
 
 // Keys for the strings in the plist file.
 NSString *const kFIRAPIKey = @"API_KEY";
-NSString *const kFIRTrackingID = @"TRACKING_ID";
 NSString *const kFIRGoogleAppID = @"GOOGLE_APP_ID";
 NSString *const kFIRClientID = @"CLIENT_ID";
 NSString *const kFIRGCMSenderID = @"GCM_SENDER_ID";
-NSString *const kFIRAndroidClientID = @"ANDROID_CLIENT_ID";
 NSString *const kFIRDatabaseURL = @"DATABASE_URL";
 NSString *const kFIRStorageBucket = @"STORAGE_BUCKET";
 // The key to locate the expected bundle identifier in the plist file.
@@ -232,15 +230,6 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
   _optionsDictionary[kFIRClientID] = [clientID copy];
 }
 
-- (NSString *)trackingID {
-  return self.optionsDictionary[kFIRTrackingID];
-}
-
-- (void)setTrackingID:(NSString *)trackingID {
-  [self checkEditingLocked];
-  _optionsDictionary[kFIRTrackingID] = [trackingID copy];
-}
-
 - (NSString *)GCMSenderID {
   return self.optionsDictionary[kFIRGCMSenderID];
 }
@@ -257,15 +246,6 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 - (void)setProjectID:(NSString *)projectID {
   [self checkEditingLocked];
   _optionsDictionary[kFIRProjectID] = [projectID copy];
-}
-
-- (NSString *)androidClientID {
-  return self.optionsDictionary[kFIRAndroidClientID];
-}
-
-- (void)setAndroidClientID:(NSString *)androidClientID {
-  [self checkEditingLocked];
-  _optionsDictionary[kFIRAndroidClientID] = [androidClientID copy];
 }
 
 - (NSString *)googleAppID {

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -50,11 +50,6 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *clientID;
 
 /**
- * Unused.
- */
-@property(nonatomic, copy, nullable) NSString *trackingID DEPRECATED_ATTRIBUTE;
-
-/**
  * The Project Number from the Google Developer's console, for example @"012345678901", used to
  * configure Firebase Cloud Messaging.
  */
@@ -64,11 +59,6 @@ NS_SWIFT_NAME(FirebaseOptions)
  * The Project ID from the Firebase console, for example @"abc-xyz-123".
  */
 @property(nonatomic, copy, nullable) NSString *projectID;
-
-/**
- * Unused.
- */
-@property(nonatomic, copy, nullable) NSString *androidClientID DEPRECATED_ATTRIBUTE;
 
 /**
  * The Google App ID that is used to uniquely identify an instance of an app.

--- a/docs/FirebaseOptionsPerProduct.md
+++ b/docs/FirebaseOptionsPerProduct.md
@@ -37,9 +37,6 @@ to GoogleService-Info.plist attributes.
 * Is there a better way to manage the fields that are only used by one product? *clientID*, *databaseURL*,
   and *storageBucket*.
 
-## Unused FirebaseOptions
-Proposal: Remove these from the SDK and stop generating them for GoogleService-Info.plist.
-
 ## Unread GoogleService-Info.plist fields
 Proposal: Stop generating these for GoogleService-Info.plist.
 

--- a/docs/FirebaseOptionsPerProduct.md
+++ b/docs/FirebaseOptionsPerProduct.md
@@ -38,10 +38,7 @@ to GoogleService-Info.plist attributes.
   and *storageBucket*.
 
 ## Unused FirebaseOptions
-Proposal: Deprecate these in the SDK and stop generating them for GoogleService-Info.plist.
-
-* *androidClientID*
-* *trackingID*
+Proposal: Remove these from the SDK and stop generating them for GoogleService-Info.plist.
 
 ## Unread GoogleService-Info.plist fields
 Proposal: Stop generating these for GoogleService-Info.plist.


### PR DESCRIPTION
These have been deprecated since Firebase 10.4