### PR TITLE
[FirebaseAI] Add support for Grounding with Google Search

### DIFF
--- a/FirebaseAI/Sources/FunctionCalling.swift
+++ b/FirebaseAI/Sources/FunctionCalling.swift
@@ -50,6 +50,17 @@ public struct FunctionDeclaration: Sendable {
   }
 }
 
+/// A tool that allows the generative model to connect to Google Search to access and incorporate
+/// up-to-date information from the web into its responses.
+///
+/// When this tool is used, the model's responses may include "Grounded Results" which are subject
+/// to the Grounding with Google Search terms outlined in the
+/// [Service Specific Terms](https://cloud.google.com/terms/service-terms).
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public struct GoogleSearch: Sendable {
+  public init() {}
+}
+
 /// A helper tool that the model may use when generating responses.
 ///
 /// A `Tool` is a piece of code that enables the system to interact with external systems to perform
@@ -58,9 +69,16 @@ public struct FunctionDeclaration: Sendable {
 public struct Tool: Sendable {
   /// A list of `FunctionDeclarations` available to the model.
   let functionDeclarations: [FunctionDeclaration]?
+  let googleSearch: GoogleSearch?
 
   init(functionDeclarations: [FunctionDeclaration]?) {
     self.functionDeclarations = functionDeclarations
+    googleSearch = nil
+  }
+
+  init(googleSearch: GoogleSearch) {
+    self.googleSearch = googleSearch
+    functionDeclarations = nil
   }
 
   /// Creates a tool that allows the model to perform function calling.
@@ -84,6 +102,24 @@ public struct Tool: Sendable {
   ///   providing generation context for the model's next turn.
   public static func functionDeclarations(_ functionDeclarations: [FunctionDeclaration]) -> Tool {
     return self.init(functionDeclarations: functionDeclarations)
+  }
+
+  /// Creates a tool that allows the model to use Grounding with Google Search.
+  ///
+  /// Grounding with Google Search can be used to allow the model to connect to Google Search to
+  /// access and incorporate up-to-date information from the web into it's responses.
+  ///
+  /// When this tool is used, the model's responses may include "Grounded Results" which are subject
+  /// to the Grounding with Google Search terms outlined in the [Service Specific
+  /// Terms](https://cloud.google.com/terms/service-terms).
+  ///
+  /// - Parameters:
+  ///   - googleSearch: An empty ``GoogleSearch`` object. The presence of this object in the list
+  ///     of tools enables the model to use Google Search.
+  ///
+  /// - Returns: A `Tool` configured for Google Search.
+  public static func googleSearch(_ googleSearch: GoogleSearch = GoogleSearch()) -> Tool {
+    return self.init(googleSearch: googleSearch)
   }
 }
 
@@ -169,6 +205,9 @@ extension FunctionCallingConfig: Encodable {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FunctionCallingConfig.Mode: Encodable {}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension GoogleSearch: Encodable {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension ToolConfig: Encodable {}

--- a/FirebaseAI/Tests/Unit/GenerativeModelGoogleAITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelGoogleAITests.swift
@@ -198,6 +198,68 @@ final class GenerativeModelGoogleAITests: XCTestCase {
     XCTAssertEqual(usageMetadata.candidatesTokensDetails[0].tokenCount, 22)
   }
 
+  func testGenerateContent_groundingMetadata() async throws {
+    MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+      forResource: "unary-success-google-search-grounding",
+      withExtension: "json",
+      subdirectory: googleAISubdirectory
+    )
+
+    let response = try await model.generateContent(testPrompt)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    let groundingMetadata = try XCTUnwrap(candidate.groundingMetadata)
+
+    XCTAssertEqual(groundingMetadata.webSearchQueries, ["current weather in London"])
+    XCTAssertNotNil(groundingMetadata.searchEntryPoint)
+    XCTAssertNotNil(groundingMetadata.searchEntryPoint?.renderedContent)
+
+    XCTAssertEqual(groundingMetadata.groundingChunks.count, 2)
+    let firstChunk = try XCTUnwrap(groundingMetadata.groundingChunks.first?.web)
+    XCTAssertEqual(firstChunk.title, "accuweather.com")
+    XCTAssertNotNil(firstChunk.uri)
+    XCTAssertNil(firstChunk.domain) // Domain is not supported by Google AI backend
+
+    XCTAssertEqual(groundingMetadata.groundingSupports.count, 3)
+    let firstSupport = try XCTUnwrap(groundingMetadata.groundingSupports.first)
+    let segment = try XCTUnwrap(firstSupport.segment)
+    XCTAssertEqual(segment.text, "The current weather in London, United Kingdom is cloudy.")
+    XCTAssertEqual(segment.startIndex, 0)
+    XCTAssertEqual(segment.partIndex, 0)
+    XCTAssertEqual(segment.endIndex, 56)
+    XCTAssertEqual(firstSupport.groundingChunkIndices, [0])
+  }
+
+  // This test case can be deleted once https://b.corp.google.com/issues/422779395 (internal) is
+  // fixed.
+  func testGenerateContent_groundingMetadata_emptyGroundingChunks() async throws {
+    MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+      forResource: "unary-success-google-search-grounding-empty-grounding-chunks",
+      withExtension: "json",
+      subdirectory: googleAISubdirectory
+    )
+
+    let response = try await model.generateContent(testPrompt)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    let groundingMetadata = try XCTUnwrap(candidate.groundingMetadata)
+    XCTAssertNotNil(groundingMetadata.searchEntryPoint?.renderedContent)
+    XCTAssertEqual(groundingMetadata.webSearchQueries, ["current weather London"])
+
+    // Chunks exist, but contain no web information.
+    XCTAssertEqual(groundingMetadata.groundingChunks.count, 2)
+    XCTAssertNil(groundingMetadata.groundingChunks[0].web)
+    XCTAssertNil(groundingMetadata.groundingChunks[1].web)
+
+    XCTAssertEqual(groundingMetadata.groundingSupports.count, 1)
+    let support = try XCTUnwrap(groundingMetadata.groundingSupports.first)
+    XCTAssertEqual(support.groundingChunkIndices, [0])
+    let segment = try XCTUnwrap(support.segment)
+    XCTAssertEqual(segment.text, "There is a 0% chance of rain and the humidity is around 41%.")
+  }
+
   func testGenerateContent_failure_invalidAPIKey() async throws {
     let expectedStatusCode = 400
     MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(

--- a/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
@@ -619,6 +619,58 @@ final class GenerativeModelVertexAITests: XCTestCase {
     XCTAssertEqual(usageMetadata.candidatesTokensDetails.isEmpty, true)
   }
 
+  func testGenerateContent_groundingMetadata() async throws {
+    MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+      forResource: "unary-success-google-search-grounding",
+      withExtension: "json",
+      subdirectory: vertexSubdirectory
+    )
+
+    let response = try await model.generateContent(testPrompt)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    let groundingMetadata = try XCTUnwrap(candidate.groundingMetadata)
+
+    XCTAssertEqual(groundingMetadata.webSearchQueries, ["current weather in London"])
+    XCTAssertNotNil(groundingMetadata.searchEntryPoint)
+    XCTAssertNotNil(groundingMetadata.searchEntryPoint?.renderedContent)
+
+    XCTAssertEqual(groundingMetadata.groundingChunks.count, 2)
+    let firstChunk = try XCTUnwrap(groundingMetadata.groundingChunks.first?.web)
+    XCTAssertEqual(firstChunk.title, "accuweather.com")
+    XCTAssertNotNil(firstChunk.uri)
+    XCTAssertNil(firstChunk.domain) // Domain is not supported by Google AI backend
+
+    XCTAssertEqual(groundingMetadata.groundingSupports.count, 3)
+    let firstSupport = try XCTUnwrap(groundingMetadata.groundingSupports.first)
+    let segment = try XCTUnwrap(firstSupport.segment)
+    XCTAssertEqual(segment.text, "The current weather in London, United Kingdom is cloudy.")
+    XCTAssertEqual(segment.startIndex, 0)
+    XCTAssertEqual(segment.partIndex, 0)
+    XCTAssertEqual(segment.endIndex, 56)
+    XCTAssertEqual(firstSupport.groundingChunkIndices, [0])
+  }
+
+  func testGenerateContent_withGoogleSearchTool() async throws {
+    let model = GenerativeModel(
+      modelName: testModelName,
+      modelResourceName: testModelResourceName,
+      firebaseInfo: GenerativeModelTestUtil.testFirebaseInfo(),
+      apiConfig: apiConfig,
+      tools: [.googleSearch()],
+      requestOptions: RequestOptions(),
+      urlSession: urlSession
+    )
+    MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
+      forResource: "unary-success-basic-reply-short",
+      withExtension: "json",
+      subdirectory: vertexSubdirectory
+    )
+
+    _ = try await model.generateContent(testPrompt)
+  }
+
   func testGenerateContent_failure_invalidAPIKey() async throws {
     let expectedStatusCode = 400
     MockURLProtocol

--- a/FirebaseAI/Tests/Unit/Types/GroundingMetadataTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GroundingMetadataTests.swift
@@ -1,0 +1,100 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class GroundingMetadataTests: XCTestCase {
+  let decoder = JSONDecoder()
+
+  func testDecodeGroundingMetadata_allFields() throws {
+    let json = """
+    {
+      "webSearchQueries": ["query1", "query2"],
+      "groundingChunks": [
+        { "web": { "uri": "uri1", "title": "title1" } }
+      ],
+      "groundingSupports": [
+        { "segment": { "endIndex": 10, "text": "text" }, "groundingChunkIndices": [0] }
+      ],
+      "searchEntryPoint": { "renderedContent": "html" }
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let metadata = try decoder.decode(GroundingMetadata.self, from: jsonData)
+
+    XCTAssertEqual(metadata.webSearchQueries, ["query1", "query2"])
+    XCTAssertEqual(metadata.groundingChunks.count, 1)
+    XCTAssertEqual(metadata.groundingChunks.first?.web?.uri, "uri1")
+    XCTAssertEqual(metadata.groundingSupports.count, 1)
+    XCTAssertEqual(metadata.groundingSupports.first?.segment?.startIndex, 0)
+    XCTAssertEqual(metadata.groundingSupports.first?.segment?.partIndex, 0)
+    XCTAssertEqual(metadata.groundingSupports.first?.segment?.endIndex, 10)
+    XCTAssertEqual(metadata.groundingSupports.first?.segment?.text, "text")
+    XCTAssertEqual(metadata.searchEntryPoint?.renderedContent, "html")
+  }
+
+  func testDecodeGroundingMetadata_missingOptionals() throws {
+    let json = "{}"
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let metadata = try decoder.decode(GroundingMetadata.self, from: jsonData)
+
+    XCTAssertTrue(metadata.webSearchQueries.isEmpty)
+    XCTAssertTrue(metadata.groundingChunks.isEmpty)
+    XCTAssertTrue(metadata.groundingSupports.isEmpty)
+    XCTAssertNil(metadata.searchEntryPoint)
+  }
+
+  func testDecodeGroundingChunk_withoutWeb() throws {
+    let json = "{}"
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+    let chunk = try decoder.decode(GroundingMetadata.GroundingChunk.self, from: jsonData)
+    XCTAssertNil(chunk.web)
+  }
+
+  func testDecodeWebGroundingChunk_withDomain() throws {
+    let json = """
+    { "uri": "uri1", "title": "title1", "domain": "example.com" }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+    let webChunk = try decoder.decode(GroundingMetadata.WebGroundingChunk.self, from: jsonData)
+    XCTAssertEqual(webChunk.uri, "uri1")
+    XCTAssertEqual(webChunk.title, "title1")
+    XCTAssertEqual(webChunk.domain, "example.com")
+  }
+
+  func testDecodeGroundingSupport_withoutSegment() throws {
+    let json = """
+    { "groundingChunkIndices": [1, 2] }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+    let support = try decoder.decode(GroundingMetadata.GroundingSupport.self, from: jsonData)
+    XCTAssertNil(support.segment)
+    XCTAssertEqual(support.groundingChunkIndices, [1, 2])
+  }
+
+  func testDecodeSegment_defaults() throws {
+    let json = "{}"
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+    let segment = try decoder.decode(Segment.self, from: jsonData)
+    XCTAssertEqual(segment.partIndex, 0)
+    XCTAssertEqual(segment.startIndex, 0)
+    XCTAssertEqual(segment.endIndex, 0)
+    XCTAssertEqual(segment.text, "")
+  }
+}

--- a/FirebaseAI/Tests/Unit/Types/ToolTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/ToolTests.swift
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseAI
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+final class ToolTests: XCTestCase {
+  let encoder = JSONEncoder()
+
+  override func setUp() {
+    super.setUp()
+    encoder.outputFormatting = .sortedKeys
+  }
+
+  func testEncodeTool_googleSearch() throws {
+    let tool = Tool.googleSearch()
+    let jsonData = try encoder.encode(tool)
+    let jsonString = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+    XCTAssertEqual(jsonString, "{\"googleSearch\":{}}")
+  }
+
+  func testEncodeTool_functionDeclarations() throws {
+    let functionDecl = FunctionDeclaration(
+      name: "test_function",
+      description: "A test function.",
+      parameters: ["param1": .string()]
+    )
+    let tool = Tool.functionDeclarations([functionDecl])
+
+    encoder.outputFormatting.insert(.withoutEscapingSlashes)
+    let jsonData = try encoder.encode(tool)
+    let jsonString = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+
+    XCTAssertEqual(jsonString, """
+    {"functionDeclarations":[{"description":"A test function.","name":"test_function","parameters":{"nullable":false,"properties":{"param1":{"nullable":false,"type":"STRING"}},"required":["param1"],"type":"OBJECT"}}]}
+    """)
+  }
+}


### PR DESCRIPTION
API Proposal: [go/fal-grounding-api](https://goto.google.com/fal-grounding-api) (internal)

- Added `GoogleSearch` tool and `.googleSearch()` static initializer
- Added `GroundingMetadata` and all subtypes
- Added unit tests