### PR TITLE
[FirebaseAI] update the jump link in README.md for quickstart-ios

### DIFF
--- a/FirebaseAI/README.md
+++ b/FirebaseAI/README.md
@@ -1,7 +1,7 @@
 # Firebase AI SDK
 
 - For developer documentation, please visit https://firebase.google.com/docs/vertex-ai.
-- Try out the [sample app](https://github.com/firebase/quickstart-ios/tree/main/vertexai to get started.
+- Try out the [sample app](https://github.com/firebase/quickstart-ios/tree/main/firebaseai) to get started.
 
 ## Development
 


### PR DESCRIPTION
quickstart-ios/vertexai has been migrated to quickstart-ios/firebaseai