### PR TITLE
[Auth] Remove 'ActionCodeSettings.dynamicLinkDomain'

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [removed] **Breaking Change**: Removed
+  `ActionCodeSettings.dynamicLinkDomain`.
+
 # 11.15.0
 - [fixed] Fixed `Sendable` warnings introduced in the Xcode 26 beta. (#14996)
 

--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeSettings.swift
@@ -62,19 +62,6 @@ import Foundation
     set { impl.androidInstallIfNotAvailable.withLock { $0 = newValue } }
   }
 
-  /// The Firebase Dynamic Link domain used for out of band code flow.
-  #if !FIREBASE_CI
-    @available(
-      *,
-      deprecated,
-      message: "Firebase Dynamic Links is deprecated. Migrate to use Firebase Hosting link and use `linkDomain` to set a custom domain instead."
-    )
-  #endif // !FIREBASE_CI
-  @objc open var dynamicLinkDomain: String? {
-    get { impl.dynamicLinkDomain.value() }
-    set { impl.dynamicLinkDomain.withLock { $0 = newValue } }
-  }
-
   /// The out of band custom domain for handling code in app.
   @objc public var linkDomain: String? {
     get { impl.linkDomain.value() }
@@ -129,15 +116,6 @@ private extension ActionCodeSettings {
     let androidMinimumVersion = FIRAllocatedUnfairLock<String?>(initialState: nil)
 
     let androidInstallIfNotAvailable = FIRAllocatedUnfairLock<Bool>(initialState: false)
-
-    #if !FIREBASE_CI
-      @available(
-        *,
-        deprecated,
-        message: "Firebase Dynamic Links is deprecated. Migrate to use Firebase Hosting link and use `linkDomain` to set a custom domain instead."
-      )
-    #endif // !FIREBASE_CI
-    let dynamicLinkDomain = FIRAllocatedUnfairLock<String?>(initialState: nil)
 
     let linkDomain = FIRAllocatedUnfairLock<String?>(initialState: nil)
 

--- a/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/RPC/GetOOBConfirmationCodeRequest.swift
@@ -75,9 +75,6 @@ private let kAndroidMinimumVersionKey = "androidMinimumVersion"
 /// or not.
 private let kCanHandleCodeInAppKey = "canHandleCodeInApp"
 
-/// The key for the "dynamic link domain" value in the request.
-private let kDynamicLinkDomainKey = "dynamicLinkDomain"
-
 /// The key for the "link domain" value in the request.
 private let kLinkDomainKey = "linkDomain"
 
@@ -104,12 +101,6 @@ private let kClientType = "clientType"
 
 /// The key for the "recaptchaVersion" value in the request.
 private let kRecaptchaVersion = "recaptchaVersion"
-
-protocol SuppressWarning {
-  var dynamicLinkDomain: String? { get set }
-}
-
-extension ActionCodeSettings: SuppressWarning {}
 
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
@@ -146,9 +137,6 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
   ///   redirected from a Firebase owned web widget.
   let handleCodeInApp: Bool
 
-  /// The Firebase Dynamic Link domain used for out of band code flow.
-  private let dynamicLinkDomain: String?
-
   /// The Firebase Hosting domain used for out of band code flow.
   private(set) var linkDomain: String?
 
@@ -183,12 +171,6 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
     androidMinimumVersion = actionCodeSettings?.androidMinimumVersion
     androidInstallApp = actionCodeSettings?.androidInstallIfNotAvailable ?? false
     handleCodeInApp = actionCodeSettings?.handleCodeInApp ?? false
-    dynamicLinkDomain =
-      if let actionCodeSettings {
-        (actionCodeSettings as SuppressWarning).dynamicLinkDomain
-      } else {
-        nil
-      }
     linkDomain = actionCodeSettings?.linkDomain
 
     super.init(
@@ -288,9 +270,6 @@ class GetOOBConfirmationCodeRequest: IdentityToolkitRequest, AuthRPCRequest {
     }
     if handleCodeInApp {
       body[kCanHandleCodeInAppKey] = true
-    }
-    if let dynamicLinkDomain {
-      body[kDynamicLinkDomainKey] = dynamicLinkDomain
     }
     if let linkDomain {
       body[kLinkDomainKey] = linkDomain

--- a/FirebaseAuth/Tests/Unit/GetOOBConfirmationCodeTests.swift
+++ b/FirebaseAuth/Tests/Unit/GetOOBConfirmationCodeTests.swift
@@ -33,7 +33,6 @@ class GetOOBConfirmationCodeTests: RPCBaseTests {
   private let kAndroidInstallAppKey = "androidInstallApp"
   private let kAndroidMinimumVersionKey = "androidMinimumVersion"
   private let kCanHandleCodeInAppKey = "canHandleCodeInApp"
-  private let kDynamicLinkDomainKey = "dynamicLinkDomain"
   private let kLinkDomainKey = "linkDomain"
   private let kExpectedAPIURL =
     "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getOobConfirmationCode?key=APIKey"
@@ -66,7 +65,6 @@ class GetOOBConfirmationCodeTests: RPCBaseTests {
       XCTAssertEqual(decodedRequest[kAndroidMinimumVersionKey] as? String, kAndroidMinimumVersion)
       XCTAssertEqual(decodedRequest[kAndroidInstallAppKey] as? Bool, true)
       XCTAssertEqual(decodedRequest[kCanHandleCodeInAppKey] as? Bool, true)
-      XCTAssertEqual(decodedRequest[kDynamicLinkDomainKey] as? String, kDynamicLinkDomain)
       XCTAssertEqual(decodedRequest[kLinkDomainKey] as? String, kLinkDomain)
     }
   }
@@ -111,7 +109,6 @@ class GetOOBConfirmationCodeTests: RPCBaseTests {
       XCTAssertEqual(decodedRequest[kAndroidMinimumVersionKey] as? String, kAndroidMinimumVersion)
       XCTAssertEqual(decodedRequest[kAndroidInstallAppKey] as? Bool, true)
       XCTAssertEqual(decodedRequest[kCanHandleCodeInAppKey] as? Bool, true)
-      XCTAssertEqual(decodedRequest[kDynamicLinkDomainKey] as? String, kDynamicLinkDomain)
       XCTAssertEqual(decodedRequest[kLinkDomainKey] as? String, kLinkDomain)
       XCTAssertEqual(decodedRequest[kCaptchaResponseKey] as? String, kTestCaptchaResponse)
       XCTAssertEqual(decodedRequest[kClientTypeKey] as? String, kTestClientType)

--- a/FirebaseAuth/Tests/Unit/ObjCAPITests.m
+++ b/FirebaseAuth/Tests/Unit/ObjCAPITests.m
@@ -64,7 +64,6 @@
   NSString *s = [codeSettings iOSBundleID];
   s = [codeSettings androidPackageName];
   s = [codeSettings androidMinimumVersion];
-  s = [codeSettings dynamicLinkDomain];
   s = [codeSettings linkDomain];
 }
 

--- a/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
+++ b/FirebaseAuth/Tests/Unit/RPCBaseTests.swift
@@ -37,7 +37,6 @@ class RPCBaseTests: XCTestCase {
   let kIosBundleID = "testBundleID"
   let kAndroidPackageName = "androidpackagename"
   let kAndroidMinimumVersion = "3.0"
-  let kDynamicLinkDomain = "test.page.link"
   let kLinkDomain = "link.firebaseapp.com"
   let kTestPhotoURL = "https://host.domain/image"
   let kCreationDateTimeIntervalInSeconds = 1_505_858_500.0
@@ -304,7 +303,6 @@ class RPCBaseTests: XCTestCase {
                                    minimumVersion: kAndroidMinimumVersion)
     settings.handleCodeInApp = true
     settings.url = URL(string: kContinueURL)
-    settings.dynamicLinkDomain = kDynamicLinkDomain
     settings.linkDomain = kLinkDomain
     return settings
   }

--- a/FirebaseAuth/Tests/Unit/SwiftAPI.swift
+++ b/FirebaseAuth/Tests/Unit/SwiftAPI.swift
@@ -41,7 +41,6 @@ class AuthAPI_hOnlyTests: XCTestCase {
        let _: String = codeSettings.iOSBundleID,
        let _: String = codeSettings.androidPackageName,
        let _: String = codeSettings.androidMinimumVersion,
-       let _: String = codeSettings.dynamicLinkDomain,
        let _: String = codeSettings.linkDomain {}
     codeSettings.linkDomain = nil
     codeSettings.linkDomain = ""


### PR DESCRIPTION
Note, there is a public enum error case that maps to the `dynamicLinkDomain` that we never deprecated. It seems possible to deprecate cases individually, so I think we could do that as well? 