### PR TITLE
[FIAM] Remove dep. warning

### DIFF
--- a/FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FirebaseInAppMessaging.h
+++ b/FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging/FirebaseInAppMessaging.h
@@ -18,6 +18,3 @@
 #import "FIRInAppMessagingErrors.h"
 #import "FIRInAppMessagingRendering.h"
 
-#if __has_include(<FirebaseInAppMessagingDisplay/FirebaseInAppMessagingDisplay.h>)
-#warning The FirebaseInAppMessagingDisplay subspec is deprecated. Please remove FirebaseInAppMessagingDisplay from your Podfile (or delete the framework).
-#endif


### PR DESCRIPTION
Was grepping around for deprecated and found this. Should be safe to remove. https://github.com/firebase/firebase-ios-sdk/blob/main/FirebaseInAppMessaging/CHANGELOG.md#0160

It was added sometime around/before Firebase 7

#no-changelog