### PR TITLE
[Storage] Remove unused, long-deprecated 'StorageMetadata.storageReference' API`

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [removed] **Breaking change**: Removed the following unused API,
+  `StorageMetadata.storageReference`.
+
 # 11.13.0
 - [fixed] `putFile` now works in App Clips. Similarly to app extensions, background session
   configurations are not used in App Clips (#14794).

--- a/FirebaseStorage/Sources/StorageMetadata.swift
+++ b/FirebaseStorage/Sources/StorageMetadata.swift
@@ -103,11 +103,6 @@ import Foundation
   @objc public let updated: Date?
 
   /**
-   * Never used API
-   */
-  @available(*, deprecated) @objc public let storageReference: StorageReference? = nil
-
-  /**
    * Creates a Dictionary from the contents of the metadata.
    * @return A Dictionary that represents the contents of the metadata.
    */

--- a/FirebaseStorage/Tests/ObjCIntegration/ObjCAPITests.m
+++ b/FirebaseStorage/Tests/ObjCIntegration/ObjCAPITests.m
@@ -169,10 +169,6 @@
   [metadata size];
   [metadata timeCreated];
   [metadata updated];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [metadata storageReference];
-#pragma clang diagnostic pop
   FIRStorageMetadata __unused *ref2 = [metadata initWithDictionary:@{}];
   NSDictionary<NSString *, id> __unused *dict = [metadata dictionaryRepresentation];
   [metadata isFile];


### PR DESCRIPTION
For Firebase 12 consideration:
- https://github.com/firebase/firebase-ios-sdk/issues/14834#issuecomment-3014652856