### PR TITLE
[Infra] Remove manual visionOS install

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -104,9 +104,6 @@ jobs:
         key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install visionOS, if needed.
-      if: matrix.platform == 'visionOS'
-      run: xcodebuild -downloadPlatform visionOS
     - name: Run setup command, if needed.
       if: inputs.setup_command != ''
       run: ${{ inputs.setup_command }}


### PR DESCRIPTION
This seems to be failing some jobs – https://github.com/firebase/firebase-ios-sdk/actions/runs/16029623005/job/45226631663?pr=15026#step:5:1

I don't know if it's still needed anymore so I'll try deleting it.

#no-changelog