### PR TITLE
[Infra] Install visionOS on runner only if it doesn't already exist

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -106,7 +106,8 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install visionOS, if needed.
       if: matrix.platform == 'visionOS'
-      run: xcodebuild -downloadPlatform visionOS
+      run: ls $(xcode-select -p)/Platforms/XROS.platform || \
+        { xcodebuild -downloadPlatform visionOS }
     - name: Run setup command, if needed.
       if: inputs.setup_command != ''
       run: ${{ inputs.setup_command }}


### PR DESCRIPTION
Seeing some network flakes when downloading the visionOS platform on CI. This PR reduces (hopefully) the times we need to download the visionOS platform, thus reducing transient network issues.

#no-changelog