### PR TITLE
Functions Cleanup

### DIFF
--- a/FirebaseFunctions/Sources/Callable+Codable.swift
+++ b/FirebaseFunctions/Sources/Callable+Codable.swift
@@ -133,7 +133,6 @@ public struct Callable<Request: Encodable, Response: Decodable>: Sendable {
   /// - Throws: An error if the callable fails to complete
   ///
   /// - Returns: The decoded `Response` value
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public func call(_ data: Request) async throws -> Response {
     let encoded = try encoder.encode(data)
     let result = try await callable.call(encoded)
@@ -160,7 +159,6 @@ public struct Callable<Request: Encodable, Response: Decodable>: Sendable {
   /// - Parameters:
   ///   - data: Parameters to pass to the trigger.
   /// - Returns: The decoded `Response` value
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public func callAsFunction(_ data: Request) async throws -> Response {
     return try await call(data)
   }
@@ -174,7 +172,7 @@ private protocol StreamResponseProtocol {}
 ///
 /// This can be used as the generic `Response` parameter to ``Callable`` to receive both the
 /// yielded messages and final return value of the streaming callable function.
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 12.0, watchOS 8.0, *)
 public enum StreamResponse<Message: Decodable & Sendable, Result: Decodable & Sendable>: Decodable,
   Sendable,
   StreamResponseProtocol {
@@ -219,7 +217,7 @@ public enum StreamResponse<Message: Decodable & Sendable, Result: Decodable & Se
   }
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 12.0, watchOS 8.0, *)
 public extension Callable where Request: Sendable, Response: Sendable {
   /// Creates a stream that yields responses from the streaming callable function.
   ///

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -386,7 +386,6 @@ enum FunctionsConstants {
     return URL(string: "https://\(region)-\(projectID).cloudfunctions.net/\(name)")
   }
 
-  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
   func callFunction(at url: URL,
                     withObject data: Any?,
                     options: HTTPSCallableOptions?,
@@ -408,50 +407,7 @@ enum FunctionsConstants {
     }
   }
 
-  private func callFunction(url: URL,
-                            withObject data: Any?,
-                            options: HTTPSCallableOptions?,
-                            timeout: TimeInterval,
-                            context: FunctionsContext,
-                            completion: @escaping @MainActor (Result<HTTPSCallableResult, Error>)
-                              -> Void) {
-    let fetcher: GTMSessionFetcher
-    do {
-      fetcher = try makeFetcher(
-        url: url,
-        data: data,
-        options: options,
-        timeout: timeout,
-        context: context
-      )
-    } catch {
-      DispatchQueue.main.async {
-        completion(.failure(error))
-      }
-      return
-    }
-
-    fetcher.beginFetch { [self] data, error in
-      let result: Result<HTTPSCallableResult, any Error>
-      if let error {
-        result = .failure(processedError(fromResponseError: error, endpointURL: url))
-      } else if let data {
-        do {
-          result = try .success(callableResult(fromResponseData: data, endpointURL: url))
-        } catch {
-          result = .failure(error)
-        }
-      } else {
-        result = .failure(FunctionsError(.internal))
-      }
-
-      DispatchQueue.main.async {
-        completion(result)
-      }
-    }
-  }
-
-  @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+  @available(macOS 12.0, watchOS 8.0, *)
   func stream(at url: URL,
               data: SendableWrapper?,
               options: HTTPSCallableOptions?,
@@ -556,7 +512,7 @@ enum FunctionsConstants {
     }
   }
 
-  @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+  @available(macOS 12.0, watchOS 8.0, *)
   private func callableStreamResult(fromResponseData data: Data,
                                     endpointURL url: URL) throws -> sending JSONStreamResponse {
     let data = try processedData(fromResponseData: data, endpointURL: url)

--- a/FirebaseFunctions/Sources/HTTPSCallable.swift
+++ b/FirebaseFunctions/Sources/HTTPSCallable.swift
@@ -160,13 +160,12 @@ public final class HTTPSCallable: NSObject, Sendable {
   /// - Parameter data: Parameters to pass to the trigger.
   /// - Throws: An error if the Cloud Functions invocation failed.
   /// - Returns: The result of the call.
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   public func call(_ data: Any? = nil) async throws -> sending HTTPSCallableResult {
     try await functions
       .callFunction(at: url, withObject: data, options: options, timeout: timeoutInterval)
   }
 
-  @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+  @available(macOS 12.0, watchOS 8.0, *)
   func stream(_ data: SendableWrapper? = nil) -> AsyncThrowingStream<JSONStreamResponse, Error> {
     functions.stream(at: url, data: data, options: options, timeout: timeoutInterval)
   }

--- a/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
@@ -36,7 +36,6 @@ struct FunctionsContextProvider: Sendable {
     self.appCheck = appCheck
   }
 
-  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
   func context(options: HTTPSCallableOptions?) async throws -> FunctionsContext {
     async let authToken = auth?.getToken(forcingRefresh: false)
     async let appCheckToken = getAppCheckToken(options: options)
@@ -52,7 +51,6 @@ struct FunctionsContextProvider: Sendable {
     )
   }
 
-  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
   private func getAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
     guard
       options?.requireLimitedUseAppCheckTokens != true,
@@ -62,7 +60,6 @@ struct FunctionsContextProvider: Sendable {
     return tokenResult.token
   }
 
-  @available(iOS 13, macCatalyst 13, macOS 10.15, tvOS 13, watchOS 7, *)
   private func getLimitedUseAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
     // At the moment, `await` doesn’t get along with Objective-C’s optional protocol methods.
     await withCheckedContinuation { (continuation: CheckedContinuation<String?, Never>) in

--- a/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
+++ b/FirebaseFunctions/Tests/CombineUnit/HTTPSCallableTests.swift
@@ -54,7 +54,6 @@ class MockFunctions: Functions, @unchecked Sendable {
   }
 }
 
-@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
 class HTTPSCallableTests: XCTestCase {
   func testCallWithoutParametersSuccess() {
     // given

--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -119,7 +119,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testDataAsync() async throws {
     let data = DataTestRequest(
       bool: true,
@@ -174,7 +173,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testScalarAsync() async throws {
     let byName = functions.httpsCallable(
       "scalarTest",
@@ -193,7 +191,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testScalarAsyncAlternateSignature() async throws {
     let byName: Callable<Int16, Int> = functions.httpsCallable("scalarTest")
     let byURL: Callable<Int16, Int> = functions.httpsCallable(emulatorURL("scalarTest"))
@@ -241,7 +238,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testTokenAsync() async throws {
     // Recreate functions with a token.
     let functions = Functions(
@@ -297,7 +293,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testFCMTokenAsync() async throws {
     let byName = functions.httpsCallable(
       "FCMTokenTest",
@@ -342,7 +337,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testNullAsync() async throws {
     let byName = functions.httpsCallable(
       "nullTest",
@@ -391,7 +385,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testMissingResultAsync() async {
     let byName = functions.httpsCallable(
       "missingResultTest",
@@ -445,7 +438,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testUnhandledErrorAsync() async {
     let byName = functions.httpsCallable(
       "unhandledErrorTest",
@@ -498,7 +490,6 @@ class IntegrationTests: XCTestCase {
     waitForExpectations(timeout: 5)
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testUnknownErrorAsync() async {
     let byName = functions.httpsCallable(
       "unknownErrorTest",
@@ -553,7 +544,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testExplicitErrorAsync() async {
     let byName = functions.httpsCallable(
       "explicitErrorTest",
@@ -608,7 +598,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testHttpErrorAsync() async {
     let byName = functions.httpsCallable(
       "httpErrorTest",
@@ -661,7 +650,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testThrowErrorAsync() async {
     let byName = functions.httpsCallable(
       "throwTest",
@@ -716,7 +704,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testTimeoutAsync() async {
     var byName = functions.httpsCallable(
       "timeoutTest",
@@ -778,7 +765,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testCallAsFunctionAsync() async throws {
     let data = DataTestRequest(
       bool: true,
@@ -841,7 +827,6 @@ class IntegrationTests: XCTestCase {
     }
   }
 
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
   func testInferredTyesAsync() async throws {
     let data = DataTestRequest(
       bool: true,
@@ -910,7 +895,7 @@ class IntegrationTests: XCTestCase {
 /// indicate the callable function does not accept parameters.
 private struct EmptyRequest: Encodable, Sendable {}
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 12.0, watchOS 8.0, *)
 extension IntegrationTests {
   func testStream_NoArgs() async throws {
     // 1. Custom `EmptyRequest` struct is passed as a placeholder generic arg.

--- a/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsAPITests.swift
@@ -85,16 +85,13 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
-      Task {
-        do {
-          let data: Any? = nil
-          let result = try await callableRef.call(data)
-          _ = result.data
-        } catch {
-          // ...
-        }
+    Task {
+      do {
+        let data: Any? = nil
+        let result = try await callableRef.call(data)
+        _ = result.data
+      } catch {
+        // ...
       }
     }
 
@@ -106,15 +103,12 @@ final class FunctionsAPITests: XCTestCase {
       }
     }
 
-    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
-      Task {
-        do {
-          let result = try await callableRef.call()
-          _ = result.data
-        } catch {
-          // ...
-        }
+    Task {
+      do {
+        let result = try await callableRef.call()
+        _ = result.data
+      } catch {
+        // ...
       }
     }
 


### PR DESCRIPTION
* Removed redundant availability attributes
* Removed the unused `callFunction(url:withObject:options:timeout:context:completion:)` method