### PR TITLE
[NFC] Remove comment from RCNRemoteConfigTest.m

### DIFF
--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -311,7 +311,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   _userDefaultsMock = nil;
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
     [(id)_configInstances[i] stopMocking];
-    // [(id)_configFetch[i] stopMocking];
   }
   [_configInstances removeAllObjects];
   [_configFetch removeAllObjects];


### PR DESCRIPTION
Commented this line out but intended to delete from https://github.com/firebase/firebase-ios-sdk/pull/15064

It's recommended to not call `stopMocking`. That seemed to fix flaky test failures due to a `configFetch` instance being used after stopping mocking. These tests will be replaced eventually in Swift without OCMock so I didn't investigate too much.