### PR TITLE
Do not log using raw print in SettingsCacheClient

### DIFF
--- a/FirebaseSessions/Sources/Settings/SettingsCacheClient.swift
+++ b/FirebaseSessions/Sources/Settings/SettingsCacheClient.swift
@@ -129,7 +129,7 @@ final class SettingsCache: SettingsCacheClient {
     guard let duration = cacheContent[Self.flagCacheDuration] as? Double else {
       return Self.cacheDurationSecondsDefault
     }
-    print("Duration: \(duration)")
+    Logger.logDebug("[Settings] Cache duration: \(duration)")
     return duration
   }
 }


### PR DESCRIPTION
Hey there!

Found a raw print in my app, and turns out that this is located in Firebase code. I propose to use standard debug log here.