### PR TITLE
[Firebase AI] Conform `GroundingMetdata` to `Equatable`

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -310,7 +310,7 @@ public struct PromptFeedback: Sendable {
 /// or Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct GroundingMetadata: Sendable {
+public struct GroundingMetadata: Sendable, Equatable, Hashable {
   /// A list of web search queries that the model performed to gather the grounding information.
   /// These can be used to allow users to explore the search results themselves.
   public let webSearchQueries: [String]
@@ -327,7 +327,7 @@ public struct GroundingMetadata: Sendable {
 
   /// A struct representing the Google Search entry point.
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-  public struct SearchEntryPoint: Sendable {
+  public struct SearchEntryPoint: Sendable, Equatable, Hashable {
     /// An HTML/CSS snippet that can be embedded in your app.
     ///
     /// To ensure proper rendering, it's recommended to display this content within a `WKWebView`.
@@ -337,14 +337,14 @@ public struct GroundingMetadata: Sendable {
   /// Represents a chunk of retrieved data that supports a claim in the model's response. This is
   /// part of the grounding information provided when grounding is enabled.
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-  public struct GroundingChunk: Sendable {
+  public struct GroundingChunk: Sendable, Equatable, Hashable {
     /// Contains details if the grounding chunk is from a web source.
     public let web: WebGroundingChunk?
   }
 
   /// A grounding chunk sourced from the web.
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-  public struct WebGroundingChunk: Sendable {
+  public struct WebGroundingChunk: Sendable, Equatable, Hashable {
     /// The URI of the retrieved web page.
     public let uri: String?
     /// The title of the retrieved web page.
@@ -358,7 +358,7 @@ public struct GroundingMetadata: Sendable {
   /// Provides information about how a specific segment of the model's response is supported by the
   /// retrieved grounding chunks.
   @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-  public struct GroundingSupport: Sendable {
+  public struct GroundingSupport: Sendable, Equatable, Hashable {
     /// Specifies the segment of the model's response content that this grounding support pertains
     /// to.
     public let segment: Segment
@@ -391,7 +391,7 @@ public struct GroundingMetadata: Sendable {
 /// Represents a specific segment within a ``ModelContent`` struct, often used to pinpoint the
 /// exact location of text or data that grounding information refers to.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct Segment: Sendable {
+public struct Segment: Sendable, Equatable, Hashable {
   /// The zero-based index of the ``Part`` object within the `parts` array of its parent
   /// ``ModelContent`` object. This identifies which part of the content the segment belongs to.
   public let partIndex: Int


### PR DESCRIPTION
Added `Equatable` and `Hashable` conformance to `GroundingMetadata` and its transitively referenced types. See https://github.com/firebase/quickstart-ios/pull/1724#discussion_r2211021007 for context. This is also considered a general good practice from Apple:
> Conforming to the `Equatable` and `Hashable` protocols is straightforward and makes it easier to use your own types in Swift. It’s a good idea for all your custom model types to conform.
-- https://developer.apple.com/documentation/swift/adopting-common-protocols

<details>
<summary>Jules Prompt</summary>

Add `Equatable` and `Hashable` conformance to `GroundingMetadata`. You will need to add the conformances to all of the types that `GroundingMetadata` transitively references.

</details>

#no-changelog