### PR TITLE
Update changelogs for 12.1.0

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.1.0
 - [fixed] Do not log using raw print in an internal class. (#15138)
 
 # 12.0.0

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.1.0
 - [fixed] Fix a formatting issue with generated TOTP URLs that prevented them
   from working with the Google Authenticator app. (#15128)
 

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.1.0
 - [fixed] Fixed accidental removal of `pod "Firebase/Firestore"` for tvOS in 12.0.0.
 
 # 11.12.0


### PR DESCRIPTION
Per [b/434932656](https://b.corp.google.com/issues/434932656),

This updates the changelogs for the 12.1.0 release.

Will wait until tomorrow, just in case there's any last minute changes by EOD.