### PR TITLE
[FirebaseMessaging] Fix crash on Xcode 26 + iOS 18

### DIFF
--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -175,8 +175,10 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
                 @"App delegate responds to application:continueUserActivity:restorationHandler:."
                  "Simulating action url opening from a web browser.");
+    // Use string literal to ensure compatibility with Xcode 26 and iOS 18
+    NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
     NSUserActivity *userActivity =
-        [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+        [[NSUserActivity alloc] initWithActivityType:browsingWebType];
     userActivity.webpageURL = url;
     BOOL handled = [self.appDelegate application:self.mainApplication
                             continueUserActivity:userActivity

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
@@ -84,8 +84,10 @@
                          continueUserActivity:[OCMArg checkWithBlock:^BOOL(id userActivity) {
                            // verifying the type and url field for the userActivity object
                            NSUserActivity *activity = (NSUserActivity *)userActivity;
+                           // Use string literal to ensure compatibility with Xcode 26 and iOS 18
+                           NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
                            return [activity.activityType
-                                      isEqualToString:NSUserActivityTypeBrowsingWeb] &&
+                                      isEqualToString:browsingWebType] &&
                                   [activity.webpageURL isEqual:url];
                          }]
                            restorationHandler:[OCMArg any]])

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -400,8 +400,10 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   // if they haven't implemented it.
   if ([NSUserActivity class] != nil &&
       [appDelegate respondsToSelector:continueUserActivitySelector]) {
+    // Use string literal to ensure compatibility with Xcode 26 and iOS 18
+    NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
     NSUserActivity *userActivity =
-        [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+        [[NSUserActivity alloc] initWithActivityType:browsingWebType];
     userActivity.webpageURL = url;
     [appDelegate application:application
         continueUserActivity:userActivity


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when launching an app linked with `FirebaseMessaging` and `FirebaseInAppMessaging` on iOS 18 devices or simulators when built with Xcode 26 Beta 4.

## Root Cause

The crash was caused by referencing the symbol `NSUserActivityTypeBrowsingWeb`, which appears to be unavailable or unresolved at runtime when using the combination of Xcode 26 and iOS 18. Attempting to access this symbol directly results in a dyld crash:

```
dyld[27074]: Symbol not found: _NSUserActivityTypeBrowsingWeb
  Referenced from: <7CB71490-F307-3C6E-853C-925749317C78> /private/var/containers/Bundle/Application/C7665515-F4B5-4EAA-B560-774A439A4F1E/Rulebook-Dev.app/Rulebook-Dev.debug.dylib
  Expected in:     <050203DD-7488-307D-A999-E587314B041A> /System/Library/Frameworks/CoreServices.framework/CoreServices
Symbol not found: _NSUserActivityTypeBrowsingWeb
  Referenced from: <7CB71490-F307-3C6E-853C-925749317C78> /private/var/containers/Bundle/Application/C7665515-F4B5-4EAA-B560-774A439A4F1E/Rulebook-Dev.app/Rulebook-Dev.debug.dylib
  Expected in:     <050203DD-7488-307D-A999-E587314B041A> /System/Library/Frameworks/CoreServices.framework/CoreServices
dyld config: DYLD_LIBRARY_PATH=/usr/lib/system/introspection DYLD_INSERT_LIBRARIES=/usr/lib/libLogRedirect.dylib:/usr/lib/libBacktraceRecording.dylib:/usr/lib/libMainThreadChecker.dylib:/usr/lib/libRPAC.dylib:/usr/lib/libViewDebuggerSupport.dylib
Symbol not found: _NSUserActivityTypeBrowsingWeb
  Referenced from: <7CB71490-F307-3C6E-853C-925749317C78> /private/var/containers/Bundle/Application/C7665515-F4B5-4EAA-B560-774A439A4F1E/Rulebook-Dev.app/Rulebook-Dev.debug.dylib
  Expected in:     <050203DD-7488-307D-A999-E587314B041A> /System/Library/Frameworks/CoreServices.framework/CoreServices
dyld config: DYLD_LIBRARY_PATH=/usr/lib/system/introspection DYLD_INSERT_LIBRARIES=/usr/lib/libLogRedirect.dylib:/usr/lib/libBacktraceRecording.dylib:/usr/lib/libMainThreadChecker.dylib:/usr/lib/libRPAC.dylib:/usr/lib/libViewDebuggerSupport.dylib
```

## Fix

Replaced the symbol reference with a raw string literal `@"NSUserActivityTypeBrowsingWeb"`, which avoids the runtime lookup and resolves the crash.

## Related Issue

This issue is discussed in https://github.com/firebase/firebase-ios-sdk/issues/15159.