### PR TITLE
[Firebase AI] Add `id` property to `FunctionCallPart`

### DIFF
--- a/FirebaseAI/Sources/Types/Internal/InternalPart.swift
+++ b/FirebaseAI/Sources/Types/Internal/InternalPart.swift
@@ -44,10 +44,12 @@ struct FileData: Codable, Equatable, Sendable {
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct FunctionCall: Equatable, Sendable {
   let name: String
+  let id: String?
   let args: JSONObject
 
-  init(name: String, args: JSONObject) {
+  init(name: String, id: String?, args: JSONObject) {
     self.name = name
+    self.id = id
     self.args = args
   }
 }
@@ -55,10 +57,12 @@ struct FunctionCall: Equatable, Sendable {
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 struct FunctionResponse: Codable, Equatable, Sendable {
   let name: String
+  let id: String?
   let response: JSONObject
 
-  init(name: String, response: JSONObject) {
+  init(name: String, id: String?, response: JSONObject) {
     self.name = name
+    self.id = id
     self.response = response
   }
 }
@@ -79,6 +83,7 @@ extension FunctionCall: Codable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     name = try container.decode(String.self, forKey: .name)
+    id = try container.decodeIfPresent(String.self, forKey: .id)
     if let args = try container.decodeIfPresent(JSONObject.self, forKey: .args) {
       self.args = args
     } else {

--- a/FirebaseAI/Sources/Types/Public/Part.swift
+++ b/FirebaseAI/Sources/Types/Public/Part.swift
@@ -109,6 +109,10 @@ public struct FunctionCallPart: Part {
   /// The name of the function to call.
   public var name: String { functionCall.name }
 
+  /// The unique ID of the function call. If specified, this identifier should be included in the
+  /// ``FunctionResponsePart``.
+  public var id: String? { functionCall.id }
+
   /// The function parameters and values.
   public var args: JSONObject { functionCall.args }
 
@@ -121,7 +125,7 @@ public struct FunctionCallPart: Part {
   ///   - name: The name of the function to call.
   ///   - args: The function parameters and values.
   public init(name: String, args: JSONObject) {
-    self.init(FunctionCall(name: name, args: args))
+    self.init(FunctionCall(name: name, id: nil, args: args))
   }
 
   init(_ functionCall: FunctionCall) {
@@ -148,9 +152,11 @@ public struct FunctionResponsePart: Part {
   ///
   /// - Parameters:
   ///   - name: The name of the function that was called.
+  ///   - id: The unique ID of the function call, if specified, that this response corresponds with;
+  ///     see ``FunctionCallPart/id`` for more details.
   ///   - response: The function's response.
-  public init(name: String, response: JSONObject) {
-    self.init(FunctionResponse(name: name, response: response))
+  public init(name: String, id: String? = nil, response: JSONObject) {
+    self.init(FunctionResponse(name: name, id: id, response: response))
   }
 
   init(_ functionResponse: FunctionResponse) {

--- a/FirebaseAI/Tests/Unit/Snippets/FunctionCallingSnippets.swift
+++ b/FirebaseAI/Tests/Unit/Snippets/FunctionCallingSnippets.swift
@@ -92,6 +92,7 @@ final class FunctionCallingSnippets: XCTestCase {
 
         functionResponses.append(FunctionResponsePart(
           name: functionCall.name,
+          id: functionCall.id,
           response: fetchWeather(city: city, state: state, date: date)
         ))
       }


### PR DESCRIPTION
Added the `id` property to `FunctionCallPart`, which should be included with the `FunctionResponsePart` if provided.

TODO:
- Add tests
- Align on parameter ordering

#no-changelog