### PR TITLE
[Firebase AI] Remove `.civicIntegrity` from `generateImage` test

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -209,6 +209,11 @@ struct GenerateContentIntegrationTests {
       topK: 1,
       responseModalities: [.text, .image]
     )
+    let safetySettings = safetySettings.filter {
+      // HARM_CATEGORY_CIVIC_INTEGRITY is deprecated in Vertex AI but only rejected when using the
+      // 'gemini-2.0-flash-preview-image-generation' model.
+      $0.harmCategory != .civicIntegrity
+    }
     let model = FirebaseAI.componentInstance(config).generativeModel(
       modelName: ModelNames.gemini2FlashPreviewImageGeneration,
       generationConfig: generationConfig,


### PR DESCRIPTION
Removed the `.civicIntegrity` safety setting from the Gemini `generateImage` integration test. [`HARM_CATEGORY_CIVIC_INTEGRITY`](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/HarmCategory#:~:text=HARM_CATEGORY_CIVIC,This%20item%20is%20deprecated!) is now deprecated on Vertex AI but requests are only rejected when using the `gemini-2.0-flash-preview-image-generation` model.

Note: I kept the `.civicIntegrity` setting enabled for the rest of the tests so that we get notified when it's deprecated in the Gemini Developer API as well. At that time we should mark the symbol deprecated in the SDK.

#no-changelog