### PR TITLE
[Firebase AI] Add `retry-tests-on-failure` for integration tests

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -521,6 +521,8 @@ case "$product-$platform-$method" in
       -scheme "FirebaseAITestApp-SPM" \
       "${xcb_flags[@]}" \
       -parallel-testing-enabled NO \
+      -retry-tests-on-failure \
+      -test-iterations 3 \
       test
     ;;
 


### PR DESCRIPTION
Added `-retry-tests-on-failure` with `-test-iterations 3` to the `xcodebuild test` invocation for the Firebase AI integration tests. This may reduce flakes since it only retries the failed tests, instead of all of them, which may exacerbate the problem when we hit quota limits or the API is under heavy load.

#no-changelog