### PR TITLE
Add Mac Catalyst disable instructions for GoogleAdsOnDeviceConversion

### DIFF
--- a/ReleaseTooling/Template/README.md
+++ b/ReleaseTooling/Template/README.md
@@ -67,13 +67,26 @@ To integrate a Firebase SDK with your app:
 
    c. Double-click the setting, click the '+' button, and add `-lc++`
 
-10. Drag the `Firebase.h` header in this directory into your project. This will
+10. If you're using Firebase Analytics, disable
+    GoogleAdsOnDeviceConversion.xcframework for Mac Catalyst:
+
+   a. In your project settings, open the **Settings** panel for your target.
+
+   b. Go to the Build Phases tab and find the
+      **GoogleAdsOnDeviceConversion.xcframework** setting in the **Link Binary
+      With Libraries** section.
+
+   c. Click on the filter icon button in the
+      **GoogleAdsOnDeviceConversion.xcframework** row and deselect the Mac Catalyst
+      checkbox.
+
+11. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-11. Drag `module.modulemap` into your project and update the
+12. Drag `module.modulemap` into your project and update the
    "User Header Search Paths" in your project's Build Settings to include the
    directory that contains the added module map.
-12. If your app does not include any Swift implementation, you may need to add
+13. If your app does not include any Swift implementation, you may need to add
    a dummy Swift file to the app to prevent Swift system library missing
    symbol linker errors. See
    https://forums.swift.org/t/using-binary-swift-sdks-from-non-swift-apps/55989.
@@ -81,7 +94,7 @@ To integrate a Firebase SDK with your app:
    > ⚠ If prompted with the option to create a corresponding bridging header
    > for the new Swift file, select **Don't create**.
 
-13. You're done! Build your target and start using Firebase.
+14. You're done! Build your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the xcframeworks for
 the new SDK. You only need to add each framework once, so if you've already


### PR DESCRIPTION
Updated tooling readme to describe this:

<img width="1079" height="583" alt="Screenshot macCatalyst" src="https://github.com/user-attachments/assets/c58f980d-f698-438a-9147-bbdd09232cbd" />
