### PR TITLE
[Firebase AI] Add `Sendable` conformance to `PartsRepresentable`

### DIFF
--- a/FirebaseAI/Sources/PartsRepresentable.swift
+++ b/FirebaseAI/Sources/PartsRepresentable.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A protocol describing any data that could be serialized to model-interpretable input data,
 /// where the serialization process cannot fail with an error.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public protocol PartsRepresentable {
+public protocol PartsRepresentable: Sendable {
   var partsValue: [any Part] { get }
 }
 


### PR DESCRIPTION
Require `Sendable` conformance for `PartsRepresentable` types.

#no-changelog