### PR TITLE
[CI] Run `cocoapods-integration` job on Xcode 16.4

### DIFF
--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
       with:
         cache_key: ${{ matrix.os }}
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Get realpath
       run: brew install coreutils
     - name: Build and test


### PR DESCRIPTION
Updated the `tests` job in the `cocoapods-integration` workflow to run on Xcode 16.4.

#no-changelog