### PR TITLE
chore(ci): Correct cron schedule comments in GitHub workflows

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -15,7 +15,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 1am(PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron: '0 9 * * *'
 
 concurrency:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -9,7 +9,7 @@ on:
     - '.github/workflows/analytics.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron: '0 9 * * *'
 
 concurrency:

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron: '0 9 * * *'
 
 concurrency:

--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -6,7 +6,7 @@ on:
     paths:
     - '.github/workflows/archiving.yml'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     # This is set to 3 hours after zip workflow finishes so zip testing can run after.
     - cron:  '0 10 * * *'
 

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -16,7 +16,7 @@ on:
     - 'scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg'
     - 'Gemfile*'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron:  '0 9 * * *'
 
 env:

--- a/.github/workflows/client_app.yml
+++ b/.github/workflows/client_app.yml
@@ -13,7 +13,7 @@ on:
       - "IntegrationTesting/ClientApp/**"
       - "Gemfile*"
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron: "0 8 * * *"
 
 env:

--- a/.github/workflows/cocoapods-integration.yml
+++ b/.github/workflows/cocoapods-integration.yml
@@ -8,7 +8,7 @@ on:
     - '.github/workflows/cocoapods-integration.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 
 concurrency:

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -42,7 +42,7 @@ on:
     # - 'Firestore/**' # (Disabled to avoid building Firestore in presubmits)
 
   schedule:
-    # Run every day at 11pm (PST) - cron uses UTC times
+    # Run every day at 12am (PDT) / 3am (EDT) - cron uses UTC times
     - cron:  '0 7 * * *'
 
 concurrency:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 
 concurrency:

--- a/.github/workflows/core_extension.yml
+++ b/.github/workflows/core_extension.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_cocoapods.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 
 jobs:

--- a/.github/workflows/core_internal.yml
+++ b/.github/workflows/core_internal.yml
@@ -15,7 +15,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 
 jobs:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -16,7 +16,7 @@ on:
     - 'Interop/Analytics/Public/*.h'
     - 'Gemfile*'
   schedule:
-    # Run every day at 10am (PST) - cron uses UTC times
+    # Run every day at 7pm (PDT) / 10pm (EDT) - cron uses UTC times
     - cron:  '0 2 * * *'
 
 concurrency:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -19,7 +19,7 @@ on:
     - 'Gemfile*'
     - 'scripts/run_database_emulator.sh'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 
 concurrency:

--- a/.github/workflows/firebase_app_check.yml
+++ b/.github/workflows/firebase_app_check.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 11pm (PST) - cron uses UTC times
+    # Run every day at 12am (PDT) / 3am (EDT) - cron uses UTC times
     - cron:  '0 7 * * *'
 
 concurrency:

--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -13,7 +13,7 @@ on:
     # Do not run for documentation-only PRs.
     - '!**.md'
   schedule:
-    # Run every day at 11pm (PST) - cron uses UTC times
+    # Run every day at 12am (PDT) / 3am (EDT) - cron uses UTC times
     - cron:  '0 7 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -11,7 +11,7 @@ on:
     - '.github/workflows/firebasepod.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron:  '0 9 * * *'
 
 concurrency:

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
   pull_request:
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 concurrency:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -20,7 +20,7 @@ on:
     - 'Gemfile*'
 
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times
     - cron:  '0 9 * * *'
 
 concurrency:

--- a/.github/workflows/generate_issues.yml
+++ b/.github/workflows/generate_issues.yml
@@ -7,7 +7,7 @@ on:
     - '.github/workflows/generate_issues.yml'
     - '.github/actions/testing_report_generation**'
   schedule:
-    # Run every day at 4am (PST) - cron uses UTC times
+    # Run every day at 5am (PDT) / 8am (EDT) - cron uses UTC times
     - cron:  '0 12 * * *'
 
 permissions:

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_cocoapods.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 10pm (PST) - cron uses UTC times
+    # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times
     - cron:  '0 6 * * *'
 
 concurrency:

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 10pm (PST) - cron uses UTC times
+    # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times
     - cron:  '0 6 * * *'
 
 concurrency:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -22,7 +22,7 @@ on:
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'
   schedule:
-    # Run every day at 10pm (PST) - cron uses UTC times
+    # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times
     - cron:  '0 6 * * *'
 
 concurrency:

--- a/.github/workflows/mlmodeldownloader.yml
+++ b/.github/workflows/mlmodeldownloader.yml
@@ -14,7 +14,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 11pm (PST) - cron uses UTC times
+    # Run every day at 12am (PDT) / 3am (EDT) - cron uses UTC times
     - cron:  '0 7 * * *'
 
 concurrency:

--- a/.github/workflows/notice_generation.yml
+++ b/.github/workflows/notice_generation.yml
@@ -10,7 +10,7 @@ on:
     - '.github/workflows/notice_generation.yml'
     - '.github/actions/notices_generation**'
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at 3am (PDT) / 6am (EDT) - cron uses UTC times
     - cron:  '0 10 * * *'
 jobs:
   generate_a_notice:

--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -13,7 +13,6 @@ on:
   #   - https://crontab.guru/
   schedule:
     # Runs every 4 hours.
-    # TODO: Validate when the timer starts after job is triggered.
     - cron:  '0 */4 * * *'
 
 concurrency:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -22,7 +22,7 @@ on:
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'
   schedule:
-    # Run every day at 11pm (PST) - cron uses UTC times
+    # Run every day at 12am (PDT) / 3am (EDT) - cron uses UTC times
     # Specified in format 'minutes hours day month dayofweek'
     - cron:  '0 7 * * *'
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ on:
     types: [closed]
   workflow_dispatch:
   schedule:
-    # Run every day at 9pm (PST) - cron uses UTC times
+    # Run every day at 10pm (PDT) / 1am (EDT) - cron uses UTC times
     - cron:  '0 5 * * *'
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     - 'Gemfile*'
   workflow_dispatch:
   schedule:
-    # Run every day at 9pm (PST) - cron uses UTC times
+    # Run every day at 10pm (PDT) / 1am (EDT) - cron uses UTC times
     - cron:  '0 5 * * *'
 
 env:

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -17,7 +17,7 @@ on:
     - 'scripts/generate_access_token.sh'
     - 'scripts/gha-encrypted/RemoteConfigSwiftAPI/**'
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 concurrency:

--- a/.github/workflows/sessions.yml
+++ b/.github/workflows/sessions.yml
@@ -15,7 +15,7 @@ on:
     - '.github/workflows/common_catalyst.yml'
     - 'Gemfile*'
   schedule:
-    # Run every day at 9am (PST) - cron uses UTC times
+    # Run every day at 6pm (PDT) / 9pm (EDT) - cron uses UTC times
     - cron:  '0 1 * * *'
 
 concurrency:

--- a/.github/workflows/shared-swift.yml
+++ b/.github/workflows/shared-swift.yml
@@ -14,7 +14,7 @@ on:
     - 'Gemfile*'
 
   schedule:
-    # Run every day at 3am (PST) - cron uses UTC times
+    # Run every day at 4am (PDT) / 7am (EDT) - cron uses UTC times
     - cron:  '0 11 * * *'
 
 concurrency:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -12,7 +12,7 @@ on:
     - 'SwiftPM-PlatformExclude'
     - 'Gemfile*'
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 # This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -16,7 +16,7 @@ on:
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile*'
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 concurrency:

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -10,7 +10,7 @@ on:
     - 'SymbolCollisionTest/**'
     - 'Gemfile*'
   schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
+    # Run every day at 1am (PDT) / 4am (EDT) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 concurrency:

--- a/.github/workflows/watchos-sample.yml
+++ b/.github/workflows/watchos-sample.yml
@@ -18,7 +18,7 @@ on:
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'
   schedule:
-    # Run every day at 10pm (PST) - cron uses UTC times
+    # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times
     - cron:  '0 6 * * *'
 
 concurrency:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -12,7 +12,7 @@ on:
     # Don't run based on any markdown only changes.
     - '!ReleaseTooling/*.md'
   schedule:
-    # Run every day at 8pm(PST) - cron uses UTC times
+    # Run every day at 9pm (PDT) / 12am (EDT) - cron uses UTC times
     - cron:  '0 4 * * *'
 
   workflow_dispatch:


### PR DESCRIPTION
The comments for the scheduled cron jobs in the GitHub Actions workflows were inaccurate. Many referenced PST instead of the correct PDT during daylight saving time, and some of the hour conversions were incorrect.

This change updates all cron schedule comments to accurately reflect their run times in both PDT and EDT, ensuring developers have a clear understanding of when these automated jobs will execute.