### PR TITLE
fix(ci): Select Xcode 16.4 in combine workflow

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -67,6 +67,9 @@ jobs:
 
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
 
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
     - name: Install xcpretty
       run: gem install xcpretty
 
@@ -88,6 +91,8 @@ jobs:
       with:
         cache_key: ${{ matrix.os }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Install xcpretty


### PR DESCRIPTION
Explicitly select Xcode 16.4 in the combine workflow to ensure the correct version is used. This addresses an issue where the CI was failing due to an incorrect Xcode version.
