### PR TITLE
fix(tooling): Use module name over spec name in XCFramework module maps

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -272,7 +272,7 @@ struct FrameworkBuilder {
   ///
   /// - Parameter framework: The name of the pod to be built.
   /// - Returns: The corresponding framework/module name.
-  private static func frameworkBuildName(_ framework: String) -> String {
+  static func frameworkBuildName(_ framework: String) -> String {
     switch framework {
     case "abseil":
       return "absl"

--- a/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -248,6 +248,11 @@ struct ModuleMapBuilder {
     installedPods[name]?.transitiveFrameworks = transitiveFrameworkDeps
     installedPods[name]?.transitiveLibraries = transitiveLibraryDeps
 
-    return ModuleMapContents(module: name, frameworks: myFrameworkDeps, libraries: myLibraryDeps)
+    let moduleName = FrameworkBuilder.frameworkBuildName(name)
+    return ModuleMapContents(
+      module: moduleName,
+      frameworks: myFrameworkDeps,
+      libraries: myLibraryDeps
+    )
   }
 }


### PR DESCRIPTION
The module maps created by our XCFramework tooling use the spec name rather than the module name (some specs configure this via `s.module_name`). For example, `gRPC-C++.podspec` sets a module name of `grpcpp`. The problem with using `gRPC-C++` as a module name is that is contains invalid characters (`-`, `+`) in the module map language.

Plan: 
- [x] Wait for CI to pass (~3 hr from now)
- [x] Check zip to ensure only module map names changes. Paste diff to this PR
- [x] Merge for M169 
- [ ] Tomorrow, release patch versions of gRPC and BoringSSL (one package)

Fix https://github.com/google/grpc-binary/issues/22