### PR TITLE
chore(ci): Catch xcodebuild log on failure for watchOS sample build in messaging.yml

### DIFF
--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -240,4 +240,10 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Build
       run: ([ -z $plist_secret ] || scripts/build.sh MessagingSampleStandaloneWatchApp watchOS)
+    - name: Upload xcodebuild logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: xcodebuild-logs-${{ matrix.target }}
+        path: xcodebuild-*.log
 


### PR DESCRIPTION
Hypothesis is that we need to specify the OS version for the watchOS flags, but uploading the xcodebuild.log should confirm

edit: This surprisingly succeeded while it failed in the nightly: https://github.com/firebase/firebase-ios-sdk/actions/runs/17118538856

Maybe get this in to debug if it fails again?

#no-changelog