### PR TITLE
chore(ci): Retry workflows on error or timeout

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -86,7 +86,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
@@ -163,7 +163,7 @@ jobs:
       run: scripts/configure_test_keychain.sh
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -112,7 +112,7 @@ jobs:
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       if: contains(join(inputs.platforms), matrix.platform) || matrix.os == 'macos-14'
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: |

--- a/.github/workflows/common_catalyst.yml
+++ b/.github/workflows/common_catalyst.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: |

--- a/.github/workflows/common_cocoapods.yml
+++ b/.github/workflows/common_cocoapods.yml
@@ -139,7 +139,7 @@ jobs:
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       if: contains(join(inputs.platforms), matrix.platform) || matrix.os == 'macos-14'
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: |

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -133,7 +133,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -81,7 +81,7 @@ jobs:
       run: FirebaseFunctions/Backend/start.sh synchronous
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: scripts/build.sh Firebase-Package iOS ${{ matrix.test }}

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -71,7 +71,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 120
+        timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)


### PR DESCRIPTION
Lots of workflows are timing out. Our configuration of the `nick-fields/retry` action only retries on error. We should retry on error or timeout. After doing some experiments, this is the default behavior. I've removed all occurrences of `retry-on: error` which retries on error only.

#no-changelog