### PR TITLE
refactor(ci): Introduce common, re-usable quickstart workflow

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -23,101 +23,84 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: ABTestingUnit
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: ABTestingUnit
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseABTesting
-      target: FirebaseABTesting-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseABTesting
+  #     target: FirebaseABTesting-Unit-unit
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebaseABTesting
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseABTesting
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    uses: ./.github/workflows/common_quickstart.yml
+    with:
+      product: ABTesting
+      setup_command: scripts/setup_quickstart.sh abtesting
+      plist_src_path: scripts/gha-encrypted/qs-database.plist.gpg
+      plist_dst_path: quickstart-ios/database/GoogleService-Info.plist
 
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: scripts/setup_quickstart.sh abtesting
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-          quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Test swift quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh ABTesting true)
+  # quickstart-ftl-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-  quickstart-ftl-cron-only:
-    # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: scripts/setup_quickstart.sh abtesting
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+  #         quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Build swift quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh ABTesting)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
 
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: scripts/setup_quickstart.sh abtesting
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-          quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Build swift quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh ABTesting)
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
+  # abtesting-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-  abtesting-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-
-    runs-on: macos-15
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: PodLibLint ABTesting Cron
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
-          FirebaseABTesting.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos]
+  #       flags: [
+  #         '--use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: PodLibLint ABTesting Cron
+  #     run: |
+  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
+  #         FirebaseABTesting.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/common_quickstart.yml
     with:
       product: ABTesting
+      is_legacy: true
       setup_command: scripts/setup_quickstart.sh abtesting
       plist_src_path: scripts/gha-encrypted/qs-database.plist.gpg
       plist_dst_path: quickstart-ios/database/GoogleService-Info.plist

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -46,8 +46,8 @@ jobs:
       setup_command: scripts/setup_quickstart.sh abtesting
       plist_src_path: scripts/gha-encrypted/qs-database.plist.gpg
       plist_dst_path: quickstart-ios/database/GoogleService-Info.plist
-    # secrets:
-    #   plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   # quickstart-ftl-cron-only:
   #   # Don't run on private repo.

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -24,21 +24,21 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: ABTestingUnit
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: ABTestingUnit
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseABTesting
-  #     target: FirebaseABTesting-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseABTesting
+      target: FirebaseABTesting-Unit-unit
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseABTesting
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseABTesting
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -51,59 +51,59 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  quickstart-ftl-cron-only:
+    # Don't run on private repo.
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: scripts/setup_quickstart.sh abtesting
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-  #         quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Build swift quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh ABTesting)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: scripts/setup_quickstart.sh abtesting
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+          quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Build swift quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh ABTesting)
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # abtesting-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  abtesting-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos, macos]
-  #       flags: [
-  #         '--use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: PodLibLint ABTesting Cron
-  #     run: |
-  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
-  #         FirebaseABTesting.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+    runs-on: macos-15
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: PodLibLint ABTesting Cron
+      run: |
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb \
+          FirebaseABTesting.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -13,6 +13,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Gemfile*'
   schedule:
     # Run every day at 2am (PDT) / 5am (EDT) - cron uses UTC times

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -46,6 +46,8 @@ jobs:
       setup_command: scripts/setup_quickstart.sh abtesting
       plist_src_path: scripts/gha-encrypted/qs-database.plist.gpg
       plist_dst_path: quickstart-ios/database/GoogleService-Info.plist
+    # secrets:
+    #   plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   # quickstart-ftl-cron-only:
   #   # Don't run on private repo.

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -28,69 +28,69 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: AuthUnit
-  #     buildonly_platforms: macOS
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: AuthUnit
+      buildonly_platforms: macOS
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseAuth
-  #     target: FirebaseAuth-Unit-unit
-  #     buildonly: true
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseAuth
+      target: FirebaseAuth-Unit-unit
+      buildonly: true
 
-  # pod_lib_lint:
-  #   strategy:
-  #     matrix:
-  #       product: [FirebaseAuthInterop, FirebaseAuth]
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: ${{  matrix.product }}
-  #     buildonly_platforms: macOS
+  pod_lib_lint:
+    strategy:
+      matrix:
+        product: [FirebaseAuthInterop, FirebaseAuth]
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: ${{  matrix.product }}
+      buildonly_platforms: macOS
 
-  # integration-tests:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   needs: spm
-  #   strategy:
-  #     matrix:
-  #       scheme: [ObjCApiTests, SwiftApiTests, AuthenticationExampleUITests]
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: actions/cache/restore@v4
-  #     with:
-  #       path: .build
-  #       key: ${{ needs.spm.outputs.cache_key }}
-  #   - name: Install Secrets
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/ObjCApiTests/AuthCredentials.h "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SwiftApplication.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/AuthCredentials.h "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/GoogleService-Info.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/GoogleService-Info_multi.plist "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/Sample.entitlements "$plist_secret"
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
-  #         FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-  #     with:
-  #       timeout_minutes: 15
-  #       max_attempts: 3
-  #       retry_wait_seconds: 120
-  #       command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
+  integration-tests:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    needs: spm
+    strategy:
+      matrix:
+        scheme: [ObjCApiTests, SwiftApiTests, AuthenticationExampleUITests]
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/cache/restore@v4
+      with:
+        path: .build
+        key: ${{ needs.spm.outputs.cache_key }}
+    - name: Install Secrets
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
+          FirebaseAuth/Tests/SampleSwift/ObjCApiTests/AuthCredentials.h "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg \
+          FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SwiftApplication.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
+          FirebaseAuth/Tests/SampleSwift/AuthCredentials.h "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
+          FirebaseAuth/Tests/SampleSwift/GoogleService-Info.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
+          FirebaseAuth/Tests/SampleSwift/GoogleService-Info_multi.plist "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
+          FirebaseAuth/Tests/SampleSwift/Sample.entitlements "$plist_secret"
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
+          FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        retry_wait_seconds: 120
+        command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -104,63 +104,63 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
-  # # quickstart-ftl-cron-only:
-  # #   # Don't run on private repo.
-  # #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-  # #   env:
-  # #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  # #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  # #   runs-on: macos-14
-  # #   steps:
-  # #   - uses: actions/checkout@v4
-  # #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  # #   - uses: actions/setup-python@v5
-  # #     with:
-  # #      python-version: '3.11'
-  # #   - name: Setup quickstart
-  # #     run: scripts/setup_quickstart.sh authentication
-  # #   - name: Install Secret GoogleService-Info.plist
-  # #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-  # #         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-  # #   - name: Build swift quickstart
-  # #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Authentication)
-  # #   - id: ftl_test
-  # #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  # #     with:
-  # #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  # #       testapp_dir: quickstart-ios/build-for-testing
-  # #       test_type: "xctest"
-
-  # auth-cron-only:
+  # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
+  # quickstart-ftl-cron-only:
   #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       # The macos and tvos tests can hang, and watchOS doesn't have tests.
-  #       target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
-  #       flags: [
-  #         '--use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #   runs-on: macos-14
   #   steps:
   #   - uses: actions/checkout@v4
   #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Configure test keychain
-  #     run: scripts/configure_test_keychain.sh
-  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+  #   - uses: actions/setup-python@v5
   #     with:
-  #       timeout_minutes: 15
-  #       max_attempts: 3
-  #       retry_wait_seconds: 120
-  #       command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #      python-version: '3.11'
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh authentication
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+  #         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+  #   - name: Build swift quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Authentication)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
+
+  auth-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+
+    runs-on: macos-15
+    strategy:
+      matrix:
+        # The macos and tvos tests can hang, and watchOS doesn't have tests.
+        target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
+        flags: [
+          '--use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        retry_wait_seconds: 120
+        command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -27,143 +27,136 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: AuthUnit
-      buildonly_platforms: macOS
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: AuthUnit
+  #     buildonly_platforms: macOS
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseAuth
-      target: FirebaseAuth-Unit-unit
-      buildonly: true
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseAuth
+  #     target: FirebaseAuth-Unit-unit
+  #     buildonly: true
 
-  pod_lib_lint:
-    strategy:
-      matrix:
-        product: [FirebaseAuthInterop, FirebaseAuth]
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: ${{  matrix.product }}
-      buildonly_platforms: macOS
+  # pod_lib_lint:
+  #   strategy:
+  #     matrix:
+  #       product: [FirebaseAuthInterop, FirebaseAuth]
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: ${{  matrix.product }}
+  #     buildonly_platforms: macOS
 
-  integration-tests:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    needs: spm
-    strategy:
-      matrix:
-        scheme: [ObjCApiTests, SwiftApiTests, AuthenticationExampleUITests]
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache/restore@v4
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
-    - name: Install Secrets
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
-          FirebaseAuth/Tests/SampleSwift/ObjCApiTests/AuthCredentials.h "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg \
-          FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SwiftApplication.plist "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
-          FirebaseAuth/Tests/SampleSwift/AuthCredentials.h "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
-          FirebaseAuth/Tests/SampleSwift/GoogleService-Info.plist "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
-          FirebaseAuth/Tests/SampleSwift/GoogleService-Info_multi.plist "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
-          FirebaseAuth/Tests/SampleSwift/Sample.entitlements "$plist_secret"
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
-          FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-      with:
-        timeout_minutes: 15
-        max_attempts: 3
-        retry_wait_seconds: 120
-        command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
-
-  quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh authentication
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-          quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Authentication false)
-
-  # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
+  # integration-tests:
+  #   # Don't run on private repo unless it is a PR.
   #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
+  #   needs: spm
+  #   strategy:
+  #     matrix:
+  #       scheme: [ObjCApiTests, SwiftApiTests, AuthenticationExampleUITests]
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-14
+  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: actions/cache/restore@v4
+  #     with:
+  #       path: .build
+  #       key: ${{ needs.spm.outputs.cache_key }}
+  #   - name: Install Secrets
+  #     run: |
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthCredentials.h.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/ObjCApiTests/AuthCredentials.h "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SwiftApplication.plist "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/AuthCredentials.h.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/AuthCredentials.h "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info.plist.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/GoogleService-Info.plist "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/GoogleService-Info_multi.plist.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/GoogleService-Info_multi.plist "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Sample.entitlements.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/Sample.entitlements "$plist_secret"
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/AuthSample/Credentials.swift.gpg \
+  #         FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+  #     with:
+  #       timeout_minutes: 15
+  #       max_attempts: 3
+  #       retry_wait_seconds: 120
+  #       command: ([ -z $plist_secret ] || scripts/build.sh Auth iOS ${{ matrix.scheme }})
+
+  quickstart:
+    uses: ./.github/workflows/common_quickstart.yml
+    with:
+      product: Authentication
+      is_legacy: false
+      setup_command: scripts/setup_quickstart.sh authentication
+      plist_src_path: scripts/gha-encrypted/qs-auth.plist.gpg
+      plist_dst_path: quickstart-ios/authentication/GoogleService-Info.plist
+      run_tests: false
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+
+  # # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
+  # # quickstart-ftl-cron-only:
+  # #   # Don't run on private repo.
+  # #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+
+  # #   env:
+  # #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  # #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  # #   runs-on: macos-14
+  # #   steps:
+  # #   - uses: actions/checkout@v4
+  # #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  # #   - uses: actions/setup-python@v5
+  # #     with:
+  # #      python-version: '3.11'
+  # #   - name: Setup quickstart
+  # #     run: scripts/setup_quickstart.sh authentication
+  # #   - name: Install Secret GoogleService-Info.plist
+  # #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+  # #         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+  # #   - name: Build swift quickstart
+  # #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Authentication)
+  # #   - id: ftl_test
+  # #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  # #     with:
+  # #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  # #       testapp_dir: quickstart-ios/build-for-testing
+  # #       test_type: "xctest"
+
+  # auth-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       # The macos and tvos tests can hang, and watchOS doesn't have tests.
+  #       target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
+  #       flags: [
+  #         '--use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
   #   steps:
   #   - uses: actions/checkout@v4
   #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
+  #   - name: Setup Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Configure test keychain
+  #     run: scripts/configure_test_keychain.sh
+  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
   #     with:
-  #      python-version: '3.11'
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh authentication
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-  #         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-  #   - name: Build swift quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Authentication)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
-
-  auth-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-
-    runs-on: macos-15
-    strategy:
-      matrix:
-        # The macos and tvos tests can hang, and watchOS doesn't have tests.
-        target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Configure test keychain
-      run: scripts/configure_test_keychain.sh
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-      with:
-        timeout_minutes: 15
-        max_attempts: 3
-        retry_wait_seconds: 120
-        command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #       timeout_minutes: 15
+  #       max_attempts: 3
+  #       retry_wait_seconds: 120
+  #       command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -13,6 +13,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'scripts/gha-encrypted/AuthSample/SwiftApplication.plist.gpg'
     - 'Gemfile*'
   schedule:

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -86,7 +86,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Run setup command.
       env:
-        LEGACY: ${{ inputs.is_legacy }}
+        LEGACY: ${{ inputs.is_legacy && true || '' }}
       run: ${{ inputs.setup_command }}
     - name: Install Secret GoogleService-Info.plist
       run: |
@@ -97,7 +97,7 @@ jobs:
     - name: Build ${{ inputs.product }} Quickstart (${{ inputs.quickstart_type }} / ${{ inputs.is_legacy && 'Legacy' || 'Non-Legacy' }})
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
-        LEGACY: ${{ inputs.is_legacy }}
+        LEGACY: ${{ inputs.is_legacy && true || '' }}
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -75,7 +75,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Run setup command.
       env:
-        LEGACY: inputs.is_legacy == true
+        LEGACY: inputs.is_legacy
       run: ${{ inputs.setup_command }}
     - name: Install Secret GoogleService-Info.plist
       run: |
@@ -83,13 +83,14 @@ jobs:
             ${{ inputs.plist_src_path }} \
             ${{ inputs.plist_dst_path }} \
             "$plist_secret"
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - name: Build ${{ inputs.product }} Quickstart
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
-        LEGACY: ${{ inputs.is_legacy == true }}
+        LEGACY: inputs.is_legacy
       with:
         timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: |
-          ([ -z $plist_secret ] ||  == true && 'LEGACY=true' || '' }} scripts/test_quickstart.sh ${{ inputs.product }} true)
+          ([ -z $plist_secret ] || scripts/test_quickstart.sh ${{ inputs.product }} true)
 

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -1,0 +1,124 @@
+name: common_cocoapods
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    # Re-usable workflows do not automatically inherit the caller's secrets.
+    #
+    # If the calling workflow uses a secret in the `setup_command` input, then
+    # it also must pass the secret to the re-usable workflow.
+    #
+    # Example:
+    #
+    #   pod_lib_lint:
+    #     uses: ./.github/workflows/common_cocoapods.yml
+    #     with:
+    #       product: FirebaseFoo
+    #       setup_command: |
+    #         scripts/decrypt_gha_secret.sh \
+    #           /path/to/GoogleService-Info.plist.gpg \
+    #           /path/to/dest/GoogleService-Info.plist "$plist_secret"
+    #     secrets:
+    #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    #
+    secrets:
+      plist_secret:
+        required: true
+
+name: common_cocoapods
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    # Re-usable workflows do not automatically inherit the caller's secrets.
+    #
+    # If the calling workflow uses a secret in the `setup_command` input, then
+    # it also must pass the secret to the re-usable workflow.
+    #
+    # Example:
+    #
+    #   pod_lib_lint:
+    #     uses: ./.github/workflows/common_cocoapods.yml
+    #     with:
+    #       product: FirebaseFoo
+    #       setup_command: |
+    #         scripts/decrypt_gha_secret.sh \
+    #           /path/to/GoogleService-Info.plist.gpg \
+    #           /path/to/dest/GoogleService-Info.plist "$plist_secret"
+    #     secrets:
+    #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    #
+    secrets:
+      plist_secret:
+        required: false
+
+    inputs:
+      # The product to test be tested (e.g. `FirebaseABTesting`).
+      product:
+        type: string
+        required: true
+
+      is_legacy:
+        type: boolean
+        required: false
+        default: false
+
+      plist_src_path:
+        type: string
+        required: true
+
+      plist_dst_path:
+        type: string
+        required: true
+
+      # A command to execute before testing.
+      #
+      # This is useful for additional set up, like starting an emulator or
+      # downloading test data.
+      #
+      # Note, this step has an env var set to decrypt plists. Use
+      # "$plist_secret" in the given command. See `secrets` documentation
+      # at top of this file.
+      #
+      # Example: `FirebaseFunctions/Backend/start.sh synchronous`
+      setup_command:
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  quickstart:
+    # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
+    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Run setup command.
+      env:
+        LEGACY: inputs.is_legacy == true
+      run: ${{ inputs.setup_command }}
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+          scripts/decrypt_gha_secret.sh \
+            ${{ inputs.plist_src_path }} \
+            ${{ inputs.plist_dst_path }} \
+            "$plist_secret"
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      env:
+        LEGACY: ${{ inputs.is_legacy == true }}
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        retry_wait_seconds: 120
+        command: |
+          ([ -z $plist_secret ] ||  == true && 'LEGACY=true' || '' }} scripts/test_quickstart.sh ${{ inputs.product }} true)
+

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -75,8 +75,9 @@ jobs:
     runs-on: macos-15
     steps:
     - id: lowercase_product
-      shell: bash
-      run: echo "lowercase_product=${{ inputs.product,, }}" >> $GITHUB_OUTPUT
+      run: |
+        lowercase_product=$(echo "${{ inputs.product }}" | tr '[:upper:]' '[:lower:]')
+        echo "lowercase_product=$lowercase_product" >> $GITHUB_OUTPUT
     - name: Remove data before upload.
       run: echo hello_${{ steps.lowercase_product.outputs.lowercase_product }}
     - uses: actions/checkout@v4

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -33,10 +33,10 @@ on:
         type: string
         required: true
 
+      # TODO: What does this mean?
       is_legacy:
         type: boolean
-        required: false
-        default: false
+        required: true
 
       plist_src_path:
         type: string
@@ -45,6 +45,9 @@ on:
       plist_dst_path:
         type: string
         required: true
+
+      # quickstart_type:
+      #   type: string
 
       # A command to execute before testing.
       #

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -46,8 +46,16 @@ on:
         type: string
         required: true
 
-      # quickstart_type:
-      #   type: string
+      # swift or objc
+      quickstart_type:
+        type: string
+        required: false
+        default: objc
+
+      run_tests:
+        type: boolean
+        required: false
+        default: true
 
       # A command to execute before testing.
       #
@@ -86,7 +94,7 @@ jobs:
             ${{ inputs.plist_src_path }} \
             ${{ inputs.plist_dst_path }} \
             "$plist_secret"
-    - name: Build ${{ inputs.product }} Quickstart
+    - name: Build ${{ inputs.product }} Quickstart (${{ inputs.quickstart_type }} / ${{ inputs.is_legacy && "Legacy" || "Non-Legacy" }})
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
         LEGACY: ${{ inputs.is_legacy }}
@@ -94,7 +102,11 @@ jobs:
         timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
-        command: scripts/test_quickstart.sh ${{ inputs.product }} true
+        command: |
+          scripts/test_quickstart.sh \
+            ${{ inputs.product }} \
+            ${{ inputs.run_tests }} \
+            ${{ inputs.quickstart_type }}
     # TODO: Add upload on fialure.
     # - name: Upload raw logs if failed.
     #   if: ${{ failure() }}

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -74,6 +74,10 @@ jobs:
       plist_secret: ${{ secrets.plist_secret }}
     runs-on: macos-15
     steps:
+    - id: lowercase_product
+      run: echo "lowercase_product=${${{ inputs.product }},,}" >> $GITHUB_OUTPUT
+    - name: Remove data before upload.
+      run: echo hello_${{ steps.lowercase_product.outputs.lowercase_product }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
@@ -101,11 +105,11 @@ jobs:
             ${{ inputs.product }} \
             ${{ inputs.run_tests }} \
             ${{ inputs.quickstart_type }}
-    # TODO: Add upload on fialure.
-    # TODO: Remove the decrypted repo secret.
-    # - name: Upload raw logs if failed.
-    #   if: ${{ failure() }}
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name:
-    #     path:
+    - name: Remove data before upload.
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh ${{ steps.lowercase_product.outputs.lowercase_product }}
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_${{ steps.lowercase_product.outputs.lowercase_product }}
+        path: quickstart-ios/

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -75,7 +75,8 @@ jobs:
     runs-on: macos-15
     steps:
     - id: lowercase_product
-      run: echo "lowercase_product=${"${{ inputs.product }}",,}" >> $GITHUB_OUTPUT
+      shell: bash
+      run: echo "lowercase_product=${{ inputs.product,, }}" >> $GITHUB_OUTPUT
     - name: Remove data before upload.
       run: echo hello_${{ steps.lowercase_product.outputs.lowercase_product }}
     - uses: actions/checkout@v4

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -94,7 +94,7 @@ jobs:
             ${{ inputs.plist_src_path }} \
             ${{ inputs.plist_dst_path }} \
             "$plist_secret"
-    - name: Build ${{ inputs.product }} Quickstart (${{ inputs.quickstart_type }} / ${{ inputs.is_legacy && "Legacy" || "Non-Legacy" }})
+    - name: Build ${{ inputs.product }} Quickstart (${{ inputs.quickstart_type }} / ${{ inputs.is_legacy && 'Legacy' || 'Non-Legacy' }})
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
         LEGACY: ${{ inputs.is_legacy }}

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -23,9 +23,9 @@ on:
     #     secrets:
     #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     #
-    # secrets:
-    #   plist_secret:
-    #     required: false
+    secrets:
+      plist_secret:
+        required: true
 
     inputs:
       # The product to test be tested (e.g. `FirebaseABTesting`).
@@ -66,7 +66,7 @@ jobs:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
     if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      plist_secret: ${{ secrets.plist_secret }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -91,8 +91,7 @@ jobs:
         timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
-        command: |
-          ([ -z $plist_secret ] || scripts/test_quickstart.sh ${{ inputs.product }} true)
+        command: scripts/test_quickstart.sh ${{ inputs.product }} true
     # TODO: Add upload on fialure.
     # - name: Upload raw logs if failed.
     #   if: ${{ failure() }}
@@ -100,6 +99,3 @@ jobs:
     #   with:
     #     name:
     #     path:
-
-
-

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -1,33 +1,4 @@
-name: common_cocoapods
-
-permissions:
-  contents: read
-
-on:
-  workflow_call:
-    # Re-usable workflows do not automatically inherit the caller's secrets.
-    #
-    # If the calling workflow uses a secret in the `setup_command` input, then
-    # it also must pass the secret to the re-usable workflow.
-    #
-    # Example:
-    #
-    #   pod_lib_lint:
-    #     uses: ./.github/workflows/common_cocoapods.yml
-    #     with:
-    #       product: FirebaseFoo
-    #       setup_command: |
-    #         scripts/decrypt_gha_secret.sh \
-    #           /path/to/GoogleService-Info.plist.gpg \
-    #           /path/to/dest/GoogleService-Info.plist "$plist_secret"
-    #     secrets:
-    #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    #
-    secrets:
-      plist_secret:
-        required: true
-
-name: common_cocoapods
+name: common_quickstart
 
 permissions:
   contents: read

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -7,19 +7,15 @@ on:
   workflow_call:
     # Re-usable workflows do not automatically inherit the caller's secrets.
     #
-    # If the calling workflow uses a secret in the `setup_command` input, then
-    # it also must pass the secret to the re-usable workflow.
+    # This workflow decrypts encrypted files, so the calling workflow needs to
+    # pass the secret to the re-usable workflow.
     #
     # Example:
     #
-    #   pod_lib_lint:
-    #     uses: ./.github/workflows/common_cocoapods.yml
+    #   quickstart:
+    #     uses: ./.github/workflows/common_quickstart.yml
     #     with:
-    #       product: FirebaseFoo
-    #       setup_command: |
-    #         scripts/decrypt_gha_secret.sh \
-    #           /path/to/GoogleService-Info.plist.gpg \
-    #           /path/to/dest/GoogleService-Info.plist "$plist_secret"
+    #       # ...
     #     secrets:
     #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     #
@@ -28,30 +24,34 @@ on:
         required: true
 
     inputs:
-      # The product to test be tested (e.g. `FirebaseABTesting`).
+      # The product to test be tested (e.g. `ABTesting`).
       product:
         type: string
         required: true
 
-      # TODO: What does this mean?
+      # TODO(docs): What does this mean?
       is_legacy:
         type: boolean
         required: true
 
+      # TODO(docs): 
       plist_src_path:
         type: string
         required: true
 
+      # TODO(docs): 
       plist_dst_path:
         type: string
         required: true
 
+      # TODO(docs):       
       # swift or objc
       quickstart_type:
         type: string
         required: false
         default: objc
 
+      # TODO(docs): 
       run_tests:
         type: boolean
         required: false
@@ -59,14 +59,7 @@ on:
 
       # A command to execute before testing.
       #
-      # This is useful for additional set up, like starting an emulator or
-      # downloading test data.
-      #
-      # Note, this step has an env var set to decrypt plists. Use
-      # "$plist_secret" in the given command. See `secrets` documentation
-      # at top of this file.
-      #
-      # Example: `FirebaseFunctions/Backend/start.sh synchronous`
+      # Example: `scripts/setup_quickstart.sh functions`
       setup_command:
         type: string
         required: false
@@ -108,6 +101,7 @@ jobs:
             ${{ inputs.run_tests }} \
             ${{ inputs.quickstart_type }}
     # TODO: Add upload on fialure.
+    # TODO: Remove the decrypted repo secret.
     # - name: Upload raw logs if failed.
     #   if: ${{ failure() }}
     #   uses: actions/upload-artifact@v4

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -29,29 +29,30 @@ on:
         type: string
         required: true
 
-      # TODO(docs): What does this mean?
+      # Whether to test the legacy version of the quickstart.
       is_legacy:
         type: boolean
         required: true
 
-      # TODO(docs): 
+      # The path to the encrypted `GoogleService-Info.plist` file.
       plist_src_path:
         type: string
         required: true
 
-      # TODO(docs): 
+      # The destination path for the decrypted `GoogleService-Info.plist` file.
       plist_dst_path:
         type: string
         required: true
 
-      # TODO(docs):       
-      # swift or objc
+      # The type of quickstart to test.
+      #
+      # Options: [swift, objc]
       quickstart_type:
         type: string
         required: false
         default: objc
 
-      # TODO(docs): 
+      # Whether to run tests or just build. Defaults to true.
       run_tests:
         type: boolean
         required: false

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: macos-15
     steps:
     - id: lowercase_product
-      run: echo "lowercase_product=${${{ inputs.product }},,}" >> $GITHUB_OUTPUT
+      run: echo "lowercase_product=${"${{ inputs.product }}",,}" >> $GITHUB_OUTPUT
     - name: Remove data before upload.
       run: echo hello_${{ steps.lowercase_product.outputs.lowercase_product }}
     - uses: actions/checkout@v4

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -72,21 +72,14 @@ jobs:
     if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     env:
       plist_secret: ${{ secrets.plist_secret }}
+      LEGACY: ${{ inputs.is_legacy && true || '' }}
     runs-on: macos-15
     steps:
-    - id: lowercase_product
-      run: |
-        lowercase_product=$(echo "${{ inputs.product }}" | tr '[:upper:]' '[:lower:]')
-        echo "lowercase_product=$lowercase_product" >> $GITHUB_OUTPUT
-    - name: Remove data before upload.
-      run: echo hello_${{ steps.lowercase_product.outputs.lowercase_product }}
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Run setup command.
-      env:
-        LEGACY: ${{ inputs.is_legacy && true || '' }}
       run: ${{ inputs.setup_command }}
     - name: Install Secret GoogleService-Info.plist
       run: |
@@ -96,8 +89,6 @@ jobs:
             "$plist_secret"
     - name: Build ${{ inputs.product }} Quickstart (${{ inputs.quickstart_type }} / ${{ inputs.is_legacy && 'Legacy' || 'Non-Legacy' }})
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-      env:
-        LEGACY: ${{ inputs.is_legacy && true || '' }}
       with:
         timeout_minutes: 15
         max_attempts: 3
@@ -107,6 +98,12 @@ jobs:
             ${{ inputs.product }} \
             ${{ inputs.run_tests }} \
             ${{ inputs.quickstart_type }}
+    # Failure sequence to upload artifact.
+    - id: lowercase_product
+      if: ${{ failure() }}
+      run: |
+        lowercase_product=$(echo "${{ inputs.product }}" | tr '[:upper:]' '[:lower:]')
+        echo "lowercase_product=$lowercase_product" >> $GITHUB_OUTPUT
     - name: Remove data before upload.
       if: ${{ failure() }}
       run: scripts/remove_data.sh ${{ steps.lowercase_product.outputs.lowercase_product }}

--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -23,9 +23,9 @@ on:
     #     secrets:
     #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     #
-    secrets:
-      plist_secret:
-        required: false
+    # secrets:
+    #   plist_secret:
+    #     required: false
 
     inputs:
       # The product to test be tested (e.g. `FirebaseABTesting`).
@@ -75,7 +75,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Run setup command.
       env:
-        LEGACY: inputs.is_legacy
+        LEGACY: ${{ inputs.is_legacy }}
       run: ${{ inputs.setup_command }}
     - name: Install Secret GoogleService-Info.plist
       run: |
@@ -86,11 +86,20 @@ jobs:
     - name: Build ${{ inputs.product }} Quickstart
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
-        LEGACY: inputs.is_legacy
+        LEGACY: ${{ inputs.is_legacy }}
       with:
         timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 120
         command: |
           ([ -z $plist_secret ] || scripts/test_quickstart.sh ${{ inputs.product }} true)
+    # TODO: Add upload on fialure.
+    # - name: Upload raw logs if failed.
+    #   if: ${{ failure() }}
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name:
+    #     path:
+
+
 

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -13,6 +13,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Interop/Analytics/Public/*.h'
     - 'Gemfile*'
   schedule:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -24,26 +24,24 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: FirebaseCrashlyticsUnit
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: FirebaseCrashlyticsUnit
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseCrashlytics
-      target: FirebaseCrashlytics-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseCrashlytics
+  #     target: FirebaseCrashlytics-Unit-unit
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebaseCrashlytics
-      buildonly_platforms: tvOS, macOS, watchOS
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseCrashlytics
+  #     buildonly_platforms: tvOS, macOS, watchOS
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     uses: ./.github/workflows/common_quickstart.yml
     with:
       product: Crashlytics
@@ -60,68 +58,68 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  quickstart-ftl-cron-only:
-    # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  # quickstart-ftl-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh crashlytics
-      env:
-        LEGACY: true
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-          quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Build swift quickstart
-      run: |
-        mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
-        # Set the deployed pod location of run and upload-symbols with the development pod version.
-        cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-        ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Crashlytics swift)
-      env:
-        LEGACY: true
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh crashlytics
+  #     env:
+  #       LEGACY: true
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+  #         quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+  #   - name: Build swift quickstart
+  #     run: |
+  #       mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
+  #       # Set the deployed pod location of run and upload-symbols with the development pod version.
+  #       cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+  #       cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+  #       ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Crashlytics swift)
+  #     env:
+  #       LEGACY: true
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
 
-  crashlytics-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  # crashlytics-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-    runs-on: macos-15
-    strategy:
-      matrix:
-        # Disable watchos because it does not support XCTest.
-        target: [ios, tvos, macos, watchos --skip-tests]
-        flags: [
-          '--use-static-frameworks',
-          '--use-modular-headers --skip-tests'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-      with:
-        timeout_minutes: 15
-        max_attempts: 3
-        retry_wait_seconds: 120
-        command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       # Disable watchos because it does not support XCTest.
+  #       target: [ios, tvos, macos, watchos --skip-tests]
+  #       flags: [
+  #         '--use-static-frameworks',
+  #         '--use-modular-headers --skip-tests'
+  #       ]
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+  #     with:
+  #       timeout_minutes: 15
+  #       max_attempts: 3
+  #       retry_wait_seconds: 120
+  #       command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -25,22 +25,22 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: FirebaseCrashlyticsUnit
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: FirebaseCrashlyticsUnit
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseCrashlytics
-  #     target: FirebaseCrashlytics-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseCrashlytics
+      target: FirebaseCrashlytics-Unit-unit
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseCrashlytics
-  #     buildonly_platforms: tvOS, macOS, watchOS
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseCrashlytics
+      buildonly_platforms: tvOS, macOS, watchOS
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -59,68 +59,68 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  quickstart-ftl-cron-only:
+    # Don't run on private repo.
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh crashlytics
-  #     env:
-  #       LEGACY: true
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-  #         quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-  #   - name: Build swift quickstart
-  #     run: |
-  #       mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
-  #       # Set the deployed pod location of run and upload-symbols with the development pod version.
-  #       cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-  #       cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-  #       ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Crashlytics swift)
-  #     env:
-  #       LEGACY: true
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup quickstart
+      run: scripts/setup_quickstart.sh crashlytics
+      env:
+        LEGACY: true
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+          quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+    - name: Build swift quickstart
+      run: |
+        mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
+        # Set the deployed pod location of run and upload-symbols with the development pod version.
+        cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+        cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
+        ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Crashlytics swift)
+      env:
+        LEGACY: true
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # crashlytics-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  crashlytics-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       # Disable watchos because it does not support XCTest.
-  #       target: [ios, tvos, macos, watchos --skip-tests]
-  #       flags: [
-  #         '--use-static-frameworks',
-  #         '--use-modular-headers --skip-tests'
-  #       ]
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-  #     with:
-  #       timeout_minutes: 15
-  #       max_attempts: 3
-  #       retry_wait_seconds: 120
-  #       command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+    runs-on: macos-15
+    strategy:
+      matrix:
+        # Disable watchos because it does not support XCTest.
+        target: [ios, tvos, macos, watchos --skip-tests]
+        flags: [
+          '--use-static-frameworks',
+          '--use-modular-headers --skip-tests'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        retry_wait_seconds: 120
+        command: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -44,31 +44,21 @@ jobs:
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh crashlytics
-      env:
-        LEGACY: true
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-          quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Test swift quickstart
-      run: |
+    uses: ./.github/workflows/common_quickstart.yml
+    with:
+      product: Crashlytics
+      is_legacy: true
+      quickstart_type: swift
+      setup_command: |
+        scripts/setup_quickstart.sh crashlytics
         mkdir quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics
         # Set the deployed pod location of run and upload-symbols with the development pod version.
         cp Crashlytics/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
         cp Crashlytics/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Pods/FirebaseCrashlytics/
-        ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Crashlytics true swift)
-      env:
-        LEGACY: true
+      plist_src_path: scripts/gha-encrypted/qs-crashlytics.plist.gpg
+      plist_dst_path: quickstart-ios/crashlytics/GoogleService-Info.plist
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   quickstart-ftl-cron-only:
     # Don't run on private repo.

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -28,46 +28,46 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   strategy:
-  #     matrix:
-  #       target: [DatabaseUnit, DatabaseUnitSwift]
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: ${{  matrix.target }}
+  spm:
+    strategy:
+      matrix:
+        target: [DatabaseUnit, DatabaseUnitSwift]
+    uses: ./.github/workflows/common.yml
+    with:
+      target: ${{  matrix.target }}
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseDatabase
-  #     target: FirebaseDatabase-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseDatabase
+      target: FirebaseDatabase-Unit-unit
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseDatabase
-  #     test_specs: unit
-  #     buildonly_platforms: macOS
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseDatabase
+      test_specs: unit
+      buildonly_platforms: macOS
 
-  # integration:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: integration${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install xcpretty
-  #     run: gem install xcpretty
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: IntegrationTest
-  #     # Only iOS to mitigate flakes.
-  #     run: scripts/third_party/travis/retry.sh scripts/build.sh Database iOS integration
+  integration:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: integration${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: IntegrationTest
+      # Only iOS to mitigate flakes.
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Database iOS integration
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -85,24 +85,24 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # database-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       podspec: [FirebaseDatabase.podspec]
-  #       target: [ios, tvos, macos]
-  #       flags: [
-  #         '--skip-tests --use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: PodLibLint database Cron
-  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  database-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    runs-on: macos-15
+    strategy:
+      matrix:
+        podspec: [FirebaseDatabase.podspec]
+        target: [ios, tvos, macos]
+        flags: [
+          '--skip-tests --use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint database Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -16,6 +16,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Gemfile*'
     - 'scripts/run_database_emulator.sh'
   schedule:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -27,87 +27,79 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    strategy:
-      matrix:
-        target: [DatabaseUnit, DatabaseUnitSwift]
-    uses: ./.github/workflows/common.yml
-    with:
-      target: ${{  matrix.target }}
+  # spm:
+  #   strategy:
+  #     matrix:
+  #       target: [DatabaseUnit, DatabaseUnitSwift]
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: ${{  matrix.target }}
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseDatabase
-      target: FirebaseDatabase-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseDatabase
+  #     target: FirebaseDatabase-Unit-unit
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebaseDatabase
-      test_specs: unit
-      buildonly_platforms: macOS
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseDatabase
+  #     test_specs: unit
+  #     buildonly_platforms: macOS
 
-  integration:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: integration${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: IntegrationTest
-      # Only iOS to mitigate flakes.
-      run: scripts/third_party/travis/retry.sh scripts/build.sh Database iOS integration
+  # integration:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: integration${{ matrix.os }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install xcpretty
+  #     run: gem install xcpretty
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: IntegrationTest
+  #     # Only iOS to mitigate flakes.
+  #     run: scripts/third_party/travis/retry.sh scripts/build.sh Database iOS integration
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh database
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-          quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Test objc quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Database false)
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Database false swift)
-
-  database-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-15
+    uses: ./.github/workflows/common_quickstart.yml
     strategy:
       matrix:
-        podspec: [FirebaseDatabase.podspec]
-        target: [ios, tvos, macos]
-        flags: [
-          '--skip-tests --use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint database Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.flags }}
+        quickstart_type: [objc, swift]
+    with:
+      product: Database
+      is_legacy: false
+      setup_command: scripts/setup_quickstart.sh database
+      plist_src_path: scripts/gha-encrypted/qs-database.plist.gpg
+      plist_dst_path: quickstart-ios/database/GoogleService-Info.plist
+      quickstart_type: ${{ matrix.quickstart_type }}
+      run_tests: false
+
+  # database-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       podspec: [FirebaseDatabase.podspec]
+  #       target: [ios, tvos, macos]
+  #       flags: [
+  #         '--skip-tests --use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: PodLibLint database Cron
+  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb ${{ matrix.podspec }} --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -81,6 +81,8 @@ jobs:
       plist_dst_path: quickstart-ios/database/GoogleService-Info.plist
       quickstart_type: ${{ matrix.quickstart_type }}
       run_tests: false
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   # database-cron-only:
   #   # Don't run on private repo.

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -598,23 +598,16 @@ jobs:
         if: needs.*.result == 'failure'
         run: exit 1
 
-  # Disable until FirebaseUI is updated to accept Firebase 9 and quickstart is updated to accept
-  # Firebase UI 12
+  # TODO: Disable until FirebaseUI is updated to accept Firebase 9 and
+  # quickstart is updated to accept Firebase UI 12
   # quickstart:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
+  #   uses: ./.github/workflows/common_quickstart.yml
+  #   with:
+  #     product: Firestore
+  #     is_legacy: true
+  #     setup_command: scripts/setup_quickstart.sh firestore
+  #     plist_src_path: scripts/gha-encrypted/qs-firestore.plist.gpg
+  #     plist_dst_path: quickstart-ios/firestore/GoogleService-Info.plist
+  #     run_tests: false
+  #   secrets:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-14
-  #   needs: check
-
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh firestore
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-  #         quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test swift quickstart
-  #     run: ([ -z $plist_secret ] ||
-  #           scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Firestore false)

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -50,32 +50,23 @@ jobs:
     with:
       target: FirebaseFunctionsUnit
 
-  # TODO: Move to macos-14 and Xcode 15. The legacy quickstart uses material which doesn't build on Xcode 15.
+  # TODO: The legacy quickstart uses material which doesn't build on Xcode 15.
   # quickstart:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     LEGACY: true
-  #   # TODO: Move to macos-14 and Xcode 15. The legacy quickstart uses material which doesn't build on Xcode 15.
-  #   runs-on: macos-12
-
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh functions
-  #   - name: install secret googleservice-info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-functions.plist.gpg \
-  #         quickstart-ios/functions/GoogleService-Info.plist "$plist_secret"
-  #   - name: Setup custom URL scheme
-  #     run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' quickstart-ios/functions/LegacyFunctionsQuickstart/FunctionsExample/Info.plist
-  #   - name: Test objc quickstart
-  #     run: ([ -z $plist_secret ] ||
-  #           scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Functions true)
-  #   - name: Test swift quickstart
-  #     run: ([ -z $plist_secret ] ||
-  #           scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Functions true swift)
+  #     uses: ./.github/workflows/common_quickstart.yml
+  #     strategy:
+  #       matrix:
+  #         quickstart_type: [objc, swift]
+  #     with:
+  #       product: Functions
+  #       is_legacy: true
+  #       setup_command: |
+  #         scripts/setup_quickstart.sh functions
+  #         sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' quickstart-ios/functions/LegacyFunctionsQuickstart/FunctionsExample/Info.plist
+  #       plist_src_path: scripts/gha-encrypted/qs-functions.plist.gpg
+  #       plist_dst_path: quickstart-ios/functions/GoogleService-Info.plist
+  #       quickstart_type: ${{ matrix.quickstart_type }}
+  #     secrets:
+  #       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   # quickstart-ftl-cron-only:
   #   # Don't run on private repo

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -23,67 +23,67 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-#   spm:
-#     uses: ./.github/workflows/common.yml
-#     with:
-#       target: FirebaseInAppMessaging-Beta
-#       platforms: iOS
-#       buildonly_platforms: iOS
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: FirebaseInAppMessaging-Beta
+      platforms: iOS
+      buildonly_platforms: iOS
 
-#   pod_lib_lint:
-#     uses: ./.github/workflows/common_cocoapods.yml
-#     with:
-#       product: FirebaseInAppMessaging
-#       platforms: iOS, tvOS
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseInAppMessaging
+      platforms: iOS, tvOS
 
-#   tests:
-#     # Don't run on private repo unless it is a PR.
-#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  tests:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-# # TODO(#12770): Update to macos-14 when tests are updated for Xcode 15.
-#     runs-on: macos-15
-#     strategy:
-#       matrix:
-# # TODO(#8682): Reenable iPad after fixing Xcode 13 test failures.
-# #        platform: [iOS, iPad]
-#         platform: [iOS]
-#         xcode: [Xcode_16.4]
-#     steps:
-#     - uses: actions/checkout@v4
-#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-#       with:
-#         cache_key: ${{ matrix.platform }}
-#     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-#     - name: Setup Bundler
-#       run: scripts/setup_bundler.sh
-#     - name: Xcode
-#       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-#     - name: Prereqs
-#       run: scripts/install_prereqs.sh InAppMessaging ${{ matrix.platform }} xcodebuild
-#     - name: Build and test
-#       run: scripts/third_party/travis/retry.sh scripts/build.sh InAppMessaging ${{ matrix.platform }} xcodebuild
+# TODO(#12770): Update to macos-14 when tests are updated for Xcode 15.
+    runs-on: macos-15
+    strategy:
+      matrix:
+# TODO(#8682): Reenable iPad after fixing Xcode 13 test failures.
+#        platform: [iOS, iPad]
+        platform: [iOS]
+        xcode: [Xcode_16.4]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.platform }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Prereqs
+      run: scripts/install_prereqs.sh InAppMessaging ${{ matrix.platform }} xcodebuild
+    - name: Build and test
+      run: scripts/third_party/travis/retry.sh scripts/build.sh InAppMessaging ${{ matrix.platform }} xcodebuild
 
-#   fiam-cron-only:
-#     # Don't run on private repo.
-#     if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  fiam-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-#     runs-on: macos-15
-#     strategy:
-#       matrix:
-#         flags: [
-#           '--use-static-frameworks'
-#         ]
-#         platform: [ios, tvos]
-#     needs: pod_lib_lint
-#     steps:
-#     - uses: actions/checkout@v4
-#     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-#     - name: Xcode
-#       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-#     - name: Setup Bundler
-#       run: scripts/setup_bundler.sh
-#     - name: PodLibLint InAppMessaging Cron
-#       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --platforms=${{ matrix.platform }} ${{ matrix.flags }}
+    runs-on: macos-15
+    strategy:
+      matrix:
+        flags: [
+          '--use-static-frameworks'
+        ]
+        platform: [ios, tvos]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint InAppMessaging Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --platforms=${{ matrix.platform }} ${{ matrix.flags }}
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -22,67 +22,67 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: FirebaseInAppMessaging-Beta
-      platforms: iOS
-      buildonly_platforms: iOS
+#   spm:
+#     uses: ./.github/workflows/common.yml
+#     with:
+#       target: FirebaseInAppMessaging-Beta
+#       platforms: iOS
+#       buildonly_platforms: iOS
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebaseInAppMessaging
-      platforms: iOS, tvOS
+#   pod_lib_lint:
+#     uses: ./.github/workflows/common_cocoapods.yml
+#     with:
+#       product: FirebaseInAppMessaging
+#       platforms: iOS, tvOS
 
-  tests:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+#   tests:
+#     # Don't run on private repo unless it is a PR.
+#     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
 
-# TODO(#12770): Update to macos-14 when tests are updated for Xcode 15.
-    runs-on: macos-15
-    strategy:
-      matrix:
-# TODO(#8682): Reenable iPad after fixing Xcode 13 test failures.
-#        platform: [iOS, iPad]
-        platform: [iOS]
-        xcode: [Xcode_16.4]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.platform }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Prereqs
-      run: scripts/install_prereqs.sh InAppMessaging ${{ matrix.platform }} xcodebuild
-    - name: Build and test
-      run: scripts/third_party/travis/retry.sh scripts/build.sh InAppMessaging ${{ matrix.platform }} xcodebuild
+# # TODO(#12770): Update to macos-14 when tests are updated for Xcode 15.
+#     runs-on: macos-15
+#     strategy:
+#       matrix:
+# # TODO(#8682): Reenable iPad after fixing Xcode 13 test failures.
+# #        platform: [iOS, iPad]
+#         platform: [iOS]
+#         xcode: [Xcode_16.4]
+#     steps:
+#     - uses: actions/checkout@v4
+#     - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+#       with:
+#         cache_key: ${{ matrix.platform }}
+#     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+#     - name: Setup Bundler
+#       run: scripts/setup_bundler.sh
+#     - name: Xcode
+#       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+#     - name: Prereqs
+#       run: scripts/install_prereqs.sh InAppMessaging ${{ matrix.platform }} xcodebuild
+#     - name: Build and test
+#       run: scripts/third_party/travis/retry.sh scripts/build.sh InAppMessaging ${{ matrix.platform }} xcodebuild
 
-  fiam-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+#   fiam-cron-only:
+#     # Don't run on private repo.
+#     if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-    runs-on: macos-15
-    strategy:
-      matrix:
-        flags: [
-          '--use-static-frameworks'
-        ]
-        platform: [ios, tvos]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint InAppMessaging Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --platforms=${{ matrix.platform }} ${{ matrix.flags }}
+#     runs-on: macos-15
+#     strategy:
+#       matrix:
+#         flags: [
+#           '--use-static-frameworks'
+#         ]
+#         platform: [ios, tvos]
+#     needs: pod_lib_lint
+#     steps:
+#     - uses: actions/checkout@v4
+#     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+#     - name: Xcode
+#       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+#     - name: Setup Bundler
+#       run: scripts/setup_bundler.sh
+#     - name: PodLibLint InAppMessaging Cron
+#       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --platforms=${{ matrix.platform }} ${{ matrix.flags }}
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -12,6 +12,7 @@ on:
     - '.github/workflows/inappmessaging.yml'
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Gemfile*'
   schedule:
     # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -85,27 +85,16 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --platforms=${{ matrix.platform }} ${{ matrix.flags }}
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-    env:
+    uses: ./.github/workflows/common_quickstart.yml
+    strategy:
+      matrix:
+        quickstart_type: [objc, swift]
+    with:
+      product: InAppMessaging
+      is_legacy: false
+      quickstart_type: ${{ matrix.quickstart_type }}
+      setup_command: scripts/setup_quickstart.sh inappmessaging
+      plist_src_path: scripts/gha-encrypted/qs-inappmessaging.plist.gpg
+      plist_dst_path: quickstart-ios/inappmessaging/GoogleService-Info.plist
+    secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh inappmessaging
-    - name: install secret googleservice-info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-          quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test objc quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart.sh InAppMessaging true)
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart.sh InAppMessaging true swift)

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -23,30 +23,30 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: FirebaseInstallations
-  #     buildonly_platforms: all
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: FirebaseInstallations
+      buildonly_platforms: all
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseInstallations
-  #     target: FirebaseInstallations-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseInstallations
+      target: FirebaseInstallations-Unit-unit
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseInstallations
-  #     setup_command: |
-  #       scripts/configure_test_keychain.sh
-  #       mkdir -p FirebaseInstallations/Source/Tests/Resources
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
-  #         FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
-  #       export FIS_INTEGRATION_TESTS_REQUIRED=1
-  #   secrets:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseInstallations
+      setup_command: |
+        scripts/configure_test_keychain.sh
+        mkdir -p FirebaseInstallations/Source/Tests/Resources
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
+          FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
+        export FIS_INTEGRATION_TESTS_REQUIRED=1
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -63,67 +63,67 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  quickstart-ftl-cron-only:
+    # Don't run on private repo.
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh installations
-  #   - name: Copy mock plist
-  #     run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/installations/GoogleService-Info.plist
-  #   - name: Build objc quickstart
-  #     run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations
-  #   - name: Build swift quickstart
-  #     run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations swift
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup quickstart
+      run: scripts/setup_quickstart.sh installations
+    - name: Copy mock plist
+      run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/installations/GoogleService-Info.plist
+    - name: Build objc quickstart
+      run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations
+    - name: Build swift quickstart
+      run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations swift
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # installations-cron-only:
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  installations-cron-only:
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-  #   runs-on: macos-15
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos, macos]
-  #       flags: [
-  #         '--use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Configure test keychain
-  #     run: scripts/configure_test_keychain.sh
-  #   - name: Install GoogleService-Info.plist
-  #     run: |
-  #       mkdir -p FirebaseInstallations/Source/Tests/Resources
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
-  #         FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
-  #   - name: Get boolean for secrets available
-  #     id: secrets
-  #     run: echo "::set-output name=val::$([[ -z $plist_secret ]] && echo "0" || echo "1")"
-  #   - name: PodLibLint Installations Cron
-  #     run: |
-  #      export FIS_INTEGRATION_TESTS_REQUIRED=${{ steps.secrets.outputs.val }}
-  #      scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInstallations.podspec \
-  #        --platforms=${{ matrix.target }} ${{ matrix.flags }} \
+    runs-on: macos-15
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
+    - name: Install GoogleService-Info.plist
+      run: |
+        mkdir -p FirebaseInstallations/Source/Tests/Resources
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
+          FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
+    - name: Get boolean for secrets available
+      id: secrets
+      run: echo "::set-output name=val::$([[ -z $plist_secret ]] && echo "0" || echo "1")"
+    - name: PodLibLint Installations Cron
+      run: |
+       export FIS_INTEGRATION_TESTS_REQUIRED=${{ steps.secrets.outputs.val }}
+       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInstallations.podspec \
+         --platforms=${{ matrix.target }} ${{ matrix.flags }} \

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -12,6 +12,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Gemfile*'
   schedule:
     # Run every day at 11pm (PDT) / 2am (EDT) - cron uses UTC times

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -22,111 +22,107 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: FirebaseInstallations
-      buildonly_platforms: all
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: FirebaseInstallations
+  #     buildonly_platforms: all
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseInstallations
-      target: FirebaseInstallations-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseInstallations
+  #     target: FirebaseInstallations-Unit-unit
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseInstallations
+  #     setup_command: |
+  #       scripts/configure_test_keychain.sh
+  #       mkdir -p FirebaseInstallations/Source/Tests/Resources
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
+  #         FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
+  #       export FIS_INTEGRATION_TESTS_REQUIRED=1
+  #   secrets:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+
+  quickstart:
+    uses: ./.github/workflows/common_quickstart.yml
+    strategy:
+      matrix:
+        quickstart_type: [objc, swift]
     with:
-      product: FirebaseInstallations
-      setup_command: |
-        scripts/configure_test_keychain.sh
-        mkdir -p FirebaseInstallations/Source/Tests/Resources
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
-          FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
-        export FIS_INTEGRATION_TESTS_REQUIRED=1
+      product: Installations
+      is_legacy: false
+      setup_command: scripts/setup_quickstart.sh installations
+      plist_src_path: scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg
+      plist_dst_path: quickstart-ios/installations/GoogleService-Info.plist
+      quickstart_type: ${{ matrix.quickstart_type }}
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # quickstart-ftl-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh installations
-    - name: Copy mock plist
-      run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/installations/GoogleService-Info.plist
-    - name: Test objc quickstart
-      run: scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Installations true
-    - name: Test swift quickstart
-      run: scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Installations true swift
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh installations
+  #   - name: Copy mock plist
+  #     run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/installations/GoogleService-Info.plist
+  #   - name: Build objc quickstart
+  #     run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations
+  #   - name: Build swift quickstart
+  #     run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations swift
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
 
-  quickstart-ftl-cron-only:
-    # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  # installations-cron-only:
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh installations
-    - name: Copy mock plist
-      run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/installations/GoogleService-Info.plist
-    - name: Build objc quickstart
-      run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations
-    - name: Build swift quickstart
-      run: scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Installations swift
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
-
-  installations-cron-only:
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-
-    runs-on: macos-15
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-        flags: [
-          '--use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Configure test keychain
-      run: scripts/configure_test_keychain.sh
-    - name: Install GoogleService-Info.plist
-      run: |
-        mkdir -p FirebaseInstallations/Source/Tests/Resources
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
-          FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
-    - name: Get boolean for secrets available
-      id: secrets
-      run: echo "::set-output name=val::$([[ -z $plist_secret ]] && echo "0" || echo "1")"
-    - name: PodLibLint Installations Cron
-      run: |
-       export FIS_INTEGRATION_TESTS_REQUIRED=${{ steps.secrets.outputs.val }}
-       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInstallations.podspec \
-         --platforms=${{ matrix.target }} ${{ matrix.flags }} \
+  #   runs-on: macos-15
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     FIR_IID_INTEGRATION_TESTS_REQUIRED: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos]
+  #       flags: [
+  #         '--use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Configure test keychain
+  #     run: scripts/configure_test_keychain.sh
+  #   - name: Install GoogleService-Info.plist
+  #     run: |
+  #       mkdir -p FirebaseInstallations/Source/Tests/Resources
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Installations/GoogleService-Info.plist.gpg \
+  #         FirebaseInstallations/Source/Tests/Resources/GoogleService-Info.plist "$plist_secret"
+  #   - name: Get boolean for secrets available
+  #     id: secrets
+  #     run: echo "::set-output name=val::$([[ -z $plist_secret ]] && echo "0" || echo "1")"
+  #   - name: PodLibLint Installations Cron
+  #     run: |
+  #      export FIS_INTEGRATION_TESTS_REQUIRED=${{ steps.secrets.outputs.val }}
+  #      scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseInstallations.podspec \
+  #        --platforms=${{ matrix.target }} ${{ matrix.flags }} \

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -82,30 +82,20 @@ jobs:
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    uses: ./.github/workflows/common_quickstart.yml
     strategy:
       matrix:
-        include:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh messaging
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-          quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Test objc quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Messaging false)
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Messaging false swift)
+        quickstart_type: [objc, swift]
+    with:
+      product: Messaging
+      is_legacy: false
+      quickstart_type: ${{ matrix.quickstart_type }}
+      setup_command: scripts/setup_quickstart.sh messaging
+      plist_src_path: scripts/gha-encrypted/qs-messaging.plist.gpg
+      plist_dst_path: quickstart-ios/messaging/GoogleService-Info.plist
+      run_tests: false
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
   quickstart-ftl-cron-only:
     # Don't run on private repo.

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -19,6 +19,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'
   schedule:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -31,54 +31,54 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: MessagingUnit
-  #     buildonly_platforms: tvOS, macOS, watchOS, catalyst, visionOS
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: MessagingUnit
+      buildonly_platforms: tvOS, macOS, watchOS, catalyst, visionOS
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseMessaging
-  #     target: FirebaseMessaging-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseMessaging
+      target: FirebaseMessaging-Unit-unit
 
-  # pod_lib_lint:
-  #   strategy:
-  #     matrix:
-  #       product: [FirebaseMessagingInterop, FirebaseMessaging]
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: ${{  matrix.product }}
+  pod_lib_lint:
+    strategy:
+      matrix:
+        product: [FirebaseMessagingInterop, FirebaseMessaging]
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: ${{  matrix.product }}
 
-  # # TODO(#12205) Update the build.sh script for this job from "test" instead of "build"
-  # messaging-integration-tests:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: integration
-  #   - name: Configure test keychain
-  #     run: scripts/configure_test_keychain.sh
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install xcpretty
-  #     run: gem install xcpretty
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: |
-  #       mkdir FirebaseMessaging/Tests/IntegrationTests/Resources
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-  #         FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist "$plist_secret"
-  #   - name: BuildAndTest
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Messaging all)
+  # TODO(#12205) Update the build.sh script for this job from "test" instead of "build"
+  messaging-integration-tests:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: integration
+    - name: Configure test keychain
+      run: scripts/configure_test_keychain.sh
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+        mkdir FirebaseMessaging/Tests/IntegrationTests/Resources
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+          FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist "$plist_secret"
+    - name: BuildAndTest
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Messaging all)
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -96,141 +96,141 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh messaging
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-  #         quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Build objc quickstart
-  #     run: ([ -z $plist_secret ] ||
-  #           scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging)
-  #   - name: Build swift quickstart
-  #     run: ([ -z $plist_secret ] ||
-  #           scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging swift)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+  quickstart-ftl-cron-only:
+    # Don't run on private repo.
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup quickstart
+      run: scripts/setup_quickstart.sh messaging
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+          quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+    - name: Build objc quickstart
+      run: ([ -z $plist_secret ] ||
+            scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging)
+    - name: Build swift quickstart
+      run: ([ -z $plist_secret ] ||
+            scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging swift)
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # messaging-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
-  #       os: [macos-14, macos-15]
-  #       include:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #           tests: --test-specs=unit
-  #         - os: macos-14
-  #           xcode: Xcode_16.2
-  #           tests: --skip-tests
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: PodLibLint Messaging Cron
-  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec ${{ matrix.tests }} --platforms=${{ matrix.target }} --use-static-frameworks
+  messaging-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    strategy:
+      matrix:
+        target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
+        os: [macos-14, macos-15]
+        include:
+          - os: macos-15
+            xcode: Xcode_16.4
+            tests: --test-specs=unit
+          - os: macos-14
+            xcode: Xcode_16.2
+            tests: --skip-tests
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: PodLibLint Messaging Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec ${{ matrix.tests }} --platforms=${{ matrix.target }} --use-static-frameworks
 
-  # messaging-sample-build-test:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: sample${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-  #   - name: Prereqs
-  #     run: scripts/install_prereqs.sh MessagingSample iOS
-  #   - name: Build
-  #     run: ([ -z $plist_secret ] || scripts/build.sh MessagingSample iOS)
+  messaging-sample-build-test:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: sample${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+    - name: Prereqs
+      run: scripts/install_prereqs.sh MessagingSample iOS
+    - name: Build
+      run: ([ -z $plist_secret ] || scripts/build.sh MessagingSample iOS)
 
-  # messaging-swiftui-sample-build-test:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: sample${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-  #   - name: Prereqs
-  #     run: scripts/install_prereqs.sh SwiftUISample iOS
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Build
-  #     run: ([ -z $plist_secret ] || scripts/build.sh SwiftUISample iOS)
+  messaging-swiftui-sample-build-test:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: sample${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+    - name: Prereqs
+      run: scripts/install_prereqs.sh SwiftUISample iOS
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Build
+      run: ([ -z $plist_secret ] || scripts/build.sh SwiftUISample iOS)
 
-  # messaging-watchos-standalone-sample-build-test:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: watch-sample${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-  #   - name: Prereqs
-  #     run: scripts/install_prereqs.sh MessagingSampleStandaloneWatchApp watchOS
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Build
-  #     run: ([ -z $plist_secret ] || scripts/build.sh MessagingSampleStandaloneWatchApp watchOS)
-  #   - name: Upload xcodebuild logs
-  #     if: failure()
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: xcodebuild-logs-${{ matrix.target }}
-  #       path: xcodebuild-*.log
+  messaging-watchos-standalone-sample-build-test:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: watch-sample${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+    - name: Prereqs
+      run: scripts/install_prereqs.sh MessagingSampleStandaloneWatchApp watchOS
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Build
+      run: ([ -z $plist_secret ] || scripts/build.sh MessagingSampleStandaloneWatchApp watchOS)
+    - name: Upload xcodebuild logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: xcodebuild-logs-${{ matrix.target }}
+        path: xcodebuild-*.log
 

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -30,54 +30,54 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: MessagingUnit
-      buildonly_platforms: tvOS, macOS, watchOS, catalyst, visionOS
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: MessagingUnit
+  #     buildonly_platforms: tvOS, macOS, watchOS, catalyst, visionOS
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseMessaging
-      target: FirebaseMessaging-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseMessaging
+  #     target: FirebaseMessaging-Unit-unit
 
-  pod_lib_lint:
-    strategy:
-      matrix:
-        product: [FirebaseMessagingInterop, FirebaseMessaging]
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: ${{  matrix.product }}
+  # pod_lib_lint:
+  #   strategy:
+  #     matrix:
+  #       product: [FirebaseMessagingInterop, FirebaseMessaging]
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: ${{  matrix.product }}
 
-  # TODO(#12205) Update the build.sh script for this job from "test" instead of "build"
-  messaging-integration-tests:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: integration
-    - name: Configure test keychain
-      run: scripts/configure_test_keychain.sh
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Install Secret GoogleService-Info.plist
-      run: |
-        mkdir FirebaseMessaging/Tests/IntegrationTests/Resources
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-          FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist "$plist_secret"
-    - name: BuildAndTest
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Messaging all)
+  # # TODO(#12205) Update the build.sh script for this job from "test" instead of "build"
+  # messaging-integration-tests:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: integration
+  #   - name: Configure test keychain
+  #     run: scripts/configure_test_keychain.sh
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install xcpretty
+  #     run: gem install xcpretty
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: |
+  #       mkdir FirebaseMessaging/Tests/IntegrationTests/Resources
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+  #         FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist "$plist_secret"
+  #   - name: BuildAndTest
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Messaging all)
 
   quickstart:
     # Don't run on private repo unless it is a PR.
@@ -97,141 +97,141 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  quickstart-ftl-cron-only:
-    # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh messaging
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-          quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Build objc quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging)
-    - name: Build swift quickstart
-      run: ([ -z $plist_secret ] ||
-            scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging swift)
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
+  # quickstart-ftl-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh messaging
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+  #         quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Build objc quickstart
+  #     run: ([ -z $plist_secret ] ||
+  #           scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging)
+  #   - name: Build swift quickstart
+  #     run: ([ -z $plist_secret ] ||
+  #           scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Messaging swift)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
 
-  messaging-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    strategy:
-      matrix:
-        target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
-        os: [macos-14, macos-15]
-        include:
-          - os: macos-15
-            xcode: Xcode_16.4
-            tests: --test-specs=unit
-          - os: macos-14
-            xcode: Xcode_16.2
-            tests: --skip-tests
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: PodLibLint Messaging Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec ${{ matrix.tests }} --platforms=${{ matrix.target }} --use-static-frameworks
+  # messaging-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
+  #       os: [macos-14, macos-15]
+  #       include:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #           tests: --test-specs=unit
+  #         - os: macos-14
+  #           xcode: Xcode_16.2
+  #           tests: --skip-tests
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: PodLibLint Messaging Cron
+  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec ${{ matrix.tests }} --platforms=${{ matrix.target }} --use-static-frameworks
 
-  messaging-sample-build-test:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: sample${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-    - name: Prereqs
-      run: scripts/install_prereqs.sh MessagingSample iOS
-    - name: Build
-      run: ([ -z $plist_secret ] || scripts/build.sh MessagingSample iOS)
+  # messaging-sample-build-test:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: sample${{ matrix.os }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: |
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+  #   - name: Prereqs
+  #     run: scripts/install_prereqs.sh MessagingSample iOS
+  #   - name: Build
+  #     run: ([ -z $plist_secret ] || scripts/build.sh MessagingSample iOS)
 
-  messaging-swiftui-sample-build-test:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: sample${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-    - name: Prereqs
-      run: scripts/install_prereqs.sh SwiftUISample iOS
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Build
-      run: ([ -z $plist_secret ] || scripts/build.sh SwiftUISample iOS)
+  # messaging-swiftui-sample-build-test:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: sample${{ matrix.os }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: |
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+  #   - name: Prereqs
+  #     run: scripts/install_prereqs.sh SwiftUISample iOS
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Build
+  #     run: ([ -z $plist_secret ] || scripts/build.sh SwiftUISample iOS)
 
-  messaging-watchos-standalone-sample-build-test:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: watch-sample${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
-          FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
-    - name: Prereqs
-      run: scripts/install_prereqs.sh MessagingSampleStandaloneWatchApp watchOS
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Build
-      run: ([ -z $plist_secret ] || scripts/build.sh MessagingSampleStandaloneWatchApp watchOS)
-    - name: Upload xcodebuild logs
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: xcodebuild-logs-${{ matrix.target }}
-        path: xcodebuild-*.log
+  # messaging-watchos-standalone-sample-build-test:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: watch-sample${{ matrix.os }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: |
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/messaging-sample-plist.gpg \
+  #         FirebaseMessaging/Apps/Shared/GoogleService-Info.plist "$plist_secret"
+  #   - name: Prereqs
+  #     run: scripts/install_prereqs.sh MessagingSampleStandaloneWatchApp watchOS
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Build
+  #     run: ([ -z $plist_secret ] || scripts/build.sh MessagingSampleStandaloneWatchApp watchOS)
+  #   - name: Upload xcodebuild logs
+  #     if: failure()
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: xcodebuild-logs-${{ matrix.target }}
+  #       path: xcodebuild-*.log
 

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -80,8 +80,6 @@ jobs:
   #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Messaging all)
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     uses: ./.github/workflows/common_quickstart.yml
     strategy:
       matrix:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -32,50 +32,50 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: PerformanceUnit
-  #     platforms: iOS, tvOS
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: PerformanceUnit
+      platforms: iOS, tvOS
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebasePerformance
-  #     target:
-  #     buildonly: true
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebasePerformance
+      target:
+      buildonly: true
 
-  # # Build and run the unit tests for Firebase performance SDK.
-  # performance:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       target: [iOS, tvOS]
-  #       test: [unit, proddev]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: ${{ matrix.target }}${{ matrix.test }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install xcpretty
-  #     run: gem install xcpretty
-  #   - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-  #     run: scripts/third_party/travis/retry.sh scripts/build.sh Performance ${{ matrix.target }} ${{ matrix.test }}
+  # Build and run the unit tests for Firebase performance SDK.
+  performance:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-15
+    strategy:
+      matrix:
+        target: [iOS, tvOS]
+        test: [unit, proddev]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: ${{ matrix.target }}${{ matrix.test }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance ${{ matrix.target }} ${{ matrix.test }}
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebasePerformance
-  #     platforms: iOS, tvOS
-  #     #TODO: tests are not supported with Xcode 15 because the test spec depends on the iOS 8 GDCWebServer
-  #     buildonly_platforms: iOS, tvOS
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebasePerformance
+      platforms: iOS, tvOS
+      #TODO: tests are not supported with Xcode 15 because the test spec depends on the iOS 8 GDCWebServer
+      buildonly_platforms: iOS, tvOS
 
   # TODO: The legacy ObjC quickstarts don't run with Xcode 15, re-able if we get these working.
   quickstart:
@@ -90,54 +90,54 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  quickstart-ftl-cron-only:
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh performance
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-performance.plist.gpg \
-  #         quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
-  #   - name: Build swift quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance swift)
-  #   # - name: Build objc quickstart
-  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup quickstart
+      run: scripts/setup_quickstart.sh performance
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-performance.plist.gpg \
+          quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
+    - name: Build swift quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance swift)
+    # - name: Build objc quickstart
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance)
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # performance-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos]
-  #       flags: [
-  #         '--skip-tests --use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: PodLibLint Performance Cron
-  #     run: |
-  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebasePerformance.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  performance-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    runs-on: macos-15
+    strategy:
+      matrix:
+        target: [ios, tvos]
+        flags: [
+          '--skip-tests --use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint Performance Cron
+      run: |
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebasePerformance.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,53 +31,53 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: PerformanceUnit
-      platforms: iOS, tvOS
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: PerformanceUnit
+  #     platforms: iOS, tvOS
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebasePerformance
-      target:
-      buildonly: true
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebasePerformance
+  #     target:
+  #     buildonly: true
 
-  # Build and run the unit tests for Firebase performance SDK.
-  performance:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-15
-    strategy:
-      matrix:
-        target: [iOS, tvOS]
-        test: [unit, proddev]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: ${{ matrix.target }}${{ matrix.test }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance ${{ matrix.target }} ${{ matrix.test }}
+  # # Build and run the unit tests for Firebase performance SDK.
+  # performance:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       target: [iOS, tvOS]
+  #       test: [unit, proddev]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: ${{ matrix.target }}${{ matrix.test }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install xcpretty
+  #     run: gem install xcpretty
+  #   - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+  #     run: scripts/third_party/travis/retry.sh scripts/build.sh Performance ${{ matrix.target }} ${{ matrix.test }}
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebasePerformance
-      platforms: iOS, tvOS
-      #TODO: tests are not supported with Xcode 15 because the test spec depends on the iOS 8 GDCWebServer
-      buildonly_platforms: iOS, tvOS
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebasePerformance
+  #     platforms: iOS, tvOS
+  #     #TODO: tests are not supported with Xcode 15 because the test spec depends on the iOS 8 GDCWebServer
+  #     buildonly_platforms: iOS, tvOS
 
-  quickstart:
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # TODO: The legacy ObjC quickstarts don't run with Xcode 15, re-able if we get these working.
+  quickstart:  
     uses: ./.github/workflows/common_quickstart.yml
     with:
       product: Performance
@@ -89,54 +89,54 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  quickstart-ftl-cron-only:
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  # quickstart-ftl-cron-only:
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
 
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh performance
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-performance.plist.gpg \
-          quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
-    - name: Build swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance swift)
-    # - name: Build objc quickstart
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance)
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh performance
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-performance.plist.gpg \
+  #         quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
+  #   - name: Build swift quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance swift)
+  #   # - name: Build objc quickstart
+  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Performance)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
 
-  performance-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-15
-    strategy:
-      matrix:
-        target: [ios, tvos]
-        flags: [
-          '--skip-tests --use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint Performance Cron
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebasePerformance.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  # performance-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos]
+  #       flags: [
+  #         '--skip-tests --use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: PodLibLint Performance Cron
+  #     run: |
+  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebasePerformance.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -19,6 +19,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     # Rebuild on Ruby infrastructure changes
     - 'Gemfile*'
   schedule:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -78,25 +78,16 @@ jobs:
 
   quickstart:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-
-    env:
+    uses: ./.github/workflows/common_quickstart.yml
+    with:
+      product: Performance
+      is_legacy: false
+      quickstart_type: swift
+      setup_command: scripts/setup_quickstart.sh performance
+      plist_src_path: scripts/gha-encrypted/qs-performance.plist.gpg
+      plist_dst_path: quickstart-ios/performance/GoogleService-Info.plist
+    secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh performance
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-performance.plist.gpg \
-          quickstart-ios/performance/GoogleService-Info.plist "$plist_secret"
-    - name: Test swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Performance true swift)
-    # TODO: The legacy ObjC quickstarts don't run with Xcode 15, re-able if we get these working.
-    # - name: Test objc quickstart
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Performance true)
 
   quickstart-ftl-cron-only:
     if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -77,7 +77,7 @@ jobs:
   #     buildonly_platforms: iOS, tvOS
 
   # TODO: The legacy ObjC quickstarts don't run with Xcode 15, re-able if we get these working.
-  quickstart:  
+  quickstart:
     uses: ./.github/workflows/common_quickstart.yml
     with:
       product: Performance

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -25,147 +25,141 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm_1:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: RemoteConfigUnit
+  # spm_1:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: RemoteConfigUnit
 
-  spm_2:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: RemoteConfigFakeConsole
-      buildonly_platforms: watchOS
+  # spm_2:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: RemoteConfigFakeConsole
+  #     buildonly_platforms: watchOS
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseRemoteConfig
-      target: FirebaseRemoteConfig-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseRemoteConfig
+  #     target: FirebaseRemoteConfig-Unit-unit
 
-  remoteconfig:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      USE_REAL_CONSOLE: true
-    runs-on: macos-15
-    strategy:
-      matrix:
-        target: [iOS]
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: rc${{ matrix.target }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/RemoteConfigSwiftAPI/GoogleService-Info.plist.gpg \
-          FirebaseRemoteConfig/Tests/Swift/SwiftAPI/GoogleService-Info.plist "$plist_secret"
-    - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
-      if: matrix.target == 'iOS'
-      run: ([ -z $plist_secret ] || scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
-          FirebaseRemoteConfig/Tests/Swift/AccessToken.json)
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Fake Console API Tests
-      run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} fakeconsole
-    - name: IntegrationTest
-      if: matrix.target == 'iOS'
-      # No retry to avoid exhausting AccessToken quota.
-      run: ([ -z $plist_secret ] || scripts/build.sh RemoteConfig iOS integration)
+  # remoteconfig:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     USE_REAL_CONSOLE: true
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       target: [iOS]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: rc${{ matrix.target }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install xcpretty
+  #     run: gem install xcpretty
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/RemoteConfigSwiftAPI/GoogleService-Info.plist.gpg \
+  #         FirebaseRemoteConfig/Tests/Swift/SwiftAPI/GoogleService-Info.plist "$plist_secret"
+  #   - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
+  #     if: matrix.target == 'iOS'
+  #     run: ([ -z $plist_secret ] || scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
+  #         FirebaseRemoteConfig/Tests/Swift/AccessToken.json)
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Fake Console API Tests
+  #     run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} fakeconsole
+  #   - name: IntegrationTest
+  #     if: matrix.target == 'iOS'
+  #     # No retry to avoid exhausting AccessToken quota.
+  #     run: ([ -z $plist_secret ] || scripts/build.sh RemoteConfig iOS integration)
 
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
-    with:
-      product: FirebaseRemoteConfig
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseRemoteConfig
 
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    env:
+    uses: ./.github/workflows/common_quickstart.yml
+    with:
+      product: Config
+      is_legacy: false
+      setup_command: scripts/setup_quickstart.sh config
+      plist_src_path: scripts/gha-encrypted/qs-config.plist.gpg
+      plist_dst_path: quickstart-ios/config/GoogleService-Info.plist
+    secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh config
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-          quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Config true)
 
-  # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
+  # # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
+  # # quickstart-ftl-cron-only:
+  # #   # Don't run on private repo.
+  # #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  # #   env:
+  # #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  # #   runs-on: macos-14
+  # #   steps:
+  # #   - uses: actions/checkout@v4
+  # #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  # #   - uses: actions/setup-python@v5
+  # #     with:
+  # #      python-version: '3.11'
+  # #   - name: Setup quickstart
+  # #     run: scripts/setup_quickstart.sh config
+  # #   - name: Install Secret GoogleService-Info.plist
+  # #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+  # #         quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+  # #   - name: Build Swift Quickstart
+  # #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Config)
+  # #   - id: ftl_test
+  # #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  # #     with:
+  # #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  # #       testapp_dir: quickstart-ios/build-for-testing
+  # #       test_type: "xctest"
+
+  # sample-build-test:
+  #   # Don't run on private repo unless it is a PR.
   #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: macos-14
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: build-test
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Prereqs
+  #     run: scripts/install_prereqs.sh RemoteConfigSample iOS
+  #   - name: Build
+  #     run: scripts/build.sh RemoteConfigSample iOS
+
+  # remoteconfig-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   runs-on: macos-15
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos]
+  #       flags: [
+  #         '--skip-tests --use-static-frameworks'
+  #       ]
+  #   needs: pod_lib_lint
   #   steps:
   #   - uses: actions/checkout@v4
   #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #      python-version: '3.11'
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh config
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-  #         quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-  #   - name: Build Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Config)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
-
-  sample-build-test:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: build-test
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Prereqs
-      run: scripts/install_prereqs.sh RemoteConfigSample iOS
-    - name: Build
-      run: scripts/build.sh RemoteConfigSample iOS
-
-  remoteconfig-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macos-15
-    strategy:
-      matrix:
-        target: [ios, tvos, macos]
-        flags: [
-          '--skip-tests --use-static-frameworks'
-        ]
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: PodLibLint RemoteConfig Cron
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: PodLibLint RemoteConfig Cron
+  #     run: |
+  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -13,6 +13,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     - 'Gemfile*'
     - 'scripts/generate_access_token.sh'
     - 'scripts/gha-encrypted/RemoteConfigSwiftAPI/**'

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -26,68 +26,68 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm_1:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: RemoteConfigUnit
+  spm_1:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: RemoteConfigUnit
 
-  # spm_2:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: RemoteConfigFakeConsole
-  #     buildonly_platforms: watchOS
+  spm_2:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: RemoteConfigFakeConsole
+      buildonly_platforms: watchOS
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseRemoteConfig
-  #     target: FirebaseRemoteConfig-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseRemoteConfig
+      target: FirebaseRemoteConfig-Unit-unit
 
-  # remoteconfig:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     USE_REAL_CONSOLE: true
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       target: [iOS]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: rc${{ matrix.target }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install xcpretty
-  #     run: gem install xcpretty
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/RemoteConfigSwiftAPI/GoogleService-Info.plist.gpg \
-  #         FirebaseRemoteConfig/Tests/Swift/SwiftAPI/GoogleService-Info.plist "$plist_secret"
-  #   - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
-  #     if: matrix.target == 'iOS'
-  #     run: ([ -z $plist_secret ] || scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
-  #         FirebaseRemoteConfig/Tests/Swift/AccessToken.json)
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Fake Console API Tests
-  #    uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-  #    with:
-  #      timeout_minutes: 15
-  #      max_attempts: 3
-  #      retry_wait_seconds: 120
-  #      command: scripts/build.sh RemoteConfig ${{ matrix.target }} fakeconsole
-  #   - name: IntegrationTest
-  #     if: matrix.target == 'iOS'
-  #     # No retry to avoid exhausting AccessToken quota.
-  #     run: ([ -z $plist_secret ] || scripts/build.sh RemoteConfig iOS integration)
+  remoteconfig:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      USE_REAL_CONSOLE: true
+    runs-on: macos-15
+    strategy:
+      matrix:
+        target: [iOS]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: rc${{ matrix.target }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/RemoteConfigSwiftAPI/GoogleService-Info.plist.gpg \
+          FirebaseRemoteConfig/Tests/Swift/SwiftAPI/GoogleService-Info.plist "$plist_secret"
+    - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
+      if: matrix.target == 'iOS'
+      run: ([ -z $plist_secret ] || scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
+          FirebaseRemoteConfig/Tests/Swift/AccessToken.json)
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Fake Console API Tests
+     uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+     with:
+       timeout_minutes: 15
+       max_attempts: 3
+       retry_wait_seconds: 120
+       command: scripts/build.sh RemoteConfig ${{ matrix.target }} fakeconsole
+    - name: IntegrationTest
+      if: matrix.target == 'iOS'
+      # No retry to avoid exhausting AccessToken quota.
+      run: ([ -z $plist_secret ] || scripts/build.sh RemoteConfig iOS integration)
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseRemoteConfig
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseRemoteConfig
 
   quickstart:
     uses: ./.github/workflows/common_quickstart.yml
@@ -100,70 +100,70 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
-  # # quickstart-ftl-cron-only:
-  # #   # Don't run on private repo.
-  # #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  # #   env:
-  # #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  # #   runs-on: macos-14
-  # #   steps:
-  # #   - uses: actions/checkout@v4
-  # #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  # #   - uses: actions/setup-python@v5
-  # #     with:
-  # #      python-version: '3.11'
-  # #   - name: Setup quickstart
-  # #     run: scripts/setup_quickstart.sh config
-  # #   - name: Install Secret GoogleService-Info.plist
-  # #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-  # #         quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-  # #   - name: Build Swift Quickstart
-  # #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Config)
-  # #   - id: ftl_test
-  # #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  # #     with:
-  # #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  # #       testapp_dir: quickstart-ios/build-for-testing
-  # #       test_type: "xctest"
-
-  # sample-build-test:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: build-test
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Prereqs
-  #     run: scripts/install_prereqs.sh RemoteConfigSample iOS
-  #   - name: Build
-  #     run: scripts/build.sh RemoteConfigSample iOS
-
-  # remoteconfig-cron-only:
+  # TODO(@sunmou99): currently have issue with this job, will re-enable it once the issue resolved.
+  # quickstart-ftl-cron-only:
   #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-  #   runs-on: macos-15
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos, macos]
-  #       flags: [
-  #         '--skip-tests --use-static-frameworks'
-  #       ]
-  #   needs: pod_lib_lint
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: macos-14
   #   steps:
   #   - uses: actions/checkout@v4
   #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: PodLibLint RemoteConfig Cron
-  #     run: |
-  #       scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #      python-version: '3.11'
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh config
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+  #         quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+  #   - name: Build Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Config)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
+
+  sample-build-test:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: build-test
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Prereqs
+      run: scripts/install_prereqs.sh RemoteConfigSample iOS
+    - name: Build
+      run: scripts/build.sh RemoteConfigSample iOS
+
+  remoteconfig-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    runs-on: macos-15
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--skip-tests --use-static-frameworks'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint RemoteConfig Cron
+      run: |
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -84,8 +84,6 @@ jobs:
   #     product: FirebaseRemoteConfig
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     uses: ./.github/workflows/common_quickstart.yml
     with:
       product: Config

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -25,57 +25,57 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # spm:
-  #   uses: ./.github/workflows/common.yml
-  #   with:
-  #     target: FirebaseStorageUnit
+  spm:
+    uses: ./.github/workflows/common.yml
+    with:
+      target: FirebaseStorageUnit
 
-  # catalyst:
-  #   uses: ./.github/workflows/common_catalyst.yml
-  #   with:
-  #     product: FirebaseStorage
-  #     target: FirebaseStorage-Unit-unit
+  catalyst:
+    uses: ./.github/workflows/common_catalyst.yml
+    with:
+      product: FirebaseStorage
+      target: FirebaseStorage-Unit-unit
 
-  # storage-integration-tests:
-  #   # Don't run on private repo unless it is a PR.
-  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-  #   strategy:
-  #     matrix:
-  #       language: [Swift, ObjC]
-  #       include:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-  #     with:
-  #       cache_key: integration${{ matrix.os }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Install xcpretty
-  #     run: gem install xcpretty
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
-  #         FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
-  #   - name: Install Credentials.h
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
-  #         FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
-  #   - name: Install Credentials.swift
-  #     run: |
-  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
-  #         FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-  #     with:
-  #       timeout_minutes: 15
-  #       max_attempts: 3
-  #       retry_wait_seconds: 120
-  #       command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
+  storage-integration-tests:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        language: [Swift, ObjC]
+        include:
+          - os: macos-15
+            xcode: Xcode_16.4
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+      with:
+        cache_key: integration${{ matrix.os }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
+    - name: Install Credentials.h
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
+          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
+    - name: Install Credentials.swift
+      run: |
+        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
+          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        retry_wait_seconds: 120
+        command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
 
   quickstart:
     # TODO: See #12399 and restore Objective-C testing for Xcode 15 if GHA is fixed.
@@ -91,60 +91,60 @@ jobs:
     secrets:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  # quickstart-ftl-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     LEGACY: true
-  #   runs-on: macos-15
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: '3.11'
-  #   - name: Setup quickstart
-  #     run: scripts/setup_quickstart.sh storage
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-  #         quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-  #   # - name: Build objc quickstart
-  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage)
-  #   - name: Build swift quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage swift)
-  #   - id: ftl_test
-  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-  #     with:
-  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-  #       testapp_dir: quickstart-ios/build-for-testing
-  #       test_type: "xctest"
+  quickstart-ftl-cron-only:
+    # Don't run on private repo.
+    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      LEGACY: true
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Setup quickstart
+      run: scripts/setup_quickstart.sh storage
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+          quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+    # - name: Build objc quickstart
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage)
+    - name: Build swift quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage swift)
+    - id: ftl_test
+      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+      with:
+        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+        testapp_dir: quickstart-ios/build-for-testing
+        test_type: "xctest"
 
-  # pod_lib_lint:
-  #   uses: ./.github/workflows/common_cocoapods.yml
-  #   with:
-  #     product: FirebaseStorage
-  #     test_specs: unit
+  pod_lib_lint:
+    uses: ./.github/workflows/common_cocoapods.yml
+    with:
+      product: FirebaseStorage
+      test_specs: unit
 
-  # storage-cron-only:
-  #   # Don't run on private repo.
-  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-  #   strategy:
-  #     matrix:
-  #       target: [ios, tvos, macos, watchos]
-  #       build-env:
-  #         - os: macos-14
-  #           xcode: Xcode_16.2
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   needs: pod_lib_lint
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Setup Bundler
-  #     run: scripts/setup_bundler.sh
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: PodLibLint Storage Cron
-  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} --use-static-frameworks --skip-tests
+  storage-cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    strategy:
+      matrix:
+        target: [ios, tvos, macos, watchos]
+        build-env:
+          - os: macos-14
+            xcode: Xcode_16.2
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: PodLibLint Storage Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} --use-static-frameworks --skip-tests

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -24,141 +24,126 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  spm:
-    uses: ./.github/workflows/common.yml
-    with:
-      target: FirebaseStorageUnit
+  # spm:
+  #   uses: ./.github/workflows/common.yml
+  #   with:
+  #     target: FirebaseStorageUnit
 
-  catalyst:
-    uses: ./.github/workflows/common_catalyst.yml
-    with:
-      product: FirebaseStorage
-      target: FirebaseStorage-Unit-unit
+  # catalyst:
+  #   uses: ./.github/workflows/common_catalyst.yml
+  #   with:
+  #     product: FirebaseStorage
+  #     target: FirebaseStorage-Unit-unit
 
-  storage-integration-tests:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        language: [Swift, ObjC]
-        include:
-          - os: macos-15
-            xcode: Xcode_16.4
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
-      with:
-        cache_key: integration${{ matrix.os }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
-          FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
-    - name: Install Credentials.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
-          FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
-    - name: Install Credentials.swift
-      run: |
-        scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
-          FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
-      with:
-        timeout_minutes: 15
-        max_attempts: 3
-        retry_wait_seconds: 120
-        command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
+  # storage-integration-tests:
+  #   # Don't run on private repo unless it is a PR.
+  #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+  #   strategy:
+  #     matrix:
+  #       language: [Swift, ObjC]
+  #       include:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: mikehardy/buildcache-action@c87cea0ccd718971d6cc39e672c4f26815b6c126
+  #     with:
+  #       cache_key: integration${{ matrix.os }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Install xcpretty
+  #     run: gem install xcpretty
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+  #         FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
+  #   - name: Install Credentials.h
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.h.gpg \
+  #         FirebaseStorage/Tests/ObjCIntegration/Credentials.h "$plist_secret"
+  #   - name: Install Credentials.swift
+  #     run: |
+  #       scripts/decrypt_gha_secret.sh scripts/gha-encrypted/Storage/Credentials.swift.gpg \
+  #         FirebaseStorage/Tests/Integration/Credentials.swift "$plist_secret"
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+  #     with:
+  #       timeout_minutes: 15
+  #       max_attempts: 3
+  #       retry_wait_seconds: 120
+  #       command: ([ -z $plist_secret ] || scripts/build.sh Storage${{ matrix.language }} all)
 
   quickstart:
-    # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     # TODO: See #12399 and restore Objective-C testing for Xcode 15 if GHA is fixed.
-    strategy:
-      matrix:
-        include:
-          #- os: macos-13
-          #  xcode: Xcode_14.2 # TODO: the legacy ObjC quickstart doesn't build with Xcode 15.
-          - swift: swift
-            os: macos-15
-            xcode: Xcode_16.4
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      LEGACY: true
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh storage
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-          quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Test quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage false ${{ matrix.swift }})
-
-  quickstart-ftl-cron-only:
-    # Don't run on private repo.
-    if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      LEGACY: true
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Setup quickstart
-      run: scripts/setup_quickstart.sh storage
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-          quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    # - name: Build objc quickstart
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage)
-    - name: Build swift quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage swift)
-    - id: ftl_test
-      uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
-      with:
-        credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
-        testapp_dir: quickstart-ios/build-for-testing
-        test_type: "xctest"
-
-  pod_lib_lint:
-    uses: ./.github/workflows/common_cocoapods.yml
+    uses: ./.github/workflows/common_quickstart.yml
     with:
-      product: FirebaseStorage
-      test_specs: unit
+      product: Storage
+      quickstart_type: swift
+      is_legacy: true
+      setup_command: scripts/setup_quickstart.sh storage
+      plist_src_path: scripts/gha-encrypted/qs-storage.plist.gpg
+      plist_dst_path: quickstart-ios/storage/GoogleService-Info.plist
+      run_tests: false
+    secrets:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
 
-  storage-cron-only:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    strategy:
-      matrix:
-        target: [ios, tvos, macos, watchos]
-        build-env:
-          - os: macos-14
-            xcode: Xcode_16.2
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    needs: pod_lib_lint
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: PodLibLint Storage Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} --use-static-frameworks --skip-tests
+  # quickstart-ftl-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     LEGACY: true
+  #   runs-on: macos-15
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: '3.11'
+  #   - name: Setup quickstart
+  #     run: scripts/setup_quickstart.sh storage
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+  #         quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+  #   # - name: Build objc quickstart
+  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage)
+  #   - name: Build swift quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Storage swift)
+  #   - id: ftl_test
+  #     uses: FirebaseExtended/github-actions/firebase-test-lab@v1.4
+  #     with:
+  #       credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
+  #       testapp_dir: quickstart-ios/build-for-testing
+  #       test_type: "xctest"
+
+  # pod_lib_lint:
+  #   uses: ./.github/workflows/common_cocoapods.yml
+  #   with:
+  #     product: FirebaseStorage
+  #     test_specs: unit
+
+  # storage-cron-only:
+  #   # Don't run on private repo.
+  #   if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+  #   strategy:
+  #     matrix:
+  #       target: [ios, tvos, macos, watchos]
+  #       build-env:
+  #         - os: macos-14
+  #           xcode: Xcode_16.2
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   needs: pod_lib_lint
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: PodLibLint Storage Cron
+  #     run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} --use-static-frameworks --skip-tests

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -13,6 +13,7 @@ on:
     - '.github/workflows/common.yml'
     - '.github/workflows/common_cocoapods.yml'
     - '.github/workflows/common_catalyst.yml'
+    - '.github/workflows/common_quickstart.yml'
     # Rebuild on Ruby infrastructure changes.
     - 'Gemfile*'
   schedule:


### PR DESCRIPTION
It's not a red diff, but is cleaner. I've added more functionality like automatic uploads of failed quickstart folders and we have a central Xcode configuration hook for quickstart tests.

#no-changelog