### PR TITLE
chore(ci): Remove unused env vars in .github/workflows/[pre]release.yml

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -45,7 +45,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -70,7 +69,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -97,7 +97,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -117,7 +116,6 @@ jobs:
 
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #   runs-on: macos-14
   #   steps:
   #   - uses: actions/checkout@v4

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -47,7 +47,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -77,7 +76,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -73,7 +73,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -605,7 +605,6 @@ jobs:
   #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #   runs-on: macos-14
   #   needs: check
 

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -56,7 +56,6 @@ jobs:
   #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #     LEGACY: true
   #   # TODO: Move to macos-14 and Xcode 15. The legacy quickstart uses material which doesn't build on Xcode 15.
   #   runs-on: macos-12
@@ -83,7 +82,6 @@ jobs:
   #   if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #     LEGACY: true
   #   # TODO: Move to macos-14 and Xcode 15. The legacy quickstart uses material which doesn't build on Xcode 15.
   #   runs-on: macos-12

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -90,7 +90,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
 
     steps:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -84,7 +84,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     strategy:
       matrix:
         include:
@@ -113,7 +112,6 @@ jobs:
     if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -81,7 +81,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -104,7 +103,6 @@ jobs:
 
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -220,7 +220,6 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -256,7 +255,6 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -286,10 +284,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -329,10 +324,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -363,10 +355,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -397,10 +386,7 @@ jobs:
     # needs: buildup_SpecsTesting_repo
     # env:
     #   plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    #   signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     #   botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-    #   testing_repo_dir: "/tmp/test/"
-    #   testing_repo: "firebase-ios-sdk"
     #   LEGACY: true
     # # TODO: The functions quickstart uses Material which isn't supported by Xcode 15
     # runs-on: macos-12
@@ -437,10 +423,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -473,10 +456,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -509,7 +489,6 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -539,10 +518,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
       LEGACY: true
     runs-on: macos-15
     steps:
@@ -572,10 +548,7 @@ jobs:
     needs: buildup_SpecsTesting_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.PRERELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,6 @@ jobs:
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #     botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-  #     testing_repo: "firebase-ios-sdk"
   #     LEGACY: true
   #   runs-on: macos-12
   #   steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,6 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -192,7 +191,6 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -222,10 +220,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -265,10 +260,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -299,10 +291,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -333,9 +322,7 @@ jobs:
   #   needs: buildup_SpecsReleasing_repo
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #     botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-  #     testing_repo_dir: "/tmp/test/"
   #     testing_repo: "firebase-ios-sdk"
   #     LEGACY: true
   #   runs-on: macos-12
@@ -370,10 +357,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -406,10 +390,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -442,7 +423,6 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
     runs-on: macos-15
     steps:
@@ -472,10 +452,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
       LEGACY: true
     runs-on: macos-15
     steps:
@@ -505,10 +482,7 @@ jobs:
     needs: buildup_SpecsReleasing_repo
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       botaccess: ${{ secrets.RELEASE_TESTING_PAT }}
-      testing_repo_dir: "/tmp/test/"
-      testing_repo: "firebase-ios-sdk"
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -88,7 +88,6 @@ jobs:
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
@@ -109,7 +108,6 @@ jobs:
   #   if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #   runs-on: macos-14
   #   steps:
   #   - uses: actions/checkout@v4

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -90,7 +90,6 @@ jobs:
             xcode: Xcode_16.4
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       LEGACY: true
     runs-on: ${{ matrix.os }}
     steps:
@@ -111,7 +110,6 @@ jobs:
     if: github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule'
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       LEGACY: true
     runs-on: macos-15
     steps:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -107,7 +107,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"
     strategy:
       matrix:
@@ -166,7 +165,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK:  "Authentication"
     strategy:
       matrix:
@@ -217,7 +215,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Config"
     strategy:
       matrix:
@@ -266,7 +263,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Crashlytics"
     strategy:
       matrix:
@@ -338,7 +334,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Database"
     strategy:
       matrix:
@@ -390,7 +385,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Firestore"
     strategy:
       matrix:
@@ -478,7 +472,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "InAppMessaging"
     strategy:
       matrix:
@@ -531,7 +524,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Messaging"
     strategy:
       matrix:
@@ -584,7 +576,6 @@ jobs:
     needs: package-head
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Storage"
     strategy:
       matrix:


### PR DESCRIPTION
Remove unused env vars.
- firebase-ios-sdk:
```console
nickcooke@nickcooke-mac2 firebase-ios-sdk (nc/unused-env) % git grep -E "testing_repo|signin_secret|testing_repo_dir"
.github/workflows/generate_issues.yml:    - '.github/actions/testing_report_generation**'
.github/workflows/generate_issues.yml:      uses: ./.github/actions/testing_report_generation/
.github/workflows/generate_issues.yml:      uses: ./.github/actions/testing_report_generation/
```
- quickstart:
```console
nickcooke@nickcooke-mac2 quickstart-ios (main) % git grep -E "testing_repo|signin_secret|testing_repo_dir"
nickcooke@nickcooke-mac2 quickstart-ios (main) % 
```