### PR TITLE
fix(ci): Update to clang-format@21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@20
+    brew install clang-format@21
     brew install mint
     ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GitHub Actions will verify that any code changes are done in a style-compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@20
+brew install clang-format@21
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@20
+brew install clang-format@21
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -56,7 +56,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  20)
+  21)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -65,7 +65,7 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 20."
+    echo "Please upgrade to clang-format version 21."
     echo "If it's installed via homebrew you can run:"
     echo "brew upgrade clang-format"
     exit 1


### PR DESCRIPTION
clang-format is used to style code. There's a bug where new versions on homebrew boot the older version off. The check CI workflow fails as a result and we need to periodically bump clang-format to the new version.
```console
git grep --name-only "clang-format@20" | xargs sed -i '' "s/clang-format@20/clang-format@21/"
```

#no-changelog