### PR TITLE
chore(ci): Upload failing build log in firebasepod.yml

### DIFF
--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -39,3 +39,8 @@ jobs:
       run: scripts/install_prereqs.sh FirebasePod iOS
     - name: Build
       run: scripts/build.sh FirebasePod iOS
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: firebasepod-xcodebuild-build.log
+        path: xcodebuild-build.log


### PR DESCRIPTION
Debugging nightly failure– https://github.com/firebase/firebase-ios-sdk/issues/15257

edit: This ended up passing last night. I could revert this, but maybe it's useful for understanding a future failure?

#no-changelog