### PR TITLE
[Release] Update Carthage artifacts for 12.2.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseABTesting-5436773ba2b9326e.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseABTesting-bd721c84362383a6.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseABTesting-bb0e44f97fd81c31.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseABTesting-328b9123860fa215.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/ABTesting-a71d17cadc209af9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAIBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAIBinary.json
@@ -3,5 +3,6 @@
   "11.14.0": "https://dl.google.com/dl/firebase/ios/carthage/11.14.0/FirebaseAI-0991ef5c3a83833a.zip",
   "11.15.0": "https://dl.google.com/dl/firebase/ios/carthage/11.15.0/FirebaseAI-ba1237ee5b7a5baa.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAI-05a4568076093001.zip",
-  "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAI-1fa7d016c66b2331.zip"
+  "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAI-1fa7d016c66b2331.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAI-8fac222fb35cd84e.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAnalytics-fe649e5740ef72e9.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAnalytics-70ead21957efa870.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAnalytics-88dad74aa8ab040a.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAnalytics-b37787f72cdbb950.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Analytics-2468c231ebeb7922.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Analytics-bc8101d420b896c5.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Analytics-d2b6a6b0242db786.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAppCheck-366c926c105319b0.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAppCheck-b9f47f169bb6249c.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAppCheck-072a1be1f8eb1177.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppCheck-dac2380c7e1b9898.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppCheck-9ef1d217cf057203.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseAppCheck-fc03215d9fe45d3a.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseAppCheck-6ebe9e9539f06003.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAppDistribution-32e12df219d91736.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAppDistribution-076c2c6efb7eb8dc.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAppDistribution-370884f5f825f098.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppDistribution-042b04483c9241b6.zip",
   "6.31.0": "https://dl.google.com/dl/firebase/ios/carthage/6.31.0/FirebaseAppDistribution-07f6a2cf7f576a8a.zip",
   "6.32.0": "https://dl.google.com/dl/firebase/ios/carthage/6.32.0/FirebaseAppDistribution-a9c4f5db794508ca.zip",
   "6.33.0": "https://dl.google.com/dl/firebase/ios/carthage/6.33.0/FirebaseAppDistribution-448a96d2ade54581.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAuth-ab131b2e07abc902.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAuth-e58b2b5f430bfbfe.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAuth-2c17100b302eb080.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAuth-9f0a14da6c12ea6d.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Auth-0fa76ba0f7956220.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Auth-5ddd2b4351012c7a.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Auth-5e248984d78d7284.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseCrashlytics-81aa29d9a106acb0.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseCrashlytics-d9a9be2a4e220017.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseCrashlytics-fbf241b0c59f3821.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseCrashlytics-623ce628d0404f39.zip",
   "6.15.0": "https://dl.google.com/dl/firebase/ios/carthage/6.15.0/FirebaseCrashlytics-1c6d22d5b73c84fd.zip",
   "6.16.0": "https://dl.google.com/dl/firebase/ios/carthage/6.16.0/FirebaseCrashlytics-938e5fd0e2eab3b3.zip",
   "6.17.0": "https://dl.google.com/dl/firebase/ios/carthage/6.17.0/FirebaseCrashlytics-fa09f0c8f31ed5d9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseDatabase-8b970d6e0f67a415.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseDatabase-18b95ef28b89f3db.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseDatabase-d6c24e13e4b05437.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseDatabase-a87ae96a7eeb2535.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Database-1f7a820452722c7d.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Database-1f7a820452722c7d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Database-59a12d87456b3e1c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseFirestore-30a2451150d46015.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseFirestore-635c7c2864cdd1a9.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseFirestore-6098779ef7b7b151.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFirestore-8d65b82dc9d53ddf.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Firestore-68fc02c229d0cc69.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Firestore-87a804ab561d91db.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Firestore-ecb3eea7bde7e8e8.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseFunctions-1681244d37d89040.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseFunctions-2ac7bbbaf94c52e1.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseFunctions-f4a1c660d9a2ea75.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFunctions-f3aa95160827b0af.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Functions-f4c426016dd41e38.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Functions-c6c44427c3034736.zip",
   "5.0.0": "https://dl.google.com/dl/firebase/ios/carthage/5.0.0/Functions-146f34c401bd459b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/GoogleSignIn-d4359fb699843869.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/GoogleSignIn-b924d38d37bc920a.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/GoogleSignIn-01f98c11db934294.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/GoogleSignIn-31b2e32d1dadbaa8.zip",
   "6.0.0": "https://dl.google.com/dl/firebase/ios/carthage/6.0.0/GoogleSignIn-de9c5d5e8eb6d6ea.zip",
   "6.1.0": "https://dl.google.com/dl/firebase/ios/carthage/6.1.0/GoogleSignIn-8c82f2870573a793.zip",
   "6.10.0": "https://dl.google.com/dl/firebase/ios/carthage/6.10.0/GoogleSignIn-ff3aef61c4a55b05.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseInAppMessaging-67bccdf31b1dc458.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseInAppMessaging-59f9fc54fc4eecb5.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseInAppMessaging-78a0d591fb574512.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseInAppMessaging-0ec7907b67ce2888.zip",
   "5.10.0": "https://dl.google.com/dl/firebase/ios/carthage/5.10.0/InAppMessaging-a7a3f933362f6e95.zip",
   "5.11.0": "https://dl.google.com/dl/firebase/ios/carthage/5.11.0/InAppMessaging-fa28ce1b88fbca93.zip",
   "5.12.0": "https://dl.google.com/dl/firebase/ios/carthage/5.12.0/InAppMessaging-fa28ce1b88fbca93.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseMLModelDownloader-2d08410294abf160.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseMLModelDownloader-1f183c6e3be7cab3.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseMLModelDownloader-3864d35f4429bc08.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMLModelDownloader-6bfb3459ae557ef3.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMLModelDownloader-8f972757fb181320.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseMLModelDownloader-058ad59fa6dc0111.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseMLModelDownloader-286479a966d2fb37.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseMessaging-379bf3738f94ef44.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseMessaging-0f018ab3d7701839.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseMessaging-252cac88c87e9c55.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMessaging-d1ab6eaf596d9b7d.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Messaging-a22ef2b5f2f30f82.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Messaging-94fa4e090c7e9185.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Messaging-2a00a1c64a19d176.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebasePerformance-9a2f8d3983650cea.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebasePerformance-0df8c67ab3cb665c.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebasePerformance-dec4dc5c3edadd9a.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebasePerformance-1913383f1952dce6.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Performance-d8693eb892bfa05b.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Performance-0a400f9460f7a71d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Performance-f5b4002ab96523e4.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseRemoteConfig-7455afe6f2231467.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseRemoteConfig-5894aa4820a265ae.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseRemoteConfig-bb5ba29a5f73cd24.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseRemoteConfig-3e803b148769baed.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/RemoteConfig-7e9635365ccd4a17.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/RemoteConfig-e7928fcb6311c439.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/RemoteConfig-9ab1ca5f360a1780.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseStorage-5a28ee1b2244be55.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseStorage-21ed034a4fa51f2a.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseStorage-faeffdccd0d44a7c.zip",
+  "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseStorage-20489713b94790a0.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Storage-6b3e77e1a7fdbc61.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Storage-4721c35d2b90a569.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Storage-821299369b9d0fb2.zip",


### PR DESCRIPTION
Updated the Carthage JSON artifacts for the https://github.com/firebase/firebase-ios-sdk/releases/tag/12.2.0.

#no-changelog