### PR TITLE
[CI] Replace refs to `qs-auth.plist.gpg` with updated name

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -98,7 +98,7 @@ jobs:
       product: Authentication
       is_legacy: false
       setup_command: scripts/setup_quickstart.sh authentication
-      plist_src_path: scripts/gha-encrypted/qs-auth.plist.gpg
+      plist_src_path: scripts/gha-encrypted/qs-authentication.plist.gpg
       plist_dst_path: quickstart-ios/authentication/GoogleService-Info.plist
       run_tests: false
     secrets:
@@ -122,7 +122,7 @@ jobs:
   #   - name: Setup quickstart
   #     run: scripts/setup_quickstart.sh authentication
   #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
   #         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
   #   - name: Build swift quickstart
   #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_ftl.sh Authentication)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
     - name: Setup testing repo and quickstart
       run: BOT_TOKEN="${botaccess}" scripts/setup_quickstart.sh Authentication nightly_release_testing
     - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
           quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
     - name: Test swift quickstart
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Authentication false)

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -196,7 +196,7 @@ jobs:
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
         quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
     - name: Test Swift Quickstart
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")


### PR DESCRIPTION
Replaced references to `qs-auth.plist.gpg`, which is now named `qs-authentication.plist.gpg`.

#no-changelog
