### PR TITLE
feat(ci): Add support for using previous zip run artifact

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -24,7 +24,7 @@ on:
       zip_run_id:
         description: 'Run ID of a previous successful zip workflow to use for quickstart testing'
         required: false
-        default: ''
+        default: '17314248036'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -113,36 +113,6 @@ jobs:
         # name of.
         path: zip_output_dir
 
-  # quickstart_framework_abtesting:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "ABTesting"
-  #   strategy:
-  #     matrix:
-  #       # Temporarily remove the artifact matrix for this test.
-  #       # artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-
-  #   - name: Get ALL framework artifacts (DEBUG)
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       # No 'name' is specified, so it will download everything.
-  #       run-id: ${{ github.event.inputs.zip_run_id }}
-
-  #   - name: See what was downloaded
-  #     run: ls -R
-
-  #   # You can comment out the rest of the steps for this test run.
-  #   # - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   # ... etc
-
   quickstart_framework_abtesting:
     needs: package-head
     if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
@@ -498,7 +468,7 @@ jobs:
         with:
           name: Firebase-actions-dir
           run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,7 +111,7 @@ jobs:
 
   quickstart_framework_abtesting:
     needs: package-head
-    if: ${{ !cancelled() }} # || (cancelled() && github.event.inputs.zip_run_id != '')
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -167,7 +167,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_auth:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: ${{ event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK:  "Authentication"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,7 +111,7 @@ jobs:
 
   quickstart_framework_abtesting:
     needs: package-head
-    if: !cancelled() # || (cancelled() && github.event.inputs.zip_run_id != '')
+    if: ${{ !cancelled() }} # || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -21,6 +21,10 @@ on:
         description: 'Custom Podspec repos'
         required: true
         default: 'https://github.com/firebase/SpecsStaging.git'
+      zip_run_id:
+        description: 'Run ID of a previous successful zip workflow to use for quickstart testing'
+        required: false
+        default: ''
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -29,7 +33,10 @@ concurrency:
 jobs:
   package-release:
     # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.repository == 'firebase/firebase-ios-sdk' &&
+      contains(fromJSON('["schedule", "pull_request", "workflow_dispatch"]'), github.event_name) &&
+      github.event.inputs.zip_run_id == ''
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -57,7 +64,10 @@ jobs:
 
   build:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.repository == 'firebase/firebase-ios-sdk' &&
+      contains(fromJSON('["schedule", "pull_request", "workflow_dispatch"]'), github.event_name) &&
+      github.event.inputs.zip_run_id == ''
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -69,8 +79,6 @@ jobs:
         swift build -v
 
   package-head:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     needs: build
     strategy:
       matrix:
@@ -102,9 +110,7 @@ jobs:
         path: zip_output_dir
 
   quickstart_framework_abtesting:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"
@@ -121,6 +127,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -160,9 +167,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_auth:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK:  "Authentication"
@@ -180,6 +185,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -210,9 +216,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_config:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Config"
@@ -229,6 +233,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -258,9 +263,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_crashlytics:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Crashlytics"
@@ -277,6 +280,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -329,9 +333,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_database:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Database"
@@ -347,6 +349,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -380,9 +383,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_firestore:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Firestore"
@@ -399,6 +400,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -436,9 +438,7 @@ jobs:
         path: quickstart_artifacts_firestore.zip
 
   check_framework_firestore_symbols:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-14
@@ -450,6 +450,7 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: Firebase-actions-dir
+          run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
@@ -467,9 +468,7 @@ jobs:
             "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
   quickstart_framework_inappmessaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "InAppMessaging"
@@ -486,6 +485,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -519,9 +519,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_messaging:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Messaging"
@@ -538,6 +536,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -571,9 +570,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_storage:
-    # Don't run on private repo.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    needs: package-head
+    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Storage"
@@ -590,6 +587,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
+        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -26,9 +26,11 @@ on:
         required: true
         default: 'https://github.com/firebase/SpecsStaging.git'
       zip_run_id:
+        # For example, in the below URL, `17335533279` is the run ID:
+        # - https://github.com/firebase/firebase-ios-sdk/actions/runs/17335533279
         description: 'Run ID of a previous successful zip workflow to use for quickstart testing'
         required: false
-        default: '17314248036'
+        default: ''
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -121,526 +121,556 @@ jobs:
       SDK: "ABTesting"
     strategy:
       matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        # Temporarily remove the artifact matrix for this test.
+        # artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
         build-env:
           - os: macos-15
             xcode: Xcode_16.4
     runs-on: ${{ matrix.build-env.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Get framework dir
+
+    - name: Get ALL framework artifacts (DEBUG)
       uses: actions/download-artifact@v4.1.7
       with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh abtesting
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_abtesting
-        path: quickstart-ios/
+        # No 'name' is specified, so it will download everything.
+        run-id: ${{ github.event.inputs.zip_run_id }}
 
-  quickstart_framework_auth:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK:  "Authentication"
-    strategy:
-      matrix:
-        os: [macos-15]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        include:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
-        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh authentiation
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_auth
-        path: quickstart-ios/
+    - name: See what was downloaded
+      run: ls -R
 
-  quickstart_framework_config:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Config"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - name: Setup Swift Quickstart
+    # You can comment out the rest of the steps for this test run.
+    # - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    # ... etc
 
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh config
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_config
-        path: quickstart-ios/
+  # quickstart_framework_abtesting:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "ABTesting"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh abtesting
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_abtesting
+  #       path: quickstart-ios/
 
-  quickstart_framework_crashlytics:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Crashlytics"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: |
-              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Setup swift quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: |
-    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Test Swift Quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh crashlytics
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_crashlytics
-        path: quickstart-ios/
+  # quickstart_framework_auth:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK:  "Authentication"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-15]
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       include:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Swift Quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
+  #       quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh authentiation
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_auth
+  #       path: quickstart-ios/
 
-  quickstart_framework_database:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Database"
-    strategy:
-      matrix:
-        os: [macos-14]
-        xcode: [Xcode_16.2]
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh database
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts database
-        path: quickstart-ios/
+  # quickstart_framework_config:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Config"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - name: Setup Swift Quickstart
 
-  quickstart_framework_firestore:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Firestore"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Upload build logs on failure
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: build_logs_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
-        path: sdk_zip/build_logs/
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload and zip directory to reduce upload size.
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh firestore; zip -r --symlinks quickstart_artifacts_firestore.zip quickstart-ios/
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
-        path: quickstart_artifacts_firestore.zip
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh config
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_config
+  #       path: quickstart-ios/
 
-  check_framework_firestore_symbols:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-    runs-on: macos-14
-    steps:
-      - name: Xcode 16.2
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-      - uses: actions/checkout@v4
-      - name: Get framework dir
-        uses: actions/download-artifact@v4.1.7
-        with:
-          name: Firebase-actions-dir
-          run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-      - name: Setup Bundler
-        run: ./scripts/setup_bundler.sh
-      - name: Install xcpretty
-        run: gem install xcpretty
-      - name: Move frameworks
-        run: |
-          mkdir -p "${HOME}"/ios_frameworks/
-          find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-      - uses: actions/checkout@v4
-      - name: Check linked Firestore.xcframework for unlinked symbols.
-        run: |
-          scripts/check_firestore_symbols.sh \
-            $(pwd) \
-            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
+  # quickstart_framework_crashlytics:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Crashlytics"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: |
+  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Setup swift quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: |
+  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   # TODO(#8057): Restore Swift Quickstart
+  #   # - name: Test Swift Quickstart
+  #   #   env:
+  #   #     LEGACY: true
+  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh crashlytics
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_crashlytics
+  #       path: quickstart-ios/
 
-  quickstart_framework_inappmessaging:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "InAppMessaging"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh inappmessaging
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_inappmessaging
-        path: quickstart-ios/
+  # quickstart_framework_database:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Database"
+  #   strategy:
+  #     matrix:
+  #       os: [macos-14]
+  #       xcode: [Xcode_16.2]
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh database
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts database
+  #       path: quickstart-ios/
 
-  quickstart_framework_messaging:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Messaging"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh messaging
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_messaging
-        path: quickstart-ios/
+  # quickstart_framework_firestore:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Firestore"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Upload build logs on failure
+  #     if: ${{ failure() }}
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: build_logs_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
+  #       path: sdk_zip/build_logs/
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Remove data before upload and zip directory to reduce upload size.
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh firestore; zip -r --symlinks quickstart_artifacts_firestore.zip quickstart-ios/
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
+  #       path: quickstart_artifacts_firestore.zip
 
-  quickstart_framework_storage:
-    needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "Storage"
-    strategy:
-      matrix:
-        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get framework dir
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ matrix.artifact }}
-        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    - name: Xcode
-      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-    - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
-    - name: Move frameworks
-      run: |
-        mkdir -p "${HOME}"/ios_frameworks/
-        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-    - uses: actions/checkout@v4
-    - name: Setup quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      env:
-        LEGACY: true
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    - name: Test Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      env:
-        LEGACY: true
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      env:
-        LEGACY: true
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh storage
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts_storage
-        path: quickstart-ios/
+  # check_framework_firestore_symbols:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+  #   runs-on: macos-14
+  #   steps:
+  #     - name: Xcode 16.2
+  #       run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+  #     - uses: actions/checkout@v4
+  #     - name: Get framework dir
+  #       uses: actions/download-artifact@v4.1.7
+  #       with:
+  #         name: Firebase-actions-dir
+  #         run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #     - name: Setup Bundler
+  #       run: ./scripts/setup_bundler.sh
+  #     - name: Install xcpretty
+  #       run: gem install xcpretty
+  #     - name: Move frameworks
+  #       run: |
+  #         mkdir -p "${HOME}"/ios_frameworks/
+  #         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #     - uses: actions/checkout@v4
+  #     - name: Check linked Firestore.xcframework for unlinked symbols.
+  #       run: |
+  #         scripts/check_firestore_symbols.sh \
+  #           $(pwd) \
+  #           "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
+
+  # quickstart_framework_inappmessaging:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "InAppMessaging"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh inappmessaging
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_inappmessaging
+  #       path: quickstart-ios/
+
+  # quickstart_framework_messaging:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Messaging"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh messaging
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_messaging
+  #       path: quickstart-ios/
+
+  # quickstart_framework_storage:
+  #   needs: package-head
+  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+  #   env:
+  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+  #     SDK: "Storage"
+  #   strategy:
+  #     matrix:
+  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       build-env:
+  #         - os: macos-15
+  #           xcode: Xcode_16.4
+  #   runs-on: ${{ matrix.build-env.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Get framework dir
+  #     uses: actions/download-artifact@v4.1.7
+  #     with:
+  #       name: ${{ matrix.artifact }}
+  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - name: Xcode
+  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+  #   - name: Setup Bundler
+  #     run: ./scripts/setup_bundler.sh
+  #   - name: Move frameworks
+  #     run: |
+  #       mkdir -p "${HOME}"/ios_frameworks/
+  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+  #   - uses: actions/checkout@v4
+  #   - name: Setup quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+  #   - name: Setup swift quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+  #   - name: Install Secret GoogleService-Info.plist
+  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+  #   - name: Test Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+  #   - name: Test Swift Quickstart
+  #     env:
+  #       LEGACY: true
+  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+  #   - name: Remove data before upload
+  #     env:
+  #       LEGACY: true
+  #     if: ${{ failure() }}
+  #     run: scripts/remove_data.sh storage
+  #   - uses: actions/upload-artifact@v4
+  #     if: ${{ failure() }}
+  #     with:
+  #       name: quickstart_artifacts_storage
+  #       path: quickstart-ios/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -110,7 +110,8 @@ jobs:
         path: zip_output_dir
 
   quickstart_framework_abtesting:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"
@@ -167,7 +168,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_auth:
-    needs: ${{ event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK:  "Authentication"
@@ -216,7 +218,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_config:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Config"
@@ -263,7 +266,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_crashlytics:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Crashlytics"
@@ -333,7 +337,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_database:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Database"
@@ -383,7 +388,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_firestore:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Firestore"
@@ -438,7 +444,8 @@ jobs:
         path: quickstart_artifacts_firestore.zip
 
   check_framework_firestore_symbols:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-14
@@ -468,7 +475,8 @@ jobs:
             "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
   quickstart_framework_inappmessaging:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "InAppMessaging"
@@ -519,7 +527,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_messaging:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Messaging"
@@ -570,7 +579,8 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_storage:
-    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: package-head
+    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Storage"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -113,36 +113,6 @@ jobs:
         # name of.
         path: zip_output_dir
 
-  quickstart_framework_abtesting:
-    needs: package-head
-    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      SDK: "ABTesting"
-    strategy:
-      matrix:
-        # Temporarily remove the artifact matrix for this test.
-        # artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-        build-env:
-          - os: macos-15
-            xcode: Xcode_16.4
-    runs-on: ${{ matrix.build-env.os }}
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Get ALL framework artifacts (DEBUG)
-      uses: actions/download-artifact@v4.1.7
-      with:
-        # No 'name' is specified, so it will download everything.
-        run-id: ${{ github.event.inputs.zip_run_id }}
-
-    - name: See what was downloaded
-      run: ls -R
-
-    # You can comment out the rest of the steps for this test run.
-    # - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-    # ... etc
-
   # quickstart_framework_abtesting:
   #   needs: package-head
   #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
@@ -151,55 +121,86 @@ jobs:
   #     SDK: "ABTesting"
   #   strategy:
   #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+  #       # Temporarily remove the artifact matrix for this test.
+  #       # artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
   #       build-env:
   #         - os: macos-15
   #           xcode: Xcode_16.4
   #   runs-on: ${{ matrix.build-env.os }}
   #   steps:
   #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
+
+  #   - name: Get ALL framework artifacts (DEBUG)
   #     uses: actions/download-artifact@v4.1.7
   #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-  #       quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh abtesting
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_abtesting
-  #       path: quickstart-ios/
+  #       # No 'name' is specified, so it will download everything.
+  #       run-id: ${{ github.event.inputs.zip_run_id }}
+
+  #   - name: See what was downloaded
+  #     run: ls -R
+
+  #   # You can comment out the rest of the steps for this test run.
+  #   # - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   # ... etc
+
+  quickstart_framework_abtesting:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "ABTesting"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCoreInternal.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FBLPromises.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
+        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh abtesting
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_abtesting
+        path: quickstart-ios/
 
   # quickstart_framework_auth:
   #   needs: package-head

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -110,7 +110,7 @@ jobs:
         path: zip_output_dir
 
   quickstart_framework_abtesting:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -79,9 +79,8 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - name: Build
       run: |
-        exit 1
         cd ReleaseTooling
-        swift build -v
+#        swift build -v
 
   package-head:
     needs: build
@@ -101,6 +100,7 @@ jobs:
       run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
       run: |
+         exit 1
          mkdir -p zip_output_dir
          sh -x scripts/build_zip.sh \
            zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,7 +111,7 @@ jobs:
 
   quickstart_framework_abtesting:
     needs: package-head
-    if: success() || (cancelled() && github.event.inputs.zip_run_id != '')
+    if: !cancelled() # || (cancelled() && github.event.inputs.zip_run_id != '')
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,5 +1,9 @@
 name: zip
 
+permissions:
+  actions: read
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -110,7 +110,7 @@ jobs:
         path: zip_output_dir
 
   quickstart_framework_abtesting:
-    needs: event.inputs.zip_run_id == '' && 'package-head' || ''
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "ABTesting"
@@ -167,7 +167,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_auth:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK:  "Authentication"
@@ -216,7 +216,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_config:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Config"
@@ -263,7 +263,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_crashlytics:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Crashlytics"
@@ -333,7 +333,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_database:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Database"
@@ -383,7 +383,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_firestore:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Firestore"
@@ -438,7 +438,7 @@ jobs:
         path: quickstart_artifacts_firestore.zip
 
   check_framework_firestore_symbols:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-14
@@ -468,7 +468,7 @@ jobs:
             "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
   quickstart_framework_inappmessaging:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "InAppMessaging"
@@ -519,7 +519,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_messaging:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Messaging"
@@ -570,7 +570,7 @@ jobs:
         path: quickstart-ios/
 
   quickstart_framework_storage:
-    needs: ${{ github.event.inputs.zip_run_id == '' && 'package-head' || '' }}
+    needs: github.event.inputs.zip_run_id == '' && 'package-head' || ''
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       SDK: "Storage"

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -128,7 +128,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -187,7 +187,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -236,7 +236,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -284,7 +284,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -354,7 +354,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -406,7 +406,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -457,7 +457,7 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: Firebase-actions-dir
-          run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+          run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
       - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
@@ -493,7 +493,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -545,7 +545,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
@@ -597,7 +597,7 @@ jobs:
       uses: actions/download-artifact@v4.1.7
       with:
         name: ${{ matrix.artifact }}
-        run_id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -100,7 +100,6 @@ jobs:
       run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
       run: |
-         exit 1
          mkdir -p zip_output_dir
          sh -x scripts/build_zip.sh \
            zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsDev.git' }}" \

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -202,476 +202,485 @@ jobs:
         name: quickstart_artifacts_abtesting
         path: quickstart-ios/
 
-  # quickstart_framework_auth:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK:  "Authentication"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-15]
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       include:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Swift Quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
-  #       quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh authentiation
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_auth
-  #       path: quickstart-ios/
+  quickstart_framework_auth:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK:  "Authentication"
+    strategy:
+      matrix:
+        os: [macos-15]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        include:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Swift Quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit FBSDKCoreKit_Basics FBAEMKit" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-authentication.plist.gpg \
+        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh authentiation
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_auth
+        path: quickstart-ios/
 
-  # quickstart_framework_config:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Config"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - name: Setup Swift Quickstart
+  quickstart_framework_config:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Config"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - name: Setup Swift Quickstart
 
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-  #       quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh config
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_config
-  #       path: quickstart-ios/
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
+        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh config
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_config
+        path: quickstart-ios/
 
-  # quickstart_framework_crashlytics:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Crashlytics"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: |
-  #             SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
-  #             chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Setup swift quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: |
-  #   #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-  #   #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-  #       quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   # TODO(#8057): Restore Swift Quickstart
-  #   # - name: Test Swift Quickstart
-  #   #   env:
-  #   #     LEGACY: true
-  #   #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh crashlytics
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_crashlytics
-  #       path: quickstart-ios/
+  quickstart_framework_crashlytics:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Crashlytics"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: |
+              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/run quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              cp quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/Firebase/upload-symbols quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/run
+              chmod +x quickstart-ios/crashlytics/LegacyCrashlyticsQuickstart/upload-symbols
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Setup swift quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: |
+    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
+    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
+        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    # TODO(#8057): Restore Swift Quickstart
+    # - name: Test Swift Quickstart
+    #   env:
+    #     LEGACY: true
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh crashlytics
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_crashlytics
+        path: quickstart-ios/
 
-  # quickstart_framework_database:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Database"
-  #   strategy:
-  #     matrix:
-  #       os: [macos-14]
-  #       xcode: [Xcode_16.2]
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-  #       quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh database
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts database
-  #       path: quickstart-ios/
+  quickstart_framework_database:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Database"
+    strategy:
+      matrix:
+        os: [macos-14]
+        xcode: [Xcode_16.2]
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseDatabaseUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
+        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh database
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts database
+        path: quickstart-ios/
 
-  # quickstart_framework_firestore:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Firestore"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Upload build logs on failure
-  #     if: ${{ failure() }}
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: build_logs_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
-  #       path: sdk_zip/build_logs/
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-  #       quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Remove data before upload and zip directory to reduce upload size.
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh firestore; zip -r --symlinks quickstart_artifacts_firestore.zip quickstart-ios/
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
-  #       path: quickstart_artifacts_firestore.zip
+  quickstart_framework_firestore:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Firestore"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseAuthUI FirebaseEmailAuthUI" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Upload build logs on failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_logs_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
+        path: sdk_zip/build_logs/
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
+        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload and zip directory to reduce upload size.
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh firestore; zip -r --symlinks quickstart_artifacts_firestore.zip quickstart-ios/
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_firestore_${{ matrix.artifact }}_${{ matrix.build-env.os }}
+        path: quickstart_artifacts_firestore.zip
 
-  # check_framework_firestore_symbols:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-  #   runs-on: macos-14
-  #   steps:
-  #     - name: Xcode 16.2
-  #       run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-  #     - uses: actions/checkout@v4
-  #     - name: Get framework dir
-  #       uses: actions/download-artifact@v4.1.7
-  #       with:
-  #         name: Firebase-actions-dir
-  #         run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #     - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #     - name: Setup Bundler
-  #       run: ./scripts/setup_bundler.sh
-  #     - name: Install xcpretty
-  #       run: gem install xcpretty
-  #     - name: Move frameworks
-  #       run: |
-  #         mkdir -p "${HOME}"/ios_frameworks/
-  #         find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #     - uses: actions/checkout@v4
-  #     - name: Check linked Firestore.xcframework for unlinked symbols.
-  #       run: |
-  #         scripts/check_firestore_symbols.sh \
-  #           $(pwd) \
-  #           "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
+  check_framework_firestore_symbols:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    runs-on: macos-14
+    steps:
+      - name: Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      - uses: actions/checkout@v4
+      - name: Get framework dir
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: Firebase-actions-dir
+          run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+      - name: Setup Bundler
+        run: ./scripts/setup_bundler.sh
+      - name: Install xcpretty
+        run: gem install xcpretty
+      - name: Move frameworks
+        run: |
+          mkdir -p "${HOME}"/ios_frameworks/
+          find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+      - uses: actions/checkout@v4
+      - name: Check linked Firestore.xcframework for unlinked symbols.
+        run: |
+          scripts/check_firestore_symbols.sh \
+            $(pwd) \
+            "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/FirebaseFirestoreInternal.xcframework
 
-  # quickstart_framework_inappmessaging:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "InAppMessaging"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-  #       quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh inappmessaging
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_inappmessaging
-  #       path: quickstart-ios/
+  quickstart_framework_inappmessaging:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "InAppMessaging"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
+        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh inappmessaging
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_inappmessaging
+        path: quickstart-ios/
 
-  # quickstart_framework_messaging:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Messaging"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-  #       quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh messaging
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_messaging
-  #       path: quickstart-ios/
+  quickstart_framework_messaging:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Messaging"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
+        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh messaging
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_messaging
+        path: quickstart-ios/
 
-  # quickstart_framework_storage:
-  #   needs: package-head
-  #   if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
-  #   env:
-  #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     SDK: "Storage"
-  #   strategy:
-  #     matrix:
-  #       artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
-  #       build-env:
-  #         - os: macos-15
-  #           xcode: Xcode_16.4
-  #   runs-on: ${{ matrix.build-env.os }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Get framework dir
-  #     uses: actions/download-artifact@v4.1.7
-  #     with:
-  #       name: ${{ matrix.artifact }}
-  #       run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
-  #   - name: Xcode
-  #     run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
-  #   - name: Setup Bundler
-  #     run: ./scripts/setup_bundler.sh
-  #   - name: Move frameworks
-  #     run: |
-  #       mkdir -p "${HOME}"/ios_frameworks/
-  #       find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
-  #   - uses: actions/checkout@v4
-  #   - name: Setup quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-  #                                              "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-  #   - name: Setup swift quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-  #   - name: Install Secret GoogleService-Info.plist
-  #     run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-  #       quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-  #   - name: Test Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-  #   - name: Test Swift Quickstart
-  #     env:
-  #       LEGACY: true
-  #     run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-  #   - name: Remove data before upload
-  #     env:
-  #       LEGACY: true
-  #     if: ${{ failure() }}
-  #     run: scripts/remove_data.sh storage
-  #   - uses: actions/upload-artifact@v4
-  #     if: ${{ failure() }}
-  #     with:
-  #       name: quickstart_artifacts_storage
-  #       path: quickstart-ios/
+  quickstart_framework_storage:
+    needs: package-head
+    if: ${{ !cancelled() && (success() || github.event.inputs.zip_run_id != '') }}
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      SDK: "Storage"
+    strategy:
+      matrix:
+        artifact: [Firebase-actions-dir, Firebase-actions-dir-dynamic]
+        build-env:
+          - os: macos-15
+            xcode: Xcode_16.4
+    runs-on: ${{ matrix.build-env.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get framework dir
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ${{ matrix.artifact }}
+        run-id: ${{ github.event.inputs.zip_run_id || github.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.build-env.xcode }}.app/Contents/Developer
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: Move frameworks
+      run: |
+        mkdir -p "${HOME}"/ios_frameworks/
+        find "${GITHUB_WORKSPACE}" -name "Firebase*latest.zip" -exec unzip -d "${HOME}"/ios_frameworks/ {} +
+    - uses: actions/checkout@v4
+    - name: Setup quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Setup swift quickstart
+      env:
+        LEGACY: true
+      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
+        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
+    - name: Test Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Test Swift Quickstart
+      env:
+        LEGACY: true
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
+    - name: Remove data before upload
+      env:
+        LEGACY: true
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh storage
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts_storage
+        path: quickstart-ios/

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -79,6 +79,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - name: Build
       run: |
+        exit 1
         cd ReleaseTooling
         swift build -v
 


### PR DESCRIPTION
This is a nice option when needing to iterate on the quickstart part of the zip workflow. A previous run ID can be used to get the zip artifact. This way, we don't have to wait hours for a new zip each commit.

This will be very helpful for testing https://github.com/firebase/quickstart-ios/pull/1666

#no-changelog