### PR TITLE
chore(ci): Remove unused secret in auth.yml

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -112,7 +112,6 @@ jobs:
 
   #   env:
   #     plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-  #     signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
   #   runs-on: macos-14
   #   steps:
   #   - uses: actions/checkout@v4


### PR DESCRIPTION
I accidentally added this back via a git mistake after a LSC.

#no-changelog

