### PR TITLE
Analytics 12.3.0

### DIFF
--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.authors          = 'Google, Inc.'
 
     s.source           = {
-        :http => 'https://dl.google.com/firebase/ios/analytics/20f7f19c421351ed/FirebaseAnalytics-12.2.0.tar.gz'
+        :http => 'https://dl.google.com/firebase/ios/analytics/7f774173bfc50ea8/FirebaseAnalytics-12.3.0.tar.gz'
     }
 
     s.cocoapods_version = '>= 1.12.0'

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.authors          = 'Google, Inc.'
 
     s.source           = {
-        :http => 'https://dl.google.com/firebase/ios/analytics/47d80ee1ff340179/GoogleAppMeasurement-12.2.0.tar.gz'
+        :http => 'https://dl.google.com/firebase/ios/analytics/1c0181b69fa16f29/GoogleAppMeasurement-12.3.0.tar.gz'
     }
 
     s.cocoapods_version = '>= 1.12.0'
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
     s.subspec 'Default' do |ss|
         ss.dependency 'GoogleAppMeasurement/Core', '12.3.0'
         ss.dependency 'GoogleAppMeasurement/IdentitySupport', '12.3.0'
-        ss.ios.dependency 'GoogleAdsOnDeviceConversion', '2.3.0'
+        ss.ios.dependency 'GoogleAdsOnDeviceConversion', '~> 3.0.0'
     end
 
     s.subspec 'Core' do |ss|

--- a/Package.swift
+++ b/Package.swift
@@ -329,8 +329,8 @@ let package = Package(
     ),
     .binaryTarget(
       name: "FirebaseAnalytics",
-      url: "https://dl.google.com/firebase/ios/swiftpm/12.2.0/FirebaseAnalytics.zip",
-      checksum: "f1b07dabcdf3f2b6c495af72baa55e40672a625b8a1b6c631fb43ec74a2ec1ca"
+      url: "https://dl.google.com/firebase/ios/swiftpm/12.3.0/FirebaseAnalytics.zip",
+      checksum: "a7fcb34227d6cc0b2db9b1d3f9dd844801e5a28217f20f1daae6c3d2b7d1e8e1"
     ),
     .testTarget(
       name: "AnalyticsSwiftUnit",
@@ -1392,7 +1392,7 @@ func googleAppMeasurementDependency() -> Package.Dependency {
     return .package(url: appMeasurementURL, branch: "main")
   }
 
-  return .package(url: appMeasurementURL, exact: "12.2.0")
+  return .package(url: appMeasurementURL, exact: "12.3.0")
 }
 
 func abseilDependency() -> Package.Dependency {


### PR DESCRIPTION
Analytics 12.3.0 #no-changelog

https://guides.cocoapods.org/syntax/podspec.html#dependency for the "~>" syntax

GoogleAdsOnDeviceConversion dependency of '~> 3.0.0' to allow 3.0.0 and 3.0.1 etc, but not 3.1