### PR TITLE
Safely copy MIMEType to prevent use after free (Issue #14734)

### DIFF
--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -251,7 +251,10 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
       self.responseCode = (int32_t)HTTPResponse.statusCode;
     }
     self.responseError = error;
-    self.responseContentType = response.MIMEType;
+    //Safely copy MIMEType to prevent use after free
+    NSURLResponse *strongRes = response;
+    NSString *mime = [[strongRes MIMEType] copy];
+    self.responseContentType = (mime.length ? mime : nil);
     [self checkpointState:FPRNetworkTraceCheckpointStateResponseCompleted];
 
     // Send the network trace for logging.


### PR DESCRIPTION
Copied response.MIMEType before assigning to responseContentType to avoid EXC_BAD_ACCESS caused by early deallocation under certain network or SDK conditions.

### Discussion

  * Fix for Issue #14734 ([Link](https://github.com/firebase/firebase-ios-sdk/issues/14734))
  
Clients state that they where experiencing a crash in FPRNetworkTrace on devices running iOS and iPadOS 17.5.1 and up, its not a 100% reproducible crash but it seems to happen under certain network conditions 

After I began to read the stack trace and logs I found out that the root cause is a use after bug that is triggered by accessing response.MIMEType from a possibly deallocated NSURLResponse object inside the didCompleteRequestWithResponse method located inside of FPRNetworkTrace.m 

Where the crash happens on the user provided stack trace (EXC_BAD_ACCESS (SIGSEGV) type crash):

`0 libsystem_malloc.dylib __CFStringDeallocate
1 CoreFoundation _CFRelease
2 CFNetwork URLResponse::getMIMEType()
3 FPRNetworkTrace didCompleteRequestWithResponse:error: `

The MIME type string returned by NSURLResponse.MIMEType is a non retained CoreFoundation owned pointer that may be deallocated if the NSURLResponse instance is no longer strongly referenced or becomes invalid if the delegate method is invoked on a separate queue after the response’s lifecycle ends, without retaining a response, this opens a race condition where response may be freed before MIMEType is accessed. 

### Possible repro scenarios (Hard to reproduce!!!)

  * Short-lived responses 
  * Heavy background thread contention
  * Custom NSURLProtocol setups (That could be Found in AppLovin SDK for example) 
  
### Proposed Fix

My proposed fix consists of modifying the assignment of response.MIMEType in -didCompleteRequestWithResponse:error: to defensively copy the value, this will address the crash users had and adds an extra layer of safety when this value is being accessed, and it also doesn’t add or makes a behavioral change to the existing flow also under certain network conditions or when third-party SDKs like AppLovin hook into NSURLSession, the original NSURLResponse instance may be prematurely deallocated or altered, copying the MIME type ensures the string is retained independently on the heap, breaking potential races with early deallocation or thread-unsafe memory access.  

### Testing

  * Ran repeatedly 1000 Unit tests locally in XCode to check for flakiness with and without network link conditioner on a: iPhone 14 Pro running iOS 18.6.2 and an iPhone SE 3rd Gen Simulator on iOS 18.6.2
  * Code Altered shouldn't edit functionality it's just an extra safety step

### Testing Screenshots

iPhone 14 Pro

<img width="628" height="166" alt="Screenshot 2025-09-10 at 5 11 22 p m" src="https://github.com/user-attachments/assets/62307ebf-4a66-4c82-8290-e104987e53e5" />

iPhone SE 3rd Gen Simulator 
   
<img width="650" height="207" alt="Screenshot 2025-09-10 at 5 14 32 p m" src="https://github.com/user-attachments/assets/0aefe4c9-4769-4ae7-b413-d0ba481bbc48" />

### API Changes

  * No API Change
  
  
