### PR TITLE
Defensive access to MIMEType

### DIFF
--- a/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRNetworkTrace.m
@@ -257,7 +257,10 @@ NSString *const kFPRNetworkTracePropertyName = @"fpr_networkTrace";
       // Safely copy MIMEType to prevent use after free
       mime = [response.MIMEType copy];
     } @catch (NSException *exception) {
-      FPRLogWarning(@"MIMETypeException", @"Exception while accessing MIMEType for URL %@: %@. Trace will continue without MIMEType.", self.URLRequest.URL, exception);
+      FPRLogWarning(@"MIMETypeException",
+                    @"Exception while accessing MIMEType for URL %@: %@. Trace will continue "
+                    @"without MIMEType.",
+                    self.URLRequest.URL, exception);
     }
     self.responseContentType = (mime.length ? mime : nil);
     [self checkpointState:FPRNetworkTraceCheckpointStateResponseCompleted];


### PR DESCRIPTION
Prevent possible crashes adressing comments from #15317 and crash reported in #14734 

### Discussion

This addresses the comments for the proposed improvements not addressing the possible crash found when MIMEType is called by adding a little try catch and keeping the improvements made in the past pull request 

@ncooke3 Hoping this is better!

### Testing

* Ran repeatedly 1000 Unit tests locally in XCode to check for flakiness with and without network link conditioner on a: iPhone 14 Pro running iOS 18.6.2 and an iPhone SE 3rd Gen Simulator on iOS 18.6.2
* Code Altered shouldn't edit functionality it's just an extra safety step

### API Changes

No API Changes
