### PR TITLE
[Firebase AI] Add macOS / Xcode 26 CI testing

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -40,6 +40,8 @@ jobs:
         include:
           - os: macos-15
             xcode: Xcode_16.4
+          - os: macos-26
+            xcode: Xcode_26.0
     runs-on: ${{ matrix.os }}
     needs: spm
     env:
@@ -87,6 +89,8 @@ jobs:
         include:
           - os: macos-15
             xcode: Xcode_16.4
+          - os: macos-26
+            xcode: Xcode_26.0
     runs-on: ${{ matrix.os }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -158,9 +158,13 @@ if [[ "$xcode_major" -lt 16 && "$method" != "cmake" ]]; then
   echo "Unsupported Xcode major version being used: $xcode_major"
   exit 1
 else
+  iphone_simulator_name="iPhone 16"
+  if [[ "$xcode_major" -gt 16 ]]; then
+    iphone_simulator_name="iPhone 16e"
+  fi
   ios_flags=(
     -sdk 'iphonesimulator'
-    -destination 'platform=iOS Simulator,name=iPhone 16'
+    -destination "platform=iOS Simulator,name=${iphone_simulator_name}"
   )
     watchos_flags=(
     -sdk 'watchsimulator'


### PR DESCRIPTION
Added quickstart and integration test runs on macOS 26 / Xcode 26 for Firebase AI Logic. Updated `build.sh` to use `"iPhone 16e"` with Xcode 26 where `"iPhone 16"` isn't installed by default.

#no-changelog