### PR TITLE
fix(ci): Update common_cocoapods_cron.yml

### DIFF
--- a/.github/workflows/common_cocoapods_cron.yml
+++ b/.github/workflows/common_cocoapods_cron.yml
@@ -46,6 +46,9 @@ on:
         required: false
         default: "macos-15"
 
+env:
+  FIREBASE_CI: true
+
 jobs:
   cron-job:
     if: |


### PR DESCRIPTION
The `FIREBASE_CI` env var should be used to disable deprecation warnings in CI, so we can, once addressing other non-deprecation related warnings, build with `-warnings-as-errors`.

#no-changelog