### PR TITLE
[Firebase AI] Make `URLContext` struct internal

### DIFF
--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -131,7 +131,7 @@ public struct Tool: Sendable {
     return self.init(googleSearch: googleSearch)
   }
 
-  public static func urlContext() -> Tool {
+  static func urlContext() -> Tool {
     return self.init(urlContext: URLContext())
   }
 

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -131,7 +131,7 @@ public struct Tool: Sendable {
     return self.init(googleSearch: googleSearch)
   }
 
-  static func urlContext() -> Tool {
+  public static func urlContext() -> Tool {
     return self.init(urlContext: URLContext())
   }
 

--- a/FirebaseAI/Sources/Types/Internal/Tools/URLContext.swift
+++ b/FirebaseAI/Sources/Types/Internal/Tools/URLContext.swift
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct URLContext: Sendable, Encodable {
+struct URLContext: Sendable, Encodable {
   init() {}
 }

--- a/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Metadata related to the URLContext tool.
+/// Metadata related to the ``Tool/urlContext()`` tool.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct URLContextMetadata: Sendable, Hashable {
   /// List of URL context.

--- a/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Metadata related to the ``URLContext`` tool.
+/// Metadata related to the URLContext tool.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct URLContextMetadata: Sendable, Hashable {
   /// List of URL context.

--- a/FirebaseAI/Sources/Types/Public/URLMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLMetadata.swift
@@ -49,7 +49,7 @@ public struct URLMetadata: Sendable, Hashable {
       AILog.MessageCode.urlMetadataUnrecognizedURLRetrievalStatus
   }
 
-  /// The URL retrieved by the ``URLContext`` tool.
+  /// The URL retrieved by the URLContext tool.
   public let retrievedURL: URL?
 
   /// The status of the URL retrieval.

--- a/FirebaseAI/Sources/Types/Public/URLMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLMetadata.swift
@@ -49,7 +49,7 @@ public struct URLMetadata: Sendable, Hashable {
       AILog.MessageCode.urlMetadataUnrecognizedURLRetrievalStatus
   }
 
-  /// The URL retrieved by the URLContext tool.
+  /// The URL retrieved by the ``Tool/urlContext()`` tool.
   public let retrievedURL: URL?
 
   /// The status of the URL retrieval.


### PR DESCRIPTION
Updated the `URLContext` struct to be internal instead of public. It doesn't need to be exposed publicly yet since it has no properties and should be initialized using `Tool.urlContext()` instead.

#no-changelog