### PR TITLE
[AI] Update empty parts check for urlContextMetadata

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -179,7 +179,8 @@ public struct Candidate: Sendable {
   // Returns `true` if the candidate contains no information that a developer could use.
   var isEmpty: Bool {
     content.parts
-      .isEmpty && finishReason == nil && citationMetadata == nil && groundingMetadata == nil
+      .isEmpty && finishReason == nil && citationMetadata == nil && groundingMetadata == nil &&
+      urlContextMetadata == nil
   }
 }
 

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -174,8 +174,8 @@ final class GenerateContentResponseTests: XCTestCase {
   }
 
   func testCandidateIsEmpty_withURLContextMetadata_isFalse() throws {
-    let urlMetadata = URLMetadata(
-      retrievedURL: try XCTUnwrap(URL(string: "https://google.com")),
+    let urlMetadata = try URLMetadata(
+      retrievedURL: XCTUnwrap(URL(string: "https://google.com")),
       retrievalStatus: .success
     )
     let urlContextMetadata = URLContextMetadata(urlMetadata: [urlMetadata])

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAI
+@testable import FirebaseAI
 import XCTest
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -156,5 +156,41 @@ final class GenerateContentResponseTests: XCTestCase {
     XCTAssertEqual(textPart.text, "Some text.")
     XCTAssertFalse(textPart.isThought)
     XCTAssertEqual(candidate.finishReason, .stop)
+  }
+
+  // MARK: - Candidate.isEmpty
+
+  func testCandidateIsEmpty_allEmpty_isTrue() throws {
+    let candidate = Candidate(
+      content: ModelContent(parts: []),
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil,
+      groundingMetadata: nil,
+      urlContextMetadata: nil
+    )
+
+    XCTAssertTrue(candidate.isEmpty, "A candidate with no content should be empty.")
+  }
+
+  func testCandidateIsEmpty_withURLContextMetadata_isFalse() throws {
+    let urlMetadata = URLMetadata(
+      retrievedURL: URL(string: "https://google.com")!,
+      retrievalStatus: .success
+    )
+    let urlContextMetadata = URLContextMetadata(urlMetadata: [urlMetadata])
+    let candidate = Candidate(
+      content: ModelContent(parts: []),
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil,
+      groundingMetadata: nil,
+      urlContextMetadata: urlContextMetadata
+    )
+
+    XCTAssertFalse(
+      candidate.isEmpty,
+      "A candidate with only `urlContextMetadata` should not be empty."
+    )
   }
 }

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -175,7 +175,7 @@ final class GenerateContentResponseTests: XCTestCase {
 
   func testCandidateIsEmpty_withURLContextMetadata_isFalse() throws {
     let urlMetadata = URLMetadata(
-      retrievedURL: URL(string: "https://google.com")!,
+      retrievedURL: try XCTUnwrap(URL(string: "https://google.com")),
       retrievalStatus: .success
     )
     let urlContextMetadata = URLContextMetadata(urlMetadata: [urlMetadata])


### PR DESCRIPTION
Follow on to https://github.com/firebase/firebase-ios-sdk/pull/15262 now that urlContext tool support has been added

## Summary of Changes



This pull request refines the `isEmpty` logic within the `Candidate` struct of the Firebase AI SDK. It specifically updates the `isEmpty` computed property to account for `urlContextMetadata`, preventing `Candidate` objects from being incorrectly identified as empty when they contain relevant URL context information. This change ensures more accurate content generation responses and is accompanied by new unit tests to validate the updated behavior.

### Highlights

* **Candidate.isEmpty logic update**: The `isEmpty` computed property in the `Candidate` struct has been updated to include `urlContextMetadata` in its evaluation, ensuring that candidates with this metadata are no longer considered empty.
* **Test coverage for Candidate.isEmpty**: New unit tests have been added to verify the correctness of the `Candidate.isEmpty` property, specifically covering scenarios where `urlContextMetadata` is present or absent.
* **@testable import for testing**: The test file `GenerateContentResponseTests.swift` now uses `@testable import FirebaseAI` to allow access to internal types for comprehensive testing.

<details>
<summary><b>Changelog</b></summary>

* **FirebaseAI/Sources/GenerateContentResponse.swift**
    * Modified the `isEmpty` computed property in the `Candidate` struct to include `urlContextMetadata` in its check.
* **FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift**
    * Added `@testable import FirebaseAI` to enable testing of internal types.
    * Introduced new test cases (`testCandidateIsEmpty_allEmpty_isTrue` and `testCandidateIsEmpty_withURLContextMetadata_isFalse`) to thoroughly validate the updated `Candidate.isEmpty` logic.
</details>



<details>
<summary><b>Activity</b></summary>

* gemini-code-assist[bot] provided information regarding its usage.
* google-oss-bot issued a warning about a missing changelog entry.
* paulb777 requested a review from Gemini Code Assist.
* gemini-code-assist[bot] provided a review comment suggesting the use of `try XCTUnwrap` for robust URL handling in tests.
* paulb777 requested a summary from Gemini Code Assist.
</details>







