### PR TITLE
[Firebase AI] Use gemini-2.5-flash-lite for URLContext test

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -430,7 +430,7 @@ struct GenerateContentIntegrationTests {
   )
   func generateContent_withURLContext_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini2_5_FlashLite,
       tools: [.urlContext()]
     )
     let prompt = """


### PR DESCRIPTION
Updated the `generateContent_withURLContext_succeeds` integration test to use the `gemini-2.5-flash-lite` model. This may reduce flakes.

#no-changelog