### PR TITLE
chore(m172): Update changelogs

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -3,6 +3,12 @@
   from provided public web URLs to inform and enhance its responses. (#15221)
 - [changed] Using Firebase AI Logic with the Gemini Developer API is now Generally Available (GA).
 - [changed] Using Firebase AI Logic with the Imagen generation APIs is now Generally Available (GA).
+- [feature] Added support for the Live API, which allows bidirectional
+  communication with the model in realtime.
+
+  To get started with the Live API, see the Firebase docs on
+  [Bidirectional streaming using the Gemini Live API](https://firebase.google.com/docs/ai-logic/live-api).
+  (#15309)
 
 # 12.3.0
 - [feature] Added support for the Code Execution tool, which enables the model
@@ -11,12 +17,6 @@
 - [fixed] Fixed a decoding error when generating images with the
   `gemini-2.5-flash-image-preview` model using `generateContentStream` or
   `sendMessageStream` with the Gemini Developer API. (#15262)
-- [feature] Added support for the Live API, which allows bidirectional
-  communication with the model in realtime.
-
-  To get started with the Live API, see the Firebase docs on
-  [Bidirectional streaming using the Gemini Live API](https://firebase.google.com/docs/ai-logic/live-api).
-  (#15309)
 
 # 12.2.0
 - [feature] Added support for returning thought summaries, which are synthesized


### PR DESCRIPTION
Updates the changelogs for fai since the PR for adding live API support got in.

It seems they got accidentally pushed into the `12.3.0` section too.