### PR TITLE
chore(ci): Upload build log in spm.yml job

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -89,7 +89,8 @@ jobs:
       if: ${{ failure() }}
       with:
         name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-build.log
-        path: xcodebuild-build.log
+        path: xcodebuild-test.log
+        if-no-files-found: error
 
   # Test iOS Device build since some Firestore dependencies build different files.
   iOS-Device:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -124,6 +124,7 @@ jobs:
       with:
         name: spm-ios-device-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-build.log
         path: xcodebuild-build.log
+        if-no-files-found: error
 
   platforms:
     # Don't run on private repo unless it is a PR.
@@ -164,4 +165,5 @@ jobs:
       with:
         name: spm-platforms-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}-logs
         path: xcodebuild-*.log
+        if-no-files-found: error
 

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -88,8 +88,8 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-test.log
-        path: xcodebuild-test.log
+        name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-logs
+        path: xcodebuild-*.log
         if-no-files-found: error
 
   # Test iOS Device build since some Firestore dependencies build different files.
@@ -122,8 +122,8 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: spm-ios-device-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-build.log
-        path: xcodebuild-build.log
+        name: spm-ios-device-${{ matrix.os }}-${{ matrix.xcode }}-logs
+        path: xcodebuild-*.log
         if-no-files-found: error
 
   platforms:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-build.log
+        name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-test.log
         path: xcodebuild-test.log
         if-no-files-found: error
 

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -85,6 +85,11 @@ jobs:
         max_attempts: 3
         retry_wait_seconds: 120
         command: scripts/build.sh Firebase-Package iOS ${{ matrix.test }}
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: spm-build-run-${{ matrix.os }}-${{ matrix.xcode }}-xcodebuild-build.log
+        path: xcodebuild-build.log
 
   # Test iOS Device build since some Firestore dependencies build different files.
   iOS-Device:


### PR DESCRIPTION
This failed in the nightly issue. I recently added steps to upload the xcodebuild log on failure, and am extending that functionality to this job. Now, all main jobs (with the exception of the shared package resolution job) should upload a build log on failure for easier debugging.

#no-changelog