### PR TITLE
fix(ai): Add missing available to extension

### DIFF
--- a/FirebaseAI/Tests/Unit/TestUtilities/FirebaseAI+DefaultAPIConfig.swift
+++ b/FirebaseAI/Tests/Unit/TestUtilities/FirebaseAI+DefaultAPIConfig.swift
@@ -14,6 +14,7 @@
 
 @testable import FirebaseAI
 
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FirebaseAI {
   static let defaultVertexAIAPIConfig = APIConfig(
     service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),


### PR DESCRIPTION
It looks like the extension of `FirebaseAI` was missing an `@available` quantifier that matched `FirebaseAI`, and this was causing a compile error. This PR adds that `@available` marker to the extension.

#no-changelog