### PR TITLE
fix(ai): Fix error propagation during setup

### DIFF
--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -74,10 +74,11 @@ enum AILog {
     case liveSessionFailedToSendClientMessage = 3023
     case liveSessionUnexpectedResponse = 3024
     case liveSessionGoingAwaySoon = 3025
-    case decodedMissingProtoDurationSuffix = 3026
-    case decodedInvalidProtoDurationString = 3027
-    case decodedInvalidProtoDurationSeconds = 3028
-    case decodedInvalidProtoDurationNanoseconds = 3029
+    case liveSessionClosedDuringSetup = 3026
+    case decodedMissingProtoDurationSuffix = 3027
+    case decodedInvalidProtoDurationString = 3028
+    case decodedInvalidProtoDurationSeconds = 3029
+    case decodedInvalidProtoDurationNanoseconds = 3030
 
     // SDK State Errors
     case generateContentResponseNoCandidates = 4000

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -179,6 +179,13 @@ actor LiveSessionService {
         close()
         throw error
       }
+      // the user called close while setup was running
+      // this can't currently happen, but could when we add automatic session resumption
+      // in such case, we don't want to raise an error. this log is more-so to catch any edge cases
+      AILog.debug(
+        code: .liveSessionClosedDuringSetup,
+        "The live session was closed before setup could complete: \(error.localizedDescription)"
+      )
     }
   }
 

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -28,7 +28,7 @@ import Foundation
 ///
 /// This mainly comes into play when we don't want to block developers from sending messages while a
 /// session is being reloaded.
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 actor LiveSessionService {
   let responses: AsyncThrowingStream<LiveServerMessage, Error>


### PR DESCRIPTION
I found that in certain edge case situations, errors could end up not propagating up during the initial setup of a live session. While fixing said error, I realized that the setup process could actually be cleaned up a decent amount. While this could cause issues if the model ever sent messages out of order (ie; a message before setupComplete), this doesn't seem like something we should necessarily design around. Furthermore, separating the setup process into a more iterative async style approach not only makes things easier to read (and reason about), but also solves various edge case error propagation issues.

The change has been tested on a local device, and seems to be working perfectly; existing functionality works, and the errors that were previously not being propagated are now properly bubbling up.

The process has also been split into helper functions, to make things easier to read, and to allow me to add documentation for each.

#no-changelog