### PR TITLE
fix(ai): Remove watchOS from available markers

### DIFF
--- a/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentServerMessage.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentServerMessage.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Response message for BidiGenerateContent RPC call.
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 @available(watchOS, unavailable)
 struct BidiGenerateContentServerMessage: Sendable {
   /// The type of the message.
@@ -48,7 +48,7 @@ struct BidiGenerateContentServerMessage: Sendable {
 
 // MARK: - Decodable
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 @available(watchOS, unavailable)
 extension BidiGenerateContentServerMessage: Decodable {
   enum CodingKeys: String, CodingKey {

--- a/FirebaseAI/Sources/Types/Public/Live/LiveServerToolCall.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveServerToolCall.swift
@@ -16,7 +16,7 @@
 ///
 /// The client should return matching ``FunctionResponsePart``, where the `functionId` fields
 /// correspond to individual ``FunctionCallPart``s.
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 @available(watchOS, unavailable)
 public struct LiveServerToolCall: Sendable {
   let serverToolCall: BidiGenerateContentToolCall

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -21,7 +21,7 @@ import Foundation
 /// through the incremental API (such as ``sendContent(_:turnComplete:)``).
 ///
 /// To create an instance of this class, see ``LiveGenerativeModel``.
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
 @available(watchOS, unavailable)
 public final class LiveSession: Sendable {
   private let service: LiveSessionService


### PR DESCRIPTION
Some of the `@available` markers had `watchOS` version specifiers, even though the next line marked them as `unavailable`. This might not have actually been an issue (as the `unavailable` likely overrode it), but I felt it better to be safe than sorry.

This PR removes those version specifiers; aligning with the other `@available` markers on the live api.

#no-changelog