### PR TITLE
fix: Fixes to artifact uploads and scheme name-related issues

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -565,8 +565,6 @@ jobs:
       run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
         quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"


### PR DESCRIPTION
Next up: 
- [x] Test against https://github.com/firebase/quickstart-ios/pull/1790 (simple revert of DB fix)
- [x] Merge https://github.com/firebase/quickstart-ios/pull/1790
- [x] Merge this PR on green
- [ ] Remove many dupl. `- uses: actions/checkout@v4`
- [ ] Get this PR green against nc/quickstarts
- [ ] QS– cleanup Swift suffixes (including infra)
- [ ] FB– cleanup Swift suffixes (including infra)
- [ ] Remove  `PINNED_RUN_ID: '17965877651'` and manual references to `nc/quickstarts`
- [ ] Remove Gemfile trigger
- [ ] Testing team onboarding
- [ ] Merge both branches to main in quickstart and firebase repos
- [ ] Re-usable workflows for zip

Follow-up work
- [ ] Migrate away from Ruby Xcodeproj (make an issue pot.)


#no-changelog

#no-changelog