### PR TITLE
chore: Remove outdated TODO

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -397,23 +397,11 @@ jobs:
         "${GITHUB_WORKSPACE}"/quickstart-ios/scripts/add_framework_script.rb --sdk "Crashlytics" --target "CrashlyticsExample_(watchOS)_Extension" --framework_path Firebase/
     - name: Patch Crashlytics Run Script Path
       run: scripts/patch_crashlytics_run_path.rb
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Setup swift quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: |
-    #           SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="ReachabilitySwift" scripts/setup_quickstart_framework.sh \
-    #                                            "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
         quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
     - name: Test Quickstart
       run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    # TODO(#8057): Restore Swift Quickstart
-    # - name: Test Swift Quickstart
-    #   env:
-    #     LEGACY: true
-    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
     - uses: actions/upload-artifact@v4
       if: failure()
       with:


### PR DESCRIPTION
- [ ] QS– cleanup Swift suffixes (including infra)
  - [ ] FIS
  - [ ] FIAM
  - [ ] Perf
  - [ ] RTDB
  - [ ] Others?
  - [x] Infra
- [ ] FB– cleanup Swift suffixes (including infra)
- [ ] Remove  `PINNED_RUN_ID: '17965877651'` and manual references to `nc/quickstarts`
- [ ] Remove Gemfile trigger
- [ ] Testing team onboarding
- [ ] Merge both branches to main in quickstart and firebase repos
  - [ ] Mark https://github.com/firebase/firebase-ios-sdk/issues/8057 as closed
- [ ] Re-usable workflows for zip

Follow-up work
- [ ] Migrate away from Ruby Xcodeproj (make an issue pot.)


#no-changelog