### PR TITLE
[Release] Update Carthage artifacts for 12.5.0

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseABTesting-328b9123860fa215.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseABTesting-240f73a221798c3b.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseABTesting-453e3715e84856d3.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseABTesting-53d336f7762176f9.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/ABTesting-a71d17cadc209af9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
@@ -1,1 +1,3 @@
-{}
+{
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAILogic-543b2fedd88a76fd.zip"
+}

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAnalytics-b37787f72cdbb950.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAnalytics-866ebeb7925d0267.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAnalytics-61b0d6c9596bf37a.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAnalytics-d3705dd81b8b5477.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Analytics-2468c231ebeb7922.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Analytics-bc8101d420b896c5.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Analytics-d2b6a6b0242db786.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppCheck-dac2380c7e1b9898.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppCheck-f0fb8c2a38b272c7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppCheck-f45ebf0c8d5ae0aa.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAppCheck-15439cab8a605863.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppCheck-9ef1d217cf057203.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseAppCheck-fc03215d9fe45d3a.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseAppCheck-6ebe9e9539f06003.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppDistribution-042b04483c9241b6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppDistribution-8498aaebd9f9e633.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppDistribution-aa1bb9ef501d82e7.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAppDistribution-935f33cbb50ac9c0.zip",
   "6.31.0": "https://dl.google.com/dl/firebase/ios/carthage/6.31.0/FirebaseAppDistribution-07f6a2cf7f576a8a.zip",
   "6.32.0": "https://dl.google.com/dl/firebase/ios/carthage/6.32.0/FirebaseAppDistribution-a9c4f5db794508ca.zip",
   "6.33.0": "https://dl.google.com/dl/firebase/ios/carthage/6.33.0/FirebaseAppDistribution-448a96d2ade54581.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAuth-9f0a14da6c12ea6d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAuth-e4ba94c15c57a75f.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAuth-9d35d5c62a3e1a75.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAuth-873cd7b4bce5c5a6.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Auth-0fa76ba0f7956220.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Auth-5ddd2b4351012c7a.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Auth-5e248984d78d7284.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseCrashlytics-623ce628d0404f39.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseCrashlytics-6054b7e88b91a91d.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseCrashlytics-49a8a1b1f30115df.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseCrashlytics-0d4111d63d6eefd0.zip",
   "6.15.0": "https://dl.google.com/dl/firebase/ios/carthage/6.15.0/FirebaseCrashlytics-1c6d22d5b73c84fd.zip",
   "6.16.0": "https://dl.google.com/dl/firebase/ios/carthage/6.16.0/FirebaseCrashlytics-938e5fd0e2eab3b3.zip",
   "6.17.0": "https://dl.google.com/dl/firebase/ios/carthage/6.17.0/FirebaseCrashlytics-fa09f0c8f31ed5d9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseDatabase-a87ae96a7eeb2535.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseDatabase-2b6c597465ec9d34.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseDatabase-34750cd661cbd49b.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseDatabase-12c5aa3455796be4.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Database-1f7a820452722c7d.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Database-1f7a820452722c7d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Database-59a12d87456b3e1c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFirestore-8d65b82dc9d53ddf.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFirestore-e8ec00ce472204d2.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFirestore-acab074433fa0c6f.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseFirestore-ff38f0cab6f32140.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Firestore-68fc02c229d0cc69.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Firestore-87a804ab561d91db.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Firestore-ecb3eea7bde7e8e8.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFunctions-f3aa95160827b0af.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFunctions-6d891e5b755e773c.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFunctions-8589fb2f6bff1e38.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseFunctions-9a267b1256451803.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Functions-f4c426016dd41e38.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Functions-c6c44427c3034736.zip",
   "5.0.0": "https://dl.google.com/dl/firebase/ios/carthage/5.0.0/Functions-146f34c401bd459b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/GoogleSignIn-31b2e32d1dadbaa8.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/GoogleSignIn-0a9fd70d77dbb99e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/GoogleSignIn-bcaadfe04c892ecb.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/GoogleSignIn-ad70a9d759c22eb6.zip",
   "6.0.0": "https://dl.google.com/dl/firebase/ios/carthage/6.0.0/GoogleSignIn-de9c5d5e8eb6d6ea.zip",
   "6.1.0": "https://dl.google.com/dl/firebase/ios/carthage/6.1.0/GoogleSignIn-8c82f2870573a793.zip",
   "6.10.0": "https://dl.google.com/dl/firebase/ios/carthage/6.10.0/GoogleSignIn-ff3aef61c4a55b05.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseInAppMessaging-0ec7907b67ce2888.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseInAppMessaging-349edad4650cdc0e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseInAppMessaging-9447455910a3800d.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseInAppMessaging-464b7174be10e192.zip",
   "5.10.0": "https://dl.google.com/dl/firebase/ios/carthage/5.10.0/InAppMessaging-a7a3f933362f6e95.zip",
   "5.11.0": "https://dl.google.com/dl/firebase/ios/carthage/5.11.0/InAppMessaging-fa28ce1b88fbca93.zip",
   "5.12.0": "https://dl.google.com/dl/firebase/ios/carthage/5.12.0/InAppMessaging-fa28ce1b88fbca93.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMLModelDownloader-6bfb3459ae557ef3.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMLModelDownloader-1d7e6bff24c9b2ec.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMLModelDownloader-2ce9f1e78f15027f.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseMLModelDownloader-99a4ce736c201f72.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMLModelDownloader-8f972757fb181320.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseMLModelDownloader-058ad59fa6dc0111.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseMLModelDownloader-286479a966d2fb37.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMessaging-d1ab6eaf596d9b7d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMessaging-2a16804f5c5602a0.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMessaging-9175a3fe41e7c83c.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseMessaging-2ffe78328b8babb2.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Messaging-a22ef2b5f2f30f82.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Messaging-94fa4e090c7e9185.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Messaging-2a00a1c64a19d176.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebasePerformance-1913383f1952dce6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebasePerformance-5e59e383ee5e57f7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebasePerformance-79cbc1d26656ac6d.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebasePerformance-31908337721c4819.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Performance-d8693eb892bfa05b.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Performance-0a400f9460f7a71d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Performance-f5b4002ab96523e4.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseRemoteConfig-3e803b148769baed.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseRemoteConfig-41aaab0dc398a6fc.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseRemoteConfig-5d12611a14be55c9.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseRemoteConfig-925f509a1b213a01.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/RemoteConfig-7e9635365ccd4a17.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/RemoteConfig-e7928fcb6311c439.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/RemoteConfig-9ab1ca5f360a1780.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -49,6 +49,7 @@
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseStorage-20489713b94790a0.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseStorage-318fa79cc514a2be.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseStorage-e758b10b671ddad7.zip",
+  "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseStorage-c060333135f118a7.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Storage-6b3e77e1a7fdbc61.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Storage-4721c35d2b90a569.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Storage-821299369b9d0fb2.zip",


### PR DESCRIPTION
Updated the Carthage JSON artifacts for the https://github.com/firebase/firebase-ios-sdk/releases/tag/12.5.0.

#no-changelog