### PR TITLE
[Firebase AI] Add Swift module name changelog

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 12.5.0
+# 12.6.0
 - [feature] Added support for
   [Server Prompt Templates](https://firebase.google.com/docs/ai-logic/server-prompt-templates/get-started).
+
+# 12.5.0
 - [changed] Renamed the `FirebaseAI` module to `FirebaseAILogic`. This is a non-breaking change.
   `FirebaseAI` references will continue to work until a future breaking change release. Going
   forward, imports should be changed to `import FirebaseAILogic` and the `FirebaseAILogic` Swift


### PR DESCRIPTION
Added a CHANGELOG entry for the `FirebaseAI` to `FirebaseAILogic` Swift module name change in https://github.com/firebase/firebase-ios-sdk/pull/15275. See the [FAQ entry](https://firebase.google.com/docs/ai-logic/faq-and-troubleshooting#swift-module-name-change)  for more details.

Note: Moved the Server Prompt Templates release note to 12.6.0 since it is not yet released.