### PR TITLE
infra: versatility and cleanup improvements to zip.yml

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -3,7 +3,7 @@
 # 1. To iterate on a PR: Set the `PINNED_RUN_ID` environment variable in this
 #    file to a successful zip packaging run. This is useful for avoiding
 #    having to manually re-run the packaging jobs for each commit.
-# 2. For manual runs: Trigger the workflow via the GitHub UI (`workflow_dispatch`)
+# 2. For manual runs: Trigger the workflow via the [GitHub UI](https://github.com/firebase/firebase-ios-sdk/actions/workflows/zip.yml)
 #    and provide a "Run ID of a previous successful zip workflow" in the input.
 # 3. By default (for scheduled and other PR runs): The workflow will build the
 #    zip from the current commit (HEAD).


### PR DESCRIPTION
- Add support for manually setting a GHA run ID within the workflow to iterate with a single zip artifact (very useful for quick iteration across many commits in a single PR).
- The remove_data.sh script is fragile in that an improper product name arg will result in the intended secret plist not being deleted. The upload artifact action supports inverse globs so we can use those to never upload a GoogleService-Info.plist

Tasks
- [x] Green CI with pinned run
- [x] Green CI without pinned run

#no-changelog