### PR TITLE
[Firebase AI] Add integration placeholder for debug token env var

### DIFF
--- a/.github/workflows/firebaseai.yml
+++ b/.github/workflows/firebaseai.yml
@@ -48,7 +48,7 @@ jobs:
             target: iOS
             xcode: Xcode_26.0
     runs-on: ${{ matrix.os }}
-    # needs: spm
+    needs: spm
     env:
       TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
       TEST_RUNNER_VTXIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Added a placeholder value for the `FIRAAppCheckDebugToken` environment variable in the Firebase AI Logic Integration Test App to simplify setting this locally. This is set automatically in CI: https://github.com/firebase/firebase-ios-sdk/blob/cc8f4aa3f8521034c9cc3839d983e9582f008873/.github/workflows/firebaseai.yml#L53

Turned off `-FIRDebugEnabled` by default to reduce noise in CI runs.

Note: Verified this on CI in this [run](https://github.com/firebase/firebase-ios-sdk/actions/runs/19614874452/job/56166004774?pr=15528) since the `spm` job is already [broken](https://github.com/firebase/firebase-ios-sdk/actions/runs/19607530424/job/56148478921).

#no-changelog