### PR TITLE
fix: Don't run QS jobs on forks

### DIFF
--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -62,8 +62,9 @@ on:
 jobs:
   quickstart:
     name: quickstart (${{ inputs.product }})
-    # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+    if: |
+      github.repository == 'firebase/firebase-ios-sdk' &&
+      contains(fromJSON('["schedule", "pull_request", "workflow_dispatch"]'), github.event_name)
     env:
       plist_secret: ${{ secrets.plist_secret }}
       QUICKSTART_BRANCH: ${{ inputs.quickstart_branch }}


### PR DESCRIPTION
Another incremental improvement. Should have prevented QS from running in #15493

#no-changelog