### PR TITLE
fix: fail scheduled builds if pinned run is set

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -56,6 +56,11 @@ jobs:
     outputs:
       should_package: ${{ steps.check.outputs.should_package }}
     steps:
+    - name: Fail workflow if PINNED_RUN_ID is set on a schedule
+      if: github.event_name == 'schedule' && env.PINNED_RUN_ID != ''
+      run: |
+        echo "ERROR: PINNED_RUN_ID is set for a scheduled run. Unset it to allow the workflow to proceed."
+        exit 1
     - name: Check if packaging should be skipped
       id: check
       run: |


### PR DESCRIPTION
The PINNED_RUN_ID variable should always be unset before merging to main. If it was unintentionally checked in, our nightly zip would use the PINNED_RUN_ID. As a safety mechanism, I want the workflow to fail so we know to unset it on main.

#no-changelog