### PR TITLE
[Sessions] Fix race condition causing unit test flakiness

### DIFF
--- a/FirebaseSessions/Sources/SessionInitiator.swift
+++ b/FirebaseSessions/Sources/SessionInitiator.swift
@@ -47,7 +47,12 @@ class SessionInitiator {
 
   func beginListening(initiateSessionStart: @escaping () -> Void) {
     self.initiateSessionStart = initiateSessionStart
-    self.initiateSessionStart()
+
+    // Dispatching asynchronously to allow the Sessions SDK to finish its
+    // initialization before the callback is called.
+    DispatchQueue.main.async {
+      self.initiateSessionStart()
+    }
 
     let notificationCenter = NotificationCenter.default
     #if os(iOS) || os(tvOS) || os(visionOS)


### PR DESCRIPTION
Gemini's analysis:

The beginListening function executes the initiateSessionStart closure synchronously on the same thread
  it was called from.

  In FirebaseSessions.swift, the beginListening call is made from within the init. Inside the initiateSessionStart closure, we have this code:

   1 all(self.subscriberPromises.values).then(on: .global(qos: .background)) { _ in
   2   // ...
   3 }

  The Promises library, when .then is called, may not execute the chained closure immediately. It might schedule it for a future run loop tick, even if the promises are
  already fulfilled.

  Here is the race condition:

   1. Sessions.init is called on the main thread.
   2. initiator.beginListening is called.
   3. The initiateSessionStart closure starts executing synchronously.
   4. It gets to all(subscriberPromises.values).then(...). The test has not had a chance to call sessions.register(subscriber:) yet, so the promises are unfulfilled.
   5. The test function continues, after Sessions.init returns.
   6. The test function calls sessions.register(subscriber:), which fulfills the promise.
   7. However, the .then block might have already been scheduled or is waiting in a way that is not being re-triggered correctly.

  The fundamental issue is the synchronous execution of a closure that relies on setup that happens after the function call returns.

  The correct fix is to ensure the session initiation logic runs after the current run loop cycle has completed, giving other components (like the test harness registering
  subscribers) a chance to execute. I will dispatch the initiateSessionStart() call to the main queue asynchronously. This will break the synchronous dependency and fix the
  race condition.