### PR TITLE
[Firebase AI] Update podspecs to Swift 6.0

### DIFF
--- a/FirebaseAI.podspec
+++ b/FirebaseAI.podspec
@@ -35,7 +35,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI SDK
     'FirebaseAI/Wrapper/Sources/**/*.swift',
   ]
 
-  s.swift_version = '5.9'
+  s.swift_version = '6.0'
 
   s.framework = 'Foundation'
   s.ios.framework = 'UIKit'

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -35,7 +35,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
     'FirebaseAI/Sources/**/*.swift',
   ]
 
-  s.swift_version = '5.9'
+  s.swift_version = '6.0'
 
   s.framework = 'Foundation'
   s.ios.framework = 'UIKit'


### PR DESCRIPTION
Updated `FirebaseAI.podspec` and `FirebaseAILogic.podspec` to `swift_version = '6.0'` to support Swift Testing unit tests and and to match [`Package.swift`](https://github.com/firebase/firebase-ios-sdk/blob/bf942b9d1510183346471c4348e6fae1ba70644a/Package.swift#L1). This currently overwritten to `6.0` in our `pod-lib-lint` jobs, except on `macos-14`: https://github.com/firebase/firebase-ios-sdk/blob/bf942b9d1510183346471c4348e6fae1ba70644a/.github/workflows/common_cocoapods.yml#L143-L145

We only support Xcode 16+ now which includes the Swift 6.0+ toolchain, even on macOS 14.

#no-changelog
