### PR TITLE
[RC] Fix data race on gIsNewDatabase

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix Data Race on gIsNewDatabase. (#14715)
+
 # 12.6.0
 - [fixed] Fixed a bug where Remote Config does not work after a restore
   of a previous backup of the device. (#14459)

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -120,12 +120,15 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder(void) {
 
 @implementation RCNConfigDBManager
 
++ (void)load {
+  gIsNewDatabaseQueue = dispatch_queue_create("com.google.FirebaseRemoteConfig.gIsNewDatabase",
+                                              DISPATCH_QUEUE_SERIAL);
+}
+
 + (instancetype)sharedInstance {
   static dispatch_once_t onceToken;
   static RCNConfigDBManager *sharedInstance;
   dispatch_once(&onceToken, ^{
-    gIsNewDatabaseQueue = dispatch_queue_create("com.google.FirebaseRemoteConfig.gIsNewDatabase",
-                                                DISPATCH_QUEUE_SERIAL);
     sharedInstance = [[RCNConfigDBManager alloc] init];
   });
   return sharedInstance;

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTests.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTests.m
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
+
+@interface RCNConfigDBManagerTests : XCTestCase
+@end
+
+@implementation RCNConfigDBManagerTests
+
+- (void)testIsNewDatabaseThreadSafety {
+  RCNConfigDBManager *dbManager = [RCNConfigDBManager sharedInstance];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Concurrent access to isNewDatabase"];
+  expectation.expectedFulfillmentCount = 100;
+
+  for (int i = 0; i < 100; i++) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      [dbManager isNewDatabase];
+      [expectation fulfill];
+    });
+  }
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+@end


### PR DESCRIPTION
Fix #14715

Gemini's analysis:
✦ I've analyzed RCNConfigDBManager.m and confirmed gIsNewDatabase is accessed in RemoteConfigCreateFilePathIfNotExist and
  isNewDatabase without proper synchronization. While dispatch_sync is present, the gIsNewDatabaseQueue is initialized too late
  within sharedInstance. To fix this, I'll move the queue's initialization into a +load method, ensuring it's set up before any
  other class methods are called. I will now apply this change.