### PR TITLE
[Infra] Remove `-sdk` flag from `xcodebuild` in `build.sh`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -165,7 +165,7 @@ else
   ios_flags=(
     -destination "platform=iOS Simulator,name=${iphone_simulator_name}"
   )
-    watchos_flags=(
+  watchos_flags=(
     -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)'
   )
 fi


### PR DESCRIPTION
In `build.sh` we always provide a specific `-destination`, which allows `xcodebuild` to automatically infer the correct `-sdk`. Removing `-sdk` allows us to support Swift macros, which need different SDKs for the host and library.

Context: Swift macros run on the build host (i.e., macOS) to expand code but specifying `-sdk 'iphonesimulator'` (or any other SDK) results in the compiler attempting to build the macro for iOS where they aren't supported. Removing the flag allows Xcode to infer macOS for the macro and iOS for the library target based on the `-destination`.

#no-changelog
