### PR TITLE
chore(m174): Update changelogs

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.7.0
 - [fixed] Add a mechanism to prevent concurrent token refreshes. (#15474)
 - [fixed] Fix "weak never mutated" build warning introduced in Xcode 26.2.
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Firebase 12.7.0
 - [fixed] [CocoaPods] Enable module map generation for Firebase pods. This
   resolves build failures when using static linking
   (`use_frameworks! :linkage => :static`) in projects using frameworks like

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.7.0
 - [fixed] Concurrency crash in FView. (#15514)
 
 # 11.9.0


### PR DESCRIPTION
This PR updates all the SDK changelogs to have their changes be under the `12.7.0` header, as part of the m174 release.