### PR TITLE
chore(m174): Update carthage versions

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseABTesting-453e3715e84856d3.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseABTesting-53d336f7762176f9.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseABTesting-0df050bbbce225b3.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseABTesting-c17935cbda0537f6.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/ABTesting-d0fdf10c43e985b1.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/ABTesting-a71d17cadc209af9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
@@ -1,4 +1,5 @@
 {
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAILogic-543b2fedd88a76fd.zip",
-  "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAILogic-127f2f25e744831a.zip"
+  "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAILogic-127f2f25e744831a.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAILogic-80017565705ec5ff.zip"
 }

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAnalytics-61b0d6c9596bf37a.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAnalytics-d3705dd81b8b5477.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAnalytics-20c5b666ede6db93.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAnalytics-1dcf775b9622470f.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Analytics-2468c231ebeb7922.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Analytics-bc8101d420b896c5.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Analytics-d2b6a6b0242db786.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppCheck-f45ebf0c8d5ae0aa.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAppCheck-15439cab8a605863.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAppCheck-d1b5e1cf2501aeac.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAppCheck-3d4878167498e8df.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseAppCheck-9ef1d217cf057203.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseAppCheck-fc03215d9fe45d3a.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseAppCheck-6ebe9e9539f06003.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppDistribution-aa1bb9ef501d82e7.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAppDistribution-935f33cbb50ac9c0.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAppDistribution-aebed6dcefe307ac.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAppDistribution-47c29d3820337399.zip",
   "6.31.0": "https://dl.google.com/dl/firebase/ios/carthage/6.31.0/FirebaseAppDistribution-07f6a2cf7f576a8a.zip",
   "6.32.0": "https://dl.google.com/dl/firebase/ios/carthage/6.32.0/FirebaseAppDistribution-a9c4f5db794508ca.zip",
   "6.33.0": "https://dl.google.com/dl/firebase/ios/carthage/6.33.0/FirebaseAppDistribution-448a96d2ade54581.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAuth-9d35d5c62a3e1a75.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAuth-873cd7b4bce5c5a6.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAuth-680198f76bfeaa62.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAuth-45979c2d5abf9cee.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Auth-0fa76ba0f7956220.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Auth-5ddd2b4351012c7a.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Auth-5e248984d78d7284.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseCrashlytics-49a8a1b1f30115df.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseCrashlytics-0d4111d63d6eefd0.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseCrashlytics-f52a803bbc42b2ef.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseCrashlytics-4c4bf3ac9f479ed4.zip",
   "6.15.0": "https://dl.google.com/dl/firebase/ios/carthage/6.15.0/FirebaseCrashlytics-1c6d22d5b73c84fd.zip",
   "6.16.0": "https://dl.google.com/dl/firebase/ios/carthage/6.16.0/FirebaseCrashlytics-938e5fd0e2eab3b3.zip",
   "6.17.0": "https://dl.google.com/dl/firebase/ios/carthage/6.17.0/FirebaseCrashlytics-fa09f0c8f31ed5d9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseDatabase-34750cd661cbd49b.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseDatabase-12c5aa3455796be4.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseDatabase-ceac2cd28fe7ad2d.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseDatabase-9e5aa8489fbbf516.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Database-1f7a820452722c7d.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Database-1f7a820452722c7d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Database-59a12d87456b3e1c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFirestore-acab074433fa0c6f.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseFirestore-ff38f0cab6f32140.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseFirestore-99b520136c671f71.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseFirestore-f206e42791aa7c7e.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Firestore-68fc02c229d0cc69.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Firestore-87a804ab561d91db.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Firestore-ecb3eea7bde7e8e8.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFunctions-8589fb2f6bff1e38.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseFunctions-9a267b1256451803.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseFunctions-c311d89541579d7d.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseFunctions-8d2d0c000a341519.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Functions-f4c426016dd41e38.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Functions-c6c44427c3034736.zip",
   "5.0.0": "https://dl.google.com/dl/firebase/ios/carthage/5.0.0/Functions-146f34c401bd459b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/GoogleSignIn-bcaadfe04c892ecb.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/GoogleSignIn-ad70a9d759c22eb6.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/GoogleSignIn-4ab016af298bb986.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/GoogleSignIn-8545064de3f144b1.zip",
   "6.0.0": "https://dl.google.com/dl/firebase/ios/carthage/6.0.0/GoogleSignIn-de9c5d5e8eb6d6ea.zip",
   "6.1.0": "https://dl.google.com/dl/firebase/ios/carthage/6.1.0/GoogleSignIn-8c82f2870573a793.zip",
   "6.10.0": "https://dl.google.com/dl/firebase/ios/carthage/6.10.0/GoogleSignIn-ff3aef61c4a55b05.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseInAppMessaging-9447455910a3800d.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseInAppMessaging-464b7174be10e192.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseInAppMessaging-aab0bd5472838c47.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseInAppMessaging-9e9ae249bd240e21.zip",
   "5.10.0": "https://dl.google.com/dl/firebase/ios/carthage/5.10.0/InAppMessaging-a7a3f933362f6e95.zip",
   "5.11.0": "https://dl.google.com/dl/firebase/ios/carthage/5.11.0/InAppMessaging-fa28ce1b88fbca93.zip",
   "5.12.0": "https://dl.google.com/dl/firebase/ios/carthage/5.12.0/InAppMessaging-fa28ce1b88fbca93.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMLModelDownloader-2ce9f1e78f15027f.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseMLModelDownloader-99a4ce736c201f72.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseMLModelDownloader-e27da274b406ee87.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseMLModelDownloader-a2f1a3387cea9bd8.zip",
   "8.0.0": "https://dl.google.com/dl/firebase/ios/carthage/8.0.0/FirebaseMLModelDownloader-8f972757fb181320.zip",
   "8.1.0": "https://dl.google.com/dl/firebase/ios/carthage/8.1.0/FirebaseMLModelDownloader-058ad59fa6dc0111.zip",
   "8.10.0": "https://dl.google.com/dl/firebase/ios/carthage/8.10.0/FirebaseMLModelDownloader-286479a966d2fb37.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMessaging-9175a3fe41e7c83c.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseMessaging-2ffe78328b8babb2.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseMessaging-6ca10fe55ee00be4.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseMessaging-9b7dc20a64c2feee.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Messaging-a22ef2b5f2f30f82.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Messaging-94fa4e090c7e9185.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Messaging-2a00a1c64a19d176.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebasePerformance-79cbc1d26656ac6d.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebasePerformance-31908337721c4819.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebasePerformance-77720536e15e847c.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebasePerformance-cdc4f0c4661a5551.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Performance-d8693eb892bfa05b.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Performance-0a400f9460f7a71d.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Performance-f5b4002ab96523e4.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseRemoteConfig-5d12611a14be55c9.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseRemoteConfig-925f509a1b213a01.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseRemoteConfig-cd6356c408f4c812.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseRemoteConfig-34441c20e227114a.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/RemoteConfig-7e9635365ccd4a17.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/RemoteConfig-e7928fcb6311c439.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/RemoteConfig-9ab1ca5f360a1780.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -51,6 +51,7 @@
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseStorage-e758b10b671ddad7.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseStorage-c060333135f118a7.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseStorage-6614a73464a18a2f.zip",
+  "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseStorage-b75867598924c838.zip",
   "4.11.0": "https://dl.google.com/dl/firebase/ios/carthage/4.11.0/Storage-6b3e77e1a7fdbc61.zip",
   "4.12.0": "https://dl.google.com/dl/firebase/ios/carthage/4.12.0/Storage-4721c35d2b90a569.zip",
   "4.9.0": "https://dl.google.com/dl/firebase/ios/carthage/4.9.0/Storage-821299369b9d0fb2.zip",


### PR DESCRIPTION
This PR updates the carthage version arrays to include the `12.7.0` release.

#no-changelog