### PR TITLE
feat: Upload xcodebuild logs for common SPM workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -123,3 +123,9 @@ jobs:
             ${{ inputs.target }} \
             ${{ matrix.platform }} \
             ${{ (contains(inputs.buildonly_platforms, matrix.platform) || contains(inputs.buildonly_platforms, 'all')) && 'spmbuildonly' || 'spm' }}
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: xcodebuild-logs-${{ inputs.target }}-${{ matrix.platform }}-${{ matrix.os }}-${{ matrix.xcode }}
+        path: xcodebuild-*.log
+        if-no-files-found: error


### PR DESCRIPTION
The common.yml is a re-usable workflow used by products for their SPM-based testing. It would be helpful to upload build  logs.

#no-changelog