### PR TITLE
fix: flaky FIRCLSLoggingTests.m

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -36,6 +36,10 @@
 - (void)setUp {
   [super setUp];
 
+  dispatch_sync(FIRCLSGetLoggingQueue(), ^{
+                    // Drain queue to prevent interference from previous tests.
+                });
+
   FIRCLSContextBaseInit();
 
   NSString* tempDir = NSTemporaryDirectory();


### PR DESCRIPTION
### Snippet from Nightly Report

From https://github.com/firebase/firebase-ios-sdk/actions/runs/20258318035/job/58164937354#step:7:1445:
```
  Test Suite 'FIRCLSLoggingTests' started at 2025-12-16 06:13:42.494.
      ✔ testEmptyKeysAndValues (0.005 seconds)
      ✔ testKeysAndValuesLog (0.006 seconds)
      ✔ testKeysAndValuesLogKeyCompaction (0.085 seconds)
      ✔ testKeysAndValuesLogMoreThanMaxKeys (0.090 seconds)
      ✔ testKeysAndValuesWithNilValue (0.005 seconds)
      ✔ testKeyValueLog (0.009 seconds)
      ✔ testKeyValueLogMoreThanMaxKeys (0.033 seconds)
      ✔ testKeyValueLogSingleKeyCompaction (0.069 seconds)
      ✔ testKeyValueWithNilKey (0.011 seconds)
      ✔ testKeyValueWithNilKeyAndValue (0.010 seconds)
  Error:     testKeyValueWithNilValue, (([[self incrementalKeyValues] count]) equal to (1)) failed: ("0") is not equal to ("1")
      ✔ testKeyValueWithNilValueCompaction (0.035 seconds)
      ✔ testLargeLogLine (0.016 seconds)
      ✔ testLoggedError (0.010 seconds)
      ✔ testLoggedErrorWithNullsInAdditionalInfo (0.005 seconds)
      ✔ testUserLog (0.016 seconds)
      ✔ testUserLogNil (0.013 seconds)
      ✔ testUserLogRotation (0.557 seconds)
      ✔ testUserLogRotationBackToBeginning (0.926 seconds)
      ✔ testWritingMaximumNumberOfLoggedErrors (0.009 seconds)
  Executed 20 tests, with 1 failure (0 unexpected) in 1.944 (1.996) seconds
```

### Hypothesis

Queue work left over from previous test cases is affecting state in subsequent tests.

### Approach

1. Search for "dispatch_async" and inspect all call hierarchies to determine which async dispatches are reached via `FIRCLSLoggingTests` test suite. This should give us all the possible async culprits. 
2. For the found tests, ignore the the ones that run after the `testKeyValueWithNilValue` flake in the nightly test log.
3. The remaining tests run before the flake and spawn in some way async work. In this case, the async work was always on the globally shared logging queue.

<img width="385" height="558" alt="Screenshot 2025-12-16 at 10 02 40 AM" src="https://github.com/user-attachments/assets/e6a52723-16e2-4e53-828c-a166eb17219b" />

Here is a snippet of the underlying async dispatch (**line 311**):

https://github.com/firebase/firebase-ios-sdk/blob/8f8f2c054e392229e0927607d3682d88cbfd6730/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m#L284-L316

### Solution

Draining the logging queue in the `FIRCLSLoggingTests` test suite's `-(void)setup` method should hopefully provide a clean slate for each test.

### Risks

It doesn't appear that the assertion depends on the finishing of the previous async work so the setup drain should be sufficient, but if flakes persist, we can replace/add a queue draining before the assertion.

```objc
// Flaking test...
- (void)testKeysAndValuesWithNilValue {
  FIRCLSUserLoggingRecordUserKeysAndValues(@{@"mykey" : [NSNull null]}); // <---- Spawns async work

  //// –––––––––––––––––––––––––––––––––––
  // Add queue draining here. 
  //// –––––––––––––––––––––––––––––––––––

  XCTAssertEqual([[self incrementalKeyValues] count], 1, @"");
}
```

#no-changelog