### PR TITLE
[Crashlytics] Conforming to Mach IPC security restrictions

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
-# Unrelased
-- [fixed] Conformed to Mach IPC security restrictions. Note: This change would potentially change mach exception types we receive from kernel which might affect issue clustering result. (#15393)
+# Unreleased
+- [fixed] Conformed to Mach IPC security restrictions. (#15393)
 
 # 12.4.0
 - [fixed] Make set development platform APIs to chain on Crashlytics context init promise.

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.h
@@ -27,24 +27,21 @@
 
 #pragma mark Structures
 #pragma pack(push, 4)
+// run `mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE=1 mach/mach_exc.defs`
+// check mach_exc.h
 typedef struct {
   mach_msg_header_t head;
   /* start of the kernel processed data */
   mach_msg_body_t msgh_body;
-  mach_msg_port_descriptor_t task_id;
-  mach_msg_port_descriptor_t thread_id;
+  mach_msg_port_descriptor_t task_id_token_t;
   /* end of the kernel processed data */
   NDR_record_t NDR;
+  uint64_t thread_id;
   exception_type_t exception;
   mach_msg_type_number_t codeCnt;
   mach_exception_data_type_t code[EXCEPTION_CODE_MAX];
   mach_msg_trailer_t trailer;
 } MachExceptionProtectedMessage;
-
-typedef struct {
-  uint64_t pad1;
-  uint64_t thread_id;
-} MachExceptionProtectedThreadInfo;
 
 typedef struct {
   mach_msg_header_t head;


### PR DESCRIPTION
Related issue: #15393 

Tested on:
- iOS15 (min version we support)
- arm macOS
- intel macOS

Note: macOS10.5 and 11 does not support identity protection so it fallback to default behavior, addressed in the later pr

Change exception behaviors from default to identity protected
Context: https://developer.apple.com/documentation/xcode/conforming-to-mach-ipc-security-restrictions