### PR TITLE
feat: improve build.sh logging and add dry run feature

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,7 +108,14 @@ source scripts/check_secrets.sh
 # Runs xcodebuild with the given flags, piping output to xcbeautify
 # If xcodebuild fails with known error codes, retries once.
 function RunXcodebuild() {
-  echo xcodebuild "$@"
+  # Print the command in a copy-pasteable format
+  echo xcodebuild $(printf "%q " "$@")
+
+  if [[ -n "${DRY_RUN:-}" ]]; then
+    echo "DRY_RUN is set. Exiting before build."
+    return 0
+  fi
+
   local xcodebuild_args=("$@")
   local buildaction="${xcodebuild_args[$# - 1]}" # buildaction is the last arg
   local log_filename="xcodebuild-${buildaction}.log"


### PR DESCRIPTION
build.sh prints the xcodebuild command, but it's not copy-and-paste friendly due to unescaped spaces:

```
  xcodebuild -scheme FirebaseSessionsUnit -destination platform=iOS Simulator,name=iPhone 16e ONLY_ACTIVE_ARCH=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=NO IPHONEOS_DEPLOYMENT_TARGET=13.0 TVOS_DEPLOYMENT_TARGET=13.0 test
```

The `-destination platform=iOS Simulator,name=iPhone 16e` will cause problems.

With this fix:
```
xcodebuild -scheme FirebaseSessionsUnit -destination platform=iOS\ Simulator\,name=iPhone\ 16 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=NO IPHONEOS_DEPLOYMENT_TARGET=13.0 TVOS_DEPLOYMENT_TARGET=13.0 test
```

Which is copy-and-paste friendly.

Also add a dry run feature, which is useful for getting the xcodebuild command for the desired scheme & platform, without actually executing the command. 

```
DRY_RUN=true ./scripts/build.sh FirebaseSessionsUnit iOS spm
```

Full example:
```
 % DRY_RUN=true ./scripts/build.sh FirebaseSessionsUnit iOS spm
Building FirebaseSessionsUnit for iOS using spm
GITHUB_BASE_REF: 
GITHUB_HEAD_REF: 
xcodebuild -scheme FirebaseSessionsUnit -destination platform=iOS\ Simulator\,name=iPhone\ 16 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=NO IPHONEOS_DEPLOYMENT_TARGET=13.0 TVOS_DEPLOYMENT_TARGET=13.0 test
DRY_RUN is set. Exiting before build.
```

#no-changelog