### PR TITLE
fix: nightly_ftl.yml workflow triggers

### DIFF
--- a/.github/workflows/nightly_ftl.yml
+++ b/.github/workflows/nightly_ftl.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
   pull_request:
+    paths:
+    - '.github/workflows/nightly_ftl.yml'
+    - 'Gemfile*'
 
 jobs:
   ftl_test:


### PR DESCRIPTION
How it is now, nightly_ftl.yml will run for all PRs, which was not my intention.

#no-changelog