### PR TITLE
fix: auth cron linting failure

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -109,6 +109,7 @@ jobs:
     uses: ./.github/workflows/common_cocoapods_cron.yml
     with:
       product: FirebaseAuth
+      ignore_deprecation_warnings: true
       platforms: '[ "ios", "tvos --skip-tests", "macos --skip-tests", "watchos --skip-tests" ]'
       flags: '[ "--use-static-frameworks" ]'
       setup_command: scripts/configure_test_keychain.sh


### PR DESCRIPTION
Fix another recurring nightly failure.

Manual dispatch: https://github.com/firebase/firebase-ios-sdk/actions/runs/20375558901

#no-changelog