### PR TITLE
fix: pod_lib_lint.rb should print copy-and-paste friendly command

### DIFF
--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -84,7 +84,9 @@ def main(args)
   command.push('--analyze') if analyze
 
   command.push(*pod_args)
-  puts command.join(' ')
+  # Quote arguments containing curly braces to ensure they are treated as literal strings
+  # by the shell when the command is copy-pasted, preventing unintended brace expansion.
+  puts command.map { |arg| arg =~ /[{}]/ ? "'#{arg}'" : arg }.join(' ')
 
   # Run the lib lint command in a thread.
   pod_lint_status = 1


### PR DESCRIPTION
Small improvement– `scripts/pod_lib_lint.rb` prints the underlying pod lib lint command. Typically this includes the `--include-podspecs` arg that takes a list of specs grouped with `{` and `}`. The command that is printed is not copy and paste friendly though since the braces are not escaped or quoted when printed.

```
scripts/pod_lib_lint.rb FirebaseSessions.podspec --platforms=iOS
```

### Currently
```
bundle exec pod lib lint <snip> -include-podspecs={FirebaseCore.podspec,FirebaseCoreInternal.podspec,FirebaseCoreExtension.podspec,FirebaseInstallations.podspec} <snip>
```

### With this PR
- The argument with `{}` is quoted when printed so it can be copied and pasted as-is.
```
bundle exec pod lib lint  <snip> '--include-podspecs={FirebaseCore.podspec,FirebaseCoreInternal.podspec,FirebaseCoreExtension.podspec,FirebaseInstallations.podspec}' <snip>
```

#no-changelog