### PR TITLE
fix: Give Firestore more time in archiving.yml

### DIFF
--- a/.github/workflows/archiving.yml
+++ b/.github/workflows/archiving.yml
@@ -62,7 +62,8 @@ jobs:
     - name: Setup project and archive
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 20
+        # Firestore gets a 60 min. timeout, everything else gets 20 min.
+        timeout_minutes: ${{ matrix.pod == "FirebaseFirestore" && 60 || 20 }}
         max_attempts: 3
         retry_wait_seconds: 300
         command: scripts/test_archiving.sh ${{ matrix.pod }} ${{ matrix.target }} ArchiveOutputs/${{ matrix.target }}.xcarchive


### PR DESCRIPTION
Fix a nightly flake

A previous successful run of Firestore x archiving took 38 minutes. I'm giving it an hour just in case. Everything else should be okay with 20 minutes.

#no-changelog