### PR TITLE
add setNumberOfStackFramesToSkipForNotFatalErrors

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -83,7 +83,8 @@ void FIRCLSUserLoggingWriteInternalKeyValue(NSString* key, NSString* value);
 
 void FIRCLSUserLoggingRecordError(NSError* error,
                                   NSDictionary<NSString*, id>* additionalUserInfo,
-                                  NSString* rolloutsInfoJSON);
+                                  NSString* rolloutsInfoJSON,
+                                  NSUInteger skipStacks);
 
 NSDictionary* FIRCLSUserLoggingGetCompactedKVEntries(FIRCLSUserLoggingKVStorage* storage,
                                                      bool decodeHex);

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -388,7 +388,8 @@ static void FIRCLSUserLoggingWriteError(FIRCLSFile *file,
 
 void FIRCLSUserLoggingRecordError(NSError *error,
                                   NSDictionary<NSString *, id> *additionalUserInfo,
-                                  NSString *rolloutsInfoJSON) {
+                                  NSString *rolloutsInfoJSON,
+                                  NSUInteger numberOfStacksToSkip) {
   if (!error) {
     return;
   }
@@ -400,6 +401,10 @@ void FIRCLSUserLoggingRecordError(NSError *error,
   // record the stacktrace and timestamp here, so we
   // are as close as possible to the user's log statement
   NSArray *addresses = [NSThread callStackReturnAddresses];
+  if (numberOfStacksToSkip > 0 && [addresses count] > numberOfStacksToSkip) {
+    NSRange range = NSMakeRange(numberOfStacksToSkip, [addresses count] - numberOfStacksToSkip);
+    addresses = [addresses subarrayWithRange:range];
+  }
   uint64_t timestamp = time(NULL);
 
   FIRCLSUserLoggingWriteAndCheckABFiles(

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -113,6 +113,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 @property(nonatomic, nullable) FBLPromise *contextInitPromise;
 
+@property(nonatomic, assign) NSUInteger stackFramesToSkip;
 @end
 
 @implementation FIRCrashlytics
@@ -147,6 +148,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
     _fileManager = [[FIRCLSFileManager alloc] init];
     _googleAppID = app.options.googleAppID;
     _dataArbiter = [[FIRCLSDataCollectionArbiter alloc] initWithApp:app withAppInfo:appInfo];
+    _stackFramesToSkip = 0;
 
     FIRCLSApplicationIdentifierModel *appModel = [[FIRCLSApplicationIdentifierModel alloc] init];
     FIRCLSSettings *settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager
@@ -413,7 +415,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
   NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
-  FIRCLSUserLoggingRecordError(error, userInfo, rolloutsInfoJSON);
+  FIRCLSUserLoggingRecordError(error, userInfo, rolloutsInfoJSON, self.stackFramesToSkip);
 }
 
 - (void)recordExceptionModel:(FIRExceptionModel *)exceptionModel {
@@ -426,6 +428,10 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
       recordOnDemandExceptionIfQuota:exceptionModel
            withDataCollectionEnabled:[self.dataArbiter isCrashlyticsCollectionEnabled]
           usingExistingReportManager:self.existingReportManager];
+}
+
+- (void)setNumberOfStackFramesToSkipForNotFatalErrors:(NSUInteger)frames {
+  self.stackFramesToSkip = frames;
 }
 
 #pragma mark - FIRSessionsSubscriber

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -243,6 +243,8 @@ NS_SWIFT_NAME(Crashlytics)
  */
 - (void)deleteUnsentReports;
 
+- (void)setNumberOfStackFramesToSkipForNotFatalErrors:(NSUInteger)frames;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Proposal for https://github.com/firebase/firebase-ios-sdk/issues/11475

### API Changes

  * This is a proposal to add a method to set number of stack trace frames to be skipped for non-fatal errors.

Similar to Bugsnag: https://docs.bugsnag.com/platforms/ios/customizing-error-reports/#modifying-stack-traces