### PR TITLE
fix: find re2 headers

### DIFF
--- a/Firestore/core/src/core/expressions_eval.cc
+++ b/Firestore/core/src/core/expressions_eval.cc
@@ -37,12 +37,12 @@
 #include "Firestore/core/src/remote/serializer.h"
 #include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/log.h"
-#include "Firestore/third_party/re2/re2.h"
 #include "absl/strings/ascii.h"  // For AsciiStrToLower/ToUpper (if needed later)
 #include "absl/strings/match.h"    // For StartsWith, EndsWith, StrContains
 #include "absl/strings/str_cat.h"  // For StrAppend
 #include "absl/strings/strip.h"    // For StripAsciiWhitespace
 #include "absl/types/optional.h"
+#include "re2/re2.h"
 
 namespace firebase {
 namespace firestore {


### PR DESCRIPTION
Address re2 header related nightlies https://github.com/firebase/firebase-ios-sdk/issues/15607#issuecomment-3705190372

Gemini Explanation:

   1. CocoaPods Cleanup: When CocoaPods installs a pod, it cleans the source directory by removing any files that are not explicitly declared in the podspec (via source_files, resources, preserve_paths, etc.).
   2. Missing Headers: Before your change, the re2 headers located in Firestore/third_party/re2 were not listed in source_files (since they are excluded or not matched) and were missing from preserve_paths. As a result, CocoaPods deleted them.
   3. Broken Search Path: Although HEADER_SEARCH_PATHS correctly pointed to /Firestore/third_party/re2, the compilation failed because the files had been removed from the disk.
   4. The Fix: Adding 'Firestore/third_party/re2/**/*.h' to preserve_paths explicitly tells CocoaPods to keep these files. This ensures they exist on disk during the build, allowing the compiler to resolve #include re2/re2.h.


Testing
- [x] Successfully staged to SpecStaging (https://github.com/firebase/SpecsStaging/commit/d4a9559418208f6494d21905f42ca953c16bfafc)
- [ ] manual prerelease: https://github.com/firebase/firebase-ios-sdk/actions/runs/20663912566
- [ ] manual release: https://github.com/firebase/firebase-ios-sdk/actions/runs/20663904925
- [ ] symbol collision: Merge main then re-trigger

Fixes #15607

#no-changelog
