### PR TITLE
[AI] Refactor JSONSchema with enum to eliminate nullables

### DIFF
--- a/FirebaseAI/Tests/Unit/Types/Generable/GenerableTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/Generable/GenerableTests.swift
@@ -229,26 +229,27 @@ final class GenerableTests: XCTestCase {
   func testPersonJSONSchema() throws {
     let schema = Person.jsonSchema
 
-    guard case let .object(_, _, properties) = schema.kind else {
+    guard case let .definition(kind, _) = schema.representation,
+          case let .object(_, _, properties) = kind else {
       XCTFail("Schema kind is not an object.")
       return
     }
 
     XCTAssertEqual(properties.count, 5)
     let firstName = try XCTUnwrap(properties.first { $0.name == "firstName" })
-    XCTAssert(firstName.type == String.self)
+    XCTAssertTrue(firstName.type == String.self)
     XCTAssertFalse(firstName.isOptional)
     let middleName = try XCTUnwrap(properties.first { $0.name == "middleName" })
-    XCTAssert(middleName.type == String.self)
+    XCTAssertTrue(middleName.type == String.self)
     XCTAssertTrue(middleName.isOptional)
     let lastName = try XCTUnwrap(properties.first { $0.name == "lastName" })
-    XCTAssert(lastName.type == String.self)
+    XCTAssertTrue(lastName.type == String.self)
     XCTAssertFalse(lastName.isOptional)
     let age = try XCTUnwrap(properties.first { $0.name == "age" })
-    XCTAssert(age.type == Int.self)
+    XCTAssertTrue(age.type == Int.self)
     XCTAssertFalse(age.isOptional)
     let address = try XCTUnwrap(properties.first { $0.name == "address" })
-    XCTAssert(address.type == Address.self)
+    XCTAssertTrue(address.type == Address.self)
     XCTAssertFalse(address.isOptional)
   }
 }


### PR DESCRIPTION
Address https://github.com/firebase/firebase-ios-sdk/pull/15650#pullrequestreview-3623565482

This pull request refactors the `JSONSchema` struct to enhance its internal representation and eliminate the use of nullable properties. By introducing a `Representation` enum, the schema's state is now explicitly defined as either a definition or a compiled version, leading to a more robust and less error-prone structure. This change simplifies the handling of `JSONSchema` instances and improves code clarity.

### Highlights

* **Refactor JSONSchema**: The `JSONSchema` struct has been refactored to eliminate nullable properties (`kind`, `source`, `schema`) by introducing a new `Representation` enum.
* **New Representation Enum**: A new `Representation` enum now encapsulates the state of a `JSONSchema`, allowing it to be either a `.definition` (containing `Kind` and `source`) or a `.compiled` schema (containing `JSONSchema.Internal`).
* **Updated Initializers and Methods**: Initializers, the `makeInternal()` method, and the `Codable` conformance's `init(from decoder:)` have been updated to correctly utilize and assign values to the new `representation` enum.
* **Test Case Adjustment**: A test case in `GenerableTests.swift` was updated to reflect the new structure of `JSONSchema` when accessing its properties.

#no-changelog