### PR TITLE
feat: upload logs for catalyst workflows and extend timeout

### DIFF
--- a/.github/workflows/common_catalyst.yml
+++ b/.github/workflows/common_catalyst.yml
@@ -37,7 +37,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: 15
+        timeout_minutes: 20
         max_attempts: 3
         retry_wait_seconds: 120
         command: |
@@ -45,3 +45,15 @@ jobs:
             ${{ inputs.product }} \
             ${{ inputs.buildonly == true && 'build' || 'test' }} \
             ${{ inputs.target }}
+    - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      if: ${{ failure() }}
+      with:
+        name: xcodebuild-logs-${{ inputs.target }}-maccatalyst
+        path: xcodebuild-*.log
+        if-no-files-found: error
+    - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      if: ${{ failure() }}
+      with:
+        name: xcresults-${{ inputs.target }}-maccatalyst
+        path: xcresults/*
+        if-no-files-found: error


### PR DESCRIPTION
- upload xcresult and build logs for catalyst CI testing
- extend timeout

Should provide more info on rarer Crashlytics flake: https://productionresultssa11.blob.core.windows.net/actions-results/02ec39f7-7972-4005-bdfe-9eb8b6e74ac3/workflow-job-run-58a11f9e-6250-546a-9ac6-ba502be8b6ee/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-05T16%3A53%3A54Z&sig=hlAUL9pmZlujpzYed3yu6DoYK1UY08JiGHKBy8Y6OoE%3D&ske=2026-01-06T04%3A15%3A30Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-05T16%3A15%3A30Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-05T16%3A43%3A49Z&sv=2025-11-05

The fact that the context manager tests started twice implies a crash during a unit test. The crash report will be included in the xcresult bundle and should provide more info:

<img width="825" height="157" alt="Screenshot 2026-01-05 at 11 45 50 AM" src="https://github.com/user-attachments/assets/77e21592-1f84-49a2-8655-beff27fdd2d5" />
