### PR TITLE
fix(ci): Update Live Session integration tests

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -117,7 +117,8 @@ struct LiveSessionTests {
   }
 
   @Test(arguments: arguments)
-  func sendVideoRealtime_receiveAudioOutputTranscripts(_ config: InstanceConfig, modelName: String) async throws {
+  func sendVideoRealtime_receiveAudioOutputTranscripts(_ config: InstanceConfig,
+                                                       modelName: String) async throws {
     let model = FirebaseAI.componentInstance(config).liveModel(
       modelName: modelName,
       generationConfig: generationConfig,


### PR DESCRIPTION
Per [b/473562404](https://b.corp.google.com/issues/473562404),

This updates the Live Session integration tests such that instead of using text responses, they use audio output transcripts. Since the new native audio models don't support text response modalities, this allows the tests to continue to function.

The system instructions for function calling needed to rephrased slightly as the models were not responding otherwise. But all the tests passed on my local run.

This PR also fixes #15640

#no-changelog