### PR TITLE
fix: Extend Firestore QS testing timeout in prerelease.yml

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Build Quickstart
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
-        timeout_minutes: ${{ matrix.timeout_minutes || 15 }} 
+        timeout_minutes: ${{ matrix.timeout_minutes || 15 }}
         max_attempts: 3
         retry_wait_seconds: 120
         command: DIR=${{ matrix.product }} scripts/test_quickstart.sh ${{ matrix.product }} ${{ matrix.run_tests }}


### PR DESCRIPTION
Address prerelease failure in https://github.com/firebase/firebase-ios-sdk/issues/15661#issuecomment-3710159422

#no-changelog