### PR TITLE
[FCM] Narrower database open recovery logic

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRmqManager.m
@@ -546,9 +546,9 @@ NSString *_Nonnull FIRMessagingStringFromSQLiteResult(int result) {
           // If it still fails after the recovery attempt, then assert and crash.
           if (result != SQLITE_OK) {
             NSString *errorString = FIRMessagingStringFromSQLiteResult(result);
-            NSString *errorMessage = [NSString stringWithFormat:
-                @"Could not open or create RMQ database at path %@, error: %@",
-                path, errorString];
+            NSString *errorMessage = [NSString
+                stringWithFormat:@"Could not open or create RMQ database at path %@, error: %@",
+                                 path, errorString];
             FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreErrorOpeningDatabase,
                                     @"%@", errorMessage);
             NSAssert(NO, errorMessage);
@@ -561,10 +561,11 @@ NSString *_Nonnull FIRMessagingStringFromSQLiteResult(int result) {
           }
         } else {
           NSString *errorString = FIRMessagingStringFromSQLiteResult(result);
-          NSString *errorMessage = [NSString stringWithFormat:
-              @"Could not open RMQ database at path %@, error: %@. Won't delete the "
-              @"database as it is not a corrupt database error.",
-              path, errorString];
+          NSString *errorMessage =
+              [NSString stringWithFormat:
+                            @"Could not open RMQ database at path %@, error: %@. Won't delete the "
+                            @"database as it is not a corrupt database error.",
+                            path, errorString];
           FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreErrorOpeningDatabase,
                                   @"%@", errorMessage);
           NSAssert(NO, errorMessage);


### PR DESCRIPTION
Follow up to #15553. Only do new recovery logic for SQLITE_CANTOPEN error instead of any open failure.

Gemini's summary:
This pull request refines the database opening and recovery logic within Firebase Messaging to ensure that the destructive recovery action (deleting and recreating the database) is only performed for specific, actionable errors. By narrowing the scope of this recovery to "SQLITE_CANTOPEN" errors, the change aims to improve the robustness and reliability of the database handling, avoiding unintended data loss or operational issues when other, non-corruption related open failures occur.

### Highlights

* **Database Recovery Logic Refinement**: The database recovery mechanism in Firebase Cloud Messaging (FCM) has been updated to be more specific. Previously, the system would attempt to delete and recreate the database for any SQLite open failure. Now, this recovery process is exclusively triggered when the "SQLITE_CANTOPEN" error is encountered, preventing unnecessary database deletions for other types of open errors.