### PR TITLE
fix: qs tests should use latest GoogleAppMeasurement

### DIFF
--- a/.github/workflows/common_quickstart.yml
+++ b/.github/workflows/common_quickstart.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       plist_secret: ${{ secrets.plist_secret }}
       QUICKSTART_BRANCH: ${{ inputs.quickstart_branch }}
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
     runs-on: macos-15
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Address https://github.com/firebase/firebase-ios-sdk/actions/runs/20766167353/job/59632659948?pr=15678#step:8:86

#no-changelog