### PR TITLE
feat: Require core approval for changes to public headers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@ ReleaseTooling/ @firebase/firebase-ios-sdk-admin
 FirebaseCore/ @firebase/firebase-ios-sdk-admin
 Package.swift @firebase/firebase-ios-sdk-admin
 Dangerfile @firebase/firebase-ios-sdk-admin
+**/Public @firebase/firebase-ios-sdk-admin
 *.podspec @firebase/firebase-ios-sdk-admin
 Gemfile* @firebase/firebase-ios-sdk-admin
 Interop/ @firebase/firebase-ios-sdk-admin


### PR DESCRIPTION
Add required core approval for changes to public headers.

From GitHub:
```
# In this example, @octocat owns any file in a `/logs` directory such as
# `/build/logs`, `/scripts/logs`, and `/deeply/nested/logs`. Any changes
# in a `/logs` directory will require approval from @octocat.
**/logs @octocat
```

Note – Doesn't seem like there is a trivial way to do this for Swift files.

#no-changelog