### PR TITLE
Resolve TODO in _ObjC_HeartbeatController.swift

### DIFF
--- a/FirebaseCore/Internal/Sources/HeartbeatLogging/_ObjC_HeartbeatController.swift
+++ b/FirebaseCore/Internal/Sources/HeartbeatLogging/_ObjC_HeartbeatController.swift
@@ -50,8 +50,6 @@ public class _ObjC_HeartbeatController: NSObject {
   /// - Note: This API is thread-safe.
   /// - Returns: A heartbeats payload for the flushed heartbeat(s).
   public func flushAsync(completionHandler: @escaping @Sendable (_ObjC_HeartbeatsPayload) -> Void) {
-    // TODO: When minimum version moves to iOS 13.0, restore the async version
-    // removed in #13952.
     heartbeatController.flushAsync { heartbeatsPayload in
       completionHandler(_ObjC_HeartbeatsPayload(heartbeatsPayload))
     }


### PR DESCRIPTION
An `async` func cannot be used since ObjC interoperability is needed.

#no-changelog