### PR TITLE
[AI] Restore URL Context integration test

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -452,9 +452,9 @@ struct GenerateContentIntegrationTests {
     let urlContextMetadata = try #require(candidate.urlContextMetadata)
     #expect(urlContextMetadata.urlMetadata.count == 1)
     let urlMetadata = try #require(urlContextMetadata.urlMetadata.first)
+    #expect(urlMetadata.retrievalStatus == .success)
     let retrievedURL = try #require(urlMetadata.retrievedURL)
     #expect(retrievedURL == URL(string: url))
-    #expect(urlMetadata.retrievalStatus == .success)
   }
 
   @Test(arguments: InstanceConfig.allConfigs)


### PR DESCRIPTION
Restore previously flaky URL Context integration test for the Developer API.

The test failures seem unrelated and also occur in the nightly #15701.

Fix #15385

#no-changelog