### PR TITLE
[AI] Update integration test for changed Gemini 3 thinking

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -222,7 +222,7 @@ struct GenerateContentIntegrationTests {
 
     let candidate = try #require(response.candidates.first)
     let thoughtParts = candidate.content.parts.compactMap { $0.isThought ? $0 : nil }
-    let thoughtSignature = candidate.content.internalParts[0].thoughtSignature
+    let thoughtSignature = candidate.content.internalParts.first?.thoughtSignature
     #expect(thoughtSignature != nil || thoughtParts
       .isEmpty != (thinkingConfig.includeThoughts ?? false))
 


### PR DESCRIPTION
Gemini 3 is now using thoughtSignature where Gemini 2.5 used separate thoughts for indicating thinking.

This PR updates the integration test accordingly.

More logs at #15701 

Fix #15701 

#no-changelog