### PR TITLE
[Crashlytics] Mach IPC identity protected address backwards compatibility

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -185,6 +185,13 @@ FBLPromise* FIRCLSContextInitialize(FIRCLSContextInitData* initData,
       _firclsContext.readonly->machException.path =
           FIRCLSContextAppendToRoot(rootPath, FIRCLSReportMachExceptionFile);
 
+      // MacOS12 below does not support identity protected behavior
+      // check releases here: https://opensource.apple.com/releases/
+      // TODO: remove EXCEPTION_DEFAULT support when we bump min MacOS support to 12+
+      _firclsContext.readonly->machException.behavior = EXCEPTION_DEFAULT;
+      if (@available(macOS 12, *)) {
+        _firclsContext.readonly->machException.behavior = EXCEPTION_IDENTITY_PROTECTED;
+      }
       FIRCLSMachExceptionInit(&_firclsContext.readonly->machException);
     });
 #endif

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.h
@@ -45,6 +45,25 @@ typedef struct {
 
 typedef struct {
   mach_msg_header_t head;
+  /* start of the kernel processed data */
+  mach_msg_body_t msgh_body;
+  mach_msg_port_descriptor_t thread;
+  mach_msg_port_descriptor_t task;
+  /* end of the kernel processed data */
+  NDR_record_t NDR;
+  exception_type_t exception;
+  mach_msg_type_number_t codeCnt;
+  mach_exception_data_type_t code[EXCEPTION_CODE_MAX];
+  mach_msg_trailer_t trailer;
+} MachExceptionDefaultMessage;
+
+union MachExceptionMessage {
+  MachExceptionProtectedMessage protected_message;
+  MachExceptionDefaultMessage default_message;
+};
+
+typedef struct {
+  mach_msg_header_t head;
   NDR_record_t NDR;
   kern_return_t retCode;
 } MachExceptionReply;
@@ -65,6 +84,7 @@ typedef struct {
 
   exception_mask_t mask;
   FIRCLSMachExceptionOriginalPorts originalPorts;
+  exception_behavior_t behavior;
 } FIRCLSMachExceptionReadContext;
 
 #pragma mark - API


### PR DESCRIPTION
Follow up for #15612
Since MacOS 10.5 and 11 does not have identity protected behavior option, we need to fall back to default behavior for backward compatibility.

#15393 

#no-changelog