### PR TITLE
fix: flaky FIRMessagingPendingTopicsListTest.m

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingPendingTopicsList.h
+++ b/FirebaseMessaging/Sources/FIRMessagingPendingTopicsList.h
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, strong, nullable) NSDate *archiveDate;
 @property(nonatomic, readonly) NSUInteger numberOfBatches;
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)init;
 - (void)addOperationForTopic:(NSString *)topic
                   withAction:(FIRMessagingTopicAction)action
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -23,6 +23,10 @@
 #import "FirebaseMessaging/Sources/FIRMessagingPendingTopicsList.h"
 #import "FirebaseMessaging/Sources/FIRMessagingTopicsCommon.h"
 
+@interface FIRMessagingPendingTopicsList (Testing)
+- (instancetype)initWithCommandQueue:(dispatch_queue_t)queue;
+@end
+
 @interface FIRMessagingPendingTopicsListTest : XCTestCase
 
 /// Using this delegate lets us prevent any topic operations from start, making it easy to measure
@@ -107,7 +111,8 @@
 }
 
 - (void)testBatchSizeReductionAfterSuccessfulTopicUpdate {
-  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc] init];
+  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc]
+      initWithCommandQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)];
   pendingTopics.delegate = self.alwaysReadyDelegate;
 
   XCTestExpectation *allOperationsCompleted =
@@ -145,7 +150,8 @@
 }
 
 - (void)testCompletionOfTopicUpdatesInSameThread {
-  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc] init];
+  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc]
+      initWithCommandQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)];
   pendingTopics.delegate = self.alwaysReadyDelegate;
 
   XCTestExpectation *allOperationsSucceededed =
@@ -181,7 +187,8 @@
 }
 
 - (void)testAddingTopicToCurrentBatchWhileCurrentBatchTopicsInFlight {
-  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc] init];
+  FIRMessagingPendingTopicsList *pendingTopics = [[FIRMessagingPendingTopicsList alloc]
+      initWithCommandQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)];
   pendingTopics.delegate = self.alwaysReadyDelegate;
 
   NSString *initialTopic = @"/topics/0";


### PR DESCRIPTION
This pull request aims to fix a flaky test in FIRMessagingPendingTopicsListTest.m by introducing a configurable dispatch queue for topic operations. This allows tests to use a specific queue, improving determinism. The changes involve adding a new internal designated initializer to FIRMessagingPendingTopicsList that accepts a dispatch_queue_t, and updating asynchronous operations to use this queue. The tests are then modified to use this new initializer with a high-priority queue.

Same approach taken in Crashlytics: https://github.com/firebase/firebase-ios-sdk/pull/15623

Fix https://github.com/firebase/firebase-ios-sdk/issues/15715

#no-changelog