### PR TITLE
feat(storage): Add cross-app-restart resumable uploads via session URI

### DIFF
--- a/FirebaseStorage/Sources/StorageReference.swift
+++ b/FirebaseStorage/Sources/StorageReference.swift
@@ -181,6 +181,77 @@ import Foundation
     return task
   }
 
+  /// Asynchronously uploads a file to the currently specified `StorageReference`,
+  /// optionally resuming from a previous upload session.
+  ///
+  /// Use this method to resume an upload that was interrupted (e.g., by app termination).
+  /// Pass the `uploadSessionUri` from a previous `StorageTaskSnapshot` to continue
+  /// from where the upload left off.
+  ///
+  /// - Parameters:
+  ///   - fileURL: A URL representing the system file path of the object to be uploaded.
+  ///   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
+  ///       about the object being uploaded.
+  ///   - existingUploadUri: The upload session URI from a previous upload attempt.
+  ///       Obtain this from `StorageTaskSnapshot.uploadSessionUri`. The URI remains valid
+  ///       for approximately one week. Pass `nil` to start a new upload.
+  /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage the
+  /// upload.
+  @objc(putFile:metadata:existingUploadUri:) @discardableResult
+  open func putFile(from fileURL: URL,
+                    metadata: StorageMetadata? = nil,
+                    existingUploadUri: URL?) -> StorageUploadTask {
+    let putMetadata: StorageMetadata = metadata ?? StorageMetadata()
+    if let path = path.object {
+      putMetadata.path = path
+      putMetadata.name = (path as NSString).lastPathComponent as String
+    }
+    let task = StorageUploadTask(reference: self,
+                                 queue: storage.dispatchQueue,
+                                 file: fileURL,
+                                 metadata: putMetadata,
+                                 existingUploadUri: existingUploadUri)
+    task.enqueue()
+    return task
+  }
+
+  /// Asynchronously uploads a file to the currently specified `StorageReference`,
+  /// optionally resuming from a previous upload session, with a completion handler.
+  ///
+  /// Use this method to resume an upload that was interrupted (e.g., by app termination).
+  /// Pass the `uploadSessionUri` from a previous `StorageTaskSnapshot` to continue
+  /// from where the upload left off.
+  ///
+  /// - Parameters:
+  ///   - fileURL: A URL representing the system file path of the object to be uploaded.
+  ///   - metadata: `StorageMetadata` containing additional information (MIME type, etc.)
+  ///       about the object being uploaded.
+  ///   - existingUploadUri: The upload session URI from a previous upload attempt.
+  ///       Obtain this from `StorageTaskSnapshot.uploadSessionUri`. The URI remains valid
+  ///       for approximately one week. Pass `nil` to start a new upload.
+  ///   - completion: A completion block that either returns the object metadata on success,
+  ///       or an error on failure.
+  /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage the
+  /// upload.
+  @objc(putFile:metadata:existingUploadUri:completion:) @discardableResult
+  open func putFile(from fileURL: URL,
+                    metadata: StorageMetadata? = nil,
+                    existingUploadUri: URL?,
+                    completion: ((_: StorageMetadata?, _: Error?) -> Void)?) -> StorageUploadTask {
+    let putMetadata: StorageMetadata = metadata ?? StorageMetadata()
+    if let path = path.object {
+      putMetadata.path = path
+      putMetadata.name = (path as NSString).lastPathComponent as String
+    }
+    let task = StorageUploadTask(reference: self,
+                                 queue: storage.dispatchQueue,
+                                 file: fileURL,
+                                 metadata: putMetadata,
+                                 existingUploadUri: existingUploadUri)
+    startAndObserveUploadTask(task: task, completion: completion)
+    return task
+  }
+
   // MARK: - Downloads
 
   /// Asynchronously downloads the object at the `StorageReference` to a `Data` instance in memory.

--- a/FirebaseStorage/Sources/StorageTaskSnapshot.swift
+++ b/FirebaseStorage/Sources/StorageTaskSnapshot.swift
@@ -51,6 +51,22 @@ import Foundation
    */
   @objc public let status: StorageTaskStatus
 
+  /**
+   * The URI for the upload session. Can be used to resume the upload after app restart
+   * by passing it to `putFile(from:metadata:existingUploadUri:)`.
+   *
+   * This URI remains valid for approximately one week after creation.
+   *
+   * - Note: Only available for upload tasks after the upload has started.
+   *   Returns `nil` for download tasks or before the upload session is established.
+   */
+  @objc public var uploadSessionUri: URL? {
+    guard let uploadTask = task as? StorageUploadTask else {
+      return nil
+    }
+    return uploadTask.uploadSessionUri
+  }
+
   // MARK: NSObject overrides
 
   @objc override public var description: String {

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -37,6 +37,10 @@ import Foundation
  *
  * Uploads are performed on a background queue, and callbacks are raised on the developer
  * specified `callbackQueue` in Storage, or the main queue if unspecified.
+ *
+ * Uploads support cross-app-restart resumption. Use `snapshot.uploadSessionUri` to get
+ * the GCS session URI during an upload, persist it, and pass it to
+ * `putFile(from:metadata:existingUploadUri:)` to resume after app restart.
  */
 @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
 @objc(FIRStorageUploadTask) open class StorageUploadTask: StorageObservableTask,
@@ -55,61 +59,111 @@ import Foundation
 
       self.state = .queueing
 
-      let dataRepresentation = self.uploadMetadata.dictionaryRepresentation()
-      let bodyData = try? JSONSerialization.data(withJSONObject: dataRepresentation)
-
       Task {
         let fetcherService = await StorageFetcherService.shared.service(reference.storage)
-        var request = self.baseRequest
-        request.httpMethod = "POST"
-        request.timeoutInterval = self.reference.storage.maxUploadRetryTime
-        request.httpBody = bodyData
-        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
-        if let count = bodyData?.count {
-          request.setValue("\(count)", forHTTPHeaderField: "Content-Length")
-        }
-
-        var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
-        if components?.host == "www.googleapis.com",
-           let path = components?.path {
-          components?.percentEncodedPath = "/upload\(path)"
-        }
-        guard let path = self.GCSEscapedString(self.uploadMetadata.path) else {
-          fatalError("Internal error enqueueing a Storage task")
-        }
-        components?.percentEncodedQuery = "uploadType=resumable&name=\(path)"
-
-        request.url = components?.url
 
         guard let contentType = self.uploadMetadata.contentType else {
           fatalError("Internal error enqueueing a Storage task")
         }
 
-        let uploadFetcher = GTMSessionUploadFetcher(
-          request: request,
-          uploadMIMEType: contentType,
-          chunkSize: self.reference.storage.uploadChunkSizeBytes,
-          fetcherService: fetcherService
-        )
+        let uploadFetcher: GTMSessionUploadFetcher
+
+        if let existingUri = self.existingUploadUri {
+          // RESUME: Use existing upload session URI
+          do {
+            uploadFetcher = try await self.createResumingFetcher(
+              sessionUri: existingUri,
+              contentType: contentType,
+              fetcherService: fetcherService
+            )
+          } catch {
+            self.state = .failed
+            self.error = StorageErrorCode.error(withServerError: error as NSError,
+                                                ref: self.reference)
+            self.metadata = self.uploadMetadata
+            self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+            return
+          }
+        } else {
+          // NEW UPLOAD: Create fresh session
+          let dataRepresentation = self.uploadMetadata.dictionaryRepresentation()
+          let bodyData = try? JSONSerialization.data(withJSONObject: dataRepresentation)
+
+          var request = self.baseRequest
+          request.httpMethod = "POST"
+          request.timeoutInterval = self.reference.storage.maxUploadRetryTime
+          request.httpBody = bodyData
+          request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+          if let count = bodyData?.count {
+            request.setValue("\(count)", forHTTPHeaderField: "Content-Length")
+          }
+
+          var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
+          if components?.host == "www.googleapis.com",
+             let path = components?.path {
+            components?.percentEncodedPath = "/upload\(path)"
+          }
+          guard let path = self.GCSEscapedString(self.uploadMetadata.path) else {
+            fatalError("Internal error enqueueing a Storage task")
+          }
+          components?.percentEncodedQuery = "uploadType=resumable&name=\(path)"
+
+          request.url = components?.url
+
+          uploadFetcher = GTMSessionUploadFetcher(
+            request: request,
+            uploadMIMEType: contentType,
+            chunkSize: self.reference.storage.uploadChunkSizeBytes,
+            fetcherService: fetcherService
+          )
+        }
+
+        // Configure the fetcher with upload data or file
         if let uploadData {
           uploadFetcher.uploadData = uploadData
           uploadFetcher.comment = "Data UploadTask"
         } else if let fileURL {
           uploadFetcher.uploadFileURL = fileURL
-          uploadFetcher.comment = "File UploadTask"
+          uploadFetcher.comment = self.existingUploadUri != nil ? "Resumed File UploadTask" : "File UploadTask"
 
-          if !GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads() {
-            uploadFetcher.useBackgroundSession = false
-          }
+          // Disable background sessions to enable retry-based offset querying.
+          // Background sessions handle network loss by pausing/waiting internally,
+          // which bypasses the retry path that queries the server for upload offset.
+          // Without this, network interruptions would not trigger the offset query.
+          uploadFetcher.useBackgroundSession = false
         }
         uploadFetcher.maxRetryInterval = self.reference.storage.maxUploadRetryInterval
+
+        // Enable retry so that retryBlock is called on errors.
+        // The fetcher service has this enabled, but upload fetchers need it explicitly.
+        uploadFetcher.isRetryEnabled = true
+
+        // Enable retry for network errors so GTMSessionUploadFetcher queries the server
+        // for the upload offset before resuming. Without this, network interruptions
+        // would restart the upload from 0% instead of continuing from the last confirmed offset.
+        uploadFetcher.retryBlock = { (suggestedWillRetry: Bool,
+                                      error: Error?,
+                                      response: @escaping GTMSessionFetcherRetryResponse) in
+          var shouldRetry = suggestedWillRetry
+          // GTMSessionFetcher does not consider being offline a retryable error, but we do.
+          // When offline, we want to retry so the upload fetcher will query for the offset.
+          if !shouldRetry, let nsError = error as? NSError {
+            shouldRetry = nsError.code == URLError.notConnectedToInternet.rawValue ||
+                          nsError.code == URLError.networkConnectionLost.rawValue ||
+                          nsError.code == URLError.timedOut.rawValue
+          }
+          response(shouldRetry)
+        }
 
         uploadFetcher.sendProgressBlock = { [weak self] (bytesSent: Int64, totalBytesSent: Int64,
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
             self.state = .progress
-            self.progress.completedUnitCount = totalBytesSent
-            self.progress.totalUnitCount = totalBytesExpectedToSend
+            // Add resume offset for resumed uploads - totalBytesSent only counts this session
+            let actualCompleted = totalBytesSent + self.resumeByteOffset
+            let actualTotal = totalBytesExpectedToSend + self.resumeByteOffset
+            self.progress.completedUnitCount = actualCompleted
+            self.progress.totalUnitCount = actualTotal
             self.metadata = self.uploadMetadata
             self.fire(for: .progress, snapshot: self.snapshot)
             self.state = .running
@@ -207,15 +261,34 @@ import Foundation
   // Hold completion in object to force it to be retained until completion block is called.
   var completionMetadata: ((StorageMetadata?, Error?) -> Void)?
 
+  /// URI for an existing upload session to resume. If provided, the upload will attempt
+  /// to resume from where the previous session left off.
+  private var existingUploadUri: URL?
+
+  /// Bytes already uploaded from a previous session (for accurate progress reporting).
+  /// GTMSessionUploadFetcher's progress callback reports bytes sent in the current session only,
+  /// so we need to add this offset for resumed uploads.
+  private var resumeByteOffset: Int64 = 0
+
+  /// The URI for the current upload session. Can be used to resume the upload after app restart.
+  /// This URI remains valid for approximately one week after creation.
+  /// - Note: This property is only available after the upload has started and the server
+  ///   has returned a session URI. Returns `nil` before that point or for data uploads.
+  public var uploadSessionUri: URL? {
+    return uploadFetcher?.uploadLocationURL
+  }
+
   // MARK: - Internal Implementations
 
   init(reference: StorageReference,
        queue: DispatchQueue,
        file: URL? = nil,
        data: Data? = nil,
-       metadata: StorageMetadata) {
+       metadata: StorageMetadata,
+       existingUploadUri: URL? = nil) {
     uploadMetadata = metadata
     uploadData = data
+    self.existingUploadUri = existingUploadUri
     super.init(reference: reference, queue: queue, file: file)
 
     if uploadMetadata.contentType == nil {
@@ -255,5 +328,134 @@ import Foundation
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$'()*,=:@"
     let allowedCharacters = CharacterSet(charactersIn: GCSObjectAllowedCharacterSet)
     return input.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
+  }
+
+  // MARK: - Resumable Upload Support
+
+  /// Creates a GTMSessionUploadFetcher configured to resume an existing upload session.
+  ///
+  /// This method queries the GCS server for the current upload state, then creates a fetcher
+  /// using the location-based initializer which puts GTMSessionUploadFetcher into "resume mode".
+  ///
+  /// - Parameters:
+  ///   - sessionUri: The GCS resumable upload session URI from a previous upload.
+  ///   - contentType: The MIME type of the content being uploaded.
+  ///   - fetcherService: The fetcher service to use for the upload.
+  /// - Returns: A configured GTMSessionUploadFetcher ready to resume the upload.
+  private func createResumingFetcher(
+    sessionUri: URL,
+    contentType: String,
+    fetcherService: GTMSessionFetcherService
+  ) async throws -> GTMSessionUploadFetcher {
+    // Query the server for current upload state
+    let bytesUploaded = try await queryUploadStatus(sessionUri: sessionUri)
+
+    // CRITICAL: Use the location-based initializer for resumption.
+    // GTMSessionUploadFetcher has two mutually exclusive modes:
+    // 1. New upload: init(request:...) - starts a fresh upload session
+    // 2. Resume: init(location:...) - continues an existing session
+    // Using init(request:) and then setting uploadLocationURL does NOT work -
+    // the fetcher will start a new session instead of resuming.
+    let uploadFetcher = GTMSessionUploadFetcher(
+      location: sessionUri,
+      uploadMIMEType: contentType,
+      chunkSize: reference.storage.uploadChunkSizeBytes,
+      fetcherService: fetcherService
+    )
+
+    // Enable retry for network errors so GTMSessionUploadFetcher queries the server
+    // for the upload offset before resuming.
+    uploadFetcher.retryBlock = { (suggestedWillRetry: Bool,
+                                  error: Error?,
+                                  response: @escaping GTMSessionFetcherRetryResponse) in
+      var shouldRetry = suggestedWillRetry
+      if !shouldRetry, let nsError = error as? NSError {
+        shouldRetry = nsError.code == URLError.notConnectedToInternet.rawValue ||
+                      nsError.code == URLError.networkConnectionLost.rawValue ||
+                      nsError.code == URLError.timedOut.rawValue
+      }
+      response(shouldRetry)
+    }
+
+    // Store resume offset for progress calculation.
+    // GTMSessionUploadFetcher's progress callback reports bytes sent in this session only.
+    self.resumeByteOffset = bytesUploaded
+
+    // Set initial progress based on server's confirmed bytes
+    self.progress.completedUnitCount = bytesUploaded
+
+    return uploadFetcher
+  }
+
+  /// Queries the GCS server for the current status of an upload session.
+  ///
+  /// This sends a "query" command to the GCS resumable upload endpoint to determine
+  /// how many bytes the server has confirmed receiving.
+  ///
+  /// - Parameter sessionUri: The GCS resumable upload session URI.
+  /// - Returns: The number of bytes the server has confirmed receiving.
+  /// - Throws: An error if the session has expired or the query fails.
+  private func queryUploadStatus(sessionUri: URL) async throws -> Int64 {
+    // Fetch auth tokens first
+    let authToken: String? = await withCheckedContinuation { continuation in
+      guard let auth = reference.storage.auth else {
+        continuation.resume(returning: nil)
+        return
+      }
+      auth.getToken(forcingRefresh: false) { token, _ in
+        continuation.resume(returning: token)
+      }
+    }
+
+    let appCheckToken: String? = await withCheckedContinuation { continuation in
+      guard let appCheck = reference.storage.appCheck else {
+        continuation.resume(returning: nil)
+        return
+      }
+      appCheck.getToken(forcingRefresh: false) { tokenResult in
+        continuation.resume(returning: tokenResult.token)
+      }
+    }
+
+    // Build the request with tokens
+    var request = URLRequest(url: sessionUri)
+    request.httpMethod = "POST"
+    request.setValue("resumable", forHTTPHeaderField: "X-Goog-Upload-Protocol")
+    request.setValue("query", forHTTPHeaderField: "X-Goog-Upload-Command")
+
+    if let authToken = authToken {
+      request.setValue("Firebase \(authToken)", forHTTPHeaderField: "Authorization")
+    }
+    if let appCheckToken = appCheckToken {
+      request.setValue(appCheckToken, forHTTPHeaderField: "X-Firebase-AppCheck")
+    }
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw StorageError.unknown(
+        message: "Invalid response when querying upload status",
+        serverError: [:]
+      )
+    }
+
+    // Check for error status codes
+    if httpResponse.statusCode >= 400 {
+      let bodyString = String(data: data, encoding: .utf8) ?? ""
+      throw StorageError.unknown(
+        message: "Upload session query failed with status \(httpResponse.statusCode). " +
+                 "The session may have expired. Response: \(bodyString.prefix(200))",
+        serverError: ["statusCode": httpResponse.statusCode]
+      )
+    }
+
+    // Parse X-Goog-Upload-Size-Received header to get confirmed bytes
+    if let bytesString = httpResponse.value(forHTTPHeaderField: "X-Goog-Upload-Size-Received"),
+       let bytes = Int64(bytesString) {
+      return bytes
+    }
+
+    // If header is missing, start from the beginning
+    return 0
   }
 }


### PR DESCRIPTION
## Summary

Adds the ability to persist and resume upload sessions across app restarts, matching the Android SDK's existing `putFile(uri, metadata, existingUploadUri)` functionality.

**Fixes #147**

### New API

```swift
// Get session URI from snapshot (persist this!)
uploadTask.observe(.progress) { snapshot in
    if let sessionUri = snapshot.uploadSessionUri {
        UserDefaults.standard.set(sessionUri.absoluteString, forKey: "uploadUri")
    }
}

// Resume upload after app restart
let savedUri = URL(string: UserDefaults.standard.string(forKey: "uploadUri")!)
let uploadTask = storageRef.putFile(from: fileURL, existingUploadUri: savedUri)
```

### Changes

| File | Changes |
|------|---------|
| `StorageUploadTask.swift` | +236 lines - Core resume logic, retry handling, progress offset tracking |
| `StorageTaskSnapshot.swift` | +16 lines - Expose `uploadSessionUri` property |
| `StorageReference.swift` | +71 lines - New `putFile(from:metadata:existingUploadUri:)` overloads |

### Implementation Details

1. **Session URI Exposure**: `StorageTaskSnapshot.uploadSessionUri` returns the GCS resumable session URI from `GTMSessionUploadFetcher.uploadLocationURL`

2. **Resume Flow**: New uploads use standard flow; resumed uploads use `GTMSessionUploadFetcher(location:)` initializer which is designed for session resumption

3. **Server Query**: `queryUploadStatus()` sends `X-Goog-Upload-Command: query` to get bytes already uploaded via `X-Goog-Upload-Size-Received` header

4. **Progress Tracking**: `resumeByteOffset` ensures accurate progress reporting for resumed uploads

5. **Network Retry**: Custom `retryBlock` treats network errors as retryable, enabling GTMSessionUploadFetcher's offset query mechanism

6. **Background Sessions**: Disabled for uploads to ensure retry-based offset queries work (background sessions pause on network loss instead of failing)

### Test Plan

- [x] Build verification (`swift build --target FirebaseStorage`)
- [x] Manual testing with real uploads and app restart simulation
- [ ] Unit tests for new properties
- [ ] Integration test for end-to-end resume flow

### Notes

- Session URIs remain valid for ~1 week (GCS limitation)
- Requires `putFile()` (file URL), not `putData()` (in-memory)
- Auth tokens are automatically refreshed during resume

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>