### PR TITLE
[Crashlytics] Add attribute for Info.plist to manually force back to mach exception default behavior

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -65,6 +65,7 @@ FIRCLSContextInitData* FIRCLSContextBuildInitData(FIRCLSInternalReport* report,
   initData.previouslyCrashedFileRootPath = [fileManager rootPath];
   initData.errorsEnabled = [settings errorReportingEnabled];
   initData.customExceptionsEnabled = [settings customExceptionsEnabled];
+  initData.machExceptionDefaultBehavior = [settings machExceptionDefaultBehavior];
   initData.maxCustomExceptions = [settings maxCustomExceptions];
   initData.maxErrorLogSize = [settings errorLogBufferSize];
   initData.maxLogSize = [settings logBufferSize];
@@ -190,7 +191,9 @@ FBLPromise* FIRCLSContextInitialize(FIRCLSContextInitData* initData,
       // TODO: remove EXCEPTION_DEFAULT support when we bump min MacOS support to 12+
       _firclsContext.readonly->machException.behavior = EXCEPTION_DEFAULT;
       if (@available(macOS 12, *)) {
-        _firclsContext.readonly->machException.behavior = EXCEPTION_IDENTITY_PROTECTED;
+        if (!initData.machExceptionDefaultBehavior) {
+          _firclsContext.readonly->machException.behavior = EXCEPTION_IDENTITY_PROTECTED;
+        }
       }
       FIRCLSMachExceptionInit(&_firclsContext.readonly->machException);
     });

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -150,7 +150,8 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 
     FIRCLSApplicationIdentifierModel *appModel = [[FIRCLSApplicationIdentifierModel alloc] init];
     FIRCLSSettings *settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager
-                                                                appIDModel:appModel];
+                                                                appIDModel:appModel
+                                                                   appInfo:appInfo];
 
     FIRCLSOnDemandModel *onDemandModel =
         [[FIRCLSOnDemandModel alloc] initWithFIRCLSSettings:settings fileManager:_fileManager];

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSContextInitData.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) NSString* betaToken;
 @property(nonatomic) BOOL errorsEnabled;
 @property(nonatomic) BOOL customExceptionsEnabled;
+@property(nonatomic) BOOL machExceptionDefaultBehavior;
 @property(nonatomic) uint32_t maxCustomExceptions;
 @property(nonatomic) uint32_t maxErrorLogSize;
 @property(nonatomic) uint32_t maxLogSize;

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -30,7 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
-                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel;
+                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel
+                            appInfo:(NSDictionary *)appInfo;
 
 /**
  * Recreates the settings dictionary by re-reading the settings file from persistent storage. This
@@ -77,6 +78,12 @@ NS_ASSUME_NONNULL_BEGIN
  * When this is false, Crashlytics will not collect custom exceptions from the API
  */
 @property(nonatomic, readonly) BOOL customExceptionsEnabled;
+
+/**
+ * When this is true, Crashlytics will fallback to EXCEPTION_DEFAULT
+ * for mach exception handler instead of EXCEPTION_IDENTITY_PROTECTED
+ */
+@property(nonatomic) BOOL machExceptionDefaultBehavior;
 
 /**
  * When this is true, Crashlytics will collect data from MetricKit

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -30,6 +30,8 @@ NSString *const CreatedAtKey = @"created_at";
 NSString *const GoogleAppIDKey = @"google_app_id";
 NSString *const BuildInstanceID = @"build_instance_id";
 NSString *const AppVersion = @"app_version";
+NSString *const FirebaseCrashlyticsMachDefaultBehaviorKey =
+    @"FirebaseCrashlyticsMachDefaultBehavior";
 
 @interface FIRCLSSettings ()
 
@@ -47,19 +49,32 @@ NSString *const AppVersion = @"app_version";
 @implementation FIRCLSSettings
 
 - (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
-                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel {
+                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel
+                            appInfo:(NSDictionary *)appInfo {
   return
       [self initWithFileManager:fileManager
                      appIDModel:appIDModel
+                        appInfo:appInfo
                   deletionQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)];
 }
 
 - (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
                          appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel
+                            appInfo:(NSDictionary *)appInfo
                       deletionQueue:(dispatch_queue_t)deletionQueue {
   self = [super init];
   if (!self) {
     return nil;
+  }
+
+  // Configure the Mach exception message receiving behavior from Info.plist the mach exception
+  // message receiving behavior
+  self.machExceptionDefaultBehavior = false;
+  id crashlyticsMachDefaultBehavior =
+      [appInfo objectForKey:FirebaseCrashlyticsMachDefaultBehaviorKey];
+  if ([crashlyticsMachDefaultBehavior isKindOfClass:[NSString class]] ||
+      [crashlyticsMachDefaultBehavior isKindOfClass:[NSNumber class]]) {
+    self.machExceptionDefaultBehavior = [crashlyticsMachDefaultBehavior boolValue];
   }
 
   _fileManager = fileManager;

--- a/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSContextManagerTests.m
@@ -47,7 +47,8 @@ NSString *const TestContextSessionID2 = @"TestContextSessionID2";
 
   FIRCLSApplicationIdentifierModel *appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
   _mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
-                                                       appIDModel:appIDModel];
+                                                       appIDModel:appIDModel
+                                                          appInfo:[[NSDictionary alloc] init]];
 
   //  NSString *name = @"exception_model_report";
   NSString *reportPath =

--- a/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
@@ -92,7 +92,9 @@ API_AVAILABLE(ios(14))
       [[FIRMockGDTCORTransport alloc] initWithMappingID:@"id" transformers:nil target:0];
   FIRCLSApplicationIdentifierModel *appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
   FIRCLSMockSettings *mockSettings =
-      [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager appIDModel:appIDModel];
+      [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
+                                           appIDModel:appIDModel
+                                              appInfo:[[NSDictionary alloc] init]];
 
   // Allow nil values only in tests
 #pragma clang diagnostic push

--- a/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
+++ b/Crashlytics/UnitTests/FIRCLSOnDemandModelTests.m
@@ -62,7 +62,8 @@
 
   FIRCLSApplicationIdentifierModel *appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
   _mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
-                                                       appIDModel:appIDModel];
+                                                       appIDModel:appIDModel
+                                                          appInfo:[[NSDictionary alloc] init]];
   _onDemandModel = [[FIRCLSMockOnDemandModel alloc] initWithFIRCLSSettings:_mockSettings
                                                                fileManager:_fileManager
                                                                 sleepBlock:^(int delay){

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -94,7 +94,8 @@
       [[FIRMockGDTCORTransport alloc] initWithMappingID:@"id" transformers:nil target:0];
   self.appIDModel = [[FIRCLSApplicationIdentifierModel alloc] init];
   self.mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
-                                                           appIDModel:self.appIDModel];
+                                                           appIDModel:self.appIDModel
+                                                              appInfo:[[NSDictionary alloc] init]];
 
   // Allow nil values only in tests
 #pragma clang diagnostic push

--- a/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
@@ -58,7 +58,8 @@ NSString *const TestFIID = @"TestFIID";
   FABMockApplicationIdentifierModel *appIDModel = [[FABMockApplicationIdentifierModel alloc] init];
   self.queue = [NSOperationQueue new];
   self.mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
-                                                           appIDModel:appIDModel];
+                                                           appIDModel:appIDModel
+                                                              appInfo:[[NSDictionary alloc] init]];
   self.mockDataTransport = [[FIRMockGDTCORTransport alloc] initWithMappingID:@"1206"
                                                                 transformers:nil
                                                                       target:kGDTCORTargetCSH];

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -62,6 +62,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 - (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
                          appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel
+                            appInfo:(nonnull NSDictionary *)appInfo
                       deletionQueue:(dispatch_queue_t)deletionQueue;
 
 @end
@@ -90,6 +91,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   _settings = [[FIRCLSSettings alloc]
       initWithFileManager:_fileManager
                appIDModel:_appIDModel
+                  appInfo:[[NSDictionary alloc] init]
             deletionQueue:dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)];
 }
 
@@ -103,6 +105,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertTrue(self.settings.errorReportingEnabled);
   XCTAssertTrue(self.settings.customExceptionsEnabled);
   XCTAssertFalse(self.settings.metricKitCollectionEnabled);
+  XCTAssertFalse(self.settings.machExceptionDefaultBehavior);
 
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
   XCTAssertEqual(self.settings.logBufferSize, 64 * 1000);
@@ -484,6 +487,36 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
+}
+
+- (void)testMachExceptionBehaviorFromAppInfo {
+  // The key is defined in FIRCLSSettings.m, so we'll redefine it here for the test.
+  NSString *const FirebaseCrashlyticsMachDefaultBehaviorKey =
+      @"FirebaseCrashlyticsMachDefaultBehavior";
+
+  NSDictionary *appInfoWithSetting = @{FirebaseCrashlyticsMachDefaultBehaviorKey : @YES};
+  _settings = [[FIRCLSSettings alloc]
+      initWithFileManager:_fileManager
+               appIDModel:_appIDModel
+                  appInfo:appInfoWithSetting
+            deletionQueue:dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)];
+  XCTAssertTrue(self.settings.machExceptionDefaultBehavior);
+
+  NSDictionary *appInfoWithSettingString = @{FirebaseCrashlyticsMachDefaultBehaviorKey : @"true"};
+  _settings = [[FIRCLSSettings alloc]
+      initWithFileManager:_fileManager
+               appIDModel:_appIDModel
+                  appInfo:appInfoWithSettingString
+            deletionQueue:dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)];
+  XCTAssertTrue(self.settings.machExceptionDefaultBehavior);
+
+  NSDictionary *appInfoWithSettingFalse = @{FirebaseCrashlyticsMachDefaultBehaviorKey : @NO};
+  _settings = [[FIRCLSSettings alloc]
+      initWithFileManager:_fileManager
+               appIDModel:_appIDModel
+                  appInfo:appInfoWithSettingFalse
+            deletionQueue:dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)];
+  XCTAssertFalse(self.settings.machExceptionDefaultBehavior);
 }
 
 @end

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -43,7 +43,8 @@
 
   FABMockApplicationIdentifierModel *appIDModel = [[FABMockApplicationIdentifierModel alloc] init];
   self.mockSettings = [[FIRCLSMockSettings alloc] initWithFileManager:self.fileManager
-                                                           appIDModel:appIDModel];
+                                                           appIDModel:appIDModel
+                                                              appInfo:[[NSDictionary alloc] init]];
 
   NSString *name = @"exception_model_report";
   self.reportPath = [self.fileManager.rootPath stringByAppendingPathComponent:name];


### PR DESCRIPTION
To preventing any unexpected issue for the upcoming release, add an attribute which user can insert into Info.plist to user can force switch back the original behavior

Revert this PR once release goes stable

#no-changelog 