### PR TITLE
fix: extend lint timeout in sdk.crashlytics.yml

### DIFF
--- a/.github/workflows/sdk.crashlytics.yml
+++ b/.github/workflows/sdk.crashlytics.yml
@@ -43,6 +43,7 @@ jobs:
     with:
       product: FirebaseCrashlytics
       buildonly_platforms: tvOS, macOS, watchOS
+      timeout_minutes: 20
 
   quickstart:
     uses: ./.github/workflows/_quickstart.yml


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-ios-sdk/actions/runs/21161372384/job/60856484901

#no-changelog
