### PR TITLE
fix: fail prerelease workflow if prerelease tagging fails

### DIFF
--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -57,7 +57,10 @@ elif [ "$TESTINGMODE" = "prerelease_testing" ]; then
   git push origin --delete "${tag_version}" > /dev/null 2>&1
   set -e
   git tag -f -a "${tag_version}" -m "release testing"
-  git push origin "${tag_version}" > /dev/null 2>&1 || echo "Push failed due to expired or insufficient token."
+  git push origin "${tag_version}" || {
+    echo "ERROR: Failed to push tag ${tag_version}. This is likely due to an expired Personal Access Token (PAT) or insufficient permissions." >&2
+    exit 1
+  }
   # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
   # ":tag => ${test_version}.nightly"
   sed -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec


### PR DESCRIPTION
I was expecting the nightly prerelease workflow to fail due to a permissions issue. It didn't fail though, and that's because the script wasn't configured to fail in the event the prerelease tags couldn't be pushed. The script should fail if these tags can't be pushed, else the workflow won't already test the true prerelease commit.

### Testing

### Before updating permissions

Failed as expected: https://github.com/firebase/firebase-ios-sdk/actions/runs/21215776440
```
Run podspec_repo_branch="${podspec_repo_branch}" \
++ TESTINGMODE=prerelease_testing
++ '[' -f /Users/runner/.cocoapods/repos ']'
++ git fetch --tags --quiet origin main
++ git checkout main
Switched to a new branch 'main'
branch 'main' set up to track 'origin/main'.
+++ git tag -l --sort=-version:refname --merged main 'CocoaPods-*[0-9]'
+++ head -n 1
++ test_version=CocoaPods-12.9.0
++ '[' -z CocoaPods-12.9.0 ']'
++ git config --global user.email google-oss-bot@example.com
++ git config --global user.name google-oss-bot
++ git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.
+++ sed s/CocoaPods-//
+++ echo CocoaPods-12.9.0
++ pod_testing_version=12.9.0
++ '[' prerelease_testing = release_testing ']'
A new tag, CocoaPods-12.9.0.nightly, for prerelease testing will be created.
++ '[' prerelease_testing = prerelease_testing ']'
++ tag_version=CocoaPods-12.9.0.nightly
++ echo 'A new tag, CocoaPods-12.9.0.nightly, for prerelease testing will be created.'
++ set +e
++ git push origin --delete CocoaPods-12.9.0.nightly
++ set -e
++ git tag -f -a CocoaPods-12.9.0.nightly -m 'release testing'
Updated tag 'CocoaPods-12.9.0.nightly' (was b3abdd910)
++ git push origin CocoaPods-12.9.0.nightly
To https://github.com/firebase/firebase-ios-sdk
 ! [rejected]            CocoaPods-12.9.0.nightly -> CocoaPods-12.9.0.nightly (already exists)
error: failed to push some refs to 'https://github.com/firebase/firebase-ios-sdk'
++ echo 'ERROR: Failed to push tag CocoaPods-12.9.0.nightly. This is likely due to an expired Personal Access Token (PAT) or insufficient permissions.'
ERROR: Failed to push tag CocoaPods-12.9.0.nightly. This is likely due to an expired Personal Access Token (PAT) or insufficient permissions.
++ exit 1
Error: Process completed with exit code 1.
```

### After updating permissions
- https://github.com/firebase/firebase-ios-sdk/actions/runs/21217213542
  - Did not work because permissions are aggregated
- https://github.com/firebase/firebase-ios-sdk/actions/runs/21217560189
  - Did not work because one permission set wasn't enforced.
- https://github.com/firebase/firebase-ios-sdk/actions/runs/21217694568

Update– I don't think it's possible to allowlist this as I want to.  I'm going to merge, and change prerelease tooling to depend on commit rather a nightly tag.

#no-changelog