### PR TITLE
[Firebase AI] Rename `Tool` to `ModelTool`

### DIFF
--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -69,15 +69,16 @@ public final class FirebaseAI: Sendable {
   ///     list of supported model names.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.
-  ///   - tools: A list of ``Tool`` objects that the model may use to generate the next response.
-  ///   - toolConfig: Tool configuration for any `Tool` specified in the request.
+  ///   - tools: A list of ``ModelTool`` objects that the model may use to generate the next
+  ///     response.
+  ///   - toolConfig: Tool configuration for any `ModelTool` specified in the request.
   ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
   ///     only text content is supported.
   ///   - requestOptions: Configuration parameters for sending requests to the backend.
   public func generativeModel(modelName: String,
                               generationConfig: GenerationConfig? = nil,
                               safetySettings: [SafetySetting]? = nil,
-                              tools: [Tool]? = nil,
+                              tools: [ModelTool]? = nil,
                               toolConfig: ToolConfig? = nil,
                               systemInstruction: ModelContent? = nil,
                               requestOptions: RequestOptions = RequestOptions())
@@ -170,8 +171,9 @@ public final class FirebaseAI: Sendable {
   /// - Parameters:
   ///   - modelName: The name of the model to use.
   ///   - generationConfig: The content generation parameters your model should use.
-  ///   - tools: A list of ``Tool`` objects that the model may use to generate the next response.
-  ///   - toolConfig: Tool configuration for any ``Tool`` specified in the request.
+  ///   - tools: A list of ``ModelTool`` objects that the model may use to generate the next
+  ///     response.
+  ///   - toolConfig: Tool configuration for any ``ModelTool`` specified in the request.
   ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
   ///     only text content is supported.
   ///   - requestOptions: Configuration parameters for sending requests to the backend.
@@ -179,7 +181,7 @@ public final class FirebaseAI: Sendable {
   @available(watchOS, unavailable)
   public func liveModel(modelName: String,
                         generationConfig: LiveGenerationConfig? = nil,
-                        tools: [Tool]? = nil,
+                        tools: [ModelTool]? = nil,
                         toolConfig: ToolConfig? = nil,
                         systemInstruction: ModelContent? = nil,
                         requestOptions: RequestOptions = RequestOptions()) -> LiveGenerativeModel {

--- a/FirebaseAI/Sources/GenerateContentRequest.swift
+++ b/FirebaseAI/Sources/GenerateContentRequest.swift
@@ -22,7 +22,7 @@ struct GenerateContentRequest: Sendable {
   let contents: [ModelContent]
   let generationConfig: GenerationConfig?
   let safetySettings: [SafetySetting]?
-  let tools: [Tool]?
+  let tools: [ModelTool]?
   let toolConfig: ToolConfig?
   let systemInstruction: ModelContent?
 

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -45,9 +45,9 @@ public final class GenerativeModel: Sendable {
   let safetySettings: [SafetySetting]?
 
   /// A list of tools the model may use to generate the next response.
-  let tools: [Tool]?
+  let tools: [ModelTool]?
 
-  /// Tool configuration for any `Tool` specified in the request.
+  /// Tool configuration for any `ModelTool` specified in the request.
   let toolConfig: ToolConfig?
 
   /// Instructions that direct the model to behave a certain way.
@@ -70,8 +70,9 @@ public final class GenerativeModel: Sendable {
   ///   - apiConfig: Configuration for the backend API used by this model.
   ///   - generationConfig: The content generation parameters your model should use.
   ///   - safetySettings: A value describing what types of harmful content your model should allow.
-  ///   - tools: A list of ``Tool`` objects that the model may use to generate the next response.
-  ///   - toolConfig: Tool configuration for any `Tool` specified in the request.
+  ///   - tools: A list of ``ModelTool`` objects that the model may use to generate the next
+  ///     response.
+  ///   - toolConfig: Tool configuration for any `ModelTool` specified in the request.
   ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
   ///     only text content is supported.
   ///   - requestOptions: Configuration parameters for sending requests to the backend.
@@ -82,7 +83,7 @@ public final class GenerativeModel: Sendable {
        apiConfig: APIConfig,
        generationConfig: GenerationConfig? = nil,
        safetySettings: [SafetySetting]? = nil,
-       tools: [Tool]?,
+       tools: [ModelTool]?,
        toolConfig: ToolConfig? = nil,
        systemInstruction: ModelContent? = nil,
        requestOptions: RequestOptions,

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -16,7 +16,8 @@ import Foundation
 
 /// Structured representation of a function declaration.
 ///
-/// This `FunctionDeclaration` is a representation of a block of code that can be used as a ``Tool``
+/// This `FunctionDeclaration` is a representation of a block of code that can be used as a
+/// ``ModelTool``
 /// by the model and executed by the client.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct FunctionDeclaration: Sendable {
@@ -63,12 +64,25 @@ public struct GoogleSearch: Sendable {
   public init() {}
 }
 
+@available(*, deprecated, renamed: "ModelTool", message: """
+`FirebaseAILogic.Tool` has been renamed to `ModelTool` to avoid naming conflicts with the `Tool` \
+type provided by the Foundation Models framework. Update call sites where applicable:
+- `Tool.functionDeclaration(...)` to `ModelTool.functionDeclarations(...)`
+- `Tool.googleSearch()` to `ModelTool.googleSearch()`
+- `Tool.urlContext()` to `ModelTool.urlContext()`
+- `Tool.codeExecution()` to `ModelTool.codeExecution()`
+
+Note: If you are using the shorthand syntax, for example `.googleSearch()`, no changes are required.
+""")
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+public typealias Tool = ModelTool
+
 /// A helper tool that the model may use when generating responses.
 ///
-/// A `Tool` is a piece of code that enables the system to interact with external systems to perform
-/// an action, or set of actions, outside of knowledge and scope of the model.
+/// A `ModelTool` is a piece of code that enables the system to interact with external systems to
+/// perform an action, or set of actions, outside of knowledge and scope of the model.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-public struct Tool: Sendable {
+public struct ModelTool: Sendable {
   /// A list of `FunctionDeclarations` available to the model.
   let functionDeclarations: [FunctionDeclaration]?
 
@@ -107,7 +121,8 @@ public struct Tool: Sendable {
   ///   ``FunctionResponsePart`` in ``ModelContent/parts`` with a ``ModelContent/role`` of
   ///   `"function"`; this response contains the result of executing the function on the client,
   ///   providing generation context for the model's next turn.
-  public static func functionDeclarations(_ functionDeclarations: [FunctionDeclaration]) -> Tool {
+  public static func functionDeclarations(_ functionDeclarations: [FunctionDeclaration])
+    -> ModelTool {
     return self.init(functionDeclarations: functionDeclarations)
   }
 
@@ -126,8 +141,8 @@ public struct Tool: Sendable {
   ///   - googleSearch: An empty ``GoogleSearch`` object. The presence of this object in the list
   ///     of tools enables the model to use Google Search.
   ///
-  /// - Returns: A `Tool` configured for Google Search.
-  public static func googleSearch(_ googleSearch: GoogleSearch = GoogleSearch()) -> Tool {
+  /// - Returns: A `ModelTool` configured for Google Search.
+  public static func googleSearch(_ googleSearch: GoogleSearch = GoogleSearch()) -> ModelTool {
     return self.init(googleSearch: googleSearch)
   }
 
@@ -136,14 +151,14 @@ public struct Tool: Sendable {
   ///
   /// By including URLs in your request, the Gemini model will access the content from those pages
   /// to inform and enhance its response.
-  public static func urlContext() -> Tool {
+  public static func urlContext() -> ModelTool {
     return self.init(urlContext: URLContext())
   }
 
   /// Creates a tool that allows the model to execute code.
   ///
   /// For more details, see ``CodeExecution``.
-  public static func codeExecution() -> Tool {
+  public static func codeExecution() -> ModelTool {
     return self.init(codeExecution: CodeExecution())
   }
 }
@@ -194,7 +209,7 @@ public struct FunctionCallingConfig: Sendable {
   }
 }
 
-/// Tool configuration for any `Tool` specified in the request.
+/// Tool configuration for any `ModelTool` specified in the request.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct ToolConfig: Sendable {
   let functionCallingConfig: FunctionCallingConfig?
@@ -223,7 +238,7 @@ extension FunctionDeclaration: Encodable {
 }
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-extension Tool: Encodable {}
+extension ModelTool: Encodable {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 extension FunctionCallingConfig: Encodable {}

--- a/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentSetup.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentSetup.swift
@@ -39,10 +39,10 @@ struct BidiGenerateContentSetup: Encodable {
 
   /// A list of `Tools` the model may use to generate the next response.
   ///
-  /// A `Tool` is a piece of code that enables the system to interact with
+  /// A `ModelTool` is a piece of code that enables the system to interact with
   /// external systems to perform an action, or set of actions, outside of
   /// knowledge and scope of the model.
-  let tools: [Tool]?
+  let tools: [ModelTool]?
 
   let toolConfig: ToolConfig?
 
@@ -59,7 +59,7 @@ struct BidiGenerateContentSetup: Encodable {
   init(model: String,
        generationConfig: BidiGenerationConfig? = nil,
        systemInstruction: ModelContent? = nil,
-       tools: [Tool]? = nil,
+       tools: [ModelTool]? = nil,
        toolConfig: ToolConfig? = nil,
        inputAudioTranscription: BidiAudioTranscriptionConfig? = nil,
        outputAudioTranscription: BidiAudioTranscriptionConfig? = nil) {

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -45,7 +45,7 @@ actor LiveSessionService {
   let apiConfig: APIConfig
   let firebaseInfo: FirebaseInfo
   let requestOptions: RequestOptions
-  let tools: [Tool]?
+  let tools: [ModelTool]?
   let toolConfig: ToolConfig?
   let systemInstruction: ModelContent?
 
@@ -67,7 +67,7 @@ actor LiveSessionService {
        urlSession: URLSession,
        apiConfig: APIConfig,
        firebaseInfo: FirebaseInfo,
-       tools: [Tool]?,
+       tools: [ModelTool]?,
        toolConfig: ToolConfig?,
        systemInstruction: ModelContent?,
        requestOptions: RequestOptions) {

--- a/FirebaseAI/Sources/Types/Public/Live/LiveGenerativeModel.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveGenerativeModel.swift
@@ -25,7 +25,7 @@ public final class LiveGenerativeModel {
   let firebaseInfo: FirebaseInfo
   let apiConfig: APIConfig
   let generationConfig: LiveGenerationConfig?
-  let tools: [Tool]?
+  let tools: [ModelTool]?
   let toolConfig: ToolConfig?
   let systemInstruction: ModelContent?
   let urlSession: URLSession
@@ -35,7 +35,7 @@ public final class LiveGenerativeModel {
        firebaseInfo: FirebaseInfo,
        apiConfig: APIConfig,
        generationConfig: LiveGenerationConfig? = nil,
-       tools: [Tool]? = nil,
+       tools: [ModelTool]? = nil,
        toolConfig: ToolConfig? = nil,
        systemInstruction: ModelContent? = nil,
        urlSession: URLSession = GenAIURLSession.default,

--- a/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLContextMetadata.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Metadata related to the ``Tool/urlContext()`` tool.
+/// Metadata related to the ``ModelTool/urlContext()`` tool.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct URLContextMetadata: Sendable, Hashable {
   /// List of URL metadata used to provide context to the Gemini model.

--- a/FirebaseAI/Sources/Types/Public/URLMetadata.swift
+++ b/FirebaseAI/Sources/Types/Public/URLMetadata.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-/// Metadata for a single URL retrieved by the ``Tool/urlContext()`` tool.
+/// Metadata for a single URL retrieved by the ``ModelTool/urlContext()`` tool.
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
 public struct URLMetadata: Sendable, Hashable {
   /// Status of the URL retrieval.

--- a/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
@@ -1869,7 +1869,7 @@ final class GenerativeModelVertexAITests: XCTestCase {
       firebaseInfo: GenerativeModelTestUtil.testFirebaseInfo(),
       apiConfig: apiConfig,
       generationConfig: generationConfig,
-      tools: [Tool(functionDeclarations: [sumFunction])],
+      tools: [ModelTool(functionDeclarations: [sumFunction])],
       systemInstruction: systemInstruction,
       requestOptions: RequestOptions(),
       urlSession: urlSession

--- a/FirebaseAI/Tests/Unit/Types/ToolTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/ToolTests.swift
@@ -26,7 +26,7 @@ final class ToolTests: XCTestCase {
   }
 
   func testEncodeTool_googleSearch() throws {
-    let tool = Tool.googleSearch()
+    let tool = ModelTool.googleSearch()
 
     let jsonData = try encoder.encode(tool)
 
@@ -41,7 +41,7 @@ final class ToolTests: XCTestCase {
   }
 
   func testEncodeTool_codeExecution() throws {
-    let tool = Tool.codeExecution()
+    let tool = ModelTool.codeExecution()
 
     let jsonData = try encoder.encode(tool)
 
@@ -61,7 +61,7 @@ final class ToolTests: XCTestCase {
       description: "A test function.",
       parameters: ["param1": .string()]
     )
-    let tool = Tool.functionDeclarations([functionDecl])
+    let tool = ModelTool.functionDeclarations([functionDecl])
     let jsonData = try encoder.encode(tool)
 
     let jsonString = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
@@ -91,7 +91,7 @@ final class ToolTests: XCTestCase {
   }
 
   func testEncodeTool_urlContext() throws {
-    let tool = Tool.urlContext()
+    let tool = ModelTool.urlContext()
 
     let jsonData = try encoder.encode(tool)
 


### PR DESCRIPTION
WIP - Draft Proposal

This PR proposes renaming `FirebaseAILogic.Tool` to `FirebaseAILogic.ModelTool` (or another name) to alleviate ambiguous type errors for developers using Foundation Models. The existing name conflicts with `FoundationModels.Tool`.

Note: Our integration tests were all using the shorthand notation so they do not demonstrate the deprecation warning:
- https://github.com/firebase/firebase-ios-sdk/blob/beda7f4e0eb1ca20fa0928ce400b86fa3a5ae9c6/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift#L177
- https://github.com/firebase/firebase-ios-sdk/blob/beda7f4e0eb1ca20fa0928ce400b86fa3a5ae9c6/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift#L474
- https://github.com/firebase/firebase-ios-sdk/blob/beda7f4e0eb1ca20fa0928ce400b86fa3a5ae9c6/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift#L416
- https://github.com/firebase/firebase-ios-sdk/blob/beda7f4e0eb1ca20fa0928ce400b86fa3a5ae9c6/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift#L455

However, our [public docs](https://firebase.google.com/docs/ai-logic/grounding-google-search#ground-the-model) qualify the names (e.g., `Tool.googleSearch()`) so they would be impacted if we made this change.

#no-changelog