### PR TITLE
Add unit tests for UnfairLock

### DIFF
--- a/FirebaseCore/Internal/Tests/Unit/UnfairLockTests.swift
+++ b/FirebaseCore/Internal/Tests/Unit/UnfairLockTests.swift
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import XCTest
 @testable import FirebaseCoreInternal
+import XCTest
 
 final class UnfairLockTests: XCTestCase {
-
   func testLockProtectsState() {
     let lock = UnfairLock(0)
     let iterations = 1000


### PR DESCRIPTION
Added FirebaseCore/Internal/Tests/Unit/UnfairLockTests.swift to test thread safety and basic functionality of UnfairLock.

---
*PR created automatically by Jules for task [16501340849775609056](https://jules.google.com/task/16501340849775609056) started by @ryanwilson*