### PR TITLE
Remote Config: Document workaround for empty data after device restore 

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] A workaround to restore service if Remote Config data remains empty
+- [issue] A workaround to restore service if Remote Config data remains empty
   after a device restore is to publish a new version of your Remote Config template
   in the Firebase console to force a full synchronization. This issue can occur if
   the app was opened with an older SDK version (< 12.6.0) before upgrading. An automatic


### PR DESCRIPTION
This PR updates the Release notes for Remote Config to document a manual workaround for a known issue where data remains empty after a device restore. This is a documentation-only change to provide immediate guidance while a permanent code-level fix is under development.

**Problem: Older vs. Newer SDK Interaction**

- The issue stems from a "stale state" created when a user interacts with different SDK versions following a restore:
- Older SDK Versions (< 12.6.0): If an app is opened on these versions immediately after a device restore, it creates an empty RemoteConfig.sqlite3 file but preserves stale metadata (like ETags) in UserDefaults.
- Newer SDK Versions (≥ 12.6.0): The existing restore fix (#15442) is only triggered if the database file is missing. Because the older SDK already created a file, the newer SDK bypasses the reset logic upon upgrade.

**The Result:** The client sends a stale ETag, the server returns NO_CHANGE, and the local database remains empty indefinitely.

**Manual Workaround**
Publishing a new Remote Config template in the Firebase console forces a full synchronization. This resolves the issue for all affected users by invalidating the stale local ETags.

External Bug: https://github.com/firebase/firebase-ios-sdk/issues/15764
Internal Bug: [b/478858294](https://buganizer.corp.google.com/issues/478858294)

