### PR TITLE
infra: fix Firestore CI cron jobs

### DIFF
--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -28,8 +28,6 @@ concurrency:
 jobs:
   changes:
     runs-on: macos-14
-    # Only when this is not a scheduled run
-    if: github.event_name != 'schedule'
     outputs:
       changed: ${{ steps.firestore_src_changes.outputs.sources == 'true' || steps.related_changes.outputs.other_changes == 'true' }}
     steps:
@@ -395,6 +393,7 @@ jobs:
           '',
         ]
         os: [macos-15]
+        xcode: [Xcode_16.4]
         # Skip matrix cells covered by pod-lib-lint job.
         exclude:
           - os: macos-15
@@ -502,6 +501,8 @@ jobs:
       FIREBASE_SOURCE_FIRESTORE: 1
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Build Test - Binary


### PR DESCRIPTION
This PR fixes two issues in the `sdk.firestore.yml` workflow:
1. The `spm-source-cron` job was failing because it didn't select an Xcode version. I added a step to select Xcode 16.2.
2. The `pod-lib-lint-cron` job was being skipped on scheduled runs because its dependency `check` depends on `changes`, which was configured to skip on schedules. I removed the skip condition from `changes` to ensure the dependency chain works.
3. I also added the missing `xcode` matrix variable to `pod-lib-lint-cron` to prevent it from failing once it starts running.

---
*PR created automatically by Jules for task [10749625727554048345](https://jules.google.com/task/10749625727554048345) started by @ncooke3*