### PR TITLE
Add unit test for App Group ID equality behavior in FirebaseOptions

### DIFF
--- a/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
@@ -155,6 +155,28 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertFalse(plainOptions.isEqual(defaultOptions1))
   }
 
+  func testAppGroupIDEqualityBehavior() {
+    let options1 = FirebaseOptions(googleAppID: "appID", gcmSenderID: "senderID")
+    let options2 = FirebaseOptions(googleAppID: "appID", gcmSenderID: "senderID")
+
+    // Verify initial equality
+    XCTAssertEqual(options1, options2)
+
+    // Modify appGroupID
+    options1.appGroupID = "group1"
+
+    // Verify inequality
+    XCTAssertNotEqual(options1, options2)
+
+    // Verify equality when both are set to same value
+    options2.appGroupID = "group1"
+    XCTAssertEqual(options1, options2)
+
+    // Verify inequality when values differ
+    options2.appGroupID = "group2"
+    XCTAssertNotEqual(options1, options2)
+  }
+
   // MARK: - Helpers
 
   private func assertOptionsMatchDefaultOptions(options: FirebaseOptions) {


### PR DESCRIPTION
Added `testAppGroupIDEqualityBehavior` to `FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift` to verify `appGroupID` equality logic. This test ensures that `FirebaseOptions` instances are considered unequal if their `appGroupID` properties differ, even if all other properties are identical. It documents and protects the behavior where `appGroupID` is explicitly checked in `isEqual:` alongside the internal options dictionary.

---
*PR created automatically by Jules for task [7490179081453909751](https://jules.google.com/task/7490179081453909751) started by @ryanwilson*