### PR TITLE
Replace the deprecated Base64Escape function call

### DIFF
--- a/Firestore/core/src/local/leveldb_key.cc
+++ b/Firestore/core/src/local/leveldb_key.cc
@@ -574,7 +574,7 @@ model::SnapshotVersion Reader::ReadSnapshotVersion() {
  */
 std::string InvalidKey(leveldb::Slice key) {
   std::string result;
-  absl::Base64Escape(MakeStringView(key), &result);
+  result = absl::Base64Escape(MakeStringView(key));
   return result;
 }
 


### PR DESCRIPTION
This PR updates the codebase to remove usages of the `Base64Escape` function, which has been marked as deprecated in the Abseil library. It replaces the call with the recommended modern alternative to ensure long-term maintainability.

**Reference**

* Deprecation source: [[abseil-cpp/absl/strings/escaping.h#L133](https://gemini.google.com/corp/app/01582a0048c4acdd)]()

### Changes

* Replaced `Base64Escape` with its non-deprecated equivalent.

### Changelog

#no-changelog