### PR TITLE
test: Add unit test for FIRBundleUtil relevantURLSchemes

### DIFF
--- a/FirebaseCore/Tests/Unit/FIRBundleUtilTest.m
+++ b/FirebaseCore/Tests/Unit/FIRBundleUtilTest.m
@@ -28,9 +28,15 @@ static NSString *const kFileType = @"fileType";
 
 @implementation FIRTestBundleUtil
 static NSArray *_bundlesToReturn;
-+ (NSArray *)bundlesToReturn { return _bundlesToReturn; }
-+ (void)setBundlesToReturn:(NSArray *)bundles { _bundlesToReturn = bundles; }
-+ (NSArray *)relevantBundles { return _bundlesToReturn ?: @[]; }
++ (NSArray *)bundlesToReturn {
+  return _bundlesToReturn;
+}
++ (void)setBundlesToReturn:(NSArray *)bundles {
+  _bundlesToReturn = bundles;
+}
++ (NSArray *)relevantBundles {
+  return _bundlesToReturn ?: @[];
+}
 @end
 
 @interface FIRBundleUtilTest : FIRTestCase
@@ -150,8 +156,8 @@ static NSArray *_bundlesToReturn;
 - (void)testRelevantURLSchemes {
   // Setup mock bundle with URL types
   NSArray *urlTypes = @[
-    @{ @"CFBundleURLSchemes": @[ @"scheme1", @"scheme2" ] },
-    @{ @"CFBundleURLSchemes": @[ @"scheme3" ] }
+    @{@"CFBundleURLSchemes" : @[ @"scheme1", @"scheme2" ]},
+    @{@"CFBundleURLSchemes" : @[ @"scheme3" ]}
   ];
   OCMStub([self.mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(urlTypes);
 


### PR DESCRIPTION
Adds a new unit test in FIRBundleUtilTest.m to verify the behavior of relevantURLSchemes.
This test ensures that URL schemes are correctly parsed from the relevant bundles' Info.plist.
A helper class FIRTestBundleUtil is introduced to mock the relevantBundles method for testing purposes.

---
*PR created automatically by Jules for task [17900932220383065709](https://jules.google.com/task/17900932220383065709) started by @ryanwilson*