### PR TITLE
[Infra] Add script to automatically add copyright to files

### DIFF
--- a/scripts/add_copyright.sh
+++ b/scripts/add_copyright.sh
@@ -16,14 +16,6 @@
 
 set -u
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-  echo "Usage: $0 [BASE_BRANCH]"
-  echo ""
-  echo "Finds newly added files compared to BASE_BRANCH (defaults to 'main')"
-  echo "and automatically prepends or updates the Google copyright header."
-  exit 0
-fi
-
 # Check if git is available.
 if ! command -v git &> /dev/null; then
     echo "git command could not be found."
@@ -31,7 +23,7 @@ if ! command -v git &> /dev/null; then
 fi
 
 # Move to the root of the repository to ensure paths are correct.
-cd "$(git rev-parse --show-toplevel)"
+cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # Define the base branch (defaulting to main).
 BASE_BRANCH=${1:-main}
@@ -52,7 +44,7 @@ echo "Checking for new files against $BASE_BRANCH..."
 # Get list of added files.
 # git diff --name-only --diff-filter=A returns paths relative to repo root.
 # We compare the working directory against the merge base of the current branch and the base branch.
-FILES=$(git diff --name-only --diff-filter=A $(git merge-base "$BASE_BRANCH" HEAD))
+FILES=$(git diff --name-only --diff-filter=A "$(git merge-base "$BASE_BRANCH" HEAD)")
 
 if [ -z "$FILES" ]; then
     echo "No new files found."


### PR DESCRIPTION
Added `scripts/add_copyright.sh` to automatically add the Apache License 2.0 header to newly added source files in the current branch. The script:
- Identifies new files using `git diff` against the merge base of the base branch (default `main`).
- Supports multiple file extensions (c, cc, cpp, h, hpp, js, m, mm, swift, cmake, py, rb, sh, yml, yaml).
- Handles shebang lines correctly by inserting the license after them.
- Uses the current year in the copyright notice.
- Updates existing copyright years in new files if a header is found (in the first 20 lines).
- Checks if the file is truly new (via git filter) to avoid modifying existing files in the repo.
- Safely handles itself (the script) by avoiding false positives from its own content.
