### PR TITLE
[AI] Combine integration test `xcodebuild` build and test steps

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -575,14 +575,7 @@ case "$product-$platform-$method" in
     ;;
 
   FirebaseAIIntegration-*-*)
-    # Build
-    RunXcodebuild \
-      -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
-      -scheme "FirebaseAITestApp-SPM" \
-      "${xcb_flags[@]}" \
-      build-for-testing
-
-    # Run tests
+    # Build and run tests
     RunXcodebuild \
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
       -scheme "FirebaseAITestApp-SPM" \
@@ -590,7 +583,7 @@ case "$product-$platform-$method" in
       -parallel-testing-enabled NO \
       -retry-tests-on-failure \
       -test-iterations 3 \
-      test-without-building
+      test
     ;;
 
   Sessions-*-integration)


### PR DESCRIPTION
Combined the `build-for-testing` and `test-without-building` to `test` for the Firebase AI Logic integration tests to see if this speeds up the CI workflow.

#no-changelog