### PR TITLE
chore(m177): Update carthage json versions

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseABTesting-5436773ba2b9326e.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseABTesting-bd721c84362383a6.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseABTesting-bb0e44f97fd81c31.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseABTesting-f8afbe4fd89721e4.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseABTesting-328b9123860fa215.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseABTesting-240f73a221798c3b.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseABTesting-453e3715e84856d3.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
@@ -1,4 +1,5 @@
 {
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAILogic-e7cf2116e42a5d8e.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAILogic-543b2fedd88a76fd.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAILogic-127f2f25e744831a.zip",
   "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAILogic-80017565705ec5ff.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAnalytics-fe649e5740ef72e9.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAnalytics-70ead21957efa870.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAnalytics-88dad74aa8ab040a.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAnalytics-df3afb09bbd5e6f4.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAnalytics-b37787f72cdbb950.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAnalytics-866ebeb7925d0267.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAnalytics-61b0d6c9596bf37a.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAppCheck-366c926c105319b0.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAppCheck-b9f47f169bb6249c.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAppCheck-072a1be1f8eb1177.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAppCheck-ac07812d496e0727.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppCheck-dac2380c7e1b9898.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppCheck-f0fb8c2a38b272c7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppCheck-f45ebf0c8d5ae0aa.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAppDistribution-32e12df219d91736.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAppDistribution-076c2c6efb7eb8dc.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAppDistribution-370884f5f825f098.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAppDistribution-65f6474aa8393329.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppDistribution-042b04483c9241b6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppDistribution-8498aaebd9f9e633.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppDistribution-aa1bb9ef501d82e7.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseAuth-ab131b2e07abc902.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseAuth-e58b2b5f430bfbfe.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseAuth-2c17100b302eb080.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAuth-0e942a3add1a3919.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAuth-9f0a14da6c12ea6d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAuth-e4ba94c15c57a75f.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAuth-9d35d5c62a3e1a75.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseCrashlytics-81aa29d9a106acb0.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseCrashlytics-d9a9be2a4e220017.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseCrashlytics-fbf241b0c59f3821.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseCrashlytics-b39296402bc5db93.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseCrashlytics-623ce628d0404f39.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseCrashlytics-6054b7e88b91a91d.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseCrashlytics-49a8a1b1f30115df.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseDatabase-8b970d6e0f67a415.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseDatabase-18b95ef28b89f3db.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseDatabase-d6c24e13e4b05437.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseDatabase-740fd2c59012f647.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseDatabase-a87ae96a7eeb2535.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseDatabase-2b6c597465ec9d34.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseDatabase-34750cd661cbd49b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseFirestore-30a2451150d46015.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseFirestore-635c7c2864cdd1a9.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseFirestore-6098779ef7b7b151.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseFirestore-bb952aca63e09d18.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFirestore-8d65b82dc9d53ddf.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFirestore-e8ec00ce472204d2.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFirestore-acab074433fa0c6f.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseFunctions-1681244d37d89040.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseFunctions-2ac7bbbaf94c52e1.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseFunctions-f4a1c660d9a2ea75.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseFunctions-61a6223e133ce1f3.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFunctions-f3aa95160827b0af.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFunctions-6d891e5b755e773c.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFunctions-8589fb2f6bff1e38.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/GoogleSignIn-d4359fb699843869.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/GoogleSignIn-b924d38d37bc920a.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/GoogleSignIn-01f98c11db934294.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/GoogleSignIn-fe7ccb3e501e785a.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/GoogleSignIn-31b2e32d1dadbaa8.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/GoogleSignIn-0a9fd70d77dbb99e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/GoogleSignIn-bcaadfe04c892ecb.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseInAppMessaging-67bccdf31b1dc458.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseInAppMessaging-59f9fc54fc4eecb5.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseInAppMessaging-78a0d591fb574512.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseInAppMessaging-ef1e19aafce40411.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseInAppMessaging-0ec7907b67ce2888.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseInAppMessaging-349edad4650cdc0e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseInAppMessaging-9447455910a3800d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseMLModelDownloader-2d08410294abf160.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseMLModelDownloader-1f183c6e3be7cab3.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseMLModelDownloader-3864d35f4429bc08.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseMLModelDownloader-971e20f69f1c0bbb.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMLModelDownloader-6bfb3459ae557ef3.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMLModelDownloader-1d7e6bff24c9b2ec.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMLModelDownloader-2ce9f1e78f15027f.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseMessaging-379bf3738f94ef44.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseMessaging-0f018ab3d7701839.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseMessaging-252cac88c87e9c55.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseMessaging-df038d1c9fa53d25.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMessaging-d1ab6eaf596d9b7d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMessaging-2a16804f5c5602a0.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMessaging-9175a3fe41e7c83c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebasePerformance-9a2f8d3983650cea.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebasePerformance-0df8c67ab3cb665c.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebasePerformance-dec4dc5c3edadd9a.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebasePerformance-c30d957c99c1f1f6.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebasePerformance-1913383f1952dce6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebasePerformance-5e59e383ee5e57f7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebasePerformance-79cbc1d26656ac6d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseRemoteConfig-7455afe6f2231467.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseRemoteConfig-5894aa4820a265ae.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseRemoteConfig-bb5ba29a5f73cd24.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseRemoteConfig-2febbb9885f9f7c1.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseRemoteConfig-3e803b148769baed.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseRemoteConfig-41aaab0dc398a6fc.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseRemoteConfig-5d12611a14be55c9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -46,6 +46,7 @@
   "11.9.0": "https://dl.google.com/dl/firebase/ios/carthage/11.9.0/FirebaseStorage-5a28ee1b2244be55.zip",
   "12.0.0": "https://dl.google.com/dl/firebase/ios/carthage/12.0.0/FirebaseStorage-21ed034a4fa51f2a.zip",
   "12.1.0": "https://dl.google.com/dl/firebase/ios/carthage/12.1.0/FirebaseStorage-faeffdccd0d44a7c.zip",
+  "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseStorage-9c80624f61f0c00e.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseStorage-20489713b94790a0.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseStorage-318fa79cc514a2be.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseStorage-e758b10b671ddad7.zip",


### PR DESCRIPTION
This PR updates the carthage json versions in the repo to include the newly published `12.10.0` versions for this release.

#no-changelog