### PR TITLE
fix(ci): Update to `clang-format@22`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ To develop Firebase software, **install**:
    To install [clang-format] and [mint] using [Homebrew]:
 
     ```console
-    brew install clang-format@21
+    brew install clang-format@22
     brew install mint
     ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GitHub Actions will verify that any code changes are done in a style-compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@21
+brew install clang-format@22
 brew install mint
 ```
 

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -35,7 +35,7 @@ fi
 
 # install clang-format
 brew update
-brew install clang-format@21
+brew install clang-format@22
 
 # mint installs tools from Mintfile on demand.
 brew install mint

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -56,7 +56,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  21)
+  22)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"


### PR DESCRIPTION
Updated to `clang-format@22` since version 21 is no longer available on Homebrew.

#no-changelog
