### PR TITLE
fix: exempt GeneratedFirebaseAI from style script

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -151,6 +151,7 @@ s%^./%%
 
 # Generated source
 \%/Firestore/core/src/util/config.h% d
+\%^GeneratedFirebaseAI/% d
 
 # Generated Code for Data Connect sample
 \%/Examples/FriendlyFlix/app/FriendlyFlixSDK/% d


### PR DESCRIPTION
The generated code does not match the oss repo's style constraints. For now, exempt the directory to prevent formatting errors on the re-import back into piper.

#no-changelog