### PR TITLE
infra: only enforce code owner reviews for root Package.swift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 ReleaseTooling/ @firebase/firebase-ios-sdk-admin
 FirebaseCore/ @firebase/firebase-ios-sdk-admin
-Package.swift @firebase/firebase-ios-sdk-admin
+/Package.swift @firebase/firebase-ios-sdk-admin
 Dangerfile @firebase/firebase-ios-sdk-admin
 **/Public @firebase/firebase-ios-sdk-admin
 *.podspec @firebase/firebase-ios-sdk-admin


### PR DESCRIPTION
Only enforce the code owners reviews for the root Package.swift.

#no-changelog