### PR TITLE
[AI] Conform `GenerationConfig` and `Schema` to `Equatable`

### DIFF
--- a/FirebaseAI/Sources/GenerationConfig.swift
+++ b/FirebaseAI/Sources/GenerationConfig.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// A struct defining model parameters to be used when sending generative AI
 /// requests to the backend model.
-public struct GenerationConfig: Sendable {
+public struct GenerationConfig: Sendable, Equatable {
   /// Controls the degree of randomness in token selection.
   var temperature: Float?
 

--- a/FirebaseAI/Sources/Types/Public/Schema.swift
+++ b/FirebaseAI/Sources/Types/Public/Schema.swift
@@ -478,3 +478,25 @@ extension Schema: Encodable {
     case propertyOrdering
   }
 }
+
+// MARK: - Equatable Conformance
+
+extension Schema: Equatable {
+  public static func == (lhs: Schema, rhs: Schema) -> Bool {
+    return lhs.dataType == rhs.dataType &&
+      lhs.format == rhs.format &&
+      lhs.description == rhs.description &&
+      lhs.title == rhs.title &&
+      lhs.nullable == rhs.nullable &&
+      lhs.enumValues == rhs.enumValues &&
+      lhs.items == rhs.items &&
+      lhs.minItems == rhs.minItems &&
+      lhs.maxItems == rhs.maxItems &&
+      lhs.minimum == rhs.minimum &&
+      lhs.maximum == rhs.maximum &&
+      lhs.properties == rhs.properties &&
+      lhs.anyOf == rhs.anyOf &&
+      lhs.requiredProperties == rhs.requiredProperties &&
+      lhs.propertyOrdering == rhs.propertyOrdering
+  }
+}

--- a/FirebaseAI/Tests/Unit/Types/SchemaTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/SchemaTests.swift
@@ -496,4 +496,93 @@ final class SchemaTests: XCTestCase {
     }
     """)
   }
+
+  // MARK: - Equatable Tests
+
+  func testEquatable_identicalSchemas() {
+    let schema1 = Schema.object(
+      properties: [
+        "id": .integer(format: .int64),
+        "name": .string(description: "User's full name"),
+        "tags": .array(items: .string()),
+      ],
+      optionalProperties: ["tags"],
+      description: "A user object",
+      nullable: true
+    )
+    let schema2 = Schema.object(
+      properties: [
+        "id": .integer(format: .int64),
+        "name": .string(description: "User's full name"),
+        "tags": .array(items: .string()),
+      ],
+      optionalProperties: ["tags"],
+      description: "A user object",
+      nullable: true
+    )
+
+    XCTAssertEqual(schema1, schema2)
+  }
+
+  func testEquatable_differentDataTypes() {
+    XCTAssertNotEqual(Schema.string(), Schema.integer())
+    XCTAssertNotEqual(Schema.float(), Schema.double())
+    XCTAssertNotEqual(Schema.boolean(), Schema.array(items: .string()))
+  }
+
+  func testEquatable_differentMetadata() {
+    XCTAssertNotEqual(
+      Schema.string(description: "A"),
+      Schema.string(description: "B")
+    )
+
+    XCTAssertNotEqual(
+      Schema.string(nullable: true),
+      Schema.string(nullable: false)
+    )
+
+    XCTAssertNotEqual(
+      Schema.integer(format: .int32),
+      Schema.integer(format: .int64)
+    )
+
+    XCTAssertNotEqual(
+      Schema.integer(minimum: 1, maximum: 10),
+      Schema.integer(minimum: 1, maximum: 20)
+    )
+
+    XCTAssertNotEqual(
+      Schema.enumeration(values: ["A", "B"]),
+      Schema.enumeration(values: ["A", "C"])
+    )
+  }
+
+  func testEquatable_differentArrayItems() {
+    let array1 = Schema.array(items: .string(), minItems: 1)
+    let array2 = Schema.array(items: .string(), minItems: 2)
+    let array3 = Schema.array(items: .integer(), minItems: 1)
+
+    XCTAssertNotEqual(array1, array2, "Differing bounds should not be equal")
+    XCTAssertNotEqual(array1, array3, "Differing item schemas should not be equal")
+  }
+
+  func testEquatable_differentObjectProperties() {
+    let obj1 = Schema.object(properties: ["a": .string()])
+    let obj2 = Schema.object(properties: ["b": .string()])
+    let obj3 = Schema.object(properties: ["a": .integer()])
+    let obj4 = Schema.object(properties: ["a": .string()], optionalProperties: ["a"])
+
+    XCTAssertNotEqual(obj1, obj2, "Differing property keys should not be equal")
+    XCTAssertNotEqual(obj1, obj3, "Differing property value schemas should not be equal")
+    XCTAssertNotEqual(obj1, obj4, "Differing required properties should not be equal")
+  }
+
+  func testEquatable_differentAnyOf() {
+    let anyOf1 = Schema.anyOf(schemas: [.string(), .integer()])
+    let anyOf2 = Schema.anyOf(schemas: [.string(), .boolean()])
+    let anyOf3 = Schema.anyOf(schemas: [.string()])
+
+    XCTAssertNotEqual(anyOf1, anyOf2, "Differing sub-schemas should not be equal")
+    XCTAssertNotEqual(anyOf1, anyOf3, "Differing sub-schema counts should not be equal")
+  }
 }


### PR DESCRIPTION
Added `Equatable` conformance to `GenerationConfig` and `Schema` as a prerequisite for making `Transcript` conform to `Equatable` in https://github.com/firebase/firebase-ios-sdk/pull/15942. Added unit tests for the `Equatable` implementation for `Schema` since auto-synthesis is not supported for classes.

#no-changelog