### PR TITLE
[Infra] Optimize `style.sh` by batching format tool execution

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -179,19 +179,43 @@ s%^./%%
 )
 
 needs_formatting=false
-for f in $files; do
-  if [[ "${f: -6}" == '.swift' ]]; then
-    # Match output that says:
-    # 1/1 files would have been formatted.  (with --dryrun)
-    # 1/1 files formatted.                  (without --dryrun)
-    mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
-  else
-    "$clang_format_bin" "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
-  fi
 
-  if [[ "$test_only" == true && $? -ne 1 ]]; then
-    echo "$f needs formatting."
-    needs_formatting=true
+# Get unique folders or root files
+folders=$(echo "$files" | awk -F/ '{print $1}' | sort -u)
+
+for folder in $folders; do
+  if [[ -z "$folder" ]]; then continue; fi
+
+  folder_files=$(echo "$files" | awk -F/ -v d="$folder" '$1==d {print $0}')
+
+  if [[ "$test_only" == true ]]; then
+    for f in $folder_files; do
+      if [[ "${f: -6}" == '.swift' ]]; then
+        # Match output that says:
+        # 1/1 files would have been formatted.  (with --dryrun)
+        # 1/1 files formatted.                  (without --dryrun)
+        mint run swiftformat "${swift_options[@]}" "$f" 2>&1 | grep '^1/1 files' > /dev/null
+        grep_status=$?
+      else
+        "$clang_format_bin" "${clang_options[@]}" "$f" | grep "<replacement " > /dev/null
+        grep_status=$?
+      fi
+
+      if [[ $grep_status -ne 1 ]]; then
+        echo "$f needs formatting."
+        needs_formatting=true
+      fi
+    done
+  else
+    swift_files=$(echo "$folder_files" | grep '\.swift$' || true)
+    clang_files=$(echo "$folder_files" | grep -v '\.swift$' || true)
+
+    if [[ -n "$swift_files" ]]; then
+      echo "$swift_files" | tr '\n' '\0' | xargs -0 mint run swiftformat "${swift_options[@]}" > /dev/null 2>&1
+    fi
+    if [[ -n "$clang_files" ]]; then
+      echo "$clang_files" | tr '\n' '\0' | xargs -0 "$clang_format_bin" "${clang_options[@]}" > /dev/null 2>&1
+    fi
   fi
 done
 


### PR DESCRIPTION
**Context:**
The `scripts/style.sh` script is used to enforce code styling across the repository using `swiftformat` and `clang-format`.

**Problem:**
Previously, the script iterated through files and invoked the formatting tools individually for each file. Executing `swiftformat` via `mint run swiftformat` incurs a noticeable startup overhead. For directories with a large number of Swift files, such as `FirebaseAI` and `FirebaseAuth`, this repetitive startup cost compounded significantly, leading to sluggish execution times.

Initial profiling revealed the following execution times for the slowest directories:

- `Firestore`: ~28.80s
- `FirebaseAuth`: ~28.00s
- `FirebaseAI`: ~21.82s

**Solution:**
This PR significantly reduces the formatting time by refactoring the `style.sh` script to batch files by their top-level directory. It now groups Swift and Clang files per folder and passes them to the formatters in a single execution using `xargs -0`.

By executing the formatters only once per directory rather than hundreds of times individually, we bypass the heavy startup overhead.

**Performance Impact:**
After the batching optimization, the same directories execute in a fraction of the time:

- `Firestore`: ~5.69s *(80% reduction)*
- `FirebaseAuth`: ~0.74s *(97% reduction)*
- `FirebaseAI`: ~0.60s *(97% reduction)*

<details>
<summary>Before</summary>

```
% ./scripts/style.sh

--- Timing Metrics by Folder ---
28.80 seconds	Firestore
28.00 seconds	FirebaseAuth
21.82 seconds	FirebaseAI
6.89 seconds	FirebaseSessions
6.37 seconds	FirebaseDatabase
5.05 seconds	FirebaseCombineSwift
5.04 seconds	FirebaseRemoteConfig
5.01 seconds	FirebaseStorage
4.89 seconds	Crashlytics
4.86 seconds	FirebaseMessaging
4.77 seconds	FirebaseInAppMessaging
4.58 seconds	FirebasePerformance
4.40 seconds	FirebaseCore
3.31 seconds	ReleaseTooling
3.01 seconds	Example
2.47 seconds	scripts
2.42 seconds	FirebaseAppCheck
2.06 seconds	FirebaseMLModelDownloader
1.68 seconds	FirebaseFunctions
1.23 seconds	FirebaseInstallations
0.93 seconds	FirebaseAppDistributionInternal
0.71 seconds	FirebaseABTesting
0.50 seconds	FirebaseAppDistribution
0.48 seconds	FirebaseFirestoreInternal
0.40 seconds	FirebaseTestingSupport
0.39 seconds	SwiftPMTests
0.39 seconds	IntegrationTesting
0.38 seconds	SharedTestUtilities
0.37 seconds	CoreOnly
0.32 seconds	FirebaseRemoteConfigSwift
0.26 seconds	FirebaseAnalytics
0.23 seconds	FirebaseSharedSwift
0.18 seconds	SwiftPM-PlatformExclude
0.11 seconds	Package.swift
0.09 seconds	SymbolCollisionTest
0.06 seconds	Interop
0.03 seconds	FirebaseAnalyticsIdentitySupportWrapper
0.03 seconds	FirebaseAnalyticsCoreWrapper
0.02 seconds	GoogleDataTransport
--------------------------------
```

</details>

<details>
<summary>After</summary>

```
% ./scripts/style.sh

--- Timing Metrics by Folder ---
5.69 seconds	Firestore
0.99 seconds	FirebaseDatabase
0.74 seconds	FirebaseAuth
0.68 seconds	Crashlytics
0.60 seconds	FirebaseAI
0.55 seconds	FirebasePerformance
0.52 seconds	FirebaseRemoteConfig
0.51 seconds	FirebaseMessaging
0.49 seconds	FirebaseInAppMessaging
0.34 seconds	FirebaseCore
0.32 seconds	FirebaseInstallations
0.31 seconds	FirebaseSessions
0.29 seconds	FirebaseStorage
0.29 seconds	FirebaseAppCheck
0.27 seconds	FirebaseCombineSwift
0.23 seconds	FirebaseAppDistribution
0.22 seconds	FirebaseABTesting
0.22 seconds	Example
0.21 seconds	ReleaseTooling
0.21 seconds	FirebaseMLModelDownloader
0.21 seconds	CoreOnly
0.20 seconds	FirebaseFunctions
0.20 seconds	FirebaseAnalytics
0.19 seconds	scripts
0.18 seconds	IntegrationTesting
0.18 seconds	FirebaseTestingSupport
0.18 seconds	FirebaseAppDistributionInternal
0.17 seconds	SwiftPMTests
0.16 seconds	FirebaseSharedSwift
0.15 seconds	Package.swift
0.15 seconds	FirebaseRemoteConfigSwift
0.07 seconds	SharedTestUtilities
0.07 seconds	FirebaseFirestoreInternal
0.07 seconds	FirebaseAnalyticsCoreWrapper
0.06 seconds	SymbolCollisionTest
0.06 seconds	SwiftPM-PlatformExclude
0.06 seconds	GoogleDataTransport
0.06 seconds	FirebaseAnalyticsIdentitySupportWrapper
0.04 seconds	Interop
--------------------------------
```

</details>

*Note: The `test-only` mode is preserved to process file-by-file, as it still needs to output the exact filenames of any files that are not style compliant.*

#no-changelog