### PR TITLE
fix: extend sdk.inappmessaging.yml linting timeout

### DIFF
--- a/.github/workflows/sdk.inappmessaging.yml
+++ b/.github/workflows/sdk.inappmessaging.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       product: FirebaseInAppMessaging
       platforms: iOS, tvOS
+      timeout_minutes: 30
 
   tests:
     strategy:


### PR DESCRIPTION
Fix an intermittent nightly failure.

#no-changelog