### PR TITLE
Fix Firestore wrapper public headers path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1640,7 +1640,7 @@ func firestoreTargets() -> [Target] {
         condition: .when(platforms: [.iOS, .macCatalyst, .tvOS, .macOS])
       )],
       path: "FirebaseFirestoreInternal",
-      publicHeadersPath: "."
+      publicHeadersPath: "FirebaseFirestore"
     ),
     firestoreInternalTarget,
   ]


### PR DESCRIPTION
## Discussion

Issue: #15978

## Summary

This points `FirebaseFirestoreInternalWrapper` at its actual public header directory.

Current declaration:

```swift
path: "FirebaseFirestoreInternal",
publicHeadersPath: "."
```

Actual exported headers:

```text
FirebaseFirestoreInternal/FirebaseFirestore/*.h
```

That mismatch is tolerated by stock SwiftPM/Xcode, but it breaks tools that repackage SwiftPM targets into xcframeworks based on the declared public header root. In my repro, Tuist cache produced a `FirebaseFirestoreInternalWrapper.xcframework` with no `Headers/` or `Modules/`.

## Testing

- Built a plain SwiftPM client that imports `FirebaseFirestore` against `12.9.0` before this change.
- Built the same client after this change.
- Verified the change restores headers in the repackaged/cached `FirebaseFirestoreInternalWrapper.xcframework`.

## API Changes

None.

Closes #15978.
