### PR TITLE
fix(fcm): add check for scene delegates in deep links

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue where deep links were not correctly routed in apps utilizing scene
+  delegates.
+
 # 12.8.0
 - [fixed] Fix missing database crash on launch. (#14880)
 

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed an issue where deep links were not correctly routed in apps utilizing scene
-  delegates.
+  delegates. (#15987)
 
 # 12.8.0
 - [fixed] Fix missing database crash on launch. (#14880)

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -390,20 +390,35 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   if (!application) {
     return;
   }
-  id<UIApplicationDelegate> appDelegate = application.delegate;
-  SEL continueUserActivitySelector =
-      @selector(application:continueUserActivity:restorationHandler:);
 
+  // Use string literal to ensure compatibility with Xcode 26 and iOS 18
+  NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
+  NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:browsingWebType];
+  userActivity.webpageURL = url;
+
+  // first look for a connected scene that can handle the activity
+  for (UIScene *scene in application.connectedScenes) {
+    if (scene.activationState == UISceneActivationStateForegroundActive ||
+        scene.activationState == UISceneActivationStateForegroundInactive) {
+      if ([scene.delegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
+        id<UISceneDelegate> sceneDelegate = (id<UISceneDelegate>)scene.delegate;
+        [sceneDelegate scene:scene continueUserActivity:userActivity];
+        return;
+      }
+    }
+  }
+
+  // fallback to the app delegate when a matching scene delegate wasn't found
   // Due to FIRAAppDelegateProxy swizzling, this selector will most likely get chosen, whether or
   // not the actual application has implemented
   // |application:continueUserActivity:restorationHandler:|. A warning will be displayed to the user
   // if they haven't implemented it.
+  id<UIApplicationDelegate> appDelegate = application.delegate;
+  SEL continueUserActivitySelector =
+      @selector(application:continueUserActivity:restorationHandler:);
+
   if ([NSUserActivity class] != nil &&
       [appDelegate respondsToSelector:continueUserActivitySelector]) {
-    // Use string literal to ensure compatibility with Xcode 26 and iOS 18
-    NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
-    NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:browsingWebType];
-    userActivity.webpageURL = url;
     [appDelegate application:application
         continueUserActivity:userActivity
           restorationHandler:^(NSArray *_Nullable restorableObjects){


### PR DESCRIPTION
Per [b/496594918](https://b.corp.google.com/issues/496594918),

This fixes an issue where deep links in FCM (when using automatic routing) would not properly propagate to the app's corresponding delegate, if the developer was using a scene delegate instead of an app delegate.

Now, the code first checks for any scene delegates that can handle the request, and falls back to the application delegate if one wasn't found.