### PR TITLE
[AI] Add `IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM` flag

### DIFF
--- a/FirebaseAI/Sources/Extensions/Internal/GenerationSchema+Gemini.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/GenerationSchema+Gemini.swift
@@ -29,14 +29,14 @@ extension FirebaseAI.GenerationSchema {
       return lastKey
     }
 
-    #if canImport(FoundationModels)
+    #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
         let generationSchemaData = try encoder.encode(self)
         let jsonSchema = try JSONDecoder().decode(JSONObject.self, from: generationSchemaData)
 
         return jsonSchema
       }
-    #endif // canImport(FoundationModels)
+    #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
     // TODO: Implement FirebaseAI.GenerationSchema encoding for iOS < 26.
     throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: """

--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -249,11 +249,11 @@
         )
       }
       let generationID = response.responseID.map {
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
           if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
             return FirebaseAI.GenerationID(responseID: $0, generationID: GenerationID())
           }
-        #endif // canImport(FoundationModels)
+        #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
         return FirebaseAI.GenerationID(responseID: $0, generationID: nil)
       }
@@ -327,13 +327,13 @@
             streamedText.append(text)
             if generationID == nil {
               generationID = chunk.responseID.map {
-                #if canImport(FoundationModels)
+                #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
                   if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
                     return FirebaseAI.GenerationID(
                       responseID: $0, generationID: FoundationModels.GenerationID()
                     )
                   }
-                #endif // canImport(FoundationModels)
+                #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
                 return FirebaseAI.GenerationID(responseID: $0, generationID: nil)
               }
@@ -392,7 +392,7 @@
         return try FirebaseAI.GeneratedContent(json: text, id: generationID, isComplete: isComplete)
       }
 
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           return FirebaseAI
             .GeneratedContent(
@@ -401,7 +401,7 @@
               isComplete: isComplete
             )
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
       return FirebaseAI.GeneratedContent(
         kind: FirebaseAI.GeneratedContent.Kind.string(text),
@@ -415,13 +415,13 @@
         return content
       }
 
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *), let contentMetatype = T
           .self as? (any FoundationModels.ConvertibleFromGeneratedContent.Type),
           let content = try contentMetatype.init(rawContent) as? T {
           return content
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
       if let contentMetatype = T.self as? (any FirebaseAI.ConvertibleFromGeneratedContent.Type),
          let content = try contentMetatype.init(rawContent) as? T {

--- a/FirebaseAI/Sources/Types/Public/StructuredOutput/GeneratedContent.swift
+++ b/FirebaseAI/Sources/Types/Public/StructuredOutput/GeneratedContent.swift
@@ -69,7 +69,7 @@
       }
 
       init(json: String, id: FirebaseAI.GenerationID?, isComplete: Bool?) throws {
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
           if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
             var generatedContent = try FoundationModels.GeneratedContent(json: json)
             generatedContent.id = id?.generationID
@@ -81,7 +81,7 @@
 
             return
           }
-        #endif // canImport(FoundationModels)
+        #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
         throw GenerativeModelSession.GenerationError.decodingFailure(
           GenerativeModelSession.GenerationError.Context(
@@ -106,7 +106,7 @@
 
       init(kind: FirebaseAI.GeneratedContent.Kind, id: FirebaseAI.GenerationID? = nil,
            isComplete: Bool) {
-        #if canImport(FoundationModels)
+        #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
           if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
             _generatedContent = FoundationModels
               .GeneratedContent(kind: kind.toFoundationModels(), id: id?.generationID)
@@ -115,7 +115,7 @@
           }
         #else
           _generatedContent = nil
-        #endif // canImport(FoundationModels)
+        #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
         self.kind = kind
         generationID = id

--- a/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationID.swift
+++ b/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationID.swift
@@ -32,7 +32,7 @@ public extension FirebaseAI {
     /// **Public Preview**: This API is a public preview and may be subject to change.
     public init() {
       responseID = UUID().uuidString
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           appleGenerationID = FoundationModels.GenerationID()
         } else {
@@ -40,7 +40,7 @@ public extension FirebaseAI {
         }
       #else
         appleGenerationID = nil
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
     }
 
     init(responseID: String, generationID: (any GenerationIDProtocol)?) {
@@ -76,13 +76,13 @@ extension FirebaseAI.GenerationID: Equatable {
       return false
     }
 
-    #if canImport(FoundationModels)
+    #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
         guard lhs.generationID == rhs.generationID else {
           return false
         }
       }
-    #endif // canImport(FoundationModels)
+    #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
     return true
   }
@@ -92,10 +92,10 @@ extension FirebaseAI.GenerationID: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(responseID)
 
-    #if canImport(FoundationModels)
+    #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
         hasher.combine(generationID)
       }
-    #endif // canImport(FoundationModels)
+    #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
   }
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -34,9 +34,11 @@
       let content = response.content
       #expect(!content.isEmpty)
       #expect(response.rawContent.isComplete)
-      if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
-        #expect(response.rawContent.kind == .string(content))
-      }
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          #expect(response.rawContent.kind == .string(content))
+        }
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       #expect(response.rawContent.generationID != nil)
       #expect(response.rawResponse.text == content)
     }
@@ -246,9 +248,11 @@
       #expect(!content.isEmpty)
       #expect(response.rawContent.isComplete, "The final response was not marked as complete.")
       #expect(response.rawContent.generationID == generationID)
-      if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
-        #expect(response.rawContent.kind == .string(content))
-      }
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          #expect(response.rawContent.kind == .string(content))
+        }
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       if let text = response.rawResponse.text {
         #expect(content.hasSuffix(text))
       }

--- a/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
@@ -86,7 +86,7 @@
       XCTAssertEqual(snapshots[0].content, "Good chunk")
     }
 
-    #if canImport(FoundationModels)
+    #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       func testResponseStream_throwsIfLastChunkFailsToDecode() async {
         let stream = GenerativeModelSession.ResponseStream<String, String> { context in
           let badRawContent = FirebaseAI.GeneratedContent(kind: .null, id: nil, isComplete: true)
@@ -120,7 +120,7 @@
           }
         }
       }
-    #endif // canImport(FoundationModels)
+    #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
     func testResponseStream_collectReturnsLatestChunk() async throws {
       let stream = GenerativeModelSession.ResponseStream<String, String> { context in
@@ -157,11 +157,11 @@
         "Expected stream to yield at least one snapshot before finishing."
       )
       XCTAssertEqual(lastResult.content, response.content)
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           XCTAssertEqual(lastResult.rawContent, response.rawContent)
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       XCTAssertEqual(lastResult.rawContent.isComplete, response.rawContent.isComplete)
     }
 

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -43,6 +43,14 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
   s.tvos.framework = 'UIKit'
   s.watchos.framework = 'WatchKit'
 
+  # Note: Foundation Models is only supported on iOS and macOS; watchOS and tvOS are omitted.
+  s.ios.pod_target_xcconfig = {
+    'OTHER_SWIFT_FLAGS' => '$(inherited) -D IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM'
+  }
+  s.osx.pod_target_xcconfig = {
+    'OTHER_SWIFT_FLAGS' => '$(inherited) -D IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM'
+  }
+
   s.dependency 'FirebaseAppCheckInterop', '~> 12.12.0'
   s.dependency 'FirebaseAuthInterop', '~> 12.12.0'
   s.dependency 'FirebaseCore', '~> 12.12.0'

--- a/Package.swift
+++ b/Package.swift
@@ -192,7 +192,13 @@ let package = Package(
         "FirebaseCore",
         "FirebaseCoreExtension",
       ],
-      path: "FirebaseAI/Sources"
+      path: "FirebaseAI/Sources",
+      swiftSettings: [
+        .define(
+          "IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM",
+          .when(platforms: [.iOS, .macCatalyst, .macOS, .visionOS])
+        ),
+      ]
     ),
     .testTarget(
       name: "FirebaseAILogicUnit",


### PR DESCRIPTION
- Added a Swift setting that defines `IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM` on iOS, macOS and visionOS only. Foundation Models is not currently supported on watchOS or tvOS.
- Added `&& IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM` to all `#if canImport(FoundationModels)` compile-time checks that wrap `if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *)` runtime checks.
  - If the `FoundationModels` framework is ever added to the tvOS or watchOS SDKs, the existing `if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *)` will return true, even on tvOS 1.0 or watchOS 1.0, where they won't actually be available and will fail to compile.

#no-changelog