### PR TITLE
fix: Stage pre-release Firestore binary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1591,8 +1591,8 @@ func firestoreTargets() -> [Target] {
     } else {
       return .binaryTarget(
         name: "FirebaseFirestoreInternal",
-        url: "https://dl.google.com/firebase/ios/bin/firestore/12.11.0/rc0/FirebaseFirestoreInternal.zip",
-        checksum: "145be6b7b058f52eb78a4dd36ce8c9a8355e322471f409d9ea4ac4e2fa7b5814"
+        url: "https://dl.google.com/firebase/ios/bin/firestore/12.12.0/pre_rc0/FirebaseFirestoreInternal.zip",
+        checksum: "f9e3e0f922f6508cad8556bbbf3c56ae41b557bb2c48f68c33802fcdec5446e9"
       )
     }
   }()


### PR DESCRIPTION
https://github.com/firebase/firebase-ios-sdk/pull/15963 added new API so a new FST binary was needed for the top-level targets to find these new symbols in the binary. Fixes some global CI checks failing as a result.

#no-changelog