### PR TITLE
[CI] Add `-retry-tests-on-failure` for `FirestoreEnterprise`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -426,6 +426,8 @@ case "$product-$platform-$method" in
           -scheme "Firestore_IntegrationTests_Enterprise_$platform" \
           -enableCodeCoverage YES \
           "${xcb_flags[@]}" \
+          -retry-tests-on-failure \
+          -test-iterations 3 \
           test-without-building
       ;;
 


### PR DESCRIPTION
Add `-retry-tests-on-failure` and `-test-iterations 3` (limit of 3 retries) for the Firestore Enterprise integration tests. These tests may be flaky and take forever to run. This performs retries on just the failing tests, rather than needing to retry the whole job.

#no-changelog