### PR TITLE
test(firestore): fix broken `parent` expression test

### DIFF
--- a/Firestore/Swift/Tests/Integration/PipelineTests.swift
+++ b/Firestore/Swift/Tests/Integration/PipelineTests.swift
@@ -3849,6 +3849,9 @@ class PipelineIntegrationTests: FSTIntegrationTestCase {
     let db = firestore()
     let randomCol = collectionRef()
 
+    // Add a dummy document directly to randomCol so the pipeline has input data to process
+    try await randomCol.document("dummy").setData(["dummy": 1])
+
     let docRef = randomCol.document("book4").collection("reviews").document("review1")
     try await docRef.setData(["foo": "bar"])
 


### PR DESCRIPTION
This test is failing in CI. The pipeline in the test has no input documentats to run against, because the `randomCol` is empty, despite calling `setData` to create a document deeper in the collection. This fixes the test by adding a dummy document to the `randomCol` collection.