### PR TITLE
[AI] Skip `GenerativeModelSessionTests` on unsupported platforms

### DIFF
--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -32,6 +32,11 @@
     var urlSession: URLSession!
 
     override func setUp() async throws {
+      // Skip tests on platforms that do not support Foundation Models. This is a
+      // workaround for XCTest ignoring the `@available` attributes. See
+      // https://stackoverflow.com/q/59645536 for more details.
+      try XCTSkipFoundationModelsUnsupported()
+
       let configuration = URLSessionConfiguration.default
       configuration.protocolClasses = [MockURLProtocol.self]
       urlSession = try XCTUnwrap(URLSession(configuration: configuration))

--- a/FirebaseAI/Tests/Unit/TestUtilities/XCTUtil.swift
+++ b/FirebaseAI/Tests/Unit/TestUtilities/XCTUtil.swift
@@ -64,3 +64,9 @@ func XCTAssertThrowsError(
     errorHandler?(error)
   }
 }
+
+func XCTSkipFoundationModelsUnsupported() throws {
+  guard #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) else {
+    throw XCTSkip("Foundation Models requires iOS/macOS/visionOS 26+.")
+  }
+}


### PR DESCRIPTION
Added a helper method to `XCTSkipFoundationModelsUnsupported` to skip tests on platforms that aren't supported by Foundation Models (pre-iOS 26). XCTest ignores the `@available` annotations on `XCTestCase` subclasses and attempts to run the tests.

#no-changelog
