### PR TITLE
fix: extend lint timeout in sdk.remoteconfig.yml

### DIFF
--- a/.github/workflows/sdk.remoteconfig.yml
+++ b/.github/workflows/sdk.remoteconfig.yml
@@ -75,6 +75,7 @@ jobs:
     uses: ./.github/workflows/_cocoapods.yml
     with:
       product: FirebaseRemoteConfig
+      timeout_minutes: 30
 
   quickstart:
     uses: ./.github/workflows/_quickstart.yml


### PR DESCRIPTION
#no-changelog