### PR TITLE
[Core] Bump `swift-tools-version` to `6.2.1`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2.1
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 
@@ -19,6 +19,10 @@
 import PackageDescription
 
 let firebaseVersion = "12.12.0"
+
+#if compiler(<6.2.3)
+  #error("Firebase 12.12.0 and later requires at least Xcode 26.2 / Swift 6.2.3.")
+#endif // swift(<6.2.3)
 
 let shouldUseSourceFirestore = Context.environment["FIREBASE_SOURCE_FIRESTORE"] != nil
 


### PR DESCRIPTION
Updated the minimum `swift-tools-version` from `6.0` to `6.2.1`. Xcode 26.1 or 26.1.1 and later include Swift tools version `6.2.1`. However, Firebase 12.12.0 and later now require Xcode 26.2, which includes the Swift 6.2.3 compiler _but_ `6.2.1` remains the latest `swift-tools-version` included in Xcode 26.2. Added an error message when compiling with Swift < `6.2.3`.

#no-changelog