### PR TITLE
fix(ci): address GHA issue for missing swift sdk with static frameworks  

### DIFF
--- a/.github/workflows/sdk.abtesting.yml
+++ b/.github/workflows/sdk.abtesting.yml
@@ -59,5 +59,6 @@ jobs:
       product: FirebaseABTesting
       platforms: '[ "ios", "tvos", "macos" ]'
       flags: '[ "--use-static-frameworks" ]'
+      # For toolchains var, see https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
       setup_command: |
         echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV

--- a/.github/workflows/sdk.core.yml
+++ b/.github/workflows/sdk.core.yml
@@ -49,5 +49,6 @@ jobs:
       flags: '[ "--use-static-frameworks" ]'
       runs_on: macos-26
       xcode: Xcode_26.4
+      # For toolchains var, see https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
       setup_command: |
         echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV

--- a/.github/workflows/sdk.functions.yml
+++ b/.github/workflows/sdk.functions.yml
@@ -60,6 +60,7 @@ jobs:
       product: FirebaseFunctions
       platforms: '[ "ios", "tvos", "macos" ]'
       flags: '[ "--use-static-frameworks" ]'
+      # For toolchains var, see https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
       setup_command: |
         echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
         FirebaseFunctions/Backend/start.sh synchronous

--- a/.github/workflows/sdk.installations.yml
+++ b/.github/workflows/sdk.installations.yml
@@ -68,6 +68,7 @@ jobs:
       product: FirebaseInstallations
       platforms: '[ "ios", "tvos", "macos" ]'
       flags: '[ "--use-static-frameworks" ]'
+      # For toolchains var, see https://github.com/actions/runner-images/issues/13135#issuecomment-3397914993
       setup_command: |
         echo "TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault" >> $GITHUB_ENV
         scripts/configure_test_keychain.sh


### PR DESCRIPTION
Some cron static linting jobs have been failing. Cannot reproduce locally. It seems to have to do with Xcode 26 changes and how GHA images are setup. More context in https://github.com/actions/runner-images/issues/13135

Manual invocations:
- installations: https://github.com/firebase/firebase-ios-sdk/actions/runs/24044960730
- abtesting: https://github.com/firebase/firebase-ios-sdk/actions/runs/24044963398
- functions: https://github.com/firebase/firebase-ios-sdk/actions/runs/24044966141
- core: https://github.com/firebase/firebase-ios-sdk/actions/runs/24044957844

Verify **cron** linting jobs succeed:
- [x]  installations
- [x]  abtesting
- [x]  functions
- [x] core

It's possible that this can be reverted once Analytics is built with Xcode 26.2. Tracking reverting investigation in https://github.com/firebase/firebase-ios-sdk/issues/16050

Fixes #16032

#no-changelog