### PR TITLE
[Perf] Fix MapTable race

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # Unreleased
 - [fixed] Prevent race condition crashes in FPRScreenTraceTracker by replacing NSMapTable with
-  thread-safe NSMutableDictionary and locking. (#14473)
+  thread-safe NSMutableDictionary and locking.
 
 # 12.12.0
 - [fixed] Fix app_start trace not firing in SwiftUI apps using @UIApplicationDelegateAdaptor. (#15802)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 - [fixed] Address crash by deferring class disposal in FPRObjectSwizzler. (#14473)
 
+# Unreleased
+- [fixed] Prevent race condition crashes in FPRScreenTraceTracker by replacing NSMapTable with
+  thread-safe NSMutableDictionary and locking. (#14473)
+
 # 12.12.0
 - [fixed] Fix app_start trace not firing in SwiftUI apps using @UIApplicationDelegateAdaptor. (#15802)
 

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Unreleased
 - [fixed] Address crash by deferring class disposal in FPRObjectSwizzler. (#14473)
-
-# Unreleased
 - [fixed] Prevent race condition crashes in FPRScreenTraceTracker by replacing NSMapTable with
   thread-safe NSMutableDictionary and locking.
 

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
@@ -47,12 +47,20 @@ FOUNDATION_EXTERN CFTimeInterval const kFPRSlowFrameThreshold;
  */
 FOUNDATION_EXTERN CFTimeInterval const kFPRFrozenFrameThreshold;
 
+@interface FPRScreenTraceHolder : NSObject
+@property(nonatomic, weak) UIViewController *viewController;
+@property(nonatomic, strong) FIRTrace *trace;
+@end
+
 @interface FPRScreenTraceTracker ()
 
-/** A map table of that has the viewControllers as the keys and their associated trace as the value.
- *  The key is weakly retained and the value is strongly retained.
+/** A dictionary that has the viewControllers as the keys (wrapped in NSValue) and their associated
+ * trace holder as the value.
  */
-@property(nonatomic) NSMapTable<UIViewController *, FIRTrace *> *activeScreenTraces;
+@property(nonatomic) NSMutableDictionary<NSValue *, FPRScreenTraceHolder *> *activeScreenTraces;
+
+/** Lock to protect access to activeScreenTraces dictionary. */
+@property(nonatomic) NSLock *activeScreenTracesLock;
 
 /** A list of all UIViewController instances that were visible before app was backgrounded. The
  *  viewControllers are reatined weakly.

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
@@ -134,6 +134,9 @@ FOUNDATION_EXTERN CFTimeInterval const kFPRFrozenFrameThreshold;
  */
 - (void)updateCachedSlowBudget;
 
+/** Cleans up stale entries in activeScreenTraces where the viewController has been deallocated. */
+- (void)cleanupStaleTraces;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
@@ -60,7 +60,7 @@ FOUNDATION_EXTERN CFTimeInterval const kFPRFrozenFrameThreshold;
 @property(nonatomic) NSMutableDictionary<NSValue *, FPRScreenTraceHolder *> *activeScreenTraces;
 
 /** Lock to protect access to activeScreenTraces dictionary. */
-@property(nonatomic) NSLock *activeScreenTracesLock;
+@property(nonatomic) NSRecursiveLock *activeScreenTracesLock;
 
 /** A list of all UIViewController instances that were visible before app was backgrounded. The
  *  viewControllers are reatined weakly.

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -330,6 +330,8 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
     return;
   }
 
+  [self cleanupStaleTraces];
+
   NSValue *key = [NSValue valueWithNonretainedObject:viewController];
 
   [self.activeScreenTracesLock lock];
@@ -370,6 +372,9 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
                       currentTotalFrames:(int64_t)currentTotalFrames
                      currentFrozenFrames:(int64_t)currentFrozenFrames
                        currentSlowFrames:(int64_t)currentSlowFrames {
+  if (viewController == nil) {
+    return;
+  }
   NSValue *key = [NSValue valueWithNonretainedObject:viewController];
 
   [self.activeScreenTracesLock lock];
@@ -462,6 +467,18 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
            [viewController isMemberOfClass:[UISplitViewController class]] ||
            [viewController isMemberOfClass:[UIPageViewController class]] ||
            [viewController isKindOfClass:[UIInputViewController class]]);
+}
+
+- (void)cleanupStaleTraces {
+  [self.activeScreenTracesLock lock];
+  NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
+  [self.activeScreenTraces enumerateKeysAndObjectsUsingBlock:^(NSValue *key, FPRScreenTraceHolder *holder, BOOL *stop) {
+    if (holder.viewController == nil) {
+      [keysToRemove addObject:key];
+    }
+  }];
+  [self.activeScreenTraces removeObjectsForKeys:keysToRemove];
+  [self.activeScreenTracesLock unlock];
 }
 
 #pragma mark - Screen Traces swizzling hooks

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -378,13 +378,12 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
 
   [self.activeScreenTracesLock lock];
   FPRScreenTraceHolder *holder = [self.activeScreenTraces objectForKey:key];
-  if (holder && holder.viewController != viewController) {
-    // Stale entry due to pointer reuse. Remove it.
-    [self.activeScreenTraces removeObjectForKey:key];
-    holder = nil;
-  }
   if (holder) {
     [self.activeScreenTraces removeObjectForKey:key];
+    if (holder.viewController != viewController) {
+      // Stale entry due to pointer reuse.
+      holder = nil;
+    }
   }
   [self.activeScreenTracesLock unlock];
 
@@ -470,7 +469,7 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
 
 - (void)cleanupStaleTraces {
   [self.activeScreenTracesLock lock];
-  NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
+  NSMutableArray *keysToRemove = [NSMutableArray array];
   [self.activeScreenTraces
       enumerateKeysAndObjectsUsingBlock:^(NSValue *key, FPRScreenTraceHolder *holder, BOOL *stop) {
         if (holder.viewController == nil) {

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -472,11 +472,12 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
 - (void)cleanupStaleTraces {
   [self.activeScreenTracesLock lock];
   NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
-  [self.activeScreenTraces enumerateKeysAndObjectsUsingBlock:^(NSValue *key, FPRScreenTraceHolder *holder, BOOL *stop) {
-    if (holder.viewController == nil) {
-      [keysToRemove addObject:key];
-    }
-  }];
+  [self.activeScreenTraces
+      enumerateKeysAndObjectsUsingBlock:^(NSValue *key, FPRScreenTraceHolder *holder, BOOL *stop) {
+        if (holder.viewController == nil) {
+          [keysToRemove addObject:key];
+        }
+      }];
   [self.activeScreenTraces removeObjectsForKeys:keysToRemove];
   [self.activeScreenTracesLock unlock];
 }

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -119,7 +119,7 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
   self = [super init];
   if (self) {
     _activeScreenTraces = [[NSMutableDictionary alloc] init];
-    _activeScreenTracesLock = [[NSLock alloc] init];
+    _activeScreenTracesLock = [[NSRecursiveLock alloc] init];
 
     _previouslyVisibleViewControllers = nil;  // Will be set when there is data.
     _screenTraceTrackerSerialQueue =
@@ -330,11 +330,10 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
     return;
   }
 
+  [self.activeScreenTracesLock lock];
   [self cleanupStaleTraces];
 
   NSValue *key = [NSValue valueWithNonretainedObject:viewController];
-
-  [self.activeScreenTracesLock lock];
   FPRScreenTraceHolder *holder = [self.activeScreenTraces objectForKey:key];
   if (holder && holder.viewController != viewController) {
     // Stale entry due to pointer reuse. Remove it.

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -80,6 +80,9 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
   }
 }
 
+@implementation FPRScreenTraceHolder
+@end
+
 @implementation FPRScreenTraceTracker {
   /** Instance variable storing the total frames observed so far. */
   atomic_int_fast64_t _totalFramesCount;
@@ -115,11 +118,8 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
 - (instancetype)init {
   self = [super init];
   if (self) {
-    // Weakly retain viewController, use pointer hashing.
-    NSMapTableOptions keyOptions = NSMapTableWeakMemory | NSMapTableObjectPointerPersonality;
-    // Strongly retain the FIRTrace.
-    NSMapTableOptions valueOptions = NSMapTableStrongMemory;
-    _activeScreenTraces = [NSMapTable mapTableWithKeyOptions:keyOptions valueOptions:valueOptions];
+    _activeScreenTraces = [[NSMutableDictionary alloc] init];
+    _activeScreenTracesLock = [[NSLock alloc] init];
 
     _previouslyVisibleViewControllers = nil;  // Will be set when there is data.
     _screenTraceTrackerSerialQueue =
@@ -217,11 +217,15 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
 
   dispatch_group_async(self.screenTraceTrackerDispatchGroup, self.screenTraceTrackerSerialQueue, ^{
     self.previouslyVisibleViewControllers = [NSPointerArray weakObjectsPointerArray];
-    id visibleViewControllersEnumerator = [self.activeScreenTraces keyEnumerator];
-    id visibleViewController = nil;
-    while (visibleViewController = [visibleViewControllersEnumerator nextObject]) {
-      [self.previouslyVisibleViewControllers addPointer:(__bridge void *)(visibleViewController)];
+    [self.activeScreenTracesLock lock];
+    NSArray<FPRScreenTraceHolder *> *holders = [self.activeScreenTraces allValues];
+    for (FPRScreenTraceHolder *holder in holders) {
+      UIViewController *vc = holder.viewController;
+      if (vc) {
+        [self.previouslyVisibleViewControllers addPointer:(__bridge void *)(vc)];
+      }
     }
+    [self.activeScreenTracesLock unlock];
 
     for (id visibleViewController in self.previouslyVisibleViewControllers) {
       [self stopScreenTraceForViewController:visibleViewController
@@ -326,16 +330,31 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
     return;
   }
 
-  // If there's a trace for this viewController, don't do anything.
-  if (![self.activeScreenTraces objectForKey:viewController]) {
+  NSValue *key = [NSValue valueWithNonretainedObject:viewController];
+
+  [self.activeScreenTracesLock lock];
+  FPRScreenTraceHolder *holder = [self.activeScreenTraces objectForKey:key];
+  if (holder && holder.viewController != viewController) {
+    // Stale entry due to pointer reuse. Remove it.
+    [self.activeScreenTraces removeObjectForKey:key];
+    holder = nil;
+  }
+
+  if (!holder) {
     NSString *traceName = FPRScreenTraceNameForViewController(viewController);
     FIRTrace *newTrace = [[FIRTrace alloc] initInternalTraceWithName:traceName];
     [newTrace start];
     [newTrace setIntValue:currentTotalFrames forMetric:kFPRTotalFramesCounterName];
     [newTrace setIntValue:currentFrozenFrames forMetric:kFPRFrozenFrameCounterName];
     [newTrace setIntValue:currentSlowFrames forMetric:kFPRSlowFrameCounterName];
-    [self.activeScreenTraces setObject:newTrace forKey:viewController];
+
+    holder = [[FPRScreenTraceHolder alloc] init];
+    holder.viewController = viewController;
+    holder.trace = newTrace;
+
+    [self.activeScreenTraces setObject:holder forKey:key];
   }
+  [self.activeScreenTracesLock unlock];
 }
 
 /** Stops a screen trace for the given UIViewController instance if it exist. This method does NOT
@@ -351,7 +370,25 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
                       currentTotalFrames:(int64_t)currentTotalFrames
                      currentFrozenFrames:(int64_t)currentFrozenFrames
                        currentSlowFrames:(int64_t)currentSlowFrames {
-  FIRTrace *previousScreenTrace = [self.activeScreenTraces objectForKey:viewController];
+  NSValue *key = [NSValue valueWithNonretainedObject:viewController];
+
+  [self.activeScreenTracesLock lock];
+  FPRScreenTraceHolder *holder = [self.activeScreenTraces objectForKey:key];
+  if (holder && holder.viewController != viewController) {
+    // Stale entry due to pointer reuse. Remove it.
+    [self.activeScreenTraces removeObjectForKey:key];
+    holder = nil;
+  }
+  if (holder) {
+    [self.activeScreenTraces removeObjectForKey:key];
+  }
+  [self.activeScreenTracesLock unlock];
+
+  if (!holder) {
+    return;
+  }
+
+  FIRTrace *previousScreenTrace = holder.trace;
 
   // Get a diff between the counters now and what they were at trace start.
   int64_t actualTotalFrames =
@@ -386,7 +423,6 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
     // The trace did not collect any data. Don't log it.
     [previousScreenTrace cancel];
   }
-  [self.activeScreenTraces removeObjectForKey:viewController];
 }
 
 #pragma mark - Filtering for screen traces

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -668,7 +668,8 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   // The blocks retain the view controllers and it sometimes takes some time to release them.
   NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:5.0];
   while (weakVC2 && [timeoutDate timeIntervalSinceNow] > 0) {
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                             beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
   }
 
   // App becomes active.

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -666,8 +666,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   testViewController2 = nil;
 
   // The blocks retain the view controllers and it sometimes takes some time to release them.
-  while (weakVC2) {
-    continue;
+  NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:5.0];
+  while (weakVC2 && [timeoutDate timeIntervalSinceNow] > 0) {
+    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
   }
 
   // App becomes active.

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -509,6 +509,8 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   }
 
   XCTAssertNil(weakVC);
+  [self.tracker cleanupStaleTraces];
+  XCTAssertEqual(self.tracker.activeScreenTraces.count, 0);
 }
 
 /** Tests that a FIRTrace is strongly retained in the map table that holds the mapping between a

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -125,8 +125,12 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   XCTAssertEqual(self.tracker.activeScreenTraces.count, 1);
   NSString *expectedTraceName =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController];
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
   XCTAssertEqualObjects(createdTrace.name, expectedTraceName);
   XCTAssertFalse(createdTrace.isCompleteAndValid);
 }
@@ -143,7 +147,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     // objectForKey: is always executed on the FPRScreenTraceTracker serial queue, which has its own
     // autorelesepool. Without the autoreleasepool, the ViewController instance is not released
     // in a timely manner and this test becomes flaky.
-    FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:newVCInstance];
+    FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                                 objectForKey:[NSValue valueWithNonretainedObject:newVCInstance]]
+                                 .trace;
     XCTAssertNil(createdTrace);
 
     // Clean up.
@@ -166,7 +172,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     // objectForKey: is always executed on the FPRScreenTraceTracker serial queue, which has its own
     // autorelesepool. Without the autoreleasepool, the ViewController instance is not released
     // in a timely manner and this test becomes flaky.
-    FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:newVCInstance];
+    FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                                 objectForKey:[NSValue valueWithNonretainedObject:newVCInstance]]
+                                 .trace;
     XCTAssertEqualObjects(createdTrace.name, expectedTraceName);
     createdTrace = nil;
 
@@ -198,7 +206,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     // objectForKey: is always executed on the FPRScreenTraceTracker serial queue, which has its own
     // autorelesepool. Without the autoreleasepool, the ViewController instance is not released
     // in a timely manner and this test becomes flaky.
-    FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:newVCInstance];
+    FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                                 objectForKey:[NSValue valueWithNonretainedObject:newVCInstance]]
+                                 .trace;
     XCTAssertEqualObjects(createdTrace.name, expectedTraceName);
     createdTrace = nil;
 
@@ -227,7 +237,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     // objectForKey: is always executed on the FPRScreenTraceTracker serial queue, which has its own
     // autorelesepool. Without the autoreleasepool, the ViewController instance is not released
     // in a timely manner and this test becomes flaky.
-    FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:newVCInstance];
+    FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                                 objectForKey:[NSValue valueWithNonretainedObject:newVCInstance]]
+                                 .trace;
     XCTAssertEqual(createdTrace.name.length, kFPRMaxNameLength);
     createdTrace = nil;
 
@@ -255,7 +267,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     // objectForKey: is always executed on the FPRScreenTraceTracker serial queue, which has its own
     // autorelesepool. Without the autoreleasepool, the ViewController instance is not released
     // in a timely manner and this test becomes flaky.
-    FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:newVCInstance];
+    FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                                 objectForKey:[NSValue valueWithNonretainedObject:newVCInstance]]
+                                 .trace;
     XCTAssertEqual(createdTrace.name.length, kFPRMaxNameLength);
     createdTrace = nil;
 
@@ -290,7 +304,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   NSString *expectedTraceName =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController];
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
   XCTAssertNotNil(createdTrace);
   XCTAssertEqualObjects(expectedTraceName, createdTrace.name);
 
@@ -315,14 +331,24 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   NSString *expectedTraceNameOne =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController];
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
-  FIRTrace *traceForScreenOne = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
+  FIRTrace *traceForScreenOne =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+          .trace;
   XCTAssertEqualObjects(traceForScreenOne.name, expectedTraceNameOne);
 
   NSString *expectedTraceNameTwo =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController2];
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController2]);
-  FIRTrace *traceForScreenTwo = [self.tracker.activeScreenTraces objectForKey:testViewController2];
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+                      .trace);
+  FIRTrace *traceForScreenTwo =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+          .trace;
   XCTAssertEqualObjects(traceForScreenTwo.name, expectedTraceNameTwo);
 
   // Test that they're different instances.
@@ -345,14 +371,24 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   NSString *expectedTraceNameOne =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController];
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
-  FIRTrace *traceForScreenOne = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
+  FIRTrace *traceForScreenOne =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+          .trace;
   XCTAssertEqualObjects(traceForScreenOne.name, expectedTraceNameOne);
 
   NSString *expectedTraceNameTwo =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController2];
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController2]);
-  FIRTrace *traceForScreenTwo = [self.tracker.activeScreenTraces objectForKey:testViewController2];
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+                      .trace);
+  FIRTrace *traceForScreenTwo =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+          .trace;
   XCTAssertEqualObjects(traceForScreenTwo.name, expectedTraceNameTwo);
 
   XCTAssertNotEqual(traceForScreenOne,
@@ -374,8 +410,14 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   XCTAssertEqual(self.tracker.activeScreenTraces.count, 2);
 
-  FIRTrace *traceForScreenOne = [self.tracker.activeScreenTraces objectForKey:testViewController];
-  FIRTrace *traceForScreenTwo = [self.tracker.activeScreenTraces objectForKey:testViewController2];
+  FIRTrace *traceForScreenOne =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+          .trace;
+  FIRTrace *traceForScreenTwo =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+          .trace;
 
   XCTAssertFalse(traceForScreenOne.isCompleteAndValid);
   XCTAssertFalse(traceForScreenTwo.isCompleteAndValid);
@@ -396,7 +438,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   NSString *expectedTraceName =
       [FPRScreenTraceTrackerTest expectedTraceNameForViewController:testViewController];
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
   XCTAssertNotNil(createdTrace);
   XCTAssertEqualObjects(createdTrace.name, expectedTraceName);
 
@@ -405,7 +449,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
   XCTAssertEqual(self.tracker.activeScreenTraces.count, 1);
-  FIRTrace *activeTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *activeTrace = [self.tracker.activeScreenTraces
+                              objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                              .trace;
   XCTAssertEqual(createdTrace, activeTrace);  // Test that it is the same trace.
 }
 
@@ -448,14 +494,21 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
  *  them.
  */
 - (void)testViewControllerIsWeaklyRetained {
+  __weak UIViewController *weakVC;
   @autoreleasepool {
     UIViewController *testViewController = [[UIViewController alloc] init];
+    weakVC = testViewController;
     id mockTrace = OCMClassMock([FIRTrace class]);
-    [self.tracker.activeScreenTraces setObject:mockTrace forKey:testViewController];
+    FPRScreenTraceHolder *holder = [[FPRScreenTraceHolder alloc] init];
+    holder.viewController = testViewController;
+    holder.trace = mockTrace;
+    [self.tracker.activeScreenTraces
+        setObject:holder
+           forKey:[NSValue valueWithNonretainedObject:testViewController]];
     testViewController = nil;
   }
 
-  XCTAssertEqual([self.tracker.activeScreenTraces dictionaryRepresentation].count, 0);
+  XCTAssertNil(weakVC);
 }
 
 /** Tests that a FIRTrace is strongly retained in the map table that holds the mapping between a
@@ -466,12 +519,22 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   NSString *traceName = @"screenTrace";
   FIRTrace *trace = [[FIRTrace alloc] initInternalTraceWithName:traceName];
 
-  [self.tracker.activeScreenTraces setObject:trace forKey:testViewController];
+  FPRScreenTraceHolder *holder = [[FPRScreenTraceHolder alloc] init];
+  holder.viewController = testViewController;
+  holder.trace = trace;
+  [self.tracker.activeScreenTraces
+      setObject:holder
+         forKey:[NSValue valueWithNonretainedObject:testViewController]];
   trace = nil;
 
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
 
-  FIRTrace *returnedTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *returnedTrace =
+      [self.tracker.activeScreenTraces
+          objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+          .trace;
   XCTAssertEqualObjects(returnedTrace.name, traceName);
 }
 
@@ -479,7 +542,12 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 - (void)testTraceWithNoCountersIsNotSent {
   id mockTrace = OCMClassMock([FIRTrace class]);
   UIViewController *testViewController = [[UIViewController alloc] init];
-  [self.tracker.activeScreenTraces setObject:mockTrace forKey:testViewController];
+  FPRScreenTraceHolder *holder = [[FPRScreenTraceHolder alloc] init];
+  holder.viewController = testViewController;
+  holder.trace = mockTrace;
+  [self.tracker.activeScreenTraces
+      setObject:holder
+         forKey:[NSValue valueWithNonretainedObject:testViewController]];
 
   OCMExpect([mockTrace cancel]);
   [[mockTrace reject] stop];
@@ -502,8 +570,10 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
-  FIRTrace *traceScreenOne = [self.tracker.activeScreenTraces objectForKey:testViewController];
-  FIRTrace *traceScreenTwo = [self.tracker.activeScreenTraces objectForKey:testViewController2];
+  NSValue *keyOne = [NSValue valueWithNonretainedObject:testViewController];
+  NSValue *keyTwo = [NSValue valueWithNonretainedObject:testViewController2];
+  FIRTrace *traceScreenOne = [self.tracker.activeScreenTraces objectForKey:keyOne].trace;
+  FIRTrace *traceScreenTwo = [self.tracker.activeScreenTraces objectForKey:keyTwo].trace;
 
   XCTAssertNotNil(traceScreenOne);
   XCTAssertNotNil(traceScreenTwo);
@@ -567,8 +637,12 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
   XCTAssertEqual(self.tracker.activeScreenTraces.count, 2);
   XCTAssertNil(self.tracker.previouslyVisibleViewControllers);
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController2]);
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController2]]
+                      .trace);
 }
 
 /** Tests that if one of the previously visible ViewControllers is deallocated, a new trace isn't
@@ -595,8 +669,10 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
   XCTAssertNil(self.tracker.previouslyVisibleViewControllers);
-  XCTAssertNotNil([self.tracker.activeScreenTraces objectForKey:testViewController]);
-  XCTAssertNil([self.tracker.activeScreenTraces objectForKey:testViewController2]);
+  XCTAssertNotNil([self.tracker.activeScreenTraces
+                      objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                      .trace);
+  XCTAssertEqual(self.tracker.activeScreenTraces.count, 1);
 }
 
 /** Tests that if consecutive frames take more time to render than the slow frames threshold, the
@@ -754,7 +830,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   [self.tracker viewControllerDidAppear:testViewController];
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
 
   self.tracker.totalFramesCount = initialTotalFramesCount + expectedTotalFramesOnTrace;
   self.tracker.slowFramesCount = initialSlowFramesCount + expectedSlowFramesOnTrace;
@@ -786,7 +864,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   [self.tracker viewControllerDidAppear:testViewController];
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
 
   self.tracker.totalFramesCount = initialTotalFramesCount + expectedTotalFramesOnTrace;
   self.tracker.slowFramesCount = initialSlowFramesCount + expectedSlowFramesOnTrace;
@@ -819,7 +899,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   [self.tracker viewControllerDidAppear:testViewController];
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
 
   self.tracker.totalFramesCount = initialTotalFramesCount + expectedTotalFramesOnTrace;
   self.tracker.slowFramesCount = initialSlowFramesCount + expectedSlowFramesOnTrace;
@@ -843,7 +925,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   [self.tracker viewControllerDidAppear:testViewController];
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
 
-  FIRTrace *createdTrace = [self.tracker.activeScreenTraces objectForKey:testViewController];
+  FIRTrace *createdTrace = [self.tracker.activeScreenTraces
+                               objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
+                               .trace;
 
   [self.tracker viewControllerDidDisappear:testViewController];
   dispatch_group_wait(self.dispatchGroupToWaitOn, DISPATCH_TIME_FOREVER);
@@ -1142,6 +1226,70 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
 + (NSString *)expectedTraceNameForViewController:(UIViewController *)viewController {
   return [@"_st_" stringByAppendingString:NSStringFromClass([viewController class])];
+}
+
+- (void)testScreenTraceTrackerStress {
+  int iterations = 100;
+  int numObjects = 10;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Stress test finished"];
+
+  dispatch_queue_t queue =
+      dispatch_queue_create("com.google.perf.stress", DISPATCH_QUEUE_CONCURRENT);
+
+  dispatch_group_t group = dispatch_group_create();
+
+  NSMutableArray<UIViewController *> *objects = [[NSMutableArray alloc] init];
+  for (int i = 0; i < numObjects; i++) {
+    [objects addObject:[[UIViewController alloc] init]];
+  }
+
+  // Thread 1: Continuously call viewControllerDidAppear
+  for (int t = 0; t < 3; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int idx = i % numObjects;
+        UIViewController *obj;
+        @synchronized(objects) {
+          obj = objects[idx];
+        }
+        [self.tracker viewControllerDidAppear:obj];
+      }
+    });
+  }
+
+  // Thread 2: Continuously call viewControllerDidDisappear
+  for (int t = 0; t < 3; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int idx = i % numObjects;
+        UIViewController *obj;
+        @synchronized(objects) {
+          obj = objects[idx];
+        }
+        [self.tracker viewControllerDidDisappear:obj];
+      }
+    });
+  }
+
+  // Thread 3: Continuously replace objects to trigger deallocation
+  for (int t = 0; t < 2; t++) {
+    dispatch_group_async(group, queue, ^{
+      for (int i = 0; i < iterations; i++) {
+        int idx = i % numObjects;
+        UIViewController *newObj = [[UIViewController alloc] init];
+        @synchronized(objects) {
+          objects[idx] = newObj;
+        }
+      }
+    });
+  }
+
+  dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 @end

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -654,16 +654,19 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   UIViewController *testViewController = [[UIViewController alloc] init];
   [testViewController view];  // Loads the view so that a screen trace is created for it.
 
-  UIViewController *testViewController2 = [[UIViewController alloc] init];
-  [testViewController2 view];  // Loads the view so that a screen trace is created for it.
+  __weak UIViewController *weakVC2;
+  @autoreleasepool {
+    UIViewController *testViewController2 = [[UIViewController alloc] init];
+    [testViewController2 view];  // Loads the view so that a screen trace is created for it.
 
-  self.tracker.previouslyVisibleViewControllers = [NSPointerArray weakObjectsPointerArray];
-  [self.tracker.previouslyVisibleViewControllers addPointer:(__bridge void *)testViewController];
-  [self.tracker.previouslyVisibleViewControllers addPointer:(__bridge void *)testViewController2];
+    self.tracker.previouslyVisibleViewControllers = [NSPointerArray weakObjectsPointerArray];
+    [self.tracker.previouslyVisibleViewControllers addPointer:(__bridge void *)testViewController];
+    [self.tracker.previouslyVisibleViewControllers addPointer:(__bridge void *)testViewController2];
 
-  // UIKit deallocates one of the ViewControllers that was previously visible.
-  __weak UIViewController *weakVC2 = testViewController2;
-  testViewController2 = nil;
+    // UIKit deallocates one of the ViewControllers that was previously visible.
+    weakVC2 = testViewController2;
+    testViewController2 = nil;
+  }
 
   // The blocks retain the view controllers and it sometimes takes some time to release them.
   NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:5.0];

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -662,7 +662,13 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   [self.tracker.previouslyVisibleViewControllers addPointer:(__bridge void *)testViewController2];
 
   // UIKit deallocates one of the ViewControllers that was previously visible.
+  __weak UIViewController *weakVC2 = testViewController2;
   testViewController2 = nil;
+
+  // The blocks retain the view controllers and it sometimes takes some time to release them.
+  while (weakVC2) {
+    continue;
+  }
 
   // App becomes active.
   NSNotification *appDidBecomeActiveNSNotification =
@@ -674,6 +680,7 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   XCTAssertNotNil([self.tracker.activeScreenTraces
                       objectForKey:[NSValue valueWithNonretainedObject:testViewController]]
                       .trace);
+  [self.tracker cleanupStaleTraces];
   XCTAssertEqual(self.tracker.activeScreenTraces.count, 1);
 }
 

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -419,7 +419,44 @@
 }
 #endif
 
+- (void)testSwizzlerDisposesGeneratedClass {
+  NSString *className;
+  __weak FPRObjectSwizzler *weakSwizzler;
 
+  XCTestExpectation *swizzlerDeallocatedExpectation =
+      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
+
+  @autoreleasepool {
+    NSObject *object = [[NSObject alloc] init];
+    FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+    [swizzler copySelector:@selector(donorDescription)
+                 fromClass:[FPRObjectSwizzlerTest class]
+           isClassSelector:NO];
+    [swizzler swizzle];
+    className = NSStringFromClass(object_getClass(object));
+    weakSwizzler = swizzler;
+
+    // Release FPRObjectSwizzler
+    [FPRObjectSwizzler setAssociatedObject:object
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:nil
+                               association:GUL_ASSOCIATION_RETAIN];
+    
+    object = nil;
+  }
+
+  // Wait for a while until FPRObjectSwizzler has disposed the generated class on the main queue.
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   [swizzlerDeallocatedExpectation fulfill];
+                 });
+
+  [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
+
+  XCTAssertNil(weakSwizzler);
+  Class cls = objc_getClass(className.UTF8String);
+  XCTAssertNil(cls);
+}
 
 - (void)testMultiSwizzling {
   NSObject *object = [[NSObject alloc] init];

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -441,15 +441,14 @@
                                        key:&kGULSwizzlerAssociatedObjectKey
                                      value:nil
                                association:GUL_ASSOCIATION_RETAIN];
-    
+
     object = nil;
   }
 
-  // Wait for a while until FPRObjectSwizzler has disposed the generated class on the main queue.
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
-                 dispatch_get_main_queue(), ^{
-                   [swizzlerDeallocatedExpectation fulfill];
-                 });
+  // Wait for FPRObjectSwizzler to dispose the generated class on the main queue.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [swizzlerDeallocatedExpectation fulfill];
+  });
 
   [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
 

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -419,43 +419,7 @@
 }
 #endif
 
-- (void)testSwizzlerDisposesGeneratedClass {
-  NSString *className;
-  __weak FPRObjectSwizzler *weakSwizzler;
 
-  XCTestExpectation *swizzlerDeallocatedExpectation =
-      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
-
-  @autoreleasepool {
-    NSObject *object = [[NSObject alloc] init];
-    FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
-    [swizzler copySelector:@selector(donorDescription)
-                 fromClass:[FPRObjectSwizzlerTest class]
-           isClassSelector:NO];
-    [swizzler swizzle];
-    className = NSStringFromClass(object_getClass(object));
-    weakSwizzler = swizzler;
-
-    // Release FPRObjectSwizzler
-    [FPRObjectSwizzler setAssociatedObject:object
-                                       key:&kGULSwizzlerAssociatedObjectKey
-                                     value:nil
-                               association:GUL_ASSOCIATION_RETAIN];
-
-    object = nil;
-  }
-
-  // Wait for FPRObjectSwizzler to dispose the generated class on the main queue.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [swizzlerDeallocatedExpectation fulfill];
-  });
-
-  [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
-
-  XCTAssertNil(weakSwizzler);
-  Class cls = objc_getClass(className.UTF8String);
-  XCTAssertNil(cls);
-}
 
 - (void)testMultiSwizzling {
   NSObject *object = [[NSObject alloc] init];


### PR DESCRIPTION
Fix #14473

Based on the source changes in [PR \#16072](https://github.com/firebase/firebase-ios-sdk/pull/16072/files), the fix addresses a crash related to `NSMapTable` by replacing it with a more manual, thread-safe implementation using `NSMutableDictionary` and `NSLock`.

### **Core Changes**

The PR moves away from `NSMapTable` (configured with weak keys and strong values) in favor of a custom "Holder" pattern to manage `UIViewController` references and their associated performance traces.

* **Introduction of `FPRScreenTraceHolder`:** A new internal class that holds a `weak` reference to the `UIViewController` and a `strong` reference to the `FIRTrace`.  
* **Storage Shift:** The `activeScreenTraces` property changed from an `NSMapTable` to a standard `NSMutableDictionary<NSValue *, FPRScreenTraceHolder *>`.  
* **Thread Safety:** Added `activeScreenTracesLock` (`NSLock`) to synchronize access to the dictionary, which was likely a contributor to the original crash.

### **Technical Analysis**

* **Pointer Reuse Protection:** The implementation now explicitly checks for "stale" entries. Since `NSValue` stores the raw pointer (non-retained), the code now verifies `if (holder && holder.viewController != viewController)` before starting or stopping a trace. This prevents a new view controller from accidentally inheriting a trace from a deallocated object that happened to share the same memory address.  
* **Memory Management:** By using a `weak` property in the `FPRScreenTraceHolder`, the SDK avoids retain cycles while still allowing the dictionary to be cleaned up when a view controller is dismissed or deallocated.  
* **Stress Testing:** The author added a robust concurrency test (`testScreenTraceTrackerStress`) that spawns multiple threads to hammer the appear/disappear/deallocate cycle simultaneously, ensuring the new locking mechanism holds up under pressure.

### **Observations**

1. **Complexity Trade-off:** While `NSMapTable` is designed to handle weak-to-strong mappings automatically, it is notoriously finicky regarding thread safety and when it actually "cleans up" nilled-out entries. This manual implementation is more verbose but significantly more predictable.  
2. **Explicit Cleanup:** In `stopScreenTraceForViewController`, the entry is now explicitly removed from the dictionary after the trace is stopped, which is cleaner than relying on the internal "garbage collection" of a map table.
