### PR TITLE
[Perf] Defer class disposal in FPRObjectSwizzler to avoid race 

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Address by deferring class disposal in FPRObjectSwizzler. (#14473)
+- [fixed] Address crash by deferring class disposal in FPRObjectSwizzler. (#14473)
 
 # 12.12.0
 - [fixed] Fix app_start trace not firing in SwiftUI apps using @UIApplicationDelegateAdaptor. (#15802)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Address by deferring class disposal in FPRObjectSwizzler. (#14473)
+
 # 12.12.0
 - [fixed] Fix app_start trace not firing in SwiftUI apps using @UIApplicationDelegateAdaptor. (#15802)
 

--- a/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
@@ -159,50 +159,10 @@
 }
 
 - (void)dealloc {
-  // When the Zombies instrument is enabled, a zombie is created for the swizzled object upon
-  // deallocation. Because this zombie subclasses the generated class, the swizzler should not
-  // dispose it during the swizzler's deallocation.
-  //
-  // There are other special cases where the generated class might be subclassed by a third-party
-  // generated classes, for example: https://github.com/firebase/firebase-ios-sdk/issues/9083
-  // To avoid errors in such cases, the environment variable `GULGeneratedClassDisposeDisabled` can
-  // be set with `YES`.
-  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-  if ([[environment objectForKey:@"NSZombieEnabled"] boolValue] ||
-      [[environment objectForKey:@"GULGeneratedClassDisposeDisabled"] boolValue]) {
-    return;
-  }
-
-  if (_generatedClass) {
-    if (_swizzledObject == nil) {
-      // The swizzled object has been deallocated already, so the generated class can be disposed
-      // now.
-      objc_disposeClassPair(_generatedClass);
-      return;
-    }
-
-    // FPRSwizzledObject is retained by the swizzled object which means that the swizzled object is
-    // being deallocated now. Let's see if we should schedule the generated class disposal.
-
-    // If the swizzled object has a different class, it most likely indicates that the object was
-    // ISA swizzled one more time. In this case it is not safe to dispose the generated class. We
-    // will have to keep it to prevent a crash.
-
-    // TODO: Consider adding a flag that can be set by the host application to dispose the class
-    // pair unconditionally. It may be used by apps that use ISA Swizzling themself and are
-    // confident in disposing their subclasses.
-    BOOL isSwizzledObjectInstanceOfGeneratedClass =
-        object_getClass(_swizzledObject) == _generatedClass;
-
-    if (isSwizzledObjectInstanceOfGeneratedClass) {
-      Class generatedClass = _generatedClass;
-
-      // Schedule the generated class disposal after the swizzled object has been deallocated.
-      dispatch_async(dispatch_get_main_queue(), ^{
-        objc_disposeClassPair(generatedClass);
-      });
-    }
-  }
+  // We do not dispose the generated class pair here to avoid race conditions where the class is
+  // disposed while instances are still being destroyed (e.g. on background threads).
+  // Disposing the class pair while instances exist can cause hard-to-debug crashes.
+  // The memory cost of leaking the class structure is negligible.
 }
 
 - (BOOL)isSwizzlingProxyObject {

--- a/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
+++ b/FirebasePerformance/Sources/ISASwizzler/FPRObjectSwizzler.m
@@ -159,10 +159,54 @@
 }
 
 - (void)dealloc {
-  // We do not dispose the generated class pair here to avoid race conditions where the class is
-  // disposed while instances are still being destroyed (e.g. on background threads).
-  // Disposing the class pair while instances exist can cause hard-to-debug crashes.
-  // The memory cost of leaking the class structure is negligible.
+  // When the Zombies instrument is enabled, a zombie is created for the swizzled object upon
+  // deallocation. Because this zombie subclasses the generated class, the swizzler should not
+  // dispose it during the swizzler's deallocation.
+  //
+  // There are other special cases where the generated class might be subclassed by a third-party
+  // generated classes, for example: https://github.com/firebase/firebase-ios-sdk/issues/9083
+  // To avoid errors in such cases, the environment variable `GULGeneratedClassDisposeDisabled` can
+  // be set with `YES`.
+  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+  if ([[environment objectForKey:@"NSZombieEnabled"] boolValue] ||
+      [[environment objectForKey:@"GULGeneratedClassDisposeDisabled"] boolValue]) {
+    return;
+  }
+
+  if (_generatedClass) {
+    if (_swizzledObject == nil) {
+      // The swizzled object has been deallocated already, so the generated class can be disposed
+      // now. Defer disposal to ensure that objc_rootDealloc of the swizzled object has completed
+      // and any weak references have been zeroed.
+      Class generatedClass = _generatedClass;
+      dispatch_async(dispatch_get_main_queue(), ^{
+        objc_disposeClassPair(generatedClass);
+      });
+      return;
+    }
+
+    // FPRSwizzledObject is retained by the swizzled object which means that the swizzled object is
+    // being deallocated now. Let's see if we should schedule the generated class disposal.
+
+    // If the swizzled object has a different class, it most likely indicates that the object was
+    // ISA swizzled one more time. In this case it is not safe to dispose the generated class. We
+    // will have to keep it to prevent a crash.
+
+    // TODO: Consider adding a flag that can be set by the host application to dispose the class
+    // pair unconditionally. It may be used by apps that use ISA Swizzling themself and are
+    // confident in disposing their subclasses.
+    BOOL isSwizzledObjectInstanceOfGeneratedClass =
+        object_getClass(_swizzledObject) == _generatedClass;
+
+    if (isSwizzledObjectInstanceOfGeneratedClass) {
+      Class generatedClass = _generatedClass;
+
+      // Schedule the generated class disposal after the swizzled object has been deallocated.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        objc_disposeClassPair(generatedClass);
+      });
+    }
+  }
 }
 
 - (BOOL)isSwizzlingProxyObject {

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -419,6 +419,45 @@
 }
 #endif
 
+- (void)testSwizzlerDisposesGeneratedClass {
+  NSString *className;
+  __weak FPRObjectSwizzler *weakSwizzler;
+
+  XCTestExpectation *swizzlerDeallocatedExpectation =
+      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
+
+  @autoreleasepool {
+    NSObject *object = [[NSObject alloc] init];
+    FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
+    [swizzler copySelector:@selector(donorDescription)
+                 fromClass:[FPRObjectSwizzlerTest class]
+           isClassSelector:NO];
+    [swizzler swizzle];
+    className = NSStringFromClass(object_getClass(object));
+    weakSwizzler = swizzler;
+
+    // Release FPRObjectSwizzler
+    [FPRObjectSwizzler setAssociatedObject:object
+                                       key:&kGULSwizzlerAssociatedObjectKey
+                                     value:nil
+                               association:GUL_ASSOCIATION_RETAIN];
+
+    object = nil;
+  }
+
+  // Wait for a while until FPRObjectSwizzler has disposed the generated class on the main queue.
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   [swizzlerDeallocatedExpectation fulfill];
+                 });
+
+  [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
+
+  XCTAssertNil(weakSwizzler);
+  Class cls = objc_getClass(className.UTF8String);
+  XCTAssertNil(cls);
+}
+
 - (void)testMultiSwizzling {
   NSObject *object = [[NSObject alloc] init];
 

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -104,7 +104,8 @@
   XCTAssertTrue([object respondsToSelector:@selector(gul_class)]);
 }
 
-/** Tests that there's no retain cycle and that the swizzler is deallocated when the object is deallocated. */
+/** Tests that there's no retain cycle and that the swizzler is deallocated when the object is
+ * deallocated. */
 - (void)testRetainCycleDoesntExistAndSwizzlerDeallocatesWithObject {
   NSObject *object = [[NSObject alloc] init];
   FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
@@ -417,8 +418,6 @@
   objc_disposeClassPair(generatedClass);
 }
 #endif
-
-
 
 - (void)testMultiSwizzling {
   NSObject *object = [[NSObject alloc] init];

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -104,8 +104,8 @@
   XCTAssertTrue([object respondsToSelector:@selector(gul_class)]);
 }
 
-/** Tests that there's no retain cycle and that -dealloc causes unswizzling. */
-- (void)testRetainCycleDoesntExistAndDeallocCausesUnswizzling {
+/** Tests that there's no retain cycle and that the swizzler is deallocated when the object is deallocated. */
+- (void)testRetainCycleDoesntExistAndSwizzlerDeallocatesWithObject {
   NSObject *object = [[NSObject alloc] init];
   FPRObjectSwizzler *objectSwizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
   [objectSwizzler copySelector:@selector(donorMethod) fromClass:[self class] isClassSelector:NO];
@@ -418,47 +418,7 @@
 }
 #endif
 
-// The test is disabled because in the case of success it should crash with SIGABRT, so it is not
-// suitable for CI.
-- (void)disabledForCI_testSwizzlerDisposesGeneratedClass {
-  __weak FPRObjectSwizzler *weakSwizzler;
 
-  XCTestExpectation *swizzlerDeallocatedExpectation =
-      [self expectationWithDescription:@"swizzlerDeallocatedExpectation"];
-
-  @autoreleasepool {
-    NSObject *object = [[NSObject alloc] init];
-
-    @autoreleasepool {
-      FPRObjectSwizzler *swizzler = [[FPRObjectSwizzler alloc] initWithObject:object];
-      weakSwizzler = swizzler;
-      [swizzler copySelector:@selector(donorDescription)
-                   fromClass:[FPRObjectSwizzlerTest class]
-             isClassSelector:NO];
-      [swizzler swizzle];
-    }
-
-    // Release FPRObjectSwizzler
-    [FPRObjectSwizzler setAssociatedObject:object
-                                       key:&kGULSwizzlerAssociatedObjectKey
-                                     value:nil
-                               association:GUL_ASSOCIATION_RETAIN];
-
-    // Wait for a while until FPRObjectSwizzler has disposed the generated class.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-                     [swizzlerDeallocatedExpectation fulfill];
-                   });
-
-    [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
-
-    XCTAssertNil(weakSwizzler);
-
-    // Must crash here with SIGABRT.
-    XCTAssertThrows([object description]);
-    XCTFail(@"The test must have crashed on the previous line.");
-  }
-}
 
 - (void)testMultiSwizzling {
   NSObject *object = [[NSObject alloc] init];

--- a/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
+++ b/FirebasePerformance/Tests/Unit/ISASwizzler/FPRObjectSwizzlerTest.m
@@ -445,11 +445,10 @@
     object = nil;
   }
 
-  // Wait for a while until FPRObjectSwizzler has disposed the generated class on the main queue.
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
-                 dispatch_get_main_queue(), ^{
-                   [swizzlerDeallocatedExpectation fulfill];
-                 });
+  // Wait for FPRObjectSwizzler to dispose the generated class on the main queue.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [swizzlerDeallocatedExpectation fulfill];
+  });
 
   [self waitForExpectations:@[ swizzlerDeallocatedExpectation ] timeout:2];
 


### PR DESCRIPTION
Fix #14473

Context at https://github.com/google/GoogleUtilities/pull/230#issuecomment-4225035876

### **Core Logic Change: Deferring Disposal**

The core of this PR is a safety fix in FPRObjectSwizzler.m.

* **The Issue:** When a swizzled object is being deallocated, the FPRObjectSwizzler (which is often tied to that object's lifecycle via an associated object) may attempt to call objc\_disposeClassPair on the generated proxy class. If this happens while the runtime is still cleaning up the original object, it can lead to a race condition or a crash if any part of the system still expects that class to exist.  
* **The Fix:** 
  dispatch\_async(dispatch\_get\_main\_queue(), ^{  
  objc\_disposeClassPair(generatedClass);  
  });

By moving the disposal to the next pass of the main run loop, the PR ensures that the `dealloc` chain of the swizzled object has fully completed, and all weak references have been safely zeroed out before the class definition is destroyed.


* 

---

### **Test Suite Enhancements**

The changes in FPRObjectSwizzlerTest.m transition the testing strategy from "manual crash verification" to "automated state verification."

| Before (Disabled Test) | After (New Implementation) |
| :---- | :---- |
| Test named disabledForCI\_testSwizzlerDisposesGeneratedClass. | Renamed to testSwizzlerDisposesGeneratedClass and **enabled**. |
| Expected a SIGABRT crash to prove the class was gone (impossible to run on CI). | Uses objc\_getClass to verify the class is nil after the swizzler is released. |
| Relied on a 1-second dispatch\_after delay. | Uses a cleaner dispatch\_async to the main queue and waitForExpectations. |

**Why this is better:** It allows the CI pipeline to actually verify that the generated class is being disposed of correctly without crashing the test runner.

---

### **Key Considerations**

* **Main Queue Requirement:** The fix explicitly uses dispatch\_get\_main\_queue(). This assumes that the objc\_disposeClassPair operation is safe to perform there and that the main queue is not being blocked. Since this is part of the Performance SDK, this is generally standard, but it does introduce a dependency on the main thread for cleanup.  
* **Changelog Entry:** The PR correctly adds an entry to the FirebasePerformance/CHANGELOG.md under the Unreleased section, linking it to the tracking issue [\#14473](https://github.com/firebase/firebase-ios-sdk/issues/14473).

### **Conclusion**

The PR is well-structured. It solves a complex threading/runtime race condition with a simple, standard pattern and converts a previously "untestable" scenario into a working unit test.
