### PR TITLE
fix(fiam): add check for scene delegates in universal links

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed an issue where universal links were not correctly routed in apps utilizing scene
-  delegates.
+  delegates. (#16083)
 
 # 12.1.0
 - [fixed] Fix Xcode 26 crash from missing `NSUserActivityTypeBrowsingWeb`

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue where universal links were not correctly routed in apps utilizing scene
+  delegates.
+
 # 12.1.0
 - [fixed] Fix Xcode 26 crash from missing `NSUserActivityTypeBrowsingWeb`
   symbol. Note that this fix isn't in the 12.1.0 zip and Carthage

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -168,9 +168,35 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
 
 // Try to handle the url as a universal link by triggering
 // application:continueUserActivity:restorationHandler: on App's delegate object directly.
+// Will also look for scene delegates in the foreground that implement scene:continueUserActivity:.
 // @return YES if that delegate method is defined and seeing a YES being returned from
 // trigging it
 - (BOOL)followURLWithContinueUserActivity:(NSURL *)url {
+  // First try to find a scene delegate to trigger, falling back to app delegate
+  for (UIScene *scene in self.mainApplication.connectedScenes) {
+    if (scene.activationState == UISceneActivationStateForegroundActive ||
+        scene.activationState == UISceneActivationStateForegroundInactive) {
+      id<UISceneDelegate> sceneDelegate = (id<UISceneDelegate>)scene.delegate;
+      if ([sceneDelegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
+        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
+                    @"Scene delegate responds to scene:continueUserActivity."
+                     "Simulating action url opening from a web browser.");
+        // Use string literal to ensure compatibility with Xcode 26 and iOS 18
+        NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
+        NSUserActivity *userActivity =
+            [[NSUserActivity alloc] initWithActivityType:browsingWebType];
+        userActivity.webpageURL = url;
+
+        [sceneDelegate scene:scene continueUserActivity:userActivity];
+
+        // The scene delegate method doesn't return anything, so we assume the response is YES
+        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240005",
+                    @"Scene handling action URL returns YES, no more further action taken");
+        return YES;
+      }
+    }
+  }
+
   if (self.isContinueUserActivityMethodDefined) {
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
                 @"App delegate responds to application:continueUserActivity:restorationHandler:."

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -139,7 +139,15 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
       return;  // following the url has been fully handled by App Delegate's
                // continueUserActivity method
     }
+    if ([self followURLWithSceneContinueUserActivity:actionURL]) {
+      completion(YES);
+      return;  // following the url has been fully handled by Scene Delegate's
+               // continueUserActivity method
+    }
   } else if ([self isCustomSchemeForCurrentApp:actionURL]) {
+    // for scene delegates, we can't reasonably support this. as such, we just follow
+    // apple's security guidance of "developers should use universal links instead".
+    // if folks want to use url schemes, it's up to them to properly support them.
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240002", @"Custom URL scheme matches.");
     if ([self followURLWithAppDelegateOpenURLActivity:actionURL]) {
       completion(YES);
@@ -168,35 +176,9 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
 
 // Try to handle the url as a universal link by triggering
 // application:continueUserActivity:restorationHandler: on App's delegate object directly.
-// Will also look for scene delegates in the foreground that implement scene:continueUserActivity:.
 // @return YES if that delegate method is defined and seeing a YES being returned from
 // trigging it
 - (BOOL)followURLWithContinueUserActivity:(NSURL *)url {
-  // First try to find a scene delegate to trigger, falling back to app delegate
-  for (UIScene *scene in self.mainApplication.connectedScenes) {
-    if (scene.activationState == UISceneActivationStateForegroundActive ||
-        scene.activationState == UISceneActivationStateForegroundInactive) {
-      id<UISceneDelegate> sceneDelegate = (id<UISceneDelegate>)scene.delegate;
-      if ([sceneDelegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
-        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
-                    @"Scene delegate responds to scene:continueUserActivity."
-                     "Simulating action url opening from a web browser.");
-        // Use string literal to ensure compatibility with Xcode 26 and iOS 18
-        NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
-        NSUserActivity *userActivity =
-            [[NSUserActivity alloc] initWithActivityType:browsingWebType];
-        userActivity.webpageURL = url;
-
-        [sceneDelegate scene:scene continueUserActivity:userActivity];
-
-        // The scene delegate method doesn't return anything, so we assume the response is YES
-        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240005",
-                    @"Scene handling action URL returns YES, no more further action taken");
-        return YES;
-      }
-    }
-  }
-
   if (self.isContinueUserActivityMethodDefined) {
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
                 @"App delegate responds to application:continueUserActivity:restorationHandler:."
@@ -227,6 +209,65 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
   } else {
     return NO;
   }
+}
+
+// Try to handle the url as a universal link by triggering
+// scene:continueUserActivity: on any active scene delegate object directly.
+// @return YES if an scene delegate implementing that method was found and
+// invoked
+- (BOOL)followURLWithSceneContinueUserActivity:(NSURL *)url {
+  NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
+  NSUserActivity *userActivity = [[NSUserActivity alloc] initWithActivityType:browsingWebType];
+  userActivity.webpageURL = url;
+
+  __block BOOL handled = NO;
+  void (^executionBlock)(void) = ^{
+    NSSet<UIScene *> *connectedScenes = self.mainApplication.connectedScenes;
+    UIScene *targetScene = nil;
+    id<UISceneDelegate> targetDelegate = nil;
+    for (UIScene *scene in connectedScenes) {
+      id<UISceneDelegate> sceneDelegate = scene.delegate;
+      if ([sceneDelegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
+        if (scene.activationState == UISceneActivationStateForegroundActive) {
+          targetScene = scene;
+          targetDelegate = sceneDelegate;
+          break;
+        } else if (scene.activationState == UISceneActivationStateForegroundInactive) {
+          // a scene in the `ForegroundInactive` state is visible and loaded
+          // in the foreground, but is temporarily not receiving touch events for
+          // whatever reason (eg; because a system dialog, permission prompt,
+          // or notification center overlay is covering it).
+          // So we fall back to any scene in this state, if we don't find
+          // a better alternative (a scene that's in the foreground and also
+          // active).
+          targetScene = scene;
+          targetDelegate = sceneDelegate;
+        }
+      }
+    }
+
+    if (targetScene && targetDelegate) {
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",
+                  @"Scene delegate responds to scene:continueUserActivity."
+                   "Simulating action url opening.");
+      [targetDelegate scene:targetScene continueUserActivity:userActivity];
+      handled = YES;
+      // since scene:continueUserActivity: returns void, we assume it is handled
+      // once we find an active scene delegate implementing it.
+    }
+  };
+
+  if ([NSThread isMainThread]) {
+    executionBlock();
+  } else {
+    // shouldn't happen in our cases, but might happen if the developer
+    // invokes the display delegate methods from a background thread in
+    // a custom UI component or something akin
+    FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM240011",
+                  @"URL following was triggered on a background thread. Moving to main thread.");
+    dispatch_sync(dispatch_get_main_queue(), executionBlock);
+  }
+  return handled;
 }
 
 - (void)followURLViaIOS:(NSURL *)url withCompletionBlock:(void (^)(BOOL success))completion {

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
@@ -53,6 +53,16 @@
 }
 @end
 
+// this delegate implements scene:continueUserActivity: for testing scene-based URL handling
+@interface MockSceneDelegate : NSObject <UISceneDelegate>
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity;
+@end
+@implementation MockSceneDelegate
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+  // no-op
+}
+@end
+
 @interface FIRIAMActionURLFollowerTests : XCTestCase
 @property FIRIAMActionURLFollower *actionFollower;
 @property UIApplication *mockApplication;
@@ -263,5 +273,180 @@
           [expectation fulfill];
         }];
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testSceneContinueUserActivityHandling {
+  // Delegate2 does not define application:continueUserActivity:restorationHandler
+  self.mockAppDelegate = OCMClassMock([Delegate2 class]);
+  OCMStub([self.mockApplication delegate]).andReturn(self.mockAppDelegate);
+
+  // Mock UIScene and MockSceneDelegate
+  id mockScene = OCMClassMock([UIScene class]);
+  OCMStub([mockScene activationState]).andReturn(UISceneActivationStateForegroundActive);
+
+  id mockSceneDelegate = OCMClassMock([MockSceneDelegate class]);
+  OCMStub([mockScene delegate]).andReturn(mockSceneDelegate);
+
+  // Mock the mainApplication.connectedScenes NSSet
+  NSSet *connectedScenes = [NSSet setWithObject:mockScene];
+  OCMStub([self.mockApplication connectedScenes]).andReturn(connectedScenes);
+
+  FIRIAMActionURLFollower *follower =
+      [[FIRIAMActionURLFollower alloc] initWithCustomURLSchemeArray:@[]
+                                                    withApplication:self.mockApplication];
+
+  NSURL *url = [NSURL URLWithString:@"http://test.com"];
+
+  // Expect sceneDelegate's scene:continueUserActivity: to be called
+  OCMExpect([mockSceneDelegate scene:mockScene
+                continueUserActivity:[OCMArg checkWithBlock:^BOOL(id userActivity) {
+                  NSUserActivity *activity = (NSUserActivity *)userActivity;
+                  NSString *browsingWebType = @"NSUserActivityTypeBrowsingWeb";
+                  return [activity.activityType isEqualToString:browsingWebType] &&
+                         [activity.webpageURL isEqual:url];
+                }]]);
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Completion Callback Triggered"];
+
+  [follower followActionURL:url
+        withCompletionBlock:^(BOOL success) {
+          XCTAssertTrue(success);
+          [expectation fulfill];
+        }];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  OCMVerifyAll(mockSceneDelegate);
+}
+
+- (void)testSceneContinueUserActivityHandlingFallback {
+  // Delegate2 does not define application:continueUserActivity:restorationHandler
+  self.mockAppDelegate = OCMClassMock([Delegate2 class]);
+  OCMStub([self.mockApplication delegate]).andReturn(self.mockAppDelegate);
+
+  // Mock UIScene but with a delegate that does NOT implement scene:continueUserActivity:
+  id mockScene = OCMClassMock([UIScene class]);
+  OCMStub([mockScene activationState]).andReturn(UISceneActivationStateForegroundActive);
+
+  // Delegate2 does not implement UISceneDelegate
+  id mockSceneDelegate = OCMClassMock([Delegate2 class]);
+  OCMStub([mockScene delegate]).andReturn(mockSceneDelegate);
+
+  NSSet *connectedScenes = [NSSet setWithObject:mockScene];
+  OCMStub([self.mockApplication connectedScenes]).andReturn(connectedScenes);
+
+  FIRIAMActionURLFollower *follower =
+      [[FIRIAMActionURLFollower alloc] initWithCustomURLSchemeArray:@[]
+                                                    withApplication:self.mockApplication];
+
+  NSURL *url = [NSURL URLWithString:@"http://test.com"];
+
+  // It should fallback to openURL on UIApplication
+  [self setupOpenURLViaIOSForUIApplicationWithReturnValue:YES];
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Completion Callback Triggered"];
+
+  [follower followActionURL:url
+        withCompletionBlock:^(BOOL success) {
+          XCTAssertTrue(success);
+          [expectation fulfill];
+        }];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testSceneContinueUserActivityHandlingForegroundInactiveFallback {
+  self.mockAppDelegate = OCMClassMock([Delegate2 class]);
+  OCMStub([self.mockApplication delegate]).andReturn(self.mockAppDelegate);
+
+  // Scene A is background state (should be skipped)
+  id mockSceneA = OCMClassMock([UIScene class]);
+  OCMStub([mockSceneA activationState]).andReturn(UISceneActivationStateBackground);
+  id mockSceneDelegateA = OCMClassMock([MockSceneDelegate class]);
+  OCMStub([mockSceneA delegate]).andReturn(mockSceneDelegateA);
+
+  // Scene B is foreground inactive (should be selected as fallback)
+  id mockSceneB = OCMClassMock([UIScene class]);
+  OCMStub([mockSceneB activationState]).andReturn(UISceneActivationStateForegroundInactive);
+  id mockSceneDelegateB = OCMClassMock([MockSceneDelegate class]);
+  OCMStub([mockSceneB delegate]).andReturn(mockSceneDelegateB);
+
+  NSSet *connectedScenes = [NSSet setWithObjects:mockSceneA, mockSceneB, nil];
+  OCMStub([self.mockApplication connectedScenes]).andReturn(connectedScenes);
+
+  FIRIAMActionURLFollower *follower =
+      [[FIRIAMActionURLFollower alloc] initWithCustomURLSchemeArray:@[]
+                                                    withApplication:self.mockApplication];
+
+  NSURL *url = [NSURL URLWithString:@"http://test.com"];
+
+  // Expect sceneDelegateB's (inactive) scene:continueUserActivity: to be called,
+  // but NOT sceneDelegateA's (background)
+  OCMExpect([mockSceneDelegateB scene:mockSceneB
+                 continueUserActivity:[OCMArg checkWithBlock:^BOOL(id userActivity) {
+                   NSUserActivity *activity = (NSUserActivity *)userActivity;
+                   return [activity.webpageURL isEqual:url];
+                 }]]);
+  OCMReject([mockSceneDelegateA scene:mockSceneA continueUserActivity:[OCMArg any]]);
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Completion Callback Triggered"];
+
+  [follower followActionURL:url
+        withCompletionBlock:^(BOOL success) {
+          XCTAssertTrue(success);
+          [expectation fulfill];
+        }];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  OCMVerifyAll(mockSceneDelegateB);
+}
+
+- (void)testSceneContinueUserActivityHandlingActivePriorityOverInactive {
+  self.mockAppDelegate = OCMClassMock([Delegate2 class]);
+  OCMStub([self.mockApplication delegate]).andReturn(self.mockAppDelegate);
+
+  // Scene A is foreground inactive
+  id mockSceneA = OCMClassMock([UIScene class]);
+  OCMStub([mockSceneA activationState]).andReturn(UISceneActivationStateForegroundInactive);
+  id mockSceneDelegateA = OCMClassMock([MockSceneDelegate class]);
+  OCMStub([mockSceneA delegate]).andReturn(mockSceneDelegateA);
+
+  // Scene B is foreground active (should be preferred)
+  id mockSceneB = OCMClassMock([UIScene class]);
+  OCMStub([mockSceneB activationState]).andReturn(UISceneActivationStateForegroundActive);
+  id mockSceneDelegateB = OCMClassMock([MockSceneDelegate class]);
+  OCMStub([mockSceneB delegate]).andReturn(mockSceneDelegateB);
+
+  // Order them so inactive is listed first in the set to test priority search
+  NSSet *connectedScenes = [NSSet setWithObjects:mockSceneA, mockSceneB, nil];
+  OCMStub([self.mockApplication connectedScenes]).andReturn(connectedScenes);
+
+  FIRIAMActionURLFollower *follower =
+      [[FIRIAMActionURLFollower alloc] initWithCustomURLSchemeArray:@[]
+                                                    withApplication:self.mockApplication];
+
+  NSURL *url = [NSURL URLWithString:@"http://test.com"];
+
+  // Expect active scene delegate (B) to be called, NOT inactive (A)
+  OCMExpect([mockSceneDelegateB scene:mockSceneB
+                 continueUserActivity:[OCMArg checkWithBlock:^BOOL(id userActivity) {
+                   NSUserActivity *activity = (NSUserActivity *)userActivity;
+                   return [activity.webpageURL isEqual:url];
+                 }]]);
+  OCMReject([mockSceneDelegateA scene:mockSceneA continueUserActivity:[OCMArg any]]);
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Completion Callback Triggered"];
+
+  [follower followActionURL:url
+        withCompletionBlock:^(BOOL success) {
+          XCTAssertTrue(success);
+          [expectation fulfill];
+        }];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  OCMVerifyAll(mockSceneDelegateB);
 }
 @end


### PR DESCRIPTION
Per [b/502983905](https://b.corp.google.com/issues/502983905),

This fixes an issue where universal links in FIAM would not properly propagate to the app's corresponding delegate, if the developer was using a scene delegate instead of an app delegate.

Now, the code first checks for any scene delegates that can handle the request, and falls back to the application delegate if one wasn't found.