### PR TITLE
Refactor GenerateContentResponse text accessors

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [fixed] Fixed a `no member 'autoFunctionDeclaration'` compilation error on
   unofficially supported Xcode versions older than 26.2. (#16037)
 - [fixed] Fixed missing thought summary output in `GenerativeModelSession.streamResponse`. (#16075)
+- [fixed] Removed unnecessary log statements related to retrieving text parts during automatic function calling.
 
 # 12.12.0
 - [feature] Added support for automatic function calling in

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -110,7 +110,20 @@ enum AILog {
   /// The argument required to enable additional logging.
   static let enableArgumentKey = "-FIRDebugEnabled"
 
+  #if DEBUG
+    /// A callback closure used to intercept log emissions during unit testing.
+    ///
+    /// This property is only available in debug builds to facilitate testing without external
+    /// dependencies.
+    nonisolated(unsafe) static var logInterceptor: ((FirebaseLoggerLevel, MessageCode, String)
+      -> Void)?
+  #endif
+
   static func log(level: FirebaseLoggerLevel, code: MessageCode, _ message: String) {
+    #if DEBUG
+      logInterceptor?(level, code, message)
+    #endif
+
     let messageCode = String(format: "I-VTX%06d", code.rawValue)
     FirebaseLogger.log(
       level: level,

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -75,7 +75,21 @@ public struct GenerateContentResponse: Sendable {
   ///
   /// - Note: This does not include thought summaries; see ``thoughtSummary`` for more details.
   public var text: String? {
-    return text(isThought: false)
+    guard candidates.first != nil else {
+      AILog.error(
+        code: .generateContentResponseNoCandidates,
+        "Could not get text from a response that had no candidates."
+      )
+      return nil
+    }
+    guard let value = text(isThought: false) else {
+      AILog.error(
+        code: .generateContentResponseNoText,
+        "Could not get a text part from any candidates."
+      )
+      return nil
+    }
+    return value
   }
 
   /// A summary of the model's thinking process, if available.
@@ -84,7 +98,21 @@ public struct GenerateContentResponse: Sendable {
   ///   ``ThinkingConfig``. For more information, see the
   ///   [Thinking](https://firebase.google.com/docs/ai-logic/thinking) documentation.
   public var thoughtSummary: String? {
-    return text(isThought: true)
+    guard candidates.first != nil else {
+      AILog.error(
+        code: .generateContentResponseNoCandidates,
+        "Could not get text from a response that had no candidates."
+      )
+      return nil
+    }
+    guard let value = text(isThought: true) else {
+      AILog.error(
+        code: .generateContentResponseNoText,
+        "Could not get a text part from any candidates."
+      )
+      return nil
+    }
+    return value
   }
 
   /// Returns function calls found in any `Part`s of the first candidate of the response, if any.
@@ -128,10 +156,6 @@ public struct GenerateContentResponse: Sendable {
 
   func text(isThought: Bool) -> String? {
     guard let candidate = candidates.first else {
-      AILog.error(
-        code: .generateContentResponseNoCandidates,
-        "Could not get text from a response that had no candidates."
-      )
       return nil
     }
     let textValues: [String] = candidate.content.parts.compactMap { part in
@@ -141,10 +165,6 @@ public struct GenerateContentResponse: Sendable {
       return textPart.text
     }
     guard textValues.count > 0 else {
-      AILog.error(
-        code: .generateContentResponseNoText,
-        "Could not get a text part from the first candidate."
-      )
       return nil
     }
     return textValues.joined(separator: " ")

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -75,7 +75,7 @@ public struct GenerateContentResponse: Sendable {
   ///
   /// - Note: This does not include thought summaries; see ``thoughtSummary`` for more details.
   public var text: String? {
-    guard candidates.first != nil else {
+    guard !candidates.isEmpty else {
       AILog.error(
         code: .generateContentResponseNoCandidates,
         "Could not get text from a response that had no candidates."
@@ -85,7 +85,7 @@ public struct GenerateContentResponse: Sendable {
     guard let value = text(isThought: false) else {
       AILog.error(
         code: .generateContentResponseNoText,
-        "Could not get a text part from any candidates."
+        "Could not get a text part from the first candidate."
       )
       return nil
     }

--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -280,7 +280,7 @@
       }
 
       let text: String
-      if let responseText = response.text {
+      if let responseText = response.text(isThought: false) {
         text = responseText
       } else if let parts = response.candidates.first?.content.parts, !parts.isEmpty {
         text = ""
@@ -350,7 +350,7 @@
               functionCalls.append(contentsOf: chunk.functionCalls)
 
               let text: String
-              if let responseText = chunk.text {
+              if let responseText = chunk.text(isThought: false) {
                 text = responseText
               } else if let parts = chunk.candidates.first?.content.parts, !parts.isEmpty {
                 text = ""
@@ -362,7 +362,7 @@
 
               // 2. If we have pending data, we now know it wasn't the last chunk.
               if let pending = pendingChunkData,
-                 !pending.text.isEmpty || pending.response.thoughtSummary != nil {
+                 !pending.text.isEmpty || pending.response.text(isThought: true) != nil {
                 let rawContent = try Self.makeRawContent(
                   from: pending.text,
                   generationID: pending.id,
@@ -415,7 +415,7 @@
               if !functionResponses.isEmpty {
                 // Yield any pending text if it's not empty, but mark it as NOT complete yet.
                 if let pending = pendingChunkData,
-                   !pending.text.isEmpty || pending.response.thoughtSummary != nil {
+                   !pending.text.isEmpty || pending.response.text(isThought: true) != nil {
                   let rawContent = try Self.makeRawContent(
                     from: pending.text,
                     generationID: pending.id,

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -108,6 +108,101 @@ final class GenerateContentResponseTests: XCTestCase {
     )
   }
 
+  func testGenerateContentResponse_noCandidates_logging() throws {
+    var loggedCodes: [AILog.MessageCode] = []
+    AILog.logInterceptor = { level, code, message in
+      loggedCodes.append(code)
+    }
+
+    let response = GenerateContentResponse(candidates: [])
+
+    _ = response.text
+    XCTAssertTrue(loggedCodes.contains(.generateContentResponseNoCandidates))
+
+    loggedCodes.removeAll()
+    _ = response.thoughtSummary
+    XCTAssertTrue(loggedCodes.contains(.generateContentResponseNoCandidates))
+  }
+
+  func testGenerateContentResponse_textIsThought_logging() throws {
+    var loggedCodes: [AILog.MessageCode] = []
+    AILog.logInterceptor = { level, code, message in
+      loggedCodes.append(code)
+    }
+
+    let imageData = Data("sample image data".utf8)
+    let inlineDataPart = InlineDataPart(data: imageData, mimeType: "image/png")
+    let candidate = Candidate(
+      content: ModelContent(parts: [inlineDataPart]),
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil
+    )
+    let response = GenerateContentResponse(candidates: [candidate])
+
+    _ = response.text
+    XCTAssertTrue(loggedCodes.contains(.generateContentResponseNoText))
+
+    loggedCodes.removeAll()
+    _ = response.thoughtSummary
+    XCTAssertTrue(loggedCodes.contains(.generateContentResponseNoText))
+  }
+
+  func testGenerateContentResponse_thoughtSummary_success() throws {
+    let thoughtPart = TextPart("This is a thought.", isThought: true, thoughtSignature: nil)
+    let modelContent = ModelContent(parts: [thoughtPart])
+    let candidate = Candidate(
+      content: modelContent,
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil
+    )
+    let response = GenerateContentResponse(candidates: [candidate])
+
+    XCTAssertEqual(response.thoughtSummary, "This is a thought.")
+  }
+
+  func testGenerateContentResponse_text_success() throws {
+    let textPart = TextPart("This is text.", isThought: false, thoughtSignature: nil)
+    let modelContent = ModelContent(parts: [textPart])
+    let candidate = Candidate(
+      content: modelContent,
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil
+    )
+    let response = GenerateContentResponse(candidates: [candidate])
+
+    XCTAssertEqual(response.text, "This is text.")
+  }
+
+  func testGenerateContentResponse_internalAccessor_doesNotLog() throws {
+    var loggedCodes: [AILog.MessageCode] = []
+    AILog.logInterceptor = { level, code, message in
+      loggedCodes.append(code)
+    }
+
+    // Case 1: No candidates
+    let noCandidatesResponse = GenerateContentResponse(candidates: [])
+    _ = noCandidatesResponse.text(isThought: false)
+    _ = noCandidatesResponse.text(isThought: true)
+    XCTAssertTrue(loggedCodes.isEmpty)
+
+    // Case 2: No text parts
+    let imageData = Data("sample image data".utf8)
+    let inlineDataPart = InlineDataPart(data: imageData, mimeType: "image/png")
+    let candidate = Candidate(
+      content: ModelContent(parts: [inlineDataPart]),
+      safetyRatings: [],
+      finishReason: nil,
+      citationMetadata: nil
+    )
+    let noTextResponse = GenerateContentResponse(candidates: [candidate])
+    _ = noTextResponse.text(isThought: false)
+    _ = noTextResponse.text(isThought: true)
+    XCTAssertTrue(loggedCodes.isEmpty)
+  }
+
   // MARK: - Decoding Tests
 
   func testDecodeCandidate_emptyURLMetadata_urlContextMetadataIsNil() throws {


### PR DESCRIPTION
This fixes an issue where `[FirebaseAI][I-VTX004001] Could not get a text part from the first candidate.` is logged during automatic function calling.

- Extracts core text retrieval logic into an internal text(isThought:) helper.
- Updates public text properties to perform logging only when accessed externally.
- Migrates internal consumers in GenerativeModelSession to avoid redundant logs.