### PR TITLE
Fix race in FIRCLSContextMarkAndCheckIfCrashed (#15384)

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fix race in FIRCLSContextMarkAndCheckIfCrashed. (#15384)
 - [fixed] Fix unfound file warnings from `swift build`. (#16012)
 - [changed] Updated `upload-symbols` to version 3.21, updated error logging in
   `upload-symbols` and started reading the `DEVELOPER_DIR` environment

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -341,14 +341,8 @@ bool FIRCLSContextMarkAndCheckIfCrashed(void) {
     return false;
   }
 
-  if (_firclsContext.writable->crashOccurred) {
-    return true;
-  }
-
-  _firclsContext.writable->crashOccurred = true;
-  __sync_synchronize();
-
-  return false;
+  // Atomic compare-and-swap: only one thread can set false -> true
+  return !__sync_bool_compare_and_swap(&_firclsContext.writable->crashOccurred, false, true);
 }
 
 static const char* FIRCLSContextAppendToRoot(NSString* root, NSString* component) {


### PR DESCRIPTION
## Description

Fixes #15384

`FIRCLSContextMarkAndCheckIfCrashed()` uses a non atomic read then write on the `crashOccurred` flag, creating a TOCTOU (Time of Check, Time of Use) race condition where multiple threads can both pass the gate and attempt to record the crash simultaneously.

## Changes

Replace the non-atomic read, check, write sequence with a single `__sync_bool_compare_and_swap` call that atomically checks and sets the flag in one CPU instruction, eliminating the race window.

## Testing

- Existing Crashlytics unit tests pass
- Single threaded behavior is identical to the old code
- No behavioral change for single crash scenarios

### API Changes

  * No API changes