### PR TITLE
tests(ai): add missing deprecation marker to test

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ServerPromptTemplateIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ServerPromptTemplateIntegrationTests.swift
@@ -92,6 +92,7 @@ struct ServerPromptTemplateIntegrationTests {
     InstanceConfig.googleAI_v1beta,
     InstanceConfig.vertexAI_v1beta,
   ])
+  @available(*, deprecated)
   func generateImages(_ config: InstanceConfig) async throws {
     let imagenModel = FirebaseAI.componentInstance(config).templateImagenModel()
     let imagenPrompt = "firefly"


### PR DESCRIPTION
One of the tests was missing a deprecation notice, this PR adds it to silence the warnings.

#no-changelog