### PR TITLE
[AI] Add `GenerationOptionsRepresentable` for hybrid generation opts

### DIFF
--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -118,7 +118,7 @@
                    schema: FoundationModels.GenerationSchema,
                    includeSchemaInPrompt: Bool = true,
                    options: any GenerationOptionsRepresentable =
-                     ResponseGenerationOptions()) async throws
+                     ResponseGenerationOptions.default) async throws
         -> GenerativeModelSession.Response<FirebaseAI.GeneratedContent> {
         // TODO: Replace `FoundationModels.GenerationSchema` and make this method public when
         // `FirebaseAI.GenerationSchema`'s public API is ready.

--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -82,7 +82,9 @@
     /// - Throws: A `GenerationError` if the model fails to generate a response.
     @discardableResult
     public nonisolated(nonsending)
-    func respond(to prompt: PartsRepresentable..., options: GenerationConfig? = nil) async throws
+    func respond(to prompt: PartsRepresentable...,
+                 options: any GenerationOptionsRepresentable
+                   = ResponseGenerationOptions.default) async throws
       -> GenerativeModelSession.Response<String> {
       return try await respond(
         to: prompt,
@@ -112,9 +114,11 @@
       @available(watchOS, unavailable)
       @discardableResult
       nonisolated(nonsending)
-      func respond(to prompt: PartsRepresentable..., schema: FoundationModels.GenerationSchema,
+      func respond(to prompt: PartsRepresentable...,
+                   schema: FoundationModels.GenerationSchema,
                    includeSchemaInPrompt: Bool = true,
-                   options: GenerationConfig? = nil) async throws
+                   options: any GenerationOptionsRepresentable =
+                     ResponseGenerationOptions()) async throws
         -> GenerativeModelSession.Response<FirebaseAI.GeneratedContent> {
         // TODO: Replace `FoundationModels.GenerationSchema` and make this method public when
         // `FirebaseAI.GenerationSchema`'s public API is ready.
@@ -149,7 +153,8 @@
       func respond<Content>(to prompt: PartsRepresentable...,
                             generating type: Content.Type = Content.self,
                             includeSchemaInPrompt: Bool = true,
-                            options: GenerationConfig? = nil) async throws
+                            options: any GenerationOptionsRepresentable
+                              = ResponseGenerationOptions.default) async throws
         -> GenerativeModelSession.Response<Content> where Content: Generable {
         return try await respond(
           to: prompt,
@@ -175,7 +180,9 @@
       @available(watchOS, unavailable)
       func streamResponse(to prompt: PartsRepresentable...,
                           schema: FoundationModels.GenerationSchema,
-                          includeSchemaInPrompt: Bool = true, options: GenerationConfig? = nil)
+                          includeSchemaInPrompt: Bool = true,
+                          options: any GenerationOptionsRepresentable
+                            = ResponseGenerationOptions.default)
         -> sending GenerativeModelSession.ResponseStream<
           FirebaseAI.GeneratedContent, FirebaseAI.GeneratedContent
         > {
@@ -206,9 +213,11 @@
       public func streamResponse<Content>(to prompt: PartsRepresentable...,
                                           generating type: Content.Type = Content.self,
                                           includeSchemaInPrompt: Bool = true,
-                                          options: GenerationConfig? = nil)
-        -> sending GenerativeModelSession.ResponseStream<Content, Content.PartiallyGenerated>
-        where Content: Generable {
+                                          options: any GenerationOptionsRepresentable =
+                                            ResponseGenerationOptions.default)
+        -> sending GenerativeModelSession.ResponseStream<
+          Content, Content.PartiallyGenerated
+        > where Content: Generable {
         return streamResponse(
           to: prompt,
           schema: FirebaseAI.GenerationSchema(type.generationSchema),
@@ -227,7 +236,9 @@
     /// generation configuration.
     /// - Returns: A `ResponseStream` that yields snapshots of the generated content.
     @available(macOS 12.0, watchOS 8.0, *)
-    public func streamResponse(to prompt: PartsRepresentable..., options: GenerationConfig? = nil)
+    public func streamResponse(to prompt: PartsRepresentable...,
+                               options: any GenerationOptionsRepresentable
+                                 = ResponseGenerationOptions.default)
       -> sending GenerativeModelSession.ResponseStream<String, String> {
       return streamResponse(
         to: prompt,
@@ -243,11 +254,11 @@
     private nonisolated(nonsending)
     func respond<Content>(to prompt: [PartsRepresentable], schema: FirebaseAI.GenerationSchema?,
                           generating type: Content.Type, includeSchemaInPrompt: Bool,
-                          options: GenerationConfig?) async throws
+                          options: any GenerationOptionsRepresentable) async throws
       -> GenerativeModelSession.Response<Content> {
       let parts = [ModelContent(parts: prompt)]
       let config = try buildConfig(
-        options: options,
+        options: options.responseGenerationOptions.geminiGenerationConfig,
         schema: schema,
         includeSchemaInPrompt: includeSchemaInPrompt
       )
@@ -317,13 +328,16 @@
                                                          schema: FirebaseAI.GenerationSchema?,
                                                          generating type: Content.Type,
                                                          includeSchemaInPrompt: Bool,
-                                                         options: GenerationConfig?)
-      -> sending GenerativeModelSession.ResponseStream<Content, PartialContent> {
+                                                         options: any GenerationOptionsRepresentable)
+      -> sending GenerativeModelSession.ResponseStream<
+        Content,
+        PartialContent
+      > {
       let initialParts = [ModelContent(parts: prompt)]
       return GenerativeModelSession.ResponseStream { context in
         do {
           let config = try self.buildConfig(
-            options: options,
+            options: options.responseGenerationOptions.geminiGenerationConfig,
             schema: schema,
             includeSchemaInPrompt: includeSchemaInPrompt
           )

--- a/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
+++ b/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
@@ -38,7 +38,7 @@
 
   extension FirebaseAI.GenerationOptions: GenerationOptionsRepresentable {
     public var responseGenerationOptions: ResponseGenerationOptions {
-      return ResponseGenerationOptions(afmGenerationOptions: self)
+      return ResponseGenerationOptions(foundationModelsGenerationOptions: self)
     }
   }
 
@@ -48,7 +48,9 @@
     @available(watchOS, unavailable)
     extension FoundationModels.GenerationOptions: GenerationOptionsRepresentable {
       public var responseGenerationOptions: ResponseGenerationOptions {
-        return ResponseGenerationOptions(afmGenerationOptions: FirebaseAI.GenerationOptions(self))
+        return ResponseGenerationOptions(
+          foundationModelsGenerationOptions: FirebaseAI.GenerationOptions(self)
+        )
       }
     }
   #endif // canImport(FoundationModels)
@@ -68,21 +70,21 @@
     ///
     /// - Parameter generationOptions: Generation options for the on-device `SystemLanguageModel`
     ///   provided by the Foundation Models framework.
-    static func foundationModels(_ generationOptions: FirebaseAI
-      .GenerationOptions) -> ResponseGenerationOptions {
+    static func foundationModels(_ generationOptions: FirebaseAI.GenerationOptions)
+      -> ResponseGenerationOptions {
       return generationOptions.responseGenerationOptions
     }
 
     #if canImport(FoundationModels)
-      /// Initializes response generation options for on-device requests.
+      /// Returns response generation options for on-device requests.
       ///
       /// - Parameter generationOptions: Generation options for the on-device `SystemLanguageModel`
       ///   provided by the Foundation Models framework.
       @available(iOS 26.0, macOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
-      static func foundationModels(_ generationOptions: FoundationModels
-        .GenerationOptions) -> Self {
+      static func foundationModels(_ generationOptions: FoundationModels.GenerationOptions)
+        -> ResponseGenerationOptions {
         return generationOptions.responseGenerationOptions
       }
 
@@ -98,9 +100,9 @@
       static func hybrid(gemini: GenerationConfig,
                          foundationModels: FoundationModels.GenerationOptions)
         -> ResponseGenerationOptions {
-        return Self(
+        return ResponseGenerationOptions(
           geminiGenerationConfig: gemini,
-          afmGenerationOptions: FirebaseAI.GenerationOptions(foundationModels)
+          foundationModelsGenerationOptions: FirebaseAI.GenerationOptions(foundationModels)
         )
       }
     #endif // canImport(FoundationModels)
@@ -114,7 +116,10 @@
     static func hybrid(gemini: GenerationConfig,
                        foundationModels: FirebaseAI.GenerationOptions)
       -> ResponseGenerationOptions {
-      return Self(geminiGenerationConfig: gemini, afmGenerationOptions: foundationModels)
+      return ResponseGenerationOptions(
+        geminiGenerationConfig: gemini,
+        foundationModelsGenerationOptions: foundationModels
+      )
     }
   }
 

--- a/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
+++ b/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  #if canImport(FoundationModels)
+    import FoundationModels
+  #endif // canImport(FoundationModels)
+
+  /// A type that represents options for controlling model response generation.
+  ///
+  /// For Gemini models, this may be a ``GenerationConfig`` value. For the `SystemLanguageModel`
+  /// provided by the Apple Foundation Models framework, this may be a
+  /// ``FirebaseAI/GenerationOptions`` or a `Foundation Models`
+  /// [`GenerationOptions`](https://developer.apple.com/documentation/foundationmodels/generationoptions)
+  /// value. For hybrid (on-device and cloud) configurations, use
+  /// ``hybrid(gemini:foundationModels:)`` to specify options for each model.
+  public protocol GenerationOptionsRepresentable: Sendable {
+    /// Options for controlling model response generation.
+    var responseGenerationOptions: ResponseGenerationOptions { get }
+  }
+
+  extension GenerationConfig: GenerationOptionsRepresentable {
+    public var responseGenerationOptions: ResponseGenerationOptions {
+      return ResponseGenerationOptions(geminiGenerationConfig: self)
+    }
+  }
+
+  extension FirebaseAI.GenerationOptions: GenerationOptionsRepresentable {
+    public var responseGenerationOptions: ResponseGenerationOptions {
+      return ResponseGenerationOptions(afmGenerationOptions: self)
+    }
+  }
+
+  #if canImport(FoundationModels)
+    @available(iOS 26.0, macOS 26.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension FoundationModels.GenerationOptions: GenerationOptionsRepresentable {
+      public var responseGenerationOptions: ResponseGenerationOptions {
+        return ResponseGenerationOptions(afmGenerationOptions: FirebaseAI.GenerationOptions(self))
+      }
+    }
+  #endif // canImport(FoundationModels)
+
+  public extension GenerationOptionsRepresentable where Self == ResponseGenerationOptions {
+    /// The default response generation options for a model.
+    static var `default`: ResponseGenerationOptions { return ResponseGenerationOptions() }
+
+    /// Returns response generation options for Gemini requests.
+    ///
+    /// - Parameter generationConfig: Generation options for Gemini models.
+    static func gemini(_ generationConfig: GenerationConfig) -> ResponseGenerationOptions {
+      return generationConfig.responseGenerationOptions
+    }
+
+    /// Returns response generation options for on-device requests.
+    ///
+    /// - Parameter generationOptions: Generation options for the on-device `SystemLanguageModel`
+    ///   provided by the Foundation Models framework.
+    static func foundationModels(_ generationOptions: FirebaseAI
+      .GenerationOptions) -> ResponseGenerationOptions {
+      return generationOptions.responseGenerationOptions
+    }
+
+    #if canImport(FoundationModels)
+      /// Initializes response generation options for on-device requests.
+      ///
+      /// - Parameter generationOptions: Generation options for the on-device `SystemLanguageModel`
+      ///   provided by the Foundation Models framework.
+      @available(iOS 26.0, macOS 26.0, *)
+      @available(tvOS, unavailable)
+      @available(watchOS, unavailable)
+      static func foundationModels(_ generationOptions: FoundationModels
+        .GenerationOptions) -> Self {
+        return generationOptions.responseGenerationOptions
+      }
+    #endif // canImport(FoundationModels)
+
+    /// Returns response generation options for hybrid (on-device and cloud) requests.
+    ///
+    /// - Parameters:
+    ///   - gemini: Generation options for Gemini models.
+    ///   - foundationModels: Generation options for the on-device `SystemLanguageModel` provided by
+    ///     the Foundation Models framework.
+    static func hybrid(gemini: GenerationConfig,
+                       foundationModels: FirebaseAI
+                         .GenerationOptions) -> ResponseGenerationOptions {
+      return Self(geminiGenerationConfig: gemini, afmGenerationOptions: foundationModels)
+    }
+  }
+
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
+++ b/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
@@ -85,6 +85,24 @@
         .GenerationOptions) -> Self {
         return generationOptions.responseGenerationOptions
       }
+
+      /// Returns response generation options for hybrid (on-device and cloud) requests.
+      ///
+      /// - Parameters:
+      ///   - gemini: Generation options for Gemini models.
+      ///   - foundationModels: Generation options for the on-device `SystemLanguageModel` provided
+      ///     by the Foundation Models framework.
+      @available(iOS 26.0, macOS 26.0, *)
+      @available(tvOS, unavailable)
+      @available(watchOS, unavailable)
+      static func hybrid(gemini: GenerationConfig,
+                         foundationModels: FoundationModels.GenerationOptions)
+        -> ResponseGenerationOptions {
+        return Self(
+          geminiGenerationConfig: gemini,
+          afmGenerationOptions: FirebaseAI.GenerationOptions(foundationModels)
+        )
+      }
     #endif // canImport(FoundationModels)
 
     /// Returns response generation options for hybrid (on-device and cloud) requests.
@@ -94,8 +112,8 @@
     ///   - foundationModels: Generation options for the on-device `SystemLanguageModel` provided by
     ///     the Foundation Models framework.
     static func hybrid(gemini: GenerationConfig,
-                       foundationModels: FirebaseAI
-                         .GenerationOptions) -> ResponseGenerationOptions {
+                       foundationModels: FirebaseAI.GenerationOptions)
+      -> ResponseGenerationOptions {
       return Self(geminiGenerationConfig: gemini, afmGenerationOptions: foundationModels)
     }
   }

--- a/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
@@ -12,22 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Options for controlling model response generation.
-///
-/// See ``GenerationOptionsRepresentable`` for details on how to configure generation options.
-public struct ResponseGenerationOptions: Sendable, Equatable {
-  let geminiGenerationConfig: GenerationConfig?
-  let afmGenerationOptions: FirebaseAI.GenerationOptions?
+#if compiler(>=6.2.3)
+  /// Options for controlling model response generation.
+  ///
+  /// See ``GenerationOptionsRepresentable`` for details on how to configure generation options.
+  public struct ResponseGenerationOptions: Sendable, Equatable {
+    let geminiGenerationConfig: GenerationConfig?
+    let afmGenerationOptions: FirebaseAI.GenerationOptions?
 
-  init(geminiGenerationConfig: GenerationConfig? = nil,
-       afmGenerationOptions: FirebaseAI.GenerationOptions? = nil) {
-    self.geminiGenerationConfig = geminiGenerationConfig
-    self.afmGenerationOptions = afmGenerationOptions
+    init(geminiGenerationConfig: GenerationConfig? = nil,
+         afmGenerationOptions: FirebaseAI.GenerationOptions? = nil) {
+      self.geminiGenerationConfig = geminiGenerationConfig
+      self.afmGenerationOptions = afmGenerationOptions
+    }
   }
-}
 
-extension ResponseGenerationOptions: GenerationOptionsRepresentable {
-  public var responseGenerationOptions: ResponseGenerationOptions {
-    return self
+  extension ResponseGenerationOptions: GenerationOptionsRepresentable {
+    public var responseGenerationOptions: ResponseGenerationOptions {
+      return self
+    }
   }
-}
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
@@ -18,12 +18,12 @@
   /// See ``GenerationOptionsRepresentable`` for details on how to configure generation options.
   public struct ResponseGenerationOptions: Sendable, Equatable {
     let geminiGenerationConfig: GenerationConfig?
-    let afmGenerationOptions: FirebaseAI.GenerationOptions?
+    let foundationModelsGenerationOptions: FirebaseAI.GenerationOptions?
 
     init(geminiGenerationConfig: GenerationConfig? = nil,
-         afmGenerationOptions: FirebaseAI.GenerationOptions? = nil) {
+         foundationModelsGenerationOptions: FirebaseAI.GenerationOptions? = nil) {
       self.geminiGenerationConfig = geminiGenerationConfig
-      self.afmGenerationOptions = afmGenerationOptions
+      self.foundationModelsGenerationOptions = foundationModelsGenerationOptions
     }
   }
 

--- a/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/ResponseGenerationOptions.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Options for controlling model response generation.
+///
+/// See ``GenerationOptionsRepresentable`` for details on how to configure generation options.
+public struct ResponseGenerationOptions: Sendable, Equatable {
+  let geminiGenerationConfig: GenerationConfig?
+  let afmGenerationOptions: FirebaseAI.GenerationOptions?
+
+  init(geminiGenerationConfig: GenerationConfig? = nil,
+       afmGenerationOptions: FirebaseAI.GenerationOptions? = nil) {
+    self.geminiGenerationConfig = geminiGenerationConfig
+    self.afmGenerationOptions = afmGenerationOptions
+  }
+}
+
+extension ResponseGenerationOptions: GenerationOptionsRepresentable {
+  public var responseGenerationOptions: ResponseGenerationOptions {
+    return self
+  }
+}

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -24,13 +24,15 @@
 
   @Suite(.serialized)
   struct GenerativeModelSessionTests {
+    let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)
+
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
     func respondText(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
       let prompt = "Why is the sky blue?"
 
-      let response = try await session.respond(to: prompt)
+      let response = try await session.respond(to: prompt, options: .default)
 
       let content = response.content
       #expect(!content.isEmpty)
@@ -69,7 +71,11 @@
         let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
         let prompt = "Generate a cute rescue cat"
 
-        let response = try await session.respond(to: prompt, schema: CatProfile.generationSchema)
+        let response = try await session.respond(
+          to: prompt,
+          schema: CatProfile.generationSchema,
+          options: .gemini(generationConfig)
+        )
 
         let content = response.content
         #expect(content.isComplete)
@@ -180,7 +186,11 @@
         let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
         let prompt = "Generate a recipe for a pasta dish with meat."
 
-        let response = try await session.respond(to: prompt, generating: Recipe.self)
+        let response = try await session.respond(
+          to: prompt,
+          generating: Recipe.self,
+          options: generationConfig
+        )
 
         let recipe = response.content
         #expect(!recipe.name.isEmpty)
@@ -205,7 +215,11 @@
         let prompt =
           "Generate three recipes for a full-course vegetarian meal (appetizer, main, dessert)."
 
-        let response = try await session.respond(to: prompt, generating: RecipeList.self)
+        let response = try await session.respond(
+          to: prompt,
+          generating: RecipeList.self,
+          options: .gemini(generationConfig)
+        )
 
         let recipeList = response.content
         #expect(recipeList.recipes.count == 3)
@@ -278,7 +292,7 @@
       )
       let prompt = "What is the current temperature in Waterloo, Ontario, Canada?"
 
-      let response = try await session.respond(to: prompt)
+      let response = try await session.respond(to: prompt, options: generationConfig)
 
       let content = response.content
       #expect(!content.isEmpty)
@@ -312,7 +326,8 @@
 
       let response = try await session.respond(
         to: prompt,
-        generating: GetTemperature.Temperature.self
+        generating: GetTemperature.Temperature.self,
+        options: .gemini(generationConfig)
       )
 
       let content = response.content
@@ -332,7 +347,7 @@
       let url = "https://blog.google/innovation-and-ai/technology/developers-tools/functiongemma/"
       let prompt = "What was the name of the model announced in: \(url)"
 
-      let response = try await session.respond(to: prompt)
+      let response = try await session.respond(to: prompt, options: generationConfig)
 
       #expect(response.content.contains("FunctionGemma"))
       let candidate = try #require(response.rawResponse.candidates.first)
@@ -350,7 +365,7 @@
       let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
       let prompt = "Why is the sky blue?"
 
-      let stream = session.streamResponse(to: prompt)
+      let stream = session.streamResponse(to: prompt, options: .gemini(generationConfig))
 
       var generationID: FirebaseAI.GenerationID?
       var isComplete = false
@@ -398,7 +413,8 @@
 
         let stream = session.streamResponse(
           to: prompt,
-          schema: CatProfile.generationSchema
+          schema: CatProfile.generationSchema,
+          options: generationConfig
         )
 
         var generationID: FirebaseAI.GenerationID?
@@ -536,7 +552,7 @@
         )
         let prompt = "What is the current temperature in Waterloo, Ontario, Canada?"
 
-        let stream = session.streamResponse(to: prompt)
+        let stream = session.streamResponse(to: prompt, options: .gemini(generationConfig))
 
         var generationID: FirebaseAI.GenerationID?
         var isComplete = false

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -217,6 +217,50 @@
       XCTAssertEqual(functionResponse.response, ["result": .string(CurrentTimeTool.currentTime)])
     }
 
+    func testRespondTo_withOptions() async throws {
+      let config = GenerationConfig(temperature: 0.5, responseMIMEType: "application/json")
+      let bundle = BundleTestUtil.bundle()
+      let fileURL = try XCTUnwrap(bundle.url(
+        forResource: "unary-success-thinking-reply-thought-summary",
+        withExtension: "json",
+        subdirectory: googleAISubdirectory
+      ))
+      MockURLProtocol.requestHandler = { request in
+        let requestBody = try XCTUnwrap(request.extractBodyData(), "Empty request body.")
+        let requestURL = try XCTUnwrap(request.url)
+        let response = try XCTUnwrap(HTTPURLResponse(
+          url: requestURL,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        ))
+
+        let json = try JSONDecoder().decode(JSONObject.self, from: requestBody)
+        guard case let .object(generationConfig) = json["generationConfig"] else {
+          XCTFail("Expected an object for JSON key 'generationConfig', got: \(json)")
+          return (response, nil)
+        }
+        guard case let .number(temperature) = generationConfig["temperature"] else {
+          XCTFail("Expected a number for JSON key 'temperature', got: \(json)")
+          return (response, nil)
+        }
+        XCTAssertEqual(Float(temperature), config.temperature)
+        guard case let .string(responseMIMEType) = generationConfig["responseMimeType"] else {
+          XCTFail("Expected a string for JSON key 'responseMimeType', got: \(json)")
+          return (response, nil)
+        }
+        XCTAssertEqual(responseMIMEType, config.responseMIMEType)
+
+        return (response, fileURL.lines)
+      }
+      let model = try mockGenerativeModel()
+      let session = GenerativeModelSession(model: model)
+
+      let response = try await session.respond(to: testPrompt, options: .gemini(config))
+
+      XCTAssertEqual(response.content, "Mountain View")
+    }
+
     func testStreamResponseTo_functionCall() async throws {
       MockURLProtocol.requestHandlersQueue = try [
         GenerativeModelTestUtil.httpRequestHandler(

--- a/FirebaseAI/Tests/Unit/ResponseGenerationOptionsTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseGenerationOptionsTests.swift
@@ -24,48 +24,56 @@
       let options = config.responseGenerationOptions
 
       XCTAssertEqual(options.geminiGenerationConfig, config)
-      XCTAssertNil(options.afmGenerationOptions)
+      XCTAssertNil(options.foundationModelsGenerationOptions)
     }
 
     func testGenerationOptionsConversion() {
-      let afmOptions = FirebaseAI.GenerationOptions(
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions(
         sampling: .random(probabilityThreshold: 0.9),
         temperature: 0.5
       )
 
-      let options = afmOptions.responseGenerationOptions
+      let options = foundationModelsGenerationOptions.responseGenerationOptions
 
       XCTAssertNil(options.geminiGenerationConfig)
-      XCTAssertEqual(options.afmGenerationOptions, afmOptions)
+      XCTAssertEqual(options.foundationModelsGenerationOptions, foundationModelsGenerationOptions)
     }
 
     func testFactoryMethods() {
       let config = GenerationConfig(temperature: 0.7, topP: 0.8)
-      let afmOptions = FirebaseAI.GenerationOptions(
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions(
         sampling: .greedy, temperature: 0.4, maximumResponseTokens: 200
       )
 
       let geminiOptions = ResponseGenerationOptions.gemini(config)
       XCTAssertEqual(geminiOptions.geminiGenerationConfig, config)
-      XCTAssertNil(geminiOptions.afmGenerationOptions)
+      XCTAssertNil(geminiOptions.foundationModelsGenerationOptions)
 
-      let foundationOptions = ResponseGenerationOptions.foundationModels(afmOptions)
+      let foundationOptions = ResponseGenerationOptions.foundationModels(
+        foundationModelsGenerationOptions
+      )
       XCTAssertNil(foundationOptions.geminiGenerationConfig)
-      XCTAssertEqual(foundationOptions.afmGenerationOptions, afmOptions)
+      XCTAssertEqual(
+        foundationOptions.foundationModelsGenerationOptions,
+        foundationModelsGenerationOptions
+      )
 
       let hybridOptions = ResponseGenerationOptions.hybrid(
         gemini: config,
-        foundationModels: afmOptions
+        foundationModels: foundationModelsGenerationOptions
       )
       XCTAssertEqual(hybridOptions.geminiGenerationConfig, config)
-      XCTAssertEqual(hybridOptions.afmGenerationOptions, afmOptions)
+      XCTAssertEqual(
+        hybridOptions.foundationModelsGenerationOptions,
+        foundationModelsGenerationOptions
+      )
     }
 
     func testDefaultOptions() {
       let defaultOptions = ResponseGenerationOptions.default
 
       XCTAssertNil(defaultOptions.geminiGenerationConfig)
-      XCTAssertNil(defaultOptions.afmGenerationOptions)
+      XCTAssertNil(defaultOptions.foundationModelsGenerationOptions)
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/ResponseGenerationOptionsTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseGenerationOptionsTests.swift
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  import XCTest
+
+  @testable import FirebaseAILogic
+
+  final class ResponseGenerationOptionsTests: XCTestCase {
+    func testGenerationConfigConversion() {
+      let config = GenerationConfig(temperature: 0.5, topK: 40)
+
+      let options = config.responseGenerationOptions
+
+      XCTAssertEqual(options.geminiGenerationConfig, config)
+      XCTAssertNil(options.afmGenerationOptions)
+    }
+
+    func testGenerationOptionsConversion() {
+      let afmOptions = FirebaseAI.GenerationOptions(
+        sampling: .random(probabilityThreshold: 0.9),
+        temperature: 0.5
+      )
+
+      let options = afmOptions.responseGenerationOptions
+
+      XCTAssertNil(options.geminiGenerationConfig)
+      XCTAssertEqual(options.afmGenerationOptions, afmOptions)
+    }
+
+    func testFactoryMethods() {
+      let config = GenerationConfig(temperature: 0.7, topP: 0.8)
+      let afmOptions = FirebaseAI.GenerationOptions(
+        sampling: .greedy, temperature: 0.4, maximumResponseTokens: 200
+      )
+
+      let geminiOptions = ResponseGenerationOptions.gemini(config)
+      XCTAssertEqual(geminiOptions.geminiGenerationConfig, config)
+      XCTAssertNil(geminiOptions.afmGenerationOptions)
+
+      let foundationOptions = ResponseGenerationOptions.foundationModels(afmOptions)
+      XCTAssertNil(foundationOptions.geminiGenerationConfig)
+      XCTAssertEqual(foundationOptions.afmGenerationOptions, afmOptions)
+
+      let hybridOptions = ResponseGenerationOptions.hybrid(
+        gemini: config,
+        foundationModels: afmOptions
+      )
+      XCTAssertEqual(hybridOptions.geminiGenerationConfig, config)
+      XCTAssertEqual(hybridOptions.afmGenerationOptions, afmOptions)
+    }
+
+    func testDefaultOptions() {
+      let defaultOptions = ResponseGenerationOptions.default
+
+      XCTAssertNil(defaultOptions.geminiGenerationConfig)
+      XCTAssertNil(defaultOptions.afmGenerationOptions)
+    }
+  }
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/TestUtilities/GenerativeModelTestUtil.swift
+++ b/FirebaseAI/Tests/Unit/TestUtilities/GenerativeModelTestUtil.swift
@@ -152,3 +152,41 @@ private extension String {
     return components(separatedBy: substring).count - 1
   }
 }
+
+extension URLRequest {
+  func extractBodyData() throws -> Data? {
+    if let body = httpBody {
+      return body
+    }
+
+    guard let stream = httpBodyStream else {
+      return nil
+    }
+
+    stream.open()
+    defer { stream.close() }
+
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    var data = Data()
+    while stream.hasBytesAvailable {
+      let bytesRead = stream.read(buffer, maxLength: bufferSize)
+
+      if bytesRead < 0 {
+        if let error = stream.streamError {
+          throw error
+        }
+        XCTFail("Unknown error while reading `httpBodyStream`.")
+        return nil
+      } else if bytesRead == 0 {
+        break
+      }
+
+      data.append(buffer, count: bytesRead)
+    }
+
+    return data
+  }
+}

--- a/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
@@ -37,35 +37,35 @@
           maximumResponseTokens: 100
         )
 
-        let afmOptions = options.toFoundationModels()
+        let foundationModelsGenerationOptions = options.toFoundationModels()
 
-        XCTAssertEqual(afmOptions.temperature, 0.5)
-        XCTAssertEqual(afmOptions.maximumResponseTokens, 100)
-        XCTAssertNotNil(afmOptions.sampling)
-        XCTAssertEqual(afmOptions.sampling, .greedy)
+        XCTAssertEqual(foundationModelsGenerationOptions.temperature, 0.5)
+        XCTAssertEqual(foundationModelsGenerationOptions.maximumResponseTokens, 100)
+        XCTAssertNotNil(foundationModelsGenerationOptions.sampling)
+        XCTAssertEqual(foundationModelsGenerationOptions.sampling, .greedy)
       }
     #endif // canImport(FoundationModels)
 
     func testEquatable_emptyOptions() throws {
-      let options = FirebaseAI.GenerationOptions()
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions()
 
-      XCTAssertNil(options.sampling)
-      XCTAssertNil(options.temperature)
-      XCTAssertNil(options.maximumResponseTokens)
+      XCTAssertNil(foundationModelsGenerationOptions.sampling)
+      XCTAssertNil(foundationModelsGenerationOptions.temperature)
+      XCTAssertNil(foundationModelsGenerationOptions.maximumResponseTokens)
     }
 
     func testGenerationSchema_greedy() throws {
       let temperature = 0.9
       let maximumResponseTokens = 200
-      let options = FirebaseAI.GenerationOptions(
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions(
         sampling: .greedy,
         temperature: temperature,
         maximumResponseTokens: maximumResponseTokens
       )
 
-      XCTAssertEqual(options.sampling, .greedy)
-      XCTAssertEqual(options.temperature, temperature)
-      XCTAssertEqual(options.maximumResponseTokens, maximumResponseTokens)
+      XCTAssertEqual(foundationModelsGenerationOptions.sampling, .greedy)
+      XCTAssertEqual(foundationModelsGenerationOptions.temperature, temperature)
+      XCTAssertEqual(foundationModelsGenerationOptions.maximumResponseTokens, maximumResponseTokens)
     }
 
     func testGenerationSchema_probabilityThreshold() throws {
@@ -73,15 +73,18 @@
       let seed: UInt64 = 5_000_000_000
       let temperature = 0.6
       let maximumResponseTokens = 80
-      let options = FirebaseAI.GenerationOptions(
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions(
         sampling: .random(probabilityThreshold: topP, seed: seed),
         temperature: temperature,
         maximumResponseTokens: maximumResponseTokens
       )
 
-      XCTAssertEqual(options.sampling, .random(probabilityThreshold: topP, seed: seed))
-      XCTAssertEqual(options.temperature, temperature)
-      XCTAssertEqual(options.maximumResponseTokens, maximumResponseTokens)
+      XCTAssertEqual(
+        foundationModelsGenerationOptions.sampling,
+        .random(probabilityThreshold: topP, seed: seed)
+      )
+      XCTAssertEqual(foundationModelsGenerationOptions.temperature, temperature)
+      XCTAssertEqual(foundationModelsGenerationOptions.maximumResponseTokens, maximumResponseTokens)
     }
 
     func testGenerationSchema_topK() throws {
@@ -89,15 +92,15 @@
       let seed: UInt64 = 6_000_000_000
       let temperature = 0.4
       let maximumResponseTokens = 1000
-      let options = FirebaseAI.GenerationOptions(
+      let foundationModelsGenerationOptions = FirebaseAI.GenerationOptions(
         sampling: .random(top: topK, seed: seed),
         temperature: temperature,
         maximumResponseTokens: maximumResponseTokens
       )
 
-      XCTAssertEqual(options.sampling, .random(top: topK, seed: seed))
-      XCTAssertEqual(options.temperature, temperature)
-      XCTAssertEqual(options.maximumResponseTokens, maximumResponseTokens)
+      XCTAssertEqual(foundationModelsGenerationOptions.sampling, .random(top: topK, seed: seed))
+      XCTAssertEqual(foundationModelsGenerationOptions.temperature, temperature)
+      XCTAssertEqual(foundationModelsGenerationOptions.maximumResponseTokens, maximumResponseTokens)
     }
   }
 #endif // compiler(>=6.2.3)


### PR DESCRIPTION
Added a `GenerationOptionsRepresentable` protocol to support setting generation options for Gemini and/or `FoundationModels.SystemLanguageModel` in `respond(to:options:)` and `streamResponse(to:options)` calls. In particular, the `hybrid(gemini:foundationModels:)` is needed to allow different options to be specified for each model in hybrid (on-device and cloud) configurations in https://github.com/firebase/firebase-ios-sdk/pull/16043.

Since the on-device and cloud (Gemini) models are dramatically different sizes, and offer different capabilities, it's unlikely that the same `temperature`, `topP`, etc., settings will be suitable for both models in hybrid use cases.

#no-changelog