### PR TITLE
[AI] Add `HybridModel` to support a fallback model

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -71,6 +71,8 @@ public struct GenerateContentResponse: Sendable {
 
   let responseID: String?
 
+  let modelVersion: String?
+
   /// The response's content as text, if it exists.
   ///
   /// - Note: This does not include thought summaries; see ``thoughtSummary`` for more details.
@@ -152,6 +154,17 @@ public struct GenerateContentResponse: Sendable {
     self.promptFeedback = promptFeedback
     self.usageMetadata = usageMetadata
     responseID = nil
+    modelVersion = nil
+  }
+
+  init(candidates: [Candidate], promptFeedback: PromptFeedback? = nil,
+       usageMetadata: UsageMetadata? = nil, responseID: String? = nil,
+       modelVersion: String? = nil) {
+    self.candidates = candidates
+    self.promptFeedback = promptFeedback
+    self.usageMetadata = usageMetadata
+    self.responseID = responseID
+    self.modelVersion = modelVersion
   }
 
   func text(isThought: Bool) -> String? {
@@ -468,6 +481,7 @@ extension GenerateContentResponse: Decodable {
     case promptFeedback
     case usageMetadata
     case responseID = "responseId"
+    case modelVersion
   }
 
   public init(from decoder: Decoder) throws {
@@ -494,6 +508,7 @@ extension GenerateContentResponse: Decodable {
     promptFeedback = try container.decodeIfPresent(PromptFeedback.self, forKey: .promptFeedback)
     usageMetadata = try container.decodeIfPresent(UsageMetadata.self, forKey: .usageMetadata)
     responseID = try container.decodeIfPresent(String.self, forKey: .responseID)
+    modelVersion = try container.decodeIfPresent(String.self, forKey: .modelVersion)
   }
 }
 

--- a/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
+++ b/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
@@ -47,6 +47,20 @@
     }
   }
 
+  public extension LanguageModelProvider where Self == HybridModelProvider {
+    /// **[Public Preview]** Creates a ``HybridModelProvider`` for the specified models.
+    ///
+    /// > Warning: This API is a public preview and may be subject to change.
+    ///
+    /// - Parameters:
+    ///   - primary: The main, or default, model to use.
+    ///   - secondary: The backup model to fallback to if the `primary` model is unavailable.
+    static func hybridModel(primary: any LanguageModelProvider,
+                            secondary: any LanguageModelProvider) -> HybridModelProvider {
+      return HybridModelProvider(primary: primary, secondary: secondary)
+    }
+  }
+
   // Provides backwards compatibility for the
   // `FirebaseAI.generativeModelSession(model:tools:instructions:)` method where `model` was a
   // simple `String` containing a Gemini model name.

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -113,10 +113,14 @@
               options: options
             )
 
-            for try await snapshot in stream {
-              continuation.yield(snapshot)
+            do {
+              for try await snapshot in stream {
+                continuation.yield(snapshot)
+              }
+              continuation.finish()
+            } catch {
+              continuation.finish(throwing: error)
             }
-            continuation.finish()
           }
         }
         continuation.onTermination = { _ in task.cancel() }

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  final class HybridModelSession: _ModelSession {
+    private let primary: any _ModelSession
+    private let secondary: any _ModelSession
+
+    init(primary: any _ModelSession, secondary: any _ModelSession) {
+      self.primary = primary
+      self.secondary = secondary
+    }
+
+    var _hasHistory: Bool {
+      return primary._hasHistory || secondary._hasHistory
+    }
+
+    func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                  includeSchemaInPrompt: Bool, options: any GenerationOptionsRepresentable)
+      async throws -> _ModelSessionResponse {
+      do {
+        // First try the primary session.
+        return try await primary._respond(
+          to: prompt,
+          schema: schema,
+          includeSchemaInPrompt: includeSchemaInPrompt,
+          options: options
+        )
+      } catch {
+        // Do not fallback to second session if the primary session contains history.
+        if primary._hasHistory {
+          throw error
+        }
+
+        // Fallback to the second session if the first fails or is unavailable.
+        return try await secondary._respond(
+          to: prompt,
+          schema: schema,
+          includeSchemaInPrompt: includeSchemaInPrompt,
+          options: options
+        )
+      }
+    }
+
+    @available(macOS 12.0, watchOS 8.0, *)
+    func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                         includeSchemaInPrompt: Bool,
+                         options: any GenerationOptionsRepresentable)
+      -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
+      return AsyncThrowingStream { continuation in
+        let task = Task {
+          // First try the primary session.
+          let stream = primary._streamResponse(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+
+          do {
+            for try await snapshot in stream {
+              continuation.yield(snapshot)
+            }
+            continuation.finish()
+          } catch {
+            // Do not fallback to second session if the primary session contains history.
+            if primary._hasHistory {
+              continuation.finish(throwing: error)
+              return
+            }
+
+            // Fallback to the second session if the first fails or is unavailable.
+            let stream = secondary._streamResponse(
+              to: prompt,
+              schema: schema,
+              includeSchemaInPrompt: includeSchemaInPrompt,
+              options: options
+            )
+
+            for try await snapshot in stream {
+              continuation.yield(snapshot)
+            }
+            continuation.finish()
+          }
+        }
+        continuation.onTermination = { _ in task.cancel() }
+      }
+    }
+  }
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -29,6 +29,17 @@
     func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                   includeSchemaInPrompt: Bool, options: any GenerationOptionsRepresentable)
       async throws -> _ModelSessionResponse {
+      // If the secondary session contains history then a previous fallback occurred.
+      // Stick with the secondary session to maintain conversation consistency.
+      if secondary._hasHistory {
+        return try await secondary._respond(
+          to: prompt,
+          schema: schema,
+          includeSchemaInPrompt: includeSchemaInPrompt,
+          options: options
+        )
+      }
+
       do {
         // First try the primary session.
         return try await primary._respond(
@@ -58,6 +69,17 @@
                          includeSchemaInPrompt: Bool,
                          options: any GenerationOptionsRepresentable)
       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
+      // If the secondary session contains history then a previous fallback occurred.
+      // Stick with the secondary session to maintain conversation consistency.
+      if secondary._hasHistory {
+        return secondary._streamResponse(
+          to: prompt,
+          schema: schema,
+          includeSchemaInPrompt: includeSchemaInPrompt,
+          options: options
+        )
+      }
+
       return AsyncThrowingStream { continuation in
         let task = Task {
           // First try the primary session.
@@ -68,14 +90,17 @@
             options: options
           )
 
+          var didYield = false
           do {
             for try await snapshot in stream {
+              didYield = true
               continuation.yield(snapshot)
             }
             continuation.finish()
           } catch {
-            // Do not fallback to second session if the primary session contains history.
-            if primary._hasHistory {
+            // Do not fallback to second session if the primary session contains history or has
+            // already yielded data.
+            if didYield || primary._hasHistory {
               continuation.finish(throwing: error)
               return
             }

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -13,11 +13,21 @@
 // limitations under the License.
 
 #if compiler(>=6.2.3)
+  /// A hybrid model combining a primary, or main, model and a secondary, or fallback, model.
+  ///
+  /// **Public Preview**: This API is a public preview and may be subject to change.
   public struct HybridModel: LanguageModel {
     let primary: any LanguageModel
     let secondary: any LanguageModel
 
-    init(primary: any LanguageModel, secondary: any LanguageModel) {
+    /// **[Public Preview]** Creates a ``HybridModel`` for the specified models.
+    ///
+    /// > Warning: This API is a public preview and may be subject to change.
+    ///
+    /// - Parameters:
+    ///   - primary: The main, or default, model to use.
+    ///   - secondary: The backup model to fallback to if the `primary` model is unavailable.
+    public init(primary: any LanguageModel, secondary: any LanguageModel) {
       self.primary = primary
       self.secondary = secondary
     }

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  public struct HybridModel: LanguageModel {
+    let primary: any LanguageModel
+    let secondary: any LanguageModel
+
+    init(primary: any LanguageModel, secondary: any LanguageModel) {
+      self.primary = primary
+      self.secondary = secondary
+    }
+
+    // MARK: LanguageModel Conformance
+
+    public var _modelName: String {
+      return "hybrid:\(primary._modelName),\(secondary._modelName)"
+    }
+
+    public func _startSession(tools: [any ToolRepresentable]?,
+                              instructions: String?) throws -> any _ModelSession {
+      let primarySession = try primary._startSession(tools: tools, instructions: instructions)
+      let secondarySession = try secondary._startSession(tools: tools, instructions: instructions)
+
+      return HybridModelSession(primary: primarySession, secondary: secondarySession)
+    }
+  }
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -64,13 +64,13 @@
       } else if let secondarySession {
         return secondarySession
       } else {
-        let debugDescription = """
-        Failed to start session for model "\(primary._modelName)": \(primaryError.debugDescription);
-        Failed to start session for model "\(secondary._modelName)": \
-        \(secondaryError.debugDescription)
-        """
         let context = GenerativeModelSession.GenerationError.Context(
-          debugDescription: debugDescription
+          debugDescription: """
+          Failed to start session for model "\(primary._modelName)" with error: \
+          \(primaryError?.localizedDescription ?? "unknown error");
+          Failed to start session for model "\(secondary._modelName)" with error: \
+          \(secondaryError?.localizedDescription ?? "unknown error")
+          """
         )
 
         throw GenerativeModelSession.GenerationError.assetsUnavailable(context)

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -40,10 +40,41 @@
 
     public func _startSession(tools: [any ToolRepresentable]?,
                               instructions: String?) throws -> any _ModelSession {
-      let primarySession = try primary._startSession(tools: tools, instructions: instructions)
-      let secondarySession = try secondary._startSession(tools: tools, instructions: instructions)
+      var primarySession: (any _ModelSession)?
+      var primaryError: Error?
+      var secondarySession: (any _ModelSession)?
+      var secondaryError: Error?
 
-      return HybridModelSession(primary: primarySession, secondary: secondarySession)
+      do {
+        primarySession = try primary._startSession(tools: tools, instructions: instructions)
+      } catch {
+        primaryError = error
+      }
+
+      do {
+        secondarySession = try secondary._startSession(tools: tools, instructions: instructions)
+      } catch {
+        secondaryError = error
+      }
+
+      if let primarySession, let secondarySession {
+        return HybridModelSession(primary: primarySession, secondary: secondarySession)
+      } else if let primarySession {
+        return primarySession
+      } else if let secondarySession {
+        return secondarySession
+      } else {
+        let debugDescription = """
+        Failed to start session for model "\(primary._modelName)": \(primaryError.debugDescription);
+        Failed to start session for model "\(secondary._modelName)": \
+        \(secondaryError.debugDescription)
+        """
+        let context = GenerativeModelSession.GenerationError.Context(
+          debugDescription: debugDescription
+        )
+
+        throw GenerativeModelSession.GenerationError.assetsUnavailable(context)
+      }
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+/// Provides a ``HybridModel`` for an instance of ``FirebaseAI``.
+public struct HybridModelProvider: LanguageModelProvider {
+  let primary: any LanguageModelProvider
+  let secondary: any LanguageModelProvider
+
+  init(primary: any LanguageModelProvider, secondary: any LanguageModelProvider) {
+    self.primary = primary
+    self.secondary = secondary
+  }
+
+  public func _languageModel(firebaseAI: FirebaseAI) -> any LanguageModel {
+    return HybridModel(
+      primary: primary._languageModel(firebaseAI: firebaseAI),
+      secondary: secondary._languageModel(firebaseAI: firebaseAI)
+    )
+  }
+}
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 #if compiler(>=6.2.3)
-/// Provides a ``HybridModel`` for an instance of ``FirebaseAI``.
-public struct HybridModelProvider: LanguageModelProvider {
-  let primary: any LanguageModelProvider
-  let secondary: any LanguageModelProvider
+  /// Provides a ``HybridModel`` for an instance of ``FirebaseAI``.
+  public struct HybridModelProvider: LanguageModelProvider {
+    let primary: any LanguageModelProvider
+    let secondary: any LanguageModelProvider
 
-  init(primary: any LanguageModelProvider, secondary: any LanguageModelProvider) {
-    self.primary = primary
-    self.secondary = secondary
-  }
+    init(primary: any LanguageModelProvider, secondary: any LanguageModelProvider) {
+      self.primary = primary
+      self.secondary = secondary
+    }
 
-  public func _languageModel(firebaseAI: FirebaseAI) -> any LanguageModel {
-    return HybridModel(
-      primary: primary._languageModel(firebaseAI: firebaseAI),
-      secondary: secondary._languageModel(firebaseAI: firebaseAI)
-    )
+    public func _languageModel(firebaseAI: FirebaseAI) -> any LanguageModel {
+      return HybridModel(
+        primary: primary._languageModel(firebaseAI: firebaseAI),
+        secondary: secondary._languageModel(firebaseAI: firebaseAI)
+      )
+    }
   }
-}
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Remove the `#if compiler(>=6.2.3)` when Xcode 26.2 is the minimum supported version.
+#if compiler(>=6.2.3)
+  @testable import FirebaseAILogic
+  import FirebaseAITestApp
+  import Foundation
+  #if canImport(FoundationModels)
+    import FoundationModels
+  #endif // canImport(FoundationModels)
+  import Testing
+
+  @Suite(.serialized)
+  struct GenerativeModelSessionHybridTests {
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    func respondText_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let invalidModel1 = firebaseAI.geminiModel(name: "invalid-model-name-1")
+      let invalidModel2 = firebaseAI.geminiModel(name: "invalid-model-name-2")
+      let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = firebaseAI.generativeModelSession(
+        model: .hybridModel(
+          primary: invalidModel1,
+          secondary: .hybridModel( // Nested hybrid model
+            primary: invalidModel2,
+            secondary: validModel
+          )
+        )
+      )
+      let prompt = "Why is the sky blue?"
+
+      let response = try await session.respond(to: prompt)
+
+      let content = response.content
+      #expect(!content.isEmpty)
+      #expect(response.rawContent.isComplete)
+      #if canImport(FoundationModels)
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          #expect(response.rawContent.kind == .string(content))
+        }
+      #endif // canImport(FoundationModels)
+      #expect(response.rawContent.generationID != nil)
+      #expect(response.rawResponse.text == content)
+      #expect(response.rawResponse.modelVersion == validModel._modelName)
+    }
+
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @available(iOS 26.0, macOS 26.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func respondGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name-1")
+      let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = GenerativeModelSession(
+        model: HybridModel(primary: invalidModel, secondary: validModel)
+      )
+      let prompt = "Generate a cute rescue cat"
+
+      let response = try await session.respond(
+        to: prompt,
+        generating: GenerativeModelSessionTests.CatProfile.self
+      )
+
+      let catProfile = response.content
+      #expect(!catProfile.name.isEmpty)
+      #expect(catProfile.age >= 1)
+      #expect(catProfile.age <= 20)
+      #expect(!catProfile.profile.isEmpty)
+      #expect(response.rawContent.isComplete)
+      #expect(response.rawContent.generationID != nil)
+      #expect(response.rawResponse.modelVersion == validModel._modelName)
+    }
+
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    func streamResponseText_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name")
+      let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = GenerativeModelSession(
+        model: HybridModel(primary: invalidModel, secondary: validModel)
+      )
+      let prompt = "In one sentence, why is the sky blue?"
+
+      let stream = session.streamResponse(to: prompt)
+
+      var generationID: FirebaseAI.GenerationID?
+      var isComplete = false
+      for try await snapshot in stream {
+        #expect(!isComplete, "Stream yielded more elements after a snapshot was marked complete.")
+        let partial = snapshot.content
+        #expect(!partial.isEmpty)
+        if let generationID {
+          #expect(
+            generationID == snapshot.rawContent.generationID,
+            "The generation ID was not stable for the duration of the response."
+          )
+        } else {
+          #expect(snapshot.rawContent.generationID != nil)
+          generationID = snapshot.rawContent.generationID
+        }
+        isComplete = snapshot.rawContent.isComplete
+      }
+      #expect(isComplete, "The stream finished, but the final snapshot was not marked as complete.")
+
+      let response = try await stream.collect()
+      let content = response.content
+      #expect(!content.isEmpty)
+      #expect(response.rawContent.isComplete, "The final response was not marked as complete.")
+      #expect(response.rawContent.generationID == generationID)
+      #if canImport(FoundationModels)
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          #expect(response.rawContent.kind == .string(content))
+        }
+      #endif // canImport(FoundationModels)
+      if let text = response.rawResponse.text {
+        #expect(content.hasSuffix(text))
+      }
+      #expect(response.rawResponse.modelVersion == validModel._modelName)
+    }
+
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @available(iOS 26.0, macOS 26.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func streamResponseGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name")
+      let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = firebaseAI.generativeModelSession(
+        model: .hybridModel(primary: invalidModel, secondary: validModel)
+      )
+      let prompt = "Generate a cute rescue cat"
+
+      let stream = session.streamResponse(
+        to: prompt,
+        generating: GenerativeModelSessionTests.CatProfile.self
+      )
+
+      var generationID: FirebaseAI.GenerationID?
+      var isComplete = false
+      for try await snapshot in stream {
+        #expect(!isComplete, "Stream yielded more elements after a snapshot was marked complete.")
+        if let generationID {
+          #expect(
+            generationID == snapshot.rawContent.generationID,
+            "The generation ID was not stable for the duration of the response."
+          )
+        } else {
+          #expect(snapshot.rawContent.generationID != nil)
+          generationID = snapshot.rawContent.generationID
+        }
+        isComplete = snapshot.rawContent.isComplete
+      }
+      #expect(isComplete, "The stream finished, but the final snapshot was not marked as complete.")
+
+      let response = try await stream.collect()
+      let catProfile = response.content
+      #expect(!catProfile.name.isEmpty)
+      #expect(catProfile.age >= 1)
+      #expect(catProfile.age <= 20)
+      #expect(!catProfile.profile.isEmpty)
+      #expect(response.rawContent.isComplete)
+      #expect(response.rawContent.generationID != nil)
+      #expect(response.rawResponse.modelVersion == validModel._modelName)
+    }
+  }
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
@@ -24,13 +24,26 @@ import XCTest
       // Initialize a session with a Gemini model name
       _ = ai.generativeModelSession(model: "gemini-flash-latest")
 
-      // Initialize a session with a `GeminiLanguageModelProvider`
+      // Initialize a session with a `GeminiModelProvider`
       _ = ai.generativeModelSession(model: .geminiModel(name: "gemini-flash-latest"))
 
-      // Initialize a session with a `GeminiLanguageModel` model
+      // Initialize a session with a `GeminiModel`
       let geminiModel = ai.geminiModel(name: "gemini-flash-latest")
       _ = ai.generativeModelSession(model: geminiModel)
       _ = GenerativeModelSession(model: geminiModel)
+
+      // Initialize a session with a `HybridModelProvider`
+      _ = ai.generativeModelSession(
+        model: .hybridModel(
+          primary: geminiModel,
+          secondary: .geminiModel(name: "gemini-flash-lite-latest")
+        )
+      )
+
+      // Initialize a session with a `HybridModel`
+      let gemmaModel = ai.geminiModel(name: "gemma-4-31b-it")
+      let hybridModel = HybridModel(primary: gemmaModel, secondary: geminiModel)
+      _ = GenerativeModelSession(model: hybridModel)
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -168,6 +168,85 @@
       XCTAssertEqual(functionResponse.response, ["result": .string(CurrentTimeTool.currentTime)])
     }
 
+    func testRespondTo_sessionHistoryPreventsFallback() async throws {
+      let model1 = try mockGeminiModel(modelName: "gemini-2.5-flash")
+      let model2 = try mockGeminiModel(modelName: "gemini-2.0-flash")
+      let session = GenerativeModelSession(model: HybridModel(primary: model1, secondary: model2))
+      let expectedStatusCode = 400
+      try MockURLProtocol.requestHandlersQueue.append(contentsOf: [
+        GenerativeModelTestUtil.httpRequestHandler(
+          forResource: "unary-success-thinking-reply-thought-summary",
+          withExtension: "json",
+          subdirectory: googleAISubdirectory
+        ),
+        GenerativeModelTestUtil.httpRequestHandler(
+          forResource: "unary-failure-api-key",
+          withExtension: "json",
+          subdirectory: googleAISubdirectory,
+          statusCode: expectedStatusCode
+        ),
+        GenerativeModelTestUtil.httpRequestHandler(
+          forResource: "unary-success-basic-reply-short",
+          withExtension: "json",
+          subdirectory: googleAISubdirectory
+        ),
+      ])
+
+      // Verify first request succeeds.
+      let response1 = try await session.respond(to: testPrompt)
+      XCTAssertEqual(response1.content, "Mountain View")
+      XCTAssertEqual(response1.rawResponse.modelVersion, model1.modelName)
+
+      // Verify no fallback to model2 after successful request.
+      await XCTAssertThrowsError({
+        try await session.respond(to: testPrompt)
+      }, "Expected an error but request succeeded.") { error in
+        guard case let GenerateContentError.internalError(underlying: underlyingError) = error
+        else {
+          return XCTFail("Unexpected error type: \(error)")
+        }
+        guard let backendError = underlyingError as? BackendError else {
+          return XCTFail("Unexpected underlying error type: \(underlyingError)")
+        }
+        XCTAssertEqual(backendError.status, .invalidArgument)
+        XCTAssertEqual(backendError.httpResponseCode, expectedStatusCode)
+        XCTAssertTrue(backendError.message.hasPrefix("API key not valid."))
+      }
+      XCTAssertEqual(MockURLProtocol.requestHandlersQueue.count, 1, """
+      Expected 'unary-success-basic-reply-short' to remain the queue since falling back to 'model2'
+      is not supported after a successful request using model1.
+      """)
+    }
+
+    func testRespondTo_fallbackAfterFailure() async throws {
+      let model1 = try mockGeminiModel(modelName: "gemini-5.0-flash")
+      let model2 = try mockGeminiModel(modelName: "gemini-2.5-flash")
+      let session = GenerativeModelSession(model: HybridModel(primary: model1, secondary: model2))
+      let expectedStatusCode = 404
+      try MockURLProtocol.requestHandlersQueue.append(contentsOf: [
+        GenerativeModelTestUtil.httpRequestHandler(
+          forResource: "unary-failure-unknown-model",
+          withExtension: "json",
+          subdirectory: googleAISubdirectory,
+          statusCode: expectedStatusCode
+        ),
+        GenerativeModelTestUtil.httpRequestHandler(
+          forResource: "unary-success-thinking-reply-thought-summary",
+          withExtension: "json",
+          subdirectory: googleAISubdirectory
+        ),
+      ])
+
+      // Verify request falls back to model2 after initial failure with model1.
+      let response1 = try await session.respond(to: testPrompt)
+
+      XCTAssertEqual(response1.content, "Mountain View")
+      XCTAssertEqual(response1.rawResponse.modelVersion, model2.modelName)
+      XCTAssertTrue(MockURLProtocol.requestHandlersQueue.isEmpty, """
+      Expected the queue to be empty after automatically falling back to model2.
+      """)
+    }
+
     func testRespondTo_functionCall_maxFunctionCallTurnsExceeded() async throws {
       let functionCallCount = GenerativeModelSession.maxAutoFunctionCallTurns + 1
       MockURLProtocol.requestHandlersQueue = try Array(

--- a/FirebaseAI/Tests/Unit/HybridModelTests.swift
+++ b/FirebaseAI/Tests/Unit/HybridModelTests.swift
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  import XCTest
+
+  @testable import FirebaseAILogic
+
+  final class HybridModelTests: XCTestCase {
+    struct MockModel: LanguageModel {
+      let _modelName: String
+      let startSessionHandler: @Sendable () throws -> any _ModelSession
+
+      func _startSession(tools: [any ToolRepresentable]?,
+                         instructions: String?) throws -> any _ModelSession {
+        return try startSessionHandler()
+      }
+    }
+
+    struct MockSession: _ModelSession {
+      var _hasHistory: Bool = false
+
+      func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                    includeSchemaInPrompt: Bool,
+                    options: any GenerationOptionsRepresentable)
+        async throws -> _ModelSessionResponse {
+        fatalError("Not implemented")
+      }
+
+      func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                           includeSchemaInPrompt: Bool,
+                           options: any GenerationOptionsRepresentable)
+        -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
+        fatalError("Not implemented")
+      }
+    }
+
+    func testStartSession_bothSucceed() throws {
+      let session1 = MockSession()
+      let session2 = MockSession()
+      let model1 = MockModel(_modelName: "model1") { session1 }
+      let model2 = MockModel(_modelName: "model2") { session2 }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is HybridModelSession)
+    }
+
+    func testStartSession_primaryFails_secondarySucceeds() throws {
+      let session2 = MockSession()
+      let model1 = MockModel(_modelName: "model1") { throw NSError(domain: "test", code: 1) }
+      let model2 = MockModel(_modelName: "model2") { session2 }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is MockSession)
+    }
+
+    func testStartSession_primarySucceeds_secondaryFails() throws {
+      let session1 = MockSession()
+      let model1 = MockModel(_modelName: "model1") { session1 }
+      let model2 = MockModel(_modelName: "model2") { throw NSError(domain: "test", code: 2) }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is MockSession)
+    }
+
+    func testStartSession_bothFail() throws {
+      let model1 = MockModel(_modelName: "model1") {
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Error 1"])
+      }
+      let model2 = MockModel(_modelName: "model2") {
+        throw NSError(domain: "test", code: 2, userInfo: [NSLocalizedDescriptionKey: "Error 2"])
+      }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      XCTAssertThrowsError(try hybridModel._startSession(tools: nil, instructions: nil)) { error in
+        guard case let GenerativeModelSession.GenerationError.assetsUnavailable(context)
+          = error else {
+          return XCTFail("Unexpected error type: \(error)")
+        }
+        XCTAssertTrue(context.debugDescription.contains("Error 1"))
+        XCTAssertTrue(context.debugDescription.contains("Error 2"))
+      }
+    }
+  }
+#endif // compiler(>=6.2.3)


### PR DESCRIPTION
Added a new `HybridModel` type that is a combination of a primary `LanguageModel` and a secondary model to fallback to if the primary model is unavailable or throws an error. This is preparing for hybrid inference using the on-device `SystemLanguageModel` from the Foundation Models framework, as well `GeminiModel` in the cloud.

Since `HybridModel` supports any model conforming to `LanguageModel`, this also means that fallback support is available for multiple Gemini models or backends (Gemini Developer API and Vertex AI API). This feature is used in the integration tests, which specify invalid model names to simulate a model being unavailable and falling back to another valid model name.

#no-changelog