### PR TITLE
[AI] Add hybrid support with Foundation Models

### DIFF
--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -20,6 +20,9 @@
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   extension FoundationModels.LanguageModelSession: _ModelSession {
+    /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     public var _hasHistory: Bool {
       return transcript.contains { entry in
         if case .instructions = entry {
@@ -30,6 +33,16 @@
       }
     }
 
+    /// Sends a prompt to the model and returns a ``_ModelSessionResponse``.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     public func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                          includeSchemaInPrompt: Bool,
                          options: any GenerationOptionsRepresentable) async throws
@@ -56,6 +69,14 @@
       return makeResponse(from: response.rawContent, schema: schema)
     }
 
+    /// Sends a prompt to the model and streams the model's response.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                                 includeSchemaInPrompt: Bool,
                                 options: any GenerationOptionsRepresentable)

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -21,29 +21,13 @@
   @available(watchOS, unavailable)
   extension FoundationModels.LanguageModelSession: _ModelSession {
     public var _hasHistory: Bool {
-      if transcript.isEmpty {
-        return false
-      }
-
-      for entry in transcript {
-        switch entry {
-        case .instructions:
-          continue
-        case .prompt:
-          return true
-        case .toolCalls:
-          return true
-        case .toolOutput:
-          return true
-        case .response:
-          return true
-        @unknown default:
-          // Unknown entry type, assuming that it is session history.
-          return true
+      return transcript.contains { entry in
+        if case .instructions = entry {
+          return false
         }
-      }
 
-      return false
+        return true
+      }
     }
 
     public func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3) && canImport(FoundationModels)
+  import Foundation
+  import FoundationModels
+
+  @available(iOS 26.0, macOS 26.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  extension FoundationModels.LanguageModelSession: _ModelSession {
+    public var _hasHistory: Bool {
+      if transcript.isEmpty {
+        return false
+      }
+
+      for entry in transcript {
+        switch entry {
+        case .instructions:
+          continue
+        case .prompt:
+          return true
+        case .toolCalls:
+          return true
+        case .toolOutput:
+          return true
+        case .response:
+          return true
+        @unknown default:
+          // Unknown entry type, assuming that it is session history.
+          return true
+        }
+      }
+
+      return false
+    }
+
+    public func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                         includeSchemaInPrompt: Bool,
+                         options: any GenerationOptionsRepresentable) async throws
+      -> _ModelSessionResponse {
+      let prompt = try prompt.toFoundationModelsPrompt()
+
+      let response: FoundationModels.LanguageModelSession
+        .Response<FoundationModels.GeneratedContent>
+      if let schema {
+        response = try await respond(
+          to: prompt,
+          schema: schema.generationSchema,
+          includeSchemaInPrompt: includeSchemaInPrompt,
+          options: options.generationOptions
+        )
+      } else {
+        response = try await respond(
+          to: prompt,
+          schema: String.generationSchema,
+          options: options.generationOptions
+        )
+      }
+
+      // TODO: Extract common response handling code into a helper method.
+      let responseText: String
+      if schema == nil, case let .string(text) = response.rawContent.kind {
+        responseText = text
+      } else {
+        responseText = response.rawContent.jsonString
+      }
+
+      let generatedContent = response.rawContent.firebaseGeneratedContent
+      let modelContent = ModelContent(
+        role: "model",
+        parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
+      )
+      let candidate = Candidate(
+        content: modelContent,
+        safetyRatings: [],
+        finishReason: nil,
+        citationMetadata: nil
+      )
+      let rawResponse = GenerateContentResponse(
+        candidates: [candidate],
+        modelVersion: FirebaseAI.SystemLanguageModel.modelName
+      )
+
+      return _ModelSessionResponse(rawContent: generatedContent, rawResponse: rawResponse)
+    }
+
+    public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
+                                includeSchemaInPrompt: Bool,
+                                options: any GenerationOptionsRepresentable)
+      -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
+      return AsyncThrowingStream { continuation in
+        let foundationModelsPrompt: Prompt
+        do {
+          foundationModelsPrompt = try prompt.toFoundationModelsPrompt()
+        } catch {
+          continuation.finish(throwing: error)
+          return
+        }
+
+        let stream: FoundationModels.LanguageModelSession
+          .ResponseStream<FoundationModels.GeneratedContent>
+        if let schema {
+          stream = streamResponse(
+            to: foundationModelsPrompt,
+            schema: schema.generationSchema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options.generationOptions
+          )
+        } else {
+          stream = streamResponse(
+            to: foundationModelsPrompt,
+            schema: String.generationSchema,
+            // TODO: Check `includeSchemaInPrompt: includeSchemaInPrompt` behaviour with `String`
+            options: options.generationOptions
+          )
+        }
+
+        let task = Task {
+          do {
+            for try await snapshot in stream {
+              // TODO: Extract common response handling code into a helper method.
+              let responseText: String
+              if schema == nil, case let .string(text) = snapshot.rawContent.kind {
+                responseText = text
+              } else {
+                responseText = snapshot.rawContent.jsonString
+              }
+
+              let generatedContent = snapshot.rawContent.firebaseGeneratedContent
+              let modelContent = ModelContent(
+                role: "model",
+                parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
+              )
+              let candidate = Candidate(
+                content: modelContent,
+                safetyRatings: [],
+                finishReason: nil,
+                citationMetadata: nil
+              )
+              let rawResponse = GenerateContentResponse(
+                candidates: [candidate],
+                modelVersion: FirebaseAI.SystemLanguageModel.modelName
+              )
+
+              let response = _ModelSessionResponse(
+                rawContent: generatedContent,
+                rawResponse: rawResponse
+              )
+
+              continuation.yield(response)
+            }
+            continuation.finish()
+          } catch {
+            continuation.finish(throwing: error)
+            return
+          }
+        }
+        continuation.onTermination = { _ in task.cancel() }
+      }
+    }
+  }
+
+  @available(iOS 26.0, macOS 26.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  private extension GenerationOptionsRepresentable {
+    var generationOptions: FoundationModels.GenerationOptions {
+      guard let options = responseGenerationOptions.foundationModelsGenerationOptions else {
+        return FoundationModels.GenerationOptions()
+      }
+
+      return options.toFoundationModels()
+    }
+  }
+#endif // compiler(>=6.2.3) && canImport(FoundationModels)

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -115,7 +115,7 @@
       let generatedContent = content.firebaseGeneratedContent
       let modelContent = ModelContent(
         role: "model",
-        parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
+        parts: [TextPart(responseText, isThought: false, thoughtSignature: nil)]
       )
       let candidate = Candidate(
         content: modelContent,

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -69,31 +69,7 @@
         )
       }
 
-      // TODO: Extract common response handling code into a helper method.
-      let responseText: String
-      if schema == nil, case let .string(text) = response.rawContent.kind {
-        responseText = text
-      } else {
-        responseText = response.rawContent.jsonString
-      }
-
-      let generatedContent = response.rawContent.firebaseGeneratedContent
-      let modelContent = ModelContent(
-        role: "model",
-        parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
-      )
-      let candidate = Candidate(
-        content: modelContent,
-        safetyRatings: [],
-        finishReason: nil,
-        citationMetadata: nil
-      )
-      let rawResponse = GenerateContentResponse(
-        candidates: [candidate],
-        modelVersion: FirebaseAI.SystemLanguageModel.modelName
-      )
-
-      return _ModelSessionResponse(rawContent: generatedContent, rawResponse: rawResponse)
+      return makeResponse(from: response.rawContent, schema: schema)
     }
 
     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
@@ -130,34 +106,7 @@
         let task = Task {
           do {
             for try await snapshot in stream {
-              // TODO: Extract common response handling code into a helper method.
-              let responseText: String
-              if schema == nil, case let .string(text) = snapshot.rawContent.kind {
-                responseText = text
-              } else {
-                responseText = snapshot.rawContent.jsonString
-              }
-
-              let generatedContent = snapshot.rawContent.firebaseGeneratedContent
-              let modelContent = ModelContent(
-                role: "model",
-                parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
-              )
-              let candidate = Candidate(
-                content: modelContent,
-                safetyRatings: [],
-                finishReason: nil,
-                citationMetadata: nil
-              )
-              let rawResponse = GenerateContentResponse(
-                candidates: [candidate],
-                modelVersion: FirebaseAI.SystemLanguageModel.modelName
-              )
-
-              let response = _ModelSessionResponse(
-                rawContent: generatedContent,
-                rawResponse: rawResponse
-              )
+              let response = makeResponse(from: snapshot.rawContent, schema: schema)
 
               continuation.yield(response)
             }
@@ -169,6 +118,34 @@
         }
         continuation.onTermination = { _ in task.cancel() }
       }
+    }
+
+    private func makeResponse(from content: FoundationModels.GeneratedContent,
+                              schema: FirebaseAI.GenerationSchema?) -> _ModelSessionResponse {
+      let responseText: String
+      if schema == nil, case let .string(text) = content.kind {
+        responseText = text
+      } else {
+        responseText = content.jsonString
+      }
+
+      let generatedContent = content.firebaseGeneratedContent
+      let modelContent = ModelContent(
+        role: "model",
+        parts: [InternalPart(.text(responseText), isThought: false, thoughtSignature: nil)]
+      )
+      let candidate = Candidate(
+        content: modelContent,
+        safetyRatings: [],
+        finishReason: nil,
+        citationMetadata: nil
+      )
+      let rawResponse = GenerateContentResponse(
+        candidates: [candidate],
+        modelVersion: FirebaseAI.SystemLanguageModel.modelName
+      )
+
+      return _ModelSessionResponse(rawContent: generatedContent, rawResponse: rawResponse)
     }
   }
 

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -16,7 +16,7 @@
   import Foundation
   import FoundationModels
 
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   extension FoundationModels.LanguageModelSession: _ModelSession {
@@ -132,7 +132,7 @@
     }
   }
 
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   private extension GenerationOptionsRepresentable {

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -98,7 +98,6 @@
           stream = streamResponse(
             to: foundationModelsPrompt,
             schema: String.generationSchema,
-            // TODO: Check `includeSchemaInPrompt: includeSchemaInPrompt` behaviour with `String`
             options: options.generationOptions
           )
         }

--- a/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
@@ -41,17 +41,23 @@
       #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           var afmTools = [any FoundationModels.Tool]()
-          // Only function calling tools are supported by Foundation Models.
           for tool in tools ?? [] {
-            // Skips any unsupported tools such as `GoogleMaps` or `CodeExecution` since they are
-            // only
-            // supported by Gemini models.
-            // TODO: Decide whether to throw for unsupported `FirebaseAILogic.Tool` types or ignore.
+            // Only function calling tools are supported by Foundation Models.
+            if !tool.toolRepresentation.isFoundationModeCompatible {
+              assertionFailure("""
+              The tool "\(tool.toolRepresentation)" is not supported when using the on-device model.
+              """)
+            }
+
             let functionDeclarations = tool.toolRepresentation.functionDeclarations ?? []
             for functionDeclaration in functionDeclarations {
               switch functionDeclaration.kind {
               case .manual:
-                // TODO: Decide whether ignore manual function calling declarations, throw or assert.
+                assertionFailure("""
+                The manual function declaration "\(functionDeclaration)" is not supported by the 
+                Foundation Models framework; function declarations must be `FoundationModels.Tool`
+                types for use with the on-device model.
+                """)
                 continue
               case let .foundationModels(afmTool):
                 guard let afmTool = afmTool as? (any FoundationModels.Tool) else {

--- a/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
@@ -71,7 +71,12 @@
               }
             }
           }
-          return LanguageModelSession(tools: afmTools, instructions: instructions)
+
+          return LanguageModelSession(
+            model: self.systemLanguageModel,
+            tools: afmTools,
+            instructions: instructions
+          )
         }
       #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 

--- a/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
@@ -54,7 +54,7 @@
               switch functionDeclaration.kind {
               case .manual:
                 assertionFailure("""
-                The manual function declaration "\(functionDeclaration)" is not supported by the 
+                The manual function declaration "\(functionDeclaration)" is not supported by the
                 Foundation Models framework; function declarations must be `FoundationModels.Tool`
                 types for use with the on-device model.
                 """)

--- a/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
@@ -21,10 +21,16 @@
   extension FirebaseAI.SystemLanguageModel: LanguageModel {
     static let modelName = "apple-foundation-models-system-language-model"
 
+    /// Returns the name of the model.
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     public var _modelName: String {
       return FirebaseAI.SystemLanguageModel.modelName
     }
 
+    /// Returns a new session for this model.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
     public func _startSession(tools: [any ToolRepresentable]?,
                               instructions: String?) throws -> any _ModelSession {
       switch availability {

--- a/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/SystemLanguageModel+LanguageModel.swift
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.2.3)
+  import Foundation
+  #if canImport(FoundationModels)
+    import FoundationModels
+  #endif // canImport(FoundationModels)
+
+  extension FirebaseAI.SystemLanguageModel: LanguageModel {
+    static let modelName = "apple-foundation-models-system-language-model"
+
+    public var _modelName: String {
+      return FirebaseAI.SystemLanguageModel.modelName
+    }
+
+    public func _startSession(tools: [any ToolRepresentable]?,
+                              instructions: String?) throws -> any _ModelSession {
+      switch availability {
+      case .available:
+        break
+      case let .unavailable(reason):
+        throw GenerativeModelSession.GenerationError.assetsUnavailable(
+          GenerativeModelSession.GenerationError.Context(debugDescription: """
+          The Foundation Models `SystemLanguageModel` is unavailable: \(reason)
+          """)
+        )
+      }
+
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          var afmTools = [any FoundationModels.Tool]()
+          // Only function calling tools are supported by Foundation Models.
+          for tool in tools ?? [] {
+            // Skips any unsupported tools such as `GoogleMaps` or `CodeExecution` since they are
+            // only
+            // supported by Gemini models.
+            // TODO: Decide whether to throw for unsupported `FirebaseAILogic.Tool` types or ignore.
+            let functionDeclarations = tool.toolRepresentation.functionDeclarations ?? []
+            for functionDeclaration in functionDeclarations {
+              switch functionDeclaration.kind {
+              case .manual:
+                // TODO: Decide whether ignore manual function calling declarations, throw or assert.
+                continue
+              case let .foundationModels(afmTool):
+                guard let afmTool = afmTool as? (any FoundationModels.Tool) else {
+                  assertionFailure("""
+                  The function declaration "\(afmTool)" in the tool "\(tool)" is not a
+                  `FoundationModels.Tool` type.
+                  """)
+                  continue
+                }
+                afmTools.append(afmTool)
+              }
+            }
+          }
+          return LanguageModelSession(tools: afmTools, instructions: instructions)
+        }
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
+
+      throw GenerativeModelSession.GenerationError.assetsUnavailable(
+        GenerativeModelSession.GenerationError.Context(debugDescription: """
+        Failed to start a `LanguageModelSession`. The Foundation Models `SystemLanguageModel` is not
+        available on the current platform.
+        """)
+      )
+    }
+  }
+#endif // compiler(>=6.2.3)

--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -727,6 +727,9 @@
 
       case concurrentRequests(GenerativeModelSession.GenerationError.Context)
 
+      /// The content provided as a prompt is not supported by the model.
+      case unsupportedPromptContent(GenerativeModelSession.GenerationError.Context)
+
       case internalError(GenerativeModelSession.GenerationError.Context, underlyingError: any Error)
     }
 

--- a/FirebaseAI/Sources/Protocols/Internal/ConvertibleToGeneratedContent.swift
+++ b/FirebaseAI/Sources/Protocols/Internal/ConvertibleToGeneratedContent.swift
@@ -33,8 +33,7 @@
     @available(iOS 26.0, macOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    extension FirebaseAI.ConvertibleToGeneratedContent
-      where Self: FoundationModels.ConvertibleToGeneratedContent {
+    extension FoundationModels.ConvertibleToGeneratedContent {
       var firebaseGeneratedContent: FirebaseAI.GeneratedContent {
         return FirebaseAI.GeneratedContent(
           kind: generatedContent.kind,

--- a/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
+++ b/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
@@ -47,11 +47,23 @@
     }
   }
 
-  // TODO: Add docs and config options for `systemModel`
   public extension LanguageModelProvider where Self == FirebaseAI.SystemLanguageModel {
-    static func systemModel() -> FirebaseAI.SystemLanguageModel {
-      // TODO: Update to use config options
-      return FirebaseAI.SystemLanguageModel.default
+    /// **[Public Preview]** Creates a model provider for the on-device `SystemLanguageModel`
+    /// provided by Apple's Foundation Models framework.
+    ///
+    /// > Warning: This API is a public preview and may be subject to change.
+    ///
+    /// For more details about the configuration options, see the Apple
+    /// [documentation](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/init(usecase:guardrails:)).
+    ///
+    /// - Parameters:
+    ///   - useCase: The ``UseCase`` that the model is tuned for; defaults to ``UseCase/general``.
+    ///   - guardrails: The ``Guardrails`` that configure how the model handles potentially harmful
+    ///     content; defaults to ``Guardrails/default``.
+    static func systemModel(useCase: FirebaseAI.SystemLanguageModel.UseCase = .general,
+                            guardrails: FirebaseAI.SystemLanguageModel.Guardrails = .default)
+      -> FirebaseAI.SystemLanguageModel {
+      return FirebaseAI.SystemLanguageModel(useCase: useCase, guardrails: guardrails)
     }
   }
 

--- a/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
+++ b/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
@@ -47,6 +47,14 @@
     }
   }
 
+  // TODO: Add docs and config options for `systemModel`
+  public extension LanguageModelProvider where Self == FirebaseAI.SystemLanguageModel {
+    static func systemModel() -> FirebaseAI.SystemLanguageModel {
+      // TODO: Update to use config options
+      return FirebaseAI.SystemLanguageModel.default
+    }
+  }
+
   public extension LanguageModelProvider where Self == HybridModelProvider {
     /// **[Public Preview]** Creates a ``HybridModelProvider`` for the specified models.
     ///

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -132,6 +132,13 @@ public struct Tool: Sendable {
     self.urlContext = urlContext
     self.codeExecution = codeExecution
   }
+
+  /// Returns `true` if all tools contained in `Tool` are supported by Foundation Models.
+  ///
+  /// Note: Currently only function declarations are supported.
+  var isFoundationModeCompatible: Bool {
+    return googleSearch == nil && googleMaps == nil && urlContext == nil && codeExecution == nil
+  }
 }
 
 /// Configuration for specifying function calling behavior.

--- a/FirebaseAI/Sources/Types/Internal/GeminiModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/GeminiModelSession.swift
@@ -31,10 +31,23 @@ import Foundation
 
     // MARK: ModelSession Conformance
 
+    /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     var _hasHistory: Bool {
       return !chat.history.isEmpty
     }
 
+    /// Sends a prompt to the model and returns a ``_ModelSessionResponse``.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     nonisolated(nonsending)
     func _respond(to prompt: [any Part],
                   schema: FirebaseAI.GenerationSchema?,
@@ -107,6 +120,14 @@ import Foundation
       return _ModelSessionResponse(rawContent: rawContent, rawResponse: response)
     }
 
+    /// Sends a prompt to the model and streams the model's response.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     @available(macOS 12.0, watchOS 8.0, *)
     func _streamResponse(to prompt: [any Part],
                          schema: FirebaseAI.GenerationSchema?,

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -22,10 +22,23 @@
       self.secondary = secondary
     }
 
+    /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     var _hasHistory: Bool {
       return primary._hasHistory || secondary._hasHistory
     }
 
+    /// Sends a prompt to the model and returns a ``_ModelSessionResponse``.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                   includeSchemaInPrompt: Bool, options: any GenerationOptionsRepresentable)
       async throws -> _ModelSessionResponse {
@@ -64,6 +77,14 @@
       }
     }
 
+    /// Sends a prompt to the model and streams the model's response.
+    ///
+    /// - Parameters:
+    ///   - prompt: The content to send to the model.
+    ///   - schema: An optional schema for structured outputs.
+    ///   - includeSchemaInPrompt: Whether to include the `schema` in the request to the model; if
+    ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
+    ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
     @available(macOS 12.0, watchOS 8.0, *)
     func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                          includeSchemaInPrompt: Bool,

--- a/FirebaseAI/Sources/Types/Public/GeminiModel.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiModel.swift
@@ -51,10 +51,16 @@ import Foundation
   }
 
   extension GeminiModel: LanguageModel {
+    /// Returns the name of the model.
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     public var _modelName: String {
       return modelName
     }
 
+    /// Returns a new session for this model.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
     public func _startSession(tools: [any ToolRepresentable]?,
                               instructions: String?) throws -> any _ModelSession {
       let model = GenerativeModel(

--- a/FirebaseAI/Sources/Types/Public/GeminiModelProvider.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiModelProvider.swift
@@ -26,6 +26,12 @@
       self.requestOptions = requestOptions
     }
 
+    /// Returns an instance of the ``LanguageModel`` corresponding to this provider.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
+    ///
+    /// - Parameter firebaseAI: A ``FirebaseAI`` instance that provides necessary context for
+    ///   instantiating the model, such as the API configuration.
     public func _languageModel(firebaseAI: FirebaseAI) -> any LanguageModel {
       return firebaseAI.geminiModel(
         name: modelName,

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -34,10 +34,16 @@
 
     // MARK: LanguageModel Conformance
 
+    /// Returns the name of the model.
+    ///
+    /// > Important: This property is for **internal use only** and may change at any time.
     public var _modelName: String {
       return "hybrid:\(primary._modelName),\(secondary._modelName)"
     }
 
+    /// Returns a new session for this model.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
     public func _startSession(tools: [any ToolRepresentable]?,
                               instructions: String?) throws -> any _ModelSession {
       var primarySession: (any _ModelSession)?

--- a/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModelProvider.swift
@@ -23,6 +23,12 @@
       self.secondary = secondary
     }
 
+    /// Returns an instance of the ``LanguageModel`` corresponding to this provider.
+    ///
+    /// > Important: This method is for **internal use only** and may change at any time.
+    ///
+    /// - Parameter firebaseAI: A ``FirebaseAI`` instance that provides necessary context for
+    ///   instantiating the model, such as the API configuration.
     public func _languageModel(firebaseAI: FirebaseAI) -> any LanguageModel {
       return HybridModel(
         primary: primary._languageModel(firebaseAI: firebaseAI),

--- a/FirebaseAI/Sources/Types/Public/Part.swift
+++ b/FirebaseAI/Sources/Types/Public/Part.swift
@@ -371,7 +371,8 @@ public struct CodeExecutionResultPart: Part {
             throw GenerativeModelSession.GenerationError.unsupportedPromptContent(
               GenerativeModelSession.GenerationError.Context(
                 debugDescription: """
-                Prompt data type "\(data)" is not supported by the on-device model.
+                Prompt data type "\(data)" is not supported by the on-device model; currently only \
+                text content is supported.
                 """
               )
             )

--- a/FirebaseAI/Sources/Types/Public/Part.swift
+++ b/FirebaseAI/Sources/Types/Public/Part.swift
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import Foundation
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif // canImport(FoundationModels)
 
 /// A discrete piece of data in a media format interpretable by an AI model.
 ///
@@ -346,3 +349,44 @@ public struct CodeExecutionResultPart: Part {
     self.thoughtSignature = thoughtSignature
   }
 }
+
+#if compiler(>=6.2.3) && canImport(FoundationModels)
+  @available(iOS 26.0, macOS 26.0, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  extension [any Part] {
+    func toFoundationModelsPrompt() throws -> FoundationModels.Prompt {
+      let parts = ModelContent(parts: self)
+      let promptParts: [any FoundationModels.PromptRepresentable] = try parts.internalParts
+        .compactMap { part in
+          // Skip any `thought` parts since they are unused by Foundation Models.
+          guard !(part.isThought ?? false) else { return nil }
+
+          // Skip any parts without `data`, for example a `Part` containing only a thought
+          // signature, since they are unused by Foundation Models.
+          guard let data = part.data else { return nil }
+
+          // Currently only string types are supported.
+          guard case let .text(string) = data else {
+            // TODO: Create a custom error type for unsupported prompt part types.
+            throw GenerativeModelSession.GenerationError.internalError(
+              GenerativeModelSession.GenerationError.Context(
+                debugDescription: """
+                Prompt data type "\(data)" is not supported by Foundation Models.
+                """
+              ),
+              underlyingError: NSError(domain: Constants.baseErrorDomain, code: 0)
+            )
+          }
+
+          return string
+        }
+
+      return Prompt {
+        for part in promptParts {
+          part.promptRepresentation
+        }
+      }
+    }
+  }
+#endif // compiler(>=6.2.3) && canImport(FoundationModels)

--- a/FirebaseAI/Sources/Types/Public/Part.swift
+++ b/FirebaseAI/Sources/Types/Public/Part.swift
@@ -368,14 +368,12 @@ public struct CodeExecutionResultPart: Part {
 
           // Currently only string types are supported.
           guard case let .text(string) = data else {
-            // TODO: Create a custom error type for unsupported prompt part types.
-            throw GenerativeModelSession.GenerationError.internalError(
+            throw GenerativeModelSession.GenerationError.unsupportedPromptContent(
               GenerativeModelSession.GenerationError.Context(
                 debugDescription: """
-                Prompt data type "\(data)" is not supported by Foundation Models.
+                Prompt data type "\(data)" is not supported by the on-device model.
                 """
-              ),
-              underlyingError: NSError(domain: Constants.baseErrorDomain, code: 0)
+              )
             )
           }
 

--- a/FirebaseAI/Sources/Types/Public/Part.swift
+++ b/FirebaseAI/Sources/Types/Public/Part.swift
@@ -351,7 +351,7 @@ public struct CodeExecutionResultPart: Part {
 }
 
 #if compiler(>=6.2.3) && canImport(FoundationModels)
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   extension [any Part] {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -88,7 +88,7 @@
     }
 
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func respondGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -60,6 +60,37 @@
     @available(iOS 26.0, macOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
+    func respondText_fallbackOnFoundationModelsError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let systemModel = FirebaseAI.SystemLanguageModel.default
+      let geminiModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = firebaseAI.generativeModelSession(
+        model: HybridModel(primary: systemModel, secondary: geminiModel)
+      )
+      let prompt = "In one sentence, why is the sky blue?"
+
+      let response = try await session.respond(to: prompt)
+
+      let content = response.content
+      #expect(!content.isEmpty)
+      #expect(response.rawContent.isComplete)
+      #expect(response.rawContent.kind == .string(content))
+      #expect(response.rawContent.generationID != nil)
+      #expect(response.rawResponse.text == content)
+      // Check for the on-device model name when running on Apple Intelligence supported devices; in
+      // this case, no fallback occurs. When running on devices that do not support Apple
+      // Intelligence, including GitHub Runner Images, check for the cloud (Gemini) model name.
+      if await foundationModelsIsAvailable() {
+        #expect(response.rawResponse.modelVersion == systemModel._modelName)
+      } else {
+        #expect(response.rawResponse.modelVersion == geminiModel._modelName)
+      }
+    }
+
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @available(iOS 26.0, macOS 26.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     func respondGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name-1")
@@ -175,6 +206,37 @@
       #expect(response.rawContent.isComplete)
       #expect(response.rawContent.generationID != nil)
       #expect(response.rawResponse.modelVersion == validModel._modelName)
+    }
+
+    /// Returns `true` if `FoundationModels.SystemLanguageModel` is available.
+    ///
+    /// This is a workaround for `SystemLanguageModel.isAvailable`, which returns `true` if *any*
+    /// version of the model is available. However, calls to `LanguageModelSession().respond(to:)`
+    /// throw a `ModelManagerError` if the simulator's model version does not match the host macOS
+    /// version. A new version of the model was introduced in Xcode/macOS/iOS 26.4.
+    func foundationModelsIsAvailable() async -> Bool {
+      #if canImport(FoundationModels)
+        if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
+          let model = SystemLanguageModel.default
+          guard model.isAvailable else {
+            return false
+          }
+
+          let session = LanguageModelSession(model: model)
+          do {
+            _ = try await session.respond(
+              to: "Hello",
+              options: GenerationOptions(sampling: .greedy, temperature: 0)
+            )
+
+            return true
+          } catch {
+            return false
+          }
+        }
+      #endif // canImport(FoundationModels)
+
+      return false
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
@@ -32,7 +32,14 @@ import XCTest
       _ = ai.generativeModelSession(model: geminiModel)
       _ = GenerativeModelSession(model: geminiModel)
 
-      // Initialize a session with a `HybridModelProvider`
+      // Initialize a session with a `SystemLanguageModel` as a `LanguageModel`
+      let systemModel = FirebaseAI.SystemLanguageModel.default
+      _ = GenerativeModelSession(model: systemModel)
+
+      // Initialize a session with a `SystemLanguageModel` as a `LanguageModelProvider`
+      _ = ai.generativeModelSession(model: .systemModel())
+
+      // Initialize a session with a `HybridModelProvider` of cloud models
       _ = ai.generativeModelSession(
         model: .hybridModel(
           primary: geminiModel,
@@ -40,10 +47,21 @@ import XCTest
         )
       )
 
-      // Initialize a session with a `HybridModel`
+      // Initialize a session with a `HybridModelProvider` of cloud and on-device models
+      _ = ai.generativeModelSession(
+        model: .hybridModel(
+          primary: .systemModel(),
+          secondary: .geminiModel(name: "gemini-flash-lite-latest")
+        )
+      )
+
+      // Initialize a session with a `HybridModel` of cloud models
       let gemmaModel = ai.geminiModel(name: "gemma-4-31b-it")
       let hybridModel = HybridModel(primary: gemmaModel, secondary: geminiModel)
       _ = GenerativeModelSession(model: hybridModel)
+
+      // Initialize a session with a `HybridModel` of cloud and on-device models
+      _ = HybridModel(primary: systemModel, secondary: geminiModel)
     }
   }
 #endif // compiler(>=6.2.3)


### PR DESCRIPTION
Conformed `FirebaseAI.SystemLanguageModel` to `LanguageModel` to add support for on-device inference using the Foundation Models framework. This allows `FirebaseAI.SystemLanguageModel` to be used in a `HybridModel` for hybrid inference locally and in the cloud with Gemini.

#no-changelog